### PR TITLE
Add basic caching to topValType and stripTyEqnsA

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -711,29 +711,50 @@ let reduceTyconMeasureableOrProvided (g:TcGlobals) (tycon:Tycon) tyargs =
 let reduceTyconRefMeasureableOrProvided (g:TcGlobals) (tcref:TyconRef) tyargs = 
     reduceTyconMeasureableOrProvided g tcref.Deref tyargs
 
-let rec stripTyEqnsA g canShortcut ty = 
-    let ty = stripTyparEqnsAux canShortcut ty 
-    match ty with 
-    | TType_app (tcref, tinst) -> 
-        let tycon = tcref.Deref
-        match tycon.TypeAbbrev with 
-        | Some abbrevTy -> 
-            stripTyEqnsA g canShortcut (applyTyconAbbrev abbrevTy tycon tinst)
-        | None -> 
-            // This is the point where we get to add additional coditional normalizing equations 
-            // into the type system. Such power!
-            // 
-            // Add the equation byref<'T> = byref<'T, ByRefKinds.InOut> for when using sufficient FSharp.Core
-            // See RFC FS-1053.md
-            if tyconRefEq g tcref g.byref_tcr && g.byref2_tcr.CanDeref  && g.byrefkind_InOut_tcr.CanDeref then 
-                mkByref2Ty g tinst.[0]  (TType_app(g.byrefkind_InOut_tcr, []))
+// Many calls are made to stripTyEqnsA from repeated types so we cache striped results into a ConditionalWeakTable so they can still be GC'd
+let stripCache = System.Runtime.CompilerServices.ConditionalWeakTable<TType,TType>()
 
-            // Add the equation double<1> = double for units of measure.
-            elif tycon.IsMeasureableReprTycon && List.forall (isDimensionless g) tinst then
-                stripTyEqnsA g canShortcut (reduceTyconMeasureableOrProvided g tycon tinst)
-            else 
-                ty
-    | ty -> ty
+let rec stripTyEqnsA g canShortcut ty : TType =
+    let mutable result = Unchecked.defaultof<TType>
+    match stripCache.TryGetValue(ty,&result) with 
+    | true -> result
+    | false ->
+        let key = ty
+        let ty = stripTyparEqnsAux canShortcut ty 
+        match ty with 
+        | TType_app (tcref, tinst) -> 
+            let tycon = tcref.Deref
+            match tycon.TypeAbbrev with 
+            | Some abbrevTy -> 
+                stripTyEqnsA g canShortcut (applyTyconAbbrev abbrevTy tycon tinst)
+            | None -> 
+                // This is the point where we get to add additional coditional normalizing equations 
+                // into the type system. Such power!
+                // 
+                // Add the equation byref<'T> = byref<'T, ByRefKinds.InOut> for when using sufficient FSharp.Core
+                // See RFC FS-1053.md
+                if tyconRefEq g tcref g.byref_tcr && g.byref2_tcr.CanDeref  && g.byrefkind_InOut_tcr.CanDeref then 
+                    let result = mkByref2Ty g tinst.[0]  (TType_app(g.byrefkind_InOut_tcr, []))
+                    stripCache.Add(key,result)
+                    result
+
+                // Add the equation double<1> = double for units of measure.
+                elif tycon.IsMeasureableReprTycon && List.forall (isDimensionless g) tinst then
+                    stripTyEqnsA g canShortcut (reduceTyconMeasureableOrProvided g tycon tinst)
+                else
+                    stripCache.Add(key,ty)
+                    ty
+        //cannot be cached
+        | TType_fun _ 
+        | TType_var _ -> ty
+        //can be cached
+        | TType_anon _
+        | TType_ucase _
+        | TType_forall _
+        | TType_tuple _  
+        | TType_measure _ -> 
+            stripCache.Add(key,ty)
+            ty
 
 let stripTyEqns g ty = stripTyEqnsA g false ty
 
@@ -1563,10 +1584,17 @@ let destTopForallTy g (ValReprInfo (ntps, _, _)) ty =
     let tps = NormalizeDeclaredTyparsForEquiRecursiveInference g tps
     tps, tau
 
+let topValTypeCache = System.Runtime.CompilerServices.ConditionalWeakTable<TType,Typar list * ((TType * ArgReprInfo) list list) * TType * ArgReprInfo>()
+
 let GetTopValTypeInFSharpForm g (ValReprInfo(_, argInfos, retInfo) as topValInfo) ty m =
-    let tps, tau = destTopForallTy g topValInfo ty
-    let argtysl, rty = GetTopTauTypeInFSharpForm g argInfos tau m
-    tps, argtysl, rty, retInfo
+    let mutable result = Unchecked.defaultof<Typar list * ((TType * ArgReprInfo) list list) * TType * ArgReprInfo>
+    if topValTypeCache.TryGetValue(ty,&result) then result
+    else
+        let tps, tau = destTopForallTy g topValInfo ty
+        let argtysl, rty = GetTopTauTypeInFSharpForm g argInfos tau m
+        let result = tps, argtysl, rty, retInfo
+        topValTypeCache.Add(ty,result)
+        result
 
 
 let IsCompiledAsStaticProperty g (v:Val) =
@@ -8574,5 +8602,3 @@ let isThreadOrContextStatic g attrs =
 let mkUnitDelayLambda (g: TcGlobals) m e =
     let uv, _ = mkCompGenLocal m "unitVar" g.unit_ty
     mkLambda m uv (e, tyOfExpr g e) 
-
-


### PR DESCRIPTION
To help #5938 I have added local caching to computed values of stripTyEqnsA & GetTopValTypeInFSharpForm. I had originally done major changes to the returning Tuple4, changing it to a specialised lazy loaded enumerator but something broke along the way and I could not get fixed in time.

Using these caches, I counted the calls to reused cache values and on were in the thousands (a full VS release build had something like 17k if I recall correctly). All though this is a minor change it is avoiding hundreds/thousands of re-calcs, and the use of ConditionalWeakTable means that the cached values can be collected once the `TType`s are disposed of. In the context of #5938 how do we want to test this given it should be bit faster but the bigger benefit is less allocs on repeated ttype values?