### PR TITLE
Fix test assert

### DIFF
--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -290,8 +290,10 @@ let main argv = 0"""
                     Assert.AreEqual(expectedErrorMessage, errorMessage)
                 )
 
-    let ParseWithErrors (source: string) expectedParseErrors = 
-        let parseResults = checker.ParseFile("test.fs", SourceText.ofString source, FSharpParsingOptions.Default) |> Async.RunSynchronously
+    let ParseWithErrors (source: string) expectedParseErrors =
+        let sourceFileName = "test.fs"
+        let parsingOptions = { FSharpParsingOptions.Default with SourceFiles = [| sourceFileName |] }
+        let parseResults = checker.ParseFile(sourceFileName, SourceText.ofString source, parsingOptions) |> Async.RunSynchronously
 
         Assert.True(parseResults.ParseHadErrors)
 


### PR DESCRIPTION
In this PR:   https://github.com/dotnet/fsharp/pull/7264

Sergey got an assert when running the test case :  Do Cannot Have Visibility Declarations

The assert happens simply because the ProjectOptions is incorrectly specified.  The options list of sources has no entry for SourceTextBuffer.

This fix, simply says that there is a source file called text.fs in the list of files to be sources.

The test already passed Test.fs in as the file name, this merely pretendes that Test.fs is a part of the project being verified.

With this change Sergey's test no longer asserts it fails with this error message, we seems about right to me.

````
  X Do Cannot Have Visibility Declarations [615ms]
  Error Message:
     Type check errors: [|test.fs (4,5)-(4,12) parse error Accessibility modifiers should come immediately prior to the identifier naming a construct;
  test.fs (4,13)-(4,18) parse error Accessibility modifiers are not permitted on 'do' bindings, but 'Private' was given.;
  test.fs (2,1)-(3,1) parse error Files in libraries or multiple-file applications must begin with a namespace or module declaration, e.g. 'namespace SomeNamespace.SubNamespace' or 'module SomeNamespace.SomeModule'. Only the last source file of an application may omit such a declaration.|]
  Expected: 2
  But was:  3

  Stack Trace:
     at FSharp.Compiler.UnitTests.CompilerAssert.ParseWithErrors(String source, Tuple`4[] expectedParseErrors) in C:\kevinransom\fsharp\tests\fsharp\Compiler\CompilerAssert.fs:line 233
   at FSharp.Compiler.UnitTests.Classes.Do Cannot Have Visibility Declarations() in C:\kevinransom\fsharp\tests\fsharp\Compiler\ErrorMessages\ClassesTests.fs:line 116


````