### PR TITLE
[release/dev16.4] cherry-pick yaml updates to 16.4

### DIFF
--- a/.vsts-signed.yaml
+++ b/.vsts-signed.yaml
@@ -148,7 +148,5 @@ stages:
 
 - template: eng/common/templates/post-build/post-build.yml
   parameters:
-    # NuGet validation currently fails due to the `<author>` field of the package being set to `Microsoft and F# Software Foundation` instead of just `Microsoft`
-    enableNugetValidation: false
     # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
     enableSymbolValidation: false

--- a/.vsts-signed.yaml
+++ b/.vsts-signed.yaml
@@ -11,117 +11,144 @@ variables:
 #- name: SkipTests
 #  defaultValue: false
 
-jobs:
-- job: Full_Signed
-  pool:
-    name: VSEng-MicroBuildVS2019
-  timeoutInMinutes: 300
-  variables:
-    BuildConfiguration: 'Release'
-  steps:
+stages:
+- stage: build
+  displayName: Build
 
-  # Install Signing Plugin
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
-    displayName: Install Signing Plugin
-    inputs:
-      signType: real
-      esrpSigning: true
-    condition: and(succeeded(), ne(variables['SignType'], ''))
-
-  # Build
-  - script: eng\CIBuild.cmd
-            -configuration $(BuildConfiguration)
-            -testAll
-            -officialSkipTests $(SkipTests)
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-            /p:VisualStudioDropName=$(VisualStudioDropName)
-            /p:DotNetSignType=$(SignType)
-            /p:DotNetPublishToBlobFeed=true
-            /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-            /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            /p:PublishToSymbolServer=true
-            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-    displayName: Build
-
-  # Publish logs
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Logs
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
-      ArtifactName: 'Build Diagnostic Files'
-      publishLocation: Container
-    continueOnError: true
-    condition: succeededOrFailed()
-
-  # Publish test results
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Test Results
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults'
-      ArtifactName: 'Test Results'
-      publishLocation: Container
-    continueOnError: true
-    condition: and(succeededOrFailed(), ne(variables['SkipTests'], 'true'))
-
-  # Upload VSTS Drop
-  - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
-    displayName: Upload VSTS Drop
-    inputs:
-      DropName: $(VisualStudioDropName)
-      DropFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-    condition: succeeded()
-
-  # Publish an artifact that the RoslynInsertionTool is able to find by its name.
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifact VSSetup
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-      ArtifactName: 'VSSetup'
-    condition: succeeded()
-
-  # Archive NuGet packages to DevOps.
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifact Packages
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)'
-      ArtifactName: 'Packages'
-    condition: succeeded()
-
-  # Publish nightly package to ADO
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifact Nightly
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\VisualFSharpFull.vsix'
-      ArtifactName: 'Nightly'
-    condition: succeeded()
-
-  # Package publish
-  - task: PublishBuildArtifacts@1
-    displayName: Push Asset Manifests
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
-      ArtifactName: AssetManifests
-    continueOnError: true
-    condition: succeeded()
-
-  # Publish native PDBs for archiving
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifact Symbols
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/SymStore/$(BuildConfiguration)'
-      ArtifactName: NativeSymbols
-    condition: succeeded()
-
-  # Execute cleanup tasks
-  - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-    displayName: Execute cleanup tasks
-    condition: succeededOrFailed()
-
-- template: /eng/common/templates/job/publish-build-assets.yml
-  parameters:
-    dependsOn:
-    - Full_Signed
+  jobs:
+  - job: Full_Signed
     pool:
-      vmImage: windows-2019
-    enablePublishBuildArtifacts: true
+      name: VSEng-MicroBuildVS2019
+    timeoutInMinutes: 300
+    variables:
+      BuildConfiguration: 'Release'
+    steps:
+
+    # Install Signing Plugin
+    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+      displayName: Install Signing Plugin
+      inputs:
+        signType: real
+        esrpSigning: true
+      condition: and(succeeded(), ne(variables['SignType'], ''))
+
+    # Build
+    - script: eng\CIBuild.cmd
+              -configuration $(BuildConfiguration)
+              -testAll
+              -officialSkipTests $(SkipTests)
+              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+              /p:VisualStudioDropName=$(VisualStudioDropName)
+              /p:DotNetSignType=$(SignType)
+              /p:DotNetPublishToBlobFeed=true
+              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+              /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              /p:PublishToSymbolServer=true
+              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+      displayName: Build
+
+    # Publish logs
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
+        ArtifactName: 'Build Diagnostic Files'
+        publishLocation: Container
+      continueOnError: true
+      condition: succeededOrFailed()
+
+    # Publish test results
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Test Results
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults'
+        ArtifactName: 'Test Results'
+        publishLocation: Container
+      continueOnError: true
+      condition: and(succeededOrFailed(), ne(variables['SkipTests'], 'true'))
+
+    # Upload VSTS Drop
+    - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+      displayName: Upload VSTS Drop
+      inputs:
+        DropName: $(VisualStudioDropName)
+        DropFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+      condition: succeeded()
+
+    # Publish an artifact that the RoslynInsertionTool is able to find by its name.
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact VSSetup
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+        ArtifactName: 'VSSetup'
+      condition: succeeded()
+
+    # Archive NuGet packages to DevOps.
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact Packages
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)'
+        ArtifactName: 'Packages'
+      condition: succeeded()
+
+    # Publish nightly package to ADO
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact Nightly
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\VisualFSharpFull.vsix'
+        ArtifactName: 'Nightly'
+      condition: succeeded()
+
+    # Package publish
+    - task: PublishBuildArtifacts@1
+      displayName: Push Asset Manifests
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
+        ArtifactName: AssetManifests
+      continueOnError: true
+      condition: succeeded()
+
+    # Publish PackageArtifacts for Arcade verification
+    - task: PublishBuildArtifacts@1
+      displayName: Publish PackageArtifacts
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)\Shipping'
+        ArtifactName: 'PackageArtifacts'
+      condition: succeeded()
+
+    # Publish BlobArtifacts for Arcade verification
+    - task: PublishBuildArtifacts@1
+      displayName: Publish BlobArtifacts
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)\Shipping'
+        ArtifactName: 'BlobArtifacts'
+      condition: succeeded()
+
+    # Publish native PDBs for archiving
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact Symbols
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/SymStore/$(BuildConfiguration)'
+        ArtifactName: NativeSymbols
+      condition: succeeded()
+
+    # Execute cleanup tasks
+    - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+      displayName: Execute cleanup tasks
+      condition: succeededOrFailed()
+
+  - template: /eng/common/templates/job/publish-build-assets.yml
+    parameters:
+      dependsOn:
+      - Full_Signed
+      pool:
+        vmImage: windows-2019
+      enablePublishBuildArtifacts: true
+
+- template: eng/common/templates/post-build/post-build.yml
+  parameters:
+    # NuGet validation currently fails due to the `<author>` field of the package being set to `Microsoft and F# Software Foundation` instead of just `Microsoft`
+    enableNugetValidation: false
+    # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
+    enableSymbolValidation: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,7 @@ stages:
           variables:
           - group: DotNet-Blob-Feed
           - group: DotNet-Symbol-Server-Pats
+          - group: DotNet-DevDiv-Insertion-Workflow-Variables
           - name: _SignType
             value: Real
           - name: _DotNetPublishToBlobFeed
@@ -121,6 +122,13 @@ stages:
             inputs:
               PathtoPublish: '$(Build.SourcesDirectory)\artifacts\SymStore\$(_BuildConfig)'
               ArtifactName: 'NativeSymbols'
+            condition: succeeded()
+          - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+            displayName: Upload VSTS Drop
+            inputs:
+              DropName: $(VisualStudioDropName)
+              DropFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\Insertion'
+              AccessToken: $(dn-bot-devdiv-drop-rw-code-rw)
             condition: succeeded()
 
   #-------------------------------------------------------------------------------------------------------------------#

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,285 +28,299 @@ variables:
 #- name: SkipTests
 #  defaultValue: false
 
-jobs:
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+
+  #-------------------------------------------------------------------------------------------------------------------#
+  #                                                  Signed build                                                     #
+  #-------------------------------------------------------------------------------------------------------------------#
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        enableMicrobuild: true
+        enablePublishBuildArtifacts: true
+        enablePublishTestResults: false
+        enablePublishBuildAssets: true
+        enablePublishUsingPipelines: $(_PublishUsingPipelines)
+        enableTelemetry: true
+        helixRepo: dotnet/fsharp
+        jobs:
+        - job: Full_Signed
+          pool:
+            name: NetCoreInternal-Pool
+            queue: buildpool.windows.10.amd64.vs2019
+          timeoutInMinutes: 300
+          variables:
+          - group: DotNet-Blob-Feed
+          - group: DotNet-Symbol-Server-Pats
+          - name: _SignType
+            value: Real
+          - name: _DotNetPublishToBlobFeed
+            value: true
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng\CIBuild.cmd
+                    -configuration $(_BuildConfig)
+                    -prepareMachine
+                    -testAll
+                    -officialSkipTests $(SkipTests)
+                    /p:SignType=$(_SignType)
+                    /p:DotNetSignType=$(_SignType)
+                    /p:MicroBuild_SigningEnabled=true
+                    /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                    /p:TeamName=$(_TeamName)
+                    /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                    /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                    /p:DotNetPublishToBlobFeed=true
+                    /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                    /p:PublishToSymbolServer=true
+                    /p:VisualStudioDropName=$(VisualStudioDropName)
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '*.xml'
+              searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+            continueOnError: true
+            condition: ne(variables['SkipTests'], 'true')
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Test Logs
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)'
+              ArtifactName: 'Test Logs'
+              publishLocation: Container
+            continueOnError: true
+            condition: ne(variables['SkipTests'], 'true')
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Artifact Packages
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)'
+              ArtifactName: 'Packages'
+            condition: succeeded()
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Artifact VSSetup
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\Insertion'
+              ArtifactName: 'VSSetup'
+            condition: succeeded()
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Artifact Nightly
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\VisualFSharpFull.vsix'
+              ArtifactName: 'Nightly'
+            condition: succeeded()
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Artifact Symbols
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\SymStore\$(_BuildConfig)'
+              ArtifactName: 'NativeSymbols'
+            condition: succeeded()
+
+  #-------------------------------------------------------------------------------------------------------------------#
+  #                                                    PR builds                                                      #
+  #-------------------------------------------------------------------------------------------------------------------#
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        enableMicrobuild: true
+        enablePublishBuildArtifacts: true
+        enablePublishTestResults: false
+        enablePublishBuildAssets: true
+        enablePublishUsingPipelines: $(_PublishUsingPipelines)
+        enableTelemetry: true
+        helixRepo: dotnet/fsharp
+        jobs:
+
+        # Windows
+        - job: Windows
+          pool:
+            vmImage: windows-2019
+          timeoutInMinutes: 120
+          strategy:
+            maxParallel: 4
+            matrix:
+              desktop_release:
+                _configuration: Release
+                _testKind: testDesktop
+              coreclr_release:
+                _configuration: Release
+                _testKind: testCoreclr
+              fsharpqa_release:
+                _configuration: Release
+                _testKind: testFSharpQA
+              vs_release:
+                _configuration: Release
+                _testKind: testVs
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng\CIBuild.cmd -configuration $(_configuration) -$(_testKind)
+            displayName: Build / Test
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '*.xml'
+              searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_configuration)'
+            continueOnError: true
+            condition: ne(variables['_testKind'], 'testFSharpQA')
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Test Logs
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(_configuration)'
+              ArtifactName: 'Windows $(_configuration) $(_testKind) test logs'
+              publishLocation: Container
+            continueOnError: true
+            condition: eq(variables['_testKind'], 'testFSharpQA')
+
+        # Linux
+        - job: Linux
+          pool:
+            vmImage: ubuntu-16.04
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./eng/cibuild.sh --configuration $(_BuildConfig) --testcoreclr
+            displayName: Build / Test
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '*.xml'
+              searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+            continueOnError: true
+            condition: always()
+
+        # MacOS
+        - job: MacOS
+          pool:
+            vmImage: macOS-10.13
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./eng/cibuild.sh --configuration $(_BuildConfig) --testcoreclr
+            displayName: Build / Test
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '*.xml'
+              searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+            continueOnError: true
+            condition: always()
+
+        # Source Build Linux
+        - job: SourceBuild_Linux
+          pool:
+            vmImage: ubuntu-16.04
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./eng/cibuild.sh --configuration Release /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
+            displayName: Build
+
+        # Source Build Windows
+        - job: SourceBuild_Windows
+          pool:
+            vmImage: windows-2019
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng\CIBuild.cmd -configuration Release -noSign /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
+            displayName: Build
+
+        # Up-to-date
+        - job: UpToDate_Windows
+          pool:
+            vmImage: windows-2019
+          steps:
+          - checkout: self
+            clean: true
+          - task: PowerShell@2
+            displayName: Run up-to-date build check
+            inputs:
+              filePath: eng\tests\UpToDate.ps1
+              arguments: -configuration $(_BuildConfig) -ci -binaryLog
+
+  #-------------------------------------------------------------------------------------------------------------------#
+  #                                                   FCS builds                                                      #
+  #-------------------------------------------------------------------------------------------------------------------#
+
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        enableMicrobuild: true
+        enablePublishTestResults: false
+        enablePublishBuildAssets: true
+        enablePublishUsingPipelines: false
+        enableTelemetry: true
+        helixRepo: dotnet/fsharp
+        jobs:
+
+        - job: Windows_FCS
+          pool:
+            vmImage: windows-2019
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: fcs\build.cmd TestAndNuget
+            displayName: Build / Test
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '*.xml'
+              searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
+            continueOnError: true
+            condition: always()
+
+        - job: Linux_FCS
+          pool:
+            vmImage: ubuntu-16.04
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./fcs/build.sh Build
+            displayName: Build
+
+        - job: MacOS_FCS
+          pool:
+            vmImage: macOS-10.13
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./fcs/build.sh Build
+            displayName: Build
 
 #---------------------------------------------------------------------------------------------------------------------#
-#                                                   Signed build                                                      #
+#                                                    Post Build                                                       #
 #---------------------------------------------------------------------------------------------------------------------#
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/jobs/jobs.yml
+  - template: eng/common/templates/post-build/post-build.yml
     parameters:
-      enableMicrobuild: true
-      enablePublishBuildArtifacts: true
-      enablePublishTestResults: false
-      enablePublishBuildAssets: true
-      enablePublishUsingPipelines: $(_PublishUsingPipelines)
-      enableTelemetry: true
-      helixRepo: dotnet/fsharp
-      jobs:
-      - job: Full_Signed
-        pool:
-          name: NetCoreInternal-Int-Pool
-          queue: buildpool.windows.10.amd64.vs2019
-        timeoutInMinutes: 300
-        variables:
-        - group: DotNet-Blob-Feed
-        - group: DotNet-Symbol-Server-Pats
-        - name: _SignType
-          value: Real
-        - name: _DotNetPublishToBlobFeed
-          value: true
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng\CIBuild.cmd
-                  -configuration $(_BuildConfig)
-                  -prepareMachine
-                  -testAll
-                  -officialSkipTests $(SkipTests)
-                  /p:SignType=$(_SignType)
-                  /p:DotNetSignType=$(_SignType)
-                  /p:MicroBuild_SigningEnabled=true
-                  /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                  /p:TeamName=$(_TeamName)
-                  /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                  /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                  /p:DotNetPublishToBlobFeed=true
-                  /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-                  /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                  /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                  /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                  /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                  /p:PublishToSymbolServer=true
-                  /p:VisualStudioDropName=$(VisualStudioDropName)
-        - task: PublishTestResults@2
-          displayName: Publish Test Results
-          inputs:
-            testResultsFormat: 'NUnit'
-            testResultsFiles: '*.xml'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-          continueOnError: true
-          condition: ne(variables['SkipTests'], 'true')
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Test Logs
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)'
-            ArtifactName: 'Test Logs'
-            publishLocation: Container
-          continueOnError: true
-          condition: ne(variables['SkipTests'], 'true')
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Artifact Packages
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)'
-            ArtifactName: 'Packages'
-          condition: succeeded()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Artifact VSSetup
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\Insertion'
-            ArtifactName: 'VSSetup'
-          condition: succeeded()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Artifact Nightly
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\VisualFSharpFull.vsix'
-            ArtifactName: 'Nightly'
-          condition: succeeded()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Artifact Symbols
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\SymStore\$(_BuildConfig)'
-            ArtifactName: 'NativeSymbols'
-          condition: succeeded()
-
-#---------------------------------------------------------------------------------------------------------------------#
-#                                                     PR builds                                                       #
-#---------------------------------------------------------------------------------------------------------------------#
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableMicrobuild: true
-      enablePublishBuildArtifacts: true
-      enablePublishTestResults: false
-      enablePublishBuildAssets: true
-      enablePublishUsingPipelines: $(_PublishUsingPipelines)
-      enableTelemetry: true
-      helixRepo: dotnet/fsharp
-      jobs:
-
-      # Windows
-      - job: Windows
-        pool:
-          vmImage: windows-2019
-        timeoutInMinutes: 120
-        strategy:
-          maxParallel: 4
-          matrix:
-            desktop_release:
-              _configuration: Release
-              _testKind: testDesktop
-            coreclr_release:
-              _configuration: Release
-              _testKind: testCoreclr
-            fsharpqa_release:
-              _configuration: Release
-              _testKind: testFSharpQA
-            vs_release:
-              _configuration: Release
-              _testKind: testVs
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng\CIBuild.cmd -configuration $(_configuration) -$(_testKind)
-          displayName: Build / Test
-        - task: PublishTestResults@2
-          displayName: Publish Test Results
-          inputs:
-            testResultsFormat: 'NUnit'
-            testResultsFiles: '*.xml'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_configuration)'
-          continueOnError: true
-          condition: ne(variables['_testKind'], 'testFSharpQA')
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Test Logs
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(_configuration)'
-            ArtifactName: 'Windows $(_configuration) $(_testKind) test logs'
-            publishLocation: Container
-          continueOnError: true
-          condition: eq(variables['_testKind'], 'testFSharpQA')
-
-      # Linux
-      - job: Linux
-        pool:
-          vmImage: ubuntu-16.04
-        variables:
-        - name: _SignType
-          value: Test
-        steps:
-        - checkout: self
-          clean: true
-        - script: ./eng/cibuild.sh --configuration $(_BuildConfig) --testcoreclr
-          displayName: Build / Test
-        - task: PublishTestResults@2
-          displayName: Publish Test Results
-          inputs:
-            testResultsFormat: 'NUnit'
-            testResultsFiles: '*.xml'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-          continueOnError: true
-          condition: always()
-
-      # MacOS
-      - job: MacOS
-        pool:
-          vmImage: macOS-10.13
-        variables:
-        - name: _SignType
-          value: Test
-        steps:
-        - checkout: self
-          clean: true
-        - script: ./eng/cibuild.sh --configuration $(_BuildConfig) --testcoreclr
-          displayName: Build / Test
-        - task: PublishTestResults@2
-          displayName: Publish Test Results
-          inputs:
-            testResultsFormat: 'NUnit'
-            testResultsFiles: '*.xml'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-          continueOnError: true
-          condition: always()
-
-      # Source Build Linux
-      - job: SourceBuild_Linux
-        pool:
-          vmImage: ubuntu-16.04
-        steps:
-        - checkout: self
-          clean: true
-        - script: ./eng/cibuild.sh --configuration Release /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
-          displayName: Build
-
-      # Source Build Windows
-      - job: SourceBuild_Windows
-        pool:
-          vmImage: windows-2019
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng\CIBuild.cmd -configuration Release -noSign /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
-          displayName: Build
-
-      # Up-to-date
-      - job: UpToDate_Windows
-        pool:
-          vmImage: windows-2019
-        steps:
-        - checkout: self
-          clean: true
-        - task: PowerShell@2
-          displayName: Run up-to-date build check
-          inputs:
-            filePath: eng\tests\UpToDate.ps1
-            arguments: -configuration $(_BuildConfig) -ci -binaryLog
-
-#---------------------------------------------------------------------------------------------------------------------#
-#                                                    FCS builds                                                       #
-#---------------------------------------------------------------------------------------------------------------------#
-
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableMicrobuild: true
-      enablePublishTestResults: false
-      enablePublishBuildAssets: true
-      enablePublishUsingPipelines: false
-      enableTelemetry: true
-      helixRepo: dotnet/fsharp
-      jobs:
-
-      - job: Windows_FCS
-        pool:
-          vmImage: windows-2019
-        variables:
-        - name: _SignType
-          value: Test
-        steps:
-        - checkout: self
-          clean: true
-        - script: fcs\build.cmd TestAndNuget
-          displayName: Build / Test
-        - task: PublishTestResults@2
-          displayName: Publish Test Results
-          inputs:
-            testResultsFormat: 'NUnit'
-            testResultsFiles: '*.xml'
-            searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
-          continueOnError: true
-          condition: always()
-
-      - job: Linux_FCS
-        pool:
-          vmImage: ubuntu-16.04
-        variables:
-        - name: _SignType
-          value: Test
-        steps:
-        - checkout: self
-          clean: true
-        - script: ./fcs/build.sh Build
-          displayName: Build
-
-      - job: MacOS_FCS
-        pool:
-          vmImage: macOS-10.13
-        variables:
-        - name: _SignType
-          value: Test
-        steps:
-        - checkout: self
-          clean: true
-        - script: ./fcs/build.sh Build
-          displayName: Build
+      # NuGet validation currently fails due to the `<author>` field of the package being set to `Microsoft and F# Software Foundation` instead of just `Microsoft`
+      enableNugetValidation: false
+      # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
+      enableSymbolValidation: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -320,7 +320,5 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/common/templates/post-build/post-build.yml
     parameters:
-      # NuGet validation currently fails due to the `<author>` field of the package being set to `Microsoft and F# Software Foundation` instead of just `Microsoft`
-      enableNugetValidation: false
       # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
       enableSymbolValidation: false

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Authors>Microsoft and F# Software Foundation</Authors>
     <PackageTags>Visual F# Compiler FSharp functional programming</PackageTags>
     <NuspecBasePath>$(ArtifactsBinDir)</NuspecBasePath>
   </PropertyGroup>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.csproj
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.csproj
@@ -6,7 +6,7 @@
     <PackageId>FSharp.Core</PackageId>
     <NuspecFile>FSharp.Core.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>
-    <PackageDescription>FSharp.Core redistributables from Visual F# Tools version $(FSPackageMajorVersion) For F# $(FSCoreMajorVersion)</PackageDescription>
+    <PackageDescription>FSharp.Core redistributables from Visual F# Tools version $(FSPackageMajorVersion) For F# $(FSCoreMajorVersion).  Contains code from the F# Software Foundation.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Necessary so the 16.4 branch can build correctly since it's not getting auto-flow updates from `master`.