### PR TITLE
[WIP] allow dependencies to be updated by tooling

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -498,7 +498,6 @@ echo BUILD_FROMSOURCE=%BUILD_FROMSOURCE%
 echo BUILD_FSHARP_PROJ=%BUILD_FSHARP_PROJ%
 echo.
 echo PB_SKIPTESTS=%PB_SKIPTESTS%
-echo PB_RESTORESOURCE=%PB_RESTORESOURCE%
 echo.
 echo SIGN_TYPE=%SIGN_TYPE%
 echo.
@@ -617,18 +616,6 @@ echo ---------------- Done with prepare, starting package restore --------------
 call "%~dp0init-tools.cmd"
 set _dotnetexe=%~dp0artifacts\toolset\dotnet\dotnet.exe
 set path=%~dp0artifacts\toolset\dotnet;%path%
-
-if not "%PB_PackageVersionPropsUrl%" == "" (
-    echo ----------- do dependency uptake check -----------
-
-    set dependencyUptakeDir=%~dp0artifacts\dependencyUptake
-    if not exist "!dependencyUptakeDir!" mkdir "!dependencyUptakeDir!"
-
-    :: download package version overrides
-    echo powershell -noprofile -executionPolicy RemoteSigned -command "Invoke-WebRequest -Uri '%PB_PackageVersionPropsUrl%' -OutFile '!dependencyUptakeDir!\PackageVersions.props'"
-         powershell -noprofile -executionPolicy RemoteSigned -command "Invoke-WebRequest -Uri '%PB_PackageVersionPropsUrl%' -OutFile '!dependencyUptakeDir!\PackageVersions.props'"
-    if ERRORLEVEL 1 echo Error downloading package version properties && goto :failure
-)
 
 if "%RestorePackages%" == "true" (
     if "%BUILD_FCS%" == "1" (

--- a/build/targets/PackageVersions.props
+++ b/build/targets/PackageVersions.props
@@ -15,10 +15,6 @@
       https://dotnet.myget.org/F/symreader-converter/api/v3/index.json;
     </RestoreSources>
 
-    <!-- synchronized build package sources -->
-    <RestoreSources Condition="'$(PB_RestoreSource)' != ''">$(PB_RestoreSource);$(RestoreSources)</RestoreSources>
-    <DotNetPackageVersionPropsPath>$(MSBuildThisFileDirectory)..\..\artifacts\dependencyUptake\PackageVersions.props</DotNetPackageVersionPropsPath>
-
     <!-- version numbers from files -->
     <RoslynPackageVersion>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\..\RoslynPackageVersion.txt').Trim())</RoslynPackageVersion>
 
@@ -137,8 +133,5 @@
     <XliffTasksPackageVersion>0.2.0-beta-000081</XliffTasksPackageVersion>
 
   </PropertyGroup>
-
-  <!-- dependency uptake version overrides -->
-  <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != '' AND Exists('$(DotNetPackageVersionPropsPath)')" />
 
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Dependencies>
+  <ProductDependencies></ProductDependencies>
+  <ToolsetDependencies>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19069.2">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>07ce1f4430b689a7e3aae70a34822c01473cf258</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19069.2">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>07ce1f4430b689a7e3aae70a34822c01473cf258</Sha>
+    </Dependency>
+  </ToolsetDependencies>
+</Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\targets\AssemblyVersions.props" />
+
+  <!-- version number assignment -->
+  <PropertyGroup>
+    <VersionPrefix>$(FSCoreVersion)</VersionPrefix>
+    <VersionPrefix Condition="'$(UseFSharpProductVersion)' == 'true'">$(FSProductVersion)</VersionPrefix>
+    <VersionPrefix Condition="'$(UseVsMicroBuildAssemblyVersion)' == 'true'">$(VSAssemblyVersion)</VersionPrefix>
+
+    <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Adding @chcosta for review.

Note, I'll need to migrate some dependency versions from [`build/targets/PackageVersions.props`](https://github.com/Microsoft/visualfsharp/blob/99e307f3a3ef2109ba6542ffc58affe76fc0e2a0/build/targets/PackageVersions.props) to `eng/Versions.props`, but I'm still figuring out what the proper subset of that is.