### PR TITLE
fix compiler location

### DIFF
--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -220,7 +220,6 @@ module internal FSharpEnvironment =
                 // For the prototype compiler, we can just use the current domain
                 tryCurrentDomain()
         with e -> 
-            System.Diagnostics.Debug.Assert(false, "Error while determining default location of F# compiler")
             None
 
 


### PR DESCRIPTION
This assert is not necessary the config file does not exist on the coreclr, and this assert fires on debug builds.