### PR TITLE
Add FSharpAttribute.Constructor property

### DIFF
--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -1025,6 +1025,9 @@ and [<Class>] public FSharpAttribute =
     /// The named arguments for the attribute
     member NamedArguments : IList<FSharpType * string * bool * obj>
 
+    /// The resolved attribute instance constructor.
+    member Constructor: FSharpMemberOrFunctionOrValue
+
     /// Indicates if the attribute type is in an unresolved assembly 
     member IsUnresolved : bool
 


### PR DESCRIPTION
Provides a way to get the resolved attribute constructor in Symbols API.
It currently depends on #6710.
Is there a better way to create FSharpMemberOrFunctionOrValue for IL* cases?

It's a draft due to missing test cases.