### PR TITLE
Cancel task continuations when async contexts are cancelled

### DIFF
--- a/src/fsharp/FSharp.Core/async.fs
+++ b/src/fsharp/FSharp.Core/async.fs
@@ -984,13 +984,9 @@ namespace Microsoft.FSharp.Control
                     else
                         ctxt.cont completedTask.Result) |> unfake
 
-            let cancelContinuation (cancelledTask: Task) : unit =
+            let cancelContinuation (_: Task) : unit =
                 ctxt.trampolineHolder.ExecuteWithTrampoline (fun () ->
-                    if useCcontForTaskCancellation then
-                        ctxt.OnCancellation ()
-                    else
-                        let edi = ExceptionDispatchInfo.Capture(TaskCanceledException cancelledTask)
-                        ctxt.CallExceptionContinuation edi
+                    ctxt.OnCancellation ()
                 ) |> unfake
 
             task
@@ -1015,13 +1011,9 @@ namespace Microsoft.FSharp.Control
                     else
                         ctxt.cont ()) |> unfake
 
-            let cancelContinuation (cancelledTask: Task) : unit =
+            let cancelContinuation (_: Task) : unit =
                 ctxt.trampolineHolder.ExecuteWithTrampoline (fun () ->
-                    if useCcontForTaskCancellation then
-                        ctxt.OnCancellation ()
-                    else
-                        let edi = ExceptionDispatchInfo.Capture(new TaskCanceledException(cancelledTask))
-                        ctxt.CallExceptionContinuation edi
+                    ctxt.OnCancellation ()
                 ) |> unfake
 
             task


### PR DESCRIPTION
Currently if you transform a task into an async via Async.AwaitTask and
then run that async the continuation added to the underlying task is
only ever resolved if the task itself resolved (either via completion,
exception, or cancellation). Notably if the async created by
Async.AwaitTask is cancelled the task continuation isn't.

We're seeing this manifest as a large memory leak when we repeatedly run
Async.Choice with a task that only resolves if an error elsewhere in the
system is hit. Each time we run Async.Choice it appends another task
continuation, the async is then cancelled (so if the task did resolve
the async continuation would immediately see it was cancelled anyway)
but critically the task continuations are not cancelled and so stay
allocated.

This commit changes the task continuation to now cancel if the asyncs
cancellation token requests cancellation. Note that we need to have a
second continuation to watch for the case that the first continuation is
cancelled and thus never run, the second continuation then triggers the
async cancellation or exception continuation as appropriate.

This also means that some asyncs will now report cancelled sooner (see
the changes to the StartAsTaskCancellation test) while before they would
of been blocked waiting for a task to complete before any of their
continuations could run.