### PR TITLE
[WIP] Unmanaged constructed types

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -1826,8 +1826,8 @@ let rec isUnmanagedTy g ty =
                                     typar.Constraints |> List.exists (function | TyparConstraint.IsUnmanaged _ -> true | _ -> false)
                                 | _ -> isUnmanagedTy g ty
                             | _ -> false
-                        | TType_app(fieldTcref, fieldTinst) ->
-                            // This will also handle nested generic structs
+                        | TType_app(fieldTcref, fieldTinst) when fieldTinst.Length > 0 ->
+                            // This will handle nested generic structs
                             let fieldTinst = 
                                 fieldTinst 
                                 |> List.map (fun ty -> 

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -1810,8 +1810,6 @@ let rec isUnmanagedTy g ty =
                     // Handle generic structs
                     // REVIEW: This may not be the most optimal, but it's probably better than
                     //     having to iterate over all type arguments for every field that is a 'TType_var'.
-                    //     A possible more optimal solution would be to have a flag (hopefully without having to pickle it) on a Typar that indicates it's used as a backing field. (see 'TyparFlags' type)
-                    //     That way we can ignore fields that are a 'TType_var' and just check the type arguments from 'TType_app' that have the flag.
                     //     However, what we have currently is probably just fine as unmanaged constraints are used infrequently; even more so when combined with generic struct construction.
                     let lookup = Dictionary(typars.Length)
                     (typars, tinst)
@@ -1819,8 +1817,9 @@ let rec isUnmanagedTy g ty =
 
                     tycon.AllInstanceFieldsAsList 
                     |> List.forall (fun r -> 
-                        match tryDestTyparTy g r.rfield_type with
-                        | ValueSome(fieldTypar) ->
+                        let fieldTy = stripTyEqnsAndMeasureEqns g r.rfield_type
+                        match fieldTy with
+                        | TType_var fieldTypar ->
                             match lookup.TryGetValue(fieldTypar.Stamp) with
                             | true, ty -> 
                                 match tryDestTyparTy g ty with
@@ -1829,8 +1828,20 @@ let rec isUnmanagedTy g ty =
                                 | _ ->
                                     isUnmanagedTy g ty
                             | _ -> false
-                        | _ ->
-                            isUnmanagedTy g r.rfield_type
+                        | TType_app(fieldTcref, fieldTinst) ->
+                            // This will also handle nested generic structs
+                            let fieldTinst = 
+                                fieldTinst 
+                                |> List.map (fun ty -> 
+                                    match tryDestTyparTy g ty with
+                                    | ValueSome(typar) -> 
+                                        match lookup.TryGetValue(typar.Stamp) with
+                                        | true, ty -> ty
+                                        | _ -> ty
+                                    | _ -> ty
+                                )
+                            isUnmanagedTy g (mkAppTy fieldTcref fieldTinst)
+                        | _ -> isUnmanagedTy g fieldTy
                     )
             else false
     // Handle struct tuples

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -1808,8 +1808,7 @@ let rec isUnmanagedTy g ty =
                 | [] -> tycon.AllInstanceFieldsAsList |> List.forall (fun r -> isUnmanagedTy g r.rfield_type)
                 | typars ->
                     // Handle generic structs
-                    // REVIEW: This may not be the most optimal, but it's probably better than
-                    //     having to iterate over all type arguments for every field that is a 'TType_var'.
+                    // REVIEW: This may not be the most optimal, but it's probably better than having to iterate over all type arguments for every field.
                     //     However, what we have currently is probably just fine as unmanaged constraints are used infrequently; even more so when combined with generic struct construction.
                     let lookup = Dictionary(typars.Length)
                     (typars, tinst)
@@ -1825,8 +1824,7 @@ let rec isUnmanagedTy g ty =
                                 match tryDestTyparTy g ty with
                                 | ValueSome typar ->
                                     typar.Constraints |> List.exists (function | TyparConstraint.IsUnmanaged _ -> true | _ -> false)
-                                | _ ->
-                                    isUnmanagedTy g ty
+                                | _ -> isUnmanagedTy g ty
                             | _ -> false
                         | TType_app(fieldTcref, fieldTinst) ->
                             // This will also handle nested generic structs


### PR DESCRIPTION
Matching C#'s feature: https://github.com/dotnet/csharplang/issues/1937

Allows generic structs to be 'unmanaged' at construction if it can determine to be so.

A few examples:
```fsharp
[<Struct>]
type S<'T, 'U> =

    [<DefaultValue(false)>] val X : 'T

let test (x: 'T when 'T : unmanaged) = ()

let passing () =
    test (S<float, int>())

let passing2 () =
    test (S<float, obj>()) // passes as the 'obj' type arg is not used as part of the backing field of a struct

let passing3<'T when 'T : unmanaged> () =
    test (S<'T, obj>())

let not_passing () =
    test (S<obj, int>())

let not_passing2<'T> () =
    test (S<'T, obj>())
```
Another example:
```fsharp
[<Struct>]
type S<'T> =

    val X : 'T

    new (x) = { X = x }

let test (x: 'T when 'T : unmanaged) = ()

let passing () =
    test (S(1))

let not_passing () =
    test (S(obj()))
```
Example on nested generic structs:
```fsharp
[<Struct>]
type W<'T> = { x: 'T }

[<Struct>]
type S<'T> = { x: W<'T> }

let test (x: 'T when 'T : unmanaged) = ()

let passing () =
    test Unchecked.defaultof<S<int>>

let not_passing () =
    test Unchecked.defaultof<S<obj>>
```

Remaining work:
- [ ] Tests
- [ ] Emit `IsUnmanagedAttribute` on type arguments with the 'unmanaged' constraint for interop.
- [ ] Consume type arguments from .NET assemblies that have the `IsUnmanagedAttribute` to mean they have the `unmanaged` constraint. This is also for interop.
- [ ] Support anonymous struct records
- [ ] Support struct unions
- [ ] Fix struct tuples

Regarding the struct tuples, this works:
```fsharp
let passing () = 
    let x = struct(1, 2)
    test x
```
But this doesn't:
```fsharp
let not_passing () = 
    test (struct(1, 2))
```
After some debugging, it looks like at the point where `isUnmanagedTy` gets called, the type arguments for the tuple haven't been solved yet which seems weird to me; this is a separate bug in the type system.