### PR TITLE
fix portable PDBs for anon records

### DIFF
--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -403,12 +403,17 @@ let generatePortablePdb (embedAllSource: bool) (embedSourceList: string list) (s
                         if i < 1 || offsetDelta > 0 then
                             builder.WriteCompressedInteger offsetDelta
 
-                                                                                                        // Hidden-sequence-point-record
-                            if startLine = 0xfeefee || endLine = 0xfeefee || (startColumn = 0 && endColumn = 0)
+                            // Check for hidden-sequence-point-record
+                            if startLine = 0xfeefee || 
+                               endLine = 0xfeefee || 
+                               (startColumn = 0 && endColumn = 0) || 
+                               ((endLine - startLine) = 0 && (endColumn - startColumn)  = 0)
                             then
+                                // Hidden-sequence-point-record
                                 builder.WriteCompressedInteger 0
                                 builder.WriteCompressedInteger 0
-                            else                                                                        // Non-hidden-sequence-point-record
+                            else
+                                // Non-hidden-sequence-point-record
                                 let deltaLines = endLine - startLine                                    // lines
                                 builder.WriteCompressedInteger deltaLines
 


### PR DESCRIPTION
This fixes #6512 

The [Portable PDB spec](https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#SequencePointsBlob) says that if the deltaLines and deltaColumns is zero then the sequence point is a hidden sequence point.  Without this invalid sequence point data is emitted and breakpoints get horked everywhere

This situation happens for the generated code for anonymous records

@KevinRansom Please check and add tests as you see fit?

My testing so far is only the simple scenario for #6512

