### PR TITLE
Update several links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -173,7 +173,7 @@ See the "Debugging The Compiler" section of this [article](https://medium.com/@w
    - We first need an existing F# compiler. We use the one in the `lkg` directory. Let's assume this compiler has an `FSharp.Core.dll` with version X.
    - We use this compiler to compile the source in this distribution, to produce a "proto" compiler, dropped to the `proto` directory. When run, this compiler still relies on `FSharp.Core.dll` with version X.
    - We use the proto compiler to compile the source for `FSharp.Core.dll` in this distribution.
-   s- We use the proto compiler to compile the source for `FSharp.Compiler.dll`, `fsc.exe`, `fsi.exe`, and other binaries found in this distribution.
+   - We use the proto compiler to compile the source for `FSharp.Compiler.dll`, `fsc.exe`, `fsi.exe`, and other binaries found in this distribution.
 
 ### Updating FSComp.fs, FSComp.resx and XLF
 

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -104,7 +104,7 @@ Or hard crash on launch ("Unknown Error"), delete these folders:
 
 The new builds of the Visual F# IDE Tools can no longer be installed into Visual Studio 2015.
 
-You can install Visual Studio 2019 from https://www.visualstudio.com/downloads/.
+You can install Visual Studio 2019 from <https://www.visualstudio.com/downloads/>.
 
 **Note:** This step will install a VSIX extension into Visual Studio "Next" that changes the Visual F# IDE Tools
 components installed in that VS installation.  You can revert this step by disabling or uninstalling the addin.
@@ -157,25 +157,25 @@ See the "Debugging The Compiler" section of this [article](https://medium.com/@w
 
 ## Notes
 
-#### Windows: Links to  Additional frameworks
+### Windows: Links to  Additional frameworks
 
-- [Git for windows](http://msysgit.github.io/)
-- [.NET 4.6](http://www.microsoft.com/en-us/download/details.aspx?id=48137)
-- [Windows 8.1 SDK](http://msdn.microsoft.com/en-us/library/windows/desktop/bg162891.aspx)
+- [Git for windows](https://gitforwindows.org/)
+- [.NET 4.6](https://www.microsoft.com/en-us/download/details.aspx?id=48137)
+- [Windows 8.1 SDK](https://msdn.microsoft.com/en-us/library/windows/desktop/bg162891.aspx)
 - [Windows 10 SDK](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)
 
-#### Notes on the Windows .NET Framework build
+### Notes on the Windows .NET Framework build
 
 1. The `update.cmd` script adds required strong name validation skips and NGens the compiler and libraries. This requires admin privileges.
 1. The compiler binaries produced are "private" and strong-named signed with a test key.
 1. Some additional tools are required to build the compiler, notably `fslex.exe`, `fsyacc.exe`, `FSharp.PowerPack.Build.Tasks.dll`, `FsSrGen.exe`, `FSharp.SRGen.Build.Tasks.dll`, and the other tools found in the `lkg` directory.
 1. The overall bootstrapping process executes as follows
- - We first need an existing F# compiler. We use the one in the `lkg` directory. Let's assume this compiler has an `FSharp.Core.dll` with version X.
- - We use this compiler to compile the source in this distribution, to produce a "proto" compiler, dropped to the `proto` directory. When run, this compiler still relies on `FSharp.Core.dll` with version X.
- - We use the proto compiler to compile the source for `FSharp.Core.dll` in this distribution.
- - We use the proto compiler to compile the source for `FSharp.Compiler.dll`, `fsc.exe`, `fsi.exe`, and other binaries found in this distribution.
+   - We first need an existing F# compiler. We use the one in the `lkg` directory. Let's assume this compiler has an `FSharp.Core.dll` with version X.
+   - We use this compiler to compile the source in this distribution, to produce a "proto" compiler, dropped to the `proto` directory. When run, this compiler still relies on `FSharp.Core.dll` with version X.
+   - We use the proto compiler to compile the source for `FSharp.Core.dll` in this distribution.
+   s- We use the proto compiler to compile the source for `FSharp.Compiler.dll`, `fsc.exe`, `fsi.exe`, and other binaries found in this distribution.
 
-#### Updating FSComp.fs, FSComp.resx and XLF
+### Updating FSComp.fs, FSComp.resx and XLF
 
 If your changes involve modifying the list of language keywords in any way, (e.g. when implementing a new keyword), the XLF localization files need to be synced with the corresponding resx files. This can be done automatically by running
 
@@ -185,7 +185,7 @@ If your changes involve modifying the list of language keywords in any way, (e.g
 
 This only works on Windows/.NETStandard framework, so changing this from any other platform requires editing and syncing all of the XLF files manually.
 
-#### Configuring proxy server
+### Configuring proxy server
 
 If you are behind a proxy server, NuGet client tool must be configured to use it:
 
@@ -195,6 +195,6 @@ If you are behind a proxy server, NuGet client tool must be configured to use it
 
 Where you should set proper proxy address, user name and password.
 
-#### Resources
+### Resources
 
 The primary technical guide to the core compiler code is [The F# Compiler Technical Guide](https://fsharp.github.io/2015/09/29/fsharp-compiler-guide.html).  Please read and contribute to that guide.

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -5,7 +5,7 @@
 Get the latest source code from the master branch by running this git command:
 
     git clone https://github.com/dotnet/fsharp.git
-    
+
 Before running the build scripts, ensure that you have cleaned up the visualfsharp repo by running this git command:
 
     git clean -xfd
@@ -106,7 +106,7 @@ The new builds of the Visual F# IDE Tools can no longer be installed into Visual
 
 You can install Visual Studio 2019 from https://www.visualstudio.com/downloads/.
 
-**Note:** This step will install a VSIX extension into Visual Studio "Next" that changes the Visual F# IDE Tools 
+**Note:** This step will install a VSIX extension into Visual Studio "Next" that changes the Visual F# IDE Tools
 components installed in that VS installation.  You can revert this step by disabling or uninstalling the addin.
 
 For **Debug**, uninstall then reinstall:
@@ -197,4 +197,4 @@ Where you should set proper proxy address, user name and password.
 
 #### Resources
 
-The primary technical guide to the core compiler code is [The F# Compiler Technical Guide](http://fsharp.github.io/2015/09/29/fsharp-compiler-guide.html).  Please read and contribute to that guide.
+The primary technical guide to the core compiler code is [The F# Compiler Technical Guide](https://fsharp.github.io/2015/09/29/fsharp-compiler-guide.html).  Please read and contribute to that guide.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ These are the branches in use:
 
 * `dev15.9`
   - Long-term servicing branch for VS 2017 update 15.9.x. We do not expect to service that release, but if we do, that's where the changes will go.
-  
+
 * `dev16.x`
   - Latest release branch for the particular point release of Visual Studio.
   - Incorporates features and fixes from master up to a particular branch point, then selective cherry-picks.
@@ -84,8 +84,8 @@ Evolution of the F# language and core library follows a process spanning two add
 
 The following links can help you get an overview of some technical aspects of the F# language and compiler:
 
-* [The F# Compiler Technical Guide](http://fsharp.github.io/2015/09/29/fsharp-compiler-guide.html) 
-* [The F# Language Specification](http://fsharp.org/specs/language-spec/)
+* [The F# Compiler Technical Guide](https://fsharp.github.io/2015/09/29/fsharp-compiler-guide.html)
+* [The F# Language Specification](https://fsharp.org/specs/language-spec/)
 
 ## License
 
@@ -93,11 +93,11 @@ This project is subject to the MIT License. A copy of this license is in [Licens
 
 ## Code of Conduct
 
-This project has adopted the [Contributor Covenant](http://contributor-covenant.org/) code of conduct to clarify expected behavior in our community. You can read it at [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
+This project has adopted the [Contributor Covenant](https://contributor-covenant.org/) code of conduct to clarify expected behavior in our community. You can read it at [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 
 ## Get In Touch
 
-Members of the [F# Software Foundation](http://fsharp.org) are invited to the [FSSF Slack](http://fsharp.org/guides/slack/). You can find support from other contributors in the `#compiler` and `#editor-support` channels.
+Members of the [F# Software Foundation](https://fsharp.org) are invited to the [FSSF Slack](https://fsharp.org/guides/slack/). You can find support from other contributors in the `#compiler` and `#editor-support` channels.
 
 Additionally, you can use the `#fsharp` tag on Twitter if you have general F# questions, including about this repository. Chances are you'll get multiple responses.
 
@@ -107,5 +107,5 @@ If you're curious about F# itself, check out these links:
 
 * [What is F#](https://docs.microsoft.com/dotnet/fsharp/what-is-fsharp)
 * [Get started with F#](https://docs.microsoft.com/dotnet/fsharp/get-started/)
-* [F# Software Foundation](http://fsharp.org)
-* [F# Testimonials](http://fsharp.org/testimonials)
+* [F# Software Foundation](https://fsharp.org)
+* [F# Testimonials](https://fsharp.org/testimonials)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Members of the [F# Software Foundation](https://fsharp.org) are invited to the [
 
 Additionally, you can use the `#fsharp` tag on Twitter if you have general F# questions, including about this repository. Chances are you'll get multiple responses.
 
-## About F#
+## About F\#
 
 If you're curious about F# itself, check out these links:
 

--- a/fcs/README.md
+++ b/fcs/README.md
@@ -1,5 +1,3 @@
-
-
 # The FSharp.Compiler.Service components and NuGet package
 
 This directory contains the build, packaging, test and documentation-generation logic for the NuGet package ``FSharp.Compiler.Service``.  The source for this NuGet
@@ -68,7 +66,6 @@ You can push the packages if you have permissions, either automatically using ``
     ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.MSBuild.v12.22.0.3.nupkg %APIKEY%  -Source https://nuget.org
     ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.ProjectCracker.22.0.3.nupkg %APIKEY%  -Source https://nuget.org
 
-
 ### Use of Paket and FAKE
 
 Paket is only used to get FAKE and FSharp.Formatting tools.  Eventually we will likely remove this once we update the project files to .NET SDK 2.0.
@@ -79,21 +76,19 @@ FAKE is only used to run build.fsx.  Eventually we will likely remove this once 
 
 Testing reuses the test files from ..\tests\service which were are also FCS tests.
 
-
 ### Documentation Generation
 
     fcs\build GenerateDocs
 
-Output is in ``docs``.  In the ``FSharp.Compiler.Service`` repo this is checked in and hosted as https://fsharp.github.io/FSharp.Compiler.Service.
-
+Output is in ``docs``.  In the ``FSharp.Compiler.Service`` repo this is checked in and hosted as <https://fsharp.github.io/FSharp.Compiler.Service>.
 
 ## The two other NuGet packages
 
 It also contains both the source, build, packaging and test logic for
 
-* ``FSharp.Compiler.Service.MSBuild.v12`` adds legacy MSBuild v12 support to an instance of FSharp.Compiler.Service, if exact compatibility for scripting references such as ``#r "Foo, Version=1.3.4"`` is required.
+- ``FSharp.Compiler.Service.MSBuild.v12`` adds legacy MSBuild v12 support to an instance of FSharp.Compiler.Service, if exact compatibility for scripting references such as ``#r "Foo, Version=1.3.4"`` is required.
 
-* ``FSharp.Compiler.Service.ProjectCracker`` is part of ``FsAutoComplete`` and Ionide and is used to crack old-style project formats using MSBuild. It used to be part of the FCS API.
+- ``FSharp.Compiler.Service.ProjectCracker`` is part of ``FsAutoComplete`` and Ionide and is used to crack old-style project formats using MSBuild. It used to be part of the FCS API.
 
 Both of these components are gradually becoming obsolete
 
@@ -106,4 +101,3 @@ FSharp.Compiler.Service is a somewhat awkward component. There are some things w
 1. Drop the use of ``dotnet mergenupkg`` since we should be able to use cross targeting
 1. Make FCS a DLL similar ot the rest of the build and make this an official component from Microsoft (signed etc.)
 1. Replace FSharp.Compiler.Private by FSharp.Compiler.Service
-

--- a/fcs/README.md
+++ b/fcs/README.md
@@ -11,7 +11,7 @@ Basically we are packaging up the compiler as a DLL and publishing it as a NuGet
 
 There are subtle differences between FSharp.Compiler.Service and FSharp.Compiler.Private (shipped with the Visual F# Tools)
 
-- FCS has a public API 
+- FCS has a public API
 
 - FCS is built against **.NET 4.6.1** and **FSharp.Core NuGet 4.6.2** to give broader reach
 
@@ -64,10 +64,10 @@ which does things like:
 You can push the packages if you have permissions, either automatically using ``build Release`` or manually
 
     set APIKEY=...
-    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.22.0.3.nupkg %APIKEY% -Source https://nuget.org 
+    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.22.0.3.nupkg %APIKEY% -Source https://nuget.org
     ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.MSBuild.v12.22.0.3.nupkg %APIKEY%  -Source https://nuget.org
     ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.ProjectCracker.22.0.3.nupkg %APIKEY%  -Source https://nuget.org
-    
+
 
 ### Use of Paket and FAKE
 
@@ -77,21 +77,21 @@ FAKE is only used to run build.fsx.  Eventually we will likely remove this once 
 
 ### Testing
 
-Testing reuses the test files from ..\tests\service which were are also FCS tests. 
+Testing reuses the test files from ..\tests\service which were are also FCS tests.
 
 
 ### Documentation Generation
 
     fcs\build GenerateDocs
 
-Output is in ``docs``.  In the ``FSharp.Compiler.Service`` repo this is checked in and hosted as http://fsharp.github.io/FSharp.Compiler.Service.
+Output is in ``docs``.  In the ``FSharp.Compiler.Service`` repo this is checked in and hosted as https://fsharp.github.io/FSharp.Compiler.Service.
 
 
 ## The two other NuGet packages
 
-It also contains both the source, build, packaging and test logic for 
+It also contains both the source, build, packaging and test logic for
 
-* ``FSharp.Compiler.Service.MSBuild.v12`` adds legacy MSBuild v12 support to an instance of FSharp.Compiler.Service, if exact compatibility for scripting references such as ``#r "Foo, Version=1.3.4"`` is required. 
+* ``FSharp.Compiler.Service.MSBuild.v12`` adds legacy MSBuild v12 support to an instance of FSharp.Compiler.Service, if exact compatibility for scripting references such as ``#r "Foo, Version=1.3.4"`` is required.
 
 * ``FSharp.Compiler.Service.ProjectCracker`` is part of ``FsAutoComplete`` and Ionide and is used to crack old-style project formats using MSBuild. It used to be part of the FCS API.
 
@@ -102,7 +102,7 @@ Both of these components are gradually becoming obsolete
 FSharp.Compiler.Service is a somewhat awkward component. There are some things we can do to simplify things:
 
 1. Remove the use of Paket and FAKE
-1. Move all projects under fcs\... to new .NET SDK project file format 
+1. Move all projects under fcs\... to new .NET SDK project file format
 1. Drop the use of ``dotnet mergenupkg`` since we should be able to use cross targeting
 1. Make FCS a DLL similar ot the rest of the build and make this an official component from Microsoft (signed etc.)
 1. Replace FSharp.Compiler.Private by FSharp.Compiler.Service

--- a/fcs/RELEASE_NOTES.md
+++ b/fcs/RELEASE_NOTES.md
@@ -15,23 +15,23 @@
   * Use new .NET SDK project files
   * FSharp.Compiler.Service nuget now uses net461 and netstandard2.0
   * FSharp.Compiler.Service netstandard2.0 now supports type providers
-  
+
 #### 19.0.1
   * Rename ``LogicalEnclosingEntity`` to ``ApparentEnclosingEntity`` for consistency int he F# codebase terminology.
   * Rename ``EnclosingEntity`` to ``DeclaringEntity``.  In the case of extension properties, ``EnclosingEntity`` was incorrectly returning the logical enclosing entity (i.e. the type the property appears to extend), and in this case ``ApparentEnclosingEntity`` should be used instead.
-  
+
 #### 18.0.1
   * Integrate visualfsharp master
-  
+
 #### 17.0.2
   * Integrate visualfsharp master
-  
+
 #### 16.0.3
   * [File name deduplication not working with ParseAndCheckFileInProject](https://github.com/fsharp/FSharp.Compiler.Service/issues/819)
-  
+
 #### 16.0.2
   * [ProjectCracker returns *.fsi files in FSharpProjectOptions.SourceFiles array](https://github.com/fsharp/FSharp.Compiler.Service/pull/812)
-  
+
   * [Fix line endings in the Nuget packages descriptions](https://github.com/fsharp/FSharp.Compiler.Service/pull/811)
 
 #### 16.0.1
@@ -49,15 +49,15 @@
 
 #### 13.0.1
   * Move docs --> docssrc
-  
+
 #### 13.0.0
   * Move FSharp.Compiler.Service.MSBuild.v12.dll to a separate nuget package
-  
+
 #### 12.0.8
   * Set bit on output executables correctly
-  
+
 #### 12.0.7
-  * Integrate visualfsharp master 
+  * Integrate visualfsharp master
 
 #### 12.0.6
   * [758: Fix project cracker when invalid path given](https://github.com/fsharp/FSharp.Compiler.Service/pull/758)
@@ -189,54 +189,54 @@
 * Expose QualifiedName and FileName of FSharpImplementationFileContents
 * Add FSharpErrorInfo.ErrorNumber
 
-#### 2.0.0.1-beta 
+#### 2.0.0.1-beta
 * Fix 452 - FSharpField.IsMutable = true for BCL enum cases
 * Fix 414 - Add IsInstanceMemberInCompiledCode
 
-#### 2.0.0.0-beta 
-* Feature #470, #478, #479 - Move ProjectCracker to separate nuget package and DLL, used ProjectCrackerTool.exe to run 
+#### 2.0.0.0-beta
+* Feature #470, #478, #479 - Move ProjectCracker to separate nuget package and DLL, used ProjectCrackerTool.exe to run
 * Feature #463 - Expose slot signatures of members in object expressions
-* Feature #469, #475 - Add EvalExpressionNonThrowing, EvalInteractionNonThrowing, EvalScriptNonThrowing 
+* Feature #469, #475 - Add EvalExpressionNonThrowing, EvalInteractionNonThrowing, EvalScriptNonThrowing
 * Fix #456 - FCS makes calls to kernel32.dll when running on OSX
 * Fix #473 - stack overflow in resolution logic
 * Fix #460 - Failure getting expression for a provided method call
 
-#### 1.4.2.3 - 
-* Fix bug in loop optimization, apply https://github.com/Microsoft/visualfsharp/pull/756/ 
+#### 1.4.2.3 -
+* Fix bug in loop optimization, apply https://github.com/Microsoft/visualfsharp/pull/756/
 
-#### 1.4.2.2 - 
+#### 1.4.2.2 -
 * #488 - Performance problems with project references
 
-#### 1.4.2.1 - 
-* #450 - Correct generation of ReferencedProjects 
+#### 1.4.2.1 -
+* #450 - Correct generation of ReferencedProjects
 
-#### 1.4.2.0 - 
+#### 1.4.2.0 -
 * Fix bug in double lookup of cache, see https://github.com/fsharp/FSharp.Compiler.Service/pull/447
 
-#### 1.4.1 - 
+#### 1.4.1 -
 * Add pause before backgrounnd work starts. The FCS request queue must be empty for 1 second before work will start
 * Write trace information about the reactor queue to the event log
 * Rewrite reactor to consistently prioritize queued work
 * Implement cancellation for queued work if it is cancelled prior to being executed
 * Adjust caching to check cache correctly if there is a gap before the request is executed
 
-#### 1.4.0.9 - 
+#### 1.4.0.9 -
 * FSharpType.Format fix
 * Disable maximum-memory trigger by default until use case ironed out
 
-#### 1.4.0.8 - 
+#### 1.4.0.8 -
 * FSharpType.Format now prettifies type variables.  If necessary, FSharpType.Prettify can also be called
-* Add maximum-memory trigger to downsize FCS caches. Defaults to 1.7GB of allocaed memory in the system 
+* Add maximum-memory trigger to downsize FCS caches. Defaults to 1.7GB of allocaed memory in the system
   process for a 32-bit process, and 2x this for a 64-bit process
 
-#### 1.4.0.7 - 
+#### 1.4.0.7 -
 * fix 427 - Make event information available for properties which represent first-class uses of F#-declared events
 * fix 410 - Symbols for C# fields (and especially enum fields)
 * Expose implemented abstract slots
 * Fix problem with obscure filenames caught by Microsoft\visualfsharp tests
 * Integrate with visualfsharp master
 
-#### 1.4.0.6 - 
+#### 1.4.0.6 -
 * fix 423 - Symbols for non-standard C# events
 * fix 235 - XmlDocSigs for references assemblies
 * fix 177 - GetAllUsesOfAllSymbolsInFile returns nothing for C# nested enum
@@ -244,19 +244,19 @@
 * Exposing assembly attributes on FSharpAssemblySignature
 * clean up IncrementalFSharpBuild.frameworkTcImportsCache
 
-#### 1.4.0.5 - 
-* add more entries to FSharpTokenTag 
+#### 1.4.0.5 -
+* add more entries to FSharpTokenTag
 
-#### 1.4.0.4 - 
-* add more entries to FSharpTokenTag 
+#### 1.4.0.4 -
+* add more entries to FSharpTokenTag
 * add PrettyNaming.QuoteIdentifierIfNeeded and PrettyNaming.KeywordNames
 
-#### 1.4.0.3 - 
+#### 1.4.0.3 -
 * integrate Microsoft/visualfsharp OOB cleanup via fsharp/fsharp
 * Make Parser and Lexer private
 
-#### 1.4.0.2 - 
-* #387 - types and arrays in F# attribute contructor arguments  
+#### 1.4.0.2 -
+* #387 - types and arrays in F# attribute contructor arguments
 
 #### 1.4.0.1 - F# 4.0 support
 * Use FSharp.Core 4.4.0.0 by default for scripting scenarios if not FSharp.Core referenced by host process
@@ -268,164 +268,164 @@
 * simplified source indexing with new SourceLink
 * Add noframework option in AST compiler methods
 
-#### 0.0.90 - 
+#### 0.0.90 -
 * Add fix for #343 Use ResolveReferences task
 * Expose BinFolderOfDefaultFSharpCompiler to editors
 * Fix the registry checking on mono to avoid unnecessary exceptions being thrown
 
-#### 0.0.89 - 
+#### 0.0.89 -
 * Fix output location of referenced projects
 
-#### 0.0.88 - 
+#### 0.0.88 -
 * Added Fix to allow implicit PCL references to be retrieved
 
-#### 0.0.87 - 
+#### 0.0.87 -
 * Don't report fake symbols in indexing #325
 * Add EnclosingEntity for an active pattern group #327
 * Add ImmediateSubExpressions #284
 * integrate fsharp/fsharp master into master
 
-#### 0.0.85 - 
+#### 0.0.85 -
 * Fix for FSharpSymbolUse for single case union type #301
 * Added supprt for ReturnParameter in nested functions
 
-#### 0.0.84 - 
+#### 0.0.84 -
 * Added curried parameter groups for nested functions
 
-#### 0.0.83 - 
+#### 0.0.83 -
 * Add Overloads to the symbols signature so it is publicly visible
 * Update OnEvaluation event to have FSharpSymbolUse information available
 
-#### 0.0.82 - 
+#### 0.0.82 -
 * Better support for Metadata of C# (and other) Assemblies.
 * Expose the DefaultFileSystem as a type instead of anonymous
 
-#### 0.0.81 - 
+#### 0.0.81 -
 * Update GetDeclarationListSymbols to expose FSharpSymbolUse
 * Improve reporting of format specifiers
 
-#### 0.0.80 - 
+#### 0.0.80 -
 * Update to latest F# 3.1.3 (inclunding updated FsLex/FsYacc used in build of FCS)
 * Report printf specifiers from Service API
-* Improve Accessibility of non-F# symbols 
+* Improve Accessibility of non-F# symbols
 
-#### 0.0.79 - 
+#### 0.0.79 -
 * Do not use memory mapped files when cracking a DLL to get an assembly reference
 * Fix for multilanguage projects in project cracker
 
-#### 0.0.78 - 
+#### 0.0.78 -
 * Reduce background checker memory usage
 * add docs on FSharp.Core
 * docs on caches and queues
 
-#### 0.0.77 - 
+#### 0.0.77 -
 * Update to github.com/fsharp/fsharp 05f426cee85609f2fe51b71473b07d7928bb01c8
 
-#### 0.0.76 - 
+#### 0.0.76 -
 * Fix #249 - Fix TryFullName when used on namespaces of provided erased type definitions
 * Add OnEvaluation event to FCS to allow detailed information to be exposed
 
-#### 0.0.75 - 
+#### 0.0.75 -
 * Do not use shared cursor for IL binaries (https://github.com/fsprojects/VisualFSharpPowerTools/issues/822)
 
-#### 0.0.74 - 
+#### 0.0.74 -
 * Extension members are returned as members of current modules
-* Fix exceptions while cross-reference a type provider project 
+* Fix exceptions while cross-reference a type provider project
 
-#### 0.0.73 - 
+#### 0.0.73 -
 * Add AssemblyContents and FSharpExpr to allow access to resolved, checked expression trees
 * Populate ReferencedProjects using ProjectFileInfo
 * Fix finding symbols declared in signature files
 * Add logging to project cracking facility
 
-#### 0.0.72 - 
-* Allow project parser to be used on project file with relative paths 
+#### 0.0.72 -
+* Allow project parser to be used on project file with relative paths
 * Expose attributes for non-F# symbols
 
-#### 0.0.71 - 
+#### 0.0.71 -
 * More renamings in SourceCodeServices API for more consistent use of 'FSharp' prefix
 
-#### 0.0.70 - 
+#### 0.0.70 -
 * Make FSharpProjectFileParser public
 * Fixes to project parser for Mono (.NET 4.0 component)
 * Renamings in SourceCodeServices API for more consistent use of 'FSharp' prefix
 
-#### 0.0.67 - 
+#### 0.0.67 -
 * Fixes to project parser for Mono
 
-#### 0.0.66 - 
+#### 0.0.66 -
 * Fixes to project parser for Mono
 * Use MSBuild v12.0 for reference resolution on .NET 4.5+
 
-#### 0.0.65 - 
+#### 0.0.65 -
 * Fixes to project parser
 
-#### 0.0.64 - 
+#### 0.0.64 -
 * Add project parser, particularly GetProjectOptionsFromProjectFile
 
-#### 0.0.63 - 
+#### 0.0.63 -
 * #221 - Normalize return types of .NET events
 
-#### 0.0.62 - 
-* Integrate to latest http://github.com/fsharp/fsharp (#80f9221f811217bd890b3a670d717ebc510aeeaf)
+#### 0.0.62 -
+* Integrate to latest https://github.com/fsharp/fsharp (#80f9221f811217bd890b3a670d717ebc510aeeaf)
 
-#### 0.0.61 - 
-* #216 - Return associated getters/setters from F# properties  
-* #214 - Added missing XmlDocSig for FSharpMemberOrFunctionOrValue's Events, Methods and Properties  
-* #213 - Retrieve information for all active pattern cases  
+#### 0.0.61 -
+* #216 - Return associated getters/setters from F# properties
+* #214 - Added missing XmlDocSig for FSharpMemberOrFunctionOrValue's Events, Methods and Properties
+* #213 - Retrieve information for all active pattern cases
 * #188 - Fix leak in file handles when using multiple instances of FsiEvaluationSession, and add optionally collectible assemblies
 
-#### 0.0.60 - 
-* #207 - Add IsLiteral/LiteralValue to FSharpField 
-* #205 - Add IsOptionalArg and related properties to FSharpParameter 
-* #210 - Check default/override members via 'IsOverrideOrExplicitMember' 
-* #209 - Add TryFullName to FSharpEntity 
+#### 0.0.60 -
+* #207 - Add IsLiteral/LiteralValue to FSharpField
+* #205 - Add IsOptionalArg and related properties to FSharpParameter
+* #210 - Check default/override members via 'IsOverrideOrExplicitMember'
+* #209 - Add TryFullName to FSharpEntity
 
-#### 0.0.59 - 
-* Fix for #184 - Fix EvalScript by using verbatim string for #Load  
+#### 0.0.59 -
+* Fix for #184 - Fix EvalScript by using verbatim string for #Load
 * Fix for #183 - The line no. reporting is still using 0-based indexes in errors. This is confusing.
 
-#### 0.0.58 - 
+#### 0.0.58 -
 * Fix for #156 - The FSharp.Core should be retrieved from the hosting environment
 
-#### 0.0.57 - 
+#### 0.0.57 -
 * Second fix for #160 - Nuget package now contains .NET 4.0 and 4.5
 
-#### 0.0.56 - 
+#### 0.0.56 -
 * Fix for #160 - Nuget package contains .NET 4.0 and 4.5
 
-#### 0.0.55 - 
+#### 0.0.55 -
 * Integrate changes for F# 3.1.x, Fix #166
 
-#### 0.0.54 - 
-* Fix for #159 - Unsubscribe from TP Invalidate events when disposing builders 
+#### 0.0.54 -
+* Fix for #159 - Unsubscribe from TP Invalidate events when disposing builders
 
-#### 0.0.53 - 
+#### 0.0.53 -
 * Add queue length to InteractiveChecker
 
-#### 0.0.52 - 
+#### 0.0.52 -
 * Fix caches keeping hold of stale entries
 
-#### 0.0.51 - 
+#### 0.0.51 -
 * Add IsAccessible to FSharpSymbol, and ProjectContext.AccessibilityRights to give the context of an access
 
-#### 0.0.50 - 
-* Fix #79 - FindUsesOfSymbol returns None at definition of properties with explicit getters and setters 
+#### 0.0.50 -
+* Fix #79 - FindUsesOfSymbol returns None at definition of properties with explicit getters and setters
 
-#### 0.0.49 - 
-* Fix #138 - Fix symbol equality for provided type members 
+#### 0.0.49 -
+* Fix #138 - Fix symbol equality for provided type members
 * Fix #150 - Return IsGetterMethod = true for declarations of F# properties (no separate 'property' symbol is yet returned, see #79)
 * Fix #132 - Add IsStaticInstantiation on FSharpEntity to allow clients to detect fake symbols arising from application of static parameters
 * Fix #154 - Add IsArrayType on FSharpEntity to allow clients to detect the symbols for array types
 * Fix #96 - Return resolutions of 'Module' and 'Type' in "Module.field" and "Type.field"
 
-#### 0.0.48 - 
+#### 0.0.48 -
 * Allow own fsi object without referencing FSharp.Compiler.Interactive.Settings.dll (#127)
 
-#### 0.0.47 - 
+#### 0.0.47 -
 * Adjust fix for #143 for F# types with abstract+default events
 
-#### 0.0.46 - 
+#### 0.0.46 -
 * Fix multi-project analysis when referenced projects have changed (#141)
 * Fix process exit on bad arguments to FsiEvaluationSession (#126)
 * Deprecate FsiEvaluationSession constructor and add FsiEvaluationSession.Create static method to allow for future API that can return errors
@@ -435,170 +435,170 @@
 * Change IsProperty and IsEvent to only return true for the symbols for properties and events, rather than the methods associated with these
 * Fix value of Assembly for some symbols (e.g. property symbols)
 
-#### 0.0.45 - 
+#### 0.0.45 -
 * Add optional project cache size parameter to InteractiveChecker
 * Switch to openBinariesInMemory for SimpleSourceCodeServices
 * Cleanup SimpleSourceCodeServices to avoid code duplication
 
-#### 0.0.44 - 
-* Integrate latest changes from visualfsharp.codeplex.com via github.com/fsharp/fsharp 
+#### 0.0.44 -
+* Integrate latest changes from visualfsharp.codeplex.com via github.com/fsharp/fsharp
 * Fix problem with task that generates description text of declaration
 * Add AllInterfaceTypes to FSharpEntity and FSharpType
 * Add BaseType to FSharpType to propagate instantiation
-* Add Instantiate to FSharpType 
+* Add Instantiate to FSharpType
 
-#### 0.0.43 - 
-* Fix #109 - Duplicates in GetUsesOfSymbolInFile 
+#### 0.0.43 -
+* Fix #109 - Duplicates in GetUsesOfSymbolInFile
 
-#### 0.0.42 - 
+#### 0.0.42 -
 * Fix #105 - Register enum symbols in patterns
 * Fix #107 - Return correct results for inheritance chain of .NET types
 * Fix #101 - Add DeclaringEntity property
 
-#### 0.0.41 - 
+#### 0.0.41 -
 * Fixed #104 - Make all operations that may utilize the FCS reactor async
 * Add FSharpDisplayContext and FSharpType.Format
 * Replace GetSymbolAtLocationAlternate by GetSymbolUseAtLocation
 
-#### 0.0.40 - 
+#### 0.0.40 -
 * Fixed #86 - Expose Microsoft.FSharp.Compiler.Interactive.Shell.Settings.fsi
 * Fixed #99 - Add IsNamespace property to FSharpEntity
 
-#### 0.0.39 - 
+#### 0.0.39 -
 * Fixed #79 - Usage points for symbols in union patterns
 
-#### 0.0.38 - 
+#### 0.0.38 -
 * Fixed #94 and #89 by addition of new properties to the FSharpSymbolUse type
 * Fixed #93 by addition of IsOpaque to FSharpEntity type
 * Fixed #92 - Issue with nested classes
 * Fixed #87 - Allow analysis of members from external assemblies
 
-#### 0.0.37 - 
+#### 0.0.37 -
 * Obsolete HasDefaultValue - see https://github.com/fsharp/FSharp.Compiler.Service/issues/77
 
-#### 0.0.36 - 
+#### 0.0.36 -
 * Fix #71 - Expose static parameters and xml docs of type providers
 * Fix #63 - SourceCodeServices: #r ignores include paths passed as command-line flags
 
-#### 0.0.35 - 
+#### 0.0.35 -
 * Fix #38 - FSharp.Compiler.Services should tolerate an FSharp.Core without siginfo/optdata in the search path
 
 
-#### 0.0.34 - 
+#### 0.0.34 -
 * Add StaticParameters property to entities, plus FSharpStaticParameter symbol
 * Fix #65
 
-#### 0.0.33 - 
+#### 0.0.33 -
 * Add FullName and Assembly properties for symbols
 * Fix #76
 * Add Japanese documentation
 
-#### 0.0.32 - 
+#### 0.0.32 -
 * Make ParseFileInProject asynchronous
 * Add ParseAndCheckFileInProject
 * Use cached results in ParseAndCheckFileInProject if available
 
-#### 0.0.31 - 
+#### 0.0.31 -
 * Fix performance problem with CheckFileInProject
 
-#### 0.0.30 - 
+#### 0.0.30 -
 * Add initial prototype version of multi-project support, through optional ProjectReferences in ProjectOptions. Leave this empty
   to use DLL/file-based references to results from other projects.
 
-#### 0.0.29 - 
+#### 0.0.29 -
 * Fix symbols for named union fields in patterns
 
-#### 0.0.28 - 
+#### 0.0.28 -
 * Fix symbols for named union fields
-* Add FSharpActivePatternCase to refine FSharpSymbol 
+* Add FSharpActivePatternCase to refine FSharpSymbol
 
-#### 0.0.27 - 
+#### 0.0.27 -
 * Fix exception tag symbol reporting
 
-#### 0.0.26 - 
+#### 0.0.26 -
 * Fix off-by-one in reporting of range for active pattern name
 
-#### 0.0.25 - 
+#### 0.0.25 -
 * Add optional source argument to TryGetRecentTypeCheckResultsForFile to specify that source must match exactly
 
-#### 0.0.24 - 
+#### 0.0.24 -
 * Update version number as nuget package may not have published properly
 
-#### 0.0.23 - 
+#### 0.0.23 -
 * Move to one-based line numbering everywhere
 * Provide better symbol information for active patterns
 
-#### 0.0.22 - 
+#### 0.0.22 -
 * Provide symbol location for type parameters
 
-#### 0.0.21 - 
+#### 0.0.21 -
 * Add GetUsesOfSymbolInFile
 * Better symbol resolution results for type parameter symbols
 
-#### 0.0.20 - 
+#### 0.0.20 -
 * Update version number as nuget package may not have published properly
 
-#### 0.0.19 - 
+#### 0.0.19 -
 * Change return type of GetAllUsesOfSymbol, GetAllUsesOfAllSymbols and GetAllUsesOfAllSymbolsInFile to FSharpSymbolUse
 * Add symbol uses when an abstract member is implemented.
 
-#### 0.0.18 - 
+#### 0.0.18 -
 * Add GetAllUsesOfAllSymbols and GetAllUsesOfAllSymbolsInFile
 
-#### 0.0.17 - 
-* Improvements to symbol accuracy w.r.t. type abbreviations 
+#### 0.0.17 -
+* Improvements to symbol accuracy w.r.t. type abbreviations
 
-#### 0.0.16 - 
+#### 0.0.16 -
 * Make FSharpEntity.BaseType return an option
 * FsiSesion got a new "EvalScript" method which allows to evaluate .fsx files
 
-#### 0.0.15 - 
+#### 0.0.15 -
 * Update version number as nuget package may not have published properly
 
-#### 0.0.14 - 
+#### 0.0.14 -
 * Update version number as nuget package may not have published properly
 
-#### 0.0.13-alpha - 
+#### 0.0.13-alpha -
 * Fix #39 - Constructor parameters are mistaken for record fields in classes
 
-#### 0.0.12-alpha - 
+#### 0.0.12-alpha -
 * Make the parts of the lexer/parser used by 'XmlDoc' tools in F# VS Power tools public
 
-#### 0.0.11-alpha - 
-* Add 'IsUnresolved' 
+#### 0.0.11-alpha -
+* Add 'IsUnresolved'
 
-#### 0.0.10-alpha - 
+#### 0.0.10-alpha -
 * Fix bug where 'multiple references to FSharp.Core' was given as error for scripts
 
-#### 0.0.9-alpha - 
+#### 0.0.9-alpha -
 * Fix fsc corrupting assemblies when generating pdb files (really)
 * Give better error messages for missing assemblies
 * Report more information about symbols returned by GetSymbolAtLocation (through subtypes)
 * Fix typos in docs
-* Return full project results from ParseAndCheckInteraction 
+* Return full project results from ParseAndCheckInteraction
 * Be more robust to missing assembly references by default.
 
-#### 0.0.8-alpha - 
+#### 0.0.8-alpha -
 * Fix fsc corrupting assemblies when generating pdb files
 
-#### 0.0.7-alpha - 
+#### 0.0.7-alpha -
 * Fix docs
 * Make symbols more robust to missing assemblies
 * Be robust to failures on IncrementalBuilder creation
 * Allow use of MSBuild resolution by IncrementalBuilder
 
-#### 0.0.6-alpha - 
+#### 0.0.6-alpha -
 * Fix version number
 
-#### 0.0.5-alpha - 
+#### 0.0.5-alpha -
 * Added GetUsesOfSymbol(), FSharpSymbol type, GetSymbolAtLocation(...)
 
-#### 0.0.4-alpha - 
+#### 0.0.4-alpha -
 * Added documentation of file system API
 * Reporte errors correctly from ParseAndCheckProject
 
 
-#### 0.0.3-alpha - 
+#### 0.0.3-alpha -
 * Integrate FSharp.PowerPack.Metadata as the FSharp* symbol API
 * Renamed Param --> MethodGroupItemParameter and hid record from view, made into an object
 * Renamed Method --> MethodGroupItem and hid record from view, made into an object
@@ -615,15 +615,15 @@
 * Added numerous methods to API including CheckFileInProject
 * Added experimental GetBackgroundCheckResultsForFileInProject, GetBackgroundParseResultsForFileInProject
 * Added PartialAssemblySignature to TypeCheckResults/CheckFileResults
-* Added CurrentPartialAssemblySignature to FsiEvaluationSession 
-* Added ParseAndCheckInteraction to FsiEvaluationSession to support intellisense implementation against a script fragment 
+* Added CurrentPartialAssemblySignature to FsiEvaluationSession
+* Added ParseAndCheckInteraction to FsiEvaluationSession to support intellisense implementation against a script fragment
 * Added initial testing in tests/service
 * Added ParseAndCheckProject to SourceCodeServices API. This will eventually return "whole project" information such as symbol tables.
 * Added GetDefaultConfiguration to simplify process of configuring FsiEvaluationSession
 * Added PartialAssemblySignatureUpdated event to FsiEvaluationSession
 * Added travis build
 
-#### 0.0.2-alpha - 
+#### 0.0.2-alpha -
 * Integrate hosted FSI configuration, SimpleSourceCodeServices, cleanup to SourceCodeServices API
 
 

--- a/fcs/docsrc/content/corelib.fsx
+++ b/fcs/docsrc/content/corelib.fsx
@@ -8,10 +8,10 @@ Shipping an FSharp.Core with your application
 ---------------------------------------------
 
 When building applications or plug-in components which use FSharp.Compiler.Service.dll, you will normally also
-include a copy of FSharp.Core.dll as part of your application.  
+include a copy of FSharp.Core.dll as part of your application.
 
 For example, if you build a ``HostedCompiler.exe``, you will normally place an FSharp.Core.dll (say 4.3.1.0) alongside
-your ``HostedCompiler.exe``.  
+your ``HostedCompiler.exe``.
 
 Binding redirects for your application
 --------------------------------------
@@ -37,7 +37,7 @@ Some other dependencies may also need to be reconciled and forwarded.
               <bindingRedirect oldVersion="1.0.0.0-1.2.0.0" newVersion="1.2.1.0" />
             </dependentAssembly>
           </assemblyBinding>
-        </runtime>	
+        </runtime>
     </configuration>
 
 Which FSharp.Core and .NET Framework gets referenced in compilation?
@@ -51,18 +51,18 @@ To target a specific FSharp.Core and/or .NET Framework assemblies, use the ``--n
 and the appropriate command-line arguments:
 
     [<Literal>]
-    let fsharpCorePath = 
+    let fsharpCorePath =
         @"C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.1.0\FSharp.Core.dll"
-    let errors2, exitCode2 = 
+    let errors2, exitCode2 =
       scs.Compile(
-        [| "fsc.exe"; "--noframework"; 
-           "-r"; fsharpCorePath; 
-           "-r"; @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll"; 
-           "-o"; fn3; 
+        [| "fsc.exe"; "--noframework";
+           "-r"; fsharpCorePath;
+           "-r"; @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll";
+           "-o"; fn3;
            "-a"; fn2 |])
 
 You will need to determine the location of these assemblies.  The easiest way to locate these DLLs in a cross-platform way and
-convert them to command-line arguments is to [crack an F# project file](http://fsharp.github.io/FSharp.Compiler.Service/project.html).  
+convert them to command-line arguments is to [crack an F# project file](https://fsharp.github.io/FSharp.Compiler.Service/project.html).
 Alternatively you can compute SDK paths yourself, and some helpers to do this are in [the tests for FSharp.Compiler.Service.dll](https://github.com/fsharp/FSharp.Compiler.Service/blob/8a943dd3b545648690cb3bed652a469bdb6dd869/tests/service/Common.fs#L54).
 
 
@@ -73,9 +73,9 @@ If you do _not_ explicitly reference an FSharp.Core.dll from an SDK location, or
 using ``FsiEvaluationSession`` or ``GetCheckOptionsFromScriptRoot``, then an implicit reference to FSharp.Core will be made
 by the following choice:
 
-1. The version of FSharp.Core.dll statically referenced by the host assembly returned by ``System.Reflection.Assembly.GetEntryAssembly()``. 
+1. The version of FSharp.Core.dll statically referenced by the host assembly returned by ``System.Reflection.Assembly.GetEntryAssembly()``.
 
-2. If there is no static reference to FSharp.Core in the host assembly, then 
+2. If there is no static reference to FSharp.Core in the host assembly, then
 
    - For FSharp.Compiler.Service 1.4.0.x above (F# 4.0 series), a reference to FSharp.Core version 4.4.0.0 is added
 

--- a/fcs/docsrc/content/corelib.fsx
+++ b/fcs/docsrc/content/corelib.fsx
@@ -17,7 +17,7 @@ Binding redirects for your application
 --------------------------------------
 
 The FSharp.Compiler.Service.dll component depends on FSharp.Core 4.4.0.0.  Normally your application will target
-a later version of FSharp.Core, and you may need a [binding redirect](http://msdn.microsoft.com/en-us/library/7wd6ex19(v=vs.110).aspx) to ensure
+a later version of FSharp.Core, and you may need a [binding redirect](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/redirect-assembly-versions) to ensure
 that other versions of FSharp.Core forward to the final version of FSharp.Core.dll your application uses.
 Binding redirect files are normally generated automatically by build tools. If not, you can use one like this
 (if your tool is called ``HostedCompiler.exe``, the binding redirect file is called ``HostedCompiler.exe.config``)

--- a/fcs/docsrc/content/index.md
+++ b/fcs/docsrc/content/index.md
@@ -3,7 +3,7 @@ F# Compiler Services
 
 The F# compiler services package is a component derived from the F# compiler source code that
 exposes additional functionality for implementing F# language bindings, additional
-tools based on the compiler or refactoring tools. The package also includes F# 
+tools based on the compiler or refactoring tools. The package also includes F#
 interactive service that can be used for embedding F# scripting into your applications.
 
 <div class="row">
@@ -24,35 +24,35 @@ The project currently exposes the following services that are tested & documente
 The libraries contain additional public API that can be used, but is not documented here.
 
  * [**F# Language tokenizer**](tokenizer.html) - turns any F# source code into a stream of tokens.
-   Useful for implementing source code colorization and basic tools. Correctly handle nested 
+   Useful for implementing source code colorization and basic tools. Correctly handle nested
    comments, strings etc.
 
  * [**Processing untyped AST**](untypedtree.html) - allows accessing the untyped abstract syntax tree (AST).
    This represents parsed F# syntax without type information and can be used to implement code formatting
-   and various simple processing tasks.   
+   and various simple processing tasks.
 
  * [**Using editor (IDE) services**](editor.html) - expose functionality for auto-completion, tool-tips,
    parameter information etc. These functions are useful for implementing F# support for editors
    and for getting some type information for F# code.
 
  * [**Working with signatures, types, and resolved symbols**](symbols.html) - many services related to type checking
-   return resolved symbols, representing inferred types, and the signatures of whole assemblies. 
-  
+   return resolved symbols, representing inferred types, and the signatures of whole assemblies.
+
  * [**Working with resolved expressions**](typedtree.html) - services related to working with
-   type-checked expressions and declarations, where names have been resolved to symbols. 
-  
+   type-checked expressions and declarations, where names have been resolved to symbols.
+
  * [**Working with projects and project-wide analysis**](project.html) - you can request a check of
    an entire project, and ask for the results of whole-project analyses such as find-all-references.
-   
+
  * [**Hosting F# interactive**](interactive.html) - allows calling F# interactive as a .NET library
    from your .NET code. You can use this API to embed F# as a scripting language in your projects.
- 
+
  * [**Hosting the F# compiler**](compiler.html) - allows you to embed calls to the F# compiler.
-  
+
  * [**File system API**](filesystem.html) - the `FSharp.Compiler.Service` component has a global variable
    representing the file system. By setting this variable you can host the compiler in situations where a file system
    is not available.
-  
+
 > **NOTE:** The FSharp.Compiler.Service API is subject to change when later versions of the nuget package are published
 
 Projects using the F# Compiler Services
@@ -60,10 +60,10 @@ Projects using the F# Compiler Services
 
 Some of the projects using the F# Compiler Services are:
 
- * [**The Visual F# Power Tools**](http://fsprojects.github.io/VisualFSharpPowerTools/) 
- * [**The Xamarin and MonoDevelop Tools for F#**](https://github.com/mono/monodevelop/tree/master/main/external/fsharpbinding) 
- * [**The Emacs Plugin for F#**](https://github.com/fsharp/emacs-fsharp-mode) 
- * [**The Vim Plugin for F#**](https://github.com/fsharp/vim-fsharp) 
+ * [**The Visual F# Power Tools**](http://fsprojects.github.io/VisualFSharpPowerTools/)
+ * [**The Xamarin and MonoDevelop Tools for F#**](https://github.com/mono/monodevelop/tree/master/main/external/fsharpbinding)
+ * [**The Emacs Plugin for F#**](https://github.com/fsharp/emacs-fsharp-mode)
+ * [**The Vim Plugin for F#**](https://github.com/fsharp/vim-fsharp)
  * [**iFSharp**](https://github.com/BayardRock/IfSharp)  - iPython-style notebook engine for F#
  * [**CloudSharper**](http://cloudsharper.com/) - Online web and mobile programming with big data and charting
  * [**Tsunami**](http://tsunami.io) - Tsunami enhances applications and workflows with the power of Type Safe Scripting
@@ -74,7 +74,7 @@ Some of the projects using the F# Compiler Services are:
  * [**Elucidate**](https://github.com/rookboom/Elucidate) - Visual Studio extension for rich inlined comments using MarkDown
  * [**Fable**](https://fable-compiler.github.io/) - F# to JavaScript Compiler
  * [**FSharp.Formatting**](http://tpetricek.github.io/FSharp.Formatting/) - F# tools for generating documentation (Markdown processor and F# code formatter)
- * [**FAKE**](http://fsharp.github.io/FAKE/) - "FAKE - F# Make" is a cross platform build automation system
+ * [**FAKE**](https://fsharp.github.io/FAKE/) - "FAKE - F# Make" is a cross platform build automation system
  * [**FsLab Journal**](https://visualstudiogallery.msdn.microsoft.com/45373b36-2a4c-4b6a-b427-93c7a8effddb) - Template that makes it easy to do interactive data analysis using F# Interactive and produce nice HTML reports of your work
 
 

--- a/fcs/docsrc/content/index.md
+++ b/fcs/docsrc/content/index.md
@@ -23,35 +23,35 @@ Available services
 The project currently exposes the following services that are tested & documented on this page.
 The libraries contain additional public API that can be used, but is not documented here.
 
- * [**F# Language tokenizer**](tokenizer.html) - turns any F# source code into a stream of tokens.
-   Useful for implementing source code colorization and basic tools. Correctly handle nested
-   comments, strings etc.
+* [**F# Language tokenizer**](tokenizer.html) - turns any F# source code into a stream of tokens.
+  Useful for implementing source code colorization and basic tools. Correctly handle nested
+  comments, strings etc.
 
- * [**Processing untyped AST**](untypedtree.html) - allows accessing the untyped abstract syntax tree (AST).
-   This represents parsed F# syntax without type information and can be used to implement code formatting
-   and various simple processing tasks.
+* [**Processing untyped AST**](untypedtree.html) - allows accessing the untyped abstract syntax tree (AST).
+  This represents parsed F# syntax without type information and can be used to implement code formatting
+  and various simple processing tasks.
 
- * [**Using editor (IDE) services**](editor.html) - expose functionality for auto-completion, tool-tips,
-   parameter information etc. These functions are useful for implementing F# support for editors
-   and for getting some type information for F# code.
+* [**Using editor (IDE) services**](editor.html) - expose functionality for auto-completion, tool-tips,
+  parameter information etc. These functions are useful for implementing F# support for editors
+  and for getting some type information for F# code.
 
- * [**Working with signatures, types, and resolved symbols**](symbols.html) - many services related to type checking
-   return resolved symbols, representing inferred types, and the signatures of whole assemblies.
+* [**Working with signatures, types, and resolved symbols**](symbols.html) - many services related to type checking
+  return resolved symbols, representing inferred types, and the signatures of whole assemblies.
 
- * [**Working with resolved expressions**](typedtree.html) - services related to working with
-   type-checked expressions and declarations, where names have been resolved to symbols.
+* [**Working with resolved expressions**](typedtree.html) - services related to working with
+  type-checked expressions and declarations, where names have been resolved to symbols.
 
- * [**Working with projects and project-wide analysis**](project.html) - you can request a check of
-   an entire project, and ask for the results of whole-project analyses such as find-all-references.
+* [**Working with projects and project-wide analysis**](project.html) - you can request a check of
+  an entire project, and ask for the results of whole-project analyses such as find-all-references.
 
- * [**Hosting F# interactive**](interactive.html) - allows calling F# interactive as a .NET library
-   from your .NET code. You can use this API to embed F# as a scripting language in your projects.
+* [**Hosting F# interactive**](interactive.html) - allows calling F# interactive as a .NET library
+  from your .NET code. You can use this API to embed F# as a scripting language in your projects.
 
- * [**Hosting the F# compiler**](compiler.html) - allows you to embed calls to the F# compiler.
+* [**Hosting the F# compiler**](compiler.html) - allows you to embed calls to the F# compiler.
 
- * [**File system API**](filesystem.html) - the `FSharp.Compiler.Service` component has a global variable
-   representing the file system. By setting this variable you can host the compiler in situations where a file system
-   is not available.
+* [**File system API**](filesystem.html) - the `FSharp.Compiler.Service` component has a global variable
+  representing the file system. By setting this variable you can host the compiler in situations where a file system
+  is not available.
 
 > **NOTE:** The FSharp.Compiler.Service API is subject to change when later versions of the nuget package are published
 
@@ -60,24 +60,22 @@ Projects using the F# Compiler Services
 
 Some of the projects using the F# Compiler Services are:
 
- * [**The Visual F# Power Tools**](http://fsprojects.github.io/VisualFSharpPowerTools/)
- * [**The Xamarin and MonoDevelop Tools for F#**](https://github.com/mono/monodevelop/tree/master/main/external/fsharpbinding)
- * [**The Emacs Plugin for F#**](https://github.com/fsharp/emacs-fsharp-mode)
- * [**The Vim Plugin for F#**](https://github.com/fsharp/vim-fsharp)
- * [**iFSharp**](https://github.com/BayardRock/IfSharp)  - iPython-style notebook engine for F#
- * [**CloudSharper**](http://cloudsharper.com/) - Online web and mobile programming with big data and charting
- * [**Tsunami**](http://tsunami.io) - Tsunami enhances applications and workflows with the power of Type Safe Scripting
- * [**FQuake3**](https://github.com/TIHan/FQuake3/)  - integrates F# as an interactive game scripting engine
- * [**FCell**](http://fcell.io) - Deliver the power of .NET from within Microsoft Excel
- * [**FSharpLint**](http://fsprojects.github.io/FSharpLint/) - Lint tool for F#
- * [**FsReveal**](http://fsprojects.github.io/FsReveal//) - FsReveal parses markdown and F# script file and generate reveal.js slides
- * [**Elucidate**](https://github.com/rookboom/Elucidate) - Visual Studio extension for rich inlined comments using MarkDown
- * [**Fable**](https://fable-compiler.github.io/) - F# to JavaScript Compiler
- * [**FSharp.Formatting**](http://tpetricek.github.io/FSharp.Formatting/) - F# tools for generating documentation (Markdown processor and F# code formatter)
- * [**FAKE**](https://fsharp.github.io/FAKE/) - "FAKE - F# Make" is a cross platform build automation system
- * [**FsLab Journal**](https://visualstudiogallery.msdn.microsoft.com/45373b36-2a4c-4b6a-b427-93c7a8effddb) - Template that makes it easy to do interactive data analysis using F# Interactive and produce nice HTML reports of your work
-
-
+* [**The Visual F# Power Tools**](https://fsprojects.github.io/VisualFSharpPowerTools/)
+* [**The Xamarin and MonoDevelop Tools for F#**](https://github.com/mono/monodevelop/tree/master/main/external/fsharpbinding)
+* [**The Emacs Plugin for F#**](https://github.com/fsharp/emacs-fsharp-mode)
+* [**The Vim Plugin for F#**](https://github.com/fsharp/vim-fsharp)
+* [**iFSharp**](https://github.com/BayardRock/IfSharp)  - iPython-style notebook engine for F#
+* [**CloudSharper**](https://cloudsharper.com/) - Online web and mobile programming with big data and charting
+* [**Tsunami**](http://tsunami.io) - Tsunami enhances applications and workflows with the power of Type Safe Scripting
+* [**FQuake3**](https://github.com/TIHan/FQuake3/)  - integrates F# as an interactive game scripting engine
+* [**FCell**](http://fcell.io) - Deliver the power of .NET from within Microsoft Excel
+* [**FSharpLint**](https://fsprojects.github.io/FSharpLint/) - Lint tool for F#
+* [**FsReveal**](https://fsprojects.github.io/FsReveal/) - FsReveal parses markdown and F# script file and generate reveal.js slides
+* [**Elucidate**](https://github.com/rookboom/Elucidate) - Visual Studio extension for rich inlined comments using MarkDown
+* [**Fable**](https://fable-compiler.github.io/) - F# to JavaScript Compiler
+* [**FSharp.Formatting**](http://tpetricek.github.io/FSharp.Formatting/) - F# tools for generating documentation (Markdown processor and F# code formatter)
+* [**FAKE**](https://fsharp.github.io/FAKE/) - "FAKE - F# Make" is a cross platform build automation system
+* [**FsLab Journal**](https://visualstudiogallery.msdn.microsoft.com/45373b36-2a4c-4b6a-b427-93c7a8effddb) - Template that makes it easy to do interactive data analysis using F# Interactive and produce nice HTML reports of your work
 
 Contributing and copyright
 --------------------------

--- a/fcs/docsrc/content/interactive.fsx
+++ b/fcs/docsrc/content/interactive.fsx
@@ -6,16 +6,16 @@ Interactive Service: Embedding F# Interactive
 
 This tutorial demonstrates how to embed F# interactive in your application. F# interactive
 is an interactive scripting environment that compiles F# code into highly efficient IL code
-and executes it on the fly. The F# interactive service allows you to embed F# evaluation in 
+and executes it on the fly. The F# interactive service allows you to embed F# evaluation in
 your application.
 
-> **NOTE:** There is a number of options for embedding F# Interactive. The easiest one is to use the 
+> **NOTE:** There is a number of options for embedding F# Interactive. The easiest one is to use the
 `fsi.exe` process and communicate with it using standard input and standard output. In this
 tutorial, we look at calling F# Interactive directly through .NET API. However, if you have
 no control over the input, it is a good idea to run F# interactive in a separate process.
 One reason is that there is no way to handle `StackOverflowException` and so a poorly written
-script can terminate the host process. **Remember that while calling F# Interactive through .NET API, 
-` --shadowcopyreferences` option will be ignored**. For detailed discussion, please take a look at 
+script can terminate the host process. **Remember that while calling F# Interactive through .NET API,
+` --shadowcopyreferences` option will be ignored**. For detailed discussion, please take a look at
 [this thread](https://github.com/fsharp/FSharp.Compiler.Service/issues/292).
 > **NOTE:** If `FsiEvaluationSession.Create` fails with an error saying that `FSharp.Core.dll` cannot be found,
 add the `FSharp.Core.sigdata` and `FSharp.Core.optdata` files. More info [here](https://fsharp.github.io/FSharp.Compiler.Service/corelib.html).
@@ -55,7 +55,7 @@ let argv = [| "C:\\fsi.exe" |]
 let allArgs = Array.append argv [|"--noninteractive"|]
 
 let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration()
-let fsiSession = FsiEvaluationSession.Create(fsiConfig, allArgs, inStream, outStream, errStream)  
+let fsiSession = FsiEvaluationSession.Create(fsiConfig, allArgs, inStream, outStream, errStream)
 
 
 
@@ -74,7 +74,7 @@ let evalExpression text =
   | None -> printfn "Got no result!"
 
 (**
-This takes a string as an argument and evaluates (i.e. executes) it as F# code. 
+This takes a string as an argument and evaluates (i.e. executes) it as F# code.
 *)
 evalExpression "42+1" // prints '43'
 
@@ -83,7 +83,7 @@ This can be used in a strongly typed way as follows:
 *)
 
 /// Evaluate expression & return the result, strongly typed
-let evalExpressionTyped<'T> (text) = 
+let evalExpressionTyped<'T> (text) =
     match fsiSession.EvalExpression(text) with
     | Some value -> value.ReflectionValue |> unbox<'T>
     | None -> failwith "Got no result!"
@@ -95,7 +95,7 @@ evalExpressionTyped<int> "42+1"  // gives '43'
 The `EvalInteraction` method can be used to evaluate side-effectful operations
 such as printing, declarations, or other interactions that are not valid F# expressions, but can be entered in
 the F# Interactive console. Such commands include `#time "on"` (and other directives), `open System`
-all declarations and other top-level statements. The code 
+all declarations and other top-level statements. The code
 does not require `;;` at the end. Just enter the code that you want to execute:
 *)
 fsiSession.EvalInteraction "printfn \"bye\""
@@ -116,7 +116,7 @@ Catching errors
 code has type checking warnings or errors, or if evaluation fails with an exception.
 In these cases you can use ``EvalExpressionNonThrowing``, ``EvalInteractionNonThrowing``
 and ``EvalScriptNonThrowing``. These return a tuple of a result and an array of ``FSharpErrorInfo`` values.
-These represent the errors and warnings. The result part is a ``Choice<_,_>`` between an actual 
+These represent the errors and warnings. The result part is a ``Choice<_,_>`` between an actual
 result and an exception.
 
 The result part of ``EvalExpression`` and ``EvalExpressionNonThrowing`` is an optional ``FSharpValue``.
@@ -129,7 +129,7 @@ File.WriteAllText("sample.fsx", "let twenty = 'a' + 10.0")
 let result, warnings = fsiSession.EvalScriptNonThrowing "sample.fsx"
 
 // show the result
-match result with 
+match result with
 | Choice1Of2 () -> printfn "checked and executed ok"
 | Choice2Of2 exn -> printfn "execution exception: %s" exn.Message
 
@@ -141,8 +141,8 @@ Gives:
 *)
 
 // show the errors and warnings
-for w in warnings do 
-   printfn "Warning %s at %d,%d" w.Message w.StartLineAlternate w.StartColumn 
+for w in warnings do
+   printfn "Warning %s at %d,%d" w.Message w.StartLineAlternate w.StartColumn
 
 (**
 Gives:
@@ -156,9 +156,9 @@ For expressions:
 
 let evalExpressionTyped2<'T> text =
    let res, warnings = fsiSession.EvalExpressionNonThrowing(text)
-   for w in warnings do 
-       printfn "Warning %s at %d,%d" w.Message w.StartLineAlternate w.StartColumn 
-   match res with 
+   for w in warnings do
+       printfn "Warning %s at %d,%d" w.Message w.StartLineAlternate w.StartColumn
+   match res with
    | Choice1Of2 (Some value) -> value.ReflectionValue |> unbox<'T>
    | Choice1Of2 None -> failwith "null or no result"
    | Choice2Of2 (exn:exn) -> failwith (sprintf "exception %s" exn.Message)
@@ -175,17 +175,17 @@ By default the code passed to ``EvalExpression`` is executed immediately. To exe
 
 open System.Threading.Tasks
 
-let sampleLongRunningExpr = 
+let sampleLongRunningExpr =
     """
-async { 
+async {
     // The code of what you want to run
     do System.Threading.Thread.Sleep 5000
-    return 10 
+    return 10
 }
   |> Async.StartAsTask"""
 
-let task1 = evalExpressionTyped<Task<int>>(sampleLongRunningExpr)  
-let task2 = evalExpressionTyped<Task<int>>(sampleLongRunningExpr)  
+let task1 = evalExpressionTyped<Task<int>>(sampleLongRunningExpr)
+let task2 = evalExpressionTyped<Task<int>>(sampleLongRunningExpr)
 
 (**
 Both computations have now started.  You can now fetch the results:
@@ -199,7 +199,7 @@ task2.Result // gives the result after completion (up to 5 seconds)
 Type checking in the evaluation context
 ------------------
 
-Let's assume you have a situation where you would like to typecheck code 
+Let's assume you have a situation where you would like to typecheck code
 in the context of the F# Interactive scripting session. For example, you first
 evaluation a declaration:
 *)
@@ -211,17 +211,17 @@ fsiSession.EvalInteraction "let xxx = 1 + 1"
 Now you want to typecheck the partially complete code `xxx + xx`
 *)
 
-let parseResults, checkResults, checkProjectResults = 
+let parseResults, checkResults, checkProjectResults =
     fsiSession.ParseAndCheckInteraction("xxx + xx")
     |> Async.RunSynchronously
 
-(** 
+(**
 The `parseResults` and `checkResults` have types `ParseFileResults` and `CheckFileResults`
 explained in [Editor](editor.html). You can, for example, look at the type errors in the code:
 *)
 checkResults.Errors.Length // 1
 
-(** 
+(**
 The code is checked with respect to the logical type context available in the F# interactive session
 based on the declarations executed so far.
 
@@ -230,10 +230,10 @@ You can also request declaration list information, tooltip text and symbol resol
 open FSharp.Compiler
 
 // get a tooltip
-checkResults.GetToolTipText(1, 2, "xxx + xx", ["xxx"], FSharpTokenTag.IDENT) 
+checkResults.GetToolTipText(1, 2, "xxx + xx", ["xxx"], FSharpTokenTag.IDENT)
 
 checkResults.GetSymbolUseAtLocation(1, 2, "xxx + xx", ["xxx"]) // symbol xxx
-  
+
 (**
 The 'fsi' object
 ------------------
@@ -252,16 +252,16 @@ Evaluating code in using FsiEvaluationSession generates a .NET dynamic assembly 
 You can make generated code collectible by passing `collectible=true`.  However code will only
 be collected if there are no outstanding object references involving types, for example
 `FsiValue` objects returned by `EvalExpression`, and you must have disposed the `FsiEvaluationSession`.
-See also [Restrictions on Collectible Assemblies](http://msdn.microsoft.com/en-us/library/dd554932(v=vs.110).aspx#restrictions).
+See also [Restrictions on Collectible Assemblies](https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/dd554932(v=vs.100)#restrictions).
 
 The example below shows the creation of 200 evaluation sessions. Note that `collectible=true` and
-`use session = ...` are both used. 
+`use session = ...` are both used.
 
 If collectible code is working correctly,
 overall resource usage will not increase linearly as the evaluation progresses.
 *)
 
-let collectionTest() = 
+let collectionTest() =
 
     for i in 1 .. 200 do
         let defaultArgs = [|"fsi.exe";"--noninteractive";"--nologo";"--gui-"|]
@@ -271,7 +271,7 @@ let collectionTest() =
 
         let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration()
         use session = FsiEvaluationSession.Create(fsiConfig, defaultArgs, inStream, outStream, errStream, collectible=true)
-        
+
         session.EvalInteraction (sprintf "type D = { v : int }")
         let v = session.EvalExpression (sprintf "{ v = 42 * %d }" i)
         printfn "iteration %d, result = %A" i v.Value.ReflectionValue

--- a/fcs/docsrc/content/ja/corelib.fsx
+++ b/fcs/docsrc/content/ja/corelib.fsx
@@ -31,7 +31,7 @@ FSharp.Compiler.Service.dll コンポーネントは FSharp.Core 4.3.0.0 に依�
               <bindingRedirect oldVersion="1.0.0.0-1.2.0.0" newVersion="1.2.1.0" />
             </dependentAssembly>
           </assemblyBinding>
-        </runtime>	
+        </runtime>
     </configuration>
 
 どの FSharp.Core と .NET フレームワークがコンパイル時に参照される？
@@ -42,17 +42,17 @@ FSharp.Combiler.Service コンポーネントは多かれ少なかれ、F#コー
 特定の FSharp.Core および .NET フレームワーク アセンブリ、またはそのいずれかをターゲットにする場合、 ``--noframework`` 引数と適切なコマンドライン引数を使います:
 
     [<Literal>]
-    let fsharpCorePath = 
+    let fsharpCorePath =
         @"C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.1.0\FSharp.Core.dll"
-    let errors2, exitCode2 = 
+    let errors2, exitCode2 =
       scs.Compile(
-        [| "fsc.exe"; "--noframework"; 
-           "-r"; fsharpCorePath; 
-           "-r"; @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll"; 
-           "-o"; fn3; 
+        [| "fsc.exe"; "--noframework";
+           "-r"; fsharpCorePath;
+           "-r"; @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll";
+           "-o"; fn3;
            "-a"; fn2 |])
 
-これらのアセンブリが配置されている場所を指定する必要があります。クロスプラットフォームに対応した方法でDLL を配置して、それらをコマンドライン引数に変換する最も簡単な方法は、[F# プロジェクトファイルをクラックする](http://fsharp.github.io/FSharp.Compiler.Service/ja/project.html)ことです。
+これらのアセンブリが配置されている場所を指定する必要があります。クロスプラットフォームに対応した方法でDLL を配置して、それらをコマンドライン引数に変換する最も簡単な方法は、[F# プロジェクトファイルをクラックする](https://fsharp.github.io/FSharp.Compiler.Service/ja/project.html)ことです。
 自分で SDK のパスを処理する代わりに、[FSharp.Compiler.Service.dll 用のテスト](https://github.com/fsharp/FSharp.Compiler.Service/blob/8a943dd3b545648690cb3bed652a469bdb6dd869/tests/service/Common.fs#L54)で使用しているようなヘルパー関数も用意されています。
 
 

--- a/fcs/docsrc/tools/generate.fsx
+++ b/fcs/docsrc/tools/generate.fsx
@@ -4,7 +4,7 @@
 // --------------------------------------------------------------------------------------
 
 // Binaries that have XML documentation (in a corresponding generated XML file)
-let referenceBinaries = [ "FSharp.Compiler.Service.dll" ] 
+let referenceBinaries = [ "FSharp.Compiler.Service.dll" ]
 // Web site location for the generated documentation
 let website = "https://fsharp.github.io/FSharp.Compiler.Service"
 
@@ -13,7 +13,7 @@ let info =
   [ "project-name", "F# Compiler Services"
     "project-author", "Microsoft Corporation, Dave Thomas, Anh-Dung Phan, Tomas Petricek"
     "project-summary", "F# compiler services for creating IDE tools, language extensions and for F# embedding"
-    "project-github", "http://github.com/fsharp/FSharp.Compiler.Service"
+    "project-github", "https://github.com/fsharp/FSharp.Compiler.Service"
     "project-nuget", "https://www.nuget.org/packages/FSharp.Compiler.Service" ]
 
 // --------------------------------------------------------------------------------------
@@ -42,7 +42,7 @@ let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)
 let layoutRoots =
-  [ templates; 
+  [ templates;
     formatting @@ "templates"
     formatting @@ "templates/reference" ]
 
@@ -50,7 +50,7 @@ let layoutRoots =
 let copyFiles () =
   CopyRecursive files output true |> Log "Copying file: "
   ensureDirectory (output @@ "content")
-  CopyRecursive (formatting @@ "styles") (output @@ "content") true 
+  CopyRecursive (formatting @@ "styles") (output @@ "content") true
     |> Log "Copying styles and scripts: "
 
 let clr =  System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
@@ -61,7 +61,7 @@ let buildReference () =
   CleanDir (output @@ "reference")
   for lib in referenceBinaries do
     MetadataFormat.Generate
-      ( bin @@ lib, output @@ "reference", layoutRoots, 
+      ( bin @@ lib, output @@ "reference", layoutRoots,
         parameters = ("root", root)::info,
         sourceRepo = "https://github.com/fsharp/FSharp.Compiler.Service/tree/master/src",
         sourceFolder = @"..\..\..\src",

--- a/fcs/docsrc/tools/generate.ja.fsx
+++ b/fcs/docsrc/tools/generate.ja.fsx
@@ -11,7 +11,7 @@ let info =
   [ "project-name", "F# Compiler Services"
     "project-author", "Microsoft Corporation, Dave Thomas, Anh-Dung Phan, Tomas Petricek"
     "project-summary", "F# compiler services for creating IDE tools, language extensions and for F# embedding"
-    "project-github", "http://github.com/fsharp/FSharp.Compiler.Service"
+    "project-github", "https://github.com/fsharp/FSharp.Compiler.Service"
     "project-nuget", "https://www.nuget.org/packages/FSharp.Compiler.Service" ]
 
 // --------------------------------------------------------------------------------------

--- a/fcs/docsrc/tools/templates/ja/template.cshtml
+++ b/fcs/docsrc/tools/templates/ja/template.cshtml
@@ -24,7 +24,7 @@
     <div class="container">
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
-          <li><a href="http://fsharp.org">fsharp.org</a></li>
+          <li><a href="https://fsharp.org">fsharp.org</a></li>
           <li><a href="@Properties["project-github"]">github page</a></li>
         </ul>
         <h3 class="muted">@Properties["project-name"]</h3>
@@ -50,7 +50,7 @@
             <li><a href="@Properties["project-github"]">GitHub上のソースコード</a></li>
             <li><a href="@Properties["project-github"]/blob/master/LICENSE">ライセンス</a></li>
             <li><a href="@Properties["project-github"]/blob/master/RELEASE_NOTES.md">リリースノート</a></li>
-            
+
             <li class="nav-header">はじめに</li>
             <li><a href="@Root/index.html">ホームページ</a></li>
             <li><a href="@Root/devnotes.html">開発者用メモ</a></li>

--- a/fcs/docsrc/tools/templates/template.cshtml
+++ b/fcs/docsrc/tools/templates/template.cshtml
@@ -24,7 +24,7 @@
     <div class="container">
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
-          <li><a href="http://fsharp.org">fsharp.org</a></li>
+          <li><a href="https://fsharp.org">fsharp.org</a></li>
           <li><a href="@Properties["project-github"]">github page</a></li>
         </ul>
         <h3 class="muted">@Properties["project-name"]</h3>
@@ -50,7 +50,7 @@
             <li><a href="@Properties["project-github"]">Source Code on GitHub</a></li>
             <li><a href="@Properties["project-github"]/blob/master/LICENSE">License</a></li>
             <li><a href="@Properties["project-github"]/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-            
+
             <li class="nav-header">Getting started</li>
             <li><a href="@Root/index.html">Home page</a></li>
             <li><a href="@Root/devnotes.html">Developer notes</a></li>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
-    Copyright (c) Microsoft Corporation.  All Rights Reserved.  
+    Copyright (c) Microsoft Corporation.  All Rights Reserved.
     See License.txt in the project root for license information.
-    
+
 ## About the release notes
 
 We deliver F# and F# tools for Visual Studio and .NET Core releases. These can include bug fixes, new tooling features, new compiler features, performance improvements, infrastructure improvements, and new language versions. The most recent release of F# or any F# component will be at the top of this document.
@@ -33,7 +33,7 @@ You can find all tracked VS 15.9 items in the [15.9 milestone](https://github.co
 ### F# OSS Build
 
 * Feature (#5027) - Set VisualFSharpFull as the default startup project, by [Robert Jeppesen](https://github.com/rojepp).
-    
+
 ## Visual Studio 15.8.5
 
 * Fix (#5504) - Internal MSBuild Error when building non-.NET SDK projects with MSBuild parallelism
@@ -244,7 +244,7 @@ Includes commits up to `dd8252eb8d20aaedf7b1c7576cd2a8a82d24f587`
 * Other new APIs
   * `Option.filter`, `Option.toObj`, `Option.ofObj`, `Option.toNullable`, `Option.ofNullable`
   * `String.filter`
-  * `Checked.int8`, `Checked.uint8` 
+  * `Checked.int8`, `Checked.uint8`
   * `Async.AwaitTask` (non-generic)
   * `WebClient.AsyncDownloadFile`, `WebClient.AsyncDownloadData`
   * `tryUnbox`, `isNull`
@@ -427,7 +427,7 @@ Includes commits up to `3385e58aabc91368c8e1f551650ba48705aaa285`
 * Bugfix: Errors when attempting to add reference to .NET core library
 * Bugfix: Crash in `FSComp.SR.RunStartupValidation()`
 
-[4.0.0]: http://fsharp.org
+[4.0.0]: https://fsharp.org
 [3.1.2]: http://blogs.msdn.com/b/fsharpteam/archive/2014/08/20/announcing-the-release-of-visual-f-tools-3-1-2.aspx
 [3.1.1]: http://blogs.msdn.com/b/fsharpteam/archive/2014/01/22/announcing-visual-f-3-1-1-and-support-for-desktop-express.aspx
 

--- a/src/buildtools/README-fslexyacc.md
+++ b/src/buildtools/README-fslexyacc.md
@@ -1,8 +1,8 @@
-# Notes on FsLex and FsYacc 
+# Notes on FsLex and FsYacc
 
 For better or worse the F# compiler contains three tokenizers (`*.fsl`) and three
 grammars (`*.fsy`) implemented using FsLex and FsYacc respectively, including the all-important F# grammar itself.
-The canonical home for FsLex and FsYacc is http://github.com/fsprojects/FsLexYacc.
+The canonical home for FsLex and FsYacc is https://github.com/fsprojects/FsLexYacc.
 FsLex and FsYacc are themselves built using earlier versions of FsLex and FsYacc.
 
 **If you would like to improve, modify, extend, test or document these

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         $CommonMetadataElements$
-        <iconUrl>http://fsharp.org/img/logo.png</iconUrl>
+        <iconUrl>https://fsharp.org/img/logo.png</iconUrl>
         <language>en-US</language>
         <dependencies>
             <group targetFramework=".NETStandard1.6">

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -16,11 +16,11 @@ open FSharp.Compiler.Range
 open FSharp.Compiler.Text
 
 /// <summary>Unused in this API</summary>
-type public UnresolvedReferencesSet 
+type public UnresolvedReferencesSet
 
 /// <summary>A set of information describing a project or script build configuration.</summary>
-type public FSharpProjectOptions = 
-    { 
+type public FSharpProjectOptions =
+    {
       // Note that this may not reduce to just the project directory, because there may be two projects in the same directory.
       ProjectFileName: string
 
@@ -38,7 +38,7 @@ type public FSharpProjectOptions =
       ReferencedProjects: (string * FSharpProjectOptions)[]
 
       /// When true, the typechecking environment is known a priori to be incomplete, for
-      /// example when a .fs file is opened outside of a project. In this case, the number of error 
+      /// example when a .fs file is opened outside of a project. In this case, the number of error
       /// messages reported is reduced.
       IsIncompleteTypeCheckEnvironment : bool
 
@@ -64,12 +64,12 @@ type public FSharpProjectOptions =
       /// if and only if the stamps are equal
       Stamp: int64 option
     }
-         
-[<Sealed; AutoSerializable(false)>]      
+
+[<Sealed; AutoSerializable(false)>]
 /// Used to parse and check F# source code.
 type public FSharpChecker =
     /// <summary>
-    /// Create an instance of an FSharpChecker.  
+    /// Create an instance of an FSharpChecker.
     /// </summary>
     ///
     /// <param name="projectCacheSize">The optional size of the project checking cache.</param>
@@ -131,8 +131,8 @@ type public FSharpChecker =
     /// the reconstructed types in the file.</para>
     ///
     /// <para>All files except the one being checked are read from the FileSystem API</para>
-    /// <para>Note: returns NoAntecedent if the background builder is not yet done preparing the type check context for the 
-    /// file (e.g. loading references and parsing/checking files in the project that this file depends upon). 
+    /// <para>Note: returns NoAntecedent if the background builder is not yet done preparing the type check context for the
+    /// file (e.g. loading references and parsing/checking files in the project that this file depends upon).
     /// In this case, the caller can either retry, or wait for FileTypeCheckStateIsDirty to be raised for this file.
     /// </para>
     /// </summary>
@@ -143,8 +143,8 @@ type public FSharpChecker =
     /// <param name="source">The full source for the file.</param>
     /// <param name="options">The options for the project or script.</param>
     /// <param name="textSnapshotInfo">
-    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
-    ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 
+    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if
+    ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
@@ -169,8 +169,8 @@ type public FSharpChecker =
     /// <param name="sourceText">The full source for the file.</param>
     /// <param name="options">The options for the project or script.</param>
     /// <param name="textSnapshotInfo">
-    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
-    ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 
+    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if
+    ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
@@ -178,7 +178,7 @@ type public FSharpChecker =
 
     /// <summary>
     /// <para>
-    ///   Parse and check a source code file, returning a handle to the results 
+    ///   Parse and check a source code file, returning a handle to the results
     /// </para>
     /// <para>
     ///    Note: all files except the one being checked are read from the FileSystem API
@@ -193,8 +193,8 @@ type public FSharpChecker =
     /// <param name="source">The full source for the file.</param>
     /// <param name="options">The options for the project or script.</param>
     /// <param name="textSnapshotInfo">
-    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
-    ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 
+    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if
+    ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
@@ -277,13 +277,13 @@ type public FSharpChecker =
     member GetBackgroundCheckResultsForFileInProject : filename : string * options : FSharpProjectOptions * ?userOpName: string -> Async<FSharpParseFileResults * FSharpCheckFileResults>
 
     /// <summary>
-    /// Compile using the given flags.  Source files names are resolved via the FileSystem API. 
-    /// The output file must be given by a -o flag. 
+    /// Compile using the given flags.  Source files names are resolved via the FileSystem API.
+    /// The output file must be given by a -o flag.
     /// The first argument is ignored and can just be "fsc.exe".
     /// </summary>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member Compile: argv:string[] * ?userOpName: string -> Async<FSharpErrorInfo [] * int>
-    
+
     /// <summary>
     /// TypeCheck and compile provided AST
     /// </summary>
@@ -291,15 +291,15 @@ type public FSharpChecker =
     member Compile: ast:ParsedInput list * assemblyName:string * outFile:string * dependencies:string list * ?pdbFile:string * ?executable:bool * ?noframework:bool * ?userOpName: string -> Async<FSharpErrorInfo [] * int>
 
     /// <summary>
-    /// Compiles to a dynamic assembly using the given flags.  
+    /// Compiles to a dynamic assembly using the given flags.
     ///
     /// The first argument is ignored and can just be "fsc.exe".
     ///
     /// Any source files names are resolved via the FileSystem API. An output file name must be given by a -o flag, but this will not
     /// be written - instead a dynamic assembly will be created and loaded.
     ///
-    /// If the 'execute' parameter is given the entry points for the code are executed and 
-    /// the given TextWriters are used for the stdout and stderr streams respectively. In this 
+    /// If the 'execute' parameter is given the entry points for the code are executed and
+    /// the given TextWriters are used for the stdout and stderr streams respectively. In this
     /// case, a global setting is modified during the execution.
     /// </summary>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
@@ -310,7 +310,7 @@ type public FSharpChecker =
     /// </summary>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member CompileToDynamicAssembly: ast:ParsedInput list * assemblyName:string * dependencies:string list * execute:(TextWriter * TextWriter) option * ?debug:bool * ?noframework:bool  * ?userOpName: string -> Async<FSharpErrorInfo [] * int * System.Reflection.Assembly option>
-       
+
     /// <summary>
     /// Try to get type check results for a file. This looks up the results of recent type checks of the
     /// same file, regardless of contents. The version tag specified in the original check of the file is returned.
@@ -324,25 +324,25 @@ type public FSharpChecker =
     member TryGetRecentCheckResultsForFile : filename: string * options:FSharpProjectOptions * ?sourceText: ISourceText * ?userOpName: string -> (FSharpParseFileResults * FSharpCheckFileResults * (*version*)int) option
 
     /// This function is called when the entire environment is known to have changed for reasons not encoded in the ProjectOptions of any project/compilation.
-    member InvalidateAll : unit -> unit    
-        
+    member InvalidateAll : unit -> unit
+
     /// This function is called when the configuration is known to have changed for reasons not encoded in the ProjectOptions.
     /// For example, dependent references may have been deleted or created.
     /// <param name="startBackgroundCompileIfAlreadySeen">Start a background compile of the project if a project with the same name has already been seen before.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member InvalidateConfiguration: options: FSharpProjectOptions * ?startBackgroundCompileIfAlreadySeen: bool * ?userOpName: string -> unit    
+    member InvalidateConfiguration: options: FSharpProjectOptions * ?startBackgroundCompileIfAlreadySeen: bool * ?userOpName: string -> unit
 
     /// Set the project to be checked in the background.  Overrides any previous call to <c>CheckProjectInBackground</c>
     member CheckProjectInBackground: options: FSharpProjectOptions  * ?userOpName: string -> unit
 
     /// Stop the background compile.
-    //[<Obsolete("Explicitly stopping background compilation is not recommended and the functionality to allow this may be rearchitected in future release.  If you use this functionality please add an issue on http://github.com/fsharp/FSharp.Compiler.Service describing how you use it and ignore this warning.")>]
+    //[<Obsolete("Explicitly stopping background compilation is not recommended and the functionality to allow this may be rearchitected in future release.  If you use this functionality please add an issue on https://github.com/fsharp/FSharp.Compiler.Service describing how you use it and ignore this warning.")>]
     member StopBackgroundCompile :  unit -> unit
 
     /// Block until the background compile finishes.
-    //[<Obsolete("Explicitly waiting for background compilation is not recommended and the functionality to allow this may be rearchitected in future release.  If you use this functionality please add an issue on http://github.com/fsharp/FSharp.Compiler.Service describing how you use it and ignore this warning.")>]
+    //[<Obsolete("Explicitly waiting for background compilation is not recommended and the functionality to allow this may be rearchitected in future release.  If you use this functionality please add an issue on https://github.com/fsharp/FSharp.Compiler.Service describing how you use it and ignore this warning.")>]
     member WaitForBackgroundCompile : unit -> unit
-   
+
     /// Report a statistic for testability
     static member GlobalForegroundParseCountStatistic : int
 
@@ -352,8 +352,8 @@ type public FSharpChecker =
     /// Flush all caches and garbage collect
     member ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients : unit -> unit
 
-    /// Current queue length of the service, for debug purposes. 
-    /// In addition, a single async operation or a step of a background build 
+    /// Current queue length of the service, for debug purposes.
+    /// In addition, a single async operation or a step of a background build
     /// may be in progress - such an operation is not counted in the queue length.
     member CurrentQueueLength : int
 
@@ -362,7 +362,7 @@ type public FSharpChecker =
     /// </summary>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member NotifyProjectCleaned: options: FSharpProjectOptions * ?userOpName: string -> Async<unit>
-    
+
     /// Notify the host that the logical type checking context for a file has now been updated internally
     /// and that the file has become eligible to be re-typechecked for errors.
     ///
@@ -378,29 +378,29 @@ type public FSharpChecker =
     ///
     /// The event will be raised on a background thread.
     member FileChecked : IEvent<string * obj option>
-    
+
     /// Raised after the maxMB memory threshold limit is reached
     member MaxMemoryReached : IEvent<unit>
 
     /// A maximum number of megabytes of allocated memory. If the figure reported by <c>System.GC.GetTotalMemory(false)</c> goes over this limit, the FSharpChecker object will attempt to free memory and reduce cache sizes to a minimum.</param>
     member MaxMemory : int with get, set
-    
-    /// Get or set a flag which controls if background work is started implicitly. 
+
+    /// Get or set a flag which controls if background work is started implicitly.
     ///
     /// If true, calls to CheckFileInProject implicitly start a background check of that project, replacing
-    /// any other background checks in progress. This is useful in IDE applications with spare CPU cycles as 
+    /// any other background checks in progress. This is useful in IDE applications with spare CPU cycles as
     /// it prepares the project analysis results for use.  The default is 'true'.
     member ImplicitlyStartBackgroundWork: bool with get, set
-    
+
     /// Get or set the pause time in milliseconds before background work is started.
     member PauseBeforeBackgroundWork: int with get, set
-    
+
     /// Notify the host that a project has been fully checked in the background (using file contents provided by the file system API)
     ///
     /// The event may be raised on a background thread.
     member ProjectChecked : IEvent<string * obj option>
 
-    // For internal use only 
+    // For internal use only
     member internal ReactorOps : IReactorOperations
 
     [<Obsolete("Please create an instance of FSharpChecker using FSharpChecker.Create")>]
@@ -420,8 +420,8 @@ type public CompilerEnvironment =
     /// The default location of FSharp.Core.dll and fsc.exe based on the version of fsc.exe that is running
     static member BinFolderOfDefaultFSharpCompiler : ?probePoint: string -> string option
 
-/// Information about the compilation environment 
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]   
+/// Information about the compilation environment
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module public CompilerEnvironment =
     /// These are the names of assemblies that should be referenced for .fs or .fsi files that
     /// are not associated with a project.
@@ -436,7 +436,7 @@ module public DebuggerEnvironment =
     /// Return the language ID, which is the expression evaluator id that the
     /// debugger will use.
     val GetLanguageID : unit -> Guid
-    
+
 
 /// A set of helpers related to naming of identifiers
 module public PrettyNaming =
@@ -448,10 +448,10 @@ module public PrettyNaming =
 
     val FormatAndOtherOverloadsString : int -> string
 
-    /// A utility to help determine if an identifier needs to be quoted 
+    /// A utility to help determine if an identifier needs to be quoted
     val QuoteIdentifierIfNeeded : string -> string
 
-    /// All the keywords in the F# language 
+    /// All the keywords in the F# language
     val KeywordNames : string list
 
 /// A set of helpers for dealing with F# files.

--- a/tests/projects/Sample_VS2013_FSharp_ConsoleApp_net40/Program.fs
+++ b/tests/projects/Sample_VS2013_FSharp_ConsoleApp_net40/Program.fs
@@ -1,7 +1,7 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net40/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net40/Program.fs
@@ -1,7 +1,7 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net45/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net45/Program.fs
@@ -1,7 +1,7 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net451/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net451/Program.fs
@@ -1,7 +1,7 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net452/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net452/Program.fs
@@ -1,7 +1,7 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net46/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net46/Program.fs
@@ -1,7 +1,7 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Library_net40/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net40/Script.fsx
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+﻿// Learn more about F# at https://fsharp.org. See the 'F# Tutorial' project
 // for more guidance on F# programming.
 
 #load "Library1.fs"

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45/Script.fsx
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+﻿// Learn more about F# at https://fsharp.org. See the 'F# Tutorial' project
 // for more guidance on F# programming.
 
 #load "Library1.fs"

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Script.fsx
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+﻿// Learn more about F# at https://fsharp.org. See the 'F# Tutorial' project
 // for more guidance on F# programming.
 
 #load "Library1.fs"

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Script.fsx
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+﻿// Learn more about F# at https://fsharp.org. See the 'F# Tutorial' project
 // for more guidance on F# programming.
 
 #load "Library1.fs"

--- a/tests/projects/Sample_VS2015_FSharp_Portable259_Library/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Portable259_Library/Script.fsx
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+﻿// Learn more about F# at https://fsharp.org. See the 'F# Tutorial' project
 // for more guidance on F# programming.
 
 #load "PortableLibrary1.fs"

--- a/tests/projects/Sample_VS2015_FSharp_Portable47_Library/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Portable47_Library/Script.fsx
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+﻿// Learn more about F# at https://fsharp.org. See the 'F# Tutorial' project
 // for more guidance on F# programming.
 
 #load "PortableLibrary1.fs"

--- a/tests/projects/Sample_VS2015_FSharp_Portable78_Library/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Portable78_Library/Script.fsx
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+﻿// Learn more about F# at https://fsharp.org. See the 'F# Tutorial' project
 // for more guidance on F# programming.
 
 #load "PortableLibrary1.fs"

--- a/tests/projects/Sample_VS2015_FSharp_Portable7_Library/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Portable7_Library/Script.fsx
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+﻿// Learn more about F# at https://fsharp.org. See the 'F# Tutorial' project
 // for more guidance on F# programming.
 
 #load "PortableLibrary1.fs"

--- a/tests/projects/misc/ProjectWithBuildErrors/ProjectWithBuildErrors/Program.fs
+++ b/tests/projects/misc/ProjectWithBuildErrors/ProjectWithBuildErrors/Program.fs
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 
@@ -6,16 +6,15 @@ let private x : int = failwith ""
 
 let inline f () = x
 
-let f1 argv =     
+let f1 argv =
     //let x = 1 + 1.0
     let y = argx // this gives a multi-line error message
     printfn "%A" argv
     0 // return an integer exit code
-    
+
 [<EntryPoint>]
-let main argv = 
-    //let x = 1 + 1.0 
-    //let y = argx // this gives 
+let main argv =
+    //let x = 1 + 1.0
+    //let y = argx // this gives
     printfn "%A" argv
     0 // return an integer exit code
-     

--- a/tests/projects/misc/SameFileBelongsToMultipleProjects/SameFileBelongsToMultipleProjects/Program.fs
+++ b/tests/projects/misc/SameFileBelongsToMultipleProjects/SameFileBelongsToMultipleProjects/Program.fs
@@ -1,8 +1,8 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     let c1 = Library1.Class.PropertyAlwaysAvailable
     let c1 = Library2.Class.PropertyAlwaysAvailable

--- a/tests/projects/misc/TestProjectChanges/TestProjectChanges/Program.fs
+++ b/tests/projects/misc/TestProjectChanges/TestProjectChanges/Program.fs
@@ -1,8 +1,8 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     let c1 = Library1AlwaysInMatchingConfiguration.Class.PropertyAlwaysAvailable
     let c1 = Library2AlwaysInDebugConfiguration.Class.PropertyAlwaysAvailable

--- a/tests/projects/vs2019slow/vs2019slow/Program.fs
+++ b/tests/projects/vs2019slow/vs2019slow/Program.fs
@@ -1,7 +1,7 @@
-﻿// Learn more about F# at http://fsharp.org
+﻿// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     0 // return an integer exit code

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/Program.fs
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/Program.fs
@@ -1,7 +1,7 @@
-﻿// @@@LearnMore|Learn more about F# at http://fsharp.org@@@
+﻿// @@@LearnMore|Learn more about F# at https://fsharp.org@@@
 // @@@SeeTutorial|See the 'F# Tutorial' project for more help.@@@
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "%A" argv
     0 // @@@Return|return an integer exit code@@@

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.cs.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Další informace o F# na http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Další informace o F# na https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.de.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Weitere Informationen zu F# unter "http://fsharp.org".</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Weitere Informationen zu F# unter "https://fsharp.org".</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.es.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Más información acerca de F# en http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Más información acerca de F# en https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.fr.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">En savoir plus sur F# sur le site http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">En savoir plus sur F# sur le site https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.it.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Altre informazioni su F# all'indirizzo http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Altre informazioni su F# all'indirizzo https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.ja.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">F# の詳細については、http://fsharp.org を参照してください</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">F# の詳細については、https://fsharp.org を参照してください</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.ko.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">hF#에 대해 http://fsharp.org에서 자세히 알아보기</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">hF#에 대해 https://fsharp.org에서 자세히 알아보기</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.pl.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Dowiedz się więcej na temat języka F# pod adresem http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Dowiedz się więcej na temat języka F# pod adresem https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.pt-BR.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Saiba mais sobre F# em http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Saiba mais sobre F# em https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.ru.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Дополнительные сведения о F# см. на http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Дополнительные сведения о F# см. на https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.tr.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">F# hakkında daha fazla bilgi için bkz. http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">F# hakkında daha fazla bilgi için bkz. https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.zh-Hans.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">在 http://fsharp.org 上了解有关 F# 的详细信息</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">在 https://fsharp.org 上了解有关 F# 的详细信息</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.zh-Hant.xlf
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/xlf/Program.fs.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Program.fs">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">請參閱 http://fsharp.org，進一步了解 F#</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">請參閱 https://fsharp.org，進一步了解 F#</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Script.fsx
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Script.fsx
@@ -1,4 +1,4 @@
-﻿// @@@LearnMore|Learn more about F# at http://fsharp.org@@@
+﻿// @@@LearnMore|Learn more about F# at https://fsharp.org@@@
 // @@@SeeTutorial|See the 'F# Tutorial' project for more help.@@@
 
 #load "Library1.fs"

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.cs.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Další informace o F# na http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Další informace o F# na https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.de.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Weitere Informationen zu F# unter "http://fsharp.org".</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Weitere Informationen zu F# unter "https://fsharp.org".</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.es.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Más información acerca de F# en http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Más información acerca de F# en https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.fr.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">En savoir plus sur F# sur le site http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">En savoir plus sur F# sur le site https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.it.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Altre informazioni su F# all'indirizzo http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Altre informazioni su F# all'indirizzo https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.ja.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">F# の詳細については、http://fsharp.org を参照してください</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">F# の詳細については、https://fsharp.org を参照してください</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.ko.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">hF#에 대해 http://fsharp.org에서 자세히 알아보기</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">hF#에 대해 https://fsharp.org에서 자세히 알아보기</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.pl.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Dowiedz się więcej na temat języka F# pod adresem http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Dowiedz się więcej na temat języka F# pod adresem https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.pt-BR.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Saiba mais sobre F# em http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Saiba mais sobre F# em https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.ru.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">Дополнительные сведения о F# см. на http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">Дополнительные сведения о F# см. на https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.tr.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">F# hakkında daha fazla bilgi için bkz. http://fsharp.org</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">F# hakkında daha fazla bilgi için bkz. https://fsharp.org</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.zh-Hans.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">在 http://fsharp.org 上了解有关 F# 的详细信息</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">在 https://fsharp.org 上了解有关 F# 的详细信息</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.zh-Hant.xlf
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/xlf/Script.fsx.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Script.fsx">
     <body>
       <trans-unit id="LearnMore">
-        <source>Learn more about F# at http://fsharp.org</source>
-        <target state="translated">請參閱 http://fsharp.org，進一步了解 F#</target>
+        <source>Learn more about F# at https://fsharp.org</source>
+        <target state="translated">請參閱 https://fsharp.org，進一步了解 F#</target>
         <note />
       </trans-unit>
       <trans-unit id="SeeTutorial">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsx
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsx
@@ -6,17 +6,17 @@
 // *******************************************************************************************************
 //
 // @@@MoreAbout|For more about F#, see:@@@
-//     http://fsharp.org
+//     https://fsharp.org
 //     https://docs.microsoft.com/en-us/dotnet/articles/fsharp/
 //
 // @@@SeeDocumentaton|To see this tutorial in documentation form, see:@@@
 //     https://docs.microsoft.com/en-us/dotnet/articles/fsharp/tour
 //
 // @@@LearnMoreAbout|To learn more about applied F# programming, use@@@
-//     http://fsharp.org/guides/enterprise/
-//     http://fsharp.org/guides/cloud/
-//     http://fsharp.org/guides/web/
-//     http://fsharp.org/guides/data-science/
+//     https://fsharp.org/guides/enterprise/
+//     https://fsharp.org/guides/cloud/
+//     https://fsharp.org/guides/web/
+//     https://fsharp.org/guides/data-science/
 //
 // @@@ToInstall-Line1|To install the Visual F# Power Tools, use@@@
 //     @@@ToInstall-Line2|'Tools' --> 'Extensions and Updates' --> `Online` and search@@@
@@ -46,7 +46,7 @@ open System
 /// @@@Module-Line2|Grouping code in modules helps keep related code together and helps avoid name conflicts in your program.@@@
 ///
 /// @@@Module-Line3|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/modules@@@
-module IntegersAndNumbers = 
+module IntegersAndNumbers =
 
     /// @@@SampleInt|This is a sample integer.@@@
     let sampleInteger = 176
@@ -102,7 +102,7 @@ module Immutability =
 /// @@@FunctionsModule-Line2|useful results.@@@
 ///
 /// @@@FunctionsModule-Line3|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/functions/@@@
-module BasicFunctions = 
+module BasicFunctions =
 
     /// @@@LetFunction-Line1|You use 'let' to define a function. This one accepts an integer argument and returns an integer.@@@
     /// @@@LetFunction-Line2|Parentheses are optional for function arguments, except for when you use an explicit type annotation.@@@
@@ -125,10 +125,10 @@ module BasicFunctions =
     /// @@@Conditionals-Line1|Conditionals use if/then/elid/elif/else.@@@
     ///
     /// @@@Conditionals-Line2|Note that F# uses whitespace indentation-aware syntax, similar to languages like Python.@@@
-    let sampleFunction3 x = 
-        if x < 100.0 then 
+    let sampleFunction3 x =
+        if x < 100.0 then
             2.0*x*x - x/5.0 + 3.0
-        else 
+        else
             2.0*x*x + x/5.0 - 37.0
 
     let result3 = sampleFunction3 (6.5 + 4.5)
@@ -159,7 +159,7 @@ module Booleans =
 /// @@@Strings-Line1|Strings are fundamental data types in F#.  Here are some examples of Strings and basic String manipulation.@@@
 ///
 /// @@@Strings-Line2|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/strings@@@
-module StringManipulation = 
+module StringManipulation =
 
     /// @@@StringQuotes|Strings use double quotes.@@@
     let string1 = "Hello"
@@ -173,7 +173,7 @@ module StringManipulation =
     let string4 = """The computer said "hello world" when I told it to!"""
 
     /// @@@StringConcatenation|String concatenation is normally done with the '+' operator.@@@
-    let helloWorld = string1 + " " + string2 
+    let helloWorld = string1 + " " + string2
 
     // @@@StringPrinting|This line uses '%s' to print a string value.  This is type-safe.@@@
     printfn "%s" helloWorld
@@ -205,7 +205,7 @@ module Tuples =
     let tuple2 = (1, "fred", 3.1415)
 
     printfn "tuple1: %A\ttuple2: %A" tuple1 tuple2
-    
+
     /// @@@TupleTypeAnnotation-Line1|A simple tuple of integers with a type annotation.@@@
     /// @@@TupleTypeAnnotation-Line2|Type annotations for tuples use the * symbol to separate elements@@@
     let tuple3: int * int = (5, 9)
@@ -249,20 +249,20 @@ module PipelinesAndComposition =
 
     /// @@@FilterWithoutPipes-Line1|Given a list of integers, it filters out the even numbers,@@@
     /// @@@FilterWithoutPipes-Line2|squares the resulting odds, and adds 1 to the squared odds.@@@
-    let squareOddValuesAndAddOne values = 
+    let squareOddValuesAndAddOne values =
         let odds = List.filter isOdd values
         let squares = List.map square odds
         let result = List.map addOne squares
         result
 
     printfn "processing %A through 'squareOddValuesAndAddOne' produces: %A" numbers (squareOddValuesAndAddOne numbers)
-    
+
     /// @@@FilterShorter-Line1|A shorter way to write 'squareOddValuesAndAddOne' is to nest each@@@
     /// @@@FilterShorter-Line2|sub-result into the function calls themselves.@@@
     ///
     /// @@@FilterShorter-Line3|This makes the function much shorter, but it's difficult to see the@@@
     /// @@@FilterShorter-Line4|order in which the data is processed.@@@
-    let squareOddValuesAndAddOneNested values = 
+    let squareOddValuesAndAddOneNested values =
         List.map addOne (List.map square (List.filter isOdd values))
 
     printfn "processing %A through 'squareOddValuesAndAddOneNested' produces: %A" numbers (squareOddValuesAndAddOneNested numbers)
@@ -331,13 +331,13 @@ module Lists =
     ]
 
     /// @@@NumberList2|This is a list of integers from 1 to 1000@@@
-    let numberList = [ 1 .. 1000 ]  
+    let numberList = [ 1 .. 1000 ]
 
     /// @@@ListComputation-Line1|Lists can also be generated by computations. This is a list containing@@@
     /// @@@ListComputation-Line2|all the days of the year.@@@
-    let daysList = 
+    let daysList =
         [ for month in 1 .. 12 do
-              for day in 1 .. System.DateTime.DaysInMonth(2017, month) do 
+              for day in 1 .. System.DateTime.DaysInMonth(2017, month) do
                   yield System.DateTime(2017, month, day) ]
 
     // @@@PrintList2|Print the first 5 elements of 'daysList' using 'List.take'.@@@
@@ -345,22 +345,22 @@ module Lists =
 
     /// @@@ListComputationConditional-Line1|Computations can include conditionals.  This is a list containing the tuples@@@
     /// @@@ListComputationConditional-Line2|which are the coordinates of the black squares on a chess board.@@@
-    let blackSquares = 
+    let blackSquares =
         [ for i in 0 .. 7 do
-              for j in 0 .. 7 do 
-                  if (i+j) % 2 = 1 then 
+              for j in 0 .. 7 do
+                  if (i+j) % 2 = 1 then
                       yield (i, j) ]
 
     /// @@@ListMap-Line1|Lists can be transformed using 'List.map' and other functional programming combinators.@@@
     /// @@@ListMap-Line2|This definition produces a new list by squaring the numbers in numberList, using the pipeline@@@
     /// @@@ListMap-Line3|operator to pass an argument to List.map.@@@
-    let squares = 
-        numberList 
-        |> List.map (fun x -> x*x) 
+    let squares =
+        numberList
+        |> List.map (fun x -> x*x)
 
     /// @@@ListFilter-Line1|There are many other list combinations. The following computes the sum of the squares of the@@@
     /// @@@ListFilter-Line2|numbers divisible by 3.@@@
-    let sumOfSquares = 
+    let sumOfSquares =
         numberList
         |> List.filter (fun x -> x % 3 = 0)
         |> List.sumBy (fun x -> x * x)
@@ -386,19 +386,19 @@ module Arrays =
     let array3 = [| 1 .. 1000 |]
 
     /// @@@ArrayComputationConstruction|This is an array containing only the words "hello" and "world".@@@
-    let array4 = 
+    let array4 =
         [| for word in array2 do
-               if word.Contains("l") then 
+               if word.Contains("l") then
                    yield word |]
 
     /// @@@ArrayInit|This is an array initialized by index and containing the even numbers from 0 to 2000.@@@
-    let evenNumbers = Array.init 1001 (fun n -> n * 2) 
+    let evenNumbers = Array.init 1001 (fun n -> n * 2)
 
     /// @@@ArraySlicing|Sub-arrays are extracted using slicing notation.@@@
     let evenNumbersSlice = evenNumbers.[0..500]
 
     /// @@@ArrayLooping|You can loop over arrays and lists using 'for' loops.@@@
-    for word in array4 do 
+    for word in array4 do
         printfn "word: %s" word
 
     // @@@ArrayAssignment-Line1|You can modify the contents of an an array element by using the left arrow assignment operator.@@@
@@ -408,7 +408,7 @@ module Arrays =
 
     /// @@@ArrayMap-Line1|You can transform arrays using 'Array.map' and other functional programming operations.@@@
     /// @@@ArrayMap-Line2|The following calculates the sum of the lengths of the words that start with 'h'.@@@
-    let sumOfLengthsOfWords = 
+    let sumOfLengthsOfWords =
         array2
         |> Array.filter (fun x -> x.StartsWith "h")
         |> Array.sumBy (fun x -> x.Length)
@@ -424,7 +424,7 @@ module Arrays =
 /// @@@Sequences-Line4|Sequence processing functions can be applied to Lists and Arrays as well.@@@
 ///
 /// @@@Sequences-Line5|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/sequences@@@
-module Sequences = 
+module Sequences =
 
     /// @@@EmptySequence|This is the empty sequence.@@@
     let seq1 = Seq.empty
@@ -436,13 +436,13 @@ module Sequences =
     let numbersSeq = seq { 1 .. 1000 }
 
     /// @@@SequenceComposition|This is a sequence producing the words "hello" and "world"@@@
-    let seq3 = 
+    let seq3 =
         seq { for word in seq2 do
-                  if word.Contains("l") then 
+                  if word.Contains("l") then
                       yield word }
 
     /// @@@SequenceInit|This sequence producing the even numbers up to 2000.@@@
-    let evenNumbers = Seq.init 1001 (fun n -> n * 2) 
+    let evenNumbers = Seq.init 1001 (fun n -> n * 2)
 
     let rnd = System.Random()
 
@@ -453,8 +453,8 @@ module Sequences =
               yield! randomWalk (x + rnd.NextDouble() - 0.5) }
 
     /// @@@Sequence100Elements|This example shows the first 100 elements of the random walk.@@@
-    let first100ValuesOfRandomWalk = 
-        randomWalk 5.0 
+    let first100ValuesOfRandomWalk =
+        randomWalk 5.0
         |> Seq.truncate 100
         |> Seq.toList
 
@@ -467,11 +467,11 @@ module Sequences =
 /// @@@RecursiveFunctions-Line3|Recursion is the preferred way to process sequences or collections in F#.@@@
 ///
 /// @@@RecursiveFunctions-Line4|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/functions/index#recursive-functions@@@
-module RecursiveFunctions = 
-              
+module RecursiveFunctions =
+
     /// @@@RecFunDef-Line1|This example shows a recursive function that computes the factorial of an@@@
     /// @@@RecRunDef-Line2|integer. It uses 'let rec' to define a recursive function.@@@
-    let rec factorial n = 
+    let rec factorial n =
         if n = 0 then 1 else n * factorial (n-1)
 
     printfn "Factorial of 6 is: %d" (factorial 6)
@@ -499,7 +499,7 @@ module RecursiveFunctions =
         match xs with
         | []    -> accumulator
         | y::ys -> sumListTailRecHelper (accumulator+y) ys
-    
+
     /// @@@RecSumListTailInvoke-Line1|This invokes the tail recursive helper function, providing '0' as a seed accumulator.@@@
     /// @@@RecSumListTailInvoke-Line2|An approach like this is common in F#.@@@
     let sumListTailRecursive xs = sumListTailRecHelper 0 xs
@@ -513,18 +513,18 @@ module RecursiveFunctions =
 /// @@@Records-Line2|They are immutable and have structural equality semantics.@@@
 ///
 /// @@@Records-Line3|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/records@@@
-module RecordTypes = 
+module RecordTypes =
 
     /// @@@RecordDefinition|This example shows how to define a new record type.@@@
-    type ContactCard = 
+    type ContactCard =
         { Name     : string
           Phone    : string
           Verified : bool }
-              
+
     /// @@@RecordInstantiation1|This example shows how to instantiate a record type.@@@
-    let contact1 = 
-        { Name = "Alf" 
-          Phone = "(206) 555-0157" 
+    let contact1 =
+        { Name = "Alf"
+          Phone = "(206) 555-0157"
           Verified = false }
 
     /// @@@RecordInstantiation2|You can also do this on the same line with ';' separators.@@@
@@ -535,14 +535,14 @@ module RecordTypes =
     /// @@@UpdateRecord-Line3|the 'Phone' and 'Verified' fields.@@@
     ///
     /// @@@UpdateRecord-Line4|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/copy-and-update-record-expressions@@@
-    let contact2 = 
-        { contact1 with 
+    let contact2 =
+        { contact1 with
             Phone = "(206) 555-0112"
             Verified = true }
 
     /// @@@ProcessRecord-Line1|This example shows how to write a function that processes a record value.@@@
     /// @@@ProcessRecord-Line2|It converts a 'ContactCard' object to a string.@@@
-    let showContactCard (c: ContactCard) = 
+    let showContactCard (c: ContactCard) =
         c.Name + " Phone: " + c.Phone + (if not c.Verified then " (unverified)" else "")
 
     printfn "Alf's Contact Card: %s" (showContactCard contact1)
@@ -558,12 +558,12 @@ module RecordTypes =
         member this.PrintedContactCard =
             this.Name + " Phone: " + this.Phone + (if not this.Verified then " (unverified)" else "") + this.Address
 
-    let contactAlternate = 
-        { Name = "Alf" 
-          Phone = "(206) 555-0157" 
-          Verified = false 
+    let contactAlternate =
+        { Name = "Alf"
+          Phone = "(206) 555-0157"
+          Verified = false
           Address = "111 Alf Street" }
-   
+
     // @@@RecordAccess|Members are accessed via the '.' operator on an instantiated type.@@@
     printfn "Alf's alternate contact card is %s" contactAlternate.PrintedContactCard
 
@@ -571,7 +571,7 @@ module RecordTypes =
     /// @@@RecordStruct-Line2|This is helpful in situations where the performance of structs outweighs@@@
     /// @@@RecordStruct-Line3|the flexibility of reference types.@@@
     [<Struct>]
-    type ContactCardStruct = 
+    type ContactCardStruct =
         { Name     : string
           Phone    : string
           Verified : bool }
@@ -581,17 +581,17 @@ module RecordTypes =
 /// @@@DiscriminatedUnions-Line2|Data stored in DUs can be one of several distinct values.@@@
 ///
 /// @@@DiscriminatedUnions-Line3|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/discriminated-unions@@@
-module DiscriminatedUnions = 
+module DiscriminatedUnions =
 
     /// @@@CardSuit|The following represents the suit of a playing card.@@@
-    type Suit = 
-        | Hearts 
-        | Clubs 
-        | Diamonds 
+    type Suit =
+        | Hearts
+        | Clubs
+        | Diamonds
         | Spades
 
     /// @@@CardRank|A Disciminated Union can also be used to represent the rank of a playing card.@@@
-    type Rank = 
+    type Rank =
         /// @@@CardRankValue|Represents the rank of cards 2 .. 10@@@
         | Value of int
         | Ace
@@ -600,34 +600,34 @@ module DiscriminatedUnions =
         | Jack
 
         /// @@@CardMember|Discriminated Unions can also implement object-oriented members.@@@
-        static member GetAllRanks() = 
+        static member GetAllRanks() =
             [ yield Ace
               for i in 2 .. 10 do yield Value i
               yield Jack
               yield Queen
               yield King ]
-                                   
+
     /// @@@CardType-Line1|This is a record type that combines a Suit and a Rank.@@@
     /// @@@CardType-Line2|It's common to use both Records and Disciminated Unions when representing data.@@@
     type Card = { Suit: Suit; Rank: Rank }
-              
+
     /// @@@ComputeFullDeck|This computes a list representing all the cards in the deck.@@@
-    let fullDeck = 
+    let fullDeck =
         [ for suit in [ Hearts; Diamonds; Clubs; Spades] do
-              for rank in Rank.GetAllRanks() do 
+              for rank in Rank.GetAllRanks() do
                   yield { Suit=suit; Rank=rank } ]
 
     /// @@@CardToString|This example converts a 'Card' object to a string.@@@
-    let showPlayingCard (c: Card) = 
-        let rankString = 
-            match c.Rank with 
+    let showPlayingCard (c: Card) =
+        let rankString =
+            match c.Rank with
             | Ace -> "Ace"
             | King -> "King"
             | Queen -> "Queen"
             | Jack -> "Jack"
             | Value n -> string n
-        let suitString = 
-            match c.Suit with 
+        let suitString =
+            match c.Suit with
             | Clubs -> "clubs"
             | Diamonds -> "diamonds"
             | Spades -> "spades"
@@ -635,8 +635,8 @@ module DiscriminatedUnions =
         rankString  + " of " + suitString
 
     /// @@@PrintAllCards|This example prints all the cards in a playing deck.@@@
-    let printAllCards() = 
-        for card in fullDeck do 
+    let printAllCards() =
+        for card in fullDeck do
             printfn "%s" (showPlayingCard card)
 
     // @@@SingleCaseDu-Line1|Single-case DUs are often used for domain modeling.  This can buy you extra type safety@@@
@@ -795,7 +795,7 @@ module PatternMatching =
 /// @@@Option-Line3|languages would use null references.@@@
 ///
 /// @@@Option-Line4|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/options@@@
-module OptionValues = 
+module OptionValues =
 
     /// @@@ZipCode|First, define a zipcode defined via Single-case Discriminated Union.@@@
     type ZipCode = ZipCode of string
@@ -813,8 +813,8 @@ module OptionValues =
     /// @@@CalcShippingZone-Line2|This uses combinators in the Option module to allow a functional pipeline for@@@
     /// @@@CalcShippingZone-Line3|transforming data with Optionals.@@@
     let CustomerShippingZone (calculator: ShippingCalculator, customer: Customer) =
-        customer.ZipCode 
-        |> Option.bind calculator.GetState 
+        customer.ZipCode
+        |> Option.bind calculator.GetState
         |> Option.map calculator.GetShippingZone
 
 
@@ -822,7 +822,7 @@ module OptionValues =
 /// @@@UnitsOfMeasure-Line2|You can then perform type-safe arithmetic on these values.@@@
 ///
 /// @@@UnitsOfMeasure-Line3|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/units-of-measure@@@
-module UnitsOfMeasure = 
+module UnitsOfMeasure =
 
     /// @@@CommonUnits|First, open a collection of common unit names@@@
     open Microsoft.FSharp.Data.UnitSystems.SI.UnitNames
@@ -852,7 +852,7 @@ module UnitsOfMeasure =
 /// @@@Classes-Line3|To learn more about Classes, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/classes@@@
 ///
 /// @@@Classes-Line4|To learn more about Members, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/members@@@
-module DefiningClasses = 
+module DefiningClasses =
 
     /// @@@Vector-Line1|A simple two-dimensional Vector class.@@@
     ///
@@ -874,7 +874,7 @@ module DefiningClasses =
 
         /// @@@MemberMethod|This member is a method.  The previous members were properties.@@@
         member this.Scale(k) = Vector2D(k * this.DX, k * this.DY)
-    
+
     /// @@@InstantiateClass|This is how you instantiate the Vector2D class.@@@
     let vector1 = Vector2D(3.0, 4.0)
 
@@ -888,15 +888,15 @@ module DefiningClasses =
 /// @@@GenericClasses-Line2|In the following, 'T is the type parameter for the class.@@@
 ///
 /// @@@GenericClasses-Line3|To learn more, see: https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/generics/@@@
-module DefiningGenericClasses = 
+module DefiningGenericClasses =
 
-    type StateTracker<'T>(initialElement: 'T) = 
+    type StateTracker<'T>(initialElement: 'T) =
 
         /// @@@InternalField|This internal field store the states in a list.@@@
         let mutable states = [ initialElement ]
 
         /// @@@AddElement|Add a new element to the list of states.@@@
-        member this.UpdateState newState = 
+        member this.UpdateState newState =
             states <- newState :: states  // @@@MutableAssignment|use the '<-' operator to mutate the value.@@@
 
         /// @@@History|Get the entire list of historical states.@@@
@@ -943,18 +943,18 @@ module ImplementingInterfaces =
 ///
 /// @@@Parallel-Line3|To learn more, see: https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/array.parallel-module-%5Bfsharp%5D@@@
 module ParallelArrayProgramming =
-              
+
     /// @@@InputArray|First, an array of inputs.@@@
     let oneBigArray = [| 0 .. 100000 |]
-    
+
     // @@@ExpensiveFunction|Next, define a functions that does some CPU intensive computation.@@@
-    let rec computeSomeFunction x = 
-        if x <= 2 then 1 
+    let rec computeSomeFunction x =
+        if x <= 2 then 1
         else computeSomeFunction (x - 1) + computeSomeFunction (x - 2)
-       
+
     // @@@ParallelMap|Next, do a parallel map over a large input array.@@@
-    let computeResults() = 
-        oneBigArray 
+    let computeResults() =
+        oneBigArray
         |> Array.Parallel.map (fun x -> computeSomeFunction (x % 20))
 
     // @@@PrintParallel|Next, print the results.@@@
@@ -968,7 +968,7 @@ module ParallelArrayProgramming =
 module Events =
 
     /// @@@SimpleEvent|First, create instance of Event object that consists of subscription point (event.Publish) and event trigger (event.Trigger).@@@
-    let simpleEvent = new Event<int>() 
+    let simpleEvent = new Event<int>()
 
     // @@@AddEventHandler1|Next, add handler to the event.@@@
     simpleEvent.Publish.Add(
@@ -990,7 +990,7 @@ module Events =
 
 
 #if COMPILED
-module BoilerPlateForForm = 
+module BoilerPlateForForm =
     [<System.STAThread>]
     do ()
     do System.Windows.Forms.Application.Run()

--- a/vsintegration/tests/UnitTests/IndentationServiceTests.fs
+++ b/vsintegration/tests/UnitTests/IndentationServiceTests.fs
@@ -19,7 +19,7 @@ open UnitTests.TestLib.LanguageService
 [<TestFixture>][<Category "Roslyn Services">]
 type IndentationServiceTests()  =
     let filePath = "C:\\test.fs"
-    let projectOptions: FSharpProjectOptions = { 
+    let projectOptions: FSharpProjectOptions = {
         ProjectFileName = "C:\\test.fsproj"
         ProjectId = None
         SourceFiles =  [| filePath |]
@@ -37,22 +37,22 @@ type IndentationServiceTests()  =
     let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
     let tabSize = 4
     let indentStyle = FormattingOptions.IndentStyle.Smart
-    
+
     let indentComment = System.Text.RegularExpressions.Regex(@"\$\s*Indent:\s*(\d+)\s*\$")
 
     let consoleProjectTemplate = "
-// Learn more about F# at http://fsharp.org
+// Learn more about F# at https://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn \"%A\" argv
     0 // return an integer exit code"
 
     let libraryProjectTemplate = "
 namespace ProjectNamespace
 
-type Class1() = 
+type Class1() =
     member this.X = \"F#\""
 
     let nestedTypesTemplate = "
@@ -67,12 +67,12 @@ let plus x y =
     x + y // $Indent: 4$
 
 let mutable x = 0
-x <-     
+x <-
     10 * 2 // $Indent: 4$
 
 match some 10 with
 | None -> 0
-| Some x -> 
+| Some x ->
     x + 1 // $Indent: 4$
 
 try
@@ -132,7 +132,7 @@ while true do
     // Even if the line before only had comment like this
 // The follwing line should inherit that indentation too $Indent: 4$
 "
-    
+
     let testCases = [|
         ( None,     0, consoleProjectTemplate )
         ( None,     1, consoleProjectTemplate )
@@ -143,14 +143,14 @@ while true do
         ( Some(4),  6, consoleProjectTemplate )
         ( Some(4),  7, consoleProjectTemplate )
         ( Some(4),  8, consoleProjectTemplate )
-        
+
         ( None,     0, libraryProjectTemplate )
         ( None,     1, libraryProjectTemplate )
         ( Some(0),  2, libraryProjectTemplate )
         ( Some(0),  3, libraryProjectTemplate )
         ( Some(4),  4, libraryProjectTemplate )
         ( Some(4),  5, libraryProjectTemplate )
-        
+
         ( None,     0, nestedTypesTemplate )
         ( None,     1, nestedTypesTemplate )
         ( Some(0),  2, nestedTypesTemplate )
@@ -171,8 +171,8 @@ while true do
             ( Some(expectedIndentation), lineNumber, autoIndentTemplate ))
 
     [<Test>]
-    member this.TestIndentation() = 
-        for (expectedIndentation, lineNumber, template) in testCases do 
+    member this.TestIndentation() =
+        for (expectedIndentation, lineNumber, template) in testCases do
             let sourceText = SourceText.From(template)
 
             let parsingOptions, _ = checker.GetParsingOptionsFromProjectOptions projectOptions
@@ -181,13 +181,13 @@ while true do
             | None -> Assert.IsTrue(actualIndentation.IsNone, "No indentation was expected at line {0}", lineNumber)
             | Some indentation -> Assert.AreEqual(expectedIndentation.Value, actualIndentation.Value, "Indentation on line {0} doesn't match", lineNumber)
 
-    [<Test>]    
-    member this.TestAutoIndentation() = 
-        for (expectedIndentation, lineNumber, template) in autoIndentTestCases do 
+    [<Test>]
+    member this.TestAutoIndentation() =
+        for (expectedIndentation, lineNumber, template) in autoIndentTestCases do
 
-          
+
             let sourceText = SourceText.From(template)
-        
+
             let parsingOptions, _ = checker.GetParsingOptionsFromProjectOptions projectOptions
             let actualIndentation = FSharpIndentationService.GetDesiredIndentation(documentId, sourceText, filePath, lineNumber, tabSize, indentStyle, Some (parsingOptions, projectOptions))
             match expectedIndentation with


### PR DESCRIPTION
Updated several links and changed a lot of `http://...` to `https://...`
Further some mdlint warnings in markdowns are fixed.

I tried to give commit Messages which express what they contain.

Remark: In [fcs\docsrc\content\index.md](fcs\docsrc\content\index.md) _Projects using the F# Compiler Services_ are some links which were not reachable, namely
- https://tpetricek.github.io/FSharp.Formatting/
- https://www.fcell.io/
- http://tsunami.io/