### PR TITLE
Add NoEquality to range

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -4715,7 +4715,12 @@ and GenMatch cenv cgbuf eenv (spBind, _exprm, tree, targets, m, ty) sequel =
         match activeSP with
         | None -> ()
         | Some src ->
-            if activeSP <> cgbuf.GetLastSequencePoint() then
+            let inline sequencePointsEqual sp1 sp2 =
+                match sp1, sp2 with
+                | Some r1, Some r2 -> Range.equals r1 r2
+                | None, None -> true
+                | _ -> false
+            if sequencePointsEqual activeSP (cgbuf.GetLastSequencePoint()) then
                 CG.EmitSeqPoint cgbuf src
 
     // First try the common cases where we don't need a join point.

--- a/src/fsharp/range.fs
+++ b/src/fsharp/range.fs
@@ -200,7 +200,7 @@ let fileOfFileIndex idx = fileIndexTable.IndexToFile idx
 
 let mkPos l c = pos (l, c)
 
-[<Struct; CustomEquality; NoComparison>]
+[<Struct; NoEquality; NoComparison>]
 #if DEBUG
 [<System.Diagnostics.DebuggerDisplay("({StartLine},{StartColumn}-{EndLine},{EndColumn}) {FileName} IsSynthetic={IsSynthetic} -> {DebugCode}")>]
 #else
@@ -263,16 +263,15 @@ type range(code1:int64, code2: int64) =
 
     member r.ToShortString() = sprintf "(%d,%d--%d,%d)" r.StartLine r.StartColumn r.EndLine r.EndColumn
 
-    override r.Equals(obj) = match obj with :? range as r2 -> code1 = r2.Code1 && code2 = r2.Code2 | _ -> false
-
-    override r.GetHashCode() = hash code1 + hash code2
-
     override r.ToString() = sprintf "%s (%d,%d--%d,%d) IsSynthetic=%b" r.FileName r.StartLine r.StartColumn r.EndLine r.EndColumn r.IsSynthetic
 
 let mkRange filePath startPos endPos = range (fileIndexOfFileAux true filePath, startPos, endPos)
 
 let equals (r1: range) (r2: range) =
     r1.Code1 = r2.Code1 && r1.Code2 = r2.Code2
+
+let hashRange (r: range) =
+    r.Code1.GetHashCode() + r.Code2.GetHashCode()
 
 let mkFileIndexRange fileIndex startPos endPos = range (fileIndex, startPos, endPos)
 

--- a/src/fsharp/range.fsi
+++ b/src/fsharp/range.fsi
@@ -45,7 +45,7 @@ val mkPos : line:int -> column:int -> pos
 val posOrder : IComparer<pos>
 
 /// Represents a range within a known file
-[<Struct; CustomEquality; NoComparison>]
+[<Struct; NoEquality; NoComparison>]
 type range =
 
     /// The start line of the range
@@ -98,7 +98,11 @@ val mkFileIndexRange : FileIndex -> pos -> pos -> range
 /// This view hides the use of file indexes and just uses filenames 
 val mkRange : string -> pos -> pos -> range
 
+/// Compare two ranges to see if their inner values are equal (no boxing).
 val equals : range -> range -> bool
+
+/// Performs a hash operation on the inner values of a given range (no boxing).
+val hashRange : range -> int
 
 /// Reduce a range so it only covers a line
 val trimRangeToLine : range -> range

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -473,7 +473,10 @@ module internal LexerStateEncoding =
 
     let callLexCont lexcont args skip lexbuf =
         let argsWithIfDefs ifd =
-            if !args.ifdefStack = ifd then
+            let inline ifdefStackEntriesEqual stack1 stack2 =
+                (stack1, stack2) ||> List.forall2 (fun (entry1, r1) (entry2, r2) -> entry1 = entry2 && Range.equals r1 r2)
+
+            if ifdefStackEntriesEqual args.ifdefStack.contents ifd then
                 args
             else
                 {args with ifdefStack = ref ifd}

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -9,6 +9,7 @@ namespace FSharp.Compiler.SourceCodeServices
 
 open FSharp.Compiler.Range
 open FSharp.Compiler.Ast
+open FSharp.Compiler.AbstractIL.Internal.Library
  
 
 /// A range of utility functions to assist with traversing an AST
@@ -537,7 +538,7 @@ module public AstTraversal =
         and normalizeMembersToDealWithPeculiaritiesOfGettersAndSetters path traverseInherit (synMemberDefns:SynMemberDefns) =
             synMemberDefns 
                     // property getters are setters are two members that can have the same range, so do some somersaults to deal with this
-                    |> Seq.groupBy (fun x -> x.Range)
+                    |> Seq.groupByNoBoxWithComparison (fun x -> x.Range) FSharp.Compiler.Range.hashRange FSharp.Compiler.Range.equals
                     |> Seq.choose (fun (r, mems) ->
                         match mems |> Seq.toList with
                         | [mem] -> // the typical case, a single member has this range 'r'

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -353,6 +353,8 @@ type public FSharpProjectOptions =
       /// if and only if the stamps are equal
       Stamp: int64 option
     }
+    with
+        static member AreSameForChecking: options1: FSharpProjectOptions * options2: FSharpProjectOptions -> bool
          
 /// The result of calling TypeCheckResult including the possibility of abort and background compiler not caught up.
 [<RequireQualifiedAccess>]

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -790,7 +790,7 @@ module internal SymbolHelpers =
               | Item.CustomOperation (_, _, Some minfo) -> minfo.ComputeHashCode()
               | Item.CustomOperation (_, _, None) -> 1
               | Item.ModuleOrNamespaces(modref :: _) -> hash (fullDisplayTextOfModRef modref)          
-              | Item.SetterArg(id, _) -> hash (id.idRange, id.idText)
+              | Item.SetterArg(id, _) -> Range.hashRange id.idRange + hash id.idText
               | Item.MethodGroup(_, meths, _) -> meths |> List.fold (fun st a -> st + a.ComputeHashCode()) 0
               | Item.CtorGroup(name, meths) -> name.GetHashCode() + (meths |> List.fold (fun st a -> st + a.ComputeHashCode()) 0)
               | (Item.Value vref | Item.CustomBuilder (_, vref)) -> hash vref.LogicalName

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -227,7 +227,10 @@ type FSharpSymbol(cenv: SymbolEnv, item: (unit -> Item), access: (FSharpSymbol -
         |   :? FSharpSymbol as otherSymbol -> ItemsAreEffectivelyEqual cenv.g x.Item otherSymbol.Item
         |   _ -> false
 
-    override x.GetHashCode() = hash x.ImplementationLocation  
+    override x.GetHashCode() =
+        match x.ImplementationLocation with
+        | Some r -> Range.hashRange r
+        | None -> hash None // This is 0 today, but might as well do this just in case...
 
     override x.ToString() = "symbol " + (try item().DisplayName with _ -> "?")
 

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -142,7 +142,7 @@ type internal FSharpAddOpenCodeFixProvider
                     longIdent
                     |> List.map (fun ident ->
                         { Ident = ident.idText
-                          Resolved = not (ident.idRange = unresolvedIdentRange)})
+                          Resolved = not (Range.equals ident.idRange unresolvedIdentRange)})
                     |> List.toArray)
                                                     
             let insertionPoint = 

--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -111,7 +111,7 @@ type internal FSharpFindUsagesService
 
             for symbolUse in symbolUses do
                 match declarationRange with
-                | Some declRange when declRange = symbolUse.RangeAlternate -> ()
+                | Some declRange when equals declRange symbolUse.RangeAlternate -> ()
                 | _ ->
                     // report a reference if we're interested in all _or_ if we're looking at an implementation
                     if allReferences || symbolUse.IsFromDispatchSlotImplementation then

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -267,7 +267,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
             | FSharpFindDeclResult.DeclFound targetRange -> 
                 // if goto definition is called at we are alread at the declaration location of a symbol in
                 // either a signature or an implementation file then we jump to it's respective postion in thethe
-                if lexerSymbol.Range = targetRange then
+                if equals lexerSymbol.Range targetRange then
                     // jump from signature to the corresponding implementation
                     if isSignatureFile originDocument.FilePath then
                         let implFilePath = Path.ChangeExtension (originDocument.FilePath,"fs")

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Navigation.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Navigation.fs
@@ -24,8 +24,8 @@ type internal QuickInfoNavigation
     let solution = workspace.CurrentSolution
 
     member __.IsTargetValid (range: range) =
-        range <> rangeStartup &&
-        range <> thisSymbolUseRange &&
+        not (equals range rangeStartup) &&
+        not (equals range thisSymbolUseRange) &&
         solution.TryGetDocumentIdFromFSharpRange (range, initialDoc.Project.Id) |> Option.isSome
 
     member __.RelativePath (range: range) =

--- a/vsintegration/src/FSharp.LanguageService/Colorize.fs
+++ b/vsintegration/src/FSharp.LanguageService/Colorize.fs
@@ -164,7 +164,7 @@ type internal FSharpScanner_DEPRECATED(makeLineTokenizer : string -> FSharpLineT
                    inOneButNotTheOther.SymmetricExceptWith(newExtraColorizationsKeyed.Keys)
                    let inBoth = HashSet(oldExtraColorizationsKeyed.Keys)
                    inBoth.IntersectWith(newExtraColorizationsKeyed.Keys)
-                   inBoth.RemoveWhere(fun i -> newExtraColorizationsKeyed.[i] = oldExtraColorizationsKeyed.[i]) |> ignore
+                   inBoth.RemoveWhere(fun i -> (newExtraColorizationsKeyed.[i], oldExtraColorizationsKeyed.[i]) ||> Array.forall2 (fun (r1, sct1) (r2, sct2) -> Range.equals r1 r2 && sct1 = sct2)) |> ignore
                    Array.append (Seq.toArray inOneButNotTheOther) (Seq.toArray inBoth)
             Array.sortInPlace changedLines
             changedLines

--- a/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
+++ b/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
@@ -334,7 +334,8 @@ type internal ProjectSitesAndFiles() =
                 | Some (_parsingOptions, _site, projectOptions) ->
                     if projectSite.CompilationSourceFiles <> projectOptions.SourceFiles ||
                        projectSite.CompilationOptions <> projectOptions.OtherOptions ||
-                       referencedProjectOptions <> projectOptions.ReferencedProjects then
+                       (referencedProjectOptions, projectOptions.ReferencedProjects)
+                       ||> Array.forall2 (fun (s1, options1) (s2, options2) -> s1 = s2 && FSharpProjectOptions.AreSameForChecking(options1, options2)) then
                             newOption()
                     else
                             projectOptions


### PR DESCRIPTION
This is to address #6052 

It's quite a bit of machinery that I think might actually be better served by having the compiler properly handle equality and comparison for structs with custom equality. But that could also be a breaking change IIRC - @TIHan @dsyme is that accurate?

Some notes:

* Lack of ability to pass in a custom comparer to List/Seq/Array combinators is why there is duplication going on here - should there be a core library change to support something like this? That would allow for far less code additions and open up doing the same for `List`, which is currently blocked because the actual implementation ultimately relies on inline IL which is only available in FSharp.Core.
* Some of this is pretty ugly; I imagine it could get cleaned up