### PR TITLE
fixed List.map3 misleading error message on different length lists

### DIFF
--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -311,7 +311,7 @@ module internal List =
         | h1 :: t1, h2 :: t2, h3 :: t3 ->
             let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(mapping)
             let cons = freshConsNoTail (f.Invoke(h1, h2, h3))
-            map3ToFreshConsTail cons f t1 t2 t3 0
+            map3ToFreshConsTail cons f t1 t2 t3 1
             cons
         | xs1, xs2, xs3 ->
             invalidArg3ListsDifferent "list1" "list2" "list3" xs1.Length xs2.Length xs3.Length

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -294,16 +294,16 @@ module internal List =
         | [], xs2 -> invalidArgDifferentListLength "list1" "list2" xs2.Length
         | xs1, [] -> invalidArgDifferentListLength "list2" "list1" xs1.Length
 
-    let rec map3ToFreshConsTail cons (f:OptimizedClosures.FSharpFunc<_, _, _, _>) xs1 xs2 xs3 =
+    let rec map3ToFreshConsTail cons (f:OptimizedClosures.FSharpFunc<_, _, _, _>) xs1 xs2 xs3 cut =
         match xs1, xs2, xs3 with
         | [], [], [] ->
             setFreshConsTail cons []
         | h1 :: t1, h2 :: t2, h3 :: t3 ->
             let cons2 = freshConsNoTail (f.Invoke(h1, h2, h3))
             setFreshConsTail cons cons2
-            map3ToFreshConsTail cons2 f t1 t2 t3
+            map3ToFreshConsTail cons2 f t1 t2 t3 (cut + 1)
         | xs1, xs2, xs3 ->
-            invalidArg3ListsDifferent "list1" "list2" "list3" xs1.Length xs2.Length xs3.Length
+            invalidArg3ListsDifferent "list1" "list2" "list3" (xs1.Length + cut) (xs2.Length + cut) (xs3.Length + cut)
 
     let map3 mapping xs1 xs2 xs3 =
         match xs1, xs2, xs3 with
@@ -311,7 +311,7 @@ module internal List =
         | h1 :: t1, h2 :: t2, h3 :: t3 ->
             let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(mapping)
             let cons = freshConsNoTail (f.Invoke(h1, h2, h3))
-            map3ToFreshConsTail cons f t1 t2 t3
+            map3ToFreshConsTail cons f t1 t2 t3 0
             cons
         | xs1, xs2, xs3 ->
             invalidArg3ListsDifferent "list1" "list2" "list3" xs1.Length xs2.Length xs3.Length

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -102,7 +102,16 @@ type ListModule02() =
         let longerList = [1; 2]
         CheckThrowsArgumentException  (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)
         CheckThrowsArgumentException  (fun () -> List.map3 funcInt shortList longerList shortList |> ignore)
-        CheckThrowsArgumentException  (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)  
+        CheckThrowsArgumentException  (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)
+        
+        // exception message checking
+        let expectedMessage =
+            "The lists had different lengths.\n" +
+            sprintf " list1.Length = %i, list2.Length = %i, list3.Length = %i\n" shortList.Length shortList.Length longerList.Length +
+            "Parameter name: list1, list2, list3"
+        let ex = Assert.Throws(typeof<ArgumentException>,
+                               (fun () -> List.map3 funcInt shortList shortList longerList |> ignore))
+        Assert.AreEqual(expectedMessage, ex.Message)
 
         // empty List
         let resultEpt = List.map3 funcInt List.empty List.empty List.empty

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -107,8 +107,8 @@ type ListModule02() =
         // exception message checking
         let expectedMessage =
             "The lists had different lengths.\n" +
-            sprintf " list1.Length = %i, list2.Length = %i, list3.Length = %i\n" shortList.Length shortList.Length longerList.Length +
-            "Parameter name: list1, list2, list3"
+            sprintf " list1.Length = %i, list2.Length = %i, list3.Length = %i" shortList.Length shortList.Length longerList.Length +
+            Environment.NewLine + "Parameter name: list1, list2, list3"
         let ex = Assert.Throws(typeof<ArgumentException>,
                                (fun () -> List.map3 funcInt shortList shortList longerList |> ignore))
         Assert.AreEqual(expectedMessage, ex.Message)


### PR DESCRIPTION
Fixed #6897 by adding a parameter to map3ToFreshConstTail that counts number of cut elements.