### PR TITLE
Add IFileSystem.SourceFileReadShim returning char[]

### DIFF
--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -69,6 +69,8 @@ let B = File1.A + File1.A"""
         member __.AssemblyLoadFrom(fileName) = defaultFileSystem.AssemblyLoadFrom fileName
         member __.AssemblyLoad(assemblyName) = defaultFileSystem.AssemblyLoad assemblyName 
 
+        member __.SourceFileReadShim(fileName, codepage) = defaultFileSystem.SourceFileReadShim(fileName, codepage)
+
 let UseMyFileSystem() = 
     let myFileSystem = MyFileSystem(Shim.FileSystem)
     Shim.FileSystem <- myFileSystem


### PR DESCRIPTION
Adds API allowing to pass `char[]` to be used by lexer instead of returning `Stream` which is read to `string` which is then thrown away with `.ToCharArray()`.

PR continues work by @smoothdeveloper in #4882 but is aimed at the file system shim clients.

It would be great to use `ReadOnlySpan<char>` (and probably make this API return `string`) instead at some point.