### PR TITLE
add framework for LSP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ extras
 ossreadme*.txt
 *.csproj.user
 *.fsproj.user
+*.vbproj.user
 *.sln.DotSettings.user
 *.log
 *.jrs

--- a/FSharp.sln
+++ b/FSharp.sln
@@ -38,6 +38,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Packages", "Packages", "{38
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.FSharp.Compiler", "src\fsharp\FSharp.Compiler.nuget\Microsoft.FSharp.Compiler.csproj", "{81B9FE26-C976-4FC7-B6CC-C7DB5903CAA7}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.LanguageServer", "src\fsharp\FSharp.Compiler.LanguageServer\FSharp.Compiler.LanguageServer.fsproj", "{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.LanguageServer.UnitTests", "tests\FSharp.Compiler.LanguageServer.UnitTests\FSharp.Compiler.LanguageServer.UnitTests.fsproj", "{C97819B0-B428-4B96-9CD7-497D2D1C738C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -180,6 +184,30 @@ Global
 		{81B9FE26-C976-4FC7-B6CC-C7DB5903CAA7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{81B9FE26-C976-4FC7-B6CC-C7DB5903CAA7}.Release|x86.ActiveCfg = Release|Any CPU
 		{81B9FE26-C976-4FC7-B6CC-C7DB5903CAA7}.Release|x86.Build.0 = Release|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Debug|x86.Build.0 = Debug|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Proto|Any CPU.Build.0 = Debug|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Proto|x86.ActiveCfg = Debug|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Proto|x86.Build.0 = Debug|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Release|x86.ActiveCfg = Release|Any CPU
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA}.Release|x86.Build.0 = Release|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Debug|x86.Build.0 = Debug|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Proto|Any CPU.Build.0 = Debug|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Proto|x86.ActiveCfg = Debug|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Proto|x86.Build.0 = Debug|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Release|x86.ActiveCfg = Release|Any CPU
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -196,6 +224,8 @@ Global
 		{88E2D422-6852-46E3-A740-83E391DC7973} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
 		{53C0DAAD-158C-4658-8EC7-D7341530239F} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
 		{81B9FE26-C976-4FC7-B6CC-C7DB5903CAA7} = {3840F2E7-3898-45F7-8CF7-1E6829E56DB8}
+		{99B3F4A5-80B4-41D9-A073-117DB6D7DBBA} = {B8DDA694-7939-42E3-95E5-265C2217C142}
+		{C97819B0-B428-4B96-9CD7-497D2D1C738C} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BD5177C7-1380-40E7-94D2-7768E1A8B1B8}

--- a/VisualFSharp.sln
+++ b/VisualFSharp.sln
@@ -154,6 +154,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TutorialProject", "vsintegr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FSharp.Core.nuget", "src\fsharp\FSharp.Core.nuget\FSharp.Core.nuget.csproj", "{8EC30B2E-F1F9-4A98-BBB5-DD0CF6C84DDC}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.LanguageServer", "src\fsharp\FSharp.Compiler.LanguageServer\FSharp.Compiler.LanguageServer.fsproj", "{60BAFFA5-6631-4328-B044-2E012AB76DCA}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.LanguageServer.UnitTests", "tests\FSharp.Compiler.LanguageServer.UnitTests\FSharp.Compiler.LanguageServer.UnitTests.fsproj", "{AAF2D233-1C38-4090-8FFA-F7C545625E06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -884,6 +888,30 @@ Global
 		{8EC30B2E-F1F9-4A98-BBB5-DD0CF6C84DDC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8EC30B2E-F1F9-4A98-BBB5-DD0CF6C84DDC}.Release|x86.ActiveCfg = Release|Any CPU
 		{8EC30B2E-F1F9-4A98-BBB5-DD0CF6C84DDC}.Release|x86.Build.0 = Release|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Debug|x86.Build.0 = Debug|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Proto|Any CPU.Build.0 = Debug|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Proto|x86.ActiveCfg = Debug|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Proto|x86.Build.0 = Debug|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Release|x86.ActiveCfg = Release|Any CPU
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA}.Release|x86.Build.0 = Release|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Debug|x86.Build.0 = Debug|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Proto|Any CPU.Build.0 = Debug|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Proto|x86.ActiveCfg = Debug|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Proto|x86.Build.0 = Debug|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Release|x86.ActiveCfg = Release|Any CPU
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -956,6 +984,8 @@ Global
 		{C32806E0-71C2-40E4-AEC4-517F73F6A18A} = {BED74F9E-A0D2-48E2-9EE7-449832100487}
 		{7B345E51-F2C0-4D4B-B0E0-05432EC9D5E1} = {BED74F9E-A0D2-48E2-9EE7-449832100487}
 		{8EC30B2E-F1F9-4A98-BBB5-DD0CF6C84DDC} = {647810D0-5307-448F-99A2-E83917010DAE}
+		{60BAFFA5-6631-4328-B044-2E012AB76DCA} = {B8DDA694-7939-42E3-95E5-265C2217C142}
+		{AAF2D233-1C38-4090-8FFA-F7C545625E06} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {48EDBBBE-C8EE-4E3C-8B19-97184A487B37}

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -270,6 +270,7 @@ try {
 
     if ($testDesktop) {
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $desktopTargetFramework
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.LanguageServer.UnitTests\FSharp.Compiler.LanguageServer.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Build.UnitTests\FSharp.Build.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\fsharp\FSharpSuite.Tests.fsproj" -targetFramework $desktopTargetFramework
@@ -277,6 +278,7 @@ try {
 
     if ($testCoreClr) {
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.LanguageServer.UnitTests\FSharp.Compiler.LanguageServer.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Build.UnitTests\FSharp.Build.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\fsharp\FSharpSuite.Tests.fsproj" -targetFramework $coreclrTargetFramework

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -175,5 +175,6 @@
     <NunitXmlTestLoggerVersion>2.1.36</NunitXmlTestLoggerVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
     <StrawberryPerl64Version>5.22.2.1</StrawberryPerl64Version>
+    <StreamJsonRpcVersion>2.0.187</StreamJsonRpcVersion>
   </PropertyGroup>
 </Project>

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -245,6 +245,7 @@ BuildSolution
 if [[ "$test_core_clr" == true ]]; then
   coreclrtestframework=netcoreapp2.1
   TestUsingNUnit --testproject "$repo_root/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.UnitTests.fsproj" --targetframework $coreclrtestframework
+  TestUsingNUnit --testproject "$repo_root/tests/FSharp.Compiler.LanguageServer.UnitTests/FSharp.Compiler.LanguageServer.UnitTests.fsproj" --targetframework $coreclrtestframework
   TestUsingNUnit --testproject "$repo_root/tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj" --targetframework $coreclrtestframework
   TestUsingNUnit --testproject "$repo_root/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj" --targetframework $coreclrtestframework
 fi

--- a/src/fsharp/FSharp.Compiler.LanguageServer/Directory.Build.props
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseFSharpProductVersion>true</UseFSharpProductVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/fsharp/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
@@ -1,0 +1,31 @@
+﻿<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetExt>.exe</TargetExt>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.1</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <PackageDescription>Implements the Language Server Protocol (LSP) for F#.</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="State.fs" />
+    <Compile Include="LspTypes.fs" />
+    <Compile Include="TextDocument.fs" />
+    <Compile Include="Methods.fs" />
+    <Compile Include="Server.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/fsharp/FSharp.Compiler.LanguageServer/LspTypes.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/LspTypes.fs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+// Interfaces as defined at https://microsoft.github.io/language-server-protocol/specification.  The properties on these
+// types are camlCased to match the underlying JSON properties to avoid attributes on every field:
+//   [<JsonProperty("camlCased")>]
+
+/// Represents a zero-based line and column of a text document.
+type Position =
+    { line: int
+      character: int }
+
+type Range =
+    { start: Position
+      ``end``: Position }
+
+type DocumentUri = string
+
+type Location =
+    { uri: DocumentUri
+      range: Range }
+
+type DiagnosticRelatedInformation =
+    { location: Location
+      message: string }
+
+type Diagnostic =
+    { range: Range
+      severity: int
+      code: string
+      source: string // "F#"
+      message: string
+      relatedInformation: DiagnosticRelatedInformation[] }
+    static member Error = 1
+    static member Warning = 2
+    static member Information = 3
+    static member Hint = 4
+
+type PublishDiagnosticsParams =
+    { uri: DocumentUri
+      diagnostics: Diagnostic[] }
+
+type InitializeParams = string // TODO:
+
+// Note, this type has many more optional values that can be expanded as support is added.
+type ServerCapabilities =
+    { hoverProvider: bool }
+    static member DefaultCapabilities() =
+        { ServerCapabilities.hoverProvider = true }
+
+type InitializeResult =
+    { capabilities: ServerCapabilities }
+
+type MarkupKind =
+    | PlainText
+    | Markdown
+
+type MarkupContent =
+    { kind: MarkupKind
+      value: string }
+
+type Hover =
+    { contents: MarkupContent
+      range: Range option }
+
+type TextDocumentIdentifier =
+    { uri: DocumentUri }
+
+type TextDocumentPositionParams =
+    { textDocument: TextDocumentIdentifier
+      position: Position }

--- a/src/fsharp/FSharp.Compiler.LanguageServer/Methods.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/Methods.fs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+open StreamJsonRpc
+
+// https://microsoft.github.io/language-server-protocol/specification
+type Methods(state: State) =
+
+    [<JsonRpcMethod("initialize")>]
+    member __.Initialize (args: InitializeParams) =
+        async {
+            // note, it's important that this method is `async` because unit tests can then properly verify that the
+            // JSON RPC handling of async methods is correct
+            return ServerCapabilities.DefaultCapabilities()
+        } |> Async.StartAsTask
+
+    [<JsonRpcMethod("shutdown")>]
+    member __.Shutdown() = state.DoShutdown()
+
+    [<JsonRpcMethod("textDocument/hover")>]
+    member __.TextDocumentHover (args: TextDocumentPositionParams) = TextDocument.Hover(state, args) |> Async.StartAsTask

--- a/src/fsharp/FSharp.Compiler.LanguageServer/Program.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/Program.fs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+open System
+
+module Program =
+
+    [<EntryPoint>]
+    let main(args: string[]) =
+        async {
+            let server = new Server(Console.OpenStandardOutput(), Console.OpenStandardInput())
+            server.StartListening()
+            do! server.WaitForExitAsync()
+            return 0
+        } |> Async.RunSynchronously

--- a/src/fsharp/FSharp.Compiler.LanguageServer/Server.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/Server.fs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+open System
+open System.IO
+open StreamJsonRpc
+
+type Server(sendingStream: Stream, receivingStream: Stream) =
+
+    let state = State()
+    let methods = Methods(state)
+    let rpc = new JsonRpc(sendingStream, receivingStream, methods)
+
+    member __.StartListening() =
+        rpc.StartListening()
+
+    member __.WaitForExitAsync() =
+        async {
+            do! Async.AwaitEvent (state.Shutdown)
+        }
+
+    interface IDisposable with
+        member __.Dispose() =
+            rpc.Dispose()

--- a/src/fsharp/FSharp.Compiler.LanguageServer/State.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/State.fs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+type State() =
+
+    let shutdownEvent = new Event<_>()
+
+    [<CLIEvent>]
+    member __.Shutdown = shutdownEvent.Publish
+
+    member __.DoShutdown() = shutdownEvent.Trigger()

--- a/src/fsharp/FSharp.Compiler.LanguageServer/TextDocument.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/TextDocument.fs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+module TextDocument =
+
+    let Hover(state: State, args: TextDocumentPositionParams) =
+        async {
+            return {
+                Hover.contents = {
+                    MarkupContent.kind = MarkupKind.PlainText
+                    value = "TODO"
+                }
+                range = Some({
+                    Range.start = {
+                        Position.line = 0
+                        character = 0
+                    }
+                    ``end`` = {
+                        Position.line = 0
+                        character = 0
+                    }
+                })
+            }
+        }
+
+    let PublishDiagnostics(state: State) =
+        async {
+            return {
+                PublishDiagnosticsParams.uri = ""
+                diagnostics = [||]
+            }
+        }

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -49,6 +49,7 @@
     <InternalsVisibleTo Include="FSharp.ProjectSystem.FSharp" />
     <InternalsVisibleTo Include="FSharp.ProjectSystem.PropertyPages" />
     <InternalsVisibleTo Include="FSharp.Compiler.Interactive.Settings" />
+    <InternalsVisibleTo Include="FSharp.Compiler.LanguageServer" />
     <InternalsVisibleTo Include="FSharp.Compiler.Server.Shared" />
     <InternalsVisibleTo Include="VisualFSharp.Salsa" />
     <InternalsVisibleTo Include="VisualFSharp.UnitTests" />

--- a/tests/FSharp.Compiler.LanguageServer.UnitTests/Directory.Build.props
+++ b/tests/FSharp.Compiler.LanguageServer.UnitTests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseFSharpProductVersion>true</UseFSharpProductVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/tests/FSharp.Compiler.LanguageServer.UnitTests/FSharp.Compiler.LanguageServer.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.LanguageServer.UnitTests/FSharp.Compiler.LanguageServer.UnitTests.fsproj
@@ -1,0 +1,25 @@
+﻿<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.1</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <UnitTestType>nunit</UnitTestType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ProtocolTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.LanguageServer\FSharp.Compiler.LanguageServer.fsproj" />
+    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FSharp.Compiler.LanguageServer.UnitTests/ProtocolTests.fs
+++ b/tests/FSharp.Compiler.LanguageServer.UnitTests/ProtocolTests.fs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer.UnitTests
+
+open System.Diagnostics
+open System.Threading.Tasks
+open FSharp.Compiler.LanguageServer
+open NUnit.Framework
+open StreamJsonRpc
+
+[<TestFixture>]
+type ProtocolTests() =
+
+#if !NETCOREAPP
+    // The `netcoreapp2.1` version of `FSharp.Compiler.LanguageServer.exe` can't be run without a `publish` step so
+    // we're artificially restricting this test to the full framework.
+    [<Test>]
+#endif
+    member __.``Server consuming stdin and stdout``() =
+        async {
+            // start server as a console app
+            let serverAssemblyPath = typeof<Server>.Assembly.Location
+            let startInfo = ProcessStartInfo(serverAssemblyPath)
+            startInfo.UseShellExecute <- false
+            startInfo.RedirectStandardInput <- true
+            startInfo.RedirectStandardOutput <- true
+            let proc = Process.Start(startInfo)
+
+            // create a fake client
+            let client = new JsonRpc(proc.StandardInput.BaseStream, proc.StandardOutput.BaseStream)
+            client.StartListening()
+
+            // initialize
+            let! capabilitites = client.InvokeAsync<ServerCapabilities>("initialize", "") |> Async.AwaitTask
+            Assert.True(capabilitites.hoverProvider)
+
+            // shutdown the server
+            do! client.NotifyAsync("shutdown") |> Async.AwaitTask
+            if not (proc.WaitForExit(5000)) then failwith "Expected server process to exit."
+        } |> Async.StartAsTask :> Task


### PR DESCRIPTION
This is woefully and purposefully lacking in functionality as it's meant to lay the groundwork for an eventual move to an official [Language Server Protocol](https://microsoft.github.io/language-server-protocol/specification) implementation.

While there are other F# LSP projects out there, this one is being designed slightly differently, namely with one assembly I hope to use `FSharp.Compiler.LanguageServer` as:

- a regular IL reference for consumption from other F# libraries (also from C#/VB, but the `async` interop is odd)
- a regular IL reference for LSP over `System.IO.Stream` objects
- a console application that communicates via `stdin`/`stdout`
- **the important one**: strongly tied to a specific version of the compiler and editor tools

For now this project exists in isolation, but eventually `FSharp.Editor` will use these APIs and basically be a small shim between `FSharp.Compiler.LanguageServer` and Visual Studio.