### PR TITLE
Only check distinct errors

### DIFF
--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -73,8 +73,12 @@ module CompilerAssert =
             | FSharpCheckFileAnswer.Aborted _ -> Assert.Fail("Type Checker Aborted")
             | FSharpCheckFileAnswer.Succeeded(typeCheckResults) ->
 
-            Assert.AreEqual(1, typeCheckResults.Errors.Length, sprintf "Expected one type check error: %A" typeCheckResults.Errors)
-            typeCheckResults.Errors
+            let errors = 
+                typeCheckResults.Errors
+                |> Array.distinctBy (fun e -> e.Severity, e.ErrorNumber, e.StartLineAlternate, e.StartColumn, e.EndLineAlternate, e.EndColumn, e.Message)
+
+            Assert.AreEqual(1, errors.Length, sprintf "Expected one type check error: %A" typeCheckResults.Errors)
+            errors
             |> Array.iter (fun info ->
                 Assert.AreEqual(FSharpErrorSeverity.Error, info.Severity)
                 Assert.AreEqual(expectedErrorNumber, info.ErrorNumber, "expectedErrorNumber")


### PR DESCRIPTION
this change is needed to make #7104 pass. 

I talked to @dsyme about this. While it is suboptimal to let the compiler emit the same error twice, we now believe this is not a big issue. I first believed it could be the source for a performance problem, but @dsyme had a plausible explanation. 

"When we have "F x y z" we kind of traverse twice, once to propagate known information from F (return type and arguments types, before processing the actual arguments) and once for each individual application/argument."

So basically we have the same type equation from both sides. In #7123 I disabled the error recovery for a test and we saw that only the first type equation was added and then the typechecker stopped. 


Edit …  Just have the quote, instead of the scrollable single line code block. **kcr**