### PR TITLE
Use GetFullPath when determining the full path in command line options

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -378,11 +378,15 @@ type internal FSharpProjectOptionsManager
             match Microsoft.CodeAnalysis.ExternalAccess.FSharp.LanguageServices.FSharpVisualStudioWorkspaceExtensions.TryGetProjectIdByBinPath(workspace, path) with
             | true, projectId -> projectId
             | false, _ -> Microsoft.CodeAnalysis.ExternalAccess.FSharp.LanguageServices.FSharpVisualStudioWorkspaceExtensions.GetOrCreateProjectIdForPath(workspace, path, projectDisplayNameOf path)
-        let path = Microsoft.CodeAnalysis.ExternalAccess.FSharp.LanguageServices.FSharpVisualStudioWorkspaceExtensions.GetProjectFilePath(workspace, projectId);
-        let fullPath p =
-            if Path.IsPathRooted(p) || path = null then p
-            else Path.Combine(Path.GetDirectoryName(path), p)
-        let sourcePaths = sources |> Seq.map(fun s -> fullPath s.Path) |> Seq.toArray
+        let path = Microsoft.CodeAnalysis.ExternalAccess.FSharp.LanguageServices.FSharpVisualStudioWorkspaceExtensions.GetProjectFilePath(workspace, projectId)
+
+        let getFullPath p =
+            let p' =
+                if Path.IsPathRooted(p) || path = null then p
+                else Path.Combine(Path.GetDirectoryName(path), p)
+            Path.GetFullPathSafe(p')
+
+        let sourcePaths = sources |> Seq.map(fun s -> getFullPath s.Path) |> Seq.toArray
 
         reactor.SetCpsCommandLineOptions(projectId, sourcePaths, options.ToArray())
 


### PR DESCRIPTION
Fixes #4016, #5521, #4446

This is @chadunit's idea here: https://github.com/dotnet/fsharp/issues/4016#issuecomment-348663946

Quick writeup:

* When QuickInfo navigation is built out, it uses ranges coming from the actual F# symbol(s) it has access to. The ranges for these symbols include path information that has been normalized.
* When f12 is invoked, it calls into a [route](https://github.com/dotnet/fsharp/blob/03538255e20a0bff7b2427d95b22bd9233838c0b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs#L712-L716) that creates a `range` type based on the file name that the editor host supplies.
* The VS editor host *did not* normalize file paths prior to this change, so the 2nd point means that the `range` types created won't match actual `range`s that live on a symbol
* This discrepancy causes a failure in an equality check in name resolution
* This equality failure results in an inability to navigate to the symbol under the caret