### PR TITLE
publish test results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,22 @@ jobs:
                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                   /p:PublishToSymbolServer=true
                   /p:VisualStudioDropName=$(VisualStudioDropName)
+        - task: PublishTestResults@2
+          displayName: Publish Test Results
+          inputs:
+            testResultsFormat: 'NUnit'
+            testResultsFiles: '*.xml'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          continueOnError: true
+          condition: ne(variables['SkipTests'], 'true')
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Test Logs
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)'
+            ArtifactName: 'Test Logs'
+            publishLocation: Container
+          continueOnError: true
+          condition: ne(variables['SkipTests'], 'true')
         - task: PublishBuildArtifacts@1
           displayName: Publish Artifact Packages
           inputs:
@@ -140,6 +156,22 @@ jobs:
           clean: true
         - script: eng\CIBuild.cmd -configuration $(_configuration) -$(_testKind)
           displayName: Build / Test
+        - task: PublishTestResults@2
+          displayName: Publish Test Results
+          inputs:
+            testResultsFormat: 'NUnit'
+            testResultsFiles: '*.xml'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_configuration)'
+          continueOnError: true
+          condition: ne(variables['_testKind'], 'testFSharpQA')
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Test Logs
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(_configuration)'
+            ArtifactName: 'Windows $(_configuration) $(_testKind) test logs'
+            publishLocation: Container
+          continueOnError: true
+          condition: eq(variables['_testKind'], 'testFSharpQA')
 
       # Linux
       - job: Linux
@@ -153,6 +185,14 @@ jobs:
           clean: true
         - script: ./eng/cibuild.sh --configuration $(_BuildConfig) --testcoreclr
           displayName: Build / Test
+        - task: PublishTestResults@2
+          displayName: Publish Test Results
+          inputs:
+            testResultsFormat: 'NUnit'
+            testResultsFiles: '*.xml'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          continueOnError: true
+          condition: always()
 
       # MacOS
       - job: MacOS
@@ -166,6 +206,14 @@ jobs:
           clean: true
         - script: ./eng/cibuild.sh --configuration $(_BuildConfig) --testcoreclr
           displayName: Build / Test
+        - task: PublishTestResults@2
+          displayName: Publish Test Results
+          inputs:
+            testResultsFormat: 'NUnit'
+            testResultsFiles: '*.xml'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          continueOnError: true
+          condition: always()
 
       # Source Build Linux
       - job: SourceBuild_Linux
@@ -213,6 +261,14 @@ jobs:
           clean: true
         - script: fcs\build.cmd TestAndNuget
           displayName: Build / Test
+        - task: PublishTestResults@2
+          displayName: Publish Test Results
+          inputs:
+            testResultsFormat: 'NUnit'
+            testResultsFiles: '*.xml'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
+          continueOnError: true
+          condition: always()
 
       - job: Linux_FCS
         pool:


### PR DESCRIPTION
Add steps to publish test results that were inadvertently lost when PR builds migrated from `.vsts-ci.yaml` to `azure-pipelines.yml`.

~~Initial attempt also includes a hijacked test to force a failure.~~ See comment below for details about logs, hijacked tests have been restored.