### PR TITLE
[WIP] enable preview LSP support

### DIFF
--- a/VisualFSharp.sln
+++ b/VisualFSharp.sln
@@ -158,6 +158,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.LanguageSer
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.LanguageServer.UnitTests", "tests\FSharp.Compiler.LanguageServer.UnitTests\FSharp.Compiler.LanguageServer.UnitTests.fsproj", "{AAF2D233-1C38-4090-8FFA-F7C545625E06}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FSharp.Editor.Helpers", "vsintegration\src\FSharp.Editor.Helpers\FSharp.Editor.Helpers.csproj", "{79255A92-ED00-40BA-9D64-12FCC664A976}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -912,6 +914,18 @@ Global
 		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Release|x86.ActiveCfg = Release|Any CPU
 		{AAF2D233-1C38-4090-8FFA-F7C545625E06}.Release|x86.Build.0 = Release|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Debug|x86.Build.0 = Debug|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Proto|Any CPU.ActiveCfg = Release|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Proto|Any CPU.Build.0 = Release|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Proto|x86.ActiveCfg = Release|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Proto|x86.Build.0 = Release|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Release|x86.ActiveCfg = Release|Any CPU
+		{79255A92-ED00-40BA-9D64-12FCC664A976}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -986,6 +1000,7 @@ Global
 		{8EC30B2E-F1F9-4A98-BBB5-DD0CF6C84DDC} = {647810D0-5307-448F-99A2-E83917010DAE}
 		{60BAFFA5-6631-4328-B044-2E012AB76DCA} = {B8DDA694-7939-42E3-95E5-265C2217C142}
 		{AAF2D233-1C38-4090-8FFA-F7C545625E06} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
+		{79255A92-ED00-40BA-9D64-12FCC664A976} = {4C7B48D7-19AF-4AE7-9D1D-3BB289D5480D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {48EDBBBE-C8EE-4E3C-8B19-97184A487B37}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,7 +92,7 @@
     <SystemThreadingTasksParallelVersion>4.3.0</SystemThreadingTasksParallelVersion>
     <SystemThreadingThreadVersion>4.3.0</SystemThreadingThreadVersion>
     <SystemThreadingThreadPoolVersion>4.3.0</SystemThreadingThreadPoolVersion>
-    <SystemValueTupleVersion>4.4.0</SystemValueTupleVersion>
+    <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <!-- Roslyn packages -->
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>
     <MicrosoftCodeAnalysisEditorFeaturesTextVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesTextVersion>
@@ -115,6 +115,7 @@
     <MicrosoftVisualStudioEditorVersion>16.0.467</MicrosoftVisualStudioEditorVersion>
     <MicrosoftVisualStudioImageCatalogVersion>16.0.28727</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioImagingVersion>16.0.28729</MicrosoftVisualStudioImagingVersion>
+    <MicrosoftVisualStudioLanguageServerClientVersion>16.1.3121</MicrosoftVisualStudioLanguageServerClientVersion>
     <MicrosoftVisualStudioLanguageStandardClassificationVersion>16.0.467</MicrosoftVisualStudioLanguageStandardClassificationVersion>
     <MicrosoftVisualStudioLanguageVersion>16.0.467</MicrosoftVisualStudioLanguageVersion>
     <MicrosoftVisualStudioLanguageIntellisenseVersion>16.0.467</MicrosoftVisualStudioLanguageIntellisenseVersion>

--- a/src/fsharp/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
@@ -11,8 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="State.fs" />
+    <Compile Include="JsonDUConverter.fs" />
+    <Compile Include="JsonOptionConverter.fs" />
     <Compile Include="LspTypes.fs" />
+    <Compile Include="LspExternalAccess.fs" />
+    <Compile Include="State.fs" />
     <Compile Include="TextDocument.fs" />
     <Compile Include="Methods.fs" />
     <Compile Include="Server.fs" />
@@ -27,5 +30,20 @@
   <ItemGroup>
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
   </ItemGroup>
+
+  <Target Name="GatherPublishedProjectOutputGroupItems"
+          DependsOnTargets="Publish">
+    <ItemGroup>
+      <_PublishedProjectOutputGroupFiles Include="$(PublishDir)\**" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PublishedProjectOutputGroup"
+          Returns="@(PublishedProjectOutputGroupOutput)"
+          DependsOnTargets="GatherPublishedProjectOutputGroupItems">
+    <ItemGroup>
+      <PublishedProjectOutputGroupOutput Include="@(_PublishedProjectOutputGroupFiles)" TargetPath="Agent\%(RecursiveDir)%(FileName)%(Extension)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/fsharp/FSharp.Compiler.LanguageServer/JsonDUConverter.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/JsonDUConverter.fs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+open System
+open FSharp.Reflection
+open Newtonsoft.Json
+
+type JsonDUConverter() =
+    inherit JsonConverter()
+    override __.CanConvert(typ) = FSharpType.IsUnion(typ)
+    override __.WriteJson(writer, value, _serializer) =
+        writer.WriteValue(value.ToString().ToLowerInvariant())
+    override __.ReadJson(reader, typ, x, serializer) =
+        let cases = FSharpType.GetUnionCases(typ)
+        let str = serializer.Deserialize(reader, typeof<string>) :?> string
+        let case = cases |> Array.find (fun c -> String.Compare(c.Name, str, StringComparison.OrdinalIgnoreCase) = 0)
+        FSharpValue.MakeUnion(case, [||])

--- a/src/fsharp/FSharp.Compiler.LanguageServer/JsonOptionConverter.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/JsonOptionConverter.fs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+open System
+open FSharp.Reflection
+open Newtonsoft.Json
+
+type JsonOptionConverter() =
+    inherit JsonConverter()
+    override __.CanConvert(typ) = typ.IsGenericType && typ.GetGenericTypeDefinition() = typedefof<option<_>>
+    override __.WriteJson(writer, value, serializer) =
+        let value = match value with
+                    | null -> null
+                    | _ ->
+                        let _, fields =  FSharpValue.GetUnionFields(value, value.GetType())
+                        fields.[0]
+        serializer.Serialize(writer, value)
+    override __.ReadJson(reader, typ, _, serializer) =
+        let innerType = typ.GetGenericArguments().[0]
+        let innerType =
+            if innerType.IsValueType then (typedefof<Nullable<_>>).MakeGenericType([|innerType|])
+            else innerType
+        let value = serializer.Deserialize(reader, innerType)
+        let cases = FSharpType.GetUnionCases(typ)
+        if value = null then FSharpValue.MakeUnion(cases.[0], [||])
+        else FSharpValue.MakeUnion(cases.[1], [|value|])

--- a/src/fsharp/FSharp.Compiler.LanguageServer/LspExternalAccess.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/LspExternalAccess.fs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer
+
+open StreamJsonRpc
+
+[<AutoOpen>]
+module FunctionNames =
+    [<Literal>]
+    let OptionsSet = "options/set"
+
+type Options =
+    { usePreviewTextHover: bool }
+    static member Default() =
+        { usePreviewTextHover = false }
+
+module Extensions =
+    type JsonRpc with
+        member jsonRpc.SetOptionsAsync (options: Options) =
+            async {
+                do! jsonRpc.InvokeAsync(OptionsSet, options) |> Async.AwaitTask
+            }

--- a/src/fsharp/FSharp.Compiler.LanguageServer/LspTypes.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/LspTypes.fs
@@ -2,8 +2,11 @@
 
 namespace FSharp.Compiler.LanguageServer
 
-// Interfaces as defined at https://microsoft.github.io/language-server-protocol/specification.  The properties on these
-// types are camlCased to match the underlying JSON properties to avoid attributes on every field:
+open Newtonsoft.Json.Linq
+open Newtonsoft.Json
+
+// Interfaces as defined at https://microsoft.github.io/language-server-protocol/specification.  The properties on
+// these types are camlCased to match the underlying JSON properties to avoid attributes on every field:
 //   [<JsonProperty("camlCased")>]
 
 /// Represents a zero-based line and column of a text document.
@@ -27,11 +30,11 @@ type DiagnosticRelatedInformation =
 
 type Diagnostic =
     { range: Range
-      severity: int
+      severity: int option
       code: string
-      source: string // "F#"
+      source: string option // "F#"
       message: string
-      relatedInformation: DiagnosticRelatedInformation[] }
+      relatedInformation: DiagnosticRelatedInformation[] option }
     static member Error = 1
     static member Warning = 2
     static member Information = 3
@@ -41,9 +44,23 @@ type PublishDiagnosticsParams =
     { uri: DocumentUri
       diagnostics: Diagnostic[] }
 
-type InitializeParams = string // TODO:
+type ClientCapabilities =
+    { workspace: JToken option // TODO: WorkspaceClientCapabilities
+      textDocument: JToken option // TODO: TextDocumentCapabilities
+      experimental: JToken option
+      supportsVisualStudioExtensions: bool option }
 
-// Note, this type has many more optional values that can be expanded as support is added.
+[<JsonConverter(typeof<JsonDUConverter>)>]
+type Trace =
+    | Off
+    | Messages
+    | Verbose
+
+type WorkspaceFolder =
+    { uri: DocumentUri
+      name: string }
+
+/// Note, this type has many more optional values that can be expanded as support is added.
 type ServerCapabilities =
     { hoverProvider: bool }
     static member DefaultCapabilities() =
@@ -52,6 +69,7 @@ type ServerCapabilities =
 type InitializeResult =
     { capabilities: ServerCapabilities }
 
+[<JsonConverter(typeof<JsonDUConverter>)>]
 type MarkupKind =
     | PlainText
     | Markdown
@@ -66,7 +84,3 @@ type Hover =
 
 type TextDocumentIdentifier =
     { uri: DocumentUri }
-
-type TextDocumentPositionParams =
-    { textDocument: TextDocumentIdentifier
-      position: Position }

--- a/src/fsharp/FSharp.Compiler.LanguageServer/Methods.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/Methods.fs
@@ -2,21 +2,66 @@
 
 namespace FSharp.Compiler.LanguageServer
 
+open System
+open System.Runtime.InteropServices
+open System.Threading
+open Newtonsoft.Json.Linq
 open StreamJsonRpc
 
 // https://microsoft.github.io/language-server-protocol/specification
 type Methods(state: State) =
 
+    /// Helper to run Async<'T> with a CancellationToken.
+    let runAsync (cancellationToken: CancellationToken) (computation: Async<'T>) = Async.StartAsTask(computation, cancellationToken=cancellationToken)
+
+    member __.State = state
+
+    //--------------------------------------------------------------------------
+    // official LSP methods
+    //--------------------------------------------------------------------------
+
     [<JsonRpcMethod("initialize")>]
-    member __.Initialize (args: InitializeParams) =
-        async {
-            // note, it's important that this method is `async` because unit tests can then properly verify that the
-            // JSON RPC handling of async methods is correct
-            return ServerCapabilities.DefaultCapabilities()
-        } |> Async.StartAsTask
+    member __.Initialize
+        (
+            processId: Nullable<int>,
+            [<Optional; DefaultParameterValue(null: string)>] rootPath: string,
+            [<Optional; DefaultParameterValue(null: string)>] rootUri: DocumentUri,
+            [<Optional; DefaultParameterValue(null: JToken)>] initializationOptions: JToken,
+            capabilities: ClientCapabilities,
+            [<Optional; DefaultParameterValue(null: string)>] trace: string,
+            [<Optional; DefaultParameterValue(null: WorkspaceFolder[])>] workspaceFolders: WorkspaceFolder[]
+        ) =
+        { InitializeResult.capabilities = ServerCapabilities.DefaultCapabilities() }
+
+    [<JsonRpcMethod("initialized")>]
+    member __.Initialized () = ()
 
     [<JsonRpcMethod("shutdown")>]
-    member __.Shutdown() = state.DoShutdown()
+    member __.Shutdown(): obj = state.DoShutdown(); null
+
+    [<JsonRpcMethod("exit")>]
+    member __.Exit() = state.DoExit()
+
+    [<JsonRpcMethod("$/cancelRequest")>]
+    member __.cancelRequest (id: JToken) = state.DoCancel()
 
     [<JsonRpcMethod("textDocument/hover")>]
-    member __.TextDocumentHover (args: TextDocumentPositionParams) = TextDocument.Hover(state, args) |> Async.StartAsTask
+    member __.TextDocumentHover
+        (
+            textDocument: TextDocumentIdentifier,
+            position: Position,
+            [<Optional; DefaultParameterValue(CancellationToken())>] cancellationToken: CancellationToken
+        ) =
+        TextDocument.Hover state textDocument position |> runAsync cancellationToken
+
+    //--------------------------------------------------------------------------
+    // unofficial LSP methods that we implement separately
+    //--------------------------------------------------------------------------
+
+    [<JsonRpcMethod(OptionsSet)>]
+    member __.OptionsSet
+        (
+            options: Options
+        ) =
+        sprintf "got options %A" options |> Console.Error.WriteLine
+        state.Options <- options

--- a/src/fsharp/FSharp.Compiler.LanguageServer/State.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/State.fs
@@ -5,8 +5,22 @@ namespace FSharp.Compiler.LanguageServer
 type State() =
 
     let shutdownEvent = new Event<_>()
+    let exitEvent = new Event<_>()
+    let cancelEvent = new Event<_>()
 
     [<CLIEvent>]
     member __.Shutdown = shutdownEvent.Publish
 
+    [<CLIEvent>]
+    member __.Exit = exitEvent.Publish
+
+    [<CLIEvent>]
+    member __.Cancel = cancelEvent.Publish
+
     member __.DoShutdown() = shutdownEvent.Trigger()
+
+    member __.DoExit() = exitEvent.Trigger()
+
+    member __.DoCancel() = cancelEvent.Trigger()
+
+    member val Options = Options.Default() with get, set

--- a/src/fsharp/FSharp.Compiler.LanguageServer/TextDocument.fs
+++ b/src/fsharp/FSharp.Compiler.LanguageServer/TextDocument.fs
@@ -2,26 +2,23 @@
 
 namespace FSharp.Compiler.LanguageServer
 
+open System
+
 module TextDocument =
 
-    let Hover(state: State, args: TextDocumentPositionParams) =
+    let Hover (state: State) (textDocument: TextDocumentIdentifier) (position: Position) =
         async {
-            return {
-                Hover.contents = {
-                    MarkupContent.kind = MarkupKind.PlainText
-                    value = "TODO"
+            Console.Error.WriteLine("hover at " + position.line.ToString() + "," + position.character.ToString())
+            if not state.Options.usePreviewTextHover then return None
+            else
+                let startCol, endCol =
+                    if position.character = 0 then 0, 1
+                    else position.character, position.character + 1
+                return Some { contents = { kind = MarkupKind.PlainText
+                                           value = "servivng textDocument/hover from LSP" }
+                              range = Some { start = { line = position.line; character = startCol }
+                                             ``end`` = { line = position.line; character = endCol } }
                 }
-                range = Some({
-                    Range.start = {
-                        Position.line = 0
-                        character = 0
-                    }
-                    ``end`` = {
-                        Position.line = 0
-                        character = 0
-                    }
-                })
-            }
         }
 
     let PublishDiagnostics(state: State) =

--- a/tests/FSharp.Compiler.LanguageServer.UnitTests/FSharp.Compiler.LanguageServer.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.LanguageServer.UnitTests/FSharp.Compiler.LanguageServer.UnitTests.fsproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Compile Include="ProtocolTests.fs" />
+    <Compile Include="SerializationTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FSharp.Compiler.LanguageServer.UnitTests/SerializationTests.fs
+++ b/tests/FSharp.Compiler.LanguageServer.UnitTests/SerializationTests.fs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.LanguageServer.UnitTests
+
+open System
+open FSharp.Compiler.LanguageServer
+open NUnit.Framework
+open Newtonsoft.Json
+
+[<TestFixture>]
+type SerializationTests() =
+
+    let verifyRoundTrip (str: string) (typ: Type) =
+        let deserialized = JsonConvert.DeserializeObject(str, typ)
+        let roundTripped = JsonConvert.SerializeObject(deserialized)
+        Assert.AreEqual(str, roundTripped)
+
+    let verifyRoundTripWithConverter (str: string) (typ: Type) (converter: JsonConverter) =
+        let deserialized = JsonConvert.DeserializeObject(str, typ, converter)
+        let roundTripped = JsonConvert.SerializeObject(deserialized, converter)
+        Assert.AreEqual(str, roundTripped)
+
+    [<Test>]
+    member __.``Discriminated union as lower-case string``() =
+        verifyRoundTrip "\"plaintext\"" typeof<MarkupKind>
+        verifyRoundTrip "\"markdown\"" typeof<MarkupKind>
+
+    [<Test>]
+    member __.``Option<'T> as obj/null``() =
+        verifyRoundTripWithConverter "1" typeof<option<int>> (JsonOptionConverter())
+        verifyRoundTripWithConverter "null" typeof<option<int>> (JsonOptionConverter())
+        verifyRoundTripWithConverter "{\"contents\":{\"kind\":\"plaintext\",\"value\":\"v\"},\"range\":{\"start\":{\"line\":1,\"character\":2},\"end\":{\"line\":3,\"character\":4}}}" typeof<option<Hover>> (JsonOptionConverter())
+        verifyRoundTripWithConverter "null" typeof<option<Hover>> (JsonOptionConverter())

--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -20,6 +20,7 @@
       <Action Type="Ngen" Path="FSharp.Compiler.Server.Shared.dll" />
       <Action Type="Ngen" Path="FSharp.Core.dll" />
       <Action Type="Ngen" Path="FSharp.Editor.dll" />
+      <Action Type="Ngen" Path="FSharp.Editor.Helpers.dll" />
       <Action Type="Ngen" Path="FSharp.UIResources.dll" />
       <Action Type="Ngen" Path="FSharp.LanguageService.Base.dll" />
       <Action Type="Ngen" Path="FSharp.LanguageService.dll" />
@@ -27,6 +28,7 @@
       <Action Type="Ngen" Path="FSharp.ProjectSystem.FSharp.dll" />
       <Action Type="Ngen" Path="FSharp.ProjectSystem.PropertyPages.dll" />
       <Action Type="Ngen" Path="FSharp.VS.FSI.dll" />
+      <Action Type="Ngen" Path="Agent\FSharp.Compiler.LanguageServer.exe" />
     </Actions>
   </Installer>
   <Dependencies>

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -7,6 +7,7 @@
     <ExtensionInstallationFolder>Microsoft\FSharp</ExtensionInstallationFolder>
     <PackageTargetFallback>netcoreapp1.0</PackageTargetFallback>
     <IsShipping>true</IsShipping>
+    <DependencyTargetFramework>net472</DependencyTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +41,7 @@
       <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(DependencyTargetFramework)</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj">
       <Project>{649FA588-F02E-457C-9FCF-87E46407481E}</Project>
@@ -51,7 +52,15 @@
       <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(DependencyTargetFramework)</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.LanguageServer\FSharp.Compiler.LanguageServer.fsproj">
+      <Project>{60BAFFA5-6631-4328-B044-2E012AB76DCA}</Project>
+      <Name>FSharp.Compiler.LanguageServer</Name>
+      <IncludeOutputGroupsInVSIX>PublishedProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Targets>Build;Publish</Targets>
+      <AdditionalProperties>TargetFramework=$(DependencyTargetFramework)</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Server.Shared\FSharp.Compiler.Server.Shared.fsproj">
       <Project>{D5870CF0-ED51-4CBC-B3D7-6F56DA84AC06}</Project>
@@ -62,7 +71,7 @@
       <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(DependencyTargetFramework)</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj">
       <Project>{2E4D67B4-522D-4CF7-97E4-BA940F0B18F3}</Project>
@@ -73,7 +82,7 @@
       <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(DependencyTargetFramework)</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
@@ -96,7 +105,7 @@
       <NgenArchitecture>X64</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(DependencyTargetFramework)</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\..\..\src\fsharp\fsi\fsi.fsproj">
       <Project>{D0E98C0D-490B-4C61-9329-0862F6E87645}</Project>
@@ -108,7 +117,7 @@
       <NgenArchitecture>X86</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(DependencyTargetFramework)</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\..\..\src\fsharp\fsc\fsc.fsproj">
       <Project>{C94C257C-3C0A-4858-B5D8-D746498D1F08}</Project>
@@ -120,11 +129,21 @@
       <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=$(DependencyTargetFramework)</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Editor\FSharp.Editor.fsproj">
       <Project>{65e0e82a-eace-4787-8994-888674c2fe87}</Project>
       <Name>FSharp.Editor</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Editor.Helpers\FSharp.Editor.Helpers.csproj">
+      <Project>{0A3099F1-F0C7-4ADE-AB9B-526EF193A56F}</Project>
+      <Name>FSharp.Editor.Helpers</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>true</Ngen>
@@ -259,6 +278,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualFSharp.Type.Providers.Redist" Version="$(MicrosoftVisualFSharpTypeProvidersRedistVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>

--- a/vsintegration/src/FSharp.Editor.Helpers/FSharp.Editor.Helpers.csproj
+++ b/vsintegration/src/FSharp.Editor.Helpers/FSharp.Editor.Helpers.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="$(MicrosoftVisualStudioLanguageServerClientVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="Microsoft.VisualStudio.Shell.ProvideCodeBaseAttribute">
+      <AssemblyName>FSharp.Editor.Helpers</AssemblyName>
+      <Version>$(VSAssemblyVersion)</Version>
+      <CodeBase>$PackageFolder$\FSharp.Editor.Helpers.dll</CodeBase>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/vsintegration/src/FSharp.Editor.Helpers/LanguageClient.cs
+++ b/vsintegration/src/FSharp.Editor.Helpers/LanguageClient.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.FSharp.Editor.Helpers
+{
+    /// <summary>
+    /// Exists as an abstract implementor of <see cref="ILanguageClient" /> purely to manage the non-standard async
+    /// event handlers.
+    /// </summary>
+    public abstract class LanguageClient : ILanguageClient
+    {
+        public abstract string Name { get; }
+
+        public abstract IEnumerable<string> ConfigurationSections { get; }
+
+        public abstract object InitializationOptions { get; }
+
+        public abstract IEnumerable<string> FilesToWatch { get; }
+
+        public event AsyncEventHandler<EventArgs> StartAsync;
+
+#pragma warning disable 67 // The event 'LanguageClient.StopAsync' is never used
+        public event AsyncEventHandler<EventArgs> StopAsync;
+#pragma warning restore 67
+
+        public abstract Task<Connection> ActivateAsync(CancellationToken token);
+
+        protected abstract Task DoLoadAsync();
+
+        public async Task OnLoadedAsync()
+        {
+            await DoLoadAsync();
+            await StartAsync.InvokeAsync(this, EventArgs.Empty);
+        }
+
+        public abstract Task OnServerInitializeFailedAsync(Exception e);
+
+        public abstract Task OnServerInitializedAsync();
+    }
+}

--- a/vsintegration/src/FSharp.Editor/Common/Constants.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Constants.fs
@@ -32,6 +32,10 @@ module internal FSharpConstants =
     let FSharpContentTypeName = "F#"
 
     [<Literal>]
+    /// ".fs"
+    let FSharpFileExtension = ".fs"
+
+    [<Literal>]
     /// "F# Signature Help"
     let FSharpSignatureHelpContentTypeName = "F# Signature Help"
     

--- a/vsintegration/src/FSharp.Editor/Common/LspService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LspService.fs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System.ComponentModel.Composition
+open FSharp.Compiler.LanguageServer
+open FSharp.Compiler.LanguageServer.Extensions
+open StreamJsonRpc
+
+[<Export(typeof<LspService>)>]
+type LspService() =
+    let mutable options = Options.Default()
+    let mutable jsonRpc: JsonRpc option = None
+
+    let sendOptions () =
+        async {
+            match jsonRpc with
+            | None -> ()
+            | Some rpc -> do! rpc.SetOptionsAsync(options)
+        }
+
+    member __.SetJsonRpc(rpc: JsonRpc) =
+        jsonRpc <- Some rpc
+        sendOptions()
+
+    member __.SetOptions(opt: Options) =
+        options <- opt
+        sendOptions()

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -36,6 +36,10 @@
     <Compile Include="Common\CodeAnalysisExtensions.fs" />
     <Compile Include="Common\ContentType.fs" />
     <Compile Include="Common\Vs.fs" />
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.LanguageServer\LspExternalAccess.fs">
+      <Link>Common\LspExternalAccess.fs</Link>
+    </Compile>
+    <Compile Include="Common\LspService.fs" />
     <Compile Include="Options\SettingsPersistence.fs" />
     <Compile Include="Options\UIHelpers.fs" />
     <Compile Include="Options\EditorOptions.fs" />
@@ -52,6 +56,10 @@
     <Compile Include="LanguageService\SingleFileWorkspaceMap.fs" />
     <Compile Include="LanguageService\LegacyProjectWorkspaceMap.fs" />
     <Compile Include="LanguageService\LanguageService.fs" />
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.LanguageServer\JsonOptionConverter.fs">
+      <Link>LanguageService\JsonOptionConverter.fs</Link>
+    </Compile>
+    <Compile Include="LanguageService\FSharpLanguageClient.fs" />
     <Compile Include="LanguageService\AssemblyContentProvider.fs" />
     <Compile Include="LanguageService\SymbolHelpers.fs" />
     <Compile Include="Classification\ClassificationDefinitions.fs" />
@@ -116,6 +124,7 @@
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj" />
+    <ProjectReference Include="..\FSharp.Editor.Helpers\FSharp.Editor.Helpers.csproj" />
     <ProjectReference Include="..\FSharp.PatternMatcher\FSharp.PatternMatcher.csproj" />
     <ProjectReference Include="..\FSharp.UIResources\FSharp.UIResources.csproj" />
     <ProjectReference Include="..\FSharp.VS.FSI\FSharp.VS.FSI.fsproj" />
@@ -144,6 +153,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="$(MicrosoftVisualStudioLanguageServerClientVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.15.0" Version="$(MicrosoftVisualStudioPackageLanguageService150Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectAggregator" Version="$(MicrosoftVisualStudioProjectAggregatorVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="$(MicrosoftVisualStudioProjectSystemVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
@@ -158,6 +168,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="$(MicrosoftVisualStudioTextManagerInterop120Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="System.Design" Version="$(SystemDesignVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpLanguageClient.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpLanguageClient.fs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor.LanguageService
+
+open System.ComponentModel.Composition
+open System.Diagnostics
+open System.IO
+open System.Threading
+open System.Threading.Tasks
+open FSharp.Compiler.LanguageServer
+open Microsoft.FSharp.Control
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.FSharp.Editor.Helpers
+open Microsoft.VisualStudio.LanguageServer.Client
+open Microsoft.VisualStudio.Utilities
+open StreamJsonRpc
+
+// https://docs.microsoft.com/en-us/visualstudio/extensibility/adding-an-lsp-extension?view=vs-2019
+
+/// Provides exports necessary to register the language client.
+type FSharpContentDefinition() =
+
+    [<Export>]
+    [<Name(FSharpConstants.FSharpLanguageName)>]
+    [<BaseDefinition(CodeRemoteContentDefinition.CodeRemoteContentTypeName)>]
+    static member val FSharpContentTypeDefinition: ContentTypeDefinition = null with get, set
+
+    [<Export>]
+    [<FileExtension(FSharpConstants.FSharpFileExtension)>]
+    [<ContentType(FSharpConstants.FSharpLanguageName)>]
+    static member val FSharpFileExtensionDefinition: FileExtensionToContentTypeDefinition = null with get, set
+
+[<Export(typeof<ILanguageClient>)>]
+[<ContentType(FSharpConstants.FSharpLanguageName)>]
+type internal FSharpLanguageClient
+    [<ImportingConstructor>]
+    (
+        lspService: LspService
+    ) =
+    inherit LanguageClient()
+    override __.Name = "F# Language Service"
+    override this.ActivateAsync(_token: CancellationToken) =
+        async {
+            let thisAssemblyPath = Path.GetDirectoryName(this.GetType().Assembly.Location)
+            let serverAssemblyPath = Path.Combine(thisAssemblyPath, "Agent", "FSharp.Compiler.LanguageServer.exe")
+            let startInfo = ProcessStartInfo(serverAssemblyPath)
+            startInfo.UseShellExecute <- false
+            startInfo.CreateNoWindow <- true // comment to see log messages written to stderr
+            startInfo.RedirectStandardInput <- true
+            startInfo.RedirectStandardOutput <- true
+            let proc = new Process()
+            proc.StartInfo <- startInfo
+            return
+                if proc.Start() then new Connection(proc.StandardOutput.BaseStream, proc.StandardInput.BaseStream)
+                else null
+        } |> Async.StartAsTask
+    override __.ConfigurationSections = null
+    override __.FilesToWatch = null
+    override __.InitializationOptions = null
+    override __.DoLoadAsync() = Task.CompletedTask
+    override __.OnServerInitializeFailedAsync(_e: exn) = Task.CompletedTask
+    override __.OnServerInitializedAsync() = Task.CompletedTask
+    interface ILanguageClientCustomMessage with
+        member __.CustomMessageTarget = null
+        member __.MiddleLayer = null
+        member __.AttachForCustomMessageAsync(rpc: JsonRpc) =
+            rpc.JsonSerializer.Converters.Add(JsonOptionConverter()) // ensure we can set `'T option` values
+            lspService.SetJsonRpc(rpc) |> Async.StartAsTask :> Task

--- a/vsintegration/src/FSharp.Editor/Options/UIHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Options/UIHelpers.fs
@@ -57,6 +57,10 @@ module internal OptionsUIHelpers =
             // next time         
             needsLoadOnNextActivate <- true
 
+        member this.GetService<'T when 'T : not struct>() =
+            let scm = this.Site.GetService(typeof<SComponentModel>) :?> IComponentModel
+            scm.GetService<'T>()
+
     //data binding helpers
     let radioButtonCoverter =
       { new IValueConverter with

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -163,7 +163,8 @@ type internal FSharpAsyncQuickInfoSource
         xmlMemberIndexService: IVsXMLMemberIndexService,
         checkerProvider:FSharpCheckerProvider,
         projectInfoManager:FSharpProjectOptionsManager,
-        textBuffer:ITextBuffer
+        textBuffer:ITextBuffer,
+        settings: EditorOptions
     ) =
 
     static let joinWithLineBreaks segments =
@@ -205,6 +206,9 @@ type internal FSharpAsyncQuickInfoSource
         // This method can be called from the background thread.
         // Do not call IServiceProvider.GetService here.
         override __.GetQuickInfoItemAsync(session:IAsyncQuickInfoSession, cancellationToken:CancellationToken) : Task<QuickInfoItem> =
+            // if using LSP, just bail early
+            if settings.Advanced.UsePreviewTextHover then Task.FromResult<QuickInfoItem>(null)
+            else
             let triggerPoint = session.GetTriggerPoint(textBuffer.CurrentSnapshot)
             match triggerPoint.HasValue with
             | false -> Task.FromResult<QuickInfoItem>(null)
@@ -269,7 +273,8 @@ type internal FSharpAsyncQuickInfoSourceProvider
     (
         [<Import(typeof<SVsServiceProvider>)>] serviceProvider: IServiceProvider,
         checkerProvider:FSharpCheckerProvider,
-        projectInfoManager:FSharpProjectOptionsManager
+        projectInfoManager:FSharpProjectOptionsManager,
+        settings: EditorOptions
     ) =
 
     interface IAsyncQuickInfoSourceProvider with
@@ -278,4 +283,4 @@ type internal FSharpAsyncQuickInfoSourceProvider
             // It is safe to do it here (see #4713)
             let statusBar = StatusBar(serviceProvider.GetService<SVsStatusbar,IVsStatusbar>())
             let xmlMemberIndexService = serviceProvider.XMLMemberIndexService
-            new FSharpAsyncQuickInfoSource(statusBar, xmlMemberIndexService, checkerProvider, projectInfoManager, textBuffer) :> IAsyncQuickInfoSource
+            new FSharpAsyncQuickInfoSource(statusBar, xmlMemberIndexService, checkerProvider, projectInfoManager, textBuffer, settings) :> IAsyncQuickInfoSource

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.PropertiesPages.vbproj
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.PropertiesPages.vbproj
@@ -66,44 +66,20 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.vb" />
-    <Compile Include="Common\ArgumentValidation.vb">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="Common\ArgumentValidation.vb" />
     <Compile Include="Common\DTEUtils.vb" />
-    <Compile Include="Common\ShellUtil.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Common\Utils.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Common\Switches.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Common\wmuserconstants.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Common\myapplicationproperties.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="DesignFramework\BaseRootDesigner.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="DesignFramework\DesignerMenuCommand.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="DesignFramework\DesignerMessageBox.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="DesignFramework\DesignUtil.vb">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="Common\ShellUtil.vb" />
+    <Compile Include="Common\Utils.vb" />
+    <Compile Include="Common\Switches.vb" />
+    <Compile Include="Common\wmuserconstants.vb" />
+    <Compile Include="Common\myapplicationproperties.vb" />
+    <Compile Include="DesignFramework\BaseRootDesigner.vb" />
+    <Compile Include="DesignFramework\DesignerMenuCommand.vb" />
+    <Compile Include="DesignFramework\DesignerMessageBox.vb" />
+    <Compile Include="DesignFramework\DesignUtil.vb" />
     <Compile Include="HelpKeywords.vb" />
-    <Compile Include="interop\IVbpackage.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Interop\IVsAppId.vb">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="interop\IVbpackage.vb" />
+    <Compile Include="Interop\IVsAppId.vb" />
     <Compile Include="Interop\IVsBuildEventCommandLineDialogService.vb" />
     <Compile Include="Interop\IVsBuildEventMacroProvider.vb" />
     <Compile Include="Interop\NativeMethods.vb" />
@@ -114,12 +90,8 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
-    <Compile Include="Package\Constants.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Package\InternalException.vb">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="Package\Constants.vb" />
+    <Compile Include="Package\InternalException.vb" />
     <Compile Include="PropertyPages\ApplicationPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
@@ -129,9 +101,7 @@
     <Compile Include="PropertyPages\BuildEventCommandLineDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="PropertyPages\BuildEventCommandLineDialogService.vb">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="PropertyPages\BuildEventCommandLineDialogService.vb" />
     <Compile Include="PropertyPages\BuildEventsPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
@@ -149,18 +119,12 @@
     <Compile Include="PropertyPages\ReferencePathsPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropertyPages\PropPage.vb">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="PropertyPages\PropPage.vb" />
     <Compile Include="DesignFramework\BaseDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="PropertyPages\ValidationException.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="PropertyPages\PropertyControlData.vb">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="PropertyPages\ValidationException.vb" />
+    <Compile Include="PropertyPages\PropertyControlData.vb" />
     <Compile Include="PropertyPages\ControlDataFlags.vb" />
     <Compile Include="PropertyPages\PropPageHostDialog.vb">
       <SubType>Form</SubType>
@@ -170,12 +134,8 @@
     </Compile>
     <Compile Include="PropertyPages\VSProductSKU.vb" />
     <Compile Include="PropertyPages\ValidationResult.vb" />
-    <Compile Include="PropertyPages\ChildPageSite.vb">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="PropertyPages\ProjectReloadedException.vb">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="PropertyPages\ChildPageSite.vb" />
+    <Compile Include="PropertyPages\ProjectReloadedException.vb" />
     <Compile Include="PropertyPages\SingleConfigPropertyControlData.vb" />
     <Compile Include="PropertyPages\TargetFrameworkAssemblies.vb" />
     <Compile Include="PropertyPages\TargetFrameworkMoniker.vb" />

--- a/vsintegration/src/FSharp.UIResources/AdvancedOptionsControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/AdvancedOptionsControl.xaml
@@ -24,6 +24,10 @@
                     <CheckBox x:Name="toggleOutloning" IsChecked="{Binding IsOutliningEnabled}"
                               Content="{x:Static local:Strings.Show_Outlining}"/>
                 </GroupBox>
+                <GroupBox Header="{x:Static local:Strings.Use_out_of_process_language_server}">
+                    <CheckBox x:Name="usePreviewTextHover" IsChecked="{Binding UsePreviewTextHover}"
+                              Content="{x:Static local:Strings.Text_hover}" />
+                </GroupBox>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -358,6 +358,15 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Text hover.
+        /// </summary>
+        public static string Text_hover {
+            get {
+                return ResourceManager.GetString("Text_hover", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Time until stale results are used (in milliseconds).
         /// </summary>
         public static string Time_until_stale_completion {
@@ -399,6 +408,15 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         public static string Unused_opens_code_fix {
             get {
                 return ResourceManager.GetString("Unused_opens_code_fix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (Preview) Use out of process language server.
+        /// </summary>
+        public static string Use_out_of_process_language_server {
+            get {
+                return ResourceManager.GetString("Use_out_of_process_language_server", resourceCulture);
             }
         }
     }

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -231,4 +231,10 @@
   <data name="Suggest_names_for_errors_code_fix" xml:space="preserve">
     <value>Suggest names for unresolved identifiers</value>
   </data>
+  <data name="Use_out_of_process_language_server" xml:space="preserve">
+    <value>(Preview) Use out of process language server</value>
+  </data>
+  <data name="Text_hover" xml:space="preserve">
+    <value>Text hover</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -102,6 +102,11 @@
         <target state="translated">_Plné podtržení</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Odebrat nepoužívané otevřené výkazy</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Navrhovat názvy pro nerozpoznané identifikátory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -102,6 +102,11 @@
         <target state="translated">_Durchgezogene Unterstreichung</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Nicht verwendete "open"-Anweisungen entfernen</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Namen für nicht aufgelöste Bezeichner vorschlagen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Su_brayado sólido</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Quitar instrucciones open no usadas</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Sugerir nombres para los identificadores no resueltos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Soulig_nement avec un trait uni</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Supprimer les instructions open inutilisées</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Suggérer des noms pour les identificateurs non résolus</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Sottolineatura _continua</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Rimuovi istruzioni OPEN inutilizzate</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Suggerisci nomi per gli identificatori non risolti</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -102,6 +102,11 @@
         <target state="translated">実線の下線(_S)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">未使用の Open ステートメントを削除する</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">未解決の識別子の名前を提案します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -102,6 +102,11 @@
         <target state="translated">실선 밑줄(_S)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">사용되지 않는 open 문 제거</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">확인되지 않은 식별자의 이름 제안</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Podkreślenie _ciągłe</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Usuń nieużywane otwarte instrukcje</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Sugeruj nazwy w przypadku nierozpoznanych identyfikatorów</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Sublinhado _sólido</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Remover instruções abertas não usadas</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Sugerir nomes para identificadores não resolvidos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -102,6 +102,11 @@
         <target state="translated">_Сплошнное подчеркивание</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Удалить неиспользуемые открытые операторы</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Предлагать имена для неразрешенных идентификаторов</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">_Kesintisiz alt çizgi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">Kullanılmayan açık deyimleri kaldır</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">Çözümlenmemiş tanımlayıcılar için ad öner</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="translated">实线下划线(_S)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">删除未使用的 open 语句</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">为未解析标识符建议名称</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="translated">實線底線(_S)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Text_hover">
+        <source>Text hover</source>
+        <target state="new">Text hover</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unused_opens_code_fix">
         <source>Remove unused open statements</source>
         <target state="translated">移除未使用的 open 陳述式</target>
@@ -190,6 +195,11 @@
       <trans-unit id="Suggest_names_for_errors_code_fix">
         <source>Suggest names for unresolved identifiers</source>
         <target state="translated">為未解析的識別碼建議名稱</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Use_out_of_process_language_server">
+        <source>(Preview) Use out of process language server</source>
+        <target state="new">(Preview) Use out of process language server</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Marked **[WIP]** and operating out of a feature branch so I can verify signed builds and VS insertion before merging to `master`.

This allows VS to consume the out-of-process `FSharp.Compiler.LanguageServer` and threads through the appropriate options.  As it currently stands the default behavior for everything remains the same, but it does enable the following scenario:

Consume the regular QuickInfo:

![image](https://user-images.githubusercontent.com/926281/58992212-0120fe00-879f-11e9-90f7-d6e791e8ab1d.png)

**Or** check the option `Text Editor -> F# -> Advanced -> (Preview) Use out of process language server -> Text hover` to instead have `FSharp.Compiler.LanguageServer` provide the LSP equivalent:

![image](https://user-images.githubusercontent.com/926281/58992228-10a04700-879f-11e9-8690-8a93e882fcf6.png)

![image](https://user-images.githubusercontent.com/926281/58992254-20b82680-879f-11e9-8879-5baf96376181.png)

The process going forward to add new LSP features will be to:
- Add the appropriate method(s) in `src/fsharp/FSharp.Compiler.LanguageServer/Methods.fs`
- Indicate that our LSP supports that feature by updating the `ServerCapabilities` record in `src/fsharp/FSharp.Compiler.LanguageServer/LspTypes.fs`
- Add a new option:
  - Add a flag to the `Options` record in `src/fsharp/FSharp.Compiler.LanguageServer/LspExternalAccess.fs`.
  - Add a flag to the `AdvancedOptions` record in `vsintegration/src/FSharp.Editor/Options/EditorOptions.fs`
  - Add the check box to `vsintegration/src/FSharp.UIResources/AdvancedOptionsControl.xaml`
- Honor those options in:
  - The language server (e.g., the `Hover` method in `src/fsharp/FSharp.Compiler.LanguageServer/TextDocument.fs` returns `None` if the option is not enabled.)
  - The VS feature (e.g., the method `GetQuickInfoItemAsync` in `vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs` returns `null` if the preview option is enabled.)

Next steps:
- Once this is in I plan on reverting in `release/dev16.2` just the UI changes in `AdvancedOptionsControl.xaml` and removing the `[<Export>]` attribute from `FSharpLanguageClient.fs` because I think we need much more runway of testing this in nightly builds.