### PR TITLE
[WIP] - No IVTs to VS IDE unit tests

### DIFF
--- a/src/fsharp/ErrorLogger.fs
+++ b/src/fsharp/ErrorLogger.fs
@@ -395,10 +395,6 @@ module ErrorLoggerExtensions =
             x.ErrorR exn
             raise (ReportedError (Some exn))
 
-        member x.SimulateError   (ph: PhasedDiagnostic) = 
-            x.DiagnosticSink (ph, true)
-            raise (ReportedError (Some ph.Exception))
-
         member x.ErrorRecovery (exn: exn) (m: range) =
             // Never throws ReportedError.
             // Throws StopProcessing and exceptions raised by the DiagnosticSink(exn) handler.
@@ -475,9 +471,6 @@ let warning exn = CompileThreadStatic.ErrorLogger.Warning exn
 
 /// Raises a special exception and returns 'T - can be caught later at an errorRecovery point.
 let error exn = CompileThreadStatic.ErrorLogger.Error exn
-
-/// Simulates an error. For test purposes only.
-let simulateError (p : PhasedDiagnostic) = CompileThreadStatic.ErrorLogger.SimulateError p
 
 let diagnosticSink (phasedError, isError) = CompileThreadStatic.ErrorLogger.DiagnosticSink (phasedError, isError)
 let errorSink pe = diagnosticSink (pe, true)

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -43,8 +43,6 @@
     <InternalsVisibleTo Include="FSharp.LanguageService" />
     <InternalsVisibleTo Include="FSharp.LanguageService.Base" />
     <InternalsVisibleTo Include="FSharp.Compiler.Server.Shared" />
-    <InternalsVisibleTo Include="VisualFSharp.Salsa" />
-    <InternalsVisibleTo Include="VisualFSharp.UnitTests" />
     <InternalsVisibleTo Include="FSharp.Compiler.UnitTests" />
     <InternalsVisibleTo Include="HostedCompilerServer" />
     <InternalsVisibleTo Include="FSharp.Tests.FSharpSuite" />

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -646,8 +646,6 @@ module internal SymbolHelpers =
             GetXmlDocHelpSigOfItemForLookup infoReader m d
         else
             FSharpXmlDoc.Text result
-
-    let mutable ToolTipFault  = None
     
     let GetXmlCommentForMethInfoItem infoReader m d (minfo: MethInfo) = 
         if minfo.HasDirectXmlComment || minfo.XmlDoc.NonEmpty then
@@ -661,11 +659,6 @@ module internal SymbolHelpers =
 
     /// Generate the structured tooltip for a method info
     let FormatOverloadsToList (infoReader: InfoReader) m denv (item: ItemWithInst) minfos : FSharpStructuredToolTipElement = 
-        ToolTipFault |> Option.iter (fun msg -> 
-           let exn = Error((0, msg), range.Zero)
-           let ph = PhasedDiagnostic.Create(exn, BuildPhase.TypeCheck)
-           simulateError ph)
-        
         let layouts = 
             [ for minfo in minfos -> 
                 let prettyTyparInst, layout = NicePrint.prettyLayoutOfMethInfoFreeStyle infoReader.amap m denv item.TyparInst minfo

--- a/src/fsharp/symbols/SymbolHelpers.fsi
+++ b/src/fsharp/symbols/SymbolHelpers.fsi
@@ -160,7 +160,6 @@ module internal SymbolHelpers =
     val fileNameOfItem : TcGlobals -> string option -> range -> Item -> string
     val FullNameOfItem : TcGlobals -> Item -> string
     val ccuOfItem : TcGlobals -> Item -> CcuThunk option
-    val mutable ToolTipFault : string option
     val IsAttribute : InfoReader -> Item -> bool
     val IsExplicitlySuppressed : TcGlobals -> Item -> bool
     val FlattenItems : TcGlobals -> range -> Item -> Item list

--- a/vsintegration/tests/Salsa/SalsaUtils.fs
+++ b/vsintegration/tests/Salsa/SalsaUtils.fs
@@ -4,10 +4,8 @@ namespace Salsa
 
 open System
 open System.IO
-open Microsoft.VisualStudio.FSharp.ProjectSystem
 open Microsoft.VisualStudio.FSharp.LanguageService
 open Microsoft.VisualStudio.TextManager.Interop
-open FSharp.Compiler.SourceCodeServices
 open NUnit.Framework
 
 open Salsa.Salsa
@@ -139,7 +137,6 @@ module internal VsOpsUtils =
     let ReplaceFileInMemory(file :OpenFile) lines = (opsOfFile file).ReplaceFileInMemory(file,lines,true)
     let ReplaceFileInMemoryWithoutCoffeeBreak(file :OpenFile) lines   = (opsOfFile file).ReplaceFileInMemory(file,lines,false)
     let SaveFileToDisk(file :OpenFile)  = (opsOfFile file).SaveFileToDisk(file)
-    let AutoCompleteMemberDataTipsThrowsScope(vs : VisualStudio, message)  = vs.VsOps.AutoCompleteMemberDataTipsThrowsScope(message)
     let Cleanup(vs : VisualStudio) = vs.VsOps.CleanUp(vs) 
 
     let OutOfConeFilesAreAddedAsLinks(vs : VisualStudio) = vs.VsOps.OutOfConeFilesAreAddedAsLinks

--- a/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
+++ b/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
@@ -17,9 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(FSharpSourcesRoot)\utils\CompilerLocationUtils.fs">
-      <Link>CompilerLocationUtils.fs</Link>
-    </Compile>
     <Compile Include="..\unittests\TestLib.Utils.fs">
       <Link>UnitTests.TestLib.Utils.fs</Link>
     </Compile>

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
@@ -4568,7 +4568,7 @@ let x = query { for bbbb in abbbbc(*D0*) do
               | _ -> ()
       
     // If there is a compile error that prevents a data tip from resolving then show that data tip.
-    [<Test>]
+    [<Ignore("This test is highly coupled to compiler internals. We removed those internals, so this test is disabled until it can simulate what it needs without coupling."); Test>]
     member public this.``MemberInfoCompileErrorsShowInDataTip``() =     
         let code = 
                                     [ 
@@ -4579,8 +4579,9 @@ let x = query { for bbbb in abbbbc(*D0*) do
                                     ]
         let (_,_, file) = this.CreateSingleFileProject(code)
         MoveCursorToEndOfMarker(file,"foovalue.B") 
-    
-        use scope = AutoCompleteMemberDataTipsThrowsScope(this.VS, "Simulated compiler error")
+        
+        // Disabled: this test was highly coupled to compiler internals.
+        //use scope = AutoCompleteMemberDataTipsThrowsScope(this.VS, "Simulated compiler error")
         let completions = time1 CtrlSpaceCompleteAtCursor file "Time of first autocomplete."
         Assert.IsTrue(completions.Length>0)      
         for completion in completions do 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.ErrorList.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.ErrorList.fs
@@ -2,13 +2,10 @@
 
 namespace Tests.LanguageService.ErrorList
 
-open System
-open System.IO
 open NUnit.Framework
 open Microsoft.VisualStudio.FSharp
 open Salsa.Salsa
 open Salsa.VsOpsUtils
-open UnitTests.TestLib.Salsa
 open UnitTests.TestLib.Utils
 open UnitTests.TestLib.LanguageService
 open UnitTests.TestLib.ProjectSystem

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.ErrorRecovery.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.ErrorRecovery.fs
@@ -2,13 +2,9 @@
 
 namespace Tests.LanguageService.ErrorRecovery
 
-open System
-open System.IO
 open NUnit.Framework
 open Salsa.Salsa
 open Salsa.VsOpsUtils
-open UnitTests.TestLib.Salsa
-open UnitTests.TestLib.Utils
 open UnitTests.TestLib.LanguageService
 open UnitTests.TestLib.ProjectSystem
 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.General.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.General.fs
@@ -7,14 +7,12 @@ open System
 open System.IO
 open System.Reflection
 open System.Runtime.InteropServices
-open FSharp.Compiler
 open FSharp.Compiler.SourceCodeServices
 open Microsoft.VisualStudio.FSharp.LanguageService
 open Salsa.Salsa
 open Salsa
 open Salsa.VsOpsUtils
 open UnitTests.TestLib.Salsa
-open UnitTests.TestLib.Utils
 open UnitTests.TestLib.LanguageService
 open UnitTests.TestLib.ProjectSystem
 
@@ -334,27 +332,6 @@ type UsingMSBuild() =
                "if specificIdent x <> x then exit 1"
                "exit 0"] 
                 )
-
-
-   /// Verifies that token info returns correct trigger classes 
-    /// - this is used in MPF for triggering various intellisense features
-    [<Test>]
-    member public this.``TokenInfo.TriggerClasses``() =      
-      let important = 
-        [ // Member select for dot completions
-          Parser.DOT, (FSharpTokenColorKind.Punctuation,FSharpTokenCharKind.Delimiter,FSharpTokenTriggerClass.MemberSelect)
-          // for parameter info
-          Parser.LPAREN, (FSharpTokenColorKind.Punctuation,FSharpTokenCharKind.Delimiter, FSharpTokenTriggerClass.ParamStart ||| FSharpTokenTriggerClass.MatchBraces)
-          Parser.COMMA,  (FSharpTokenColorKind.Punctuation,FSharpTokenCharKind.Delimiter, FSharpTokenTriggerClass.ParamNext)
-          Parser.RPAREN, (FSharpTokenColorKind.Punctuation,FSharpTokenCharKind.Delimiter, FSharpTokenTriggerClass.ParamEnd ||| FSharpTokenTriggerClass.MatchBraces) ]
-      let matching =           
-        [ // Other cases where we expect MatchBraces
-          Parser.LQUOTE("", false); Parser.LBRACK; Parser.LBRACE; Parser.LBRACK_BAR;
-          Parser.RQUOTE("", false); Parser.RBRACK; Parser.RBRACE; Parser.BAR_RBRACK ]
-        |> List.map (fun n -> n, (FSharpTokenColorKind.Punctuation,FSharpTokenCharKind.Delimiter, FSharpTokenTriggerClass.MatchBraces))
-      for tok, expected in List.concat [ important; matching ] do
-        let info = TestExpose.TokenInfo tok
-        AssertEqual(expected, info)
 
     [<Test>]
     member public this.``MatchingBraces.VerifyMatches``() = 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.GotoDefinition.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.GotoDefinition.fs
@@ -2,7 +2,6 @@
 
 namespace Tests.LanguageService.GotoDefinition
 
-open System
 open System.IO
 open NUnit.Framework
 open Salsa.Salsa
@@ -10,7 +9,6 @@ open Salsa.VsOpsUtils
 open UnitTests.TestLib.Salsa
 open UnitTests.TestLib.Utils
 open System.Collections.Generic
-open System.Text.RegularExpressions
 open UnitTests.TestLib.LanguageService
 open UnitTests.TestLib.ProjectSystem
 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.IncrementalBuild.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.IncrementalBuild.fs
@@ -2,6 +2,8 @@
 
 namespace Tests.LanguageService
 
+#if DISABLED_OLD_UNITTESTS
+
 open System
 open System.IO
 open System.Threading
@@ -625,4 +627,4 @@ type IncrementalBuild() =
         let evaled = Eval cache ctok save outputs  bound  |> Cancellable.runWithoutCancellation
         let outputs = GetVectorResult(outputs,evaled)
         ()               
-              
+#endif 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.NavigationBar.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.NavigationBar.fs
@@ -2,12 +2,7 @@
 
 namespace Tests.LanguageService.NavigationBar
 
-open System
 open NUnit.Framework
-open Salsa.Salsa
-open Salsa.VsOpsUtils
-open UnitTests.TestLib.Salsa
-open UnitTests.TestLib.Utils
 open UnitTests.TestLib.LanguageService
 open UnitTests.TestLib.ProjectSystem
 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.ParameterInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.ParameterInfo.fs
@@ -4,7 +4,6 @@ namespace Tests.LanguageService.ParameterInfo
 
 open System
 open NUnit.Framework
-open Salsa.Salsa
 open Salsa.VsOpsUtils
 open UnitTests.TestLib.Salsa
 open UnitTests.TestLib.Utils

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickParse.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickParse.fs
@@ -2,7 +2,6 @@
 
 namespace Tests.LanguageService
 
-open System
 open NUnit.Framework
 open FSharp.Compiler
 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.TimeStamp.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.TimeStamp.fs
@@ -2,13 +2,10 @@
 
 namespace Tests.LanguageService.TimeStamp
 
-open System
-open System.IO
 open NUnit.Framework
 open Salsa.Salsa
 open Salsa.VsOpsUtils
 open UnitTests.TestLib.Salsa
-open UnitTests.TestLib.Utils
 open UnitTests.TestLib.LanguageService
 
 [<TestFixture>]
@@ -321,11 +318,8 @@ type UsingMSBuild()  =
 
 //Allow the TimeStampTests run under different context
 namespace Tests.LanguageService.TimeStamp
-open Tests.LanguageService
-open UnitTests.TestLib.LanguageService
 open UnitTests.TestLib.ProjectSystem
 open NUnit.Framework
-open Salsa.Salsa
 
 // Context project system
 [<TestFixture>] 

--- a/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.Configs.fs
+++ b/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.Configs.fs
@@ -3,10 +3,7 @@
 namespace Tests.ProjectSystem
 
 // System namespaces
-open System
-open System.Collections.Generic
 open System.IO
-open System.Text.RegularExpressions
 open System.Xml.Linq
 open NUnit.Framework
 
@@ -14,12 +11,9 @@ open NUnit.Framework
 open Microsoft.VisualStudio
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.FSharp
-open Microsoft.VisualStudio.FSharp.ProjectSystem
 
 // Internal unittest namespaces
-open Salsa
 open UnitTests.TestLib.Utils.Asserts
-open UnitTests.TestLib.Utils.FilesystemHelpers
 open UnitTests.TestLib.ProjectSystem
 
 

--- a/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.Miscellaneous.fs
+++ b/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.Miscellaneous.fs
@@ -7,7 +7,6 @@ open System
 open System.Collections.Generic
 open System.Globalization
 open System.IO
-open System.Text
 open System.Text.RegularExpressions
 
 // VS namespaces 

--- a/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.MultiTargeting.fs
+++ b/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.MultiTargeting.fs
@@ -6,11 +6,9 @@ open System
 open System.Collections.Generic
 open System.IO
 open System.Reflection
-open System.Text.RegularExpressions
 open System.Xml.Linq
 open NUnit.Framework
 open Salsa
-open UnitTests.TestLib.Utils.Asserts
 open UnitTests.TestLib.Utils.FilesystemHelpers
 open UnitTests.TestLib.ProjectSystem
 open Microsoft.VisualStudio.FSharp.ProjectSystem
@@ -141,26 +139,3 @@ type MultiTargeting() =
         validatePair (new System.Runtime.Versioning.FrameworkName(".NETFramework", new System.Version(2,0,0))) "v2.0"
         validatePair (new System.Runtime.Versioning.FrameworkName(".NETFramework", new System.Version(2,0,0,0))) "v2.0"
         validatePair (new System.Runtime.Versioning.FrameworkName(".NETFramework", new System.Version(2,0,0,1))) "v2.0"
-
-        (*
-    [<Test>]
-    member public this.``Multitargeting.AddAppConfigIfRetargetTo40Full`` () =
-        DoWithTempFile "Test.fsproj" (fun projFile ->
-            let sp, ccn = VsMocks.MakeMockServiceProviderAndConfigChangeNotifier20()
-            
-            // add mock service for SLocalRegistry so that CreateInstance on it will return a text buffer
-            sp.AddService (typeof<SLocalRegistry>, box(VsMocks.vsLocalRegistry (fun () -> VsMocks.Vs.MakeTextLines())), false)
-            
-            let refLibPath = this.prepTest(projFile)
-            use project = TheTests.CreateProject(projFile, "true", ccn, sp)
-            let fn = new System.Runtime.Versioning.FrameworkName(".NETFramework", new System.Version(4, 0))
-            project.FixupAppConfigOnTargetFXChange(fn.ToString(), "4.3.0.0", false) |> ignore
-            let appFile = Path.Combine((Path.GetDirectoryName projFile), "app.config")
-            let appText = System.IO.File.ReadAllText(appFile)
-            Assert.IsTrue(appText.Contains("<supportedRuntime version=\"v4.0\" sku=\".NETFramework,Version=v4.0\" />"))
-            //Assert.IsTrue(appText.Contains("<supportedRuntime version=\"v4.0\" sku=\".NETFramework,Version=v4.0,Profile=Client\" />"))
-            //Assert.IsTrue(appText.Contains("<supportedRuntime version=\"v2.0.50727\" sku=\"Client\" />"))
-            //Assert.IsTrue(appText.Contains("<supportedRuntime version=\"v2.0.50727\" />"))
-            ()
-        )
-        *)

--- a/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.ProjectItems.fs
+++ b/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.ProjectItems.fs
@@ -2,13 +2,10 @@
 
 namespace Tests.ProjectSystem
 
-open System
 open System.IO
 open NUnit.Framework
 open UnitTests.TestLib.Utils.Asserts
 open UnitTests.TestLib.ProjectSystem
-open Microsoft.VisualStudio.FSharp.ProjectSystem
-
 
 [<TestFixture>][<Category "ProjectSystem">]
 type ProjectItems() = 

--- a/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.RoundTrip.fs
+++ b/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.RoundTrip.fs
@@ -6,10 +6,8 @@ open System
 open System.IO
 open System.Text.RegularExpressions
 open NUnit.Framework
-open UnitTests.TestLib.Utils.Asserts
 open UnitTests.TestLib.Utils.FilesystemHelpers
 open UnitTests.TestLib.ProjectSystem
-open Microsoft.VisualStudio.FSharp.ProjectSystem
 
 
 [<TestFixture>][<Category "ProjectSystem">]

--- a/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.UpToDate.fs
+++ b/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.UpToDate.fs
@@ -4,16 +4,11 @@ namespace Tests.ProjectSystem
 
 // System namespaces
 open System
-open System.Collections.Generic
-open System.Globalization
 open System.IO
-open System.Text
 open System.Text.RegularExpressions
 
 // VS namespaces 
 open Microsoft.VisualStudio
-open Microsoft.VisualStudio.Shell
-open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.FSharp
 open Microsoft.VisualStudio.FSharp.ProjectSystem
 

--- a/vsintegration/tests/UnitTests/TestLib.LanguageService.fs
+++ b/vsintegration/tests/UnitTests/TestLib.LanguageService.fs
@@ -3,16 +3,12 @@
 namespace UnitTests.TestLib.LanguageService
 
 open System
-open System.Reflection
 open NUnit.Framework
 open System.Diagnostics
-open System.IO
 open Salsa.Salsa
 open Salsa.VsOpsUtils
-open Salsa.VsMocks
 open UnitTests.TestLib.Salsa
 open UnitTests.TestLib.Utils
-open FSharp.Compiler
 open System.Text.RegularExpressions 
 open FSharp.Compiler.SourceCodeServices
 open Microsoft.VisualStudio.FSharp
@@ -155,6 +151,7 @@ type internal Helper =
             AssertMatches regex s
             i <- regexStr.IndexOf(c, i+1)       
 
+#if DISABLED_OLD_UNITTESTS
 type internal GlobalParseAndTypeCheckCounter private(initialParseCount:int, initialTypeCheckCount:int, initialEventNum:int, vs) =
     static member StartNew(vs) =
         TakeCoffeeBreak(vs)
@@ -216,7 +213,7 @@ type internal GlobalParseAndTypeCheckCounter private(initialParseCount:int, init
             Assert.Fail(msg)
         elif not ok then
             Assert.Fail(sprintf "Got expected events, but also: %s" note)
-
+#endif
 /// REVIEW: Should be able to get data tip when hovering over a class member method name ie  "member private art.attemptUpgradeToMSBuild hierarchy"
 
 (* Not Unittested Yet ----------------------------------------------------------------------------------------------------------------- *)        

--- a/vsintegration/tests/UnitTests/TestLib.ProjectSystem.fs
+++ b/vsintegration/tests/UnitTests/TestLib.ProjectSystem.fs
@@ -3,9 +3,6 @@
 namespace UnitTests.TestLib.ProjectSystem
 
 open System 
-open System.CodeDom
-open System.CodeDom.Compiler
-open System.Runtime.Serialization
 open System.Collections.Generic
 open System.Text.RegularExpressions
 open System.Diagnostics
@@ -21,8 +18,6 @@ open Microsoft.VisualStudio.FSharp.ProjectSystem
 open Microsoft.VisualStudio.FSharp.Editor
 open Microsoft.VisualStudio.Shell.Interop
 
-open Microsoft.Build.Execution
-open Microsoft.Build.Framework
         
 #nowarn "52" // The value has been copied to ensure the original is not mutated
 open NUnit.Framework
@@ -567,7 +562,6 @@ and (*type*) MSBuildItems =
         | MSBuildItems(l) -> l
         
 module LanguageServiceExtension =
-    open UnitTests.TestLib.LanguageService
     open Salsa.Salsa
 
     type internal ProjInfo() =
@@ -737,8 +731,7 @@ module LanguageServiceExtension =
             member ops.SaveFileToDisk file = msbuild.SaveFileToDisk file 
             member ops.CreatePhysicalProjectFileInMemory (files, references, projectReferences, disabledWarnings, defines, versionFile, otherFlags, otherProjMisc, targetFrameworkVersion) = msbuild.CreatePhysicalProjectFileInMemory (files, references, projectReferences, disabledWarnings, defines, versionFile, otherFlags, otherProjMisc, targetFrameworkVersion) 
             member ops.CleanUp vs = msbuild.CleanUp vs 
-            member ops.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients vs = msbuild.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients vs 
-            member ops.AutoCompleteMemberDataTipsThrowsScope message = msbuild.AutoCompleteMemberDataTipsThrowsScope message 
+            member ops.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients vs = msbuild.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients vs
             member ops.CleanInvisibleProject vs = msbuild.CleanInvisibleProject vs 
     
     let internal ProjectSystemTestFlavour = ProjectSystemTestFlavour()

--- a/vsintegration/tests/UnitTests/TestLib.Salsa.fs
+++ b/vsintegration/tests/UnitTests/TestLib.Salsa.fs
@@ -2,10 +2,7 @@
 
 module UnitTests.TestLib.Salsa
 
-open System
-open System.IO
 open NUnit.Framework
-open Salsa.Salsa
 open Salsa.VsOpsUtils
 open System.Text.RegularExpressions
 
@@ -66,11 +63,6 @@ let AssertMatchesRegex (c : char) (regexStr : string) (s:string) =
         AssertMatches regex s
         i <- regexStr.IndexOf(c, i+1)
         
-// Common TestFixture methods -------------------------------------------------
-
-open System.IO
-open UnitTests.TestLib.Utils
-
 // adds qualifier to the global functions
 // Non-controlled usage of these functions can easily lead to the violation of invariants in tests:
 // - modification of shared VS\solution is prohibited and the only permitted operation is CreateSingleFileProject

--- a/vsintegration/tests/UnitTests/TestLib.Utils.fs
+++ b/vsintegration/tests/UnitTests/TestLib.Utils.fs
@@ -87,10 +87,7 @@ module FilesystemHelpers =
         r
 
 module Spawn = 
-    open System
-    open System.IO
     open System.Diagnostics
-    open System.Text
 
     /// Set this flag to true to see spawned commands.
     let mutable showSpawnedCommands = false

--- a/vsintegration/tests/UnitTests/Tests.InternalCollections.fs
+++ b/vsintegration/tests/UnitTests/Tests.InternalCollections.fs
@@ -2,11 +2,7 @@
 
 namespace Tests.Compiler.InternalCollections
 
-open System
-open System.IO
 open NUnit.Framework
-open Internal.Utilities.Collections
-       
                 
 [<TestFixture>] 
 type MruCache = 
@@ -111,7 +107,6 @@ type MruCache =
         let s = m.Get (("w",6)) // forces discard of y
         printfn "discarded = %A" discarded.Value
         Assert.IsTrue(discarded.Value = ["y";"x";"Apple";"Banana"], "Check6")                                      
-#endif
 
 type AccessToken() = class end
             
@@ -219,3 +214,4 @@ type AgedLookup() =
     [<Test>] member public rb.WeakRef1() = WeakRefTest 1
     [<Test>] member public rb.WeakRef2() = WeakRefTest 2
     [<Test>] member public rb.WeakRef3() = WeakRefTest 3
+#endif

--- a/vsintegration/tests/UnitTests/Tests.TaskReporter.fs
+++ b/vsintegration/tests/UnitTests/Tests.TaskReporter.fs
@@ -16,7 +16,7 @@ open Microsoft.VisualStudio.Shell
 open Salsa.Salsa
 open Salsa.VsMocks
 
-(*
+#if DISABLED_OLD_UNITTESTS
 type TextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan
 type DocumentTask = Microsoft.VisualStudio.FSharp.LanguageService.DocumentTask
 
@@ -367,4 +367,4 @@ type TaskReporterTests() =
         AssertEqual (backgroundTasks.GetLength(0)) 0
         
         ()                
-*)
+#endif

--- a/vsintegration/tests/UnitTests/Tests.Watson.fs
+++ b/vsintegration/tests/UnitTests/Tests.Watson.fs
@@ -7,8 +7,6 @@ namespace Tests.Compiler.Watson
 open FSharp.Compiler
 open FSharp.Compiler.AbstractIL.ILBinaryReader
 open FSharp.Compiler.AbstractIL.Internal.Library 
-open FSharp.Compiler.CompileOps
-open FSharp.Compiler.Driver
 open NUnit.Framework
 open System
 open System.Text.RegularExpressions 
@@ -16,6 +14,8 @@ open System.Diagnostics
 open System.Collections.Generic
 open System.IO
 open System.Reflection
+
+#if DISABLED_OLD_UNITTESTS
 
 type Check = 
     static member public FscLevelException<'TException when 'TException :> exn>(simulationCode)  =
@@ -65,10 +65,6 @@ module WatsonTests =
     
     [<Test>]
     let FscInvalidOperation() = Check.FscLevelException<System.InvalidOperationException>("fsc-invop")        
-
-// As of .NET 4.0 some exception types cannot be caught. As a result, we cannot test this case. I did visually confirm a Watson report is sent, though.
-//    [<Test>]
-//    let FscAccessViolation() = Check.FscLevelException<System.AccessViolationException>("fsc-ac")        
 
     [<Test>]
     let FscArgumentOutOfRange() = Check.FscLevelException<System.ArgumentOutOfRangeException>("fsc-aor")        
@@ -172,4 +168,4 @@ module WatsonTests =
 
     [<Test>]
     let TypeCheckFailure() = Check.FscLevelException<System.Exception>("tc-fail")            
-
+#endif

--- a/vsintegration/tests/UnitTests/Tests.XmlDocComments.fs
+++ b/vsintegration/tests/UnitTests/Tests.XmlDocComments.fs
@@ -2,16 +2,14 @@
 
 namespace Tests.LanguageService
 
-open System
 open NUnit.Framework
 open Salsa.Salsa
 open Salsa.VsOpsUtils
 open UnitTests.TestLib.Salsa
-open UnitTests.TestLib.Utils
 
 [<TestFixture>]
 type XmlDocComments() =
-    inherit UnitTests.TestLib.LanguageService.LanguageServiceBaseTests(VsOpts = InstalledMSBuildTestFlavour())
+    inherit UnitTests.TestLib.LanguageService.LanguageServiceBaseTests(VsOpts = BuiltMSBuildTestFlavour())
 
     // Work around an innocuous 'feature' with how QuickInfo is displayed, lines which
     // should have a "\r\n" just have a "\r"

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -19,15 +19,6 @@
 
   <ItemGroup>
     <Compile Include="AssemblyResolver.fs" />
-    <Compile Include="$(FSharpSourcesRoot)\fsharp\InternalCollections.fsi">
-      <Link>Internal.Utilities.Collections.fsi</Link>
-    </Compile>
-    <Compile Include="$(FSharpSourcesRoot)\fsharp\InternalCollections.fs">
-      <Link>Internal.Utilities.Collections.fs</Link>
-    </Compile>
-    <Compile Include="$(FSharpSourcesRoot)\utils\CompilerLocationUtils.fs">
-      <Link>Internal.Utilities.CompilerLocationUtils.fs</Link>
-    </Compile>
     <Compile Include="TestLib.Utils.fs" />
     <Compile Include="TestLib.Salsa.fs" />
     <Compile Include="TestLib.LanguageService.fs" />
@@ -66,15 +57,15 @@
     <Compile Include="..\..\..\tests\service\Symbols.fs">
       <Link>CompilerService\Symbols.fs</Link>
     </Compile>
-    <Compile Include="..\..\..\tests\service\EditorTests.fs">
+    <!--<Compile Include="..\..\..\tests\service\EditorTests.fs">
       <Link>CompilerService\EditorTests.fs</Link>
-    </Compile>
+    </Compile>-->
     <Compile Include="..\..\..\tests\service\FileSystemTests.fs">
       <Link>CompilerService\FileSystemTests.fs</Link>
     </Compile>
-    <Compile Include="..\..\..\tests\service\ProjectAnalysisTests.fs">
+    <!--<Compile Include="..\..\..\tests\service\ProjectAnalysisTests.fs">
       <Link>CompilerService\ProjectAnalysisTests.fs</Link>
-    </Compile>
+    </Compile>-->
 <!-- TODO:  Fix this test
     <Compile Include="..\..\..\tests\service\MultiProjectAnalysisTests.fs">
       <Link>CompilerService\MultiProjectAnalysisTests.fs</Link>


### PR DESCRIPTION
This one is a real piece of work:

- [x] Remove IVTs
- [x] Remove silly parts of the compiler that exist only for these tests (and thus highly couple internals to the tests)
- [ ] Remove parts of the tests that use these silly parts of compiler internals
- [ ] Disable many tests that are of questionable value to use now that we use Roslyn and a proper project system
- [ ] Figure out what to do about the FCS tests that similarly are highly coupled to the compiler, but are brought in via linked files