### PR TITLE
[release/dev16.2] don't ship LSP in VS in `release/dev16.2`

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IncludeVsLanguageServer>true</IncludeVsLanguageServer>
+    <!-- this should be false for branch `release/dev16.2`, true otherwise -->
+    <IncludeVsLanguageServer>false</IncludeVsLanguageServer>
   </PropertyGroup>
 
 </Project>

--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -28,7 +28,10 @@
       <Action Type="Ngen" Path="FSharp.ProjectSystem.FSharp.dll" />
       <Action Type="Ngen" Path="FSharp.ProjectSystem.PropertyPages.dll" />
       <Action Type="Ngen" Path="FSharp.VS.FSI.dll" />
+      <!-- this Ngen action should be disabled in branch `release/dev16.2`, enabled otherwise -->
+      <!--
       <Action Type="Ngen" Path="Agent\FSharp.Compiler.LanguageServer.exe" />
+      -->
     </Actions>
   </Installer>
   <Dependencies>

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -164,7 +164,7 @@ type internal FSharpAsyncQuickInfoSource
         checkerProvider:FSharpCheckerProvider,
         projectInfoManager:FSharpProjectOptionsManager,
         textBuffer:ITextBuffer,
-        settings: EditorOptions
+        _settings: EditorOptions
     ) =
 
     static let joinWithLineBreaks segments =
@@ -206,9 +206,10 @@ type internal FSharpAsyncQuickInfoSource
         // This method can be called from the background thread.
         // Do not call IServiceProvider.GetService here.
         override __.GetQuickInfoItemAsync(session:IAsyncQuickInfoSession, cancellationToken:CancellationToken) : Task<QuickInfoItem> =
-            // if using LSP, just bail early
-            if settings.Advanced.UsePreviewTextHover then Task.FromResult<QuickInfoItem>(null)
-            else
+            // The following lines should be disabled for branch `release/dev16.2`, enabled otherwise
+            //// if using LSP, just bail early
+            //if settings.Advanced.UsePreviewTextHover then Task.FromResult<QuickInfoItem>(null)
+            //else
             let triggerPoint = session.GetTriggerPoint(textBuffer.CurrentSnapshot)
             match triggerPoint.HasValue with
             | false -> Task.FromResult<QuickInfoItem>(null)

--- a/vsintegration/src/FSharp.UIResources/AdvancedOptionsControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/AdvancedOptionsControl.xaml
@@ -24,10 +24,13 @@
                     <CheckBox x:Name="toggleOutloning" IsChecked="{Binding IsOutliningEnabled}"
                               Content="{x:Static local:Strings.Show_Outlining}"/>
                 </GroupBox>
+                <!-- this group box should be disabled for branch `release/dev16.2`, enabled otherwise -->
+                <!--
                 <GroupBox Header="{x:Static local:Strings.Use_out_of_process_language_server}">
                     <CheckBox x:Name="usePreviewTextHover" IsChecked="{Binding UsePreviewTextHover}"
                               Content="{x:Static local:Strings.Text_hover}" />
                 </GroupBox>
+                -->
             </StackPanel>
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
As per #6945 VS should not consume the experimental out-of-process LSP in the `release/dev16.2` branch.