### PR TITLE
Enable 4.7 by default

### DIFF
--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -19,14 +19,16 @@ open System
 /// LanguageFeature enumeration
 [<RequireQualifiedAccess>]
 type LanguageFeature =
-    | LanguageVersion46 = 0
-    | LanguageVersion47 = 1
-    | SingleUnderscorePattern = 2
-    | WildCardInForLoop = 3
-    | RelaxWhitespace = 4
-    | NameOf = 5
-    | ImplicitYield = 6
-    | OpenStaticClasses = 7
+    | PreviewVersion = 0
+    | LanguageVersion46 = 1
+    | LanguageVersion47 = 2
+    | SingleUnderscorePattern = 3
+    | WildCardInForLoop = 4
+    | RelaxWhitespace = 5
+    | NameOf = 6
+    | ImplicitYield = 7
+    | OpenStaticClasses = 8
+
 
 /// LanguageVersion management
 type LanguageVersion (specifiedVersion) =
@@ -34,25 +36,25 @@ type LanguageVersion (specifiedVersion) =
     // When we increment language versions here preview is higher than current RTM version
     static let languageVersion46 = 4.6m
     static let languageVersion47 = 4.7m
-
-    static let previewVersion = languageVersion47       // Language version when preview specified
-    static let defaultVersion = languageVersion46       // Language version when default specified
+    static let previewVersion = 9999m                   // Language version when preview specified
+    static let defaultVersion = languageVersion47       // Language version when default specified
     static let latestVersion = defaultVersion           // Language version when latest specified
     static let latestMajorVersion = languageVersion46   // Language version when latestmajor specified
 
     static let validOptions = [| "preview"; "default"; "latest"; "latestmajor" |]
-    static let languageVersions = set [| latestVersion |]
+    static let languageVersions = set [| languageVersion46; languageVersion47 |]
 
     static let features = dict [|
         // Add new LanguageVersions here ...
-        LanguageFeature.LanguageVersion47, 4.7m
-        LanguageFeature.LanguageVersion46, 4.6m
-        LanguageFeature.SingleUnderscorePattern, previewVersion
-        LanguageFeature.WildCardInForLoop, previewVersion
-        LanguageFeature.RelaxWhitespace, previewVersion
-        LanguageFeature.NameOf, previewVersion
-        LanguageFeature.ImplicitYield, previewVersion
-        LanguageFeature.OpenStaticClasses, previewVersion
+        LanguageFeature.LanguageVersion46, languageVersion46
+        LanguageFeature.LanguageVersion47, languageVersion47
+        LanguageFeature.PreviewVersion, previewVersion
+        LanguageFeature.SingleUnderscorePattern, languageVersion47
+        LanguageFeature.WildCardInForLoop, languageVersion47
+        LanguageFeature.RelaxWhitespace, languageVersion47
+        LanguageFeature.NameOf, languageVersion47
+        LanguageFeature.ImplicitYield, languageVersion47
+        LanguageFeature.OpenStaticClasses, languageVersion47
         |]
 
     let specified =
@@ -91,4 +93,3 @@ type LanguageVersion (specifiedVersion) =
             let label = if v = defaultVersion || v = latestVersion then "(Default)" else ""
             yield sprintf "%M %s" v label
             |]
-

--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -90,6 +90,6 @@ type LanguageVersion (specifiedVersion) =
     /// Get a list of valid versions for help text
     member __.ValidVersions = [|
         for v in languageVersions |> Seq.sort do
-            let label = if v = defaultVersion || v = latestVersion then "(Default)" else ""
-            yield sprintf "%M %s" v label
+            let label = if v = defaultVersion then " (Default)" else ""
+            yield sprintf "%M%s" v label
             |]

--- a/src/fsharp/LanguageFeatures.fsi
+++ b/src/fsharp/LanguageFeatures.fsi
@@ -6,14 +6,16 @@ module internal FSharp.Compiler.Features
 /// LanguageFeature enumeration
 [<RequireQualifiedAccess>]
 type LanguageFeature =
-    | LanguageVersion46 = 0
-    | LanguageVersion47 = 1
-    | SingleUnderscorePattern = 2
-    | WildCardInForLoop = 3
-    | RelaxWhitespace = 4
-    | NameOf = 5
-    | ImplicitYield = 6
-    | OpenStaticClasses = 7
+    | PreviewVersion = 0
+    | LanguageVersion46 = 1
+    | LanguageVersion47 = 2
+    | SingleUnderscorePattern = 3
+    | WildCardInForLoop = 4
+    | RelaxWhitespace = 5
+    | NameOf = 6
+    | ImplicitYield = 7
+    | OpenStaticClasses = 8
+
 
 /// LanguageVersion management
 type LanguageVersion =

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1824,25 +1824,25 @@ module VersionTests =
     let ``member-selfidentifier-version4.6``() = singleTestBuildAndRunVersion "core/members/self-identifier/version46" FSC_BUILDONLY "4.6"
 
     [<Test>]
-    let ``member-selfidentifier-version4.7``() = singleTestBuildAndRunVersion "core/members/self-identifier/version47" FSC_BUILDONLY "preview"
+    let ``member-selfidentifier-version4.7``() = singleTestBuildAndRun "core/members/self-identifier/version47" FSC_BUILDONLY
 
     [<Test>]
     let ``indent-version4.6``() = singleTestBuildAndRunVersion "core/indent/version46" FSC_BUILDONLY "4.6"
 
     [<Test>]
-    let ``indent-version4.7``() = singleTestBuildAndRunVersion "core/indent/version47" FSC_BUILDONLY "preview"
+    let ``indent-version4.7``() = singleTestBuildAndRun "core/indent/version47" FSC_BUILDONLY
 
     [<Test>]
     let ``nameof-version4.6``() = singleTestBuildAndRunVersion "core/nameof/version46" FSC_BUILDONLY "4.6"
 
     [<Test>]
-    let ``nameof-version4.7``() = singleTestBuildAndRunVersion "core/nameof/version47" FSC_BUILDONLY "preview"
+    let ``nameof-version4.7``() = singleTestBuildAndRun "core/nameof/version47" FSC_BUILDONLY
 
     [<Test>]
-    let ``nameof-execute``() = singleTestBuildAndRunVersion "core/nameof/version47" FSC_BASIC "preview"
+    let ``nameof-execute``() = singleTestBuildAndRun "core/nameof/version47" FSC_BASIC
 
     [<Test>]
-    let ``nameof-fsi``() = singleTestBuildAndRunVersion "core/nameof/version47" FSI_BASIC "preview"
+    let ``nameof-fsi``() = singleTestBuildAndRun "core/nameof/version47" FSI_BASIC
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
 module ToolsTests = 

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/langversion/langversionhelp.437.1033.bsl
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/langversion/langversionhelp.437.1033.bsl
@@ -3,4 +3,5 @@ preview
 default
 latest
 latestmajor
-4.6 (Default)
+4.6
+4.7 (Default)

--- a/tests/fsharpqa/Source/CompilerOptions/fsi/langversion/langversionhelp.437.1033.bsl
+++ b/tests/fsharpqa/Source/CompilerOptions/fsi/langversion/langversionhelp.437.1033.bsl
@@ -3,4 +3,5 @@ preview
 default
 latest
 latestmajor
-4.6 (Default)
+4.6
+4.7 (Default)

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/NameOf/env.lst
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/NameOf/env.lst
@@ -1,11 +1,11 @@
-  SOURCE=E_NameOfIntConst.fs                    SCFLAGS="--langversion:preview"    # E_NameOfIntConst.fs
-  SOURCE=E_NameOfStringConst.fs                 SCFLAGS="--langversion:preview"    # E_NameOfStringConst.fs
-  SOURCE=E_NameOfAppliedFunction.fs             SCFLAGS="--langversion:preview"    # E_NameOfAppliedFunction.fs
-  SOURCE=E_NameOfIntegerAppliedFunction.fs      SCFLAGS="--langversion:preview"    # E_NameOfIntegerAppliedFunction.fs
-  SOURCE=E_NameOfPartiallyAppliedFunction.fs    SCFLAGS="--langversion:preview"    # E_NameOfPartiallyAppliedFunction.fs
-  SOURCE=E_NameOfDictLookup.fs                  SCFLAGS="--langversion:preview"    # E_NameOfDictLookup.fs
-  SOURCE=E_NameOfAdditionExpr.fs                SCFLAGS="--langversion:preview"    # E_NameOfAdditionExpr.fs
-  SOURCE=E_NameOfParameterAppliedFunction.fs    SCFLAGS="--langversion:preview"    # E_NameOfParameterAppliedFunction.fs
-  SOURCE=E_NameOfAsAFunction.fs                 SCFLAGS="--langversion:preview"    # E_NameOfAsAFunction.fs
-  SOURCE=E_NameOfWithPipe.fs                    SCFLAGS="--langversion:preview"    # E_NameOfWithPipe.fs
-  SOURCE=E_NameOfUnresolvableName.fs            SCFLAGS="--langversion:preview"    # E_NameOfUnresolvableName.fs
+  SOURCE=E_NameOfIntConst.fs                    # E_NameOfIntConst.fs
+  SOURCE=E_NameOfStringConst.fs                 # E_NameOfStringConst.fs
+  SOURCE=E_NameOfAppliedFunction.fs             # E_NameOfAppliedFunction.fs
+  SOURCE=E_NameOfIntegerAppliedFunction.fs      # E_NameOfIntegerAppliedFunction.fs
+  SOURCE=E_NameOfPartiallyAppliedFunction.fs    # E_NameOfPartiallyAppliedFunction.fs
+  SOURCE=E_NameOfDictLookup.fs                  # E_NameOfDictLookup.fs
+  SOURCE=E_NameOfAdditionExpr.fs                # E_NameOfAdditionExpr.fs
+  SOURCE=E_NameOfParameterAppliedFunction.fs    # E_NameOfParameterAppliedFunction.fs
+  SOURCE=E_NameOfAsAFunction.fs                 # E_NameOfAsAFunction.fs
+  SOURCE=E_NameOfWithPipe.fs                    # E_NameOfWithPipe.fs
+  SOURCE=E_NameOfUnresolvableName.fs            # E_NameOfUnresolvableName.fs

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/SequenceExpressions/env.lst
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/SequenceExpressions/env.lst
@@ -1,9 +1,9 @@
 	SOURCE=version46/W_IfThenElse01.fs   SCFLAGS="--langversion:4.6 --test:ErrorRanges"	    # version46 W_IfThenElse01.fs
 	SOURCE=version46/W_IfThenElse02.fs   SCFLAGS="--langversion:4.6 --test:ErrorRanges"	    # version46 W_IfThenElse02.fs
 	SOURCE=version46/W_IfThenElse03.fs   SCFLAGS="--langversion:4.6 --test:ErrorRanges"	    # version46 W_IfThenElse03.fs
-	SOURCE=version47/W_IfThenElse01.fs   SCFLAGS="--langversion:preview --test:ErrorRanges"	# version47 W_IfThenElse01.fs
-	SOURCE=version47/W_IfThenElse02.fs   SCFLAGS="--langversion:preview --test:ErrorRanges"	# version47 W_IfThenElse02.fs
-	SOURCE=version47/W_IfThenElse03.fs   SCFLAGS="--langversion:preview --test:ErrorRanges"	# version47 W_IfThenElse03.fs
+	SOURCE=version47/W_IfThenElse01.fs   SCFLAGS="--test:ErrorRanges"	# W_IfThenElse01.fs
+	SOURCE=version47/W_IfThenElse02.fs   SCFLAGS="--test:ErrorRanges"	# W_IfThenElse02.fs
+	SOURCE=version47/W_IfThenElse03.fs   SCFLAGS="--test:ErrorRanges"	# W_IfThenElse03.fs
 
 	SOURCE=IfThenElse04.fs               SCFLAGS="--test:ErrorRanges --warnaserror"	# IfThenElse04.fs
 	SOURCE=IfThenElse05.fs               SCFLAGS="--test:ErrorRanges --warnaserror"	# IfThenElse05.fs

--- a/tests/fsharpqa/Source/Warnings/env.lst
+++ b/tests/fsharpqa/Source/Warnings/env.lst
@@ -80,9 +80,9 @@
 	SOURCE=version46/WarnIfDiscardedInList.fs       SCFLAGS="--langversion:4.6"     #version46/WarnIfDiscardedInList
 	SOURCE=version46/WarnIfDiscardedInList2.fs      SCFLAGS="--langversion:4.6"     #version46/WarnIfDiscardedInList2
 	SOURCE=version46/WarnIfDiscardedInList3.fs      SCFLAGS="--langversion:4.6"     #version46/WarnIfDiscardedInList3
-	SOURCE=version47/WarnIfDiscardedInList.fs       SCFLAGS="--langversion:preview"     #version47/WarnIfDiscardedInList
-	SOURCE=version47/WarnIfDiscardedInList2.fs      SCFLAGS="--langversion:preview"     #version47/WarnIfDiscardedInList2
-	SOURCE=version47/WarnIfDiscardedInList3.fs      SCFLAGS="--langversion:preview"     #version47/WarnIfDiscardedInList3
+	SOURCE=version47/WarnIfDiscardedInList.fs                                       #version47/WarnIfDiscardedInList
+	SOURCE=version47/WarnIfDiscardedInList2.fs                                      #version47/WarnIfDiscardedInList2
+	SOURCE=version47/WarnIfDiscardedInList3.fs                                      #version47/WarnIfDiscardedInList3
 	SOURCE=WarnOnlyOnLastExpression.fs
 	SOURCE=WarnIfPossiblePropertySetter.fs
 	SOURCE=DoCannotHaveVisibilityDeclarations.fs


### PR DESCRIPTION
This enables FSharp4.7 language features by default in the compiler.  And updates the tests to no longer use:  "--langversion:preview"

Will need updating after:  https://github.com/dotnet/fsharp/pull/7195 is merged.