### PR TITLE
[WIP] enable simple snippet support

### DIFF
--- a/vsintegration/Snippets/1033/README.txt
+++ b/vsintegration/Snippets/1033/README.txt
@@ -1,0 +1,3 @@
+The files in this directory should be kept in sync with the following files:
+
+$(RepoRoot)\vsintegration\Vsix\VisualFSharpFull\Snippets.targets

--- a/vsintegration/Snippets/1033/Snippets/match.snippet
+++ b/vsintegration/Snippets/1033/Snippets/match.snippet
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets  xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>match</Title>
+      <Shortcut>match</Shortcut>
+      <Description>Code snippet for 'match' expression</Description>
+      <Author>Microsoft Corporation</Author>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+        <SnippetType>SurroundsWith</SnippetType>
+      </SnippetTypes>
+    </Header>
+    <Snippet>
+      <Declarations>
+        <Literal>
+          <ID>expression</ID>
+          <Default>expr</Default>
+          <ToolTip>Expression</ToolTip>
+        </Literal>
+        <Literal>
+          <ID>value</ID>
+          <Default>value</Default>
+          <ToolTip>Value</ToolTip>
+        </Literal>
+      </Declarations>
+      <Code Language="fsharp"><![CDATA[match $expression$ with
+| $value$ -> $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/vsintegration/Snippets/1033/SnippetsIndex.xml
+++ b/vsintegration/Snippets/1033/SnippetsIndex.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<SnippetCollection>
+  <Language Lang="FSharp" Guid="{bc6dd5a5-d4d6-4dab-a00d-a51242dbaf1b}">
+    <SnippetDir>
+      <OnOff>On</OnOff>
+      <Installed>true</Installed>
+      <Locale>1033</Locale>
+      <DirPath>%InstallRoot%\FSharp\Snippets\1033\Snippets\</DirPath>
+      <LocalizedName>F# snippets</LocalizedName>
+    </SnippetDir>
+  </Language>
+</SnippetCollection>

--- a/vsintegration/Vsix/VisualFSharpFull/Properties/launchSettings.json
+++ b/vsintegration/Vsix/VisualFSharpFull/Properties/launchSettings.json
@@ -3,7 +3,10 @@
     "VisualFSharpFull": {
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
-      "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log"
+      "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log",
+      "environmentVariables": {
+        "COMPLUS_ZAPDisable": "1"
+      }
     }
   }
 }

--- a/vsintegration/Vsix/VisualFSharpFull/Snippets.targets
+++ b/vsintegration/Vsix/VisualFSharpFull/Snippets.targets
@@ -1,0 +1,27 @@
+<Project>
+
+  <!--
+
+  This file should be kept in sync with the "$(RepoRoot)\vsintegration\Snippets\1033\" directory.
+
+  -->
+
+  <PropertyGroup>
+    <SnippetIndexLocation>$(MSBuildThisFileDirectory)..\..\Snippets\1033</SnippetIndexLocation>
+    <SnippetsLocation>$(SnippetIndexLocation)\Snippets</SnippetsLocation>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="$(SnippetIndexLocation)\SnippetsIndex.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Snippets\1033\SnippetsIndex.xml</Link>
+    </Content>
+    <Content Include="$(SnippetsLocation)\match.snippet">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Snippets\1033\Snippets\match.snippet</Link>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -220,4 +220,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
+  <Import Project="Snippets.targets" />
+
 </Project>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -41,6 +41,9 @@
     <Compile Include="Options\UIHelpers.fs" />
     <Compile Include="Options\EditorOptions.fs" />
     <Compile Include="LanguageService\ProvideBraceCompletionAttribute.fs" />
+    <Compile Include="Snippets\ProvideCodeExpansionsAttribute.fs" />
+    <Compile Include="Snippets\FSharpSnippetExpansionClient.fs" />
+    <Compile Include="Snippets\SnippetCommandFilter.fs" />
     <Compile Include="LanguageService\FSharpEditorFactory.fs" />
     <Compile Include="LanguageService\TextViewCreationListener.fs" />
     <Compile Include="LanguageService\Tokenizer.fs" />
@@ -139,7 +142,6 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectAggregator" Version="$(MicrosoftVisualStudioProjectAggregatorPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="$(MicrosoftVisualStudioProjectSystemManagedVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="$(MicrosoftVisualStudioShellImmutable100PackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" Version="$(MicrosoftVisualStudioShellImmutable110PackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop110PackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
@@ -147,6 +149,7 @@
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="$(MicrosoftVisualStudioTextManagerInterop120PackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsPackageVersion)"  PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.MSXML" Version="$(MicrosoftMSXMLPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="VSSDK.VSLangProj" Version="$(VSSDKVSLangProjPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
@@ -207,4 +207,8 @@
   <data name="6012" xml:space="preserve">
     <value>Advanced</value>
   </data>
+  <data name="InsertSnippet" xml:space="preserve">
+    <value>Insert Snippet</value>
+    <comment>Shown as the prompt when inserting a code snippet.</comment>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -35,6 +35,7 @@ open Microsoft.VisualStudio.LanguageServices.ProjectSystem
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.ComponentModelHost
+open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text.Outlining
 open FSharp.NativeInterop
 
@@ -345,6 +346,8 @@ type internal FSharpCheckerWorkspaceServiceFactory
 [<ProvideLanguageExtension(typeof<FSharpLanguageService>, ".ml")>]
 [<ProvideLanguageExtension(typeof<FSharpLanguageService>, ".mli")>]
 [<ProvideBraceCompletion(FSharpConstants.FSharpLanguageName)>]
+[<ProvideCodeExpansions(FSharpConstants.languageServiceGuidString, false, 106s, "FSharp", @"Snippets\1033\SnippetsIndex.xml")>]
+[<ProvideCodeExpansionPath("FSharp", "Description", @"Snippets\1033\Snippets\")>]
 [<ProvideLanguageService(languageService = typeof<FSharpLanguageService>,
                             strLanguageName = FSharpConstants.FSharpLanguageName,
                             languageResourceID = 100,

--- a/vsintegration/src/FSharp.Editor/Snippets/FSharpSnippetExpansionClient.fs
+++ b/vsintegration/src/FSharp.Editor/Snippets/FSharpSnippetExpansionClient.fs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.Runtime.InteropServices
+open System.Threading
+open System.Xml.Linq
+
+open Microsoft.CodeAnalysis
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.Editor
+open Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
+open Microsoft.VisualStudio.Text
+open Microsoft.VisualStudio.Text.Editor
+open Microsoft.VisualStudio.TextManager.Interop
+open MSXML
+
+type FSharpSnippetExpansionClient
+    (
+        textView: ITextView,
+        editorAdaptersFactoryService: IVsEditorAdaptersFactoryService
+    ) =
+    inherit AbstractSnippetExpansionClient(Guid(FSharpConstants.languageServiceGuidString), textView, textView.TextBuffer, editorAdaptersFactoryService)
+        override __.GetExpansionFunction(_xmlFunctionNode: IXMLDOMNode, _bstrFieldName: string, pfunc: byref<IVsExpansionFunction>): int =
+            pfunc <- null
+            VSConstants.E_INVALIDARG
+        override __.InsertEmptyCommentAndGetEndPositionTrackingSpan(): ITrackingSpan =
+            // this method is only called through `AbstractSnippetExpansionClient.FormatSpan` which is manually overridden below
+            raise (NotSupportedException())
+        override __.AddImports(_document: Document, _position: int, _snippetNode: XElement, _placeSystemNamespaceFirst: bool, _cancellationToken: CancellationToken): Document =
+            // this method is only called through `AbstractSnippetExpansionClient.FormatSpan` which is manually overridden below
+            raise (NotSupportedException())
+    interface IVsExpansionClient with
+        // this method is implemented by `AbstractSnippetExpansionClient` and is dependent on Roslyn syntax nodes which F# doesn't expose so we handle it ourselves here
+        member __.FormatSpan(pBuffer: IVsTextLines, ts: TextSpan []): int =
+            if ts.Length = 1 then
+                let ts = ts.[0]
+                match pBuffer.GetLineText(ts.iStartLine, ts.iStartIndex, ts.iEndLine, ts.iEndIndex) with
+                | (result, text) when result = VSConstants.S_OK ->
+                    // split the text at the newlines and ensure each line after the first has the same indention level as the first
+                    let lines = text.Split('\n')
+                    let indent = String(' ', ts.iStartIndex) // TODO: this doesn't handle virtual spaces
+                    for i in 1..lines.Length - 1 do
+                        lines.[i] <- indent + lines.[i]
+                    let newText = String.Join("\n", lines)
+                    let changedSpan: TextSpan array = Array.zeroCreate 1
+                    let mutable textPointer = Unchecked.defaultof<nativeint>
+                    try
+                        // the new text has to traverse through unmanaged memory
+                        textPointer <- Marshal.StringToHGlobalUni(newText)
+                        match pBuffer.ReplaceLines(ts.iStartLine, ts.iStartIndex, ts.iEndLine, ts.iEndIndex, textPointer, newText.Length, changedSpan) with
+                        | result when result = VSConstants.S_OK ->
+                            // success replacing text
+                            VSConstants.S_OK
+                        | _ ->
+                            // error replacing text
+                            VSConstants.S_OK
+                    finally
+                        Marshal.FreeHGlobal(textPointer)
+                | _ -> VSConstants.S_OK
+            else
+                VSConstants.E_INVALIDARG

--- a/vsintegration/src/FSharp.Editor/Snippets/ProvideCodeExpansionsAttribute.fs
+++ b/vsintegration/src/FSharp.Editor/Snippets/ProvideCodeExpansionsAttribute.fs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.IO
+open Microsoft.FSharp.Core
+open Microsoft.VisualStudio.Shell
+
+type ProvideCodeExpansionsAttribute(
+                                    languageGuidString: string,
+                                    showRoots: bool,
+                                    displayName: int16,
+                                    languageStringId: string,
+                                    indexPath: string) =
+    inherit RegistrationAttribute()
+
+    let languageName = @"Languages\CodeExpansions\" + languageStringId
+
+    override this.Register(context: RegistrationAttribute.RegistrationContext) =
+        if context <> null then
+            let fullEscapedPath p =
+                Path.Combine(context.ComponentPath, p)
+                |> Path.GetFullPath
+                |> context.EscapePath
+            use childKey = context.CreateKey(languageName)
+            childKey.SetValue("", new Guid(languageGuidString))
+            childKey.SetValue("DisplayName", displayName.ToString())
+            childKey.SetValue("IndexPath", fullEscapedPath indexPath)
+            childKey.SetValue("LangStringId", languageStringId.ToLowerInvariant())
+            childKey.SetValue("Package", context.ComponentType.GUID.ToString("B"))
+            childKey.SetValue("ShowRoots", if showRoots then 1 else 0)
+
+    override this.Unregister(context: RegistrationAttribute.RegistrationContext) =
+        if context <> null then
+            context.RemoveKey(languageName)
+
+type ProvideCodeExpansionPathAttribute(
+                                       languageStringId: string,
+                                       description: string,
+                                       paths: string) =
+    inherit RegistrationAttribute()
+
+    let languageName = @"Languages\CodeExpansions\" + languageStringId
+
+    override this.Register(context: RegistrationAttribute.RegistrationContext) =
+        if context <> null then
+            use childKey = context.CreateKey(languageName)
+            let snippetPaths =
+                Path.Combine(context.ComponentPath, paths)
+                |> Path.GetFullPath
+                |> context.EscapePath
+            use pathsSubKey = childKey.CreateSubkey("Paths")
+            pathsSubKey.SetValue(description, snippetPaths)
+
+    override this.Unregister(_context: RegistrationAttribute.RegistrationContext) =
+        ()

--- a/vsintegration/src/FSharp.Editor/Snippets/SnippetCommandFilter.fs
+++ b/vsintegration/src/FSharp.Editor/Snippets/SnippetCommandFilter.fs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.ComponentModel.Composition
+open System.Threading
+
+open Microsoft.CodeAnalysis
+open Microsoft.VisualStudio.Commanding
+open Microsoft.VisualStudio.Editor
+open Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
+open Microsoft.VisualStudio.Text.Editor
+open Microsoft.VisualStudio.Shell
+open Microsoft.VisualStudio.Text
+open Microsoft.VisualStudio.Utilities
+
+[<Export(typeof<ICommandHandler>)>]
+[<ContentType(FSharpConstants.FSharpLanguageName)>]
+[<Name("F# Snippets")>]
+//[<Order(After=Microsoft.CodeAnalysis.Editor.PredefinedCommandHandlerNames.Completion)>]
+[<Order(After=Microsoft.CodeAnalysis.Editor.PredefinedCommandHandlerNames.IntelliSense)>]
+type SnippetCommandHandler
+    [<ImportingConstructor>]
+    (
+        editorAdaptersFactoryService: IVsEditorAdaptersFactoryService,
+        serviceProvider: SVsServiceProvider
+    ) =
+    inherit AbstractSnippetCommandHandler(editorAdaptersFactoryService, serviceProvider)
+        override __.IsSnippetExpansionContext(_document: Document, _startPosition: int, _cancellationToken: CancellationToken) =
+            // TODO: only true if not in a string or comment
+            true
+        override __.GetSnippetExpansionClient(textView: ITextView, _subjectBuffer: ITextBuffer) =
+            upcast FSharpSnippetExpansionClient(textView, editorAdaptersFactoryService)
+        override this.TryInvokeInsertionUI(textView: ITextView, subjectBuffer: ITextBuffer, _surroundWith: bool) =
+            match this.TryGetExpansionManager() with
+            | (true, expansionManager) ->
+                let types = [|"Expansion"; "SurroundsWith"|]
+                let client = this.GetSnippetExpansionClient(textView, subjectBuffer)
+                expansionManager.InvokeInsertionUI(
+                    editorAdaptersFactoryService.GetViewAdapter(textView), // pView
+                    client, // pClient
+                    Guid(FSharpConstants.languageServiceGuidString), // guidLang
+                    types, // bstrTypes
+                    types.Length, // iCountTypes
+                    1, // fIncludeNULLType
+                    null, // bstrKinds
+                    0, // iCountKinds
+                    0, // fIncludeNULLKind
+                    SR.InsertSnippet(), //bstrPrefixText
+                    ">" // bstrCompletionChar
+                ) |> ignore
+                true
+            | _ -> false

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Upřesnit</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Erweitert</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.en.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.en.xlf
@@ -152,6 +152,11 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Avanzadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Avancé</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Avanzate</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
@@ -152,6 +152,11 @@
         <target state="translated">詳細</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
@@ -152,6 +152,11 @@
         <target state="translated">고급</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Zaawansowane</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Avançado</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Дополнительно</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Gelişmiş</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="translated">高级</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="translated">進階</target>
         <note />
       </trans-unit>
+      <trans-unit id="InsertSnippet">
+        <source>Insert Snippet</source>
+        <target state="new">Insert Snippet</target>
+        <note>Shown as the prompt when inserting a code snippet.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
There are many caveats with this:

- The snippets themselves don't yet support localization; there will be a lot of work in figuring out exactly how this will work.
- We can't yet cycle through the snippet's literals; the whole thing is simply pasted into the document.
- There are known bugs, specifically around offering snippets in comments and strings and not handling virtual spaces properly.
- There is a null ref that I'm currently working on when the snippet is invoked via the regular completion list (but `Ctrl+K`, `Ctrl+X` works fine.)  **Edit: dotnet/roslyn#29103 is addressing this.**
- There are no unit tests yet; that will likely require a bunch of test infrastructure work.
- I've only added a simple snippet for the `match` expression.  The purpose of this PR is to get all of the backing code working so that it's trivial to add more in the future.