### PR TITLE
Use ILCallingConv singletons for default ILArgConvention

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -549,18 +549,18 @@ type ILCallingConv =
     member x.IsStatic           = match x.ThisConv with ILThisConvention.Static -> true | _ -> false
 
     static member Instance = ILCallingConvStatics.Instance
-
+    static member InstanceExplicit = ILCallingConvStatics.InstanceExplicit
     static member Static = ILCallingConvStatics.Static
 
 /// Static storage to amortize the allocation of <c>ILCallingConv.Instance</c> and <c>ILCallingConv.Static</c>.
 and ILCallingConvStatics() = 
 
     static let instanceCallConv = Callconv(ILThisConvention.Instance, ILArgConvention.Default)
-
+    static let instanceExplicitCallConv = Callconv(ILThisConvention.InstanceExplicit, ILArgConvention.Default)
     static let staticCallConv =  Callconv(ILThisConvention.Static, ILArgConvention.Default)
 
     static member Instance = instanceCallConv
-
+    static member InstanceExplicit = instanceExplicitCallConv
     static member Static = staticCallConv
 
 type ILBoxity = 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -134,6 +134,7 @@ type ILCallingConv =
     member BasicConv: ILArgConvention
 
     static member Instance: ILCallingConv
+    static member InstanceExplicit: ILCallingConv
     static member Static  : ILCallingConv
 
 /// Array shapes. For most purposes the rank is the only thing that matters. 

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2230,7 +2230,15 @@ and byteAsCallConv b =
         elif ccMaxked = e_IMAGE_CEE_CS_CALLCONV_VARARG then ILArgConvention.VarArg 
         else  ILArgConvention.Default
     let generic = (b &&& e_IMAGE_CEE_CS_CALLCONV_GENERIC) <> 0x0uy
-    generic, Callconv (byteAsHasThis b, cc) 
+    let callConv =
+        if cc = ILArgConvention.Default then
+            let hasthis_masked = b &&& 0x60uy
+            if hasthis_masked = e_IMAGE_CEE_CS_CALLCONV_INSTANCE then ILCallingConv.Instance
+            elif hasthis_masked = e_IMAGE_CEE_CS_CALLCONV_INSTANCE_EXPLICIT then ILCallingConv.InstanceExplicit 
+            else ILCallingConv.Static
+        else
+            Callconv (byteAsHasThis b, cc)
+    generic, callConv
       
 and seekReadMemberRefAsMethodData ctxt numtypars idx : VarArgMethodData = 
     ctxt.seekReadMemberRefAsMethodData (MemberRefAsMspecIdx (numtypars, idx))


### PR DESCRIPTION
According to the following comment, singletons can be used in most cases. I added a branch checking for these cases and returning an existing object when possible.
https://github.com/Microsoft/visualfsharp/blob/6d40f35f260b0740a2a4422de869c609fa35453f/src/absil/il.fsi#L101-L104

<img width="744" alt="screen shot 2018-07-06 at 12 31 56" src="https://user-images.githubusercontent.com/3923587/42396947-93c8a9a4-816c-11e8-86f4-cb927589b7fb.png">
<img width="917" alt="screen shot 2018-07-06 at 13 02 02" src="https://user-images.githubusercontent.com/3923587/42396952-9b3c947a-816c-11e8-8890-f203eb4dae0a.png">

Project | Before | After
---|---|---
Console app | 38,037 | 59
ReSharper.FSharp | 537,598 | 1,021