### PR TITLE
[WIP] Improve error reporting: Missing = on type declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ tests/fsharpqa/testenv/bin/System.ValueTuple.dll
 msbuild.binlog
 /fcs/FSharp.Compiler.Service.netstandard/*.fs
 /fcs/FSharp.Compiler.Service.netstandard/*.fsi
+.idea/

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1458,3 +1458,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3245,tcCopyAndUpdateNeedsRecordType,"The input to a copy-and-update expression that creates an anonymous record must be either an anonymous record or a record"
 3300,chkInvalidFunctionParameterType,"The parameter '%s' has an invalid type '%s'. This is not permitted by the rules of Common IL."
 3301,chkInvalidFunctionReturnType,"The function or method has an invalid return type '%s'. This is not permitted by the rules of Common IL."
+3302,parsEqualsMissingInTypeDefinition,"Unexpected symbol '{' in type definition. Did you forget to use the = operator?"

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1441,8 +1441,10 @@ tyconDefn:
   | typeNameInfo 
      { TypeDefn($1,SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range),$1.Range),[],$1.Range) }
 
-  | typeNameInfo EQUALS tyconDefnRhsBlock
-     { let nameRange = rhs parseState 1
+  | typeNameInfo opt_EQUALS tyconDefnRhsBlock
+     {
+       if Option.isNone $2 then raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsEqualsMissingInTypeDefinition())
+       let nameRange = rhs parseState 1
        let (tcDefRepr:SynTypeDefnRepr),members = $3 nameRange
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
        let mWhole = (declRange, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)    
@@ -4934,6 +4936,10 @@ opt_ODECLEND:
 deprecated_opt_equals: 
   | EQUALS      { deprecatedWithError (FSComp.SR.parsNoEqualShouldFollowNamespace()) (lhs parseState); () } 
   | /* EMPTY */ {  }
+
+opt_EQUALS:
+  | EQUALS      { } 
+  | /* EMPTY */ { }
 
 opt_OBLOCKSEP: 
   | OBLOCKSEP   { }


### PR DESCRIPTION
This is my attempt to implement #1121.
I've been digging into FsLex/FsYacc parsing rules and was able to find out the changes I need to make.
But after I've made them, the project just doesn't build anymore. Without changes introduced in this PR build works fine for me so it's most likely that my code is wrong.
Unfortunately I don't get any error messages and I can't figure out where is the problem by myself.
I would like someone to take a look at this PR and advise me what is the problem here.

VS 2019 developer cmd output:

```
C:\Projects\visualfsharp>build.cmd -c Debug
Building bootstrap compiler
dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.504/dotnet-sdk-2.1.504-win-x64.zip
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.504/dotnet-sdk-2.1.504-win-x64.zip
dotnet-install: Adding to current process PATH: "C:\Projects\visualfsharp\.dotnet\". Note: This change will not be visible if PowerShell was run as a child process.
dotnet-install: Installation finished
  Restore completed in 1.19 sec for C:\Projects\visualfsharp\src\buildtools\fslex\fslex.fsproj.
  Restore completed in 55.86 ms for C:\Projects\visualfsharp\src\buildtools\fsyacc\fsyacc.fsproj.
  fslex -> C:\Projects\visualfsharp\artifacts\bin\fslex\Proto\netcoreapp2.1\fslex.dll
  fsyacc -> C:\Projects\visualfsharp\artifacts\bin\fsyacc\Proto\netcoreapp2.1\fsyacc.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:10.26
  Restore completed in 2.77 sec for C:\Projects\visualfsharp\src\fsharp\FSharp.Build\FSharp.Build.fsproj.
  Restore completed in 3.17 sec for C:\Projects\visualfsharp\src\fsharp\FSharp.Core\FSharp.Core.fsproj.
  Restore completed in 9.89 ms for C:\Projects\visualfsharp\src\fsharp\FSharp.Build\FSharp.Build.fsproj.
  Restore completed in 26.84 ms for C:\Projects\visualfsharp\src\fsharp\FSharp.Core\FSharp.Core.fsproj.
  Restore completed in 572.34 ms for C:\Projects\visualfsharp\src\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private
  .fsproj.
  Restore completed in 624.21 ms for C:\Projects\visualfsharp\src\fsharp\fsc\fsc.fsproj.
  Restore completed in 16.16 ms for C:\Projects\visualfsharp\src\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.
  fsproj.
  Restore completed in 18.3 ms for C:\Projects\visualfsharp\src\fsharp\FSharp.Core\FSharp.Core.fsproj.
  Restore completed in 105 ms for C:\Projects\visualfsharp\src\fsharp\FSharp.Compiler.Server.Shared\FSharp.Compiler.Serv
  er.Shared.fsproj.
  Restore completed in 387.59 ms for C:\Projects\visualfsharp\src\fsharp\FSharp.Compiler.Interactive.Settings\FSharp.Com
  piler.Interactive.Settings.fsproj.
  Restore completed in 438.37 ms for C:\Projects\visualfsharp\src\fsharp\fsi\fsi.fsproj.
  FSharp.Core -> C:\Projects\visualfsharp\artifacts\bin\FSharp.Core\Proto\net45\FSharp.Core.dll
  FSharp.Build -> C:\Projects\visualfsharp\artifacts\bin\FSharp.Build\Proto\net472\FSharp.Build.dll
  FSharp.Compiler.Interactive.Settings -> C:\Projects\visualfsharp\artifacts\bin\FSharp.Compiler.Interactive.Settings\Pr
  oto\net472\FSharp.Compiler.Interactive.Settings.dll

Build FAILED.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:26.14
Command failed to execute with exit code 1: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\\MSBuild\Current\Bin\MSBuild.exe  /p:TreatWarningsAsErrors=true /nologo /nodeReuse:false /p:Configuration=Proto  /warnaserror /consoleloggerparameters:Verbosity=minimal;summary /m /restore /t:Build C:\Projects\visualfsharp\proto.proj
System.Management.Automation.RuntimeException: Command failed to execute with exit code 1: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\\MSBuild\Current\Bin\MSBuild.exe  /p:TreatWarningsAsErrors=true /nologo /nodeReuse:false /p:Configuration=Proto  /warnaserror /consoleloggerparameters:Verbosity=minimal;summary /m /restore /t:Build C:\Projects\visualfsharp\proto.proj
at Exec-CommandCore, C:\Projects\visualfsharp\eng\build-utils.ps1: line 50
at Exec-Console, C:\Projects\visualfsharp\eng\build-utils.ps1: line 119
at Run-MSBuild, C:\Projects\visualfsharp\eng\build-utils.ps1: line 228
at Make-BootstrapBuild, C:\Projects\visualfsharp\eng\build-utils.ps1: line 250
at <ScriptBlock>, C:\Projects\visualfsharp\eng\build.ps1: line 235
at <ScriptBlock>, <No file>: line 1
```