### PR TITLE
enable tests to be skipped during an official build

### DIFF
--- a/.vsts-signed.yaml
+++ b/.vsts-signed.yaml
@@ -5,6 +5,12 @@ variables:
 - name: VisualStudioDropName
   value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 
+# Variables defined in yml cannot be overridden at queue time; instead overridable variables must be defined in the web UI.
+# Commenting out until something like this is supported: https://github.com/Microsoft/azure-pipelines-yaml/pull/129
+#variables:
+#- name: SkipTests
+#  defaultValue: false
+
 jobs:
 - job: Full_Signed
   pool:
@@ -26,6 +32,7 @@ jobs:
   - script: eng\CIBuild.cmd
             -configuration $(BuildConfiguration)
             -testAll
+            -officialSkipTests $(SkipTests)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             /p:VisualStudioDropName=$(VisualStudioDropName)
             /p:DotNetSignType=$(SignType)
@@ -55,7 +62,7 @@ jobs:
       ArtifactName: 'Test Results'
       publishLocation: Container
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), ne(variables['SkipTests'], 'true'))
 
   # Upload VSTS Drop
   - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,12 @@ variables:
   - name: VisualStudioDropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 
+# Variables defined in yml cannot be overridden at queue time; instead overridable variables must be defined in the web UI.
+# Commenting out until something like this is supported: https://github.com/Microsoft/azure-pipelines-yaml/pull/129
+#variables:
+#- name: SkipTests
+#  defaultValue: false
+
 jobs:
 
 #---------------------------------------------------------------------------------------------------------------------#
@@ -55,6 +61,7 @@ jobs:
                   -configuration $(_BuildConfig)
                   -prepareMachine
                   -testAll
+                  -officialSkipTests $(SkipTests)
                   /p:SignType=$(_SignType)
                   /p:DotNetSignType=$(_SignType)
                   /p:MicroBuild_SigningEnabled=true

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -52,6 +52,7 @@ param (
     [switch]$testFSharpQA,
     [switch]$testVs,
     [switch]$testAll,
+    [string]$officialSkipTests = "false",
 
     [parameter(ValueFromRemainingArguments=$true)][string[]]$properties)
 
@@ -84,6 +85,7 @@ function Print-Usage() {
     Write-Host "  -testFSharpCore           Run FSharpCore unit tests"
     Write-Host "  -testFSharpQA             Run F# Cambridge tests"
     Write-Host "  -testVs                   Run F# editor unit tests"
+    Write-Host "  -officialSkipTests <bool> Set to 'true' to skip running tests"
     Write-Host ""
     Write-Host "Advanced settings:"
     Write-Host "  -ci                       Set when running on CI server"
@@ -110,6 +112,17 @@ function Process-Arguments() {
         $script:testCoreClr = $True
         $script:testFSharpQA = $True
         $script:testVs = $True
+    }
+
+    if ([System.Boolean]::Parse($script:officialSkipTests)) {
+        $script:testAll = $False
+        $script:testCambridge = $False
+        $script:testCompiler = $False
+        $script:testDesktop = $False
+        $script:testCoreClr = $False
+        $script:testFSharpCore = $False
+        $script:testFSharpQA = $False
+        $script:testVs = $False
     }
 
     if ($noRestore) {


### PR DESCRIPTION
Primarily useful when testing build process changes.