### PR TITLE
Set IsImplicitlyDefined on implicit package references

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -94,7 +94,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </ItemGroup>
 
   <ItemGroup Condition="'$(DisableImplicitFSharpCoreReference)' != 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreImplicitPackageVersion)" />
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreImplicitPackageVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
 </Project>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -69,7 +69,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <ItemGroup Condition="'$(DisableImplicitSystemValueTupleReference)' != 'true'
                         and ('$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp')
                         and !('$(_TargetFrameworkVersionWithoutV)' >= '2.0' )">
-    <PackageReference Include="System.ValueTuple" Version="$(ValueTupleImplicitPackageVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(ValueTupleImplicitPackageVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -90,7 +90,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
                                      '$(_TargetFrameworkVersionWithoutV)' == '4.6.1' or
                                      '$(_TargetFrameworkVersionWithoutV)' == '4.6.2' or
                                      '$(_TargetFrameworkVersionWithoutV)' == '4.7')) ">
-    <PackageReference Include="System.ValueTuple" Version="$(ValueTupleImplicitPackageVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(ValueTupleImplicitPackageVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DisableImplicitFSharpCoreReference)' != 'true'">


### PR DESCRIPTION
SDKs should add the `IsImplicitlyDefined` metadata to implicit package references so that build logic can differentiate between packages that users defined versus packages added by external build logic.  One example is [NETStandard.Library](https://github.com/dotnet/sdk/blob/bb764dea3b6b7173522688fffe0f48640d714833/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props#L40).

This change sets the standard `IsImplicitlyDefined` metadata to `true` so that the FSharp SDK follows this pattern.

Fixes #3678