### PR TITLE
Added -noVisualStudio flag for build.cmd.

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -52,6 +52,10 @@ After you build the first time you can open and use this solution:
 
 If you are just developing the core compiler and library then building ``FSharp.sln`` will be enough.
 
+If you do not have Visual Studio installed and want to simply build the compiler as a .NET Core application, use this:
+
+    Build.cmd -noVisualStudio
+
 ### Developing the F# Compiler (Linux/macOS)
 
 For Linux/Mac:

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -53,7 +53,7 @@ param (
     [switch]$testVs,
     [switch]$testAll,
     [string]$officialSkipTests = "false",
-    [switch]$compiler,
+    [switch]$noVisualStudio,
 
     [parameter(ValueFromRemainingArguments=$true)][string[]]$properties)
 
@@ -97,7 +97,7 @@ function Print-Usage() {
     Write-Host "  -procdump                 Monitor test runs with procdump"
     Write-Host "  -prepareMachine           Prepare machine for CI run, clean up processes after build"
     Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
-    Write-Host "  -compiler                 Only build fsc and fsi as .NET Core applications. No VS required. '-configuration', '-verbosity', '-norestore', '-rebuild' are supported."
+    Write-Host "  -noVisualStudio           Only build fsc and fsi as .NET Core applications. No Visual Studio required. '-configuration', '-verbosity', '-norestore', '-rebuild' are supported."
     Write-Host ""
     Write-Host "Command line arguments starting with '/p:' are passed through to MSBuild."
 }
@@ -147,13 +147,13 @@ function Process-Arguments() {
 }
 
 function Update-Arguments() {
-    if ($script:compiler) {
+    if ($script:noVisualStudio) {
         $script:bootstrapTfm = "netcoreapp2.1"
         $script:msbuildEngine = "dotnet"
     }
 
     if ($bootstrapTfm -eq "netcoreapp2.1") {
-        if (-Not (Test-Path "$ArtifactsDir\Bootstrap\netcoreapp2.1\fsc\fsc.exe")) {
+        if (-Not (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.runtimeconfig.json")) {
             $script:bootstrap = $True
         }
     } else {
@@ -240,7 +240,16 @@ function TestUsingNUnit([string] $testProject, [string] $targetFramework) {
     $projectName = [System.IO.Path]::GetFileNameWithoutExtension($testProject)
     $testLogPath = "$ArtifactsDir\TestResults\$configuration\${projectName}_$targetFramework.xml"
     $testBinLogPath = "$LogDir\${projectName}_$targetFramework.binlog"
-    $args = "test $testProject --no-restore --no-build -c $configuration -f $targetFramework -v n --test-adapter-path . --logger ""nunit;LogFilePath=$testLogPath"" /bl:$testBinLogPath"
+    $args = "test $testProject -c $configuration -f $targetFramework -v n --test-adapter-path . --logger ""nunit;LogFilePath=$testLogPath"" /bl:$testBinLogPath"
+
+    if (-not $noVisualStudio -or $norestore) {
+        $args += " --no-restore"
+    }
+
+    if (-not $noVisualStudio) {
+        $args += " --no-build"
+    }
+
     Exec-Console $dotnetExe $args
 }
 
@@ -250,15 +259,14 @@ function BuildCompiler() {
         $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
         $fscProject = "$RepoRoot\src\fsharp\fsc\fsc.fsproj"
         $fsiProject = "$RepoRoot\src\fsharp\fsi\fsi.fsproj"
-        $protoOutputPath = "$ArtifactsDir\Bootstrap\netcoreapp2.1"
         
         $argNoRestore = if ($norestore) { " --no-restore" } else { "" }
         $argNoIncremental = if ($rebuild) { " --no-incremental" } else { "" }
 
-        $args = "build $fscProject -c $configuration -v $verbosity -f netcoreapp2.1 /p:ProtoOutputPath=$protoOutputPath" + $argNoRestore + $argNoIncremental
+        $args = "build $fscProject -c $configuration -v $verbosity -f netcoreapp2.1" + $argNoRestore + $argNoIncremental
         Exec-Console $dotnetExe $args
 
-        $args = "build $fsiProject -c $configuration -v $verbosity -f netcoreapp2.1 /p:ProtoOutputPath=$protoOutputPath" + $argNoRestore + $argNoIncremental
+        $args = "build $fsiProject -c $configuration -v $verbosity -f netcoreapp2.1" + $argNoRestore + $argNoIncremental
         Exec-Console $dotnetExe $args
     }
 }
@@ -291,7 +299,7 @@ try {
     }
 
     if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish) {
-        if ($compiler) {
+        if ($noVisualStudio) {
             BuildCompiler
         } else {
             BuildSolution
@@ -305,7 +313,7 @@ try {
     $desktopTargetFramework = "net472"
     $coreclrTargetFramework = "netcoreapp2.1"
 
-    if ($testDesktop) {
+    if ($testDesktop -and -not $noVisualStudio) {
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.LanguageServer.UnitTests\FSharp.Compiler.LanguageServer.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Build.UnitTests\FSharp.Build.UnitTests.fsproj" -targetFramework $desktopTargetFramework
@@ -321,7 +329,7 @@ try {
         TestUsingNUnit -testProject "$RepoRoot\tests\fsharp\FSharpSuite.Tests.fsproj" -targetFramework $coreclrTargetFramework
     }
 
-    if ($testFSharpQA) {
+    if ($testFSharpQA -and -not $noVisualStudio) {
         Push-Location "$RepoRoot\tests\fsharpqa\source"
         $resultsRoot = "$ArtifactsDir\TestResults\$configuration"
         $resultsLog = "test-net40-fsharpqa-results.log"
@@ -340,21 +348,27 @@ try {
     }
 
     if ($testFSharpCore) {
-        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $desktopTargetFramework
+        if (-not $noVisualStudio) {
+            TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $desktopTargetFramework
+        }
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
     }
 
     if ($testCompiler) {
-        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $desktopTargetFramework
+        if (-not $noVisualStudio) {
+            TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $desktopTargetFramework
+        }
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
     }
 
     if ($testCambridge) {
-        TestUsingNUnit -testProject "$RepoRoot\tests\fsharp\FSharpSuite.Tests.fsproj" -targetFramework $desktopTargetFramework
+        if (-not $noVisualStudio) {
+            TestUsingNUnit -testProject "$RepoRoot\tests\fsharp\FSharpSuite.Tests.fsproj" -targetFramework $desktopTargetFramework
+        }
         TestUsingNUnit -testProject "$RepoRoot\tests\fsharp\FSharpSuite.Tests.fsproj" -targetFramework $coreclrTargetFramework
     }
 
-    if ($testVs) {
+    if ($testVs -and -not $noVisualStudio) {
         TestUsingNUnit -testProject "$RepoRoot\vsintegration\tests\GetTypesVS.UnitTests\GetTypesVS.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\vsintegration\tests\UnitTests\VisualFSharp.UnitTests.fsproj" -targetFramework $desktopTargetFramework
     }

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -157,7 +157,7 @@ function Update-Arguments() {
             $script:bootstrap = $True
         }
     } else {
-        if (-Not (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.exe")) {
+        if (-Not (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.exe") -or (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.runtimeconfig.json")) {
             $script:bootstrap = $True
         }
     }

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -178,7 +178,7 @@ function Get-PackageDir([string]$name, [string]$version = "") {
     return $p
 }
 
-function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]$logFileName = "", [switch]$parallel = $true, [switch]$summary = $true, [switch]$warnAsError = $true, [string]$configuration = $script:configuration, [string]$verbosity = $script:verbosity) {
+function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]$logFileName = "", [switch]$parallel = $true, [switch]$summary = $true, [switch]$warnAsError = $true, [string]$configuration = $script:configuration, [string]$verbosity = $script:verbosity, [string]$protoOutputPath = "") {
     # Because we override the C#/VB toolset to build against our LKG package, it is important
     # that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise,
     # we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
@@ -216,6 +216,10 @@ function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]
         $args += " /p:ContinuousIntegrationBuild=true"
     }
 
+    if (-not ($protoOutputPath -eq "")) {
+        $args += " /p:ProtoOutputPath=$protoOutputPath"
+    }
+
     $args += " $buildArgs"
     $args += " $projectFilePath"
     $args += " $properties"
@@ -230,7 +234,7 @@ function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]
 # Important to not set $script:bootstrapDir here yet as we're actually in the process of
 # building the bootstrap.
 function Make-BootstrapBuild() {
-    Write-Host "Building bootstrap compiler"
+    Write-Host "Building bootstrap '$bootstrapTfm' compiler"
 
     $dir = Join-Path $ArtifactsDir "Bootstrap"
     Remove-Item -re $dir -ErrorAction SilentlyContinue
@@ -241,9 +245,13 @@ function Make-BootstrapBuild() {
     Copy-Item "$ArtifactsDir\bin\fslex\$bootstrapConfiguration\netcoreapp2.1\publish" -Destination "$dir\fslex" -Force -Recurse
     Copy-Item "$ArtifactsDir\bin\fsyacc\$bootstrapConfiguration\netcoreapp2.1\publish" -Destination "$dir\fsyacc" -Force  -Recurse
 
+    if ($bootstrapTfm -eq "netcoreapp2.1") {
+        $dir = Join-Path $ArtifactsDir "Bootstrap\netcoreapp2.1"
+    }
+
     # prepare compiler
     $projectPath = "$RepoRoot\proto.proj"
-    Run-MSBuild $projectPath "/restore /t:Publish" -logFileName "Bootstrap" -configuration $bootstrapConfiguration
+    Run-MSBuild $projectPath "/restore /t:Publish /p:TargetFramework=$bootstrapTfm;ProtoTargetFramework=$bootstrapTfm" -logFileName "Bootstrap" -configuration $bootstrapConfiguration -protoOutputPath $dir
     Copy-Item "$ArtifactsDir\bin\fsc\$bootstrapConfiguration\$bootstrapTfm\publish" -Destination "$dir\fsc" -Force -Recurse
     Copy-Item "$ArtifactsDir\bin\fsi\$bootstrapConfiguration\$bootstrapTfm\publish" -Destination "$dir\fsi" -Force -Recurse
 

--- a/proto.proj
+++ b/proto.proj
@@ -6,9 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Projects Include="src\fsharp\FSharp.Build\FSharp.Build.fsproj" />
-    <Projects Include="src\fsharp\fsc\fsc.fsproj" />
-    <Projects Include="src\fsharp\fsi\fsi.fsproj" />
+    <Projects Include="src\fsharp\FSharp.Build\FSharp.Build.fsproj">
+      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
+    </Projects>
+    <Projects Include="src\fsharp\fsc\fsc.fsproj">
+      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
+    </Projects>
+    <Projects Include="src\fsharp\fsi\fsi.fsproj">
+      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
+    </Projects>
   </ItemGroup>
 
   <Target Name="Build">

--- a/proto.proj
+++ b/proto.proj
@@ -6,18 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Projects Include="src\fsharp\FSharp.Build\FSharp.Build.fsproj">
-      <AdditionalProperties Condition="'$(OS)' != 'Unix'">TargetFramework=net472</AdditionalProperties>
-      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
-    </Projects>
-    <Projects Include="src\fsharp\fsc\fsc.fsproj">
-      <AdditionalProperties Condition="'$(OS)' != 'Unix'">TargetFramework=net472</AdditionalProperties>
-      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
-    </Projects>
-    <Projects Include="src\fsharp\fsi\fsi.fsproj">
-      <AdditionalProperties Condition="'$(OS)' != 'Unix'">TargetFramework=net472</AdditionalProperties>
-      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
-    </Projects>
+    <Projects Include="src\fsharp\FSharp.Build\FSharp.Build.fsproj" />
+    <Projects Include="src\fsharp\fsc\fsc.fsproj" />
+    <Projects Include="src\fsharp\fsi\fsi.fsproj" />
   </ItemGroup>
 
   <Target Name="Build">

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -4,7 +4,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' != ''">$(ProtoTargetFramework)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.1</TargetFrameworks>
     <AssemblyName>FSharp.Build</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>

--- a/src/fsharp/fsc/fsc.fsproj
+++ b/src/fsharp/fsc/fsc.fsproj
@@ -4,7 +4,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' != ''">$(ProtoTargetFramework)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.1</TargetFrameworks>
     <TargetExt>.exe</TargetExt>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -4,7 +4,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' != ''">$(ProtoTargetFramework)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.1</TargetFrameworks>
     <TargetExt>.exe</TargetExt>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>


### PR DESCRIPTION
This adds a '-noVisualStudio' flag when using `build.cmd`. It will build fsc + fsi projects as netcoreapp2.1 and doesn't require visual studio to do it. You can also run tests in combination with this flag.