### PR TITLE
Need to call `stripExpr` before the match in IlxGen.fs

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2533,7 +2533,8 @@ and GenAllocUnionCase cenv cgbuf eenv (c,tyargs,args,m) sequel =
     GenSequel cenv eenv.cloc cgbuf sequel
 
 and GenLinearExpr cenv cgbuf eenv sp expr sequel canProcessSequencePoint (contf: FakeUnit -> FakeUnit) =
-    match stripExpr expr with 
+    let expr = stripExpr expr
+    match expr with 
     | LinearOpExpr (TOp.UnionCase c, tyargs, argsFront, argLast, m) ->
         GenExprs cenv cgbuf eenv argsFront
         GenLinearExpr cenv cgbuf eenv SPSuppress argLast Continue (* canProcessSequencePoint *) true (contf << (fun Fake -> 


### PR DESCRIPTION
This hasn't shown a bug yet, but it is more correct to call `stripExpr` and have `expr` be the stripped expr always in `GenLinearExpr`.