### PR TITLE
List.transpose should throw error when given jagged array (#6908)

### DIFF
--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -717,25 +717,28 @@ module internal List =
                         invalidArgDifferentListLength "list.[0]" (System.String.Format("list.[{0}]", j)) t.Length
                 [], [], 0
             | h :: t ->
+                let mutable j = 0
+                for t' in tail do
+                    j <- j + 1
+                    if t'.IsEmpty then
+                        invalidArgDifferentListLength (System.String.Format("list.[{0}]", j)) "list.[0]" (t.Length + 1)
                 let headsCons = freshConsNoTail h
                 let tailsCons = freshConsNoTail t
                 let headCount = transposeGetHeadsFreshConsTail headsCons tailsCons tail 1
                 headsCons, tailsCons, headCount
 
     /// Append the next element to the transposed list
-    let rec transposeToFreshConsTail cons list expectedCount =
+    let rec transposeToFreshConsTail cons list =
         match list with
         | [] -> setFreshConsTail cons []
         | _ ->
             match transposeGetHeads list with
             | [], _, _ ->
                 setFreshConsTail cons []
-            | heads, tails, headCount ->
-                if headCount < expectedCount then
-                    invalidArgDifferentListLength (System.String.Format("list.[{0}]", headCount)) "list.[0]" <| tails.[0].Length + 1
+            | heads, tails, _ ->
                 let cons2 = freshConsNoTail heads
                 setFreshConsTail cons cons2
-                transposeToFreshConsTail cons2 tails expectedCount
+                transposeToFreshConsTail cons2 tails
 
     /// Build the transposed list
     let transpose (list: 'T list list) =
@@ -746,7 +749,7 @@ module internal List =
             let heads, tails, headCount = transposeGetHeads list
             if headCount = 0 then [] else
             let cons = freshConsNoTail heads
-            transposeToFreshConsTail cons tails headCount
+            transposeToFreshConsTail cons tails
             cons
 
     let rec truncateToFreshConsTail cons count list =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -842,7 +842,9 @@ type ListModule02() =
         // jagged lists
         CheckThrowsArgumentException (fun () -> List.transpose [[1; 2]; [3]] |> ignore)
         CheckThrowsArgumentException (fun () -> List.transpose [[1]; [2; 3]] |> ignore)
+        CheckThrowsArgumentException (fun () -> List.transpose [[]; [1; 2]; [3; 4]] |> ignore)
         CheckThrowsArgumentException (fun () -> List.transpose [[1; 2]; []; [3; 4]] |> ignore)
+        CheckThrowsArgumentException (fun () -> List.transpose [[1; 2]; [3; 4]; []] |> ignore)
 
     [<Test>]
     member this.Truncate() =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -842,6 +842,7 @@ type ListModule02() =
         // jagged lists
         CheckThrowsArgumentException (fun () -> List.transpose [[1; 2]; [3]] |> ignore)
         CheckThrowsArgumentException (fun () -> List.transpose [[1]; [2; 3]] |> ignore)
+        CheckThrowsArgumentException (fun () -> List.transpose [[1; 2]; []; [3; 4]] |> ignore)
 
     [<Test>]
     member this.Truncate() =


### PR DESCRIPTION
* transpose does not throw when one of the elements is empty

Fixes #6908 