### PR TITLE
Add get/set to item description tooltip

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1408,11 +1408,11 @@ module InfoMemberPrinting =
         let getterSetter =
             match pinfo.HasGetter, pinfo.HasSetter with
             | (true, false) ->
-                "with get" |> tagText |> wordL 
+                wordL (tagKeyword "with") ^^ wordL (tagText "get")
             | (false, true) ->
-                "with set"  |> tagText |> wordL
+                wordL (tagKeyword "with") ^^ wordL (tagText "set")
             | (true, true) ->
-                "with get, set"  |> tagText |> wordL
+                wordL (tagKeyword "with") ^^ wordL (tagText "get, set")
             | (false, false) ->
                 emptyL
 

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1405,12 +1405,22 @@ module InfoMemberPrinting =
             | None -> tagProperty
             | Some vref -> tagProperty >> mkNav vref.DefinitionRange
         let nameL = DemangleOperatorNameAsLayout tagProp pinfo.PropertyName
+        let accessibilityText =
+            if pinfo.HasGetter && not pinfo.HasSetter then
+                "get"
+            elif pinfo.HasSetter && not pinfo.HasGetter then
+                "set"
+            else
+                "get, set"
+
         wordL (tagText (FSComp.SR.typeInfoProperty())) ^^
         layoutTyconRef denv pinfo.ApparentEnclosingTyconRef ^^
         SepL.dot ^^
         nameL ^^
         RightL.colon ^^
-        layoutType denv rty
+        layoutType denv rty ^^
+        wordL (tagKeyword "with") ^^
+        wordL (tagText accessibilityText)
 
     let formatMethInfoToBufferFreeStyle amap m denv os (minfo: MethInfo) = 
         let _, resL = prettyLayoutOfMethInfoFreeStyle amap m denv emptyTyparInst minfo 

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1405,13 +1405,16 @@ module InfoMemberPrinting =
             | None -> tagProperty
             | Some vref -> tagProperty >> mkNav vref.DefinitionRange
         let nameL = DemangleOperatorNameAsLayout tagProp pinfo.PropertyName
-        let accessibilityText =
-            if pinfo.HasGetter && not pinfo.HasSetter then
-                "get"
-            elif pinfo.HasSetter && not pinfo.HasGetter then
-                "set"
-            else
-                "get, set"
+        let getterSetter =
+            match pinfo.HasGetter, pinfo.HasSetter with
+            | (true, false) ->
+                "with get" |> tagText |> wordL 
+            | (false, true) ->
+                "with set"  |> tagText |> wordL
+            | (true, true) ->
+                "with get, set"  |> tagText |> wordL
+            | (false, false) ->
+                emptyL
 
         wordL (tagText (FSComp.SR.typeInfoProperty())) ^^
         layoutTyconRef denv pinfo.ApparentEnclosingTyconRef ^^
@@ -1419,8 +1422,7 @@ module InfoMemberPrinting =
         nameL ^^
         RightL.colon ^^
         layoutType denv rty ^^
-        wordL (tagKeyword "with") ^^
-        wordL (tagText accessibilityText)
+        getterSetter
 
     let formatMethInfoToBufferFreeStyle amap m denv os (minfo: MethInfo) = 
         let _, resL = prettyLayoutOfMethInfoFreeStyle amap m denv emptyTyparInst minfo 

--- a/vsintegration/tests/UnitTests/QuickInfoTests.fs
+++ b/vsintegration/tests/UnitTests/QuickInfoTests.fs
@@ -440,6 +440,6 @@ module Test =
         }
 """
     let quickInfo = GetQuickInfoTextFromCode code
-    let expected = "property MyDistance.asNautical: MyDistance"
+    let expected = "property MyDistance.asNautical: MyDistance with get"
     Assert.AreEqual(expected, quickInfo)
     ()


### PR DESCRIPTION
Fixes #7007 by adding an additional section in the formatted tooltip text for properties that indicates if it is a getter, setter, or both.

Using this code:

```fsharp
type C() =
    member __.GetOnly = 3
    member __.GetSet with get () = () and set () = ()
    member __.SetOnly with set () = ()

let c = C()
```

Getter:

![image](https://user-images.githubusercontent.com/6309070/59710965-f6af2d00-91be-11e9-8bcb-589d191aeae1.png)

Setter:

![image](https://user-images.githubusercontent.com/6309070/59710984-00d12b80-91bf-11e9-8285-65486bce0484.png)

Both:

![image](https://user-images.githubusercontent.com/6309070/59711000-09296680-91bf-11e9-814e-6078bc66c11e.png)
