### PR TITLE
Added support for #warnon pragma

### DIFF
--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -1509,6 +1509,7 @@ let rangeOfLid (lid: Ident list) =
 [<RequireQualifiedAccess>]
 type ScopedPragma =
    | WarningOff of range:range * int
+   | WarningOn  of range:range * int
    // Note: this type may be extended in the future with optimization on/off switches etc.
 
 // These are the results of parsing + folding in the implicit file name

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1963,6 +1963,10 @@ type internal FsiInteractionProcessor
                 List.iter (fun (d:string) -> tcConfigB.TurnWarningOff(m,d)) numbers
                 istate,Completed None
 
+            | IHash (ParsedHashDirective("warnon",numbers,m),_) ->
+                List.iter (fun (d:string) -> tcConfigB.TurnWarningOn(m,d)) numbers
+                istate,Completed None
+
             | IHash (ParsedHashDirective("terms",[],_),_) -> 
                 tcConfigB.showTerms <- not tcConfig.showTerms
                 istate,Completed None

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -732,7 +732,8 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf,
                     | true,"quit" 
                     | true,"help" 
                     // These are for script and non-script
-                    | _,"nowarn" -> 
+                    | _,"nowarn"
+                    | _,"warnon" -> 
                         // Merge both tokens into one.
                         let lexcontFinal = if (isCached) then lexcontInitial else LexerStateEncoding.computeNextLexState token lexcontInitial 
                         let tokenData = {tokenData with RightColumn=rightc;ColorClass=FSharpTokenColorKind.PreprocessorKeyword;CharClass=FSharpTokenCharKind.Keyword;FSharpTokenTriggerClass=FSharpTokenTriggerClass.None} 

--- a/tests/fsharpqa/Source/Warnings/WarnAfterWarnonPragma.fs
+++ b/tests/fsharpqa/Source/Warnings/WarnAfterWarnonPragma.fs
@@ -1,0 +1,10 @@
+﻿// #Warnings
+//<Expects status="Warning" span="(8,11)" id="FS0025">The result of this equality expression has type 'bool' and is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'.</Expects>
+
+#nowarn "25"
+let foo = function [] -> true
+#warnon "25"
+
+let bar = function [] -> true
+
+exit 0

--- a/tests/fsharpqa/Source/Warnings/WarnAfterWarnonPragma.fs
+++ b/tests/fsharpqa/Source/Warnings/WarnAfterWarnonPragma.fs
@@ -1,5 +1,5 @@
 ﻿// #Warnings
-//<Expects status="Warning" span="(8,11)" id="FS0025">The result of this equality expression has type 'bool' and is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'.</Expects>
+//<Expects status="Warning" span="(8,11)" id="FS0025">Incomplete pattern matches on this expression.</Expects>
 
 #nowarn "25"
 let foo = function [] -> true


### PR DESCRIPTION
This PR adds support for the `#warnon` pragma.

It has the exact same syntax as the `#nowarn` pragma, and simply re-enables the previously disabled warnings.

For instance, the following file...

```fsharp
#nowarn "25"
let f a = match a with [] -> 0
#warnon "25"

let g a = match a with [] -> 1

printfn "foo: %d" (f [])
```

... reports **nothing** when compiled without the patch, and the following warning with the patch.

```
foo.fs(8,17): warning FS0025: Incomplete pattern matches on this expression. For example, the value '[_]' may indicate a case not covered by the pattern(s).
```

This is more of a "conversation-starting" PR. I understand that documentation and tests will probably need to be added, but I'd like to get this work out there.