### PR TITLE
move attribution of F# Software Foundation to package description

### DIFF
--- a/.vsts-signed.yaml
+++ b/.vsts-signed.yaml
@@ -148,7 +148,5 @@ stages:
 
 - template: eng/common/templates/post-build/post-build.yml
   parameters:
-    # NuGet validation currently fails due to the `<author>` field of the package being set to `Microsoft and F# Software Foundation` instead of just `Microsoft`
-    enableNugetValidation: false
     # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
     enableSymbolValidation: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -320,7 +320,5 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/common/templates/post-build/post-build.yml
     parameters:
-      # NuGet validation currently fails due to the `<author>` field of the package being set to `Microsoft and F# Software Foundation` instead of just `Microsoft`
-      enableNugetValidation: false
       # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
       enableSymbolValidation: false

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Authors>Microsoft and F# Software Foundation</Authors>
     <PackageTags>Visual F# Compiler FSharp functional programming</PackageTags>
     <NuspecBasePath>$(ArtifactsBinDir)</NuspecBasePath>
   </PropertyGroup>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.csproj
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.csproj
@@ -6,7 +6,7 @@
     <PackageId>FSharp.Core</PackageId>
     <NuspecFile>FSharp.Core.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>
-    <PackageDescription>FSharp.Core redistributables from Visual F# Tools version $(FSPackageMajorVersion) For F# $(FSCoreMajorVersion)</PackageDescription>
+    <PackageDescription>FSharp.Core redistributables from Visual F# Tools version $(FSPackageMajorVersion) For F# $(FSCoreMajorVersion).  Contains code from the F# Software Foundation.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Due to internal package publishing policies, the author of a package published via a Microsoft account must be exactly 'Microsoft'.  To preserve attribution to the F# Software Foundation, mention is made in the  `<description>` tag of FSharp.Core.

Internal validation build passed.