### PR TITLE
ensure Microsoft.FSharp.NetSdk.props makes it into VisualFSharpFull.vsix

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -5,29 +5,30 @@
   <Import Project="eng\targets\NGenBinaries.targets" />
   <Import Project="FSharp.Profiles.props" />
 
-  <Target Name="CopyAndSubstituteTextFiles"
-          Inputs="@(CopyAndSubstituteText)"
-          Outputs="@(CopyAndSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
-          BeforeTargets="BeforeBuild">
+  <Target Name="NoneSubstituteTextFiles"
+          Inputs="@(NoneSubstituteText)"
+          Outputs="@(NoneSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
+          BeforeTargets="AssignTargetPaths;BeforeBuild">
 
     <PropertyGroup>
-      <__TargetFilePath>@(CopyAndSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')</__TargetFilePath>
-      <__TargetFileName>@(CopyAndSubstituteText->'%(Filename)%(Extension)')</__TargetFileName>
+      <__TargetFilePath>@(NoneSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')</__TargetFilePath>
+      <__TargetFileName>@(NoneSubstituteText->'%(Filename)%(Extension)')</__TargetFileName>
 
-      <_ReplacementText>$([System.IO.File]::ReadAllText('%(CopyAndSubstituteText.FullPath)'))</_ReplacementText>
-      <_ReplacementText Condition="'%(CopyAndSubstituteText.Pattern1)' != ''">$(_ReplacementText.Replace('%(CopyAndSubstituteText.Pattern1)', '%(CopyAndSubstituteText.Replacement1)'))</_ReplacementText>
-      <_ReplacementText Condition="'%(CopyAndSubstituteText.Pattern2)' != ''">$(_ReplacementText.Replace('%(CopyAndSubstituteText.Pattern2)', '%(CopyAndSubstituteText.Replacement2)'))</_ReplacementText>
+      <_ReplacementText>$([System.IO.File]::ReadAllText('%(NoneSubstituteText.FullPath)'))</_ReplacementText>
+      <_ReplacementText Condition="'%(NoneSubstituteText.Pattern1)' != ''">$(_ReplacementText.Replace('%(NoneSubstituteText.Pattern1)', '%(NoneSubstituteText.Replacement1)'))</_ReplacementText>
+      <_ReplacementText Condition="'%(NoneSubstituteText.Pattern2)' != ''">$(_ReplacementText.Replace('%(NoneSubstituteText.Pattern2)', '%(NoneSubstituteText.Replacement2)'))</_ReplacementText>
+
+      <_CopyToOutputDirectory Condition="'%(NoneSubstituteText.CopyToOutputDirectory)' != ''">%(NoneSubstituteText.CopyToOutputDirectory)</_CopyToOutputDirectory>
+      <_CopyToOutputDirectory Condition="'%(NoneSubstituteText.CopyToOutputDirectory)' == ''">Never</_CopyToOutputDirectory>
     </PropertyGroup>
 
-    <MakeDir
-      Directories="$(IntermediateOutputPath)"
-      Condition="!Exists('$(IntermediateOutputPath)')" />
+    <MakeDir Directories="$(IntermediateOutputPath)"
+             Condition="!Exists('$(IntermediateOutputPath)')" />
     <WriteLinesToFile File="$(__TargetFilePath)" Lines="$(_ReplacementText)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
     <!-- Make sure it will get cleaned  -->
     <ItemGroup >
-      <None Include="$(__TargetFilePath)" Condition="'$(__TargetFileName)' == 'App.config'" CopyToOutputDirectory="Never" />
-      <None Include="$(__TargetFilePath)" Condition="'$(__TargetFileName)' != 'App.config'" CopyToOutputDirectory="PreserveNewest" />
+      <None Include="$(__TargetFilePath)" CopyToOutputDirectory="$(_CopyToOutputDirectory)" />
       <FileWrites Include="$(__TargetFilePath)" Condition="'$(__TargetFileName)' != 'App.config'" />
     </ItemGroup>
   </Target>

--- a/fcs/Directory.Build.targets
+++ b/fcs/Directory.Build.targets
@@ -1,28 +1,29 @@
 <Project>
 
-  <Target Name="CopyAndSubstituteTextFiles"
-          Inputs="@(CopyAndSubstituteText)"
-          Outputs="@(CopyAndSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
-          BeforeTargets="BeforeBuild">
+  <Target Name="NoneSubstituteTextFiles"
+          Inputs="@(NoneSubstituteText)"
+          Outputs="@(NoneSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
+          BeforeTargets="AssignTargetPaths;BeforeBuild">
 
     <PropertyGroup>
-      <__TargetFilePath>@(CopyAndSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')</__TargetFilePath>
-      <__TargetFileName>@(CopyAndSubstituteText->'%(Filename)%(Extension)')</__TargetFileName>
+      <__TargetFilePath>@(NoneSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')</__TargetFilePath>
+      <__TargetFileName>@(NoneSubstituteText->'%(Filename)%(Extension)')</__TargetFileName>
 
-      <_ReplacementText>$([System.IO.File]::ReadAllText('%(CopyAndSubstituteText.FullPath)'))</_ReplacementText>
-      <_ReplacementText Condition="'%(CopyAndSubstituteText.Pattern1)' != ''">$(_ReplacementText.Replace('%(CopyAndSubstituteText.Pattern1)', '%(CopyAndSubstituteText.Replacement1)'))</_ReplacementText>
-      <_ReplacementText Condition="'%(CopyAndSubstituteText.Pattern2)' != ''">$(_ReplacementText.Replace('%(CopyAndSubstituteText.Pattern2)', '%(CopyAndSubstituteText.Replacement2)'))</_ReplacementText>
+      <_ReplacementText>$([System.IO.File]::ReadAllText('%(NoneSubstituteText.FullPath)'))</_ReplacementText>
+      <_ReplacementText Condition="'%(NoneSubstituteText.Pattern1)' != ''">$(_ReplacementText.Replace('%(NoneSubstituteText.Pattern1)', '%(NoneSubstituteText.Replacement1)'))</_ReplacementText>
+      <_ReplacementText Condition="'%(NoneSubstituteText.Pattern2)' != ''">$(_ReplacementText.Replace('%(NoneSubstituteText.Pattern2)', '%(NoneSubstituteText.Replacement2)'))</_ReplacementText>
+
+      <_CopyToOutputDirectory Condition="'%(NoneSubstituteText.CopyToOutputDirectory)' != ''">%(NoneSubstituteText.CopyToOutputDirectory)</_CopyToOutputDirectory>
+      <_CopyToOutputDirectory Condition="'%(NoneSubstituteText.CopyToOutputDirectory)' == ''">Never</_CopyToOutputDirectory>
     </PropertyGroup>
 
-    <MakeDir
-      Directories="$(IntermediateOutputPath)"
-      Condition="!Exists('$(IntermediateOutputPath)')" />
+    <MakeDir Directories="$(IntermediateOutputPath)"
+             Condition="!Exists('$(IntermediateOutputPath)')" />
     <WriteLinesToFile File="$(__TargetFilePath)" Lines="$(_ReplacementText)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
     <!-- Make sure it will get cleaned  -->
     <ItemGroup >
-      <None Include="$(__TargetFilePath)" Condition="'$(__TargetFileName)' == 'App.config'" CopyToOutputDirectory="Never" />
-      <None Include="$(__TargetFilePath)" Condition="'$(__TargetFileName)' != 'App.config'" CopyToOutputDirectory="PreserveNewest" />
+      <None Include="$(__TargetFilePath)" CopyToOutputDirectory="$(_CopyToOutputDirectory)" />
       <FileWrites Include="$(__TargetFilePath)" Condition="'$(__TargetFileName)' != 'App.config'" />
     </ItemGroup>
   </Target>

--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -73,10 +73,10 @@
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\Program.fs" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
       <Link>Program.fs</Link>
     </Compile>
-    <CopyAndSubstituteText Include="App.config">
+    <NoneSubstituteText Include="App.config">
       <Pattern1>{{FSCoreVersion}}</Pattern1>
       <Replacement1>$(FSCoreVersion)</Replacement1>
-    </CopyAndSubstituteText>
+    </NoneSubstituteText>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="$(FcsFSharpCorePkgVersion)" />

--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -67,7 +67,7 @@ let releaseDir = Path.Combine(__SOURCE_DIRECTORY__, "../artifacts/bin/fcs/Releas
 let release = LoadReleaseNotes (__SOURCE_DIRECTORY__ + "/RELEASE_NOTES.md")
 let isAppVeyorBuild = buildServer = BuildServer.AppVeyor
 let isJenkinsBuild = buildServer = BuildServer.Jenkins
-let isVersionTag tag = Version.TryParse tag |> fst
+let isVersionTag (tag: string) = Version.TryParse tag |> fst
 let hasRepoVersionTag = isAppVeyorBuild && AppVeyorEnvironment.RepoTag && isVersionTag AppVeyorEnvironment.RepoTagName
 let assemblyVersion = if hasRepoVersionTag then AppVeyorEnvironment.RepoTagName else release.NugetVersion
 

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -29,13 +29,13 @@
     <None Include="Microsoft.FSharp.Targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Microsoft.Portable.FSharp.Targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Microsoft.FSharp.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
-    <CopyAndSubstituteText Include="Microsoft.FSharp.NetSdk.props">
+    <NoneSubstituteText Include="Microsoft.FSharp.NetSdk.props" CopyToOutputDirectory="PreserveNewest">
       <TargetFileName>Microsoft.FSharp.NetSdk.props</TargetFileName>
       <Pattern1>{{FSharpCoreShippedPackageVersion}}</Pattern1>
       <Replacement1>$(FSharpCoreShippedPackageVersion)</Replacement1>
       <Pattern2>{{FSharpCorePreviewPackageVersion}}</Pattern2>
       <Replacement2>$(FSharpCorePreviewPackageVersion)</Replacement2>
-    </CopyAndSubstituteText>
+    </NoneSubstituteText>
     <None Include="Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/src/fsharp/fsc/fsc.fsproj
+++ b/src/fsharp/fsc/fsc.fsproj
@@ -25,10 +25,10 @@
       <Link>default.win32manifest</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <CopyAndSubstituteText Include="App.config">
+    <NoneSubstituteText Include="App.config">
       <Pattern1>{{FSCoreVersion}}</Pattern1>
       <Replacement1>$(FSCoreVersion)</Replacement1>
-    </CopyAndSubstituteText>
+    </NoneSubstituteText>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -22,10 +22,10 @@
   <ItemGroup>
     <Compile Include="console.fs" />
     <Compile Include="fsimain.fs" />
-    <CopyAndSubstituteText Include="App.config">
+    <NoneSubstituteText Include="App.config">
       <Pattern1>{{FSCoreVersion}}</Pattern1>
       <Replacement1>$(FSCoreVersion)</Replacement1>
-    </CopyAndSubstituteText>
+    </NoneSubstituteText>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/fsharp/fsiAnyCpu/fsiAnyCpu.fsproj
+++ b/src/fsharp/fsiAnyCpu/fsiAnyCpu.fsproj
@@ -22,10 +22,10 @@
   <ItemGroup>
     <Compile Include="..\fsi\console.fs" />
     <Compile Include="..\fsi\fsimain.fs" />
-    <CopyAndSubstituteText Include="App.config">
+    <NoneSubstituteText Include="App.config">
       <Pattern1>{{FSCoreVersion}}</Pattern1>
       <Replacement1>$(FSCoreVersion)</Replacement1>
-    </CopyAndSubstituteText>
+    </NoneSubstituteText>
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -165,10 +165,10 @@
     <Compile Include="DocumentHighlightsServiceTests.fs">
       <Link>Roslyn\DocumentHighlightsServiceTests.fs</Link>
     </Compile>
-    <CopyAndSubstituteText Include="App.config">
+    <NoneSubstituteText Include="App.config">
       <Pattern1>{{FSCoreVersion}}</Pattern1>
       <Replacement1>$(FSCoreVersion)</Replacement1>
-    </CopyAndSubstituteText>
+    </NoneSubstituteText>
     <None Include="app.runsettings" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The result of #6761 is that `Microsoft.FSharp.NetSdk.props` wasn't getting F5 deployed with VisualFSharpFull.vsix which makes local debugging difficult.

During a build/deploy in VS the target `BeforeBuild` wasn't getting called on FSharp.Build.fsproj if up-to-date checks passed which meant the `.props` file wasn't getting added to the `@(None)` item group.  The fix is to make that target depend on `AssignTargetPaths` which is run in both the VS build as well as the command line build.