### PR TITLE
Cambridge test suite - minor issues

### DIFF
--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -139,10 +139,10 @@ let main argv = 0"""
                 File.WriteAllText (runtimeConfigFilePath, """
 {
   "runtimeOptions": {
-    "tfm": "netcoreapp2.1",
+    "tfm": "netcoreapp3.0",
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "2.1.0"
+      "version": "3.0.0-preview6-27804-01"
     }
   }
 }

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -215,7 +215,7 @@ let singleTestBuildAndRunCore cfg copyFiles p =
     let extraSources = ["testlib.fsi";"testlib.fs";"test.mli";"test.ml";"test.fsi";"test.fs";"test2.fsi";"test2.fs";"test.fsx";"test2.fsx"]
     let utilitySources = [__SOURCE_DIRECTORY__  ++ "coreclr_utilities.fs"]
     let referenceItems =  if String.IsNullOrEmpty(copyFiles) then [] else [copyFiles]
-    let framework = "netcoreapp2.0"
+    let framework = "netcoreapp2.1"
 
     // Arguments:
     //    outputType = OutputType.Exe, OutputType.Library or OutputType.Script
@@ -293,8 +293,8 @@ let singleTestBuildAndRunCore cfg copyFiles p =
                 printfn "Filename: %s" projectFileName
 
     match p with
-    | FSC_CORECLR -> executeSingleTestBuildAndRun OutputType.Exe "coreclr" "netcoreapp2.0" true
-    | FSI_CORECLR -> executeSingleTestBuildAndRun OutputType.Script "coreclr" "netcoreapp2.0" true
+    | FSC_CORECLR -> executeSingleTestBuildAndRun OutputType.Exe "coreclr" "netcoreapp2.1" true
+    | FSI_CORECLR -> executeSingleTestBuildAndRun OutputType.Script "coreclr" "netcoreapp2.1" true
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
     | FSC_OPT_PLUS_DEBUG -> executeSingleTestBuildAndRun OutputType.Exe "net40" "net472" true

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -94,7 +94,7 @@ let generateOverrides =
 // Arguments:
 //    pc = ProjectConfiguration
 //    outputType = OutputType.Exe, OutputType.Library or OutputType.Script
-//    targetFramework optimize = "net472" OR NETCOREAPP2.1 etc ...
+//    targetFramework optimize = "net472" OR NETCOREAPP3.0 etc ...
 //    optimize = true or false
 //    configuration = "Release" or "Debug"
 //
@@ -215,12 +215,12 @@ let singleTestBuildAndRunCore cfg copyFiles p =
     let extraSources = ["testlib.fsi";"testlib.fs";"test.mli";"test.ml";"test.fsi";"test.fs";"test2.fsi";"test2.fs";"test.fsx";"test2.fsx"]
     let utilitySources = [__SOURCE_DIRECTORY__  ++ "coreclr_utilities.fs"]
     let referenceItems =  if String.IsNullOrEmpty(copyFiles) then [] else [copyFiles]
-    let framework = "netcoreapp2.1"
+    let framework = "netcoreapp3.0"
 
     // Arguments:
     //    outputType = OutputType.Exe, OutputType.Library or OutputType.Script
     //    compilerType = "coreclr" or "net40"
-    //    targetFramework optimize = "net472" OR NETCOREAPP2.1 etc ...
+    //    targetFramework optimize = "net472" OR NETCOREAPP3.0 etc ...
     //    optimize = true or false
     let executeSingleTestBuildAndRun outputType compilerType targetFramework optimize =
         let mutable result = false
@@ -293,8 +293,8 @@ let singleTestBuildAndRunCore cfg copyFiles p =
                 printfn "Filename: %s" projectFileName
 
     match p with
-    | FSC_CORECLR -> executeSingleTestBuildAndRun OutputType.Exe "coreclr" "netcoreapp2.1" true
-    | FSI_CORECLR -> executeSingleTestBuildAndRun OutputType.Script "coreclr" "netcoreapp2.1" true
+    | FSC_CORECLR -> executeSingleTestBuildAndRun OutputType.Exe "coreclr" "netcoreapp3.0" true
+    | FSI_CORECLR -> executeSingleTestBuildAndRun OutputType.Script "coreclr" "netcoreapp3.0" true
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
     | FSC_OPT_PLUS_DEBUG -> executeSingleTestBuildAndRun OutputType.Exe "net40" "net472" true

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -3,6 +3,7 @@
 open System
 open System.IO
 open System.Diagnostics
+open System.Threading
 open NUnit.Framework
 open TestFramework
 
@@ -227,7 +228,7 @@ let singleTestBuildAndRunCore cfg copyFiles p =
             let mutable result = ""
             lock lockObj <| (fun () ->
                 let rec loop () =
-                    let dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+                    let dir = Path.Combine(Path.GetTempPath(), "FSharp.Cambridge", Path.GetRandomFileName() + "."+ Thread.CurrentThread.ManagedThreadId.ToString())
                     if Directory.Exists(dir) then
                         loop ()
                     else


### PR DESCRIPTION
1.   The Cambridge tests have been failing intermittently due to a bit of a race.
2.   The tests also fail on a machine with no netcoreapp2.0 installed
3.    The CompilerAssert test build when a NetCoreApp2.1 can not be found

1. RACE …..

The fix is simply to include the ManagedThreadId when generating the random file name.  That means even if two threads miraculously pick the same random file name, the actual name will end up different because it include the threadid.

````
Passed   members-ctree-FSC_BASIC
Passed   members-ctree-FSI_BASIC
Failed   members-factors-FSC_BASIC
Error Message:
 Error running command 'C:\kevinransom\fsharp\tests\fsharp\..\..\.dotnet\dotnet.exe' with args 'run -f net472' in directory 'C:\Users\kevinr\AppData\Local\Temp\FSharp.Cambridge\hqohi41b.tuu'.
---- stdout below ---
FSC : error FS0193: The process cannot access the file 'C:\Users\kevinr\AppData\Local\Temp\FSharp.Cambridge\hqohi41b.tuu\obj\release\net472\x30iwyjb.qgu.exe' because it is being used by another process. [C:\Users\kevinr\AppData\Local\Temp\FSharp.Cambridge\hqohi41b.tuu\x30iwyjb.qgu.fsproj]

---- stderr below ---

The build failed. Fix the build errors and run again.
 . ERRORLEVEL 1
Stack Trace:
   at TestFramework.checkResult(CmdResult result) in C:\kevinransom\fsharp\tests\fsharp\test-framework.fs:line 261
   at SingleTest.executeFsc@275.Invoke(String testCompilerVersion, String targetFramework) in C:\kevinransom\fsharp\tests\fsharp\single-test.fs:line 283
   at SingleTest.executeSingleTestBuildAndRun@225.Invoke(OutputType outputType, String compilerType, String targetFramework, Boolean optimize, Boolean buildOnly) in C:\kevinransom\fsharp\tests\fsharp\single-test.fs:line 285
   at SingleTest.singleTestBuildAndRunCore(TestConfig cfg, String copyFiles, Permutation p, String languageVersion) in C:\kevinransom\fsharp\tests\fsharp\single-test.fs:line 314
   at SingleTest.singleTestBuildAndRunAux(TestConfig cfg, Permutation p) in C:\kevinransom\fsharp\tests\fsharp\single-test.fs:line 369
   at SingleTest.singleTestBuildAndRun(String dir, Permutation p) in C:\kevinransom\fsharp\tests\fsharp\single-test.fs:line 376
   at FSharp-Tests-Core.CoreTests.members-factors-FSC_BASIC() in C:\kevinransom\fsharp\tests\fsharp\tests.fs:line 164

Standard Output Messages:
 ------------------ C:\kevinransom\fsharp\tests\fsharp\core\members\factors ---------------
 cd C:\kevinransom\fsharp\tests\fsharp\core\members\factors
 C:\kevinransom\fsharp\tests\fsharp\..\..\.dotnet\dotnet.exe run -f net472 1>C:\Users\kevinr\AppData\Local\Temp\FSharp.Cambridge\hqohi41b.tuu\buildoutput.txt 2>1
 Configuration: C:\kevinransom\fsharp\tests\fsharp\core\members\factors
 Directory: C:\Users\kevinr\AppData\Local\Temp\FSharp.Cambridge\hqohi41b.tuu
 Filename: C:\Users\kevinr\AppData\Local\Temp\FSharp.Cambridge\hqohi41b.tuu\x30iwyjb.qgu.fsproj
````

2.  Netcoreapp2.0 missing
The fix is simply to target netcoreapp2.1 in the tests
````
Passed   Matching Method With Same Name Is Not Abstract
Failed   float 32 with underscores
Error Message:
 It was not possible to find any compatible framework version
The specified framework 'Microsoft.NETCore.App', version '2.1.0' was not found.
  - The following frameworks were found:
      3.0.0-preview6-27804-01 at [C:\kevinransom\fsharp\.dotnet\shared\Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The .NET Core frameworks can be found at:
  - https://aka.ms/dotnet-download

Stack Trace:
   at FSharp.Compiler.UnitTests.CompilerAssert.CompileExeAndRun@222.Invoke(Tuple`2 tupledArg) in C:\kevinransom\fsharp\tests\fsharp\Compiler\CompilerAssert.fs:line 243
   at FSharp.Compiler.UnitTests.CompilerAssert.compile@130.Invoke(Unit unitVar0) in C:\kevinransom\fsharp\tests\fsharp\Compiler\CompilerAssert.fs:line 156
   at FSharp.Compiler.UnitTests.CompilerAssert.compile[a](Boolean isExe, String source, FSharpFunc`2 f) in C:\kevinransom\fsharp\tests\fsharp\Compiler\CompilerAssert.fs:line 130
   at FSharp.Compiler.UnitTests.CompilerAssert.CompileExeAndRun(String source) in C:\kevinransom\fsharp\tests\fsharp\Compiler\CompilerAssert.fs:line 222
   at FSharp.Compiler.UnitTests.Basic Grammar Element Constants.float 32 with underscores() in C:\kevinransom\fsharp\tests\fsharp\Compiler\Conformance\BasicGrammarElements\BasicConstants.fs:line 67

Passed   Invalid member constraint with ErrorRanges
P
````

3. CompilerAssert
   Use netcoreapp3.0 and the framework version that matches the one downloaded by the build.




