### PR TITLE
Clean navigation

### DIFF
--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -441,10 +441,12 @@ module NavigationImpl =
         items |> Array.sortInPlaceWith (fun a b -> compare a.Declaration.Name b.Declaration.Name)
         new FSharpNavigationItems(items)
 
+[<RequireQualifiedAccess>]
+module FSharpNavigation =
     let getNavigation (parsedInput: ParsedInput) =
         match parsedInput with
-        | ParsedInput.SigFile (ParsedSigFileInput (modules = modules)) -> getNavigationFromSigFile modules
-        | ParsedInput.ImplFile (ParsedImplFileInput (modules = modules)) -> getNavigationFromImplFile modules
+        | ParsedInput.SigFile (ParsedSigFileInput (modules = modules)) -> NavigationImpl.getNavigationFromSigFile modules
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = modules)) -> NavigationImpl.getNavigationFromImplFile modules
 
     let empty = FSharpNavigationItems([||])
 

--- a/src/fsharp/service/ServiceNavigation.fsi
+++ b/src/fsharp/service/ServiceNavigation.fsi
@@ -60,12 +60,10 @@ type public FSharpNavigationTopLevelDeclaration =
 type public FSharpNavigationItems =
     member Declarations : FSharpNavigationTopLevelDeclaration[]
 
-// implementation details used by other code in the compiler    
-module internal NavigationImpl =
-    val internal getNavigationFromImplFile : Ast.SynModuleOrNamespace list -> FSharpNavigationItems
-    val internal getNavigationFromSigFile : Ast.SynModuleOrNamespaceSig list -> FSharpNavigationItems
-    val internal getNavigation : Ast.ParsedInput -> FSharpNavigationItems
+// Functionality to access navigable F# items.
+module public FSharpNavigation =
     val internal empty : FSharpNavigationItems
+    val getNavigation : Ast.ParsedInput -> FSharpNavigationItems
 
 module public NavigateTo =
     [<RequireQualifiedAccess>]

--- a/src/fsharp/service/ServiceUntypedParse.fs
+++ b/src/fsharp/service/ServiceUntypedParse.fs
@@ -111,15 +111,15 @@ type FSharpParseFileResults(errors: FSharpErrorInfo[], input: Ast.ParsedInput op
        ErrorScope.Protect Range.range0 
             (fun () -> 
                 match input with
-                | Some (ParsedInput.ImplFile (ParsedImplFileInput (modules = modules))) ->
-                    NavigationImpl.getNavigationFromImplFile modules 
-                | Some (ParsedInput.SigFile (ParsedSigFileInput _)) ->
-                    NavigationImpl.empty
+                | Some (ParsedInput.ImplFile(_) as p) ->
+                    FSharpNavigation.getNavigation p
+                | Some (ParsedInput.SigFile(_)) ->
+                    FSharpNavigation.empty
                 | _ -> 
-                    NavigationImpl.empty )
+                    FSharpNavigation.empty)
             (fun err -> 
                 Trace.TraceInformation(sprintf "FCS: recovering from error in GetNavigationItemsImpl: '%s'" err)
-                NavigationImpl.empty)   
+                FSharpNavigation.empty)
             
     member private scope.ValidateBreakpointLocationImpl pos =
         let isMatchRange m = rangeContainsPos m pos || m.StartLine = pos.Line

--- a/src/fsharp/service/ServiceUntypedParse.fs
+++ b/src/fsharp/service/ServiceUntypedParse.fs
@@ -111,9 +111,9 @@ type FSharpParseFileResults(errors: FSharpErrorInfo[], input: Ast.ParsedInput op
        ErrorScope.Protect Range.range0 
             (fun () -> 
                 match input with
-                | Some (ParsedInput.ImplFile(_) as p) ->
+                | Some (ParsedInput.ImplFile _ as p) ->
                     FSharpNavigation.getNavigation p
-                | Some (ParsedInput.SigFile(_)) ->
+                | Some (ParsedInput.SigFile _) ->
                     FSharpNavigation.empty
                 | _ -> 
                     FSharpNavigation.empty)

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigationBarItemService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigationBarItemService.fs
@@ -6,11 +6,9 @@ open System.Composition
 open System.Collections.Generic
 open System.Threading.Tasks
 
-open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Editor
 open Microsoft.CodeAnalysis.Navigation
 open Microsoft.CodeAnalysis.Host.Mef
-open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.Notification
 
 open FSharp.Compiler.SourceCodeServices
@@ -35,9 +33,9 @@ type internal FSharpNavigationBarItemService
                 let! parsingOptions, _options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document, cancellationToken)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! parsedInput = checkerProvider.Checker.ParseDocument(document, parsingOptions, sourceText=sourceText, userOpName=userOpName)
-                let navItems = NavigationImpl.getNavigation parsedInput
+                let navItems = FSharpNavigation.getNavigation parsedInput
                 let rangeToTextSpan range = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, range)
-                return 
+                return
                     navItems.Declarations
                     |> Array.choose (fun topLevelDecl ->
                         rangeToTextSpan(topLevelDecl.Declaration.Range)


### PR DESCRIPTION
Removes the internal reference to navigation stuff, opening up an API and consuming things that way uniformly. This was found by turning off our IVT to FSharp.Compiler.Private in FSharp.Editor.