### PR TITLE
Fixed line directive ranges when not applying a line directive

### DIFF
--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -524,10 +524,14 @@ rule token args skip = parse
           // Construct the new position
           if args.applyLineDirectives then 
               lexbuf.EndPos <- pos.ApplyLineDirective((match file with Some f -> fileIndexOfFile f | None -> pos.FileIndex), line)
-
+          else
+              // add a newline when we don't apply a directive since we consumed a newline getting here
+              newline lexbuf
           token args skip lexbuf 
-        else 
-          if not skip then (HASH_LINE (LexCont.Token !args.ifdefStack)) else token args skip lexbuf }
+        else
+          // add a newline when we don't apply a directive since we consumed a newline getting here
+          newline lexbuf
+          (HASH_LINE (LexCont.Token !args.ifdefStack)) }
             
  | "<@" { checkExprOp lexbuf; LQUOTE ("<@ @>", false) }
  | "<@@" { checkExprOp lexbuf; LQUOTE ("<@@ @@>", true) }

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5291,7 +5291,7 @@ let ``Test line directives in foreground analysis`` () = // see https://github.c
     for e in checkResults1.Errors do 
         printfn "ProjectLineDirectives checkResults1 error file: <<<%s>>>" e.FileName
 
-    [ for e in checkResults1.Errors -> e.StartLineAlternate, e.EndLineAlternate, e.FileName ] |> shouldEqual [(4, 4, ProjectLineDirectives.fileName1)]
+    [ for e in checkResults1.Errors -> e.StartLineAlternate, e.EndLineAlternate, e.FileName ] |> shouldEqual [(5, 5, ProjectLineDirectives.fileName1)]
 
 //------------------------------------------------------
 


### PR DESCRIPTION
Resolves this issue: https://github.com/dotnet/fsharp/issues/7000

Lexing a line directive would consume a newline which would put the LexBuffer in an invalid state, but is adjusted once the line directive was applied. In tooling, we disable applying the line directive which means the LexBuffer would remain in an invalid state. Adding a newline corrects this in cases where we don't apply the line directive.