### PR TITLE
ensure reference alias is set before csc is invoked

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectSystem.Base.csproj
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectSystem.Base.csproj
@@ -72,13 +72,13 @@
     <PackageReference Include="VSSDK.VSLangProj.8" Version="$(VSSDKVSLangProj8PackageVersion)" />
   </ItemGroup>
 
-  <Target Name="HACK_AddAliasToMicrosoftVisualStudioShell140" BeforeTargets="ResolveReferences">
+  <Target Name="HACK_AddAliasToMicrosoftVisualStudioShell140" BeforeTargets="CoreCompile">
     <ItemGroup>
       <!--
       We require a reference to Microsoft.VisualStudio.Shell.14.0.dll, but that causes some issues with duplicate type
       names.  The ~hack~ fix is to include the package reference and ensure the Aliases metadata gets set afterwards.
       -->
-      <ReferencePath Update="%(Identity)" Aliases="Shell14" Condition="'%(ReferencePath.PackageName)' == 'Microsoft.VisualStudio.Shell.14.0'" />
+      <ReferencePathWithRefAssemblies Update="%(Identity)" Aliases="Shell14" Condition="'%(ReferencePathWithRefAssemblies.NuGetPackageId)' == 'Microsoft.VisualStudio.Shell.14.0'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
In some recent versions of the C# SDK targets the `ResolveReferences` target is being invoked _after_ `CoreCompile`.  There is likely another bug around that, but in the meantime this modifies a hack to happen directly before `CoreCompile` to unblock some users building.