### PR TITLE
fixes issue #6832

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -75,6 +75,7 @@
     <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/Microsoft/visualfsharp</RepositoryUrl>
     <RepositoryType Condition="'$(RepositoryType)' == ''">git</RepositoryType>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(FSharpSourceBuild)' == 'true' AND '$(RepositoryCommit)' == ''">
     <_DotGitDir>$(RepoRoot).git</_DotGitDir>
     <_HeadFileContent Condition="Exists('$(_DotGitDir)/HEAD')">$([System.IO.File]::ReadAllText('$(_DotGitDir)/HEAD').Trim())</_HeadFileContent>
@@ -87,7 +88,7 @@
   <PropertyGroup>
     <NoWarn Condition="'$(Language)' == 'F#'">$(NoWarn);FS2003</NoWarn><!-- warning when AssemblyInformationalVersion looks like '1.2.3-dev' -->
     <NoCompilerStandardLib>true</NoCompilerStandardLib><!-- necessary for resource generation using csc.exe -->
-    <DebugType>portable</DebugType>
+    <DebugType>embedded</DebugType>
     <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
     <UseStandardResourceNames>false</UseStandardResourceNames>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -224,13 +224,14 @@ function UpdatePath() {
     TestAndAddToPath "$ArtifactsDir\bin\fsiAnyCpu\$configuration\net472"
 }
 
-function VerifyAssemblyVersions() {
-    $fsiPath = Join-Path $ArtifactsDir "bin\fsi\Proto\net472\publish\fsi.exe"
+function VerifyAssemblyVersionsAndSymbols() {
+    $assemblyVerCheckPath = Join-Path $ArtifactsDir "Bootstrap\AssemblyCheck\AssemblyCheck.dll"
 
     # Only verify versions on CI or official build
     if ($ci -or $official) {
-        $asmVerCheckPath = "$RepoRoot\scripts"
-        Exec-Console $fsiPath """$asmVerCheckPath\AssemblyVersionCheck.fsx"" -- ""$ArtifactsDir"""
+        $dotnetPath = InitializeDotNetCli
+        $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
+        Exec-Console $dotnetExe """$assemblyVerCheckPath"" ""$ArtifactsDir"""
     }
 }
 
@@ -307,7 +308,7 @@ try {
     }
 
     if ($build) {
-        VerifyAssemblyVersions
+        VerifyAssemblyVersionsAndSymbols
     }
 
     $desktopTargetFramework = "net472"

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -236,10 +236,11 @@ function Make-BootstrapBuild() {
     Remove-Item -re $dir -ErrorAction SilentlyContinue
     Create-Directory $dir
 
-    # prepare FsLex and Fsyacc
+    # prepare FsLex and Fsyacc and AssemblyCheck
     Run-MSBuild "$RepoRoot\src\buildtools\buildtools.proj" "/restore /t:Publish" -logFileName "BuildTools" -configuration $bootstrapConfiguration
     Copy-Item "$ArtifactsDir\bin\fslex\$bootstrapConfiguration\netcoreapp2.1\publish" -Destination "$dir\fslex" -Force -Recurse
     Copy-Item "$ArtifactsDir\bin\fsyacc\$bootstrapConfiguration\netcoreapp2.1\publish" -Destination "$dir\fsyacc" -Force  -Recurse
+    Copy-Item "$ArtifactsDir\bin\AssemblyCheck\$bootstrapConfiguration\netcoreapp2.1\publish" -Destination "$dir\AssemblyCheck" -Force  -Recurse
 
     # prepare compiler
     $projectPath = "$RepoRoot\proto.proj"

--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -186,7 +186,7 @@ let pdbGetEmbeddedPdbDebugInfo (embeddedPdbChunk: BinaryChunk) (uncompressedLeng
         Buffer.BlockCopy(stream.ToArray(), 0, buffer, offset, size)
         buffer
     { iddCharacteristics = 0                                                    // Reserved
-      iddMajorVersion = 0                                                       // VersionMajor should be 0
+      iddMajorVersion = 0x0100                                                  // VersionMajor should be 0
       iddMinorVersion = 0x0100                                                  // VersionMinor should be 0x0100
       iddType = 17                                                              // IMAGE_DEBUG_TYPE_EMBEDDEDPDB
       iddTimestamp = 0

--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -186,7 +186,7 @@ let pdbGetEmbeddedPdbDebugInfo (embeddedPdbChunk: BinaryChunk) (uncompressedLeng
         Buffer.BlockCopy(stream.ToArray(), 0, buffer, offset, size)
         buffer
     { iddCharacteristics = 0                                                    // Reserved
-      iddMajorVersion = 0x0100                                                  // VersionMajor should be 0
+      iddMajorVersion = 0x0100                                                  // VersionMajor should be 0x0100
       iddMinorVersion = 0x0100                                                  // VersionMinor should be 0x0100
       iddType = 17                                                              // IMAGE_DEBUG_TYPE_EMBEDDEDPDB
       iddTimestamp = 0

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -58,7 +58,7 @@ module AssemblyCheck =
 
         let fsharpExecutingWithEmbeddedPdbs =
             fsharpAssemblies
-            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\") || p.Contains(@".resources.") || p.Contains(@"\FSharpSdk\" || p.Contains(@"\tmp\" || p.Contains(@"\obj\")))
+            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\") || p.Contains(@".resources.") || p.Contains(@"\FSharpSdk\") || p.Contains(@"\tmp\" || p.Contains(@"\obj\")))
 
         // verify that all assemblies have a version number other than 0.0.0.0 or 1.0.0.0
         let failedVersionCheck =

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -76,6 +76,7 @@ module AssemblyCheck =
         // verify that all assemblies have a commit hash
         let failedCommitHash =
             fsharpAssemblies
+            |> List.filter (fun p -> not (p.Contains(@"\FSharpSdk\")))
             |> List.filter (fun a ->
                 let fileProductVersion = FileVersionInfo.GetVersionInfo(a).ProductVersion
                 not (commitHashPattern.IsMatch(fileProductVersion) || devVersionPattern.IsMatch(fileProductVersion)))

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -7,7 +7,7 @@ open System.Reflection
 open System.Reflection.PortableExecutable
 open System.Text.RegularExpressions
 
-module AssemblyVersionCheck =
+module AssemblyCheck =
 
     let private versionZero = Version(0, 0, 0, 0)
     let private versionOne = Version(1, 0, 0, 0)
@@ -55,11 +55,10 @@ module AssemblyVersionCheck =
             |> Seq.concat
             |> List.ofSeq
             |> List.filter (fun p -> (Set.contains (Path.GetFileName(p)) excludedAssemblies) |> not)
-            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\")  || p.Contains(@".resources.")))
 
         let fsharpExecutingWithEmbeddedPdbs =
             fsharpAssemblies
-            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\")  || p.Contains(@".resources.")))
+            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\") || p.Contains(@".resources.") || p.Contains(@"\FSharpSdk\")))
 
         // verify that all assemblies have a version number other than 0.0.0.0 or 1.0.0.0
         let failedVersionCheck =
@@ -105,7 +104,7 @@ module AssemblyVersionCheck =
 [<EntryPoint>]
 let main (argv:string array) =
     if argv.Length <> 1 then
-        printfn "Usage: dotnet AssemblyVersionCheck.dll -- path/to/binaries"
+        printfn "Usage: dotnet AssemblyCheck.dll -- path/to/binaries"
         1
     else
-        AssemblyVersionCheck.verifyAssemblies argv.[0]
+        AssemblyCheck.verifyAssemblies argv.[0]

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -58,7 +58,7 @@ module AssemblyCheck =
 
         let fsharpExecutingWithEmbeddedPdbs =
             fsharpAssemblies
-            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\") || p.Contains(@".resources.") || p.Contains(@"\FSharpSdk\") || p.Contains(@"\tmp\" || p.Contains(@"\obj\")))
+            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\") || p.Contains(@".resources.") || p.Contains(@"\FSharpSdk\") || p.Contains(@"\tmp\") || p.Contains(@"\obj\")))
 
         // verify that all assemblies have a version number other than 0.0.0.0 or 1.0.0.0
         let failedVersionCheck =

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -58,7 +58,7 @@ module AssemblyCheck =
 
         let fsharpExecutingWithEmbeddedPdbs =
             fsharpAssemblies
-            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\") || p.Contains(@".resources.") || p.Contains(@"\FSharpSdk\")))
+            |> List.filter (fun p -> not (p.Contains(@"\Proto\") || p.Contains(@"\Bootstrap\") || p.Contains(@".resources.") || p.Contains(@"\FSharpSdk\" || p.Contains(@"\tmp\" || p.Contains(@"\obj\")))
 
         // verify that all assemblies have a version number other than 0.0.0.0 or 1.0.0.0
         let failedVersionCheck =

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\fsharp\FSharp.Core\FSharp.Core.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Program.fs" />
+    <Compile Include="AssemblyCheck.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/buildtools/AssemblyCheck/Program.fs
+++ b/src/buildtools/AssemblyCheck/Program.fs
@@ -87,7 +87,7 @@ module AssemblyVersionCheck =
         else
             printfn "All shipping assemblies had an appropriate commit hash."
 
-        // verify that all assemblies have a commit hash
+        // verify that all assemblies have an embedded pdb
         let failedVerifyEmbeddedPdb =
             fsharpExecutingWithEmbeddedPdbs
             |> List.filter (fun a -> not (verifyEmbeddedPdb a))

--- a/src/buildtools/buildtools.proj
+++ b/src/buildtools/buildtools.proj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Projects Include="fslex\fslex.fsproj" />
     <Projects Include="fsyacc\fsyacc.fsproj" />
+    <Projects Include="AssemblyCheck\AssemblyCheck.fsproj" />
   </ItemGroup>
 
   <Target Name="Build">

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -49,15 +49,7 @@
         <file src="FSharp.Compiler.Private\$Configuration$\netstandard2.0\FSharp.Compiler.Private.dll"    target="lib\netcoreapp2.1" />
         <file src="FSharp.Build\$Configuration$\netcoreapp2.1\FSharp.Build.dll"                           target="lib\netcoreapp2.1" />
         <file src="FSharp.Compiler.Interactive.Settings\$Configuration$\netstandard2.0\FSharp.Compiler.Interactive.Settings.dll"
-                                                                                                                            target="lib\netcoreapp2.1" />
-        <!-- symbols -->
-        <file src="fsc\$Configuration$\netcoreapp2.1\fsc.pdb"                                             target="lib\netcoreapp2.1" />
-        <file src="fsi\$Configuration$\netcoreapp2.1\fsi.pdb"                                             target="lib\netcoreapp2.1" />
-        <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.pdb"                            target="lib\netcoreapp2.1" />
-        <file src="FSharp.Compiler.Private\$Configuration$\netstandard2.0\FSharp.Compiler.Private.pdb"    target="lib\netcoreapp2.1" />
-        <file src="FSharp.Build\$Configuration$\netcoreapp2.1\FSharp.Build.pdb"                           target="lib\netcoreapp2.1" />
-        <file src="FSharp.Compiler.Interactive.Settings\$Configuration$\netstandard2.0\FSharp.Compiler.Interactive.Settings.pdb"
-                                                                                                                            target="lib\netcoreapp2.1" />
+                                                                                                          target="lib\netcoreapp2.1" />
         <!-- additional files -->
         <file src="fsc\$Configuration$\netcoreapp2.1\default.win32manifest"                               target="contentFiles\any\any" />
         <file src="FSharp.Build\$Configuration$\netcoreapp2.1\Microsoft.FSharp.Targets"                   target="contentFiles\any\any" />
@@ -69,9 +61,9 @@
         <!-- resources -->
         <file src="FSharp.Core\$Configuration$\netstandard1.6\**\FSharp.Core.resources.dll"               target="lib\netcoreapp2.1" />
         <file src="FSharp.Compiler.Private\$Configuration$\netstandard2.0\**\FSharp.Compiler.Private.resources.dll"
-                                                                                                                            target="lib\netcoreapp2.1" />
+                                                                                                          target="lib\netcoreapp2.1" />
         <file src="FSharp.Compiler.Interactive.Settings\$Configuration$\netstandard2.0\**\FSharp.Compiler.Interactive.Settings.resources.dll"
-                                                                                                                            target="lib\netcoreapp2.1" />
+                                                                                                          target="lib\netcoreapp2.1" />
         <file src="FSharp.Build\$Configuration$\netcoreapp2.1\**\FSharp.Build.resources.dll"              target="lib\netcoreapp2.1" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuspec
@@ -38,13 +38,11 @@
     </metadata>
     <files>
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.dll"     target="lib\netstandard1.6" />
-        <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.pdb"     target="lib\netstandard1.6" />
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.sigdata" target="lib\netstandard1.6" />
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.optdata" target="lib\netstandard1.6" />
         <file src="FSharp.Core\$Configuration$\netstandard1.6\FSharp.Core.xml"     target="lib\netstandard1.6" />
 
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.dll"     target="lib\net45" />
-        <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.pdb"     target="lib\net45" />
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.sigdata" target="lib\net45" />
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.optdata" target="lib\net45" />
         <file src="FSharp.Core\$Configuration$\net45\FSharp.Core.xml"     target="lib\net45" />


### PR DESCRIPTION
This fixes #6832 --- The error when reading an F# dll with an embedded pdb file.

The fix is trivial, it just sets the version major field of the Debug Directory entry to 0x100.  The spec was not clear about what this should be.  Tomas has cleared it up.

This PR also embeds a portable pdb in each FSharp product assembly.

The AssemblyVersion validation code has been updated to ensure that the .dll is loadable by SRM and also that the product dll's contain an embedded pdb file.

The AssemblyValidation code is now built as a binary rather than run under fsi.  The reason for this is that, the coreclr contains SRM by default, whereas the desktop does not.

