### PR TITLE
Don't stop type checking recursive module on unresolved open

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -12545,15 +12545,18 @@ let TcTyconMemberSpecs cenv env containerInfo declKind tpenv (augSpfn: SynMember
 let TcModuleOrNamespaceLidAndPermitAutoResolve tcSink env amap (longId: Ident list) =
     let ad = env.eAccessRights
     match longId with
-    | [] -> Result []
+    | [] -> []
     | id :: rest ->
         let m = longId |> List.map (fun id -> id.idRange) |> List.reduce unionRanges
         match ResolveLongIndentAsModuleOrNamespace tcSink ResultCollectionSettings.AllResults amap m true OpenQualified env.eNameResEnv ad id rest true with 
-        | Result res -> Result res
-        | Exception err -> raze err
+        | Result res -> res
+        | Exception err ->
+            errorR(err); []
 
 let TcOpenDecl tcSink (g: TcGlobals) amap m scopem env (longId: Ident list) = 
-    let modrefs = ForceRaise (TcModuleOrNamespaceLidAndPermitAutoResolve tcSink env amap longId)
+    match TcModuleOrNamespaceLidAndPermitAutoResolve tcSink env amap longId with
+    | [] -> env
+    | modrefs ->
 
     // validate opened namespace names
     for id in longId do


### PR DESCRIPTION
Fixes the compiler stopping type checking the whole recursive module/namespace when it cannot resolve namespace/module in an open declaration.

Instead of raising an exception and effectively stopping the type checking it now reports the error to the logger and continues checking without adding the open declaration to the environment.

Before:
<img width="300" alt="Screenshot 2019-06-09 at 00 45 05" src="https://user-images.githubusercontent.com/3923587/59152587-da3d2300-8a4f-11e9-9e74-e5b5ba99e799.png">

After:
<img width="319" alt="Screenshot 2019-06-09 at 00 43 13" src="https://user-images.githubusercontent.com/3923587/59152589-dc06e680-8a4f-11e9-877f-4d412747a937.png">

<details>
  <summary>An example of what it looked like with a bigger file.</summary>
  <img width="1027" alt="Screenshot 2019-05-30 at 20 04 48" src="https://user-images.githubusercontent.com/3923587/59159162-5e35f000-8ace-11e9-8472-f877a8b3468c.png">
</details>