### PR TITLE
remove NuGet dependency from fslex/fsyacc

### DIFF
--- a/src/buildtools/fslex/fslex.fsproj
+++ b/src/buildtools/fslex/fslex.fsproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DefineConstants>INTERNALIZED_FSLEXYACC_RUNTIME;$(DefineConstant)</DefineConstants>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +18,10 @@
     <Compile Include="fslexpars.fs" />
     <Compile Include="fslexlex.fs" />
     <Compile Include="fslex.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\fsharp\FSharp.Core\FSharp.Core.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/buildtools/fsyacc/fsyacc.fsproj
+++ b/src/buildtools/fsyacc/fsyacc.fsproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DefineConstants>INTERNALIZED_FSLEXYACC_RUNTIME;$(DefineConstant)</DefineConstants>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +18,10 @@
     <Compile Include="fsyaccpars.fs" />
     <Compile Include="fsyacclex.fs" />
     <Compile Include="fsyacc.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\fsharp\FSharp.Core\FSharp.Core.fsproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
As per #6912 the implicit NuGet reference to the FSharp.Core package needs to be removed from `fslex.fsproj` and `fsyacc.fsproj`.  Our two options were to either try to steal the `FSharp.Core.dll` that's next to the running compiler, or pre-build `FSharp.Core.fsproj`.  I opted for the latter because the first option seemed very prone to failure, and while there has been support in the past for `fsc.exe` to magically provide an `FSharp.Core.dll`, I think we'd be better served getting out of the business of implicit binary references, especially with the possibility that the LKG compiler (and therefore it's `FSharp.Core.dll`) and `fslex.dll` might not target the same TFM.  While the path I took increases the initial build time, the TFM/platform will always be correct, it should be more stable and easier to diagnose any failures that may arise.

Fixes #6912.