### PR TITLE
WIP: Build for all TFMs in the makefile

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -47,6 +47,27 @@
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net47'">$(MonoLibFolder)/4.7-api</FrameworkPathOverride>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net471'">$(MonoLibFolder)/4.7.1-api</FrameworkPathOverride>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net472'">$(MonoLibFolder)/4.7.2-api</FrameworkPathOverride>
+    <!--
+      Need Facades search directory as well for some netframework TFMs. THIS IS BAD. 
+      We have to copy/paste in search directories straight out of MSBuild: https://github.com/Microsoft/msbuild/blob/master/src/Tasks/Microsoft.Common.CurrentVersion.targets#L560-L571.
+      This is because a simple override of `$(FrameworkPathOverride);$(FrameworkPathOverride)/Facades;$(AssemblySearchPaths)` resolves before MSBuild's own logic, 
+      and so this default set of paths is never added.  This is likely because of the layering order of Directory.Build.props
+     -->
+    <AssemblySearchPaths >
+      {CandidateAssemblyFiles};
+      $(ReferencePath);
+      {HintPathFromItem};
+      {TargetFrameworkDirectory};
+      $(FrameworkPathOverride);
+      $(FrameworkPathOverride)/Facades;
+      $(AssemblyFoldersConfigFileSearchPath)
+      {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
+      {AssemblyFolders};
+      {GAC};
+      {RawFileName};
+      $(OutDir);
+      </AssemblySearchPaths>
+    <!-- <AssemblySearchPaths>$(AssemblySearchPaths);</AssemblySearchPaths> -->
   </PropertyGroup>
 
   <!-- signing -->

--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -53,7 +53,7 @@
       This is because a simple override of `$(FrameworkPathOverride);$(FrameworkPathOverride)/Facades;$(AssemblySearchPaths)` resolves before MSBuild's own logic, 
       and so this default set of paths is never added.  This is likely because of the layering order of Directory.Build.props
      -->
-    <AssemblySearchPaths Condition="'$(MonoPackaging)' != 'true'">
+    <AssemblySearchPaths Condition="'$(MonoPackaging)' == 'true'">
       {CandidateAssemblyFiles};
       $(ReferencePath);
       {HintPathFromItem};

--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -53,7 +53,7 @@
       This is because a simple override of `$(FrameworkPathOverride);$(FrameworkPathOverride)/Facades;$(AssemblySearchPaths)` resolves before MSBuild's own logic, 
       and so this default set of paths is never added.  This is likely because of the layering order of Directory.Build.props
      -->
-    <AssemblySearchPaths >
+    <AssemblySearchPaths Condition="'$(MonoPackaging)' != 'true'">
       {CandidateAssemblyFiles};
       $(ReferencePath);
       {HintPathFromItem};

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build: proto restore
 	$(DotNetExe) build -c $(Configuration) src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
 	$(DotNetExe) build -c $(Configuration) src/fsharp/fsc/fsc.fsproj
 	$(DotNetExe) build -c $(Configuration) src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
-	$(DotNetExe) build -c $(Configuration) src/fsharp/fsi/fsi.fsproj
+	$(DotNetExe) build -c $(Configuration) -v detailed src/fsharp/fsi/fsi.fsproj
 	$(DotNetExe) build -c $(Configuration) tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
 	$(DotNetExe) build -c $(Configuration) tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ proto: tools
 	$(DotNetExe) restore src/fsharp/fsc/fsc.fsproj
 	$(DotNetExe) build src/buildtools/buildtools.proj -c Proto
 	$(DotNetExe) build src/fsharp/FSharp.Build/FSharp.Build.fsproj -c Proto
-	$(DotNetExe) build src/fsharp/fsc/fsc.fsproj -v detailed -c Proto
+	$(DotNetExe) build src/fsharp/fsc/fsc.fsproj -c Proto
 
 restore:
 	$(DotNetExe) restore src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -34,13 +34,13 @@ build: proto restore
 	$(DotNetExe) build -c $(Configuration) src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
 	$(DotNetExe) build -c $(Configuration) src/fsharp/fsc/fsc.fsproj
 	$(DotNetExe) build -c $(Configuration) src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
-	$(DotNetExe) build -c $(Configuration) -v detailed src/fsharp/fsi/fsi.fsproj
+	$(DotNetExe) build -c $(Configuration) src/fsharp/fsi/fsi.fsproj
 	$(DotNetExe) build -c $(Configuration) tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
 	$(DotNetExe) build -c $(Configuration) tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
 
 test: build
-	$(DotNetExe) test -c $(Configuration) -v detailed --no-restore --no-build tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Core.UnitTests.trx"
-	$(DotNetExe) test -c $(Configuration) -v detailed --no-restore --no-build tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Build.UnitTests.trx"
+	$(DotNetExe) test -c $(Configuration) --no-restore --no-build tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Core.UnitTests.trx"
+	$(DotNetExe) test -c $(Configuration) --no-restore --no-build tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Build.UnitTests.trx"
 
 clean:
 	rm -rf $(CURDIR)/artifacts

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ proto: tools
 	$(DotNetExe) restore src/fsharp/FSharp.Build/FSharp.Build.fsproj
 	$(DotNetExe) restore src/fsharp/fsc/fsc.fsproj
 	$(DotNetExe) build src/buildtools/buildtools.proj -c Proto
-	$(DotNetExe) build src/fsharp/FSharp.Build/FSharp.Build.fsproj -f netstandard2.0 -c Proto
-	$(DotNetExe) build src/fsharp/fsc/fsc.fsproj -f netcoreapp2.1 -c Proto
+	$(DotNetExe) build src/fsharp/FSharp.Build/FSharp.Build.fsproj -c Proto
+	$(DotNetExe) build src/fsharp/fsc/fsc.fsproj -c Proto
 
 restore:
 	$(DotNetExe) restore src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -29,18 +29,18 @@ restore:
 
 build: proto restore
 	$(DotNetExe) build-server shutdown
-	$(DotNetExe) build -c $(Configuration) -f netstandard1.6 src/fsharp/FSharp.Core/FSharp.Core.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Build/FSharp.Build.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.1 src/fsharp/fsc/fsc.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.1 src/fsharp/fsi/fsi.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.0 tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.0 tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
+	$(DotNetExe) build -c $(Configuration) src/fsharp/FSharp.Core/FSharp.Core.fsproj
+	$(DotNetExe) build -c $(Configuration) src/fsharp/FSharp.Build/FSharp.Build.fsproj
+	$(DotNetExe) build -c $(Configuration) src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+	$(DotNetExe) build -c $(Configuration) src/fsharp/fsc/fsc.fsproj
+	$(DotNetExe) build -c $(Configuration) src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
+	$(DotNetExe) build -c $(Configuration) src/fsharp/fsi/fsi.fsproj
+	$(DotNetExe) build -c $(Configuration) tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
+	$(DotNetExe) build -c $(Configuration) tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
 
 test: build
-	$(DotNetExe) test -f netcoreapp2.0 -c $(Configuration) --no-restore --no-build tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Core.UnitTests.coreclr.trx"
-	$(DotNetExe) test -f netcoreapp2.0 -c $(Configuration) --no-restore --no-build tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Build.UnitTests.coreclr.trx"
+	$(DotNetExe) test -c $(Configuration) -v detailed --no-restore --no-build tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Core.UnitTests.trx"
+	$(DotNetExe) test -c $(Configuration) -v detailed --no-restore --no-build tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Build.UnitTests.trx"
 
 clean:
 	rm -rf $(CURDIR)/artifacts

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ proto: tools
 	$(DotNetExe) restore src/fsharp/fsc/fsc.fsproj
 	$(DotNetExe) build src/buildtools/buildtools.proj -c Proto
 	$(DotNetExe) build src/fsharp/FSharp.Build/FSharp.Build.fsproj -c Proto
-	$(DotNetExe) build src/fsharp/fsc/fsc.fsproj -c Proto
+	$(DotNetExe) build src/fsharp/fsc/fsc.fsproj -v detailed -c Proto
 
 restore:
 	$(DotNetExe) restore src/fsharp/FSharp.Core/FSharp.Core.fsproj

--- a/src/buildtools/buildtools.targets
+++ b/src/buildtools/buildtools.targets
@@ -20,14 +20,14 @@
           BeforeTargets="CoreCompile">
 
     <PropertyGroup>
-        <FsLexPath Condition="'$(FsLexPath)' == ''">$(ArtifactsDir)\bin\fslex\Proto\netcoreapp2.0\fslex.dll</FsLexPath>
+        <FsLexPath Condition="'$(FsLexPath)' == ''">$(ArtifactsDir)\Bootstrap\fslex.dll</FsLexPath>
     </PropertyGroup>
 
     <!-- Create the output directory -->
     <MakeDir Directories="$(FsLexOutputFolder)"/>
 
     <!-- Run the tool -->
-    <Exec Command="$(DotNetTool) $(FsLexPath) -o $(FsLexOutputFolder)%(FsLex.Filename).fs %(FsLex.OtherFlags) %(FsLex.Identity)" />
+    <Exec Command="&quot;$(DotNetTool)&quot; &quot;$(FsLexPath)&quot; -o &quot;$(FsLexOutputFolder)%(FsLex.Filename).fs&quot; %(FsLex.OtherFlags) %(FsLex.Identity)" />
 
     <!-- Make sure it will get cleaned -->
     <CreateItem Include="$(FsLexOutputFolder)%(FsLex.Filename).fs">
@@ -43,14 +43,14 @@
           BeforeTargets="CoreCompile">
 
     <PropertyGroup>
-        <FsYaccPath Condition="'$(FsYaccPath)' == ''">$(ArtifactsDir)\bin\fsyacc\Proto\netcoreapp2.0\fsyacc.dll</FsYaccPath>
+        <FsYaccPath Condition="'$(FsYaccPath)' == ''">$(ArtifactsDir)\Bootstrap\fsyacc.dll</FsYaccPath>
     </PropertyGroup>
 
     <!-- Create the output directory -->
     <MakeDir Directories="$(FsYaccOutputFolder)" />
 
     <!-- Run the tool -->
-    <Exec Command="$(DotNetTool) $(FsYaccPath) -o $(FsYaccOutputFolder)%(FsYacc.Filename).fs %(FsYacc.OtherFlags) %(FsYacc.Identity)" />
+    <Exec Command="&quot;$(DotNetTool)&quot; &quot;$(FsYaccPath)&quot; -o &quot;$(FsYaccOutputFolder)%(FsYacc.Filename).fs&quot; %(FsYacc.OtherFlags) %(FsYacc.Identity)" />
 
     <!-- Make sure it will get cleaned -->
     <CreateItem Include="$(FsYaccOutputFolder)%(FsYacc.Filename).fs">

--- a/src/buildtools/buildtools.targets
+++ b/src/buildtools/buildtools.targets
@@ -20,14 +20,14 @@
           BeforeTargets="CoreCompile">
 
     <PropertyGroup>
-        <FsLexPath Condition="'$(FsLexPath)' == ''">$(ArtifactsDir)\Bootstrap\fslex.dll</FsLexPath>
+        <FsLexPath Condition="'$(FsLexPath)' == ''">$(ArtifactsDir)\bin\fslex\Proto\netcoreapp2.0\fslex.dll</FsLexPath>
     </PropertyGroup>
 
     <!-- Create the output directory -->
     <MakeDir Directories="$(FsLexOutputFolder)"/>
 
     <!-- Run the tool -->
-    <Exec Command="&quot;$(DotNetTool)&quot; &quot;$(FsLexPath)&quot; -o &quot;$(FsLexOutputFolder)%(FsLex.Filename).fs&quot; %(FsLex.OtherFlags) %(FsLex.Identity)" />
+    <Exec Command="$(DotNetTool) $(FsLexPath) -o $(FsLexOutputFolder)%(FsLex.Filename).fs %(FsLex.OtherFlags) %(FsLex.Identity)" />
 
     <!-- Make sure it will get cleaned -->
     <CreateItem Include="$(FsLexOutputFolder)%(FsLex.Filename).fs">
@@ -43,14 +43,14 @@
           BeforeTargets="CoreCompile">
 
     <PropertyGroup>
-        <FsYaccPath Condition="'$(FsYaccPath)' == ''">$(ArtifactsDir)\Bootstrap\fsyacc.dll</FsYaccPath>
+        <FsYaccPath Condition="'$(FsYaccPath)' == ''">$(ArtifactsDir)\bin\fsyacc\Proto\netcoreapp2.0\fsyacc.dll</FsYaccPath>
     </PropertyGroup>
 
     <!-- Create the output directory -->
     <MakeDir Directories="$(FsYaccOutputFolder)" />
 
     <!-- Run the tool -->
-    <Exec Command="&quot;$(DotNetTool)&quot; &quot;$(FsYaccPath)&quot; -o &quot;$(FsYaccOutputFolder)%(FsYacc.Filename).fs&quot; %(FsYacc.OtherFlags) %(FsYacc.Identity)" />
+    <Exec Command="$(DotNetTool) $(FsYaccPath) -o $(FsYaccOutputFolder)%(FsYacc.Filename).fs %(FsYacc.OtherFlags) %(FsYacc.Identity)" />
 
     <!-- Make sure it will get cleaned -->
     <CreateItem Include="$(FsYaccOutputFolder)%(FsYacc.Filename).fs">

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -675,8 +675,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <Reference Include="ISymWrapper, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <!-- ISymWrapper is only present on Windows, and is late-bound anyway in the compiler, so it doesn't need to be a reference on all platforms. -->
+    <Reference Include="ISymWrapper" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.IO" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -676,6 +676,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <Reference Include="ISymWrapper, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />


### PR DESCRIPTION
Building off of #6181 this MR continues the quest to get this repo building significant portions of the code for all supported TFMs via the Makefile.  With these changes I can run `make` and restore, build proto, build fsc/fsi, and build the tests on my OSX machine for all supported TFMs in those projects.

The only caveat to this is that the tests hang in the Async portion for me currently, not quite sure if that's mono/netcore or environmental.

There really wasn't a lot of work necessary after #6181, the main piece of work was adding in the missing Mono Facades directory to the search path in a way that meshed with the other properties.  I had to do a bit of hackiness (which I explained with a comment) to get the search path listings to evaluate at the correct point in time.

I'm sending this up now as a sanity-check and to see how your CI works with this, as well as to solicit opinions!