### PR TITLE
Removed reference counting from IncrementalBuilder; now relies on GC.

### DIFF
--- a/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <Import Project="..\..\src\buildtools\buildtools.targets" />
   <PropertyGroup>
@@ -543,17 +543,17 @@
     <Compile Include="$(FSharpSourcesRoot)\fsharp\symbols\SymbolPatterns.fs">
       <Link>Symbols/SymbolPatterns.fs</Link>
     </Compile>
-    <Compile Include="$(FSharpSourcesRoot)\fsharp\service\IncrementalBuild.fsi">
-      <Link>Service/IncrementalBuild.fsi</Link>
-    </Compile>
-    <Compile Include="$(FSharpSourcesRoot)\fsharp\service\IncrementalBuild.fs">
-      <Link>Service/IncrementalBuild.fs</Link>
-    </Compile>
     <Compile Include="$(FSharpSourcesRoot)\fsharp\service\Reactor.fsi">
       <Link>Service/Reactor.fsi</Link>
     </Compile>
     <Compile Include="$(FSharpSourcesRoot)\fsharp\service\Reactor.fs">
       <Link>Service/Reactor.fs</Link>
+    </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\service\IncrementalBuild.fsi">
+      <Link>Service/IncrementalBuild.fsi</Link>
+    </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\service\IncrementalBuild.fs">
+      <Link>Service/IncrementalBuild.fs</Link>
     </Compile>
     <Compile Include="$(FSharpSourcesRoot)\fsharp\service\ServiceConstants.fs">
       <Link>Service/ServiceConstants.fs</Link>

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3783,7 +3783,7 @@ and TcImportsWeakHack (tcImports: WeakReference<TcImports>) =
 #endif          
 /// Represents a table of imported assemblies with their resolutions.
 /// Is a disposable object, but it is recommended not to explicitly call Dispose unless you absolutely know nothing will be using its contents after the disposal.
-/// Otherwise, simply allow the GC to collect this and it will properly call Dispose from the Finalizer.
+/// Otherwise, simply allow the GC to collect this and it will properly call Dispose from the finalizer.
 and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAssemblyResolutions, importsBase: TcImports option, ilGlobalsOpt, typeProviderThread: ITypeProviderThread) as this = 
 
     let mutable resolutions = initialResolutions

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3848,7 +3848,9 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
             dllTable
             
 #if !NO_EXTENSIONTYPING
-    member tcImports.Weak = tcImportsWeak
+    member tcImports.Weak = 
+            CheckDisposed()
+            tcImportsWeak
 #endif
         
     member tcImports.RegisterCcu ccuInfo =

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1964,7 +1964,7 @@ type ResolvedExtensionReference = ResolvedExtensionReference of string * Assembl
 
 type ITypeProviderThread =
 
-    abstract EnqueueWorkAndWait: (unit -> 'T) -> 'T
+    abstract EnqueueWork: (unit -> unit) -> unit
 #endif
 
 type ImportedBinary = 
@@ -2278,7 +2278,7 @@ type TcConfigBuilder =
           continueAfterParseFailure = false
 #if !NO_EXTENSIONTYPING
           showExtensionTypeMessages = false
-          typeProviderThread = { new ITypeProviderThread with member __.EnqueueWorkAndWait work = work () }
+          typeProviderThread = { new ITypeProviderThread with member __.EnqueueWork work = work () }
 #endif
           pause = false 
           alwaysCallVirt = true
@@ -3815,7 +3815,7 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
         let actions = disposeTypeProviderActions
         disposeTypeProviderActions <- []
         if actions.Length > 0 then
-            typeProviderThread.EnqueueWorkAndWait (fun () -> for action in actions do action())
+            typeProviderThread.EnqueueWork (fun () -> for action in actions do action())
 #endif
         let actions = disposeActions
         disposeActions <- []

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -603,7 +603,7 @@ type TcAssemblyResolutions =
 
 /// Represents a table of imported assemblies with their resolutions.
 /// Is a disposable object, but it is recommended not to explicitly call Dispose unless you absolutely know nothing will be using its contents after the disposal.
-/// Otherwise, simply allow the GC to collect this and it will properly call Dispose from the Finalizer.
+/// Otherwise, simply allow the GC to collect this and it will properly call Dispose from the finalizer.
 [<Sealed>] 
 type TcImports =
     interface System.IDisposable

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -207,16 +207,15 @@ type UnresolvedAssemblyReference = UnresolvedAssemblyReference of string * Assem
 
 #if !NO_EXTENSIONTYPING
 type ResolvedExtensionReference = ResolvedExtensionReference of string * AssemblyReference list * Tainted<ITypeProvider> list
+#endif
 
-/// The thread in which type provider calls will be enqueued and done work on.
-/// Type provider calls must be executed on the same thread sequentially. Type provider authors expect this.
+/// The thread in which compilation calls will be enqueued and done work on.
 /// Note: This is currently only used when disposing of type providers and will be extended to all the other type provider calls when compilations can be done in parallel.
 ///       Right now all calls in FCS to type providers are single-threaded through use of the reactor thread. 
-type ITypeProviderThread =
+type ICompilationThread =
 
-    /// Enqueue work to be done on the type provider thread.
-    abstract EnqueueWork: (unit -> unit) -> unit
-#endif
+    /// Enqueue work to be done on a compilation thread.
+    abstract EnqueueWork: (CompilationThreadToken -> unit) -> unit
 
 [<RequireQualifiedAccess>]
 type CompilerTarget = 
@@ -359,8 +358,8 @@ type TcConfigBuilder =
       mutable continueAfterParseFailure: bool
 #if !NO_EXTENSIONTYPING
       mutable showExtensionTypeMessages: bool
-      mutable typeProviderThread: ITypeProviderThread
 #endif
+      mutable compilationThread: ICompilationThread
       mutable pause: bool 
       mutable alwaysCallVirt: bool
       mutable noDebugData: bool
@@ -519,8 +518,8 @@ type TcConfig =
     member continueAfterParseFailure: bool
 #if !NO_EXTENSIONTYPING
     member showExtensionTypeMessages: bool
-    member typeProviderThread: ITypeProviderThread
 #endif
+    member compilationThread: ICompilationThread
     member pause: bool 
     member alwaysCallVirt: bool
     member noDebugData: bool

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -215,8 +215,7 @@ type ResolvedExtensionReference = ResolvedExtensionReference of string * Assembl
 type ITypeProviderThread =
 
     /// Enqueue work to be done on the type provider thread.
-    /// This is a synchronous call.
-    abstract EnqueueWorkAndWait: (unit -> 'T) -> 'T
+    abstract EnqueueWork: (unit -> unit) -> unit
 #endif
 
 [<RequireQualifiedAccess>]

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -560,6 +560,12 @@
     <Compile Include="..\symbols\SymbolPatterns.fs">
       <Link>Symbols/SymbolPatterns.fs</Link>
     </Compile>
+    <Compile Include="..\service\Reactor.fsi">
+      <Link>Service/Reactor.fsi</Link>
+    </Compile>
+    <Compile Include="..\service\Reactor.fs">
+      <Link>Service/Reactor.fs</Link>
+    </Compile>
 
     <!-- the incremental builder and service . -->
     <Compile Include="..\service\IncrementalBuild.fsi">
@@ -567,12 +573,6 @@
     </Compile>
     <Compile Include="..\service\IncrementalBuild.fs">
       <Link>Service/IncrementalBuild.fs</Link>
-    </Compile>
-    <Compile Include="..\service\Reactor.fsi">
-      <Link>Service/Reactor.fsi</Link>
-    </Compile>
-    <Compile Include="..\service\Reactor.fs">
-      <Link>Service/Reactor.fs</Link>
     </Compile>
     <Compile Include="..\service\ServiceConstants.fs">
       <Link>Service/ServiceConstants.fs</Link>

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1752,11 +1752,10 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
 #if !NO_EXTENSIONTYPING
                 tcConfigB.typeProviderThread <- 
                     { new ITypeProviderThread with 
-                        member __.EnqueueWorkAndWait work = 
-                            Reactor.Singleton.EnqueueAndAwaitOpAsync ("Unknown", "ITypeProvider.EnqueueWorkAndWait", "work", fun _ ->
-                                // not cancellable
-                                Cancellable.ret (work ())
-                            ) |> Async.RunSynchronously
+                        member __.EnqueueWork work = 
+                            Reactor.Singleton.EnqueueOp ("Unknown", "ITypeProvider.EnqueueWorkAndWait", "work", fun _ ->
+                                work ()
+                            )
                     }
 #endif
 

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1753,7 +1753,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                 tcConfigB.typeProviderThread <- 
                     { new ITypeProviderThread with 
                         member __.EnqueueWork work = 
-                            Reactor.Singleton.EnqueueOp ("Unknown", "ITypeProvider.EnqueueWorkAndWait", "work", fun _ ->
+                            Reactor.Singleton.EnqueueOp ("Unknown", "ITypeProvider.EnqueueWork", "work", fun _ ->
                                 work ()
                             )
                     }

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1211,7 +1211,9 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                         keepAssemblyContents, keepAllBackgroundResolutions, maxTimeShareMilliseconds) =
 
     let tcConfigP = TcConfigProvider.Constant tcConfig
+#if !NO_EXTENSIONTYPING
     let importsInvalidated = new Event<string>()
+#endif
     let fileParsed = new Event<string>()
     let beforeFileChecked = new Event<string>()
     let fileChecked = new Event<string>()
@@ -1242,26 +1244,9 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
            for (_, f, _) in sourceFiles do
                 yield f |]
 
-    // The IncrementalBuilder needs to hold up to one item that needs to be disposed, which is the tcImports for the incremental
-    // build. 
-    let mutable cleanupItem = None: TcImports option
-    let disposeCleanupItem() =
-            match cleanupItem with 
-            | None -> ()
-            | Some item -> 
-                cleanupItem <- None
-                dispose item 
-
-    let setCleanupItem x = 
-            assert cleanupItem.IsNone
-            cleanupItem <- Some x
-
-    let mutable disposed = false
-    let assertNotDisposed() =
-        if disposed then  
-            System.Diagnostics.Debug.Assert(false, "IncrementalBuild object has already been disposed!")
-
-    let mutable referenceCount = 0
+#if !NO_EXTENSIONTYPING
+    let mutable isInvalidatedByTypeProviders = false
+#endif
 
     //----------------------------------------------------
     // START OF BUILD TASK FUNCTIONS 
@@ -1270,14 +1255,12 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     ///
     /// Get the timestamp of the given file name.
     let StampFileNameTask (cache: TimeStampCache) _ctok (_m: range, filename: string, _isLastCompiland) =
-        assertNotDisposed()
         cache.GetFileTimeStamp filename
 
     /// This is a build task function that gets placed into the build rules as the computation for a VectorMap
     ///
     /// Parse the given file and return the given input.
     let ParseTask ctok (sourceRange: range, filename: string, isLastCompiland) =
-        assertNotDisposed()
         DoesNotRequireCompilerThreadTokenAndCouldPossiblyBeMadeConcurrent  ctok
 
         let errorLogger = CompilationErrorLogger("ParseTask", tcConfig.errorSeverityOptions)
@@ -1300,7 +1283,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     ///
     /// Timestamps of referenced assemblies are taken from the file's timestamp.
     let StampReferencedAssemblyTask (cache: TimeStampCache) ctok (_ref, timeStamper) =
-        assertNotDisposed()
         timeStamper cache ctok
                 
          
@@ -1309,7 +1291,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     // Link all the assemblies together and produce the input typecheck accumulator               
     let CombineImportedAssembliesTask ctok _ : Cancellable<TypeCheckAccumulator> =
       cancellable {
-        assertNotDisposed()
         let errorLogger = CompilationErrorLogger("CombineImportedAssembliesTask", tcConfig.errorSeverityOptions)
         // Return the disposable object that cleans up
         use _holder = new CompilationGlobalsScope(errorLogger, BuildPhase.Parameter)
@@ -1317,10 +1298,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         let! tcImports = 
           cancellable {
             try
-                // We dispose any previous tcImports, for the case where a dependency changed which caused this part
-                // of the partial build to be re-evaluated.
-                disposeCleanupItem()
-
                 let! tcImports = TcImports.BuildNonFrameworkTcImports(ctok, tcConfigP, tcGlobals, frameworkTcImports, nonFrameworkResolutions, unresolvedReferences)  
 #if !NO_EXTENSIONTYPING
                 tcImports.GetCcusExcludingBase() |> Seq.iter (fun ccu -> 
@@ -1342,15 +1319,8 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                     ccu.Deref.InvalidateEvent.Add(fun msg -> 
                         match capturedImportsInvalidated.TryGetTarget() with 
                         | true, tg -> tg.Trigger msg
-                        | _ -> ()))
+                        | _ -> ()))  
 #endif
-                    
-                    
-                // The tcImports must be cleaned up if this builder ever gets disposed. We also dispose any previous
-                // tcImports should we be re-creating an entry because a dependency changed which caused this part
-                // of the partial build to be re-evaluated.
-                setCleanupItem tcImports
-
                 return tcImports
             with e -> 
                 System.Diagnostics.Debug.Assert(false, sprintf "Could not BuildAllReferencedDllTcImports %A" e)
@@ -1390,7 +1360,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     ///
     /// Type check all files.     
     let TypeCheckTask ctok (tcAcc: TypeCheckAccumulator) input: Eventually<TypeCheckAccumulator> =    
-        assertNotDisposed()
         match input with 
         | Some input, _sourceRange, filename, parseErrors->
             IncrementalBuilderEventTesting.MRU.Add(IncrementalBuilderEventTesting.IBETypechecked filename)
@@ -1462,7 +1431,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     /// Finish up the typechecking to produce outputs for the rest of the compilation process
     let FinalizeTypeCheckTask ctok (tcStates: TypeCheckAccumulator[]) = 
       cancellable {
-        assertNotDisposed()
         DoesNotRequireCompilerThreadTokenAndCouldPossiblyBeMadeConcurrent  ctok
 
         let errorLogger = CompilationErrorLogger("CombineImportedAssembliesTask", tcConfig.errorSeverityOptions)
@@ -1568,7 +1536,11 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     // END OF BUILD DESCRIPTION
     // ---------------------------------------------------------------------------------------------            
 
-    do IncrementalBuilderEventTesting.MRU.Add(IncrementalBuilderEventTesting.IBECreated)
+    do 
+        IncrementalBuilderEventTesting.MRU.Add(IncrementalBuilderEventTesting.IBECreated)
+#if !NO_EXTENSIONTYPING
+        importsInvalidated.Publish.Add (fun _ -> isInvalidatedByTypeProviders <- true)
+#endif
 
     let buildInputs = [ BuildInput.VectorInput (fileNamesNode, sourceFiles)
                         BuildInput.VectorInput (referencedAssembliesNode, nonFrameworkAssemblyInputs) ]
@@ -1581,21 +1553,11 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         partialBuild <- b
 
     let MaxTimeStampInDependencies cache (ctok: CompilationThreadToken) (output: INode) = 
-        IncrementalBuild.MaxTimeStampInDependencies cache ctok output.Name partialBuild 
+        IncrementalBuild.MaxTimeStampInDependencies cache ctok output.Name partialBuild
 
-    member this.IncrementUsageCount() = 
-        assertNotDisposed() 
-        System.Threading.Interlocked.Increment(&referenceCount) |> ignore
-        { new System.IDisposable with member __.Dispose() = this.DecrementUsageCount() }
-
-    member __.DecrementUsageCount() = 
-        assertNotDisposed()
-        let currentValue =  System.Threading.Interlocked.Decrement(&referenceCount)
-        if currentValue = 0 then 
-                disposed <- true
-                disposeCleanupItem()
-
-    member __.IsAlive = referenceCount > 0
+#if !NO_EXTENSIONTYPING
+    member __.IsInvalidatedByTypeProviders = isInvalidatedByTypeProviders
+#endif
 
     member __.TcConfig = tcConfig
 
@@ -1610,17 +1572,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     member __.ImportedCcusInvalidated = importsInvalidated.Publish
 
     member __.AllDependenciesDeprecated = allDependencies
-
-#if !NO_EXTENSIONTYPING
-    member __.ThereAreLiveTypeProviders = 
-        let liveTPs =
-            match cleanupItem with 
-            | None -> []
-            | Some tcImports -> [for ia in tcImports.GetImportedAssemblies() do yield! ia.TypeProviders]
-        match liveTPs with
-        | [] -> false
-        | _ -> true                
-#endif
 
     member __.Step (ctok: CompilationThreadToken) =  
       cancellable {
@@ -1887,11 +1838,3 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
 
         return builderOpt, diagnostics
       }
-
-    static member KeepBuilderAlive (builderOpt: IncrementalBuilder option) = 
-        match builderOpt with 
-        | Some builder -> builder.IncrementUsageCount() 
-        | None -> { new System.IDisposable with member __.Dispose() = () }
-
-    member __.IsBeingKeptAliveApartFromCacheEntry = (referenceCount >= 2)
-

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1749,15 +1749,13 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                 // Never open PDB files for the language service, even if --standalone is specified
                 tcConfigB.openDebugInformationForLaterStaticLinking <- false
 
-#if !NO_EXTENSIONTYPING
-                tcConfigB.typeProviderThread <- 
-                    { new ITypeProviderThread with 
+                tcConfigB.compilationThread <- 
+                    { new ICompilationThread with 
                         member __.EnqueueWork work = 
-                            Reactor.Singleton.EnqueueOp ("Unknown", "ITypeProvider.EnqueueWork", "work", fun _ ->
-                                work ()
+                            Reactor.Singleton.EnqueueOp ("Unknown", "ICompilationThread.EnqueueWork", "work", fun ctok ->
+                                work ctok
                             )
                     }
-#endif
 
                 tcConfigB, sourceFilesNew
 

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1218,6 +1218,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
 #if !NO_EXTENSIONTYPING
     let importsInvalidatedByTypeProvider = new Event<string>()
 #endif
+    let mutable currentTcImportsOpt = None
 
     // Check for the existence of loaded sources and prepend them to the sources list if present.
     let sourceFiles = tcConfig.GetAvailableLoadedSources() @ (sourceFiles |>List.map (fun s -> rangeStartup, s))
@@ -1317,6 +1318,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                         | true, tg -> tg.Trigger msg
                         | _ -> ()))  
 #endif
+                currentTcImportsOpt <- Some tcImports
                 return tcImports
             with e -> 
                 System.Diagnostics.Debug.Assert(false, sprintf "Could not BuildAllReferencedDllTcImports %A" e)
@@ -1560,6 +1562,8 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
 #if !NO_EXTENSIONTYPING
     member __.ImportsInvalidatedByTypeProvider = importsInvalidatedByTypeProvider.Publish
 #endif
+
+    member __.TryGetCurrentTcImports () = currentTcImportsOpt
 
     member __.AllDependenciesDeprecated = allDependencies
 

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -80,11 +80,6 @@ type internal PartialCheckResults =
 [<Class>]
 type internal IncrementalBuilder = 
 
-#if !NO_EXTENSIONTYPING
-      /// Check if the builder is invalidated by type providers.
-      member IsInvalidatedByTypeProviders : bool
-#endif
-
       /// The TcConfig passed in to the builder creation.
       member TcConfig : TcConfig
 
@@ -106,8 +101,10 @@ type internal IncrementalBuilder =
       /// overall analysis results for the project will be quick.
       member ProjectChecked : IEvent<unit>
 
+#if !NO_EXTENSIONTYPING
       /// Raised when a type provider invalidates the build.
-      member ImportedCcusInvalidated : IEvent<string>
+      member ImportsInvalidatedByTypeProvider : IEvent<string>
+#endif
 
       /// The list of files the build depends on
       member AllDependenciesDeprecated : string[]

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -106,6 +106,9 @@ type internal IncrementalBuilder =
       member ImportsInvalidatedByTypeProvider : IEvent<string>
 #endif
 
+      /// Tries to get the current successful TcImports. This is only used in testing. Do not use it for other stuff.
+      member TryGetCurrentTcImports : unit -> TcImports option
+
       /// The list of files the build depends on
       member AllDependenciesDeprecated : string[]
 

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -80,8 +80,10 @@ type internal PartialCheckResults =
 [<Class>]
 type internal IncrementalBuilder = 
 
-      /// Check if the builder is not disposed
-      member IsAlive : bool
+#if !NO_EXTENSIONTYPING
+      /// Check if the builder is invalidated by type providers.
+      member IsInvalidatedByTypeProviders : bool
+#endif
 
       /// The TcConfig passed in to the builder creation.
       member TcConfig : TcConfig
@@ -109,10 +111,7 @@ type internal IncrementalBuilder =
 
       /// The list of files the build depends on
       member AllDependenciesDeprecated : string[]
-#if !NO_EXTENSIONTYPING
-      /// Whether there are any 'live' type providers that may need a refresh when a project is Cleaned
-      member ThereAreLiveTypeProviders : bool
-#endif
+
       /// Perform one step in the F# build. Return true if the background work is finished.
       member Step : CompilationThreadToken -> Cancellable<bool>
 
@@ -163,13 +162,6 @@ type internal IncrementalBuilder =
       member GetParseResultsForFile : CompilationThreadToken * filename:string -> Cancellable<Ast.ParsedInput option * Range.range * string * (PhasedDiagnostic * FSharpErrorSeverity)[]>
 
       static member TryCreateBackgroundBuilderForProjectOptions : CompilationThreadToken * ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * FrameworkImportsCache * scriptClosureOptions:LoadClosure option * sourceFiles:string list * commandLineArgs:string list * projectReferences: IProjectReference list * projectDirectory:string * useScriptResolutionRules:bool * keepAssemblyContents: bool * keepAllBackgroundResolutions: bool * maxTimeShareMilliseconds: int64 * tryGetMetadataSnapshot: ILBinaryReader.ILReaderTryGetMetadataSnapshot * suggestNamesForErrors: bool -> Cancellable<IncrementalBuilder option * FSharpErrorInfo[]>
-
-      /// Increment the usage count on the IncrementalBuilder by 1. This initial usage count is 0 so immediately after creation 
-      /// a call to KeepBuilderAlive should be made. The returns an IDisposable which will 
-      /// decrement the usage count and dispose if the usage count goes to zero
-      static member KeepBuilderAlive : IncrementalBuilder option -> IDisposable
-
-      member IsBeingKeptAliveApartFromCacheEntry : bool
 
 /// Generalized Incremental Builder. This is exposed only for unittesting purposes.
 module internal IncrementalBuild =

--- a/src/fsharp/service/ServiceDeclarationLists.fs
+++ b/src/fsharp/service/ServiceDeclarationLists.fs
@@ -492,11 +492,12 @@ type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: strin
     member __.StructuredDescriptionTextAsync = 
         let userOpName = "ToolTip"
         match info with
-        | Choice1Of2 (_, _, _, _, reactor:IReactorOperations) -> 
+        | Choice1Of2 (items: CompletionItem list, infoReader, m, denv, reactor:IReactorOperations) -> 
             // reactor causes the lambda to execute on the background compiler thread, through the Reactor
             reactor.EnqueueAndAwaitOpAsync (userOpName, "StructuredDescriptionTextAsync", name, fun ctok -> 
                 RequireCompilationThread ctok
-                cancellable.Return(FSharpToolTipText [ FSharpStructuredToolTipElement.Single(wordL (tagText (FSComp.SR.descriptionUnavailable())), FSharpXmlDoc.None) ]))
+                cancellable.Return(FSharpToolTipText(items |> List.map (fun x -> SymbolHelpers.FormatStructuredDescriptionOfItem true infoReader m denv x.ItemWithInst)))
+            )
             | Choice2Of2 result -> 
                 async.Return result
 

--- a/src/fsharp/service/ServiceDeclarationLists.fs
+++ b/src/fsharp/service/ServiceDeclarationLists.fs
@@ -492,19 +492,11 @@ type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: strin
     member __.StructuredDescriptionTextAsync = 
         let userOpName = "ToolTip"
         match info with
-        | Choice1Of2 (items: CompletionItem list, infoReader, m, denv, reactor:IReactorOperations, checkAlive) -> 
+        | Choice1Of2 (_, _, _, _, reactor:IReactorOperations) -> 
             // reactor causes the lambda to execute on the background compiler thread, through the Reactor
             reactor.EnqueueAndAwaitOpAsync (userOpName, "StructuredDescriptionTextAsync", name, fun ctok -> 
                 RequireCompilationThread ctok
-                // This is where we do some work which may touch TAST data structures owned by the IncrementalBuilder - infoReader, item etc. 
-                // It is written to be robust to a disposal of an IncrementalBuilder, in which case it will just return the empty string. 
-                // It is best to think of this as a "weak reference" to the IncrementalBuilder, i.e. this code is written to be robust to its
-                // disposal. Yes, you are right to scratch your head here, but this is ok.
-                cancellable.Return(
-                    if checkAlive() then 
-                        FSharpToolTipText(items |> List.map (fun x -> SymbolHelpers.FormatStructuredDescriptionOfItem true infoReader m denv x.ItemWithInst))
-                    else 
-                        FSharpToolTipText [ FSharpStructuredToolTipElement.Single(wordL (tagText (FSComp.SR.descriptionUnavailable())), FSharpXmlDoc.None) ]))
+                cancellable.Return(FSharpToolTipText [ FSharpStructuredToolTipElement.Single(wordL (tagText (FSComp.SR.descriptionUnavailable())), FSharpXmlDoc.None) ]))
             | Choice2Of2 result -> 
                 async.Return result
 
@@ -559,7 +551,7 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[], isForT
     member __.IsError = isError
 
     // Make a 'Declarations' object for a set of selected items
-    static member Create(infoReader:InfoReader, m, denv, getAccessibility, items: CompletionItem list, reactor, currentNamespaceOrModule: string[] option, isAttributeApplicationContext: bool, checkAlive) = 
+    static member Create(infoReader:InfoReader, m: range, denv, getAccessibility, items: CompletionItem list, reactor, currentNamespaceOrModule: string[] option, isAttributeApplicationContext: bool) = 
         let g = infoReader.g
         let isForType = items |> List.exists (fun x -> x.Type.IsSome)
         let items = items |> SymbolHelpers.RemoveExplicitlySuppressedCompletionItems g
@@ -697,7 +689,7 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[], isForT
                             | ns -> Some (System.String.Join(".", ns)))
 
                     FSharpDeclarationListItem(
-                        name, nameInCode, fullName, glyph, Choice1Of2 (items, infoReader, m, denv, reactor, checkAlive), getAccessibility item.Item,
+                        name, nameInCode, fullName, glyph, Choice1Of2 (items, infoReader, m, denv, reactor), getAccessibility item.Item,
                         item.Kind, item.IsOwnMember, item.MinorPriority, item.Unresolved.IsNone, namespaceToOpen))
 
         new FSharpDeclarationListInfo(Array.ofList decls, isForType, false)

--- a/src/fsharp/service/ServiceDeclarationLists.fsi
+++ b/src/fsharp/service/ServiceDeclarationLists.fsi
@@ -67,7 +67,7 @@ type public FSharpDeclarationListInfo =
     member IsError : bool
 
     // Implementation details used by other code in the compiler    
-    static member internal Create : infoReader:InfoReader * m:range * denv:DisplayEnv * getAccessibility:(Item -> FSharpAccessibility option) * items:CompletionItem list * reactor:IReactorOperations * currentNamespace:string[] option * isAttributeApplicationContex:bool * checkAlive:(unit -> bool) -> FSharpDeclarationListInfo
+    static member internal Create : infoReader:InfoReader * m:range * denv:DisplayEnv * getAccessibility:(Item -> FSharpAccessibility option) * items:CompletionItem list * reactor:IReactorOperations * currentNamespace:string[] option * isAttributeApplicationContex:bool -> FSharpDeclarationListInfo
 
     static member internal Error : message:string -> FSharpDeclarationListInfo
 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1956,6 +1956,11 @@ type FSharpCheckFileResults(filename: string, errors: FSharpErrorInfo[], scopeOp
     member info.Errors = errors
 
     member info.HasFullTypeCheckInfo = details.IsSome
+
+    member info.TryGetCurrentTcImports () =
+        match builderX with
+        | Some builder -> builder.TryGetCurrentTcImports ()
+        | _ -> None
     
     /// Intellisense autocompletions
     member info.GetDeclarationListInfo(parseResultsOpt, line, lineStr, partialName, ?getAllEntities, ?hasTextChangedSinceLastTypecheck, ?userOpName: string) = 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1941,29 +1941,8 @@ type FSharpCheckProjectResults(projectFileName:string, tcConfigOption, keepAssem
 // the corresponding background builder to be alive. That is, they are simply plain-old-data through pre-formatting of all result text.
 type FSharpCheckFileResults(filename: string, errors: FSharpErrorInfo[], scopeOptX: TypeCheckInfo option, dependencyFiles: string[], builderX: IncrementalBuilder option, reactorOpsX:IReactorOperations, keepAssemblyContents: bool) =
 
-    // This may be None initially, or may be set to None when the object is disposed or finalized
+    // This may be None initially.
     let mutable details = match scopeOptX with None -> None | Some scopeX -> Some (scopeX, builderX, reactorOpsX)
-
-    // Increment the usage count on the IncrementalBuilder. We want to keep the IncrementalBuilder and all associated
-    // resources and type providers alive for the duration of the lifetime of this object.
-    let decrementer = 
-        match details with 
-        | Some (_,builderOpt,_) -> IncrementalBuilder.KeepBuilderAlive builderOpt
-        | _ -> { new System.IDisposable with member x.Dispose() = () } 
-
-    let mutable disposed = false
-
-    let dispose() = 
-       if not disposed then 
-           disposed <- true 
-           match details with 
-           | Some (_,_,reactor) -> 
-               // Make sure we run disposal in the reactor thread, since it may trigger type provider disposals etc.
-               details <- None
-               reactor.EnqueueOp ("GCFinalizer","FSharpCheckFileResults.DecrementUsageCountOnIncrementalBuilder", filename, fun ctok -> 
-                   RequireCompilationThread ctok
-                   decrementer.Dispose())
-           | _ -> () 
 
     // Run an operation that needs to access a builder and be run in the reactor thread
     let reactorOp userOpName opName dflt f = 
@@ -1971,12 +1950,12 @@ type FSharpCheckFileResults(filename: string, errors: FSharpErrorInfo[], scopeOp
         match details with
         | None -> 
             return dflt
-        | Some (_, Some builder, _) when not builder.IsAlive -> 
-            System.Diagnostics.Debug.Assert(false,"unexpected dead builder") 
+#if !NO_EXTENSIONTYPING
+        | Some (_, Some builder, _) when not builder.IsInvalidatedByTypeProviders -> 
+            System.Diagnostics.Debug.Assert(false,"builder invalidated by type providers") 
             return dflt
-        | Some (scope, builderOpt, reactor) -> 
-            // Increment the usage count to ensure the builder doesn't get released while running operations asynchronously. 
-            use _unwind = IncrementalBuilder.KeepBuilderAlive builderOpt
+#endif
+        | Some (scope, _, reactor) -> 
             let! res = reactor.EnqueueAndAwaitOpAsync(userOpName, opName, filename, fun ctok ->  f ctok scope |> cancellable.Return)
             return res
       }
@@ -1986,10 +1965,6 @@ type FSharpCheckFileResults(filename: string, errors: FSharpErrorInfo[], scopeOp
         match details with
         | None -> dflt()
         | Some (scope, _builderOpt, _ops) -> f scope
-
-    // At the moment we only dispose on finalize - we never explicitly dispose these objects. Explicitly disposing is not
-    // really worth much since the underlying project builds are likely to still be in the incrementalBuilder cache.
-    override info.Finalize() = dispose() 
 
     member info.Errors = errors
 
@@ -2388,9 +2363,6 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                    options.UseScriptResolutionRules, keepAssemblyContents, keepAllBackgroundResolutions, maxTimeShareMilliseconds,
                    tryGetMetadataSnapshot, suggestNamesForErrors)
 
-        // We're putting the builder in the cache, so increment its count.
-        let decrement = IncrementalBuilder.KeepBuilderAlive builderOpt
-
         match builderOpt with 
         | None -> ()
         | Some builder -> 
@@ -2410,7 +2382,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
             builder.FileChecked.Add (fun file -> fileChecked.Trigger(file, options.ExtraProjectInfo))
             builder.ProjectChecked.Add (fun () -> projectChecked.Trigger (options.ProjectFileName, options.ExtraProjectInfo))
 
-        return (builderOpt, diagnostics, decrement)
+        return (builderOpt, diagnostics)
       }
 
     // STATIC ROOT: FSharpLanguageServiceTestable.FSharpChecker.backgroundCompiler.incrementalBuildersCache. This root typically holds more 
@@ -2419,27 +2391,23 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     // 
     /// Cache of builds keyed by options.        
     let incrementalBuildersCache = 
-        MruCache<CompilationThreadToken, FSharpProjectOptions, (IncrementalBuilder option * FSharpErrorInfo[] * IDisposable)>
+        MruCache<CompilationThreadToken, FSharpProjectOptions, (IncrementalBuilder option * FSharpErrorInfo[])>
                 (keepStrongly=projectCacheSize, keepMax=projectCacheSize, 
                  areSame =  FSharpProjectOptions.AreSameForChecking, 
-                 areSimilar =  FSharpProjectOptions.UseSameProject,
-                 requiredToKeep=(fun (builderOpt,_,_) -> match builderOpt with None -> false | Some (b:IncrementalBuilder) -> b.IsBeingKeptAliveApartFromCacheEntry),
-                 onDiscard = (fun (_, _, decrement:IDisposable) -> decrement.Dispose()))
+                 areSimilar =  FSharpProjectOptions.UseSameProject)
 
-    let getOrCreateBuilderAndKeepAlive (ctok, options, userOpName) =
+    let getOrCreateBuilder (ctok, options, userOpName) =
       cancellable {
           RequireCompilationThread ctok
           match incrementalBuildersCache.TryGet (ctok, options) with
-          | Some (builderOpt,creationErrors,_) -> 
+          | Some (builderOpt,creationErrors) -> 
               Logger.Log LogCompilerFunctionId.Service_IncrementalBuildersCache_GettingCache
-              let decrement = IncrementalBuilder.KeepBuilderAlive builderOpt
-              return builderOpt,creationErrors, decrement
+              return builderOpt,creationErrors
           | None -> 
               Logger.Log LogCompilerFunctionId.Service_IncrementalBuildersCache_BuildingNewCache
-              let! (builderOpt,creationErrors,_) as info = CreateOneIncrementalBuilder (ctok, options, userOpName)
+              let! (builderOpt,creationErrors) as info = CreateOneIncrementalBuilder (ctok, options, userOpName)
               incrementalBuildersCache.Set (ctok, options, info)
-              let decrement = IncrementalBuilder.KeepBuilderAlive builderOpt
-              return builderOpt, creationErrors, decrement
+              return builderOpt, creationErrors
       }
 
     let parseCacheLock = Lock<ParseCacheLockToken>()
@@ -2530,8 +2498,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     member bc.GetBackgroundParseResultsForFileInProject(filename, options, userOpName) =
         reactor.EnqueueAndAwaitOpAsync(userOpName, "GetBackgroundParseResultsForFileInProject ", filename, fun ctok -> 
             cancellable {
-                let! builderOpt, creationErrors, decrement = getOrCreateBuilderAndKeepAlive (ctok, options, userOpName)
-                use _unwind = decrement
+                let! builderOpt, creationErrors = getOrCreateBuilder (ctok, options, userOpName)
                 match builderOpt with
                 | None -> return FSharpParseFileResults(creationErrors, None, true, [| |])
                 | Some builder -> 
@@ -2595,12 +2562,17 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                     | None ->
                         if beingCheckedFileTable.TryAdd(beingCheckedFileKey, ()) then
                             try
+#if !NO_EXTENSIONTYPING
+                                let checkIsAlive = (fun () -> not builder.IsInvalidatedByTypeProviders)
+#else
+                                let checkIsAlive = (fun () -> true)
+#endif
                                 // Get additional script #load closure information if applicable.
                                 // For scripts, this will have been recorded by GetProjectOptionsFromScript.
                                 let loadClosure = scriptClosureCacheLock.AcquireLock (fun ltok -> scriptClosureCache.TryGet (ltok, options))
                                 let! tcErrors, tcFileResult = 
                                     Parser.CheckOneFile(parseResults, sourceText, fileName, options.ProjectFileName, tcPrior.TcConfig, tcPrior.TcGlobals, tcPrior.TcImports, 
-                                                        tcPrior.TcState, tcPrior.ModuleNamesDict, loadClosure, tcPrior.TcErrors, reactorOps, (fun () -> builder.IsAlive), textSnapshotInfo, userOpName, suggestNamesForErrors)
+                                                        tcPrior.TcState, tcPrior.ModuleNamesDict, loadClosure, tcPrior.TcErrors, reactorOps, checkIsAlive, textSnapshotInfo, userOpName, suggestNamesForErrors)
                                 let parsingOptions = FSharpParsingOptions.FromTcConfig(tcPrior.TcConfig, Array.ofList builder.SourceFiles, options.UseScriptResolutionRules)
                                 let checkAnswer = MakeCheckFileAnswer(fileName, tcFileResult, options, builder, Array.ofList tcPrior.TcDependencyFiles, creationErrors, parseResults.Errors, tcErrors)
                                 bc.RecordTypeCheckFileInProjectResults(fileName, options, parsingOptions, parseResults, fileVersion, tcPrior.TimeStamp, Some checkAnswer, sourceText.GetHashCode())
@@ -2629,11 +2601,10 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                 let! cachedResults = 
                   execWithReactorAsync <| fun ctok ->   
                    cancellable {
-                    let! _builderOpt,_creationErrors,decrement = getOrCreateBuilderAndKeepAlive (ctok, options, userOpName)
-                    use _unwind = decrement
+                    let! _builderOpt,_creationErrors = getOrCreateBuilder (ctok, options, userOpName)
 
                     match incrementalBuildersCache.TryGetAny (ctok, options) with
-                    | Some (Some builder, creationErrors, _) ->
+                    | Some (Some builder, creationErrors) ->
                         match bc.GetCachedCheckFileResult(builder, filename, sourceText, options) with
                         | Some (_, checkResults) -> return Some (builder, creationErrors, Some (FSharpCheckFileAnswer.Succeeded checkResults))
                         | _ -> return Some (builder, creationErrors, None)
@@ -2668,8 +2639,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
             try 
                 if implicitlyStartBackgroundWork then 
                     reactor.CancelBackgroundOp() // cancel the background work, since we will start new work after we're done
-                let! builderOpt,creationErrors, decrement = execWithReactorAsync (fun ctok -> getOrCreateBuilderAndKeepAlive (ctok, options, userOpName))
-                use _unwind = decrement
+                let! builderOpt,creationErrors = execWithReactorAsync (fun ctok -> getOrCreateBuilder (ctok, options, userOpName))
                 match builderOpt with
                 | None -> return FSharpCheckFileAnswer.Succeeded (MakeCheckFileResultsEmpty(filename, creationErrors))
                 | Some builder -> 
@@ -2699,8 +2669,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                     Logger.LogMessage (filename + strGuid + "-Cancelling background work") LogCompilerFunctionId.Service_ParseAndCheckFileInProject
                     reactor.CancelBackgroundOp() // cancel the background work, since we will start new work after we're done
 
-                let! builderOpt,creationErrors,decrement = execWithReactorAsync (fun ctok -> getOrCreateBuilderAndKeepAlive (ctok, options, userOpName))
-                use _unwind = decrement
+                let! builderOpt,creationErrors = execWithReactorAsync (fun ctok -> getOrCreateBuilder (ctok, options, userOpName))
                 match builderOpt with
                 | None -> 
                     Logger.LogBlockMessageStop (filename + strGuid + "-Failed_Aborted") LogCompilerFunctionId.Service_ParseAndCheckFileInProject
@@ -2738,8 +2707,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     member bc.GetBackgroundCheckResultsForFileInProject(filename, options, userOpName) =
         reactor.EnqueueAndAwaitOpAsync(userOpName, "GetBackgroundCheckResultsForFileInProject", filename, fun ctok -> 
           cancellable {
-            let! builderOpt, creationErrors, decrement = getOrCreateBuilderAndKeepAlive (ctok, options, userOpName)
-            use _unwind = decrement
+            let! builderOpt, creationErrors = getOrCreateBuilder (ctok, options, userOpName)
             match builderOpt with
             | None -> 
                 let parseResults = FSharpParseFileResults(creationErrors, None, true, [| |])
@@ -2753,6 +2721,11 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                 let tcErrors = [| yield! creationErrors; yield! ErrorHelpers.CreateErrorInfos (errorOptions, false, filename, tcProj.TcErrors, suggestNamesForErrors) |]
                 let parseResults = FSharpParseFileResults(errors = untypedErrors, input = parseTreeOpt, parseHadErrors = false, dependencyFiles = builder.AllDependenciesDeprecated)
                 let loadClosure = scriptClosureCacheLock.AcquireLock (fun ltok -> scriptClosureCache.TryGet (ltok, options) )
+#if !NO_EXTENSIONTYPING
+                let checkIsAlive = (fun () -> not builder.IsInvalidatedByTypeProviders)
+#else
+                let checkIsAlive = (fun () -> true)
+#endif
                 let scope = 
                     TypeCheckInfo(tcProj.TcConfig, tcProj.TcGlobals, 
                                   Option.get tcProj.LastestCcuSigForFile, 
@@ -2761,7 +2734,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                                   List.head tcProj.TcResolutionsRev, 
                                   List.head tcProj.TcSymbolUsesRev,
                                   tcProj.TcEnvAtEnd.NameEnv,
-                                  loadClosure, reactorOps, (fun () -> builder.IsAlive), None, 
+                                  loadClosure, reactorOps, checkIsAlive, None, 
                                   tcProj.LatestImplementationFile,
                                   List.head tcProj.TcOpenDeclarationsRev)     
                 let typedResults = MakeCheckFileResults(filename, options, builder, scope, Array.ofList tcProj.TcDependencyFiles, creationErrors, parseResults.Errors, tcErrors)
@@ -2782,8 +2755,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     /// Parse and typecheck the whole project (the implementation, called recursively as project graph is evaluated)
     member private bc.ParseAndCheckProjectImpl(options, ctok, userOpName) : Cancellable<FSharpCheckProjectResults> =
       cancellable {
-        let! builderOpt,creationErrors,decrement = getOrCreateBuilderAndKeepAlive (ctok, options, userOpName)
-        use _unwind = decrement
+        let! builderOpt,creationErrors = getOrCreateBuilder (ctok, options, userOpName)
         match builderOpt with 
         | None -> 
             return FSharpCheckProjectResults (options.ProjectFileName, None, keepAssemblyContents, creationErrors, None)
@@ -2803,19 +2775,10 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
 
         // NOTE: This creation of the background builder is currently run as uncancellable.  Creating background builders is generally
         // cheap though the timestamp computations look suspicious for transitive project references.
-        let builderOpt,_creationErrors,decrement = getOrCreateBuilderAndKeepAlive (ctok, options, userOpName + ".TryGetLogicalTimeStampForProject") |> Cancellable.runWithoutCancellation
-        use _unwind = decrement
+        let builderOpt,_creationErrors = getOrCreateBuilder (ctok, options, userOpName + ".TryGetLogicalTimeStampForProject") |> Cancellable.runWithoutCancellation
         match builderOpt with 
         | None -> None
         | Some builder -> Some (builder.GetLogicalTimeStampForProject(cache, ctok))
-
-    /// Keep the projet builder alive over a scope
-    member bc.KeepProjectAlive(options, userOpName) =
-        reactor.EnqueueAndAwaitOpAsync(userOpName, "KeepProjectAlive", options.ProjectFileName, fun ctok -> 
-          cancellable {
-            let! _builderOpt,_creationErrors,decrement = getOrCreateBuilderAndKeepAlive (ctok, options, userOpName)
-            return decrement
-          })
 
     /// Parse and typecheck the whole project.
     member bc.ParseAndCheckProject(options, userOpName) =
@@ -2912,10 +2875,9 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     member bc.CheckProjectInBackground (options, userOpName) =
         reactor.SetBackgroundOp (Some (userOpName, "CheckProjectInBackground", options.ProjectFileName, (fun ctok ct -> 
             // The creation of the background builder can't currently be cancelled
-            match getOrCreateBuilderAndKeepAlive (ctok, options, userOpName) |> Cancellable.run ct with
+            match getOrCreateBuilder (ctok, options, userOpName) |> Cancellable.run ct with
             | ValueOrCancelled.Cancelled _ -> false
-            | ValueOrCancelled.Value (builderOpt,_,decrement) -> 
-                use _unwind = decrement
+            | ValueOrCancelled.Value (builderOpt,_) ->
                 match builderOpt with 
                 | None -> false
                 | Some builder -> 
@@ -3204,10 +3166,6 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
         let userOpName = defaultArg userOpName "Unknown"
         ic.CheckMaxMemoryReached()
         backgroundCompiler.ParseAndCheckProject(options, userOpName)
-
-    member ic.KeepProjectAlive(options, ?userOpName: string) =
-        let userOpName = defaultArg userOpName "Unknown"
-        backgroundCompiler.KeepProjectAlive(options, userOpName)
 
     /// For a given script file, get the ProjectOptions implied by the #load closure
     member ic.GetProjectOptionsFromScript(filename, source, ?loadedTimeStamp, ?otherFlags, ?useFsiAuxLib, ?useSdkRefs, ?assumeDotNetFramework, ?extraProjectInfo: obj, ?optionsStamp: int64, ?userOpName: string) = 

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -98,6 +98,9 @@ type public FSharpCheckFileResults =
     /// an unrecoverable error in earlier checking/parsing/resolution steps.
     member HasFullTypeCheckInfo: bool
 
+    /// Tries to get the current successful TcImports. This is only used in testing. Do not use it for other stuff.
+    member internal TryGetCurrentTcImports: unit -> TcImports option
+
     /// Indicates the set of files which must be watched to accurately track changes that affect these results,
     /// Clients interested in reacting to updates to these files should watch these files and take actions as described
     /// in the documentation for compiler service.

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -505,14 +505,6 @@ type public FSharpChecker =
     member ParseAndCheckProject : options: FSharpProjectOptions * ?userOpName: string -> Async<FSharpCheckProjectResults>
 
     /// <summary>
-    /// <para>Create resources for the project and keep the project alive until the returned object is disposed.</para>
-    /// </summary>
-    ///
-    /// <param name="options">The options for the project or script.</param>
-    /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member KeepProjectAlive : options: FSharpProjectOptions * ?userOpName: string -> Async<IDisposable>
-
-    /// <summary>
     /// <para>For a given script file, get the FSharpProjectOptions implied by the #load closure.</para>
     /// <para>All files are read from the FileSystem API, except the file being checked.</para>
     /// </summary>

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -348,11 +348,6 @@ let ``Test ManyProjectsStressTest cache too small`` () =
 
     let checker = ManyProjectsStressTest.makeCheckerForStressTest false
 
-    // Because the cache is too small, we need explicit calls to KeepAlive to avoid disposal of project information
-    let disposals = 
-        [ for p in ManyProjectsStressTest.jointProject :: ManyProjectsStressTest.projects do
-             yield checker.KeepProjectAlive p.Options |> Async.RunSynchronously ]
-
     let wholeProjectResults = checker.ParseAndCheckProject(ManyProjectsStressTest.jointProject.Options) |> Async.RunSynchronously
 
     [ for x in wholeProjectResults.AssemblySignature.Entities -> x.DisplayName ] |> shouldEqual ["JointProject"]


### PR DESCRIPTION
IB (`IncrementalBuilder`) was responsible for keeping `TcImports` and itself alive using referencing counting.

Now this removes reference counting from IB.
Allows `TcImports` to dispose of type providers and binary readers when the GC is about to collect it by leveraging the finalizer, `override x.Finalize () = ...`

The main reason for doing this is that it removes complexity: 
- You had to worry about decrementing IB's reference count. 
- There was invasive checks spread throughout FCS about whether an IB was alive or not. 
- Calling into an IB or `TcImports` that was disposed would throw an assert and that's bad news. In uncommon circumstances, this could happen and it's unclear how it does. 
    - It would more likely happen when we tried to evict IBs from the IB cache. This hurts our ability to get cache eviction for IBs working again, this time with in-memory cross project referencing.

Now, this is completely swept away. Lifetime is GC. If you want `TcImports` alive, you simply hold onto it. This will pave the path for a stateless / snapshot model for FCS as we will stop thinking about explicitly disposing of resources.

---

A few cons:

- There are a few hacks to accommodate working with old type providers that had an enforced contract dictated by TypeProviderSDK's reflection code. See https://github.com/fsprojects/FSharp.TypeProviders.SDK/pull/305. The reflection code has been removed and type providers that use the newer TypeProviderSDK will not be bound by such a contract.

- One downside is that disposal is not deterministic. Type provider resources will not eagerly be disposed of. This isn't necessarily a problem; most of everything is on the GC and in Gen2 at this point anyway. It will mean that any native resources a type provider might have, will now take a bit longer for it to get cleaned up; but it's not going to be a problem as `Dispose` will eventually be called for a type provider when `TcImports` is about to be collected. Trust the GC.

---

Remaining work:

- [x] Tests