### PR TITLE
WIP: Cleanup amap TcGlobals

### DIFF
--- a/src/fsharp/AccessibilityLogic.fs
+++ b/src/fsharp/AccessibilityLogic.fs
@@ -183,7 +183,7 @@ let CheckTyconAccessible amap m ad tcref =
 let IsTyconReprAccessible amap m ad tcref =
     IsEntityAccessible amap m ad tcref &&
     IsAccessible ad tcref.TypeReprAccessibility
-            
+
 /// Check that a type definition and its representation contents are accessible
 let CheckTyconReprAccessible amap m ad tcref =
     CheckTyconAccessible amap m ad tcref &&
@@ -193,7 +193,7 @@ let CheckTyconReprAccessible amap m ad tcref =
      res)
             
 /// Indicates if a type is accessible (both definition and instantiation)
-let rec IsTypeAccessible (amap:Import.ImportMap) m ad ty = 
+let rec IsTypeAccessible (amap: Import.ImportMap) m ad ty = 
     match tryAppTy amap.g ty with
     | ValueNone -> true
     | ValueSome(tcref, tinst) ->

--- a/src/fsharp/AccessibilityLogic.fs
+++ b/src/fsharp/AccessibilityLogic.fs
@@ -63,7 +63,7 @@ let IsAccessible ad taccess =
         List.exists (canAccessFrom taccess) cpaths
 
 /// Indicates if an IL member is accessible (ignoring its enclosing type)
-let private IsILMemberAccessible (amap: Import.ImportMap) m (tcrefOfViewedItem: TyconRef) ad access =
+let private IsILMemberAccessible amap m (tcrefOfViewedItem: TyconRef) ad access =
     match ad with 
     | AccessibleFromEverywhere -> 
             access = ILMemberAccess.Public
@@ -81,7 +81,7 @@ let private IsILMemberAccessible (amap: Import.ImportMap) m (tcrefOfViewedItem: 
                 match tcrefViewedFromOption with 
                 | None -> false
                 | Some tcrefViewedFrom ->
-                    ExistsHeadTypeInEntireHierarchy amap.g amap m (generalizedTyconRef tcrefViewedFrom) tcrefOfViewedItem)     
+                    ExistsHeadTypeInEntireHierarchy amap m (generalizedTyconRef tcrefViewedFrom) tcrefOfViewedItem)     
 
             let accessibleByInternalsVisibleTo = 
                 (access = ILMemberAccess.Assembly || access = ILMemberAccess.FamilyOrAssembly) && 
@@ -93,7 +93,7 @@ let private IsILMemberAccessible (amap: Import.ImportMap) m (tcrefOfViewedItem: 
                 match tcrefViewedFromOption with 
                 | None -> false
                 | Some tcrefViewedFrom ->
-                    ExistsHeadTypeInEntireHierarchy amap.g amap m (generalizedTyconRef tcrefViewedFrom) tcrefOfViewedItem    
+                    ExistsHeadTypeInEntireHierarchy amap m (generalizedTyconRef tcrefViewedFrom) tcrefOfViewedItem    
 
             (access = ILMemberAccess.Public) || accessibleByFamily || accessibleByInternalsVisibleTo || accessibleByFamilyAndAssembly
 

--- a/src/fsharp/AccessibilityLogic.fs
+++ b/src/fsharp/AccessibilityLogic.fs
@@ -193,21 +193,21 @@ let CheckTyconReprAccessible amap m ad tcref =
      res)
             
 /// Indicates if a type is accessible (both definition and instantiation)
-let rec IsTypeAccessible g amap m ad ty = 
-    match tryAppTy g ty with
+let rec IsTypeAccessible (amap:Import.ImportMap) m ad ty = 
+    match tryAppTy amap.g ty with
     | ValueNone -> true
     | ValueSome(tcref, tinst) ->
-        IsEntityAccessible amap m ad tcref && IsTypeInstAccessible g amap m ad tinst
+        IsEntityAccessible amap m ad tcref && IsTypeInstAccessible amap m ad tinst
 
-and IsTypeInstAccessible g amap m ad tinst = 
+and IsTypeInstAccessible amap m ad tinst = 
     match tinst with 
     | [] -> true 
-    | _ -> List.forall (IsTypeAccessible g amap m ad) tinst
+    | _ -> List.forall (IsTypeAccessible amap m ad) tinst
 
 /// Indicate if a provided member is accessible
 let IsProvidedMemberAccessible (amap:Import.ImportMap) m ad ty access = 
     let g = amap.g
-    let isTyAccessible = IsTypeAccessible g amap m ad ty
+    let isTyAccessible = IsTypeAccessible amap m ad ty
     if not isTyAccessible then false
     else
         not (isAppTy g ty) ||
@@ -312,7 +312,7 @@ let CheckILFieldInfoAccessible amap m ad finfo =
 let IsTypeAndMethInfoAccessible amap m accessDomainTy ad = function
     | ILMeth (_, x, _) -> IsILMethInfoAccessible amap m accessDomainTy ad x 
     | FSMeth (_, _, vref, _) -> IsValAccessible ad vref
-    | DefaultStructCtor(g, ty) -> IsTypeAccessible g amap m ad ty
+    | DefaultStructCtor(_, ty) -> IsTypeAccessible amap m ad ty
 #if !NO_EXTENSIONTYPING
     | ProvidedMeth(amap, tpmb, _, m) as etmi -> 
         let access = tpmb.PUntaint((fun mi -> ComputeILAccess mi.IsPublic mi.IsFamily mi.IsFamilyOrAssembly mi.IsFamilyAndAssembly), m)        

--- a/src/fsharp/AttributeChecking.fs
+++ b/src/fsharp/AttributeChecking.fs
@@ -127,7 +127,8 @@ let AttribInfosOfIL amap scoref m (attribs: ILAttributes) =
 let AttribInfosOfFS g attribs = 
     attribs |> List.map (fun a -> FSAttribInfo (g, a))
 
-let GetAttribInfosOfEntity g amap m (tcref:TyconRef) = 
+let GetAttribInfosOfEntity (amap: Import.ImportMap) m (tcref:TyconRef) =
+    let g = amap.g
     match metadataOfTycon tcref.Deref with 
 #if !NO_EXTENSIONTYPING
     // TODO: provided attributes
@@ -507,7 +508,9 @@ let CheckRecdFieldInfoAttributes g (x:RecdFieldInfo) m =
 
     
 // Identify any security attributes
-let IsSecurityAttribute (g: TcGlobals) amap (casmap : Dictionary<Stamp, bool>) (Attrib(tcref, _, _, _, _, _, _)) m =
+let IsSecurityAttribute (amap: Import.ImportMap) (casmap : Dictionary<Stamp, bool>) (Attrib(tcref, _, _, _, _, _, _)) m =
+    let g = amap.g
+
     // There's no CAS on Silverlight, so we have to be careful here
     match g.attrib_SecurityAttribute with
     | None -> false

--- a/src/fsharp/AugmentWithHashCompare.fs
+++ b/src/fsharp/AugmentWithHashCompare.fs
@@ -704,7 +704,8 @@ let getAugmentationAttribs g (tycon: Tycon) =
     TryFindFSharpBoolAttribute g g.attrib_CustomComparisonAttribute tycon.Attribs, 
     TryFindFSharpBoolAttribute g g.attrib_StructuralComparisonAttribute tycon.Attribs 
 
-let CheckAugmentationAttribs isImplementation g amap (tycon: Tycon) = 
+let CheckAugmentationAttribs isImplementation (amap: Import.ImportMap) (tycon: Tycon) = 
+    let g = amap.g
     let m = tycon.Range
     let attribs = getAugmentationAttribs g tycon
     match attribs with 
@@ -784,7 +785,7 @@ let CheckAugmentationAttribs isImplementation g amap (tycon: Tycon) =
     
     let hasNominalInterface tcref =
         let ty = generalizedTyconRef (mkLocalTyconRef tycon)
-        ExistsHeadTypeInEntireHierarchy g amap tycon.Range ty tcref
+        ExistsHeadTypeInEntireHierarchy amap tycon.Range ty tcref
 
     let hasExplicitICompare = 
         hasNominalInterface g.tcref_System_IStructuralComparable || 

--- a/src/fsharp/AugmentWithHashCompare.fsi
+++ b/src/fsharp/AugmentWithHashCompare.fsi
@@ -7,7 +7,7 @@ open FSharp.Compiler
 open FSharp.Compiler.Tast
 open FSharp.Compiler.TcGlobals
 
-val CheckAugmentationAttribs : bool -> TcGlobals -> Import.ImportMap -> Tycon -> unit
+val CheckAugmentationAttribs : bool -> Import.ImportMap -> Tycon -> unit
 val TyconIsCandidateForAugmentationWithCompare  : TcGlobals -> Tycon -> bool
 val TyconIsCandidateForAugmentationWithEquals   : TcGlobals -> Tycon -> bool
 val TyconIsCandidateForAugmentationWithHash     : TcGlobals -> Tycon -> bool

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -122,7 +122,7 @@ let GetRangeOfDiagnostic(err: PhasedDiagnostic) =
       
       | TypeTestUnnecessary m
       | RuntimeCoercionSourceSealed(_, _, m)
-      | OverrideDoesntOverride(_, _, _, _, _, m)
+      | OverrideDoesntOverride(_, _, _, _, m)
       | UnionPatternsBindDifferentNames m 
       | UnionCaseWrongArguments (_, _, _, m) 
       | TypeIsImplicitlyAbstract m 
@@ -1239,7 +1239,8 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
       | QuotationTranslator.IgnoringPartOfQuotedTermWarning (msg, _) -> 
           Printf.bprintf os "%s" msg
 
-      | OverrideDoesntOverride(denv, impl, minfoVirtOpt, g, amap, m) ->
+      | OverrideDoesntOverride(denv, impl, minfoVirtOpt, amap, m) ->
+          let g = amap.g
           let sig1 = DispatchSlotChecking.FormatOverride denv impl
           match minfoVirtOpt with 
           | None -> 

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -1709,8 +1709,8 @@ let ApplyAllOptimizations (tcConfig:TcConfig, tcGlobals, tcVal, outfile, importM
                     optEnvFirstLoop, isIncrementalFragment,
                     tcConfig.emitTailcalls, hidden, implFile)
 
-            let implFile = AutoBox.TransformImplFile tcGlobals importMap implFile 
-                            
+            let implFile = AutoBox.TransformImplFile importMap implFile
+
             // Only do this on the first pass!
             let optSettings = { optSettings with abstractBigTargets = false; reportingPhase = false }
 #if DEBUG

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1658,7 +1658,7 @@ and AddConstraint (csenv: ConstraintSolverEnv) ndeep m2 trace tp newConstraint  
               // constraints are head-types and so any further inferences are equational. 
               let collect ty = 
                   let res = ref [] 
-                  IterateEntireHierarchyOfType (fun x -> res := x :: !res) g amap m AllowMultiIntfInstantiations.No ty
+                  IterateEntireHierarchyOfType (fun x -> res := x :: !res) amap m AllowMultiIntfInstantiations.No ty
                   List.rev !res
               let parents1 = collect ty1
               let parents2 = collect ty2

--- a/src/fsharp/FindUnsolved.fs
+++ b/src/fsharp/FindUnsolved.fs
@@ -147,7 +147,7 @@ and accLambdas cenv env topValInfo e ety =
     | Expr.TyChoose (_tps, e1, _m)  -> accLambdas cenv env topValInfo e1 ety      
     | Expr.Lambda _
     | Expr.TyLambda _ ->
-        let _tps, ctorThisValOpt, baseValOpt, vsl, body, bodyty = destTopLambda cenv.g cenv.amap topValInfo (e, ety) 
+        let _tps, ctorThisValOpt, baseValOpt, vsl, body, bodyty = destTopLambda cenv.amap topValInfo (e, ety) 
         accTy cenv env bodyty
         vsl |> List.iterSquared (accVal cenv env)
         baseValOpt |> Option.iter (accVal cenv env)

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -5243,13 +5243,13 @@ and GenBindingAfterSequencePoint cenv cgbuf eenv sp (TBind(vspec, rhsExpr, _)) s
 
     // The initialization code for static 'let' and 'do' bindings gets compiled into the initialization .cctor for the whole file
     | _ when vspec.IsClassConstructor && isNil vspec.TopValDeclaringEntity.TyparsNoRange ->
-        let tps, _, _, _, cctorBody, _ = IteratedAdjustArityOfLambda g cenv.amap vspec.ValReprInfo.Value rhsExpr
+        let tps, _, _, _, cctorBody, _ = IteratedAdjustArityOfLambda cenv.amap vspec.ValReprInfo.Value rhsExpr
         let eenv = EnvForTypars tps eenv
         CommitStartScope cgbuf startScopeMarkOpt
         GenExpr cenv cgbuf eenv SPSuppress cctorBody discard
     
     | Method (topValInfo, _, mspec, _, paramInfos, methodArgTys, retInfo) ->
-        let tps, ctorThisValOpt, baseValOpt, vsl, body', bodyty = IteratedAdjustArityOfLambda g cenv.amap topValInfo rhsExpr
+        let tps, ctorThisValOpt, baseValOpt, vsl, body', bodyty = IteratedAdjustArityOfLambda cenv.amap topValInfo rhsExpr
         let methodVars = List.concat vsl
         CommitStartScope cgbuf startScopeMarkOpt
 
@@ -5784,7 +5784,7 @@ and GenMethodForBinding cenv mgbuf eenv (v, mspec, access, paramInfos, retInfo, 
     // check if the hasPreserveSigNamedArg and hasSynchronizedImplFlag implementation flags have been specified
     let hasPreserveSigImplFlag, hasSynchronizedImplFlag, hasNoInliningFlag, hasAggressiveInliningImplFlag, attrs = ComputeMethodImplAttribs cenv v attrs
     
-    let securityAttributes, attrs = attrs |> List.partition (fun a -> IsSecurityAttribute g cenv.amap cenv.casApplied a m)
+    let securityAttributes, attrs = attrs |> List.partition (fun a -> IsSecurityAttribute cenv.amap cenv.casApplied a m)
 
     let permissionSets = CreatePermissionSets cenv eenv securityAttributes
 
@@ -6869,7 +6869,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
 
         // DebugDisplayAttribute gets copied to the subtypes generated as part of DU compilation
         let debugDisplayAttrs, normalAttrs = tycon.Attribs |> List.partition (IsMatchingFSharpAttribute g g.attrib_DebuggerDisplayAttribute)
-        let securityAttrs, normalAttrs = normalAttrs |> List.partition (fun a -> IsSecurityAttribute g cenv.amap cenv.casApplied a m)
+        let securityAttrs, normalAttrs = normalAttrs |> List.partition (fun a -> IsSecurityAttribute cenv.amap cenv.casApplied a m)
         let generateDebugDisplayAttribute = not g.compilingFslib && tycon.IsUnionTycon && isNil debugDisplayAttrs
         let generateDebugProxies = (not (tyconRefEq g tcref g.unit_tcr_canon) &&
                                     not (HasFSharpAttribute g g.attrib_DebuggerTypeProxyAttribute tycon.Attribs))
@@ -7579,7 +7579,7 @@ let GenerateCode (cenv, anonTypeTable, eenv, TypedAssemblyAfterOptimization file
     let ilNetModuleAttrs = GenAttrs cenv eenv moduleAttribs
 
     let casApplied = new Dictionary<Stamp, bool>()
-    let securityAttrs, topAssemblyAttrs = assemAttribs |> List.partition (fun a -> IsSecurityAttribute g cenv.amap casApplied a rangeStartup)
+    let securityAttrs, topAssemblyAttrs = assemAttribs |> List.partition (fun a -> IsSecurityAttribute cenv.amap casApplied a rangeStartup)
     // remove any security attributes from the top-level assembly attribute list
     let permissionSets = CreatePermissionSets cenv eenv securityAttrs
 

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2183,7 +2183,7 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv sp expr sequel =
   ProcessSequencePointForExpr cenv cgbuf sp expr
 
   // A sequence expression will always match Expr.App.
-  match (if compileSequenceExpressions then LowerCallsAndSeqs.LowerSeqExpr g cenv.amap expr else None) with
+  match (if compileSequenceExpressions then LowerCallsAndSeqs.LowerSeqExpr cenv.amap expr else None) with
   | Some info ->
       GenSequenceExpr cenv cgbuf eenv info sequel
   | None ->
@@ -5619,7 +5619,7 @@ and GenPropertyForMethodDef compileAsInstance tref mdef (v: Val) (memberInfo: Va
 /// Generate an ILEventDef for a [<CLIEvent>] member
 and GenEventForProperty cenv eenvForMeth (mspec: ILMethodSpec) (v: Val) ilAttrsThatGoOnPrimaryItem m returnTy =
     let evname = v.PropertyName
-    let delegateTy = Infos.FindDelegateTypeOfPropertyEvent cenv.g cenv.amap evname m returnTy
+    let delegateTy = Infos.FindDelegateTypeOfPropertyEvent cenv.amap evname m returnTy
     let ilDelegateTy = GenType cenv.amap m eenvForMeth.tyenv delegateTy
     let ilThisTy = mspec.DeclaringType
     let addMethRef = mkILMethRef (ilThisTy.TypeRef, mspec.CallingConv, "add_" + evname, 0, [ilDelegateTy], ILType.Void)

--- a/src/fsharp/LowerCallsAndSeqs.fs
+++ b/src/fsharp/LowerCallsAndSeqs.fs
@@ -117,7 +117,9 @@ let isVarFreeInExpr v e = Zset.contains v (freeInExpr CollectTyparsAndLocals e).
 /// The analysis is done in two phases. The first phase determines the state variables and state labels (as Abstract IL code labels).
 /// We then allocate an integer pc for each state label and proceed with the second phase, which builds two related state machine
 /// expressions: one for 'MoveNext' and one for 'Dispose'.
-let LowerSeqExpr g amap overallExpr =
+let LowerSeqExpr (amap:Import.ImportMap) overallExpr =
+    let g = amap.g
+
     /// Detect a 'yield x' within a 'seq { ... }'
     let (|SeqYield|_|) expr =
         match expr with
@@ -537,7 +539,7 @@ let LowerSeqExpr g amap overallExpr =
                 None
             else
                 let tyConfirmsToSeq g ty = isAppTy g ty && tyconRefEq g (tcrefOfAppTy g ty) g.tcref_System_Collections_Generic_IEnumerable
-                match SearchEntireHierarchyOfType (tyConfirmsToSeq g) g amap m (tyOfExpr g arbitrarySeqExpr) with
+                match SearchEntireHierarchyOfType (tyConfirmsToSeq g) amap m (tyOfExpr g arbitrarySeqExpr) with
                 | None ->
                     // printfn "FAILED - yield! did not yield a sequence! %s" (stringOfRange m)
                     None

--- a/src/fsharp/LowerCallsAndSeqs.fsi
+++ b/src/fsharp/LowerCallsAndSeqs.fsi
@@ -19,4 +19,4 @@ val LowerImplFile: g: TcGlobals -> assembly: TypedImplFile -> TypedImplFile
 /// a program counter (pc) that records the current state, and a current generated value (current).
 /// All these variables are then represented as fields in a hosting closure object along with any additional
 /// free variables of the sequence expression.
-val LowerSeqExpr: g: TcGlobals -> amap: ImportMap -> overallExpr: Expr -> (ValRef * ValRef * ValRef * ValRef list * Expr * Expr * Expr * TType * range) option
+val LowerSeqExpr: amap: ImportMap -> overallExpr: Expr -> (ValRef * ValRef * ValRef * ValRef list * Expr * Expr * Expr * TType * range) option

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -1286,7 +1286,7 @@ let RecdFieldInstanceChecks g amap ad m (rfinfo: RecdFieldInfo) =
 
 let ILFieldInstanceChecks  g amap ad m (finfo : ILFieldInfo) =
     if finfo.IsStatic then error (Error (FSComp.SR.tcStaticFieldUsedWhenInstanceFieldExpected(), m))
-    CheckILFieldInfoAccessible g amap m ad finfo
+    CheckILFieldInfoAccessible amap m ad finfo
     CheckILFieldAttributes g finfo m
 
 let MethInfoChecks g amap isInstance tyargsOpt objArgs ad m (minfo: MethInfo)  =

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -864,7 +864,7 @@ let BuildNewDelegateExpr (eventInfoOpt: EventInfo option, g, amap, delegateTy, i
             delArgVals, expr
             
         | Some _ -> 
-            let _, _, _, vsl, body, _ = IteratedAdjustArityOfLambda g amap topValInfo f
+            let _, _, _, vsl, body, _ = IteratedAdjustArityOfLambda amap topValInfo f
             List.concat vsl, body
             
     let meth = TObjExprMethod(slotsig, [], [], [delArgVals], expr, m)

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -48,7 +48,7 @@ type RequiredSlot = RequiredSlot of MethInfo * (* isOptional: *) bool
 type SlotImplSet = SlotImplSet of RequiredSlot list * NameMultiMap<RequiredSlot> * OverrideInfo list * PropInfo list
 
 exception TypeIsImplicitlyAbstract of range
-exception OverrideDoesntOverride of DisplayEnv * OverrideInfo * MethInfo option * TcGlobals * Import.ImportMap * range
+exception OverrideDoesntOverride of DisplayEnv * OverrideInfo * MethInfo option * Import.ImportMap * range
 
 module DispatchSlotChecking =
 
@@ -389,12 +389,12 @@ module DispatchSlotChecking =
                 // This is all error reporting
                 match relevantVirts |> List.filter (fun dispatchSlot -> IsPartialMatch g dispatchSlot (CompiledSigOfMeth g amap m dispatchSlot) overrideBy) with 
                 | [dispatchSlot] -> 
-                    errorR(OverrideDoesntOverride(denv, overrideBy, Some dispatchSlot, g, amap, m))
+                    errorR(OverrideDoesntOverride(denv, overrideBy, Some dispatchSlot, amap, m))
                 | _ -> 
                     match relevantVirts |> List.filter (fun dispatchSlot -> IsNameMatch dispatchSlot overrideBy) with 
-                    | [] -> errorR(OverrideDoesntOverride(denv, overrideBy, None, g, amap, m))
+                    | [] -> errorR(OverrideDoesntOverride(denv, overrideBy, None, amap, m))
                     | [dispatchSlot] -> 
-                        errorR(OverrideDoesntOverride(denv, overrideBy, Some dispatchSlot, g, amap, m))
+                        errorR(OverrideDoesntOverride(denv, overrideBy, Some dispatchSlot, amap, m))
                     | possibleDispatchSlots -> 
                        let details =
                             possibleDispatchSlots

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -440,14 +440,14 @@ module DispatchSlotChecking =
                     let baseTyOpt = if isObjExpr then Some reqdTy else GetSuperTypeOfType g amap m reqdTy 
                     match baseTyOpt with 
                     | None -> ()
-                    | Some baseTy -> yield! AllInterfacesOfType g amap m AllowMultiIntfInstantiations.Yes baseTy  ]
+                    | Some baseTy -> yield! AllInterfacesOfType amap m AllowMultiIntfInstantiations.Yes baseTy  ]
                     
         // For each implemented type, get a list containing the transitive closure of
         // interface types implied by the type. This includes the implemented type itself if the implemented type
         // is an interface type.
         let intfSets = 
             allReqdTys |> List.mapi (fun i (reqdTy, m) -> 
-                let interfaces = AllInterfacesOfType g amap m AllowMultiIntfInstantiations.Yes reqdTy 
+                let interfaces = AllInterfacesOfType amap m AllowMultiIntfInstantiations.Yes reqdTy 
                 let impliedTys = (if isInterfaceTy g reqdTy then interfaces else reqdTy :: interfaces)
                 (i, reqdTy, impliedTys, m))
 

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -235,7 +235,7 @@ module DispatchSlotChecking =
     let OverrideImplementsDispatchSlot g amap m dispatchSlot availPriorOverride =
         IsExactMatch g amap m dispatchSlot availPriorOverride &&
         // The override has to actually be in some subtype of the dispatch slot
-        ExistsHeadTypeInEntireHierarchy g amap m (generalizedTyconRef availPriorOverride.BoundingTyconRef) dispatchSlot.DeclaringTyconRef
+        ExistsHeadTypeInEntireHierarchy amap m (generalizedTyconRef availPriorOverride.BoundingTyconRef) dispatchSlot.DeclaringTyconRef
 
     /// Check if a dispatch slot is already implemented
     let DispatchSlotIsAlreadyImplemented g amap m availPriorOverridesKeyed (dispatchSlot: MethInfo) =
@@ -706,7 +706,7 @@ let FinalTypeDefinitionChecksAtEndOfInferenceScope (infoReader: InfoReader, nenv
         else
             warning(Error(FSComp.SR.typrelTypeImplementsIComparableDefaultObjectEqualsProvided(tycon.DisplayName), tycon.Range))
 
-    AugmentWithHashCompare.CheckAugmentationAttribs isImplementation g amap tycon
+    AugmentWithHashCompare.CheckAugmentationAttribs isImplementation amap tycon
     // Check some conditions about generic comparison and hashing. We can only check this condition after we've done the augmentation 
     if isImplementation 
 #if !NO_EXTENSIONTYPING

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -124,12 +124,13 @@ module DispatchSlotChecking =
         Override(implKind, overrideBy.MemberApparentEntity, mkSynId overrideBy.Range nm, (memberMethodTypars, memberToParentInst), argTys, retTy, isFakeEventProperty, overrideBy.IsCompilerGenerated)
 
     /// Get the override information for an object expression method being used to implement dispatch slots
-    let GetObjectExprOverrideInfo g amap (implty, id: Ident, memberFlags, ty, arityInfo, bindingAttribs, rhsExpr) = 
+    let GetObjectExprOverrideInfo (amap: Import.ImportMap) (implty, id: Ident, memberFlags, ty, arityInfo, bindingAttribs, rhsExpr) =
+        let g = amap.g
         // Dissect the type
         let tps, argInfos, retTy, _ = GetMemberTypeInMemberForm g memberFlags arityInfo ty id.idRange
         let argTys = argInfos |> List.mapSquared fst
         // Dissect the implementation
-        let _, ctorThisValOpt, baseValOpt, vsl, rhsExpr, _ = destTopLambda g amap arityInfo (rhsExpr, ty)
+        let _, ctorThisValOpt, baseValOpt, vsl, rhsExpr, _ = destTopLambda amap arityInfo (rhsExpr, ty)
         assert ctorThisValOpt.IsNone
 
         // Drop 'this'

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1202,7 +1202,7 @@ let GetNestedTypesOfType (ad, ncenv: NameResolver, optFilter, staticResInfo, che
                     mty.TypesByAccessNames.Values
                     |> List.choose (fun entity ->
                         let ty = tcref.NestedTyconRef entity |> MakeNestedType ncenv tinst m
-                        if IsTypeAccessible g ncenv.amap m ad ty then Some ty else None)
+                        if IsTypeAccessible ncenv.amap m ad ty then Some ty else None)
         | _ -> [])
 
 //-------------------------------------------------------------------------

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3480,13 +3480,13 @@ let ResolveCompletionsInType (ncenv: NameResolver) nenv (completionTargets: Reso
         |> List.filter (fun x ->
             not x.IsSpecialName &&
             x.IsStatic = statics &&
-            IsILFieldInfoAccessible g amap m ad x)
+            IsILFieldInfoAccessible amap m ad x)
 
     let pinfosIncludingUnseen =
         AllPropInfosOfTypeInScope ResultCollectionSettings.AllResults ncenv.InfoReader nenv None ad PreferOverrides m ty
         |> List.filter (fun x ->
             x.IsStatic = statics &&
-            IsPropInfoAccessible g amap m ad x)
+            IsPropInfoAccessible amap m ad x)
 
     // Exclude get_ and set_ methods accessed by properties
     let pinfoMethNames =
@@ -3677,7 +3677,7 @@ let rec ResolvePartialLongIdentInType (ncenv: NameResolver) nenv isApplicableMet
 
       (ty
          |> AllPropInfosOfTypeInScope ResultCollectionSettings.AllResults ncenv.InfoReader nenv (Some id) ad IgnoreOverrides m
-         |> List.filter (fun pinfo -> pinfo.IsStatic = statics && IsPropInfoAccessible g amap m ad pinfo)
+         |> List.filter (fun pinfo -> pinfo.IsStatic = statics && IsPropInfoAccessible amap m ad pinfo)
          |> List.collect (fun pinfo -> (FullTypeOfPinfo pinfo) |> ResolvePartialLongIdentInType ncenv nenv isApplicableMeth m ad false rest)) @
 
       (if statics then []
@@ -3699,7 +3699,7 @@ let rec ResolvePartialLongIdentInType (ncenv: NameResolver) nenv isApplicableMet
          |> List.filter (fun x ->
              not x.IsSpecialName &&
              x.IsStatic = statics &&
-             IsILFieldInfoAccessible g amap m ad x)
+             IsILFieldInfoAccessible amap m ad x)
          |> List.collect (fun x -> x.FieldType(amap, m) |> ResolvePartialLongIdentInType ncenv nenv isApplicableMeth m ad false rest))
 
 let InfosForTyconConstructors (ncenv: NameResolver) m ad (tcref: TyconRef) =
@@ -4176,7 +4176,7 @@ let ResolveCompletionsInTypeForItem (ncenv: NameResolver) nenv m ad statics ty (
                 |> List.filter (fun x ->
                     not x.IsSpecialName &&
                     x.IsStatic = statics &&
-                    IsILFieldInfoAccessible g amap m ad x)
+                    IsILFieldInfoAccessible amap m ad x)
                 |> List.map Item.ILField
         | Item.Types _ ->
             if statics then
@@ -4193,7 +4193,7 @@ let ResolveCompletionsInTypeForItem (ncenv: NameResolver) nenv m ad statics ty (
                 AllPropInfosOfTypeInScope ResultCollectionSettings.AllResults ncenv.InfoReader nenv None ad PreferOverrides m ty
                 |> List.filter (fun x ->
                     x.IsStatic = statics &&
-                    IsPropInfoAccessible g amap m ad x)
+                    IsPropInfoAccessible amap m ad x)
 
             // Exclude get_ and set_ methods accessed by properties
             let pinfoMethNames =
@@ -4360,7 +4360,7 @@ let rec ResolvePartialLongIdentInTypeForItem (ncenv: NameResolver) nenv m ad sta
           let pinfos =
               ty
               |> AllPropInfosOfTypeInScope ResultCollectionSettings.AllResults ncenv.InfoReader nenv (Some id) ad IgnoreOverrides m
-              |> List.filter (fun pinfo -> pinfo.IsStatic = statics && IsPropInfoAccessible g amap m ad pinfo)
+              |> List.filter (fun pinfo -> pinfo.IsStatic = statics && IsPropInfoAccessible amap m ad pinfo)
 
           for pinfo in pinfos do
               yield! (fullTypeOfPinfo pinfo) |> ResolvePartialLongIdentInTypeForItem ncenv nenv m ad false rest item
@@ -4382,7 +4382,7 @@ let rec ResolvePartialLongIdentInTypeForItem (ncenv: NameResolver) nenv m ad sta
 
           // e.g. <val-id>.<il-field-id>.<more>
           for finfo in ncenv.InfoReader.GetILFieldInfosOfType(Some id, ad, m, ty) do
-              if not finfo.IsSpecialName && finfo.IsStatic = statics && IsILFieldInfoAccessible g amap m ad finfo then
+              if not finfo.IsSpecialName && finfo.IsStatic = statics && IsILFieldInfoAccessible amap m ad finfo then
                   yield! finfo.FieldType(amap, m) |> ResolvePartialLongIdentInTypeForItem ncenv nenv m ad false rest item
     }
 

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -43,9 +43,9 @@ module internal PrintUtilities =
         | [x] -> x
         | x :: xs -> List.fold (^^) x xs 
 
-    let suppressInheritanceAndInterfacesForTyInSimplifiedDisplays g amap m ty = 
-        isEnumTy g ty || isDelegateTy g ty || ExistsHeadTypeInEntireHierarchy g amap m ty g.exn_tcr || ExistsHeadTypeInEntireHierarchy g amap m ty g.tcref_System_Attribute 
-
+    let suppressInheritanceAndInterfacesForTyInSimplifiedDisplays (amap: Import.ImportMap) m ty =
+        let g = amap.g
+        isEnumTy g ty || isDelegateTy g ty || ExistsHeadTypeInEntireHierarchy amap m ty g.exn_tcr || ExistsHeadTypeInEntireHierarchy amap m ty g.tcref_System_Attribute 
 
     let applyMaxMembers maxMembers (alldecls: _ list) = 
         match maxMembers with 
@@ -1574,7 +1574,7 @@ module private TastDefinitionPrinting =
             |> List.filter (fun v -> shouldShow v.ArbitraryValRef)
 
         let iimplsLs = 
-            if suppressInheritanceAndInterfacesForTyInSimplifiedDisplays g amap m ty then 
+            if suppressInheritanceAndInterfacesForTyInSimplifiedDisplays amap m ty then 
                 []
             else 
                 GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes g amap m ty |> List.map (fun ity -> wordL (tagKeyword (if isInterfaceTy g ty then "inherit" else "interface")) --- layoutType denv ity)
@@ -1635,7 +1635,7 @@ module private TastDefinitionPrinting =
               []
 
         let inherits = 
-            if suppressInheritanceAndInterfacesForTyInSimplifiedDisplays g amap m ty then 
+            if suppressInheritanceAndInterfacesForTyInSimplifiedDisplays amap m ty then 
                 []
             else
                 match GetSuperTypeOfType g amap m ty with 

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1396,7 +1396,8 @@ module InfoMemberPrinting =
             prettyTyparInst, layoutMethInfoCSharpStyle amap m denv methInfo methInfo.FormalMethodInst
     #endif
 
-    let prettyLayoutOfPropInfoFreeStyle g amap m denv (pinfo: PropInfo) =
+    let prettyLayoutOfPropInfoFreeStyle (amap:Import.ImportMap) m denv (pinfo: PropInfo) =
+        let g = amap.g
         let rty = pinfo.GetPropertyType(amap, m) 
         let rty = if pinfo.IsIndexer then mkRefTupledTy g (pinfo.GetParamTypes(amap, m)) --> rty else rty 
         let rty, _ = PrettyTypes.PrettifyType g rty
@@ -2021,7 +2022,7 @@ let formatMethInfoToBufferFreeStyle amap m denv buf d = InfoMemberPrinting.forma
 let prettyLayoutOfMethInfoFreeStyle amap m denv typarInst minfo = InfoMemberPrinting.prettyLayoutOfMethInfoFreeStyle amap m denv typarInst minfo
 
 /// Convert a PropInfo to a string
-let prettyLayoutOfPropInfoFreeStyle g amap m denv d = InfoMemberPrinting.prettyLayoutOfPropInfoFreeStyle g amap m denv d
+let prettyLayoutOfPropInfoFreeStyle amap m denv d = InfoMemberPrinting.prettyLayoutOfPropInfoFreeStyle amap m denv d
 
 /// Convert a MethInfo to a string
 let stringOfMethInfo amap m denv d = bufs (fun buf -> InfoMemberPrinting.formatMethInfoToBufferFreeStyle amap m denv buf d)

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -2774,15 +2774,15 @@ and TryInlineApplication cenv env finfo (tyargs: TType list, args: Expr list, m)
                             | CompiledTypeRepr.ILAsmNamed(iltr, _, _) -> iltr.Scope.AssemblyRef.Name = "FSharp.Core"
                             | _ -> false
                     | _ -> false
-                | _ -> false                                          
-        
+                | _ -> false
+
         if isValFromLazyExtensions then None else
 
         let isSecureMethod =
           match finfo.Info with
           | ValValue(vref, _) ->
-                vref.Attribs |> List.exists (fun a -> (IsSecurityAttribute cenv.g cenv.amap cenv.casApplied a m) || (IsSecurityCriticalAttribute cenv.g a))
-          | _ -> false                              
+                vref.Attribs |> List.exists (fun a -> (IsSecurityAttribute cenv.amap cenv.casApplied a m) || (IsSecurityCriticalAttribute cenv.g a))
+          | _ -> false
 
         if isSecureMethod then None else
 
@@ -2891,7 +2891,7 @@ and OptimizeLambdas (vspec: Val option) cenv env topValInfo e ety =
     match e with 
     | Expr.Lambda (lambdaId, _, _, _, _, m, _)  
     | Expr.TyLambda (lambdaId, _, _, m, _) ->
-        let tps, ctorThisValOpt, baseValOpt, vsl, body, bodyty = IteratedAdjustArityOfLambda cenv.g cenv.amap topValInfo e
+        let tps, ctorThisValOpt, baseValOpt, vsl, body, bodyty = IteratedAdjustArityOfLambda cenv.amap topValInfo e
         let env = { env with functionVal = (match vspec with None -> None | Some v -> Some (v, topValInfo)) }
         let env = Option.foldBack (BindInternalValToUnknown cenv) ctorThisValOpt env
         let env = Option.foldBack (BindInternalValToUnknown cenv) baseValOpt env

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -962,9 +962,9 @@ and CheckExpr (cenv: cenv) (env: env) origExpr (context: PermitByRefExpr) : Limi
 
         let interfaces = 
             [ if isInterfaceTy g ty then 
-                  yield! AllSuperTypesOfType g cenv.amap m AllowMultiIntfInstantiations.Yes ty
+                  yield! AllSuperTypesOfType cenv.amap m AllowMultiIntfInstantiations.Yes ty
               for (ty, _) in iimpls do
-                  yield! AllSuperTypesOfType g cenv.amap m AllowMultiIntfInstantiations.Yes ty  ]
+                  yield! AllSuperTypesOfType cenv.amap m AllowMultiIntfInstantiations.Yes ty  ]
             |> List.filter (isInterfaceTy g)
 
         CheckMultipleInterfaceInstantiations cenv interfaces m
@@ -2182,7 +2182,7 @@ let CheckEntityDefn cenv env (tycon: Entity) =
 
 
     let interfaces = 
-        AllSuperTypesOfType g cenv.amap tycon.Range AllowMultiIntfInstantiations.Yes ty
+        AllSuperTypesOfType cenv.amap tycon.Range AllowMultiIntfInstantiations.Yes ty
             |> List.filter (isInterfaceTy g)
             
     if tycon.IsFSharpInterfaceTycon then 
@@ -2196,7 +2196,7 @@ let CheckEntityDefn cenv env (tycon: Entity) =
             let immediateInterfaces = GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes g cenv.amap m ty
             let interfaces = 
               [ for ty in immediateInterfaces do
-                    yield! AllSuperTypesOfType g cenv.amap m AllowMultiIntfInstantiations.Yes ty  ]
+                    yield! AllSuperTypesOfType cenv.amap m AllowMultiIntfInstantiations.Yes ty  ]
             CheckMultipleInterfaceInstantiations cenv interfaces m
         
         // Check struct fields. We check these late because we have to have first checked that the structs are

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -1403,7 +1403,7 @@ and CheckLambdas isTop (memInfo: ValMemberInfo option) cenv env inlined topValIn
 
     | Expr.Lambda (_, _, _, _, _, m, _)  
     | Expr.TyLambda (_, _, _, m, _) ->
-        let tps, ctorThisValOpt, baseValOpt, vsl, body, bodyty = destTopLambda g cenv.amap topValInfo (e, ety) in
+        let tps, ctorThisValOpt, baseValOpt, vsl, body, bodyty = destTopLambda cenv.amap topValInfo (e, ety) in
         let env = BindTypars g env tps 
         let thisAndBase = Option.toList ctorThisValOpt @ Option.toList baseValOpt
         let restArgs = List.concat vsl

--- a/src/fsharp/SignatureConformance.fs
+++ b/src/fsharp/SignatureConformance.fs
@@ -185,7 +185,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                 let aintfsUser = implTycon.TypeContents.tcaug_interfaces |> List.filter (fun (_, compgen, _) -> not compgen) |> List.map p13 
                 let flatten tys = 
                    tys 
-                   |> List.collect (AllSuperTypesOfType g amap m AllowMultiIntfInstantiations.Yes) 
+                   |> List.collect (AllSuperTypesOfType amap m AllowMultiIntfInstantiations.Yes) 
                    |> ListSet.setify (typeEquiv g) 
                    |> List.filter (isInterfaceTy g)
                 let aintfs     = flatten aintfs 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -6689,7 +6689,7 @@ and ComputeObjectExprOverrides cenv (env: TcEnv) tpenv impls =
                     let partialValInfo = TranslateTopValSynInfo id.idRange (TcAttributes cenv env) valSynData
                     let tps, _ = tryDestForallTy cenv.g ty
                     let valInfo = TranslatePartialArity tps partialValInfo
-                    DispatchSlotChecking.GetObjectExprOverrideInfo cenv.g cenv.amap (implty, id, memberFlags, ty, valInfo, bindingAttribs, bindingBody))
+                    DispatchSlotChecking.GetObjectExprOverrideInfo cenv.amap (implty, id, memberFlags, ty, valInfo, bindingAttribs, bindingBody))
 
             (m, implty, reqdSlots, dispatchSlotsKeyed, availPriorOverrides, overrides), tpenv)
 
@@ -10961,7 +10961,7 @@ and TcAttribute canFail cenv (env: TcEnv) attrTgt (synAttr: SynAttribute) =
 
     let ad = env.eAccessRights
 
-    if not (IsTypeAccessible cenv.g cenv.amap mAttr ad ty) then errorR(Error(FSComp.SR.tcTypeIsInaccessible(), mAttr))
+    if not (IsTypeAccessible cenv.amap mAttr ad ty) then errorR(Error(FSComp.SR.tcTypeIsInaccessible(), mAttr))
 
     let tcref = tcrefOfAppTy cenv.g ty
 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -11031,7 +11031,7 @@ and TcAttribute canFail cenv (env: TcEnv) attrTgt (synAttr: SynAttribute) =
         | Exception _ when canFail -> [ ], true
         | res -> 
         let item = ForceRaise res
-        if not (ExistsHeadTypeInEntireHierarchy cenv.g cenv.amap mAttr ty cenv.g.tcref_System_Attribute) then warning(Error(FSComp.SR.tcTypeDoesNotInheritAttribute(), mAttr))
+        if not (ExistsHeadTypeInEntireHierarchy cenv.amap mAttr ty cenv.g.tcref_System_Attribute) then warning(Error(FSComp.SR.tcTypeDoesNotInheritAttribute(), mAttr))
         let attrib = 
             match item with 
             | Item.CtorGroup(methodName, minfos) ->

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -1552,7 +1552,6 @@ let MakeAndPublishBaseVal cenv env baseIdOpt ty =
 let InstanceMembersNeedSafeInitCheck cenv m thisTy = 
     ExistsInEntireHierarchyOfType 
         (fun ty -> not (isStructTy cenv.g ty) && (match tryDestAppTy cenv.g ty with ValueSome tcref when tcref.HasSelfReferentialConstructor -> true | _ -> false))
-        cenv.g 
         cenv.amap
         m 
         AllowMultiIntfInstantiations.Yes
@@ -4490,7 +4489,7 @@ and TcValSpec cenv env declKind newOk containerInfo memFlagsOpt thisTyOpt tpenv 
               if CompileAsEvent cenv.g attrs then 
                     let valSynInfo = EventDeclarationNormalization.ConvertSynInfo id.idRange valSynInfo
                     let memberFlags = EventDeclarationNormalization.ConvertMemberFlags memberFlags
-                    let delTy = FindDelegateTypeOfPropertyEvent cenv.g cenv.amap id.idText id.idRange declaredTy 
+                    let delTy = FindDelegateTypeOfPropertyEvent cenv.amap id.idText id.idRange declaredTy 
                     let ty = 
                        if memberFlags.IsInstance then 
                          thisTy --> (delTy --> cenv.g.unit_ty)
@@ -5449,7 +5448,7 @@ and TcPat warnOnUpper cenv env topValInfo vFlags (tpenv, names, takenNames) ty p
                 
         | Item.ILField finfo ->
             // LITERAL .NET FIELDS 
-            CheckILFieldInfoAccessible cenv.g cenv.amap m env.eAccessRights finfo
+            CheckILFieldInfoAccessible cenv.amap m env.eAccessRights finfo
             if not finfo.IsStatic then errorR (Error (FSComp.SR.tcFieldIsNotStatic(finfo.FieldName), m))
             CheckILFieldAttributes cenv.g finfo m
             match finfo.LiteralValue with 
@@ -6241,7 +6240,6 @@ and TcIndexerThen cenv env overallTy mWholeExpr mDot tpenv wholeExpr e1 indexArg
                         | [] -> None
                         | _ -> item
                  | _ -> acc)
-              cenv.g 
               cenv.amap 
               mWholeExpr 
               AllowMultiIntfInstantiations.Yes
@@ -9267,7 +9265,7 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
 
     | Item.ILField finfo -> 
 
-        CheckILFieldInfoAccessible g cenv.amap mItem ad finfo
+        CheckILFieldInfoAccessible cenv.amap mItem ad finfo
         if not finfo.IsStatic then error (Error (FSComp.SR.tcFieldIsNotStatic(finfo.FieldName), mItem))
         CheckILFieldAttributes g finfo mItem
         let fref = finfo.ILFieldRef
@@ -11059,7 +11057,7 @@ and TcAttribute canFail cenv (env: TcEnv) attrTgt (synAttr: SynAttribute) =
                             errorR(Error(FSComp.SR.tcPropertyCannotBeSet0(), m))
                           id.idText, true, pinfo.GetPropertyType(cenv.amap, m)
                       | Item.ILField finfo -> 
-                          CheckILFieldInfoAccessible cenv.g cenv.amap m ad finfo
+                          CheckILFieldInfoAccessible cenv.amap m ad finfo
                           CheckILFieldAttributes cenv.g finfo m
                           id.idText, false, finfo.FieldType(cenv.amap, m)
                       | Item.RecdField rfinfo when not rfinfo.IsStatic -> 
@@ -15954,7 +15952,7 @@ module EstablishTypeDefinitionCores =
             // validate ConditionalAttribute, should it be applied (it's only valid on a type if the type is an attribute type)
             match attrs |> List.tryFind (IsMatchingFSharpAttribute g g.attrib_ConditionalAttribute) with
             | Some _ ->
-                if not(ExistsInEntireHierarchyOfType (fun t -> typeEquiv g t (mkAppTy g.tcref_System_Attribute [])) g cenv.amap m AllowMultiIntfInstantiations.Yes thisTy) then
+                if not(ExistsInEntireHierarchyOfType (fun t -> typeEquiv g t (mkAppTy g.tcref_System_Attribute [])) cenv.amap m AllowMultiIntfInstantiations.Yes thisTy) then
                     errorR(Error(FSComp.SR.tcConditionalAttributeUsage(), m))
             | _ -> ()         
                    

--- a/src/fsharp/TypeRelations.fs
+++ b/src/fsharp/TypeRelations.fs
@@ -245,8 +245,8 @@ let tryDestTopLambda g amap (ValReprInfo (tpNames, _, _) as tvd) (e, ty) =
     else
         Some (tps, ctorThisValOpt, baseValOpt, vsl, body, retTy)
 
-let destTopLambda g amap topValInfo (e, ty) = 
-    match tryDestTopLambda g amap topValInfo (e, ty) with 
+let destTopLambda (amap: Import.ImportMap) topValInfo (e, ty) = 
+    match tryDestTopLambda amap.g amap topValInfo (e, ty) with 
     | None -> error(Error(FSComp.SR.typrelInvalidValue(), e.Range))
     | Some res -> res
     
@@ -259,8 +259,9 @@ let IteratedAdjustArityOfLambdaBody g arities vsl body  =
 /// iterated lambdas, producing one method.  
 /// The required iterated function arity (List.length topValInfo) must be identical 
 /// to the iterated function arity of the input lambda (List.length vsl) 
-let IteratedAdjustArityOfLambda g amap topValInfo e =
-    let tps, ctorThisValOpt, baseValOpt, vsl, body, bodyty = destTopLambda g amap topValInfo (e, tyOfExpr g e)
+let IteratedAdjustArityOfLambda (amap:Import.ImportMap) topValInfo e =
+    let g = amap.g
+    let tps, ctorThisValOpt, baseValOpt, vsl, body, bodyty = destTopLambda amap topValInfo (e, tyOfExpr g e)
     let arities = topValInfo.AritiesOfArgs
     if arities.Length <> vsl.Length then 
         errorR(InternalError(sprintf "IteratedAdjustArityOfLambda, List.length arities = %d, List.length vsl = %d" arities.Length vsl.Length, body.Range))

--- a/src/fsharp/autobox.fs
+++ b/src/fsharp/autobox.fs
@@ -32,7 +32,7 @@ let DecideLambda exprF cenv topValInfo expr ety z   =
     match expr with 
     | Expr.Lambda _
     | Expr.TyLambda _ ->
-        let _tps, ctorThisValOpt, baseValOpt, vsl, body, _bodyty = destTopLambda cenv.g cenv.amap topValInfo (expr, ety) 
+        let _tps, ctorThisValOpt, baseValOpt, vsl, body, _bodyty = destTopLambda cenv.amap topValInfo (expr, ety) 
         let snoc = fun x y -> y :: x
         let args = List.concat vsl
         let args = Option.fold snoc args baseValOpt

--- a/src/fsharp/autobox.fsi
+++ b/src/fsharp/autobox.fsi
@@ -7,6 +7,6 @@ open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Import
 
 /// Rewrite mutable locals to reference cells across an entire implementation file
-val TransformImplFile: g: TcGlobals -> amap: ImportMap -> implFile: TypedImplFile -> TypedImplFile
+val TransformImplFile: amap: ImportMap -> implFile: TypedImplFile -> TypedImplFile
 
 

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -269,8 +269,8 @@ let ExistsSameHeadTypeInHierarchy g amap m typeToSearchFrom typeToLookFor =
     ExistsInEntireHierarchyOfType (HaveSameHeadType g typeToLookFor) amap m AllowMultiIntfInstantiations.Yes typeToSearchFrom
 
 /// Check if a type exists somewhere in the hierarchy which has the given head type.
-let ExistsHeadTypeInEntireHierarchy g amap m typeToSearchFrom tcrefToLookFor =
-    ExistsInEntireHierarchyOfType (HasHeadType g tcrefToLookFor) amap m AllowMultiIntfInstantiations.Yes typeToSearchFrom
+let ExistsHeadTypeInEntireHierarchy (amap: Import.ImportMap) m typeToSearchFrom tcrefToLookFor =
+    ExistsInEntireHierarchyOfType (HasHeadType amap.g tcrefToLookFor) amap m AllowMultiIntfInstantiations.Yes typeToSearchFrom
 
 
 /// Read an Abstract IL type from metadata and convert to an F# type.

--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -281,7 +281,6 @@ type public FSharpCheckFileResults =
         mainInputFileName: string * 
         projectFileName: string *
         tcConfig: TcConfig *
-        tcGlobals: TcGlobals *
         isIncompleteTypeCheckEnvironment: bool *
         builder: IncrementalBuilder * 
         dependencyFiles: string[] * 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -677,7 +677,6 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                         (filename, 
                          options.ProjectFileName, 
                          tcProj.TcConfig, 
-                         tcProj.TcGlobals, 
                          options.IsIncompleteTypeCheckEnvironment, 
                          builder, 
                          Array.ofList tcProj.TcDependencyFiles, 

--- a/src/fsharp/symbols/Exprs.fs
+++ b/src/fsharp/symbols/Exprs.fs
@@ -1248,7 +1248,7 @@ and FSharpImplementationFileContents(cenv, mimpl) =
         let v = bind.Var
         assert v.IsCompiledAsTopLevel
         let topValInfo = InferArityOfExprBinding cenv.g AllowTypeDirectedDetupling.Yes v bind.Expr
-        let tps, _ctorThisValOpt, _baseValOpt, vsl, body, _bodyty = IteratedAdjustArityOfLambda cenv.g cenv.amap topValInfo bind.Expr
+        let tps, _ctorThisValOpt, _baseValOpt, vsl, body, _bodyty = IteratedAdjustArityOfLambda cenv.amap topValInfo bind.Expr
         let v = FSharpMemberOrFunctionOrValue(cenv, mkLocalValRef v)
         let gps = v.GenericParameters
         let vslR = List.map (List.map (FSharpExprConvert.ConvVal cenv)) vsl 

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -1114,7 +1114,7 @@ module internal SymbolHelpers =
 
         // F# and .NET properties
         | Item.Property(_, pinfo :: _) -> 
-            let layout = NicePrint.prettyLayoutOfPropInfoFreeStyle  g amap m denv pinfo
+            let layout = NicePrint.prettyLayoutOfPropInfoFreeStyle amap m denv pinfo
             FSharpStructuredToolTipElement.Single (layout, xml)
 
         // Custom operations in queries

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -987,7 +987,7 @@ module internal SymbolHelpers =
             | Item.Types(_, ((TType_app(tcref, _)) :: _))
             | Item.UnqualifiedType(tcref :: _) ->
                 let ty = generalizedTyconRef tcref
-                Infos.ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_Attribute
+                Infos.ExistsHeadTypeInEntireHierarchy amap range0 ty g.tcref_System_Attribute
             | _ -> false
         with _ -> false
 

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -552,7 +552,7 @@ and FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
     member x.AllInterfaces = 
         if isUnresolved() then makeReadOnlyCollection [] else
         ErrorLogger.protectAssemblyExploration [] (fun () -> 
-            [ for ty in AllInterfacesOfType  cenv.g cenv.amap range0 AllowMultiIntfInstantiations.Yes (generalizedTyconRef entity) do 
+            [ for ty in AllInterfacesOfType cenv.amap range0 AllowMultiIntfInstantiations.Yes (generalizedTyconRef entity) do 
                  yield FSharpType(cenv, ty) ])
         |> makeReadOnlyCollection
     
@@ -1363,11 +1363,11 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
                               //match d with 
                               //| E e -> 
                               //    match e with 
-                              //    | EventInfo.ILEvent (_, e) -> AccessibilityLogic.IsILEventInfoAccessible g cenv.amap range0 ad e
+                              //    | EventInfo.ILEvent (_, e) -> AccessibilityLogic.IsILEventInfoAccessible cenv.amap range0 ad e
                               //    | EventInfo.FSEvent (_, _, vref, _) ->  AccessibilityLogic.IsValAccessible ad vref
                               //    | _ -> true
                               //| M m -> AccessibilityLogic.IsMethInfoAccessible cenv.amap range0 ad m
-                              //| P p -> AccessibilityLogic.IsPropInfoAccessible g cenv.amap range0 ad p
+                              //| P p -> AccessibilityLogic.IsPropInfoAccessible cenv.amap range0 ad p
                               //| V v -> AccessibilityLogic.IsValAccessible ad v
                           )
 
@@ -2156,7 +2156,7 @@ and FSharpType(cenv, ty:TType) =
 
     member x.AllInterfaces = 
         if isUnresolved() then makeReadOnlyCollection [] else
-        [ for ty in AllInterfacesOfType  cenv.g cenv.amap range0 AllowMultiIntfInstantiations.Yes ty do 
+        [ for ty in AllInterfacesOfType  cenv.amap range0 AllowMultiIntfInstantiations.Yes ty do 
              yield FSharpType(cenv, ty) ]
         |> makeReadOnlyCollection
 
@@ -2282,7 +2282,8 @@ and FSharpAttribute(cenv: SymbolEnv, attrib: AttribInfo) =
             match attrib with
             | AttribInfo.FSAttribInfo(g, attrib) ->
                 NicePrint.stringOfFSAttrib (denv.Contents g) attrib
-            | AttribInfo.ILAttribInfo (g, _, _scoref, cattr, _) -> 
+            | AttribInfo.ILAttribInfo (amap, _scoref, cattr, _) ->
+                let g = amap.g
                 let parms, _args = decodeILAttribData g.ilg cattr 
                 NicePrint.stringOfILAttrib (denv.Contents g) (cattr.Method.DeclaringType, parms)
 
@@ -2405,7 +2406,7 @@ and FSharpAssemblySignature (cenv, topAttribs: TypeChecker.TopAttribs option, op
                     match ilModule.Manifest with 
                     | None -> ()
                     | Some manifest -> 
-                        for a in AttribInfosOfIL cenv.g cenv.amap cenv.thisCcu.ILScopeRef range0 manifest.CustomAttrs do
+                        for a in AttribInfosOfIL cenv.amap cenv.thisCcu.ILScopeRef range0 manifest.CustomAttrs do
                             yield FSharpAttribute(cenv, a)
                 | None -> 
                     // If no module is available, then look in the CCU contents. 

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -691,7 +691,7 @@ and FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
 
     member __.Attributes = 
         if isUnresolved() then makeReadOnlyCollection[] else
-        GetAttribInfosOfEntity cenv.g cenv.amap range0 entity
+        GetAttribInfosOfEntity cenv.amap range0 entity
         |> List.map (fun a -> FSharpAttribute(cenv, a))
         |> makeReadOnlyCollection
 

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -560,13 +560,13 @@ and FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
         if isUnresolved() then false else
         let ty = generalizedTyconRef entity
         ErrorLogger.protectAssemblyExploration false <| fun () -> 
-        Infos.ExistsHeadTypeInEntireHierarchy cenv.g cenv.amap range0 ty cenv.g.tcref_System_Attribute
+        Infos.ExistsHeadTypeInEntireHierarchy cenv.amap range0 ty cenv.g.tcref_System_Attribute
         
     member x.IsDisposableType =
         if isUnresolved() then false else
         let ty = generalizedTyconRef entity
         ErrorLogger.protectAssemblyExploration false <| fun () -> 
-        Infos.ExistsHeadTypeInEntireHierarchy cenv.g cenv.amap range0 ty cenv.g.tcref_System_IDisposable
+        Infos.ExistsHeadTypeInEntireHierarchy cenv.amap range0 ty cenv.g.tcref_System_IDisposable
 
     member x.BaseType = 
         checkIsResolved()        


### PR DESCRIPTION
When reviewing a PR recently we noticed that I had added plumbing for a TcGlobals to an api that also has  (amap: Import.ImportMap) , which carries g a TcGlobals.

A quick perusal of the code showed that this was fairly common.  I just spent a while going through the code base and this is what I got.

There is still a ton more to do:

@dsyme … is this worthwhile?  should I continue?



