### PR TITLE
Open Implement Interface APIs

### DIFF
--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -4,7 +4,6 @@ namespace FSharp.Compiler.SourceCodeServices
 
 open System
 open System.Diagnostics
-open System.Collections.Generic
 open FSharp.Compiler
 open FSharp.Compiler.Ast
 open FSharp.Compiler.Range
@@ -102,7 +101,7 @@ module internal CodeGenerationUtils =
 
 /// Capture information about an interface in ASTs
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
-type internal InterfaceData =
+type InterfaceData =
     | Interface of SynType * SynMemberDefns option
     | ObjExpr of SynType * SynBinding list
     member x.Range =
@@ -168,7 +167,7 @@ type internal InterfaceData =
             | _ ->
                 [||]
 
-module internal InterfaceStubGenerator =
+module InterfaceStubGenerator =
     [<NoComparison>]
     type internal Context =
         {

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fsi
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fsi
@@ -2,25 +2,20 @@
 
 namespace FSharp.Compiler.SourceCodeServices
 
-open System
-open System.Diagnostics
-open System.Collections.Generic
-open FSharp.Compiler
 open FSharp.Compiler.Ast
 open FSharp.Compiler.Range
 open FSharp.Compiler.SourceCodeServices
-open FSharp.Compiler.AbstractIL.Internal.Library 
         
 #if !FX_NO_INDENTED_TEXT_WRITER
 /// Capture information about an interface in ASTs
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
-type internal InterfaceData =
+type InterfaceData =
     | Interface of SynType * SynMemberDefns option
     | ObjExpr of SynType * SynBinding list
     member Range : range
     member TypeParameters : string[]
 
-module internal InterfaceStubGenerator =
+module InterfaceStubGenerator =
 
     /// Get members in the decreasing order of inheritance chain
     val getInterfaceMembers : FSharpEntity -> seq<FSharpMemberOrFunctionOrValue * seq<FSharpGenericParameter * FSharpType>>

--- a/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
@@ -7,7 +7,6 @@ open System.Composition
 open System.Threading
 open System.Threading.Tasks
 
-open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Formatting
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes


### PR DESCRIPTION
This is necessary to kill off our IVT into FSharp.Editor. Since all the code is in the compiler service, I don't see why it shouldn't be public at this point. Should also allow other editors to use it.