### PR TITLE
Enable Langversion to control relaxwhitespace language feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,9 @@ ossreadme*.txt
 *.log
 *.jrs
 *.chk
-*.bak
+*.bak                                                     
+*.vserr
+*.err
 *.orig
 *.mdf
 *.ldf

--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -22,6 +22,7 @@ type LanguageFeature =
     | LanguageVersion46 = 0
     | LanguageVersion47 = 1
     | SingleUnderscorePattern = 2
+    | RelaxWhitespace = 4
     | Nullness = 1000
     | ScriptingPackageManagement = 1001
 
@@ -44,6 +45,7 @@ type LanguageVersion (specifiedVersion) =
         // Add new LanguageVersions here ...
         LanguageFeature.LanguageVersion47, 4.7m
         LanguageFeature.LanguageVersion46, 4.6m
+        LanguageFeature.RelaxWhitespace, previewVersion
         LanguageFeature.Nullness, previewVersion
         LanguageFeature.ScriptingPackageManagement, previewVersion
         LanguageFeature.SingleUnderscorePattern, previewVersion

--- a/src/fsharp/LanguageFeatures.fsi
+++ b/src/fsharp/LanguageFeatures.fsi
@@ -9,6 +9,7 @@ type LanguageFeature =
     | LanguageVersion46 = 0
     | LanguageVersion47 = 1
     | SingleUnderscorePattern = 2
+    | RelaxWhitespace = 4
     | Nullness = 1000
     | ScriptingPackageManagement = 1001
 

--- a/tests/fsharp/HandleExpects.fs
+++ b/tests/fsharp/HandleExpects.fs
@@ -44,7 +44,7 @@ let stripFromFileExpectations source =
                 else expect.Replace(content, "")
 
             let rdr = XmlReader.Create(new StringReader(nocontentxpect))
-            let mutable element = { status="success";  id = ""; span = ""; pattern = content; matched = false; line=nocontentxpect }
+            let mutable element = { status="success";  id = ""; span = ""; pattern = content; matched = false; line=expect }
             let mutable insideExpects = false
             let mutable foundOne = false
             try

--- a/tests/fsharp/core/indent/version46/test.fsx
+++ b/tests/fsharp/core/indent/version46/test.fsx
@@ -1,0 +1,121 @@
+//<Expects id="FS0058" status="warning" span="(60,9)">Possible incorrect indentation: this token is offside of context started at position \(59:19\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(60,9)">Possible incorrect indentation: this token is offside of context started at position \(59:19\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(64,9)">Possible incorrect indentation: this token is offside of context started at position \(63:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(64,9)">Possible incorrect indentation: this token is offside of context started at position \(63:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(70,3)">Possible incorrect indentation: this token is offside of context started at position \(69:23\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(70,3)">Possible incorrect indentation: this token is offside of context started at position \(69:23\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(78,7)">Possible incorrect indentation: this token is offside of context started at position \(77:25\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(78,7)">Possible incorrect indentation: this token is offside of context started at position \(77:25\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(84,7)">Possible incorrect indentation: this token is offside of context started at position \(83:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(84,7)">Possible incorrect indentation: this token is offside of context started at position \(83:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(89,7)">Possible incorrect indentation: this token is offside of context started at position \(88:25\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(89,7)">Possible incorrect indentation: this token is offside of context started at position \(88:25\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(92,5)">Possible incorrect indentation: this token is offside of context started at position \(91:20\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(92,5)">Possible incorrect indentation: this token is offside of context started at position \(91:20\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(96,9)">Possible incorrect indentation: this token is offside of context started at position \(95:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(96,9)">Possible incorrect indentation: this token is offside of context started at position \(95:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(101,2)">Possible incorrect indentation: this token is offside of context started at position \(100:20\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(101,2)">Possible incorrect indentation: this token is offside of context started at position \(100:20\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(105,6)">Possible incorrect indentation: this token is offside of context started at position \(104:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(105,6)">Possible incorrect indentation: this token is offside of context started at position \(104:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(60,9)">Possible incorrect indentation: this token is offside of context started at position \(59:19\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(60,9)">Possible incorrect indentation: this token is offside of context started at position \(59:19\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(64,9)">Possible incorrect indentation: this token is offside of context started at position \(63:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(64,9)">Possible incorrect indentation: this token is offside of context started at position \(63:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(70,3)">Possible incorrect indentation: this token is offside of context started at position \(69:23\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(70,3)">Possible incorrect indentation: this token is offside of context started at position \(69:23\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(78,7)">Possible incorrect indentation: this token is offside of context started at position \(77:25\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(78,7)">Possible incorrect indentation: this token is offside of context started at position \(77:25\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(84,7)">Possible incorrect indentation: this token is offside of context started at position \(83:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(84,7)">Possible incorrect indentation: this token is offside of context started at position \(83:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(89,7)">Possible incorrect indentation: this token is offside of context started at position \(88:25\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(89,7)">Possible incorrect indentation: this token is offside of context started at position \(88:25\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(92,5)">Possible incorrect indentation: this token is offside of context started at position \(91:20\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(92,5)">Possible incorrect indentation: this token is offside of context started at position \(91:20\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(96,9)">Possible incorrect indentation: this token is offside of context started at position \(95:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(96,9)">Possible incorrect indentation: this token is offside of context started at position \(95:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(101,2)">Possible incorrect indentation: this token is offside of context started at position \(100:20\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(101,2)">Possible incorrect indentation: this token is offside of context started at position \(100:20\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(105,6)">Possible incorrect indentation: this token is offside of context started at position \(104:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(105,6)">Possible incorrect indentation: this token is offside of context started at position \(104:21\). Try indenting this token further or using standard formatting conventions.</Expects>
+
+
+module Global
+
+let failures = ref []
+
+let report_failure (s : string) = 
+    stderr.Write" NO: "
+    stderr.WriteLine s
+    failures := !failures @ [s]
+
+let test (s : string) b = 
+    stderr.Write(s)
+    if b then stderr.WriteLine " OK"
+    else report_failure (s)
+
+let check s b1 b2 = test s (b1 = b2)
+
+type OffsideCheck(a:int,
+        b:int, c:int, // 4.6 warning: 4.7 no warning
+        d:int, e:int,
+        f:int) =
+    static member M(a:int,
+        b:int, c:int, // 4.6 warning: 4.7 no warning
+        d:int, e:int,
+        f:int) = 1
+
+module M = 
+    type OffsideCheck(a:int,
+  b:int, c:int, // 4.6 warning: 4.7 warning
+  d:int, e:int,
+  f:int) =
+        class end
+
+module M2 = 
+    type OffsideCheck() =
+        static member M(a:int,
+      b:int, c:int, // 4.6 warning: 4.7 warning
+      d:int, e:int,
+      f:int) = 1
+
+type C() = 
+    static member P with get() = 
+      1 // 4.6 warning: 4.7 no warning
+
+module M3 = 
+    type C() = 
+        static member P with get() = 
+      1 // warning
+
+type OffsideCheck2(a:int,
+    b:int, c:int, // 4.6 warning: 4.7 no warning
+    d:int, e:int,
+    f:int) =
+    static member M(a:int,
+        b:int, c:int, // 4.6 warning: 4.7 no warning
+        d:int, e:int,
+        f:int) = 1
+
+type OffsideCheck3(a:int,
+ b:int, c:int, // no warning
+ d:int, e:int,
+ f:int) =
+    static member M(a:int,
+     b:int, c:int, // 4.6 warning: 4.7 no warning
+     d:int, e:int,
+     f:int) = 1
+
+#if TESTS_AS_APP
+let RUN() = !failures
+#else
+let aa =
+  match !failures with 
+  | [] -> 
+      stdout.WriteLine "Test Passed"
+      System.IO.File.WriteAllText("test.ok","ok")
+      exit 0
+  | _ -> 
+      stdout.WriteLine "Test Failed"
+      exit 1
+#endif

--- a/tests/fsharp/core/indent/version47/test.fsx
+++ b/tests/fsharp/core/indent/version47/test.fsx
@@ -1,0 +1,93 @@
+//<Expects id="FS0058" status="warning" span="(42,3)">Possible incorrect indentation: this token is offside of context started at position \(41:5\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(42,3)">Possible incorrect indentation: this token is offside of context started at position \(41:5\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(50,7)">Possible incorrect indentation: this token is offside of context started at position \(49:9\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(50,7)">Possible incorrect indentation: this token is offside of context started at position \(49:9\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(61,7)">Possible incorrect indentation: this token is offside of context started at position \(60:9\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(61,7)">Possible incorrect indentation: this token is offside of context started at position \(60:9\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(42,3)">Possible incorrect indentation: this token is offside of context started at position \(41:5\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(42,3)">Possible incorrect indentation: this token is offside of context started at position \(41:5\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(50,7)">Possible incorrect indentation: this token is offside of context started at position \(49:9\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(50,7)">Possible incorrect indentation: this token is offside of context started at position \(49:9\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(61,7)">Possible incorrect indentation: this token is offside of context started at position \(60:9\). Try indenting this token further or using standard formatting conventions.</Expects>
+//<Expects id="FS0058" status="warning" span="(61,7)">Possible incorrect indentation: this token is offside of context started at position \(60:9\). Try indenting this token further or using standard formatting conventions.</Expects>
+
+
+module Global
+
+let failures = ref []
+
+let report_failure (s : string) = 
+    stderr.Write" NO: "
+    stderr.WriteLine s
+    failures := !failures @ [s]
+
+let test (s : string) b = 
+    stderr.Write(s)
+    if b then stderr.WriteLine " OK"
+    else report_failure (s)
+
+let check s b1 b2 = test s (b1 = b2)
+
+type OffsideCheck(a:int,
+        b:int, c:int, // no warning
+        d:int, e:int,
+        f:int) =
+    static member M(a:int,
+        b:int, c:int, // no warning
+        d:int, e:int,
+        f:int) = 1
+
+module M = 
+    type OffsideCheck(a:int,
+  b:int, c:int, // 4.6 warning: 4.7 warning
+  d:int, e:int,
+  f:int) =
+        class end
+
+module M2 = 
+    type OffsideCheck() =
+        static member M(a:int,
+      b:int, c:int, // 4.6 warning: 4.7 warning
+      d:int, e:int,
+      f:int) = 1
+
+type C() = 
+    static member P with get() = 
+      1 // 4.6 warning: 4.7 no warning
+
+module M3 = 
+    type C() = 
+        static member P with get() = 
+      1 // warning
+
+type OffsideCheck2(a:int,
+    b:int, c:int, // 4.6 warning: 4.7 no warning
+    d:int, e:int,
+    f:int) =
+    static member M(a:int,
+        b:int, c:int, // 4.6 warning: 4.7 no warning
+        d:int, e:int,
+        f:int) = 1
+
+type OffsideCheck3(a:int,
+ b:int, c:int, // no warning
+ d:int, e:int,
+ f:int) =
+    static member M(a:int,
+     b:int, c:int, // 4.6 warning: 4.7 no warning
+     d:int, e:int,
+     f:int) = 1
+
+#if TESTS_AS_APP
+let RUN() = !failures
+#else
+let aa =
+  match !failures with 
+  | [] -> 
+      stdout.WriteLine "Test Passed"
+      System.IO.File.WriteAllText("test.ok","ok")
+      exit 0
+  | _ -> 
+      stdout.WriteLine "Test Failed"
+      exit 1
+#endif

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1811,6 +1811,13 @@ module VersionTests =
     [<Test>]
     let ``member-selfidentifier-version4.7``() = singleTestBuildAndRunVersion "core/members/self-identifier/version47" FSC_BUILDONLY "preview"
 
+    [<Test>]
+    let ``indent-version4.6``() = singleTestBuildAndRunVersion "core/indent/version46" FSC_BUILDONLY "4.6"
+
+    [<Test>]
+    let ``indent-version4.7``() = singleTestBuildAndRunVersion "core/indent/version47" FSC_BUILDONLY "preview"
+
+
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
 module ToolsTests = 
 
@@ -1820,7 +1827,7 @@ module ToolsTests =
         let cfg = testConfig "tools/bundle"
 
         fsc cfg "%s --progress --standalone -o:test-one-fsharp-module.exe -g" cfg.fsc_flags ["test-one-fsharp-module.fs"]
-   
+
         peverify cfg "test-one-fsharp-module.exe"
    
         fsc cfg "%s -a -o:test_two_fsharp_modules_module_1.dll -g" cfg.fsc_flags ["test_two_fsharp_modules_module_1.fs"]

--- a/tests/fsharp/typecheck/sigs/neg77.bsl
+++ b/tests/fsharp/typecheck/sigs/neg77.bsl
@@ -4,15 +4,3 @@ neg77.fsx(134,15,134,16): parse error FS0058: Possible incorrect indentation: th
 neg77.fsx(134,15,134,16): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (133:19). Try indenting this token further or using standard formatting conventions.
 
 neg77.fsx(134,15,134,16): parse error FS0010: Unexpected symbol '|' in expression
-
-neg77.fsx(259,3,259,4): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (258:5). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(259,3,259,4): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (258:5). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(267,7,267,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (266:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(267,7,267,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (266:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(278,7,278,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (277:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(278,7,278,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (277:9). Try indenting this token further or using standard formatting conventions.

--- a/tests/fsharp/typecheck/sigs/neg77.fsx
+++ b/tests/fsharp/typecheck/sigs/neg77.fsx
@@ -243,60 +243,6 @@ do Application.Run(form)
 #endif
 
 
-open System
-
-type OffsideCheck(a:int,
-        b:int, c:int, // no warning
-        d:int, e:int,
-        f:int) =
-    static member M(a:int,
-        b:int, c:int, // no warning
-        d:int, e:int,
-        f:int) = 1
-
-module M = 
-    type OffsideCheck(a:int,
-  b:int, c:int, // warning
-  d:int, e:int,
-  f:int) =
-        class end
-
-module M2 = 
-    type OffsideCheck() =
-        static member M(a:int,
-      b:int, c:int, // warning
-      d:int, e:int,
-      f:int) = 1
-
-type C() = 
-    static member P with get() = 
-      1 // no warning
-
-module M3 = 
-    type C() = 
-        static member P with get() = 
-      1 // warning
-
-
-type OffsideCheck2(a:int,
-    b:int, c:int, // no warning
-    d:int, e:int,
-    f:int) =
-    static member M(a:int,
-        b:int, c:int, // no warning
-        d:int, e:int,
-        f:int) = 1
-
-type OffsideCheck3(a:int,
- b:int, c:int, // no warning
- d:int, e:int,
- f:int) =
-    static member M(a:int,
-     b:int, c:int, // no warning
-     d:int, e:int,
-     f:int) = 1
-
-
 
 
 

--- a/tests/fsharp/typecheck/sigs/neg77.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg77.vsbsl
@@ -5,34 +5,10 @@ neg77.fsx(134,15,134,16): parse error FS0058: Possible incorrect indentation: th
 
 neg77.fsx(134,15,134,16): parse error FS0010: Unexpected symbol '|' in expression
 
-neg77.fsx(259,3,259,4): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (258:5). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(259,3,259,4): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (258:5). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(267,7,267,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (266:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(267,7,267,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (266:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(278,7,278,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (277:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(278,7,278,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (277:9). Try indenting this token further or using standard formatting conventions.
-
 neg77.fsx(134,15,134,16): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (133:19). Try indenting this token further or using standard formatting conventions.
 
 neg77.fsx(134,15,134,16): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (133:19). Try indenting this token further or using standard formatting conventions.
 
 neg77.fsx(134,15,134,16): parse error FS0010: Unexpected symbol '|' in expression
-
-neg77.fsx(259,3,259,4): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (258:5). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(259,3,259,4): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (258:5). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(267,7,267,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (266:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(267,7,267,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (266:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(278,7,278,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (277:9). Try indenting this token further or using standard formatting conventions.
-
-neg77.fsx(278,7,278,8): parse error FS0058: Possible incorrect indentation: this token is offside of context started at position (277:9). Try indenting this token further or using standard formatting conventions.
 
 neg77.fsx(153,75,153,79): typecheck error FS0001: The type 'Planet * 'a' is not compatible with the type 'Planet'


### PR DESCRIPTION
These are getting easier now.

Controls the whitespace relaxation language change.

again the bulk of this PR exists already in the unmerged pr: https://github.com/dotnet/fsharp/pull/6891
The only part worth looking at is this commit:  https://github.com/dotnet/fsharp/commit/7f0bdb7ffcdfe72346e3aae17c6a004c6d7ade77

It adds, feature flags, the feature enabling modification
and moves the neg tests to versioning tests

````
C:\temp\ws>c:\kevinransom\fsharp\artifacts\bin\fsc\Release\net472\fsc Program.fs
Microsoft (R) F# Compiler version 10.6.0.0 for F# 4.7
Copyright (c) Microsoft Corporation. All Rights Reserved.

Program.fs(6,9): warning FS0058: Possible incorrect indentation: this token is offside of context started at position (5:19). Try indenting this token further or using standard formatting conventions.

Program.fs(6,9): warning FS0058: Possible incorrect indentation: this token is offside of context started at position (5:19). Try indenting this token further or using standard formatting conventions.

Program.fs(11,9): warning FS0058: Possible incorrect indentation: this token is offside of context started at position (10:21). Try indenting this token further or using standard formatting conventions.

Program.fs(11,9): warning FS0058: Possible incorrect indentation: this token is offside of context started at position (10:21). Try indenting this token further or using standard formatting conventions.

C:\temp\ws>c:\kevinransom\fsharp\artifacts\bin\fsc\Release\net472\fsc --langversion:preview Program.fs
Microsoft (R) F# Compiler version 10.6.0.0 for F# 4.7
Copyright (c) Microsoft Corporation. All Rights Reserved.

C:\temp\ws>
````