### PR TITLE
Allow to set PreferredUILang from tests

### DIFF
--- a/src/fsharp/service/Reactor.fs
+++ b/src/fsharp/service/Reactor.fs
@@ -35,7 +35,7 @@ type Reactor() =
 
     // We need to store the culture for the VS thread that is executing now, 
     // so that when the reactor picks up a thread from the threadpool we can set the culture
-    let culture = new CultureInfo(CultureInfo.CurrentUICulture.Name)
+    let mutable culture = CultureInfo(CultureInfo.CurrentUICulture.Name)
 
     let mutable bgOpCts = new CancellationTokenSource()
     /// Mailbox dispatch function.
@@ -134,6 +134,17 @@ type Reactor() =
                 with e -> 
                     Debug.Assert(false, String.Format("unexpected failure in reactor loop {0}, restarting", e))
         }
+
+    member __.SetPreferredUILang(preferredUiLang: string option) = 
+        match preferredUiLang with
+        | Some s -> 
+            culture <- CultureInfo s
+#if FX_RESHAPED_GLOBALIZATION
+            CultureInfo.CurrentUICulture <- culture
+#else
+            Thread.CurrentThread.CurrentUICulture <- culture
+#endif
+        | None -> ()
 
     // [Foreground Mailbox Accessors] -----------------------------------------------------------                
     member r.SetBackgroundOp(bgOpOpt) = 

--- a/src/fsharp/service/Reactor.fsi
+++ b/src/fsharp/service/Reactor.fsi
@@ -23,6 +23,9 @@ type internal IReactorOperations =
 [<Sealed>]
 type internal Reactor =
 
+    /// Allows to specify the language for error messages
+    member SetPreferredUILang : string option -> unit
+
     /// Set the background building function, which is called repeatedly
     /// until it returns 'false'.  If None then no background operation is used.
     member SetBackgroundOp : ( (* userOpName:*) string * (* opName: *) string * (* opArg: *) string *  (CompilationThreadToken -> CancellationToken -> bool)) option -> unit

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -518,6 +518,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                                          keepAssemblyContents,
                                          suggestNamesForErrors)
                                 let parsingOptions = FSharpParsingOptions.FromTcConfig(tcPrior.TcConfig, Array.ofList builder.SourceFiles, options.UseScriptResolutionRules)
+                                reactor.SetPreferredUILang tcPrior.TcConfig.preferredUiLang
                                 bc.RecordTypeCheckFileInProjectResults(fileName, options, parsingOptions, parseResults, fileVersion, tcPrior.TimeStamp, Some checkAnswer, sourceText.GetHashCode()) 
                                 return checkAnswer
                             finally
@@ -635,6 +636,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                     
                         // Do the parsing.
                         let parsingOptions = FSharpParsingOptions.FromTcConfig(builder.TcConfig, Array.ofList (builder.SourceFiles), options.UseScriptResolutionRules)
+                        reactor.SetPreferredUILang tcPrior.TcConfig.preferredUiLang
                         let parseErrors, parseTreeOpt, anyErrors = ParseAndCheckFile.parseFile (sourceText, filename, parsingOptions, userOpName, suggestNamesForErrors)
                         let parseResults = FSharpParseFileResults(parseErrors, parseTreeOpt, anyErrors, builder.AllDependenciesDeprecated)
                         let! checkResults = bc.CheckOneFileImpl(parseResults, sourceText, filename, options, textSnapshotInfo, fileVersion, builder, tcPrior, creationErrors, userOpName)

--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -25,7 +25,7 @@ module CompilerAssert =
             ProjectId = None
             SourceFiles = [|"test.fs"|]
 #if !NETCOREAPP
-            OtherOptions = [||]
+            OtherOptions = [|"--preferreduilang:en-US";|]
 #else
             OtherOptions = 
                 // Hack: Currently a hack to get the runtime assemblies for netcore in order to compile.
@@ -36,7 +36,7 @@ module CompilerAssert =
                     |> Seq.toArray
                     |> Array.filter (fun x -> x.ToLowerInvariant().Contains("system."))
                     |> Array.map (fun x -> sprintf "-r:%s" x)
-                Array.append [|"--targetprofile:netcore"; "--noframework"|] assemblies
+                Array.append [|"--preferreduilang:en-US"; "--targetprofile:netcore"; "--noframework"|] assemblies
 #endif
             ReferencedProjects = [||]
             IsIncompleteTypeCheckEnvironment = false


### PR DESCRIPTION
this fixes couple of red tests on my machine. those are failing since they are run with current ui culture ("de-DE" in my case), but the assertions are checking the en-US version.

Important for https://github.com/dotnet/fsharp/issues/7075