### PR TITLE
Moving AccessOfTypeAbbreviationTests over to NUnit

### DIFF
--- a/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
+++ b/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
@@ -19,7 +19,7 @@ module Library =
             FSharpErrorSeverity.Warning
             44
             (4, 8, 4, 16)
-            "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 
     [<Test>]
     let ``Test2``() =
@@ -41,7 +41,7 @@ module Library =
             FSharpErrorSeverity.Warning
             44
             (4, 8, 4, 16)
-            "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 
     [<Test>]
     let ``Test4``() =
@@ -53,8 +53,8 @@ module Library =
             """
             FSharpErrorSeverity.Warning
             44
-            (4, 8, 4, 16)
-            "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+            (4, 17, 4, 25)
+            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 
     [<Test>]
     let ``Test5``() =

--- a/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
+++ b/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
@@ -19,7 +19,7 @@ module Library =
 exit 0
             """
             FSharpErrorSeverity.Warning
-            1
+            44
             (2, 8, 2, 15)
             "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 
@@ -45,7 +45,7 @@ module Library =
 exit 0
             """
             FSharpErrorSeverity.Warning
-            1
+            44
             (2, 8, 2, 15)
             "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 
@@ -60,7 +60,7 @@ module Library =
 exit 0
             """
             FSharpErrorSeverity.Warning
-            1
+            44
             (2, 8, 2, 15)
             "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 

--- a/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
+++ b/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
@@ -9,7 +9,7 @@ open FSharp.Compiler.SourceCodeServices
 module ``Access Of Type Abbreviation`` =
 
     [<Test>]
-    let ``Test``() =
+    let ``Test1``() =
         CompilerAssert.TypeCheckSingleError
             """
 module Library =
@@ -19,7 +19,7 @@ module Library =
             FSharpErrorSeverity.Warning
             44
             (4, 8, 4, 16)
-            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in.\r\nAs of F# 4.1, the accessibility of type abbreviations is checked at compile-time. Consider changing the accessibility of the type abbreviation. Ignoring this warning might lead to runtime errors."
 
     [<Test>]
     let ``Test2``() =
@@ -41,7 +41,7 @@ module Library =
             FSharpErrorSeverity.Warning
             44
             (4, 8, 4, 16)
-            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in.\r\nAs of F# 4.1, the accessibility of type abbreviations is checked at compile-time. Consider changing the accessibility of the type abbreviation. Ignoring this warning might lead to runtime errors."
 
     [<Test>]
     let ``Test4``() =
@@ -54,7 +54,7 @@ module Library =
             FSharpErrorSeverity.Warning
             44
             (4, 17, 4, 25)
-            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+            "This construct is deprecated. The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in.\r\nAs of F# 4.1, the accessibility of type abbreviations is checked at compile-time. Consider changing the accessibility of the type abbreviation. Ignoring this warning might lead to runtime errors."
 
     [<Test>]
     let ``Test5``() =

--- a/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
+++ b/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
@@ -15,12 +15,10 @@ module ``Access Of Type Abbreviation`` =
 module Library =
   type private Hidden = Hidden of unit
   type Exported = Hidden
-    
-exit 0
             """
             FSharpErrorSeverity.Warning
             44
-            (2, 8, 2, 15)
+            (4, 8, 4, 16)
             "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 
     [<Test>]
@@ -30,8 +28,6 @@ exit 0
 module Library =
   type internal Hidden = Hidden of unit
   type internal Exported = Hidden
-    
-exit 0
             """
 
     [<Test>]
@@ -41,12 +37,10 @@ exit 0
 module Library =
   type internal Hidden = Hidden of unit
   type Exported = Hidden
-    
-exit 0
             """
             FSharpErrorSeverity.Warning
             44
-            (2, 8, 2, 15)
+            (4, 8, 4, 16)
             "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 
     [<Test>]
@@ -56,12 +50,10 @@ exit 0
 module Library =
   type private Hidden = Hidden of unit
   type internal Exported = Hidden
-    
-exit 0
             """
             FSharpErrorSeverity.Warning
             44
-            (2, 8, 2, 15)
+            (4, 8, 4, 16)
             "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
 
     [<Test>]
@@ -71,8 +63,6 @@ exit 0
 module Library =
   type private Hidden = Hidden of unit
   type private Exported = Hidden
-    
-exit 0
             """
 
     [<Test>]
@@ -82,6 +72,4 @@ exit 0
 module Library =
   type Hidden = Hidden of unit
   type Exported = Hidden
-    
-exit 0
             """

--- a/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
+++ b/tests/fsharp/Compiler/ErrorMessages/AccessOfTypeAbbreviationTests.fs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.UnitTests
+
+open NUnit.Framework
+open FSharp.Compiler.SourceCodeServices
+
+[<TestFixture>]
+module ``Access Of Type Abbreviation`` =
+
+    [<Test>]
+    let ``Test``() =
+        CompilerAssert.TypeCheckSingleError
+            """
+module Library =
+  type private Hidden = Hidden of unit
+  type Exported = Hidden
+    
+exit 0
+            """
+            FSharpErrorSeverity.Warning
+            1
+            (2, 8, 2, 15)
+            "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+
+    [<Test>]
+    let ``Test2``() =
+        CompilerAssert.Pass
+            """
+module Library =
+  type internal Hidden = Hidden of unit
+  type internal Exported = Hidden
+    
+exit 0
+            """
+
+    [<Test>]
+    let ``Test3``() =
+        CompilerAssert.TypeCheckSingleError
+            """
+module Library =
+  type internal Hidden = Hidden of unit
+  type Exported = Hidden
+    
+exit 0
+            """
+            FSharpErrorSeverity.Warning
+            1
+            (2, 8, 2, 15)
+            "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+
+    [<Test>]
+    let ``Test4``() =
+        CompilerAssert.TypeCheckSingleError
+            """
+module Library =
+  type private Hidden = Hidden of unit
+  type internal Exported = Hidden
+    
+exit 0
+            """
+            FSharpErrorSeverity.Warning
+            1
+            (2, 8, 2, 15)
+            "The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in"
+
+    [<Test>]
+    let ``Test5``() =
+        CompilerAssert.Pass
+            """
+module Library =
+  type private Hidden = Hidden of unit
+  type private Exported = Hidden
+    
+exit 0
+            """
+
+    [<Test>]
+    let ``Test6``() =
+        CompilerAssert.Pass
+            """
+module Library =
+  type Hidden = Hidden of unit
+  type Exported = Hidden
+    
+exit 0
+            """

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="tests.fs" />
     <Compile Include="Compiler\ILChecker.fs" />
     <Compile Include="Compiler\CompilerAssert.fs" />
+    <Compile Include="Compiler\ErrorMessages\AccessOfTypeAbbreviationTests.fs" />
     <Compile Include="Compiler\ErrorMessages\ElseBranchHasWrongTypeTests.fs" />
     <Compile Include="Compiler\SourceTextTests.fs" />
     <Compile Include="Compiler\Language\AnonRecordTests.fs" />

--- a/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation.fs
+++ b/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation.fs
@@ -1,8 +1,0 @@
-// #Warnings
-//<Expects status="warning" id="FS0044">The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in</Expects>
-
-module Library =
-  type private Hidden = Hidden of unit
-  type Exported = Hidden
-    
-exit 0

--- a/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation2.fs
+++ b/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation2.fs
@@ -1,8 +1,0 @@
-// #Warnings
-//<Expects status="success"></Expects>
-
-module Library =
-  type internal Hidden = Hidden of unit
-  type internal Exported = Hidden
-    
-exit 0

--- a/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation3.fs
+++ b/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation3.fs
@@ -1,8 +1,0 @@
-// #Warnings
-//<Expects status="warning" id="FS0044">The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in</Expects>
-
-module Library =
-  type internal Hidden = Hidden of unit
-  type Exported = Hidden
-    
-exit 0

--- a/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation4.fs
+++ b/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation4.fs
@@ -1,8 +1,0 @@
-// #Warnings
-//<Expects status="warning" id="FS0044">The type 'Hidden' is less accessible than the value, member or type 'Exported' it is used in</Expects>
-
-module Library =
-  type private Hidden = Hidden of unit
-  type internal Exported = Hidden
-    
-exit 0

--- a/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation5.fs
+++ b/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation5.fs
@@ -1,8 +1,0 @@
-// #Warnings
-//<Expects status="success"></Expects>
-
-module Library =
-  type private Hidden = Hidden of unit
-  type private Exported = Hidden
-    
-exit 0

--- a/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation6.fs
+++ b/tests/fsharpqa/Source/Warnings/AccessOfTypeAbbreviation6.fs
@@ -1,8 +1,0 @@
-// #Warnings
-//<Expects status="success"></Expects>
-
-module Library =
-  type Hidden = Hidden of unit
-  type Exported = Hidden
-    
-exit 0

--- a/tests/fsharpqa/Source/Warnings/env.lst
+++ b/tests/fsharpqa/Source/Warnings/env.lst
@@ -16,12 +16,6 @@
 	SOURCE=WrongArity.fs # WrongArity.fs
 	SOURCE=OverrideErrors.fs # OverrideErrors.fs
 	SOURCE=MethodIsNotStatic.fs # MethodIsNotStatic.fs
-	SOURCE=AccessOfTypeAbbreviation.fs # AccessOfTypeAbbreviation.fs
-	SOURCE=AccessOfTypeAbbreviation2.fs # AccessOfTypeAbbreviation2.fs
-	SOURCE=AccessOfTypeAbbreviation3.fs # AccessOfTypeAbbreviation3.fs
-	SOURCE=AccessOfTypeAbbreviation4.fs # AccessOfTypeAbbreviation4.fs
-	SOURCE=AccessOfTypeAbbreviation5.fs # AccessOfTypeAbbreviation5.fs
-	SOURCE=AccessOfTypeAbbreviation6.fs # AccessOfTypeAbbreviation6.fs
 	SOURCE=EqualsInsteadOfInInForLoop.fs # EqualsInsteadOfInInForLoop.fs
 	SOURCE=DontWarnExternalFunctionAsUnused.fs SCFLAGS="--warnon:1182 --warnaserror+" # DontWarnExternalFunctionAsUnused.fs
 	SOURCE=SuggestTypesInModule.fs # SuggestTypesInModule.fs


### PR DESCRIPTION
This is draft of PR because want to test it and I cannot run `FSharpSuite.Tests.fsproj` on `macOS`.
I did not find out (yet) the way to quickly compile and test on Win/Parallels VM. 
I have tried `eng/Build.ps1 -restore -build` and have to turn off VM after 30 min of 100% CPU load.

Attempt to contribute to #7075