### PR TITLE
publish pdbs in FSharp.Core.nupkg

### DIFF
--- a/.vsts-signed.yaml
+++ b/.vsts-signed.yaml
@@ -105,6 +105,14 @@ jobs:
     continueOnError: true
     condition: succeeded()
 
+  # Publish native PDBs for archiving
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Artifact Symbols
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/SymStore/$(BuildConfiguration)'
+      ArtifactName: NativeSymbols
+    condition: succeeded()
+
   # Execute cleanup tasks
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: Execute cleanup tasks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,6 +113,12 @@ jobs:
             PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\VisualFSharpFull.vsix'
             ArtifactName: 'Nightly'
           condition: succeeded()
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Artifact Symbols
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\SymStore\$(_BuildConfig)'
+            ArtifactName: 'NativeSymbols'
+          condition: succeeded()
 
 #---------------------------------------------------------------------------------------------------------------------#
 #                                                     PR builds                                                       #

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuspec
@@ -38,11 +38,13 @@
     </metadata>
     <files>
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.dll"     target="lib\netstandard1.6" />
+        <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.pdb"     target="lib\netstandard1.6" />
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.sigdata" target="lib\netstandard1.6" />
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.optdata" target="lib\netstandard1.6" />
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.xml"     target="lib\netstandard1.6" />
 
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.dll"     target="lib\net45" />
+        <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.pdb"     target="lib\net45" />
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.sigdata" target="lib\net45" />
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.optdata" target="lib\net45" />
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.xml"     target="lib\net45" />


### PR DESCRIPTION
To make debugging as well as internal symbol archiving easier, include `FSharp.Core.pdb` in the `.nupkg`.