### PR TITLE
Use LangVersion on 'Add missing case for underscore in for _ ='

### DIFF
--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -22,8 +22,7 @@ type LanguageFeature =
     | LanguageVersion46 = 0
     | LanguageVersion47 = 1
     | SingleUnderscorePattern = 2
-    | Nullness = 1000
-    | ScriptingPackageManagement = 1001
+    | WildCardInForLoop = 3
 
 /// LanguageVersion management
 type LanguageVersion (specifiedVersion) =
@@ -44,9 +43,8 @@ type LanguageVersion (specifiedVersion) =
         // Add new LanguageVersions here ...
         LanguageFeature.LanguageVersion47, 4.7m
         LanguageFeature.LanguageVersion46, 4.6m
-        LanguageFeature.Nullness, previewVersion
-        LanguageFeature.ScriptingPackageManagement, previewVersion
         LanguageFeature.SingleUnderscorePattern, previewVersion
+        LanguageFeature.WildCardInForLoop, previewVersion
 
         // Add new LanguageFeatures here ...
         |]

--- a/src/fsharp/LanguageFeatures.fsi
+++ b/src/fsharp/LanguageFeatures.fsi
@@ -9,8 +9,7 @@ type LanguageFeature =
     | LanguageVersion46 = 0
     | LanguageVersion47 = 1
     | SingleUnderscorePattern = 2
-    | Nullness = 1000
-    | ScriptingPackageManagement = 1001
+    | WildCardInForLoop = 3
 
 /// LanguageVersion management
 type LanguageVersion =

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -130,10 +130,11 @@ let mkDefnBindings (mWhole,BindingSetPreAttrs(_,isRec,isUse,declsPreAttrs,_bindi
     let attrDecls = if not (isNil freeAttrs) then [ SynModuleDecl.Attributes (freeAttrs,attrsm) ] else [] 
     attrDecls @ letDecls
 
-let idOfPat m p = 
+let idOfPat (parseState:IParseState) m p = 
     match p with
-    | SynPat.Wild r -> mkSynId r "_"    
-    | SynPat.Named (SynPat.Wild _,id,false,_,_) -> id 
+    | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop ->
+        mkSynId r "_"
+    | SynPat.Named (SynPat.Wild _,id,false,_,_) -> id
     | SynPat.LongIdent(LongIdentWithDots([id],_),_,None, SynConstructorArgs.Pats [], None,_) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier())
 
@@ -3992,7 +3993,7 @@ forLoopBinder:
 
 forLoopRange: 
   | parenPattern EQUALS declExpr forLoopDirection declExpr 
-      { idOfPat (rhs parseState 1) $1,$3,$4,$5 }
+      { idOfPat parseState (rhs parseState 1) $1,$3,$4,$5 }
 
   | parenPattern EQUALS rangeSequenceExpr
      { raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedSymbolEqualsInsteadOfIn()) }

--- a/tests/fsharp/core/forexpression/test.fsx
+++ b/tests/fsharp/core/forexpression/test.fsx
@@ -110,18 +110,7 @@ let sumOverRange () =
 let sumOverString () =
     let mutable sum = 0
     for i in testString do
-#if NETCOREAPP
-        sum <- sum + ((int (i :?> char)) - (int '0'))
-#else
         sum <- sum + ((int i) - (int '0'))
-#endif
-    sum
-    
-// usingWildcard counts using a wildcard in a for loop
-let usingWildcard () =
-    let mutable sum = 0
-    for _ = 0 to count do
-        sum <- sum + 1
     sum
 
 let arraySum                = sumOverArray ()
@@ -132,7 +121,6 @@ let listSum                 = sumOverList ()
 let ilistSum                = sumOverIList ()
 let rangeSum                = sumOverRange ()
 let stringSum               = sumOverString ()
-let wildCard                = usingWildcard ()
 
 do test "arraySum"          (expectedArraySum   = arraySum      )
 do test "seqSum"            (expectedArraySum   = seqSum        )
@@ -142,7 +130,6 @@ do test "listSum"           (expectedArraySum   = listSum       )
 do test "ilistSum"          (expectedArraySum   = ilistSum      )
 do test "rangeSum"          (expectedRangeSum   = rangeSum      )
 do test "stringSum"         (expectedStringSum  = stringSum     )
-do test "wildCard"          (expectedWildCard   = wildCard      )
 
 #if TESTS_AS_APP
 let RUN() = !failures

--- a/tests/fsharp/core/forexpression/version46/test.fs
+++ b/tests/fsharp/core/forexpression/version46/test.fs
@@ -1,0 +1,41 @@
+//<Expects id="FS0525" status="error" span="(21,9)">An integer for loop must use a simple identifier</Expects>
+module Global
+
+let failures = ref []
+
+let report_failure (s : string) = 
+    stderr.Write" NO: "
+    stderr.WriteLine s
+    failures := !failures @ [s]
+
+let test (s : string) b = 
+    stderr.Write(s)
+    if b then stderr.WriteLine " OK"
+    else report_failure (s)
+
+let check s b1 b2 = test s (b1 = b2)
+
+// usingWildcard counts using a wildcard in a for loop
+let usingWildcard () =
+    let mutable sum = 0
+    for _ = 0 to count do
+        sum <- sum + 1
+
+    printfn "usingWildcards expected to produce sum of 4 : sum='%d'"sum
+
+do test "wildCard"          (4 = usingWildcard () )
+
+#if TESTS_AS_APP
+let RUN() = !failures
+#else
+let aa =
+  match !failures with 
+  | [] -> 
+      stdout.WriteLine "Test Passed"
+      System.IO.File.WriteAllText("test.ok","ok")
+      exit 0
+  | _ -> 
+      stdout.WriteLine "Test Failed"
+      exit 1
+#endif
+

--- a/tests/fsharp/core/forexpression/version47/test.fs
+++ b/tests/fsharp/core/forexpression/version47/test.fs
@@ -1,0 +1,43 @@
+//<Expects status="success">usingWildcards expected to produce sum of 4 : sum='4'</Expects>
+#if TESTS_AS_APP
+module Core_forexpression_47
+#endif
+
+let failures = ref []
+
+let report_failure (s : string) = 
+    stderr.Write" NO: "
+    stderr.WriteLine s
+    failures := !failures @ [s]
+
+let test (s : string) b = 
+    stderr.Write(s)
+    if b then stderr.WriteLine " OK"
+    else report_failure (s)
+
+let check s b1 b2 = test s (b1 = b2)
+
+// usingWildcard counts using a wildcard in a for loop
+let usingWildcard () =
+    let mutable sum = 0
+    for _ = 0 to count do
+        sum <- sum + 1
+
+    printfn "usingWildcards expected to produce sum of 4 : sum='%d'"sum
+
+do test "wildCard"          (4 = usingWildcard () )
+
+#if TESTS_AS_APP
+let RUN() = !failures
+#else
+let aa =
+  match !failures with 
+  | [] -> 
+      stdout.WriteLine "Test Passed"
+      System.IO.File.WriteAllText("test.ok","ok")
+      exit 0
+  | _ -> 
+      stdout.WriteLine "Test Failed"
+      exit 1
+#endif
+

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -298,7 +298,7 @@ let singleTestBuildAndRunCore cfg copyFiles p languageVersion =
             result <- true
         finally
             if result <> false then
-                Directory.Delete(directory, true)
+                try Directory.Delete(directory, true) with _ -> ()
             else
                 printfn "Configuration: %s" cfg.Directory
                 printfn "Directory: %s" directory


### PR DESCRIPTION
https://github.com/dotnet/fsharp/pull/6867

This makes this recently merged file respond to the langversion flag.

This PR builds on the unmergedPR:  "Ensure that Language Version support flows to Parser"
https://github.com/dotnet/fsharp/pull/6891


The commit to review is the most recent.   https://github.com/dotnet/fsharp/pull/6931/commits/51538fd4dc5748df11ba6ead62c27ed40ee21e0b

1. The PR: tests for language version support for the feature.
2. Re-enables the "core/forexpression" tests for some reason they weren't running.
3. Hides the forexpression tests if the build is a version earlier than 4.7
4. Adds versioning tests that ensure:
    a. When langVersion is 4.6, we get the error
    b. When langVersion is 4.7 or above it succeeds
