### PR TITLE
Update the default version of System.ValueTuple to the latest one.

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -73,7 +73,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </ItemGroup>
 
   <PropertyGroup>
-    <DefaultValueTuplePackageVersion>4.4.0</DefaultValueTuplePackageVersion>
+    <DefaultValueTuplePackageVersion>4.5.0</DefaultValueTuplePackageVersion>
     <DefaultFSharpCorePackageVersion>{{FSharpCoreShippedPackageVersion}}</DefaultFSharpCorePackageVersion>
     <DefaultFSharpCorePreviewPackageVersion>{{FSharpCorePreviewPackageVersion}}</DefaultFSharpCorePreviewPackageVersion>
     <ValueTupleImplicitPackageVersion>$(DefaultValueTuplePackageVersion)</ValueTupleImplicitPackageVersion>


### PR DESCRIPTION
Version 4.5.0 was released a little more than a year ago and specifically targets .NET Framework 4.5.

I see no reason to keep using the old version.