### PR TITLE
Fix VS crash when inline IL is invalid

### DIFF
--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -1982,7 +1982,7 @@ let ParseAssemblyCodeInstructions s m =
     try FSharp.Compiler.AbstractIL.Internal.AsciiParser.ilInstrs
            FSharp.Compiler.AbstractIL.Internal.AsciiLexer.token
            (UnicodeLexing.StringAsLexbuf s)
-    with RecoverableParseError ->
+    with _ ->
       errorR(Error(FSComp.SR.astParseEmbeddedILError(), m)); [| |]
 #endif
 


### PR DESCRIPTION
Resolves this issue: https://github.com/dotnet/fsharp/issues/7164

Basically, if any kind of error happens when trying to parse inline IL, then recover so the normal F# parsing continues.

The reason why it takes down VS is because when a `failwith "parse error"` occurs on parsing a file, while it will catch it, it will re-raise the exception because we want to report it as a watson; which then nothing handles it and takes down VS. 