### PR TITLE
Use FCS API for keywords instead of LexHelp internals

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -7,7 +7,6 @@ open System.Collections.Generic
 open System.Collections.Immutable
 open System.Threading
 open System.Threading.Tasks
-open System.Runtime.CompilerServices
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Completion
@@ -15,13 +14,10 @@ open Microsoft.CodeAnalysis.Options
 open Microsoft.CodeAnalysis.Text
 
 open Microsoft.VisualStudio.Shell
-open Microsoft.VisualStudio.Shell.Interop
 
 open FSharp.Compiler
 open FSharp.Compiler.Range
 open FSharp.Compiler.SourceCodeServices
-open System.Runtime.Caching
-open System.Collections.Concurrent
 
 module Logger = Microsoft.VisualStudio.FSharp.Editor.Logger
 
@@ -48,7 +44,7 @@ type internal FSharpCompletionProvider
     static let [<Literal>] IndexPropName = "Index"
 
     static let keywordCompletionItems =
-        Lexhelp.Keywords.keywordsWithDescription
+        Keywords.KeywordsWithDescription
         |> List.filter (fun (keyword, _) -> not (PrettyNaming.IsOperatorName keyword))
         |> List.sortBy (fun (keyword, _) -> keyword)
         |> List.mapi (fun n (keyword, description) ->

--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -57,7 +57,7 @@ type internal InlineRenameLocationSet(locations: InlineRenameLocation [], origin
                     match symbolKind with
                     | LexerSymbolKind.GenericTypeParameter
                     | LexerSymbolKind.StaticallyResolvedTypeParameter -> replacementText
-                    | _ -> Lexhelp.Keywords.NormalizeIdentifierBackticks replacementText
+                    | _ -> Keywords.NormalizeIdentifierBackticks replacementText
                 return 
                     { new IInlineRenameReplacementInfo with
                         member __.NewSolution = newSolution

--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -809,7 +809,7 @@ module internal Tokenizer =
                         else PrettyNaming.IsIdentifierPartCharacter c) 
         
         let isFixableIdentifier (s: string) = 
-            not (String.IsNullOrEmpty s) && Lexhelp.Keywords.NormalizeIdentifierBackticks s |> isIdentifier
+            not (String.IsNullOrEmpty s) && Keywords.NormalizeIdentifierBackticks s |> isIdentifier
         
         let forbiddenChars = [| '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '\"' |]
         


### PR DESCRIPTION
Removes another dependency on FSharp.Editor's IVT into FSharp.Compiler.Private. Also removes some unused `open` statements.