### PR TITLE
Ignore ionide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ tests/fsharpqa/testenv/bin/System.ValueTuple.dll
 msbuild.binlog
 /fcs/FSharp.Compiler.Service.netstandard/*.fs
 /fcs/FSharp.Compiler.Service.netstandard/*.fsi
+/.ionide/


### PR DESCRIPTION
I'm working with ionide on the compiler (hey @Krzysztof-Cieslak *wave*) and I think we should ignore its temp files.