### PR TITLE
properly fail the build on unix failures

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -176,7 +176,11 @@ function TestUsingNUnit() {
   projectname="${projectname%.*}"
   testlogpath="$artifacts_dir/TestResults/$configuration/${projectname}_$targetframework.xml"
   args="test \"$testproject\" --no-restore --no-build -c $configuration -f $targetframework --test-adapter-path . --logger \"nunit;LogFilePath=$testlogpath\""
-  "$DOTNET_INSTALL_DIR/dotnet" $args
+  "$DOTNET_INSTALL_DIR/dotnet" $args || {
+    local exit_code=$?
+    echo "dotnet test failed (exit code '$exit_code')." >&2
+    ExitWithExitCode $exit_code
+  }
 }
 
 function BuildSolution {


### PR DESCRIPTION
I discovered that unix (linux/macos) failures would report the failing tests via the `Tests` tab in ADO, but the specific build step would appear green which made diagnosing failures difficult.