### PR TITLE
Encore une fois

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -93,6 +93,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OS)' == 'Unix'">
+    <DefineConstants>$(DefineConstants);TESTING_ON_LINUX</DefineConstants>
+  </PropertyGroup>
+
   <!-- SDK targets override -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto' AND '$(DisableCompilerRedirection)'!='true' AND Exists('$(ProtoOutputPath)')">
     <FSharpTargetsPath>$(ProtoOutputPath)\fsc\Microsoft.FSharp.Targets</FSharpTargetsPath>

--- a/FSharpTests.Directory.Build.props
+++ b/FSharpTests.Directory.Build.props
@@ -16,10 +16,6 @@
     <DotnetFsiCompilerPath></DotnetFsiCompilerPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)' == 'Unix'">
-    <DefineConstants>($(DefineConstants);TESTING_ON_LINUX</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(FSharpTestCompilerVersion)' == 'coreclr'">
     <DisableAutoSetFscCompilerPath>true</DisableAutoSetFscCompilerPath>
 


### PR DESCRIPTION
The unit test projects don't build using "FSharpTests.Directory.Build.props"
So set the define in the FSharpBuild.Directory.Build.props"

