### PR TITLE
Disable flakey test - RaceBetweenCancellationAndError.Parallel

### DIFF
--- a/FSharpTests.Directory.Build.props
+++ b/FSharpTests.Directory.Build.props
@@ -16,6 +16,10 @@
     <DotnetFsiCompilerPath></DotnetFsiCompilerPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OS)' == 'Unix'">
+    <DefineConstants>($(DefineConstants);TESTING_ON_LINUX</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(FSharpTestCompilerVersion)' == 'coreclr'">
     <DisableAutoSetFscCompilerPath>true</DisableAutoSetFscCompilerPath>
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -168,8 +168,8 @@ type AsyncModule() =
 
     let dispose(d : #IDisposable) = d.Dispose()
 
-    let testErrorAndCancelRace computation = 
-        for _ in 1..20 do
+    let testErrorAndCancelRace testCaseName computation = 
+        for i in 1..20 do
             let cts = new System.Threading.CancellationTokenSource()
             use barrier = new System.Threading.ManualResetEvent(false)
             async { cts.Cancel() } 
@@ -180,7 +180,7 @@ type AsyncModule() =
 
             Async.StartWithContinuations(
                 computation,
-                (fun _ -> failwith "success not expected"),
+                (fun _ -> failwith (sprintf "Testcase: %s  --- success not expected iterations 1 .. 20 - failed on iteration %d" testCaseName i)),
                 (fun _ -> incr()),
                 (fun _ -> incr()),
                 cts.Token
@@ -427,12 +427,11 @@ type AsyncModule() =
     member this.``RaceBetweenCancellationAndError.AwaitWaitHandle``() = 
         let disposedEvent = new System.Threading.ManualResetEvent(false)
         dispose disposedEvent
-
-        testErrorAndCancelRace(Async.AwaitWaitHandle disposedEvent)
+        testErrorAndCancelRace "RaceBetweenCancellationAndError.AwaitWaitHandle" (Async.AwaitWaitHandle disposedEvent)
 
     [<Test>]
     member this.``RaceBetweenCancellationAndError.Sleep``() =
-        testErrorAndCancelRace (Async.Sleep (-5))
+        testErrorAndCancelRace "RaceBetweenCancellationAndError.Sleep" (Async.Sleep (-5))
 
 #if EXPENSIVE
 #if NET46
@@ -663,11 +662,14 @@ type AsyncModule() =
             Assert.AreEqual("maxDegreeOfParallelism", exc.ParamName)
             Assert.True(exc.Message.Contains("maxDegreeOfParallelism must be positive, was -1"))
 
+//  This has been failing very regularly on LINUX --- issue   :  https://github.com/dotnet/fsharp/issues/7112
+#if !TESTING_ON_LINUX
     [<Test>]
     member this.``RaceBetweenCancellationAndError.Parallel``() =
         [| for i in 1 .. 1000 -> async { return i } |]
         |> fun cs -> Async.Parallel(cs, 1)
-        |> testErrorAndCancelRace
+        |> testErrorAndCancelRace "RaceBetweenCancellationAndError.Parallel"
+#endif
 
     [<Test>]
     member this.``error on one workflow should cancel all others with maxDegreeOfParallelism``() =


### PR DESCRIPTION
This test has been flakey on the Linux ci leg for merges into fsharp47 and fsharp5 branches.  The test case doesn't exist in master.

It will need investigating and re-enabling:  Issue: https://github.com/dotnet/fsharp/issues/7112 is tracking that work.

The PR adds some additional diagnostics, in the failure case, and disables the test when built on Linux.

