### PR TITLE
Add netstandard2.0 target to FSharp.Core project and nuget package

### DIFF
--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.csproj
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PreRelease>true</PreRelease>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0</TargetFrameworks>
     <PackageId>FSharp.Core</PackageId>
     <NuspecFile>FSharp.Core.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuspec
@@ -42,6 +42,11 @@
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.optdata" target="lib\netstandard1.6" />
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.xml"     target="lib\netstandard1.6" />
 
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.dll"     target="lib\netstandard2.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.sigdata" target="lib\netstandard2.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.optdata" target="lib\netstandard2.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.xml"     target="lib\netstandard2.0" />
+
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.dll"     target="lib\net45" />
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.sigdata" target="lib\net45" />
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.optdata" target="lib\net45" />
@@ -49,6 +54,7 @@
 
         <!-- resources -->
         <file src="FSharp.Core\$Configuration$\netstandard1.6\**\FSharp.Core.resources.dll" target="lib\netstandard1.6" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\**\FSharp.Core.resources.dll" target="lib\netstandard2.0" />
         <file src="FSharp.Core\$Configuration$\net45\**\FSharp.Core.resources.dll"          target="lib\net45" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -4,8 +4,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard1.6;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);FSHARP_CORE</DefineConstants>
@@ -217,6 +217,7 @@
     </Compile>
   </ItemGroup>
 
+  <!-- REVIEW: Are these packages still needed when targeting netstandard2.0? -->
   <ItemGroup>
     <PackageReference Include="System.Linq.Queryable" Version="$(SystemLinqQueryableVersion)" />
     <PackageReference Include="System.Net.Requests" Version="$(SystemNetRequestsVersion)" />


### PR DESCRIPTION
I noticed recently the FSharp.Core package on Nuget claims to support _net45_, _netstandard1.6_, and _netstandard2.0_. However, after downloading and inspecting the package, I found it only has _net45_ and _netstandard1.6_ binaries but no _netstandard2.0_ binaries.

This isn't a huge deal -- you can use the _netstandard1.6_ version of FSharp.Core when e.g. building a library targeting _netstandard2.0_. It is a bit annoying though, because referencing the _netstandard1.6_ version of FSharp.Core causes some additional packages (which aren't needed for _netstandard2.0_) to be pulled into a build and referenced by any _netstandard2.0_ libraries built with F#.

I've simply added the additional _netstandard2.0_ target framework to the FSharp.Core project + .nuspec files here, which means we'll actually have a _netstandard2.0_ version of FSharp.Core in the Nuget package, as advertised.

This change can stand on it's own*, but at present will still be using some conditional-compilation workarounds needed for _netstandard1.6_. I've submitted a separate, also-standalone PR in #6955 to address that.
* = If #6955 is not going to be merged, this PR will need one additional change made to undefine the ``FX_NO_REFLECTION_MODULE_HANDLES`` constant for the _netstandard2.0_ build, by modifying either ``quotations.fs`` or ``FSharp.Profiles.props``.