### PR TITLE
[WIP] Handle ObsoleteAttribute correctly with IsByRefLike Struct types

### DIFF
--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1258,6 +1258,8 @@ and [<NoComparison; NoEquality>]
           extends: ILType option * methods: ILMethodDefs * nestedTypes: ILTypeDefs * fields: ILFieldDefs * methodImpls: ILMethodImplDefs * 
           events: ILEventDefs * properties: ILPropertyDefs * securityDecls: ILSecurityDecls * customAttrs: ILAttributes -> ILTypeDef
 
+    member CustomAttributes : ILAttributes
+
     member Name: string  
     member Attributes: TypeAttributes
     member GenericParams: ILGenericParameterDefs
@@ -1605,7 +1607,11 @@ val decodeILAttribData:
 
 type ILTypeDef with
     
-    member GetCustomAttributes : ILGlobals -> ILAttributes
+    /// Gets a collection of custom attributes,
+    ///     then filters out particular attributes that we do not want to include in the list.
+    /// For example, ObsoleteAttribute with a ByRefLikeMarker string should not be included if we also have a IsByRefLikeAttribute on a struct.
+    /// The results will be cached.
+    member GetFilteredCustomAttributes : ILGlobals -> ILAttributes
 
 /// Generate simple references to assemblies and modules.
 val mkSimpleAssRef: string -> ILAssemblyRef

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1271,7 +1271,6 @@ and [<NoComparison; NoEquality>]
     member MethodImpls: ILMethodImplDefs
     member Events: ILEventDefs
     member Properties: ILPropertyDefs
-    member CustomAttrs: ILAttributes
     member IsClass: bool
     member IsStruct: bool
     member IsInterface: bool
@@ -1603,6 +1602,10 @@ val decodeILAttribData:
     ILAttribute -> 
       ILAttribElem list *  (* fixed args *)
       ILAttributeNamedArg list (* named args: values and flags indicating if they are fields or properties *) 
+
+type ILTypeDef with
+    
+    member GetCustomAttributes : ILGlobals -> ILAttributes
 
 /// Generate simple references to assemblies and modules.
 val mkSimpleAssRef: string -> ILAssemblyRef
@@ -1998,3 +2001,5 @@ type ILReferences =
 val computeILRefs: ILModuleDef -> ILReferences
 val emptyILRefs: ILReferences
 
+[<Literal>]
+val ByRefLikeMarker : string = "Types with embedded references are not supported in this version of your compiler."

--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -277,7 +277,7 @@ let rec tdef_ty2ty_ilmbody2ilmbody_mdefs2mdefs ilg enc fs (td: ILTypeDef) =
            methodImpls = mimpls_ty2ty ftye' td.MethodImpls,
            events = edefs_ty2ty ilg ftye' td.Events,
            properties = pdefs_ty2ty ilg ftye' td.Properties,
-           customAttrs = cattrs_ty2ty ilg ftye' td.CustomAttrs)
+           customAttrs = cattrs_ty2ty ilg ftye' (td.GetCustomAttributes(ilg)))
 
 and tdefs_ty2ty_ilmbody2ilmbody_mdefs2mdefs ilg enc fs tdefs = 
   morphILTypeDefs (tdef_ty2ty_ilmbody2ilmbody_mdefs2mdefs ilg enc fs) tdefs

--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -277,7 +277,7 @@ let rec tdef_ty2ty_ilmbody2ilmbody_mdefs2mdefs ilg enc fs (td: ILTypeDef) =
            methodImpls = mimpls_ty2ty ftye' td.MethodImpls,
            events = edefs_ty2ty ilg ftye' td.Events,
            properties = pdefs_ty2ty ilg ftye' td.Properties,
-           customAttrs = cattrs_ty2ty ilg ftye' (td.GetCustomAttributes(ilg)))
+           customAttrs = cattrs_ty2ty ilg ftye' td.CustomAttributes)
 
 and tdefs_ty2ty_ilmbody2ilmbody_mdefs2mdefs ilg enc fs tdefs = 
   morphILTypeDefs (tdef_ty2ty_ilmbody2ilmbody_mdefs2mdefs ilg enc fs) tdefs

--- a/src/absil/ilprint.fs
+++ b/src/absil/ilprint.fs
@@ -928,7 +928,7 @@ let rec goutput_tdef enc env contents os (cd: ILTypeDef) =
       output_string os "\n{\n ";
       if contents then 
         let tref = (mkILNestedTyRef (ILScopeRef.Local,enc,cd.Name)) 
-        goutput_custom_attrs env os cd.CustomAttrs;
+        goutput_custom_attrs env os (cd.GetCustomAttributes(env.ilGlobals));
         goutput_security_decls env os cd.SecurityDecls;
         pp_layout_decls os ();
         goutput_fdefs tref env os cd.Fields;

--- a/src/absil/ilprint.fs
+++ b/src/absil/ilprint.fs
@@ -928,7 +928,7 @@ let rec goutput_tdef enc env contents os (cd: ILTypeDef) =
       output_string os "\n{\n ";
       if contents then 
         let tref = (mkILNestedTyRef (ILScopeRef.Local,enc,cd.Name)) 
-        goutput_custom_attrs env os (cd.GetCustomAttributes(env.ilGlobals));
+        goutput_custom_attrs env os cd.CustomAttributes;
         goutput_security_decls env os cd.SecurityDecls;
         pp_layout_decls os ();
         goutput_fdefs tref env os cd.Fields;

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1848,7 +1848,7 @@ let rec buildTypeDefPass3 cenv nesting modB emEnv (tdef : ILTypeDef) =
     tdef.Events.AsList |> List.iter (buildEventPass3 cenv typB emEnv);
     tdef.Fields.AsList |> List.iter (buildFieldPass3 cenv tref typB emEnv);
     let emEnv = List.fold (buildMethodImplsPass3 cenv tref typB) emEnv tdef.MethodImpls.AsList
-    tdef.GetCustomAttributes(cenv.ilg) |> emitCustomAttrs cenv emEnv typB.SetCustomAttributeAndLog ;
+    tdef.CustomAttributes |> emitCustomAttrs cenv emEnv typB.SetCustomAttributeAndLog ;
     // custom attributes
     let emEnv = envPopTyvars emEnv
     // nested types

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1848,7 +1848,7 @@ let rec buildTypeDefPass3 cenv nesting modB emEnv (tdef : ILTypeDef) =
     tdef.Events.AsList |> List.iter (buildEventPass3 cenv typB emEnv);
     tdef.Fields.AsList |> List.iter (buildFieldPass3 cenv tref typB emEnv);
     let emEnv = List.fold (buildMethodImplsPass3 cenv tref typB) emEnv tdef.MethodImpls.AsList
-    tdef.CustomAttrs |> emitCustomAttrs cenv emEnv typB.SetCustomAttributeAndLog ;
+    tdef.GetCustomAttributes(cenv.ilg) |> emitCustomAttrs cenv emEnv typB.SetCustomAttributeAndLog ;
     // custom attributes
     let emEnv = envPopTyvars emEnv
     // nested types

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2739,7 +2739,7 @@ let rec GenTypeDefPass3 enc cenv (td:ILTypeDef) =
                        SimpleIndex (TableNames.TypeDef, tidx) |]) |> ignore
                        
       td.SecurityDecls.AsList |> GenSecurityDeclsPass3 cenv (hds_TypeDef, tidx)
-      td.CustomAttrs |> GenCustomAttrsPass3Or4 cenv (hca_TypeDef, tidx)
+      td.GetCustomAttributes(cenv.ilg) |> GenCustomAttrsPass3Or4 cenv (hca_TypeDef, tidx)
       td.GenericParams |> List.iteri (fun n gp -> GenGenericParamPass3 cenv env n (tomd_TypeDef, tidx) gp)  
       td.NestedTypes.AsList |> GenTypeDefsPass3 (enc@[td.Name]) cenv
    with e ->

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2739,7 +2739,7 @@ let rec GenTypeDefPass3 enc cenv (td:ILTypeDef) =
                        SimpleIndex (TableNames.TypeDef, tidx) |]) |> ignore
                        
       td.SecurityDecls.AsList |> GenSecurityDeclsPass3 cenv (hds_TypeDef, tidx)
-      td.GetCustomAttributes(cenv.ilg) |> GenCustomAttrsPass3Or4 cenv (hca_TypeDef, tidx)
+      td.CustomAttributes |> GenCustomAttrsPass3Or4 cenv (hca_TypeDef, tidx)
       td.GenericParams |> List.iteri (fun n gp -> GenGenericParamPass3 cenv env n (tomd_TypeDef, tidx) gp)  
       td.NestedTypes.AsList |> GenTypeDefsPass3 (enc@[td.Name]) cenv
    with e ->

--- a/src/fsharp/AttributeChecking.fs
+++ b/src/fsharp/AttributeChecking.fs
@@ -136,7 +136,7 @@ let GetAttribInfosOfEntity (g: TcGlobals) amap m (tcref:TyconRef) =
         //| None -> None
 #endif
     | ILTypeMetadata (TILObjectReprData(scoref, _, tdef)) -> 
-        tdef.GetCustomAttributes(g.ilg) |> AttribInfosOfIL g amap scoref m
+        tdef.GetFilteredCustomAttributes(g.ilg) |> AttribInfosOfIL g amap scoref m
     | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> 
         tcref.Attribs |> List.map (fun a -> FSAttribInfo (g, a))
 
@@ -188,7 +188,7 @@ let TryBindTyconRefAttribute g m (AttribInfo (atref, _) as args) (tcref:TyconRef
         | None -> None
 #endif
     | ILTypeMetadata (TILObjectReprData(_, _, tdef)) -> 
-        match TryDecodeILAttribute g atref (tdef.GetCustomAttributes(g.ilg)) with 
+        match TryDecodeILAttribute g atref (tdef.GetFilteredCustomAttributes(g.ilg)) with 
         | Some attr -> f1 attr
         | _ -> None
     | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> 
@@ -449,7 +449,7 @@ let MethInfoIsUnseen g m ty minfo =
         // We are only interested in filtering out the method on System.Object, so it is sufficient
         // just to look at the attributes on IL methods.
         if tcref.IsILTycon then 
-                tcref.ILTyconRawMetadata.GetCustomAttributes(g.ilg).AsArray 
+                tcref.ILTyconRawMetadata.GetFilteredCustomAttributes(g.ilg).AsArray 
                 |> Array.exists (fun attr -> attr.Method.DeclaringType.TypeSpec.Name = typeof<TypeProviderEditorHideMethodsAttribute>.FullName)
         else 
             false
@@ -481,7 +481,7 @@ let PropInfoIsUnseen m pinfo =
 /// Check the attributes on an entity, returning errors and warnings as data.
 let CheckEntityAttributes g (x:TyconRef) m = 
     if x.IsILTycon then 
-        CheckILAttributes g (x.ILTyconRawMetadata.GetCustomAttributes(g.ilg)) m
+        CheckILAttributes g (x.ILTyconRawMetadata.GetFilteredCustomAttributes(g.ilg)) m
     else 
         CheckFSharpAttributes g x.Attribs m
 

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -388,7 +388,9 @@ let GenReadOnlyModReqIfNecessary (g: TcGlobals) ty ilTy =
         ilTy
 
 let GenObsoleteAttributeByRefLikeMarkerIfNecessary (g: TcGlobals) (tycon: Tycon) (ilCustomAttrs: ILAttribute list) =
-    if tycon.IsFSharpStructOrEnumTycon && ilCustomAttrs |> List.exists (fun x -> x.Method.DeclaringType.TypeSpec.FullName = "System.Runtime.CompilerServices.IsByRefLikeAttribute") then
+    if tycon.IsFSharpStructOrEnumTycon && 
+       not (tycon.IsEnumTycon) && 
+       ilCustomAttrs |> List.exists (fun x -> x.Method.DeclaringType.TypeSpec.FullName = "System.Runtime.CompilerServices.IsByRefLikeAttribute") then
         let attr = 
             mkILCustomAttribute g.ilg 
                 (

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -390,7 +390,8 @@ let GenReadOnlyModReqIfNecessary (g: TcGlobals) ty ilTy =
 let GenObsoleteAttributeByRefLikeMarkerIfNecessary (g: TcGlobals) (tycon: Tycon) (ilCustomAttrs: ILAttribute list) =
     if tycon.IsFSharpStructOrEnumTycon && 
        not (tycon.IsEnumTycon) && 
-       ilCustomAttrs |> List.exists (fun x -> x.Method.DeclaringType.TypeSpec.FullName = "System.Runtime.CompilerServices.IsByRefLikeAttribute") then
+       ilCustomAttrs |> List.exists (fun x -> x.Method.DeclaringType.TypeSpec.FullName = "System.Runtime.CompilerServices.IsByRefLikeAttribute") &&
+       not (ilCustomAttrs |> List.exists (fun x -> x.Method.DeclaringType.TypeSpec.FullName = "System.ObsoleteAttribute")) then
         let attr = 
             mkILCustomAttribute g.ilg 
                 (

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3399,7 +3399,7 @@ let IsTyconUnseenObsoleteSpec ad g amap m (x:TyconRef) allowObsolete =
     not (IsEntityAccessible amap m ad x) ||
     ((not allowObsolete) &&
       (if x.IsILTycon then 
-          CheckILAttributesForUnseen g x.ILTyconRawMetadata.CustomAttrs m
+          CheckILAttributesForUnseen g (x.ILTyconRawMetadata.GetCustomAttributes(g.ilg)) m
        else 
           CheckFSharpAttributesForUnseen g x.Attribs m))
 

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3399,7 +3399,7 @@ let IsTyconUnseenObsoleteSpec ad g amap m (x:TyconRef) allowObsolete =
     not (IsEntityAccessible amap m ad x) ||
     ((not allowObsolete) &&
       (if x.IsILTycon then 
-          CheckILAttributesForUnseen g (x.ILTyconRawMetadata.GetCustomAttributes(g.ilg)) m
+          CheckILAttributesForUnseen g (x.ILTyconRawMetadata.GetFilteredCustomAttributes(g.ilg)) m
        else 
           CheckFSharpAttributesForUnseen g x.Attribs m))
 

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -2927,7 +2927,7 @@ let TryBindTyconRefAttribute g (m:range) (AttribInfo (atref, _) as args) (tcref:
         | None -> None
 #endif
     | ILTypeMetadata (TILObjectReprData(_, _, tdef)) -> 
-        match TryDecodeILAttribute g atref (tdef.GetCustomAttributes(g.ilg)) with 
+        match TryDecodeILAttribute g atref (tdef.GetFilteredCustomAttributes(g.ilg)) with 
         | Some attr -> f1 attr
         | _ -> None
     | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> 

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -2927,7 +2927,7 @@ let TryBindTyconRefAttribute g (m:range) (AttribInfo (atref, _) as args) (tcref:
         | None -> None
 #endif
     | ILTypeMetadata (TILObjectReprData(_, _, tdef)) -> 
-        match TryDecodeILAttribute g atref tdef.CustomAttrs with 
+        match TryDecodeILAttribute g atref (tdef.GetCustomAttributes(g.ilg)) with 
         | Some attr -> f1 attr
         | _ -> None
     | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -10841,7 +10841,7 @@ and TcAttribute canFail cenv (env: TcEnv) attrTgt (synAttr: SynAttribute)  =
                 let tdef = tcref.ILTyconRawMetadata
                 let tref = cenv.g.attrib_AttributeUsageAttribute.TypeRef
                 
-                match TryDecodeILAttribute cenv.g tref (tdef.GetCustomAttributes(cenv.g.ilg)) with 
+                match TryDecodeILAttribute cenv.g tref (tdef.GetFilteredCustomAttributes(cenv.g.ilg)) with 
                 | Some ([ILAttribElem.Int32 validOn ], named) -> 
                     let inherited = 
                         match List.tryPick (function ("Inherited", _, _, ILAttribElem.Bool res) -> Some res | _ -> None) named with 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -10841,7 +10841,7 @@ and TcAttribute canFail cenv (env: TcEnv) attrTgt (synAttr: SynAttribute)  =
                 let tdef = tcref.ILTyconRawMetadata
                 let tref = cenv.g.attrib_AttributeUsageAttribute.TypeRef
                 
-                match TryDecodeILAttribute cenv.g tref tdef.CustomAttrs with 
+                match TryDecodeILAttribute cenv.g tref (tdef.GetCustomAttributes(cenv.g.ilg)) with 
                 | Some ([ILAttribElem.Int32 validOn ], named) -> 
                     let inherited = 
                         match List.tryPick (function ("Inherited", _, _, ILAttribElem.Bool res) -> Some res | _ -> None) named with 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1193,7 +1193,7 @@ module StaticLinker =
                              let meths = td.Methods.AsList
                                             |> List.map (fun md ->
                                                 md.With(customAttrs = 
-                                                              mkILCustomAttrs (td.CustomAttrs.AsList |> List.filter (fun ilattr ->
+                                                              mkILCustomAttrs (td.GetCustomAttributes(ilGlobals).AsList |> List.filter (fun ilattr ->
                                                                 ilattr.Method.DeclaringType.TypeRef.FullName <> "System.Runtime.TargetedPatchingOptOutAttribute")))) 
                                             |> mkILMethods
                              let td = td.With(methods=meths)

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1193,7 +1193,7 @@ module StaticLinker =
                              let meths = td.Methods.AsList
                                             |> List.map (fun md ->
                                                 md.With(customAttrs = 
-                                                              mkILCustomAttrs (td.GetCustomAttributes(ilGlobals).AsList |> List.filter (fun ilattr ->
+                                                              mkILCustomAttrs (td.CustomAttributes.AsList |> List.filter (fun ilattr ->
                                                                 ilattr.Method.DeclaringType.TypeRef.FullName <> "System.Runtime.TargetedPatchingOptOutAttribute")))) 
                                             |> mkILMethods
                              let td = td.With(methods=meths)


### PR DESCRIPTION
Resolves this issue, https://github.com/Microsoft/visualfsharp/issues/5858.

This PR changes how we handle ObsoleteAttributes for IsByRefLike Struct types, or 'ref structs' in C#. 

Before, we only cared about having any ObsoleteAttribute on a IsByRefLike Struct. But, the correct rule for this is checking for this specific text inside of the ObsoleteAttribute: 
**"Types with embedded references are not supported in this version of your compiler."** 
We call this text, the **ByRefLikeMarker.** This PR now follows this rule.

The PR also emits an ObsoleteAttribute with the **ByRefLikeMarker** above when we create a IsByRefLike Struct; we didn't before and that violates the rule.

All as specified here: https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.2/span-safety.md#metadata-representation-or-ref-like-structs
> Obsolete attribute with a **known string** will be added to all ref-like structs. Compilers that know how to use ref-like types will ignore this particular form of Obsolete.

The PR is almost complete, these tasks are needed.

- [x] Don't emit ObsoleteAttribute with **ByRefLikeMarker** if the user decides to place an ObsoleteAttribute on the type themselves.
    > In particular, if user wants to actually put an Obsolete or Deprecated attribute on a ref-like type, we will have no choice other than not emitting the predefined one since Obsolete attribute cannot be applied more than once..
- [ ] Tests

// cc @agocke