### PR TITLE
Remove call to internal API in Simplify Name Analyzer

### DIFF
--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -94,7 +94,7 @@ type internal SimplifyNameDiagnosticAnalyzer() =
                                         match rest with
                                         | [] -> return current
                                         | headIdent :: restPlid ->
-                                            let! res = checkResults.IsRelativeNameResolvable(posAtStartOfName, current, symbolUse.Symbol.Item, userOpName=userOpName) 
+                                            let! res = checkResults.IsRelativeNameResolvableFromSymbol(posAtStartOfName, current, symbolUse.Symbol, userOpName=userOpName)
                                             if res then return current
                                             else return! loop restPlid (headIdent :: current)
                                     }

--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -7,13 +7,11 @@ open System.Collections.Immutable
 open System.Diagnostics
 open System.Threading
 open System.Threading.Tasks
-open System.Runtime.CompilerServices
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Diagnostics
 open FSharp.Compiler
 open FSharp.Compiler.Range
-open FSharp.Compiler.SourceCodeServices
 open System.Runtime.Caching
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics
 


### PR DESCRIPTION
Another one from removing the IVT to FSharp.Editor.

The internal API and the public one do the exact thing, except the analyzer was using the internal API. Also removes some unused opens.