### PR TITLE
[WIP] Added cache invalidation policy when a solution changes

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -2896,8 +2896,8 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                 if startBackgroundCompileIfAlreadySeen then 
                    bc.CheckProjectInBackground(options, userOpName + ".StartBackgroundCompile"))
 
-    member bc.ClearProjectCache(options: FSharpProjectOptions, userOpName) =
-        reactor.EnqueueOp(userOpName, "ClearProjectCache: Stamp(" + (options.Stamp |> Option.defaultValue 0L).ToString() + ")", options.ProjectFileName, fun ctok -> 
+    member bc.InvalidateProject(options: FSharpProjectOptions, userOpName) =
+        reactor.EnqueueOp(userOpName, "InvalidateProject: Stamp(" + (options.Stamp |> Option.defaultValue 0L).ToString() + ")", options.ProjectFileName, fun ctok -> 
             incrementalBuildersCache.RemoveAnySimilar (ctok, options))
 
     member bc.NotifyProjectCleaned (options : FSharpProjectOptions, userOpName) =
@@ -3180,10 +3180,10 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
         let userOpName = defaultArg userOpName "Unknown"
         backgroundCompiler.InvalidateConfiguration(options, startBackgroundCompile, userOpName)
 
-    /// Clear a project from the cache.
-    member ic.ClearProjectCache(options, ?userOpName: string) =
+    /// Invalidate a project. Removes it completely from the cache.
+    member ic.InvalidateProject(options, ?userOpName: string) =
         let userOpName = defaultArg userOpName "Unknown"
-        backgroundCompiler.ClearProjectCache(options, userOpName)
+        backgroundCompiler.InvalidateProject(options, userOpName)
 
     /// This function is called when a project has been cleaned, and thus type providers should be refreshed.
     member ic.NotifyProjectCleaned(options: FSharpProjectOptions, ?userOpName: string) =

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -639,7 +639,8 @@ type public FSharpChecker =
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member InvalidateConfiguration: options: FSharpProjectOptions * ?startBackgroundCompileIfAlreadySeen: bool * ?userOpName: string -> unit
     
-    /// Invalidate a project. Clears all caches related to this project, including check files, stale check files, etc.
+    /// Invalidate a project. Clears all caches related to this the project represented by the given FSharpProjectOptions, including check files, stale check files, etc.
+    /// <param name="options">The options for the project or script, used to determine active --define conditionals and other options relevant to parsing.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member InvalidateProject: options: FSharpProjectOptions * ?userOpName: string -> unit
 

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -374,6 +374,10 @@ type public FSharpChecker =
     /// <param name="tryGetMetadataSnapshot">An optional resolver to access the contents of .NET binaries in a memory-efficient way</param>
     static member Create : ?projectCacheSize: int * ?keepAssemblyContents: bool * ?keepAllBackgroundResolutions: bool  * ?legacyReferenceResolver: ReferenceResolver.Resolver * ?tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot * ?suggestNamesForErrors: bool -> FSharpChecker
 
+    /// For testing purposes, not for public consumption.
+    /// Tries to find if the given project exists in any kind of cache, whether it be incremental builder, check file, check file stale cache.
+    member internal ProjectExistsInAnyCache: options: FSharpProjectOptions * ?userOpName: string -> Async<bool>
+
     /// <summary>
     ///   Parse a source code file, returning information about brace matching in the file.
     ///   Return an enumeration of the matching parenthetical tokens in the file.

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -633,7 +633,11 @@ type public FSharpChecker =
     /// For example, dependent references may have been deleted or created.
     /// <param name="startBackgroundCompileIfAlreadySeen">Start a background compile of the project if a project with the same name has already been seen before.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member InvalidateConfiguration: options: FSharpProjectOptions * ?startBackgroundCompileIfAlreadySeen: bool * ?userOpName: string -> unit    
+    member InvalidateConfiguration: options: FSharpProjectOptions * ?startBackgroundCompileIfAlreadySeen: bool * ?userOpName: string -> unit
+    
+    /// Clear a project from the cache.
+    /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
+    member ClearProjectCache: options: FSharpProjectOptions * ?userOpName: string -> unit
 
     /// Set the project to be checked in the background.  Overrides any previous call to <c>CheckProjectInBackground</c>
     member CheckProjectInBackground: options: FSharpProjectOptions  * ?userOpName: string -> unit

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -635,9 +635,9 @@ type public FSharpChecker =
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member InvalidateConfiguration: options: FSharpProjectOptions * ?startBackgroundCompileIfAlreadySeen: bool * ?userOpName: string -> unit
     
-    /// Clear a project from the cache.
+    /// Invalidate a project. Removes it completely from the cache.
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member ClearProjectCache: options: FSharpProjectOptions * ?userOpName: string -> unit
+    member InvalidateProject: options: FSharpProjectOptions * ?userOpName: string -> unit
 
     /// Set the project to be checked in the background.  Overrides any previous call to <c>CheckProjectInBackground</c>
     member CheckProjectInBackground: options: FSharpProjectOptions  * ?userOpName: string -> unit

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -635,7 +635,7 @@ type public FSharpChecker =
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member InvalidateConfiguration: options: FSharpProjectOptions * ?startBackgroundCompileIfAlreadySeen: bool * ?userOpName: string -> unit
     
-    /// Invalidate a project. Removes it completely from the cache.
+    /// Invalidate a project. Clears all caches related to this project, including check files, stale check files, etc.
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member InvalidateProject: options: FSharpProjectOptions * ?userOpName: string -> unit
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -347,7 +347,6 @@ type private FSharpProjectOptionsReactor (workspace: VisualStudioWorkspaceImpl, 
 
                 | FSharpProjectOptionsMessage.Reset ->
                     clearAllCaches ()
-                    currentSolution <- None
         }
 
     let agent = MailboxProcessor.Start((fun agent -> loop agent), cancellationToken = cancellationTokenSource.Token)

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -352,7 +352,6 @@ type private FSharpProjectOptionsReactor (workspace: VisualStudioWorkspaceImpl, 
                     removeSingleFile documentId
                 | FSharpProjectOptionsMessage.Reset ->
                     clearAllCaches ()
-                    cpsCommandLineOptions.Clear ()
                     currentSolution <- None
         }
 
@@ -371,6 +370,7 @@ type private FSharpProjectOptionsReactor (workspace: VisualStudioWorkspaceImpl, 
         agent.Post(FSharpProjectOptionsMessage.RemoveSingleFile(documentId))
 
     member __.Reset () =
+        cpsCommandLineOptions.Clear ()
         agent.Post(FSharpProjectOptionsMessage.Reset)
 
     member __.SetCpsCommandLineOptions(projectId, sourcePaths, options) =
@@ -415,7 +415,7 @@ type internal FSharpProjectOptionsManager
         reactor.RemoveSingleFile(documentId)
 
     /// Reset everything. Clears all caches. 
-    /// Be sure to call this when when are definitely not receiving callbacks from HandleCommandLineChanges, e.g. closing a solution.
+    /// Be sure to call this when we are definitely not receiving callbacks from HandleCommandLineChanges, e.g. closing a solution.
     /// If calling reset when we expect HandleCommandLineChanges to fire, we can potentially lose information that we will never be able to get again, therefore losing IDE features.
     /// When HandleCommandLineChanges is removed, this comment can go away.
     member this.Reset () =

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -464,12 +464,13 @@ type internal FSharpProjectOptionsManager
             | true, project -> project.Id
             | false, _ -> workspace.ProjectTracker.GetOrCreateProjectIdForPath(path, projectDisplayNameOf path)
         let project =  workspace.ProjectTracker.GetProject(projectId)
-        let path = project.ProjectFilePath
-        let fullPath p =
-            if Path.IsPathRooted(p) || path = null then p
-            else Path.Combine(Path.GetDirectoryName(path), p)
-        let sourcePaths = sources |> Seq.map(fun s -> fullPath s.Path) |> Seq.toArray
+        if project <> null then
+            let path = project.ProjectFilePath
+            let fullPath p =
+                if Path.IsPathRooted(p) || path = null then p
+                else Path.Combine(Path.GetDirectoryName(path), p)
+            let sourcePaths = sources |> Seq.map(fun s -> fullPath s.Path) |> Seq.toArray
 
-        reactor.SetCpsCommandLineOptions(projectId, sourcePaths, options.ToArray())
+            reactor.SetCpsCommandLineOptions(projectId, sourcePaths, options.ToArray())
 
     member __.Checker = checkerProvider.Checker

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -69,6 +69,9 @@ module internal FSharpCompilationHelpers =
             // Hack to store command line options from HandleCommandLineChanges, remove it when HandleCommandLineChanges gets removed.
             cpsCommandLineOptions: ConcurrentDictionary<ProjectId, string [] * string []>
             enableInMemoryCrossProjectReferences: bool
+            /// We only use the workspace directly when checking to see if something is from cps or legacy projects.
+            /// This will go away when cps and legacy are fully unified to the workspace, meaning we can get command line options and file ordered documents from a workspace project.
+            /// This will most likely be removed when 'cpsCommandLineOptions' gets removed.
             workspace: Workspace
             mutable currentSolution: Solution option
         }

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -173,7 +173,6 @@ type private FSharpProjectOptionsReactor (workspace: VisualStudioWorkspaceImpl, 
     let rec tryComputeOptionsByFile (document: Document) (ct: CancellationToken) =
         async {
             let isScript = isScriptFile document.FilePath
-            let! version = document.Project.GetDependentVersionAsync ct |> Async.AwaitTask
             match cache.TryGetValue(document.Project.Id) with
             | false, _ ->
                 let! sourceText = document.GetTextAsync(ct) |> Async.AwaitTask
@@ -207,6 +206,7 @@ type private FSharpProjectOptionsReactor (workspace: VisualStudioWorkspaceImpl, 
                 return Some(parsingOptions, projectOptions)
 
             | true, (oldProject, parsingOptions, projectOptions) ->
+                let! version = document.Project.GetDependentVersionAsync ct |> Async.AwaitTask
                 let! oldVersion = oldProject.GetDependentVersionAsync ct |> Async.AwaitTask
                 // Only recompute if it's a script.
                 if version <> oldVersion && isScript then

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -79,7 +79,7 @@ type private FSharpSolutionEvents(projectManager: FSharpProjectOptionsManager) =
     interface IVsSolutionEvents with
 
         member __.OnAfterCloseSolution(_) =
-            projectManager.Checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
+            projectManager.Reset ()
             VSConstants.S_OK
 
         member __.OnAfterLoadProject(_, _) = VSConstants.E_NOTIMPL

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -204,8 +204,8 @@ type internal FSharpPackage() as this =
                     let projectContextFactory = this.ComponentModel.GetService<IWorkspaceProjectContextFactory>()
                     let workspace = this.ComponentModel.GetService<VisualStudioWorkspace>()
                     let miscFilesWorkspace = this.ComponentModel.GetService<MiscellaneousFilesWorkspace>()
-                    let _singleFileWorkspaceMap = new SingleFileWorkspaceMap(workspace, miscFilesWorkspace, projectInfoManager, projectContextFactory, rdt)
-                    let _legacyProjectWorkspaceMap = new LegacyProjectWorkspaceMap(solution, projectInfoManager, projectContextFactory)
+                    let _singleFileWorkspaceMap = new SingleFileWorkspaceMap(workspace, miscFilesWorkspace, projectContextFactory, rdt)
+                    let _legacyProjectWorkspaceMap = new LegacyProjectWorkspaceMap(solution, projectContextFactory)
                     ()
                 let awaiter = this.JoinableTaskFactory.SwitchToMainThreadAsync().GetAwaiter()
                 if awaiter.IsCompleted then

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -73,6 +73,33 @@ type internal FSharpCheckerWorkspaceServiceFactory
                 member this.Checker = checkerProvider.Checker
                 member this.FSharpProjectOptionsManager = projectInfoManager }    
 
+[<Sealed>]
+type private FSharpSolutionEvents(projectManager: FSharpProjectOptionsManager) =
+
+    interface IVsSolutionEvents with
+
+        member __.OnAfterCloseSolution(_) =
+            projectManager.Reset ()
+            VSConstants.S_OK
+
+        member __.OnAfterLoadProject(_, _) = VSConstants.E_NOTIMPL
+
+        member __.OnAfterOpenProject(_, _) = VSConstants.E_NOTIMPL
+
+        member __.OnAfterOpenSolution(_, _) = VSConstants.E_NOTIMPL
+
+        member __.OnBeforeCloseProject(_, _) = VSConstants.E_NOTIMPL
+
+        member __.OnBeforeCloseSolution(_) = VSConstants.E_NOTIMPL
+
+        member __.OnBeforeUnloadProject(_, _) = VSConstants.E_NOTIMPL
+
+        member __.OnQueryCloseProject(_, _, _) = VSConstants.E_NOTIMPL
+
+        member __.OnQueryCloseSolution(_, _) = VSConstants.E_NOTIMPL
+
+        member __.OnQueryUnloadProject(_, _) = VSConstants.E_NOTIMPL    
+
 [<Microsoft.CodeAnalysis.Host.Mef.ExportWorkspaceServiceFactory(typeof<EditorOptions>, Microsoft.CodeAnalysis.Host.Mef.ServiceLayer.Default)>]
 type internal FSharpSettingsFactory
     [<Composition.ImportingConstructor>] (settings: EditorOptions) =
@@ -143,6 +170,8 @@ type internal FSharpPackage() as this =
             vfsiToolWindow <- this.FindToolWindow(typeof<Microsoft.VisualStudio.FSharp.Interactive.FsiToolWindow>, 0, true) :?> Microsoft.VisualStudio.FSharp.Interactive.FsiToolWindow
         vfsiToolWindow :> Microsoft.VisualStudio.FSharp.Interactive.ITestVFSI
 
+    let mutable solutionEventsOpt = None // this is meant to strongly hold onto solution events
+
     // FSI-LINKAGE-POINT: unsited init
     do 
         Microsoft.VisualStudio.FSharp.Interactive.Hooks.fsiConsoleWindowPackageCtorUnsited (this :> Package)
@@ -162,10 +191,15 @@ type internal FSharpPackage() as this =
 
                     // FSI-LINKAGE-POINT: private method GetDialogPage forces fsi options to be loaded
                     let _fsiPropertyPage = this.GetDialogPage(typeof<Microsoft.VisualStudio.FSharp.Interactive.FsiPropertyPage>)
+                    let projectInfoManager = this.ComponentModel.DefaultExportProvider.GetExport<FSharpProjectOptionsManager>().Value
                     let solution = this.GetServiceAsync(typeof<SVsSolution>).Result
                     let solution = solution :?> IVsSolution
+                    let solutionEvents = FSharpSolutionEvents(projectInfoManager)
                     let rdt = this.GetServiceAsync(typeof<SVsRunningDocumentTable>).Result
                     let rdt = rdt :?> IVsRunningDocumentTable
+
+                    solutionEventsOpt <- Some(solutionEvents)
+                    solution.AdviseSolutionEvents(solutionEvents) |> ignore
 
                     let projectContextFactory = this.ComponentModel.GetService<IWorkspaceProjectContextFactory>()
                     let workspace = this.ComponentModel.GetService<VisualStudioWorkspace>()

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -71,34 +71,7 @@ type internal FSharpCheckerWorkspaceServiceFactory
         member this.CreateService(_workspaceServices) =
             upcast { new FSharpCheckerWorkspaceService with
                 member this.Checker = checkerProvider.Checker
-                member this.FSharpProjectOptionsManager = projectInfoManager }
-
-[<Sealed>]
-type private FSharpSolutionEvents(projectManager: FSharpProjectOptionsManager) =
-
-    interface IVsSolutionEvents with
-
-        member __.OnAfterCloseSolution(_) =
-            projectManager.Reset ()
-            VSConstants.S_OK
-
-        member __.OnAfterLoadProject(_, _) = VSConstants.E_NOTIMPL
-
-        member __.OnAfterOpenProject(_, _) = VSConstants.E_NOTIMPL
-
-        member __.OnAfterOpenSolution(_, _) = VSConstants.E_NOTIMPL
-
-        member __.OnBeforeCloseProject(_, _) = VSConstants.E_NOTIMPL
-
-        member __.OnBeforeCloseSolution(_) = VSConstants.E_NOTIMPL
-
-        member __.OnBeforeUnloadProject(_, _) = VSConstants.E_NOTIMPL
-
-        member __.OnQueryCloseProject(_, _, _) = VSConstants.E_NOTIMPL
-
-        member __.OnQueryCloseSolution(_, _) = VSConstants.E_NOTIMPL
-
-        member __.OnQueryUnloadProject(_, _) = VSConstants.E_NOTIMPL       
+                member this.FSharpProjectOptionsManager = projectInfoManager }    
 
 [<Microsoft.CodeAnalysis.Host.Mef.ExportWorkspaceServiceFactory(typeof<EditorOptions>, Microsoft.CodeAnalysis.Host.Mef.ServiceLayer.Default)>]
 type internal FSharpSettingsFactory
@@ -170,8 +143,6 @@ type internal FSharpPackage() as this =
             vfsiToolWindow <- this.FindToolWindow(typeof<Microsoft.VisualStudio.FSharp.Interactive.FsiToolWindow>, 0, true) :?> Microsoft.VisualStudio.FSharp.Interactive.FsiToolWindow
         vfsiToolWindow :> Microsoft.VisualStudio.FSharp.Interactive.ITestVFSI
 
-    let mutable solutionEventsOpt = None
-
     // FSI-LINKAGE-POINT: unsited init
     do 
         Microsoft.VisualStudio.FSharp.Interactive.Hooks.fsiConsoleWindowPackageCtorUnsited (this :> Package)
@@ -191,15 +162,10 @@ type internal FSharpPackage() as this =
 
                     // FSI-LINKAGE-POINT: private method GetDialogPage forces fsi options to be loaded
                     let _fsiPropertyPage = this.GetDialogPage(typeof<Microsoft.VisualStudio.FSharp.Interactive.FsiPropertyPage>)
-                    let projectInfoManager = this.ComponentModel.DefaultExportProvider.GetExport<FSharpProjectOptionsManager>().Value
                     let solution = this.GetServiceAsync(typeof<SVsSolution>).Result
                     let solution = solution :?> IVsSolution
-                    let solutionEvents = FSharpSolutionEvents(projectInfoManager)
                     let rdt = this.GetServiceAsync(typeof<SVsRunningDocumentTable>).Result
                     let rdt = rdt :?> IVsRunningDocumentTable
-
-                    solutionEventsOpt <- Some(solutionEvents)
-                    solution.AdviseSolutionEvents(solutionEvents) |> ignore
 
                     let projectContextFactory = this.ComponentModel.GetService<IWorkspaceProjectContextFactory>()
                     let workspace = this.ComponentModel.GetService<VisualStudioWorkspace>()

--- a/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
@@ -19,8 +19,7 @@ open Microsoft.VisualStudio.LanguageServices.ProjectSystem
 open Microsoft.VisualStudio.Shell.Interop
 
 [<Sealed>]
-type internal LegacyProjectWorkspaceMap(solution: IVsSolution, 
-                                        projectInfoManager: FSharpProjectOptionsManager,
+type internal LegacyProjectWorkspaceMap(solution: IVsSolution,
                                         projectContextFactory: IWorkspaceProjectContextFactory) as this =
 
     let invalidPathChars = set (Path.GetInvalidPathChars())
@@ -136,8 +135,7 @@ type internal LegacyProjectWorkspaceMap(solution: IVsSolution,
                                             AdviseProjectSiteChanges(fun () -> this.SyncLegacyProject(projectContext, site)))
 
             site.AdviseProjectSiteClosed(FSharpConstants.FSharpLanguageServiceCallbackName, 
-                                            AdviseProjectSiteChanges(fun () -> 
-                                            projectInfoManager.RemoveProject(projectContext.Id)
+                                            AdviseProjectSiteChanges(fun () ->
                                             optionsAssociation.Remove(projectContext) |> ignore
                                             projectContext.Dispose()))
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
@@ -137,7 +137,7 @@ type internal LegacyProjectWorkspaceMap(solution: IVsSolution,
 
             site.AdviseProjectSiteClosed(FSharpConstants.FSharpLanguageServiceCallbackName, 
                                             AdviseProjectSiteChanges(fun () -> 
-                                            projectInfoManager.ClearInfoForProject(projectContext.Id)
+                                            projectInfoManager.RemoveProject(projectContext.Id)
                                             optionsAssociation.Remove(projectContext) |> ignore
                                             projectContext.Dispose()))
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/SingleFileWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SingleFileWorkspaceMap.fs
@@ -45,7 +45,7 @@ type internal SingleFileWorkspaceMap(workspace: VisualStudioWorkspace,
             if document.Project.Language = FSharpConstants.FSharpLanguageName && document.Project.Name <> FSharpConstants.FSharpMiscellaneousFilesName then
                 match files.TryRemove(document.FilePath) with
                 | true, projectContext ->
-                    optionsManager.ClearSingleFileOptionsCache(document.Id)
+                    optionsManager.RemoveSingleFile(document.Id)
                     projectContext.Dispose()
                 | _ -> ()
         )
@@ -54,7 +54,7 @@ type internal SingleFileWorkspaceMap(workspace: VisualStudioWorkspace,
             let document = args.Document
             match files.TryRemove(document.FilePath) with
             | true, projectContext ->
-                optionsManager.ClearSingleFileOptionsCache(document.Id)
+                optionsManager.RemoveSingleFile(document.Id)
                 projectContext.Dispose()
             | _ -> ()
         )
@@ -93,7 +93,7 @@ type internal SingleFileWorkspaceMap(workspace: VisualStudioWorkspace,
                         match documentOpt with
                         | None -> ()
                         | Some(document) ->                           
-                            optionsManager.ClearSingleFileOptionsCache(document.Id)
+                            optionsManager.RemoveSingleFile(document.Id)
                             projectContext.Dispose()
                             files.[pszMkDocumentNew] <- createProjectContext pszMkDocumentNew
                     else

--- a/vsintegration/tests/UnitTests/CacheTests.fs
+++ b/vsintegration/tests/UnitTests/CacheTests.fs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+namespace Microsoft.VisualStudio.FSharp.Editor.Tests.Roslyn
+
+open System.IO
+open System.Threading
+open NUnit.Framework
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Text
+open UnitTests.TestLib.LanguageService
+
+[<TestFixture; Category "Roslyn and FCS Integration"; NonParallelizable>]
+type CacheTests() =
+
+    let testPath = """C:\test\"""
+    let testFileName = "TestFile.fs"
+    let testFilePath = Path.Combine(testPath, testFileName)
+    let testFileSourceText = SourceText.From("""module TestProject.TestFile""")       
+
+    let createTestProjectInfo name =
+        let projectId = ProjectId.CreateNewId ()
+        let documentInfos =
+            [
+                DocumentInfo.Create (DocumentId.CreateNewId (projectId), testFileName)
+            ]
+        let dllPath = Path.Combine(testPath, name + ".dll")
+        let projectPath = Path.Combine(testPath, name + ".fsproj")
+        ProjectInfo.Create (projectId, VersionStamp.Create (), name, name, (* Can't use "F#" due to exception *) "C#", documents = documentInfos, outputFilePath = dllPath, filePath = projectPath)
+
+    let createSolutionInfoWithProjectCount projectCount =
+        let testProjectInfos = [ for i = 1 to projectCount do yield createTestProjectInfo ("Test" + string i) ]
+        let solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId (), VersionStamp.Create (), projects = testProjectInfos)
+        solutionInfo
+
+    let createCompilationEnvWithProjectCount projectCount =
+        let solutionInfo = createSolutionInfoWithProjectCount projectCount
+        let projectInfos = solutionInfo.Projects
+        let workspace = new AdhocWorkspace()
+        workspace.AddSolution solutionInfo |> ignore
+        
+        let cenv = FSharpCompilationHelpers.createCompilationEnv workspace checker (* enableInMemoryCrossProjectReferences *) true
+        
+        // This will go away when HandleCommandLineChanges goes away.
+        projectInfos
+        |> Seq.iter (fun testProjectInfo ->
+            cenv.cpsCommandLineOptions.[testProjectInfo.Id] <- ([|testFilePath|], [||])
+        )
+
+        (workspace, cenv)
+
+    let basicTest () =
+        let (workspace, cenv) = createCompilationEnvWithProjectCount 3 (* we chose 3 because the Checker's default project cache size is 3 by default *)
+        let checker = cenv.checker
+
+        checker.StopBackgroundCompile ()
+        checker.InvalidateAll ()
+
+        // We shouldn't have a current solution yet.
+        Assert.True (cenv.currentSolution.IsNone) 
+
+        let fsharpProjects =
+            workspace.CurrentSolution.Projects
+            |> Seq.map (fun project ->
+                FSharpCompilationHelpers.tryComputeOptions cenv project CancellationToken.None |> Async.RunSynchronously
+            )
+            |> List.ofSeq
+
+        // We still don't have a current solution yet.
+        Assert.True (cenv.currentSolution.IsNone)
+
+        FSharpCompilationHelpers.setSolution cenv workspace.CurrentSolution
+
+        // We should now have a current solution.
+        Assert.True (cenv.currentSolution.IsSome)
+
+        Assert.True (fsharpProjects |> List.forall (fun x -> x.IsSome))
+
+        let fsharpProjects = fsharpProjects |> List.map (fun x -> snd x.Value)
+
+        Assert.True (fsharpProjects |> List.forall (fun options ->  not (checker.ProjectExistsInAnyCache options |> Async.RunSynchronously)))
+
+        fsharpProjects
+        |> List.iter (fun options ->
+            // We don't care about the results, we only care that it will create an incremental builder for each project when we make a call.
+            checker.TryParseAndCheckFileInProject(options, testFilePath, testFileSourceText, "CacheTests") |> Async.RunSynchronously |> ignore
+        )
+
+        // Projects should now exist in the cache.
+        Assert.True (fsharpProjects |> List.forall (fun options ->  checker.ProjectExistsInAnyCache options |> Async.RunSynchronously))
+        (workspace, cenv)
+
+    [<Test>]
+    member __.ProjectCacheRemoveInvdividuallyBySolutionChanges () =
+        let (workspace, cenv) = basicTest ()
+        let checker = cenv.checker
+
+        let mutable solution = workspace.CurrentSolution
+        let projectIds = solution.ProjectIds
+        let fsharpProjects =
+            projectIds
+            |> Seq.map (fun projectId ->
+                let (_, _, options) = cenv.cache.[projectId]
+                options
+            ) |> List.ofSeq
+
+        Assert.AreEqual (3, projectIds.Count)
+
+        for i = 0 to projectIds.Count - 1 do
+            solution <- solution.RemoveProject projectIds.[i]
+            FSharpCompilationHelpers.setSolution cenv solution
+
+            // Remaining projects should still be in the cache.
+            for i = i + 1 to projectIds.Count - 1 do
+                Assert.True (cenv.cache.ContainsKey projectIds.[i])
+                Assert.True (cenv.cpsCommandLineOptions.ContainsKey projectIds.[i])
+                Assert.True (checker.ProjectExistsInAnyCache fsharpProjects.[i] |> Async.RunSynchronously)
+
+            Assert.False (cenv.cache.ContainsKey projectIds.[i])
+            Assert.False (cenv.cpsCommandLineOptions.ContainsKey projectIds.[i])
+            Assert.False (checker.ProjectExistsInAnyCache fsharpProjects.[i] |> Async.RunSynchronously)
+
+        workspace.Dispose ()
+
+    [<Test>]
+    member __.ProjectCacheRemoveAllByNewSolution () =
+        let (workspace, cenv) = basicTest ()
+        let checker = cenv.checker
+
+        let solution = workspace.CurrentSolution
+        let projectIds = solution.ProjectIds
+        let fsharpProjects =
+            projectIds
+            |> Seq.map (fun projectId ->
+                let (_, _, options) = cenv.cache.[projectId]
+                options
+            ) |> List.ofSeq
+
+        Assert.AreEqual (3, projectIds.Count)
+
+        workspace.ClearSolution ()
+        let solution = workspace.AddSolution (createSolutionInfoWithProjectCount 0)
+
+        FSharpCompilationHelpers.setSolution cenv solution
+
+        for i = 0 to projectIds.Count - 1 do
+            Assert.False (cenv.cache.ContainsKey projectIds.[i])
+            Assert.False (cenv.cpsCommandLineOptions.ContainsKey projectIds.[i])
+            Assert.False (checker.ProjectExistsInAnyCache fsharpProjects.[i] |> Async.RunSynchronously)
+
+        workspace.Dispose ()
+        
+        

--- a/vsintegration/tests/UnitTests/CacheTests.fs
+++ b/vsintegration/tests/UnitTests/CacheTests.fs
@@ -112,11 +112,9 @@ type CacheTests() =
             // Remaining projects should still be in the cache.
             for i = i + 1 to projectIds.Count - 1 do
                 Assert.True (cenv.cache.ContainsKey projectIds.[i])
-                Assert.True (cenv.cpsCommandLineOptions.ContainsKey projectIds.[i])
                 Assert.True (checker.ProjectExistsInAnyCache fsharpProjects.[i] |> Async.RunSynchronously)
 
             Assert.False (cenv.cache.ContainsKey projectIds.[i])
-            Assert.False (cenv.cpsCommandLineOptions.ContainsKey projectIds.[i])
             Assert.False (checker.ProjectExistsInAnyCache fsharpProjects.[i] |> Async.RunSynchronously)
 
         workspace.Dispose ()
@@ -144,7 +142,6 @@ type CacheTests() =
 
         for i = 0 to projectIds.Count - 1 do
             Assert.False (cenv.cache.ContainsKey projectIds.[i])
-            Assert.False (cenv.cpsCommandLineOptions.ContainsKey projectIds.[i])
             Assert.False (checker.ProjectExistsInAnyCache fsharpProjects.[i] |> Async.RunSynchronously)
 
         workspace.Dispose ()

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -110,6 +110,9 @@
     <Compile Include="..\..\..\tests\service\TreeVisitorTests.fs">
       <Link>CompilerService\TreeVisitorTests.fs</Link>
     </Compile>
+    <Compile Include="CacheTests.fs">
+      <Link>Roslyn\CacheTests.fs</Link>
+    </Compile>
     <Compile Include="ProjectOptionsBuilder.fs">
       <Link>Roslyn\ProjectOptionsBuilder.fs</Link>
     </Compile>


### PR DESCRIPTION
We had a bug where we didn't clear out FCS's caches when a solution was changed. This means, for example, switching configurations between Debug to Release, and vice versa, would cause a new solution to be created with completely different project ids; it would not clear the old projects from FCS out of its cache, effectively keeping them around.

This PR addresses the issue. It also adds a new API, `InvalidateProject`, to the compiler service that allows you to clear out a specific project from the incrementalbuilder cache. The API is used in FSharp.Editor when a solution has removed projects from itself.

This also does various cleanup; unified handling of single files with normal projects which means one cache in FSharpProjectOptionsManager.