### PR TITLE
Make FSharpAccessibility.IsProtected public, optimize IsPublic property

### DIFF
--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -34,7 +34,7 @@ type FSharpAccessibility(a:Accessibility, ?isProtected) =
         | _ when List.forall isInternalCompPath p  -> Internal 
         | _ -> Private
 
-    member __.IsPublic = not isProtected && match a with Public -> true | _ -> false
+    member __.IsPublic = not isProtected && match a with TAccess [] -> true | _ -> false
 
     member __.IsPrivate = not isProtected && match a with Private -> true | _ -> false
 

--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -25,17 +25,20 @@ type internal SymbolEnv =
 type public FSharpAccessibility = 
     internal new: Accessibility * ?isProtected: bool -> FSharpAccessibility
 
-    /// Indicates the symbol has public accessibility
-    member IsPublic : bool
+    /// Indicates the symbol has public accessibility.
+    member IsPublic: bool
 
-    /// Indicates the symbol has private accessibility
-    member IsPrivate : bool
+    /// Indicates the symbol has private accessibility.
+    member IsPrivate: bool
 
-    /// Indicates the symbol has internal accessibility
-    member IsInternal : bool
+    /// Indicates the symbol has internal accessibility.
+    member IsInternal: bool
+
+    /// Indicates the symbol has protected accessibility.
+    member IsProtected: bool
 
     /// The underlying Accessibility
-    member internal Contents : Accessibility
+    member internal Contents: Accessibility
 
 
 /// Represents the information needed to format types and other information in a style


### PR DESCRIPTION
Small changes to FSharpAccessibility in Symbols API.