### PR TITLE
Don't go looking for MSBuild v12 in SimulatedMSBuildReferenceResolver

### DIFF
--- a/src/fsharp/SimulatedMSBuildReferenceResolver.fs
+++ b/src/fsharp/SimulatedMSBuildReferenceResolver.fs
@@ -10,11 +10,10 @@ open System
 open System.IO
 open System.Reflection
 open Microsoft.Win32
-open FSharp.Compiler
 open FSharp.Compiler.ReferenceResolver
 open FSharp.Compiler.AbstractIL.Internal.Library
 
-let internal SimulatedMSBuildResolver =
+let private SimulatedMSBuildResolver =
     let supportedFrameworks = [|
         "v4.7.2"
         "v4.7.1"
@@ -183,21 +182,7 @@ let internal SimulatedMSBuildResolver =
 
             results.ToArray() }
 
-let internal GetBestAvailableResolver() =
-#if !FX_RESHAPED_MSBUILD
-    let tryMSBuild v =
-        // Detect if MSBuild is on the machine, if so use the resolver from there
-        let mb = try Assembly.Load(sprintf "Microsoft.Build.Framework, Version=%s.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" v) |> Option.ofObj with _ -> None
-        let assembly = mb |> Option.bind (fun _ -> try Assembly.Load(sprintf "FSharp.Compiler.Service.MSBuild.v%s" v) |> Option.ofObj with _ -> None)
-        let ty = assembly |> Option.bind (fun a -> a.GetType("FSharp.Compiler.MSBuildReferenceResolver") |> Option.ofObj)
-        let obj = ty |> Option.bind (fun ty -> ty.InvokeMember("get_Resolver", BindingFlags.Static ||| BindingFlags.Public ||| BindingFlags.InvokeMethod ||| BindingFlags.NonPublic, null, null, [| |]) |> Option.ofObj)
-        let resolver = obj |> Option.bind (fun obj -> match obj with :? Resolver as r -> Some r | _ -> None)
-        resolver
-    match tryMSBuild "12" with
-    | Some r -> r
-    | None ->
-#endif
-    SimulatedMSBuildResolver
+let internal getResolver () = SimulatedMSBuildResolver
 
 
 #if INTERACTIVE

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2415,7 +2415,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let legacyReferenceResolver = 
         match legacyReferenceResolver with 
-        | None -> SimulatedMSBuildReferenceResolver.GetBestAvailableResolver()
+        | None -> SimulatedMSBuildReferenceResolver.getResolver()
         | Some rr -> rr
 
     let tcConfigB = 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -2946,7 +2946,7 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
         let legacyReferenceResolver = 
             match legacyReferenceResolver with
             | Some rr -> rr
-            | None -> SimulatedMSBuildReferenceResolver.GetBestAvailableResolver()
+            | None -> SimulatedMSBuildReferenceResolver.getResolver()
 
         let keepAssemblyContents = defaultArg keepAssemblyContents false
         let keepAllBackgroundResolutions = defaultArg keepAllBackgroundResolutions true


### PR DESCRIPTION
#6921 

This probing code is called only when not in the F# tools for Visual Studio. However...

...it looks for MSBuild v12, which is installed only by an older Visual Studio

...which means it only works on Windows

...and VS 2019 doesn't install MSBuild v12

So any modern, released version of F# on Windows requires you to either hunt down the last Visual Studio that installs this old MSBuild toolset, or hunt down the old toolset yourself. And then hope that the reflection code worked. All in service to some slightly better diagnostics for `#load` and `#r` directives in F# script files.