### PR TITLE
Pass IsInteractive context to assembly reader shim

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -1277,7 +1277,15 @@ module Shim =
     open Microsoft.FSharp.Core.ReflectionAdapters
 #endif
 
-    type IFileSystem = 
+    type IFileStampShim =
+        /// A shim over File.Exists
+        abstract Exists: filename: string * bypassFileSystemShim: bool -> bool
+
+        /// Utc time of the last modification
+        abstract GetLastWriteTime: filename: string * bypassFileSystemShim: bool -> DateTime
+
+    type IFileSystem =
+        inherit IFileStampShim
 
         /// A shim over File.ReadAllBytes
         abstract ReadAllBytesShim: fileName: string -> byte[] 
@@ -1304,12 +1312,6 @@ module Shim =
 
         /// A shim over Path.GetTempPath
         abstract GetTempPathShim : unit -> string
-
-        /// Utc time of the last modification
-        abstract GetLastWriteTimeShim: fileName: string -> DateTime
-
-        /// A shim over File.Exists
-        abstract SafeExists: fileName: string -> bool
 
         /// A shim over File.Delete
         abstract FileDelete: fileName: string -> unit
@@ -1362,9 +1364,9 @@ module Shim =
 
             member __.GetTempPathShim() = Path.GetTempPath()
 
-            member __.GetLastWriteTimeShim (fileName: string) = File.GetLastWriteTimeUtc fileName
+            member __.GetLastWriteTime(fileName: string, _bypassFileSystemShim) = File.GetLastWriteTimeUtc fileName
 
-            member __.SafeExists (fileName: string) = File.Exists fileName 
+            member __.Exists(fileName: string, _bypassFileSystemShim) = File.Exists fileName 
 
             member __.FileDelete (fileName: string) = File.Delete fileName
 

--- a/src/absil/ilread.fsi
+++ b/src/absil/ilread.fsi
@@ -29,8 +29,10 @@ module FSharp.Compiler.AbstractIL.ILBinaryReader
 open Internal.Utilities
 open FSharp.Compiler.AbstractIL 
 open FSharp.Compiler.AbstractIL.IL 
-open FSharp.Compiler.AbstractIL.Internal 
+open FSharp.Compiler.AbstractIL.Internal
+open FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.ErrorLogger
+open System
 open System.IO
 
 /// Used to implement a Binary file over native memory, used by Roslyn integration
@@ -62,7 +64,9 @@ type ILReaderOptions =
 
      /// A function to call to try to get an object that acts as a snapshot of the metadata section of a .NET binary,
      /// and from which we can read the metadata. Only used when metadataOnly=true.
-     tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot }
+     tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot
+
+     bypassFileSystemShim: bool }
 
 
 /// Represents a reader of the metadata of a .NET binary.  May also give some values (e.g. IL code) from the PE file
@@ -96,8 +100,9 @@ val GetStatistics : unit -> Statistics
 
 [<AutoOpen>]
 module Shim =
-
     type IAssemblyReader =
+        inherit IFileStampShim
+
         abstract GetILModuleReader: filename: string * readerOptions: ILReaderOptions -> ILModuleReader
 
     [<Sealed>]

--- a/src/absil/ilsupp.fs
+++ b/src/absil/ilsupp.fs
@@ -610,7 +610,7 @@ let linkNativeResources (unlinkedResources: byte[] list)  (ulLinkedResourceBaseR
             // Get a unique random file
             let rec GetUniqueRandomFileName path =
                 let tfn =  path + System.IO.Path.GetRandomFileName()
-                if FileSystem.SafeExists tfn then
+                if FileSystem.Exists (tfn, false) then
                     GetUniqueRandomFileName path
                 else
                     tfn

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -163,8 +163,9 @@ type IRawFSharpAssemblyData =
     abstract ShortAssemblyName: string
 
 type TimeStampCache = 
-    new: defaultTimeStamp: DateTime -> TimeStampCache
+    new: defaultTimeStamp: DateTime * bypassFileSystemShim: bool -> TimeStampCache
     member GetFileTimeStamp: string -> DateTime
+    member GetAssemblyTimeStamp: string -> DateTime
     member GetProjectReferenceTimeStamp: IProjectReference * CompilationThreadToken -> DateTime
 
 and IProjectReference = 

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -256,7 +256,7 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
             | None ->
                 errorR(Error(FSComp.SR.optsResponseFileNameInvalid rsp, rangeCmdArgs))
                 []
-            | Some path when not (FileSystem.SafeExists path) ->
+            | Some path when not (FileSystem.Exists (path, false)) ->
                 errorR(Error(FSComp.SR.optsResponseFileNotFound(rsp, path), rangeCmdArgs))
                 []
             | Some path ->

--- a/src/fsharp/MSBuildReferenceResolver.fs
+++ b/src/fsharp/MSBuildReferenceResolver.fs
@@ -374,7 +374,7 @@ module internal FSharp.Compiler.MSBuildReferenceResolver
 
            /// Perform the resolution on rooted and unrooted paths, and then combine the results.
            member __.Resolve(resolutionEnvironment, references, targetFrameworkVersion, targetFrameworkDirectories, targetProcessorArchitecture,                
-                             fsharpCoreDir, explicitIncludeDirs, implicitIncludeDir, logMessage, logDiagnostic) =
+                             fsharpCoreDir, explicitIncludeDirs, implicitIncludeDir, logMessage, logDiagnostic, bypassFileSystemShim) =
 
                 // The {RawFileName} target is 'dangerous', in the sense that is uses <c>Directory.GetCurrentDirectory()</c> to resolve unrooted file paths.
                 // It is unreliable to use this mutable global state inside Visual Studio.  As a result, we partition all references into a "rooted" set

--- a/src/fsharp/ReferenceResolver.fs
+++ b/src/fsharp/ReferenceResolver.fs
@@ -32,25 +32,26 @@ module public ReferenceResolver =
        /// Note: If an explicit "mscorlib" is given, then --noframework is being used, and the whole ReferenceResolver logic is essentially
        /// unused.  However in the future an option may be added to allow an explicit specification of
        /// a .NET Framework version to use for scripts.
-       abstract HighestInstalledNetFrameworkVersion : unit -> string
+       abstract HighestInstalledNetFrameworkVersion: unit -> string
     
        /// Get the Reference Assemblies directory for the .NET Framework (on Windows)
        /// This is added to the default resolution path for 
        /// design-time compilations.
-       abstract DotNetFrameworkReferenceAssembliesRootDirectory : string
+       abstract DotNetFrameworkReferenceAssembliesRootDirectory: string
 
        /// Perform assembly resolution on the given references under the given conditions
-       abstract Resolve :
+       abstract Resolve:
            resolutionEnvironment: ResolutionEnvironment *
            // The actual reference paths or assembly name text, plus baggage
-           references:(string (* baggage *) * string)[] *  
+           references: (string (* baggage *) * string)[] *  
            // e.g. v4.5.1
-           targetFrameworkVersion:string *
-           targetFrameworkDirectories:string list *
-           targetProcessorArchitecture:string *
-           fsharpCoreDir:string *
-           explicitIncludeDirs:string list *
-           implicitIncludeDir:string *
-           logMessage:(string->unit) *
-           logDiagnostic:(bool -> string -> string -> unit)
+           targetFrameworkVersion: string *
+           targetFrameworkDirectories: string list *
+           targetProcessorArchitecture: string *
+           fsharpCoreDir: string *
+           explicitIncludeDirs: string list *
+           implicitIncludeDir: string *
+           logMessage: (string -> unit) *
+           logDiagnostic: (bool -> string -> string -> unit) *
+           bypassFileSystemShim: bool
              -> ResolvedFile[]

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1226,7 +1226,8 @@ module StaticLinker =
                   reduceMemoryUsage = tcConfig.reduceMemoryUsage
                   metadataOnly = MetadataOnlyFlag.No
                   tryGetMetadataSnapshot = (fun _ -> None)
-                  pdbDirPath = None  } 
+                  pdbDirPath = None
+                  bypassFileSystemShim = false } 
             ILBinaryReader.OpenILModuleReader mscorlib40 opts
               
         let tdefs1 = ilxMainModule.TypeDefs.AsList  |> List.filter (fun td -> not (MainModuleBuilder.injectedCompatTypes.Contains(td.Name)))
@@ -1318,7 +1319,7 @@ module StaticLinker =
                                         if tcConfig.openDebugInformationForLaterStaticLinking then 
                                             let pdbDir = (try Filename.directoryName fileName with _ -> ".") 
                                             let pdbFile = (try Filename.chopExtension fileName with _ -> fileName)+".pdb" 
-                                            if FileSystem.SafeExists pdbFile then 
+                                            if AssemblyReader.Exists(pdbFile, tcConfig.isInteractive) then 
                                                 if verbose then dprintf "reading PDB file %s from directory %s during static linking\n" pdbFile pdbDir
                                                 Some pdbDir
                                             else 
@@ -1331,7 +1332,8 @@ module StaticLinker =
                                           metadataOnly = MetadataOnlyFlag.No // turn this off here as we need the actual IL code
                                           reduceMemoryUsage = tcConfig.reduceMemoryUsage
                                           pdbDirPath = pdbDirPathOption
-                                          tryGetMetadataSnapshot = (fun _ -> None) } 
+                                          tryGetMetadataSnapshot = (fun _ -> None)
+                                          bypassFileSystemShim = false } 
 
                                     let reader = ILBinaryReader.OpenILModuleReader dllInfo.FileName opts
                                     reader.ILModuleDef

--- a/src/fsharp/range.fs
+++ b/src/fsharp/range.fs
@@ -253,7 +253,7 @@ type range(code1:int64, code2: int64) =
             let endCol = r.EndColumn - 1
             let startCol = r.StartColumn - 1
             if FileSystem.IsInvalidPathShim r.FileName then "path invalid: " + r.FileName
-            elif not (FileSystem.SafeExists r.FileName) then "non existing file: " + r.FileName
+            elif not (FileSystem.Exists (r.FileName, false)) then "non existing file: " + r.FileName
             else
               File.ReadAllLines(r.FileName)
               |> Seq.skip (r.StartLine - 1)

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1624,7 +1624,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
 
     member __.Step (ctok: CompilationThreadToken) =  
       cancellable {
-        let cache = TimeStampCache defaultTimeStamp // One per step
+        let cache = TimeStampCache (defaultTimeStamp, tcConfig.isInteractive) // One per step
         let! res = IncrementalBuild.Step cache ctok SavePartialBuild (Target(tcStatesNode, None)) partialBuild
         match res with 
         | None -> 
@@ -1648,14 +1648,14 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     
     member builder.AreCheckResultsBeforeFileInProjectReady filename = 
         let slotOfFile = builder.GetSlotOfFileName filename
-        let cache = TimeStampCache defaultTimeStamp
+        let cache = TimeStampCache (defaultTimeStamp, tcConfig.isInteractive)
         match slotOfFile with
         | (*first file*) 0 -> IncrementalBuild.IsReady cache (Target(initialTcAccNode, None)) partialBuild 
         | _ -> IncrementalBuild.IsReady cache (Target(tcStatesNode, Some (slotOfFile-1))) partialBuild  
         
     member __.GetCheckResultsBeforeSlotInProject (ctok: CompilationThreadToken, slotOfFile) = 
       cancellable {
-        let cache = TimeStampCache defaultTimeStamp
+        let cache = TimeStampCache (defaultTimeStamp, tcConfig.isInteractive)
         let! result = 
           cancellable {
             match slotOfFile with
@@ -1685,7 +1685,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
 
     member __.GetCheckResultsAndImplementationsForProject(ctok: CompilationThreadToken) = 
       cancellable {
-        let cache = TimeStampCache defaultTimeStamp
+        let cache = TimeStampCache (defaultTimeStamp, tcConfig.isInteractive)
         let! build = IncrementalBuild.Eval cache ctok SavePartialBuild finalizedTypeCheckNode partialBuild
         match GetScalarResult(finalizedTypeCheckNode, build) with
         | Some ((ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt, tcAcc), timestamp) -> 
@@ -1732,7 +1732,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
             match GetVectorResultBySlot(stampedFileNamesNode, slotOfFile, partialBuild) with
             | Some (results, _) ->  return results
             | None -> 
-                let cache = TimeStampCache defaultTimeStamp
+                let cache = TimeStampCache (defaultTimeStamp, tcConfig.isInteractive)
                 let! build = IncrementalBuild.EvalUpTo cache ctok SavePartialBuild (stampedFileNamesNode, slotOfFile) partialBuild  
                 match GetVectorResultBySlot(stampedFileNamesNode, slotOfFile, build) with
                 | Some (results, _) -> return results

--- a/tests/service/AssemblyReaderShim.fs
+++ b/tests/service/AssemblyReaderShim.fs
@@ -7,22 +7,28 @@
 module FSharp.Compiler.Service.Tests.AssemblyReaderShim
 #endif
 
-open FSharp.Compiler.Service.Tests.Common
-open FsUnit
 open FSharp.Compiler.AbstractIL.ILBinaryReader
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FsUnit
 open NUnit.Framework
 
 [<Test>]
 let ``Assembly reader shim gets requests`` () =
-    let defaultReader = Shim.AssemblyReader
+    let defaultReader = AssemblyReader
     let mutable gotRequest = false
     let reader =
         { new IAssemblyReader with
             member x.GetILModuleReader(path, opts) =
                 gotRequest <- true
                 defaultReader.GetILModuleReader(path, opts)
-        }
-    Shim.AssemblyReader <- reader
+
+            member x.GetLastWriteTime(path, bypassFileSystemShim) =
+                FileSystem.GetLastWriteTime(path, bypassFileSystemShim)
+
+            member x.Exists(path, bypassFileSystemShim) =
+                FileSystem.Exists(path, bypassFileSystemShim) }
+
+    AssemblyReader <- reader
     let source = """
 module M
 let x = 123

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -55,13 +55,13 @@ let B = File1.A + File1.A"""
 
         // Implement the service related to temporary paths and file time stamps
         member __.GetTempPathShim() = defaultFileSystem.GetTempPathShim()
-        member __.GetLastWriteTimeShim(fileName) = defaultFileSystem.GetLastWriteTimeShim(fileName)
+        member __.GetLastWriteTime(fileName, bypassFileSystemShim) = defaultFileSystem.GetLastWriteTime(fileName, bypassFileSystemShim)
         member __.GetFullPathShim(fileName) = defaultFileSystem.GetFullPathShim(fileName)
         member __.IsInvalidPathShim(fileName) = defaultFileSystem.IsInvalidPathShim(fileName)
         member __.IsPathRootedShim(fileName) = defaultFileSystem.IsPathRootedShim(fileName)
 
         // Implement the service related to file existence and deletion
-        member __.SafeExists(fileName) = files.ContainsKey(fileName) || defaultFileSystem.SafeExists(fileName)
+        member __.Exists(fileName, bypassFileSystemShim) = files.ContainsKey(fileName) || defaultFileSystem.Exists(fileName, bypassFileSystemShim)
         member __.FileDelete(fileName) = defaultFileSystem.FileDelete(fileName)
 
         // Implement the service related to assembly loading, used to load type providers


### PR DESCRIPTION
When reading assemblies via AssemblyReaderShim there's currently no way to distinguish between using these assemblies from F# projects and from scripting/interactive environment. This knowledge could be used in scripts type checking to allow fallback to reading real assemblies on disk like it's done for output assemblies for F# projects currently.