### PR TITLE
Added inref immutability assumption removal 

### DIFF
--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -946,10 +946,15 @@ let TakeObjAddrForMethodCall g amap (minfo: MethInfo) isMutable m objArgs f =
             let objArgTy = tyOfExpr g objArgExpr
             
             let isMutable =
-                if isMutable <> NeverMutates && CanMethodNeverMutate g m minfo then
-                    NeverMutates
-                else
-                    isMutable
+                match isMutable with
+                | DefinitelyMutates
+                | NeverMutates 
+                | AddressOfOp -> isMutable
+                | PossiblyMutates ->
+                    if CanMethodNeverMutate g m minfo then
+                        NeverMutates
+                    else
+                        isMutable
 
             let wrap, objArgExprAddr, isReadOnly, _isWriteOnly =
                 mkExprAddrOfExpr g mustTakeAddress hasCallInfo isMutable objArgExpr None m

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -930,11 +930,6 @@ let ComputeConstrainedCallInfo g amap m (objArgs, minfo: MethInfo) =
 let TakeObjAddrForMethodCall g amap (minfo: MethInfo) isMutable m objArgs f =
     let ccallInfo = ComputeConstrainedCallInfo g amap m (objArgs, minfo)
 
-    let inline isObjArgReadOnlyExtensionMember amap m (minfo: MethInfo) =
-        minfo.IsCSharpStyleExtensionMember && 
-        minfo.TryObjArgByrefType(amap, m, minfo.FormalMethodInst)
-        |> Option.exists (isInByrefTy g)
-
     let wrap, objArgs = 
 
         match objArgs with
@@ -951,8 +946,8 @@ let TakeObjAddrForMethodCall g amap (minfo: MethInfo) isMutable m objArgs f =
                 | AddressOfOp -> isMutable
                 | PossiblyMutates ->
                     // Check to see if the method is read-only. Perf optimization.
-                    // If there is an extension member whose obj arg (receiver) is an inref, we must return NeverMutates.
-                    if mustTakeAddress && (minfo.IsReadOnly || isObjArgReadOnlyExtensionMember amap m minfo) then
+                    // If there is an extension member whose first arg is an inref, we must return NeverMutates.
+                    if mustTakeAddress && (minfo.IsReadOnly || minfo.IsReadOnlyExtensionMember (amap, m)) then
                         NeverMutates
                     else
                         isMutable

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -263,7 +263,8 @@ let GetLimitValByRef cenv env m v =
     { scope = scope; flags = flags }
 
 let LimitVal cenv (v: Val) limit = 
-    cenv.limitVals.[v.Stamp] <- limit
+    if not v.IgnoresByrefScope then
+        cenv.limitVals.[v.Stamp] <- limit
 
 let BindVal cenv env (v: Val) = 
     //printfn "binding %s..." v.DisplayName

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -6051,9 +6051,8 @@ let CanTakeAddressOfUnionFieldRef (g: TcGlobals) m (uref: UnionCaseRef) cidx tin
 
 let mkDerefAddrExpr mAddrGet expr mExpr exprTy =
     let rec remap mAddrGet expr mExpr exprTy contf =
-        match expr with
-        // This helps chained method calls by preventing defensive copies.
         // To do this properly with the byref scoping rules, we need to dereference directly on the call, rather than the whole expression.
+        match expr with
         | Expr.Let (bind, bodyExpr, m, freeVars) ->
             remap mAddrGet bodyExpr mExpr exprTy (contf << fun bodyExpr' -> Expr.Let (bind, bodyExpr', m, freeVars))
         | _ ->
@@ -6070,6 +6069,7 @@ let tryEraseDerefAddr g expr mut =
                   (MustTakeAddressOfByrefGet g vref2 || CanTakeAddressOfByrefGet g vref2 mut) -> 
             ValueSome (contf e)
 
+        // This helps chained method calls by preventing defensive copies.
         | Expr.Let (bind, bodyExpr, m, freeVars) ->
             remap g bodyExpr mut (contf << fun bodyExpr' -> Expr.Let (bind, bodyExpr', m, freeVars))
 

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -8991,3 +8991,7 @@ let isStaticClass (g:TcGlobals) (x: EntityRef) =
 #endif
      || (not x.IsILTycon && not x.IsProvided && HasFSharpAttribute g g.attrib_AbstractClassAttribute x.Attribs)) &&
     not (HasFSharpAttribute g g.attrib_RequireQualifiedAccessAttribute x.Attribs)
+
+let mkDereferencedByrefExpr mAddrGet expr mExpr exprTy =
+    let v, _ = mkCompGenLocal mAddrGet "byrefReturn" exprTy
+    mkCompGenLet mExpr v expr (mkAddrGet mAddrGet (mkLocalValRef v))

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -6008,7 +6008,11 @@ let MustTakeAddressOfByrefGet (g: TcGlobals) (vref: ValRef) =
 
 let CanTakeAddressOfByrefGet (g: TcGlobals) (vref: ValRef) mut = 
     isInByrefTy g vref.Type &&
-    CanTakeAddressOf g vref.Range (destByrefTy g vref.Type) mut
+    let destTy = destByrefTy g vref.Type
+    CanTakeAddressOf g vref.Range destTy mut &&
+    // If we have a .NET defined struct, we return false.
+    // We do not want to use the same immutability assumption on .NET structs for inref.
+    (isFSharpStructTy g destTy || isEnumTy g destTy)
 
 let MustTakeAddressOfRecdField (rfref: RecdField) = 
     // Static mutable fields must be private, hence we don't have to take their address

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -1679,11 +1679,6 @@ let isILReferenceTy g ty =
     | ILTypeMetadata (TILObjectReprData(_, _, td)) -> not td.IsStructOrEnum
     | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> isArrayTy g ty
 
-let isILStructTy g ty =
-    match tryDestAppTy g ty with
-    | ValueSome tcref -> tcref.Deref.IsILStructOrEnumTycon
-    | _ -> false
-
 let isILInterfaceTycon (tycon: Tycon) = 
     match metadataOfTycon tycon with 
 #if !NO_EXTENSIONTYPING

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -1679,6 +1679,11 @@ let isILReferenceTy g ty =
     | ILTypeMetadata (TILObjectReprData(_, _, td)) -> not td.IsStructOrEnum
     | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> isArrayTy g ty
 
+let isILStructTy g ty =
+    match tryDestAppTy g ty with
+    | ValueSome tcref -> tcref.Deref.IsILStructOrEnumTycon
+    | _ -> false
+
 let isILInterfaceTycon (tycon: Tycon) = 
     match metadataOfTycon tycon with 
 #if !NO_EXTENSIONTYPING
@@ -6012,7 +6017,7 @@ let CanTakeAddressOfByrefGet (g: TcGlobals) (vref: ValRef) mut =
     CanTakeAddressOf g vref.Range destTy mut &&
     // If we have a .NET defined struct, we return false.
     // We do not want to use the same immutability assumption on .NET structs for inref.
-    (isFSharpStructTy g destTy || isEnumTy g destTy)
+    (not (isILStructTy g destTy) || isEnumTy g destTy)
 
 let MustTakeAddressOfRecdField (rfref: RecdField) = 
     // Static mutable fields must be private, hence we don't have to take their address

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -6023,22 +6023,19 @@ let MustTakeAddressOfByrefGet (g: TcGlobals) (vref: ValRef) =
 
 let CanTakeAddressOfByrefGet (g: TcGlobals) (vref: ValRef) mut = 
     isInByrefTy g vref.Type && 
-    CanTakeAddressOf g vref.Range (destByrefTy g vref.Type) mut
-
-let NoDefensiveCopy g m ty mut =
-    isInByrefTy g ty && 
+    let destTy = destByrefTy g vref.Type
+    CanTakeAddressOf g vref.Range destTy mut &&
     match mut with
     | DefinitelyMutates -> false
     | NeverMutates
     | AddressOfOp -> true
     | PossiblyMutates -> 
-        let destTy = destByrefTy g ty
         // Do not assume immutability for IL types on 'inref'.
         match tryDestAppTy g destTy with
         | ValueSome tcref -> 
             not (isILStructTy g destTy &&
                  isTyconRefAssumedReadOnly g tcref &&
-                 not (isTyconRefReadOnly g m tcref))
+                 not (isTyconRefReadOnly g vref.Range tcref))
         | _ -> false
 
 let MustTakeAddressOfRecdField (rfref: RecdField) = 
@@ -6068,7 +6065,7 @@ let rec mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress 
     if mustTakeAddress then 
         match expr with 
         // LVALUE of "*x" where "x" is byref is just the byref itself
-        | Expr.Op (TOp.LValueOp (LByrefGet, vref), _, [], m) when MustTakeAddressOfByrefGet g vref || (CanTakeAddressOfByrefGet g vref mut && NoDefensiveCopy g vref.Range vref.Type mut) -> 
+        | Expr.Op (TOp.LValueOp (LByrefGet, vref), _, [], m) when MustTakeAddressOfByrefGet g vref || CanTakeAddressOfByrefGet g vref mut -> 
             let readonly = not (MustTakeAddressOfByrefGet g vref)
             let writeonly = isOutByrefTy g vref.Type
             None, exprForValRef m vref, readonly, writeonly

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -369,6 +369,9 @@ exception DefensiveCopyWarning of string * range
 
 type Mutates = AddressOfOp | DefinitelyMutates | PossiblyMutates | NeverMutates
 
+/// Helper to create an expression that dereferences an address.
+val mkDerefAddrExpr: mAddrGet: range -> expr: Expr -> mExpr: range -> exprTy: TType -> Expr
+
 /// Helper to take the address of an expression
 val mkExprAddrOfExprAux : TcGlobals -> bool -> bool -> Mutates -> Expr -> ValRef option -> range -> (Val * Expr) option * Expr * bool * bool
 
@@ -2305,5 +2308,3 @@ val isThreadOrContextStatic: TcGlobals -> Attrib list -> bool
 val mkUnitDelayLambda: TcGlobals -> range -> Expr -> Expr
 
 val isStaticClass: g: TcGlobals -> tcref: TyconRef -> bool
-
-val mkDereferencedByrefExpr: mAddrGet: range -> expr: Expr -> mExpr: range -> exprTy: TType -> Expr

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -2305,3 +2305,5 @@ val isThreadOrContextStatic: TcGlobals -> Attrib list -> bool
 val mkUnitDelayLambda: TcGlobals -> range -> Expr -> Expr
 
 val isStaticClass: g: TcGlobals -> tcref: TyconRef -> bool
+
+val mkDereferencedByrefExpr: mAddrGet: range -> expr: Expr -> mExpr: range -> exprTy: TType -> Expr

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -3394,8 +3394,7 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
         let currentExpr, enumElemTy =
             // Implicitly dereference byref for expr 'for x in ...'
             if isByrefTy cenv.g enumElemTy then
-                let v, _ = mkCompGenLocal m "byrefReturn" enumElemTy
-                let expr = mkCompGenLet currentExpr.Range v currentExpr (mkAddrGet m (mkLocalValRef v))
+                let expr = mkDereferencedByrefExpr m currentExpr currentExpr.Range enumElemTy
                 expr, destByrefTy cenv.g enumElemTy
             else
                 currentExpr, enumElemTy
@@ -4139,9 +4138,8 @@ let buildApp cenv expr resultTy arg m =
 
     | _ when isByrefTy g resultTy ->
         // Handle byref returns, byref-typed returns get implicitly dereferenced 
-        let v, _ = mkCompGenLocal m "byrefReturn" resultTy
         let expr = expr.SupplyArgument (arg, m)
-        let expr = mkCompGenLet m v expr.Expr (mkAddrGet m (mkLocalValRef v))
+        let expr = mkDereferencedByrefExpr m expr.Expr m resultTy
         let resultTy = destByrefTy g resultTy
         MakeApplicableExprNoFlex cenv expr, resultTy
 
@@ -10214,8 +10212,7 @@ and TcMethodApplication
         // byref-typed returns get implicitly dereferenced 
         let vty = tyOfExpr cenv.g callExpr0
         if isByrefTy cenv.g vty then 
-            let v, _ = mkCompGenLocal mMethExpr "byrefReturn" vty
-            mkCompGenLet mMethExpr v callExpr0 (mkAddrGet mMethExpr (mkLocalValRef v))
+            mkDereferencedByrefExpr mMethExpr callExpr0 mMethExpr vty
         else 
             callExpr0
 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -3394,7 +3394,7 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
         let currentExpr, enumElemTy =
             // Implicitly dereference byref for expr 'for x in ...'
             if isByrefTy cenv.g enumElemTy then
-                let expr = mkDereferencedByrefExpr m currentExpr currentExpr.Range enumElemTy
+                let expr = mkDerefAddrExpr m currentExpr currentExpr.Range enumElemTy
                 expr, destByrefTy cenv.g enumElemTy
             else
                 currentExpr, enumElemTy
@@ -4139,7 +4139,7 @@ let buildApp cenv expr resultTy arg m =
     | _ when isByrefTy g resultTy ->
         // Handle byref returns, byref-typed returns get implicitly dereferenced 
         let expr = expr.SupplyArgument (arg, m)
-        let expr = mkDereferencedByrefExpr m expr.Expr m resultTy
+        let expr = mkDerefAddrExpr m expr.Expr m resultTy
         let resultTy = destByrefTy g resultTy
         MakeApplicableExprNoFlex cenv expr, resultTy
 
@@ -10212,7 +10212,7 @@ and TcMethodApplication
         // byref-typed returns get implicitly dereferenced 
         let vty = tyOfExpr cenv.g callExpr0
         if isByrefTy cenv.g vty then 
-            mkDereferencedByrefExpr mMethExpr callExpr0 mMethExpr vty
+            mkDerefAddrExpr mMethExpr callExpr0 mMethExpr vty
         else 
             callExpr0
 

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1254,6 +1254,7 @@ type MethInfo =
         x.IsStruct &&
         match x with
         | ILMeth (g, ilMethInfo, _) -> ilMethInfo.IsReadOnly g
+        | FSMeth _ -> false // F# defined methods not supported yet. Must be a language feature.
         | _ -> false
 
     /// Build IL method infos.

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1238,6 +1238,9 @@ type MethInfo =
     member x.IsStruct =
         isStructTy x.TcGlobals x.ApparentEnclosingType
 
+    /// Indicates if this method is an IL method.
+    member x.IsILMethod = match x with ILMeth _ -> true | _ -> false
+
     /// Build IL method infos.
     static member CreateILMeth (amap: Import.ImportMap, m, ty: TType, md: ILMethodDef) =
         let tinfo = ILTypeInfo.FromType amap.g ty

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -116,133 +116,137 @@ type ValFlags(flags: int64) =
     new (recValInfo, baseOrThis, isCompGen, inlineInfo, isMutable, isModuleOrMemberBinding, isExtensionMember, isIncrClassSpecialMember, isTyFunc, allowTypeInst, isGeneratedEventVal) =
         let flags = 
                      (match baseOrThis with
-                                        | BaseVal ->                         0b0000000000000000000L
-                                        | CtorThisVal ->                     0b0000000000000000010L
-                                        | NormalVal ->                       0b0000000000000000100L
-                                        | MemberThisVal ->                   0b0000000000000000110L) |||
-                     (if isCompGen then                                      0b0000000000000001000L 
-                      else                                                   0b00000000000000000000L) |||
+                                        | BaseVal ->                         0b00000000000000000000L
+                                        | CtorThisVal ->                     0b00000000000000000010L
+                                        | NormalVal ->                       0b00000000000000000100L
+                                        | MemberThisVal ->                   0b00000000000000000110L) |||
+                     (if isCompGen then                                      0b00000000000000001000L 
+                      else                                                   0b000000000000000000000L) |||
                      (match inlineInfo with
-                                        | ValInline.PseudoVal ->             0b0000000000000000000L
-                                        | ValInline.Always ->                0b0000000000000010000L
-                                        | ValInline.Optional ->              0b0000000000000100000L
-                                        | ValInline.Never ->                 0b0000000000000110000L) |||
+                                        | ValInline.PseudoVal ->             0b00000000000000000000L
+                                        | ValInline.Always ->                0b00000000000000010000L
+                                        | ValInline.Optional ->              0b00000000000000100000L
+                                        | ValInline.Never ->                 0b00000000000000110000L) |||
                      (match isMutable with
-                                        | Immutable ->                       0b0000000000000000000L
-                                        | Mutable   ->                       0b0000000000001000000L) |||
+                                        | Immutable ->                       0b00000000000000000000L
+                                        | Mutable   ->                       0b00000000000001000000L) |||
 
                      (match isModuleOrMemberBinding with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000000000010000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000000000010000000L) |||
                      (match isExtensionMember with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000000000100000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000000000100000000L) |||
                      (match isIncrClassSpecialMember with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000000001000000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000000001000000000L) |||
                      (match isTyFunc with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000000010000000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000000010000000000L) |||
 
                      (match recValInfo with
-                                     | ValNotInRecScope     ->               0b0000000000000000000L
-                                     | ValInRecScope true   ->               0b0000000100000000000L
-                                     | ValInRecScope false  ->               0b0000001000000000000L) |||
+                                     | ValNotInRecScope     ->               0b00000000000000000000L
+                                     | ValInRecScope true   ->               0b00000000100000000000L
+                                     | ValInRecScope false  ->               0b00000001000000000000L) |||
 
                      (match allowTypeInst with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000100000000000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000100000000000000L) |||
 
                      (match isGeneratedEventVal with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0100000000000000000L)                                        
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00100000000000000000L)                                        
 
         ValFlags flags
 
     member x.BaseOrThisInfo = 
-                                  match (flags       &&&                     0b0000000000000000110L) with 
-                                                             |               0b0000000000000000000L -> BaseVal
-                                                             |               0b0000000000000000010L -> CtorThisVal
-                                                             |               0b0000000000000000100L -> NormalVal
-                                                             |               0b0000000000000000110L -> MemberThisVal
+                                  match (flags       &&&                     0b00000000000000000110L) with 
+                                                             |               0b00000000000000000000L -> BaseVal
+                                                             |               0b00000000000000000010L -> CtorThisVal
+                                                             |               0b00000000000000000100L -> NormalVal
+                                                             |               0b00000000000000000110L -> MemberThisVal
                                                              | _          -> failwith "unreachable"
 
 
 
-    member x.IsCompilerGenerated =      (flags       &&&                     0b0000000000000001000L) <> 0x0L
+    member x.IsCompilerGenerated =      (flags       &&&                     0b00000000000000001000L) <> 0x0L
 
     member x.SetIsCompilerGenerated isCompGen = 
-            let flags =                 (flags       &&&                  ~~~0b0000000000000001000L) |||
+            let flags =                 (flags       &&&                  ~~~0b00000000000000001000L) |||
                                         (match isCompGen with
-                                          | false           ->               0b0000000000000000000L
-                                          | true            ->               0b0000000000000001000L)
+                                          | false           ->               0b00000000000000000000L
+                                          | true            ->               0b00000000000000001000L)
             ValFlags flags
 
     member x.InlineInfo = 
-                                  match (flags       &&&                     0b0000000000000110000L) with 
-                                                             |               0b0000000000000000000L -> ValInline.PseudoVal
-                                                             |               0b0000000000000010000L -> ValInline.Always
-                                                             |               0b0000000000000100000L -> ValInline.Optional
-                                                             |               0b0000000000000110000L -> ValInline.Never
+                                  match (flags       &&&                     0b00000000000000110000L) with 
+                                                             |               0b00000000000000000000L -> ValInline.PseudoVal
+                                                             |               0b00000000000000010000L -> ValInline.Always
+                                                             |               0b00000000000000100000L -> ValInline.Optional
+                                                             |               0b00000000000000110000L -> ValInline.Never
                                                              | _          -> failwith "unreachable"
 
     member x.MutabilityInfo = 
-                                  match (flags       &&&                     0b0000000000001000000L) with 
-                                                             |               0b0000000000000000000L -> Immutable
-                                                             |               0b0000000000001000000L -> Mutable
+                                  match (flags       &&&                     0b00000000000001000000L) with 
+                                                             |               0b00000000000000000000L -> Immutable
+                                                             |               0b00000000000001000000L -> Mutable
                                                              | _          -> failwith "unreachable"
 
 
     member x.IsMemberOrModuleBinding = 
-                                  match (flags       &&&                     0b0000000000010000000L) with 
-                                                             |               0b0000000000000000000L -> false
-                                                             |               0b0000000000010000000L -> true
+                                  match (flags       &&&                     0b00000000000010000000L) with 
+                                                             |               0b00000000000000000000L -> false
+                                                             |               0b00000000000010000000L -> true
                                                              | _          -> failwith "unreachable"
 
 
-    member x.WithIsMemberOrModuleBinding = ValFlags(flags |||                0b0000000000010000000L)
+    member x.WithIsMemberOrModuleBinding = ValFlags(flags |||                0b00000000000010000000L)
 
 
-    member x.IsExtensionMember        = (flags       &&&                     0b0000000000100000000L) <> 0L
+    member x.IsExtensionMember        = (flags       &&&                     0b00000000000100000000L) <> 0L
 
-    member x.IsIncrClassSpecialMember = (flags       &&&                     0b0000000001000000000L) <> 0L
+    member x.IsIncrClassSpecialMember = (flags       &&&                     0b00000000001000000000L) <> 0L
 
-    member x.IsTypeFunction           = (flags       &&&                     0b0000000010000000000L) <> 0L
+    member x.IsTypeFunction           = (flags       &&&                     0b00000000010000000000L) <> 0L
 
-    member x.RecursiveValInfo =   match (flags       &&&                     0b0000001100000000000L) with 
-                                                             |               0b0000000000000000000L -> ValNotInRecScope
-                                                             |               0b0000000100000000000L -> ValInRecScope true
-                                                             |               0b0000001000000000000L -> ValInRecScope false
+    member x.RecursiveValInfo =   match (flags       &&&                     0b00000001100000000000L) with 
+                                                             |               0b00000000000000000000L -> ValNotInRecScope
+                                                             |               0b00000000100000000000L -> ValInRecScope true
+                                                             |               0b00000001000000000000L -> ValInRecScope false
                                                              | _                   -> failwith "unreachable"
 
     member x.WithRecursiveValInfo recValInfo = 
             let flags = 
-                     (flags       &&&                                     ~~~0b0000001100000000000L) |||
+                     (flags       &&&                                    ~~~0b00000001100000000000L) |||
                      (match recValInfo with
-                                     | ValNotInRecScope     ->               0b0000000000000000000L
-                                     | ValInRecScope true  ->               0b0000000100000000000L
-                                     | ValInRecScope false ->               0b0000001000000000000L) 
+                                     | ValNotInRecScope     ->              0b00000000000000000000L
+                                     | ValInRecScope true  ->               0b00000000100000000000L
+                                     | ValInRecScope false ->               0b00000001000000000000L) 
             ValFlags flags
 
-    member x.MakesNoCriticalTailcalls         =                   (flags &&& 0b0000010000000000000L) <> 0L
+    member x.MakesNoCriticalTailcalls         =                   (flags &&& 0b00000010000000000000L) <> 0L
 
-    member x.WithMakesNoCriticalTailcalls =               ValFlags(flags ||| 0b0000010000000000000L)
+    member x.WithMakesNoCriticalTailcalls =               ValFlags(flags ||| 0b00000010000000000000L)
 
-    member x.PermitsExplicitTypeInstantiation =                   (flags &&& 0b0000100000000000000L) <> 0L
+    member x.PermitsExplicitTypeInstantiation =                   (flags &&& 0b00000100000000000000L) <> 0L
 
-    member x.HasBeenReferenced                =                   (flags &&& 0b0001000000000000000L) <> 0L
+    member x.HasBeenReferenced                =                   (flags &&& 0b00001000000000000000L) <> 0L
 
-    member x.WithHasBeenReferenced                     =  ValFlags(flags ||| 0b0001000000000000000L)
+    member x.WithHasBeenReferenced                     =  ValFlags(flags ||| 0b00001000000000000000L)
 
-    member x.IsCompiledAsStaticPropertyWithoutField =             (flags &&& 0b0010000000000000000L) <> 0L
+    member x.IsCompiledAsStaticPropertyWithoutField =             (flags &&& 0b00010000000000000000L) <> 0L
 
-    member x.WithIsCompiledAsStaticPropertyWithoutField = ValFlags(flags ||| 0b0010000000000000000L)
+    member x.WithIsCompiledAsStaticPropertyWithoutField = ValFlags(flags ||| 0b00010000000000000000L)
 
-    member x.IsGeneratedEventVal =                                (flags &&& 0b0100000000000000000L) <> 0L
+    member x.IsGeneratedEventVal =                                (flags &&& 0b00100000000000000000L) <> 0L
 
-    member x.IsFixed                                =             (flags &&& 0b1000000000000000000L) <> 0L
+    member x.IsFixed                                =             (flags &&& 0b01000000000000000000L) <> 0L
 
-    member x.WithIsFixed                               =  ValFlags(flags ||| 0b1000000000000000000L)
+    member x.WithIsFixed                               =  ValFlags(flags ||| 0b01000000000000000000L)
+
+    member x.IgnoresByrefScope                         =          (flags &&& 0b10000000000000000000L) <> 0L
+
+    member x.WithIgnoresByrefScope                     =  ValFlags(flags ||| 0b10000000000000000000L)
 
     /// Get the flags as included in the F# binary metadata
     member x.PickledBits = 
@@ -250,7 +254,7 @@ type ValFlags(flags: int64) =
         // Clear the IsCompiledAsStaticPropertyWithoutField, only used to determine whether to use a true field for a value, and to eliminate the optimization info for observable bindings
         // Clear the HasBeenReferenced, only used to report "unreferenced variable" warnings and to help collect 'it' values in FSI.EXE
         // Clear the IsGeneratedEventVal, since there's no use in propagating specialname information for generated add/remove event vals
-                                                      (flags       &&&    ~~~0b0011001100000000000L) 
+                                                      (flags       &&&    ~~~0b10011001100000000000L) 
 
 /// Represents the kind of a type parameter
 [<RequireQualifiedAccess (* ; StructuredFormatDisplay("{DebugText}") *) >]
@@ -2747,6 +2751,9 @@ and [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
     /// Indicates if the value is pinned/fixed
     member x.IsFixed = x.val_flags.IsFixed
 
+    /// Indicates if the value will ignore byref scoping rules
+    member x.IgnoresByrefScope = x.val_flags.IgnoresByrefScope
+
     /// Indicates if this value allows the use of an explicit type instantiation (i.e. does it itself have explicit type arguments,
     /// or does it have a signature?)
     member x.PermitsExplicitTypeInstantiation = x.val_flags.PermitsExplicitTypeInstantiation
@@ -2969,6 +2976,8 @@ and [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
     member x.SetIsCompiledAsStaticPropertyWithoutField() = x.val_flags <- x.val_flags.WithIsCompiledAsStaticPropertyWithoutField
 
     member x.SetIsFixed() = x.val_flags <- x.val_flags.WithIsFixed
+
+    member x.SetIgnoresByrefScope() = x.val_flags <- x.val_flags.WithIgnoresByrefScope
 
     member x.SetValReprInfo info = 
         match x.val_opt_data with

--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -108,11 +108,11 @@ let main argv = 0"""
             ProjectId = None
             SourceFiles = [|"test.fs"|]
 #if !NETCOREAPP
-            OtherOptions = [|"--preferreduilang:en-US";|]
+            OtherOptions = [|"--preferreduilang:en-US";"--warn:5"|]
 #else
             OtherOptions = 
                 let assemblies = getNetCoreAppReferences |> Array.map (fun x -> sprintf "-r:%s" x)
-                Array.append [|"--preferreduilang:en-US"; "--targetprofile:netcore"; "--noframework"|] assemblies
+                Array.append [|"--preferreduilang:en-US"; "--targetprofile:netcore"; "--noframework";"--warn:5"|] assemblies
 #endif
             ReferencedProjects = [||]
             IsIncompleteTypeCheckEnvironment = false

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -13,10 +13,30 @@ module ByrefTests =
         CompilerAssert.Pass
             """
 open System
+open System.Runtime.CompilerServices
+
 let f (x: DateTime) = x.ToLocalTime()
 let f2 () =
     let x = DateTime.Now
     x.ToLocalTime()
+
+[<Extension; AbstractClass; Sealed>]
+type Extensions =
+
+    [<Extension>]
+    static member Test(x: inref<DateTime>) = &x
+
+    [<Extension>]
+    static member Test2(x: byref<DateTime>) = &x
+
+let test (x: inref<DateTime>) =
+    x.Test()
+
+let test2 (x: byref<DateTime>) =
+    x.Test2()
+
+let test3 (x: byref<DateTime>) =
+    x.Test()
             """
 
 #if NETCOREAPP

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -20,6 +20,7 @@ let f2 () =
 
     [<Test>]
     let ``Defensive copy on .NET struct for inref`` () =
+        // Note: This particular test could fail in the future when 'int' is considered read-only. When that happens, consider a custom C# struct type as part of the test.
         CompilerAssert.TypeCheckWithErrors
             """
 let f (x: inref<int>) = x.GetHashCode()

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.UnitTests
+
+open NUnit.Framework
+open FSharp.Compiler.SourceCodeServices
+
+[<TestFixture>]
+module ByrefTests =
+
+    [<Test>]
+    let ``No defensive copy on .NET struct`` () =
+        CompilerAssert.Pass
+            """
+let f (x: int) = x.GetHashCode()
+let f2 () =
+    let x = 1
+    x.GetHashCode()
+            """
+
+    [<Test>]
+    let ``Defensive copy on .NET struct for inref`` () =
+        CompilerAssert.TypeCheckWithErrors
+            """
+let f (x: inref<int>) = x.GetHashCode()
+let f2 () =
+    let x = 1
+    let y = &x
+    y.GetHashCode()
+            """
+            [|
+                (
+                    FSharpErrorSeverity.Warning,
+                    52,
+                    (2, 25, 2, 40),
+                    "The value has been copied to ensure the original is not mutated by this operation or because the copy is implicit when returning a struct from a member and another member is then accessed"
+                )
+                (
+                    FSharpErrorSeverity.Warning,
+                    52,
+                    (6, 5, 6, 20),
+                    "The value has been copied to ensure the original is not mutated by this operation or because the copy is implicit when returning a struct from a member and another member is then accessed"
+                )
+            |]

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -37,8 +37,80 @@ let test2 (x: byref<DateTime>) =
 
 let test3 (x: byref<DateTime>) =
     x.Test()
+
+let test4 () =
+    DateTime.Now.Test()
+
+let test5 (x: inref<DateTime>) =
+    &x.Test()
             """
 
+    [<Test>]
+    let ``Extension method scope errors`` () =
+        CompilerAssert.TypeCheckWithErrors
+            """
+open System
+open System.Runtime.CompilerServices
+
+[<Extension; AbstractClass; Sealed>]
+type Extensions =
+
+    [<Extension>]
+    static member Test(x: inref<DateTime>) = &x
+
+let f1 () =
+    &DateTime.Now.Test()
+
+let f2 () =
+    let result =
+        let dt = DateTime.Now
+        &dt.Test()
+    result
+
+let f3 () =
+    Extensions.Test(let dt = DateTime.Now in &dt)
+
+let f4 () =
+    let dt = DateTime.Now
+    &Extensions.Test(&dt)
+
+let f5 () =
+    &Extensions.Test(let dt = DateTime.Now in &dt)
+            """
+            [|
+                (
+                    FSharpErrorSeverity.Error,
+                    3228,
+                    (12, 6, 12, 25),
+                    "The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
+                )
+                (
+                    FSharpErrorSeverity.Error,
+                    3228,
+                    (17, 10, 17, 19),
+                    "The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
+                )
+                (
+                    FSharpErrorSeverity.Error,
+                    3228,
+                    (21, 5, 21, 50),
+                    "The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
+                )
+                (
+                    FSharpErrorSeverity.Error,
+                    3228,
+                    (25, 6, 25, 26),
+                    "The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
+                )
+                (
+                    FSharpErrorSeverity.Error,
+                    3228,
+                    (28, 6, 28, 51),
+                    "The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
+                )
+            |]
+
+// TODO: A better way to test the ones below are to use a custom struct in C# code that contains explicit use of their "readonly" keyword.
 #if NETCOREAPP
     // NETCORE makes DateTime a readonly struct; therefore, it should not error.
     [<Test>]
@@ -54,8 +126,19 @@ let f2 () =
 let f3 (x: inref<DateTime>) = &x
 let f4 (x: inref<DateTime>) =
     (f3 &x).ToLocalTime()
+
+open System.Runtime.CompilerServices
+[<Extension; AbstractClass; Sealed>]
+type Extensions =
+
+    [<Extension>]
+    static member Test(x: inref<DateTime>) = &x
+
+let test1 () =
+    DateTime.Now.Test().Date
             """
 #else
+    // Note: Currently this is assuming NET472. That may change which might break these tests. Consider using custom C# code.
     [<Test>]
     let ``Defensive copy on .NET struct for inref`` () =
         CompilerAssert.TypeCheckWithErrors
@@ -69,6 +152,16 @@ let f2 () =
 let f3 (x: inref<DateTime>) = &x
 let f4 (x: inref<DateTime>) =
     (f3 &x).ToLocalTime()
+
+open System.Runtime.CompilerServices
+[<Extension; AbstractClass; Sealed>]
+type Extensions =
+
+    [<Extension>]
+    static member Test(x: inref<DateTime>) = &x
+
+let test1 () =
+    DateTime.Now.Test().Date
             """
             [|
                 (
@@ -87,6 +180,12 @@ let f4 (x: inref<DateTime>) =
                     FSharpErrorSeverity.Warning,
                     52,
                     (10, 5, 10, 26),
+                    "The value has been copied to ensure the original is not mutated by this operation or because the copy is implicit when returning a struct from a member and another member is then accessed"
+                )
+                (
+                    FSharpErrorSeverity.Warning,
+                    52,
+                    (20, 5, 20, 29),
                     "The value has been copied to ensure the original is not mutated by this operation or because the copy is implicit when returning a struct from a member and another member is then accessed"
                 )
             |]

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -31,6 +31,9 @@ let f2 () =
     let x = DateTime.Now
     let y = &x
     y.ToLocalTime()
+let f3 (x: inref<DateTime>) = &x
+let f4 (x: inref<DateTime>) =
+    (f3 &x).ToLocalTime()
             """
 #else
     [<Test>]
@@ -43,6 +46,9 @@ let f2 () =
     let x = DateTime.Now
     let y = &x
     y.ToLocalTime()
+let f3 (x: inref<DateTime>) = &x
+let f4 (x: inref<DateTime>) =
+    (f3 &x).ToLocalTime()
             """
             [|
                 (
@@ -55,6 +61,12 @@ let f2 () =
                     FSharpErrorSeverity.Warning,
                     52,
                     (7, 5, 7, 20),
+                    "The value has been copied to ensure the original is not mutated by this operation or because the copy is implicit when returning a struct from a member and another member is then accessed"
+                )
+                (
+                    FSharpErrorSeverity.Warning,
+                    52,
+                    (10, 5, 10, 26),
                     "The value has been copied to ensure the original is not mutated by this operation or because the copy is implicit when returning a struct from a member and another member is then accessed"
                 )
             |]

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -43,6 +43,9 @@ let test4 () =
 
 let test5 (x: inref<DateTime>) =
     &x.Test()
+
+let test6 () =
+    DateTime.Now.Test().Test().Test()
             """
 
     [<Test>]
@@ -136,6 +139,9 @@ type Extensions =
 
 let test1 () =
     DateTime.Now.Test().Date
+
+let test2 () =
+    DateTime.Now.Test().Test().Date.Test().Test().Date.Test()
             """
 #else
     // Note: Currently this is assuming NET472. That may change which might break these tests. Consider using custom C# code.

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -51,6 +51,7 @@
     <Compile Include="Compiler\ErrorMessages\DontSuggestTests.fs" />
     <Compile Include="Compiler\Warnings\AssignmentWarningTests.fs" />
     <Compile Include="Compiler\SourceTextTests.fs" />
+    <Compile Include="Compiler\Language\ByrefTests.fs" />
     <Compile Include="Compiler\Language\AnonRecordTests.fs" />
     <Compile Include="Compiler\Language\OpenStaticClasses.fs" />
     <Compile Include="Compiler\Language\SpanOptimizationTests.fs" />

--- a/tests/fsharp/core/fsfromfsviacs/lib2.cs
+++ b/tests/fsharp/core/fsfromfsviacs/lib2.cs
@@ -125,3 +125,16 @@ namespace FSharpFuncTests
         public static Func<int, string, byte, sbyte, Int16, int> f5 = new Func<int, string, byte, sbyte, Int16, int>((int arg1, string arg2, byte arg3, sbyte arg4, Int16 arg5) => arg1 + arg2.Length + 1 + arg3 + arg4 + arg5);
     }
 }
+
+namespace StructTests
+{
+    public struct NonReadOnlyStruct
+    {
+        public int X { get; set; }
+
+        public void M(int x)
+        {
+            X = x;
+        }
+    }
+}

--- a/tests/fsharp/core/fsfromfsviacs/test.fsx
+++ b/tests/fsharp/core/fsfromfsviacs/test.fsx
@@ -210,6 +210,75 @@ let ToFSharpFunc() =
     test "vkejhwew904" (FuncConvert.FromFunc(FSharpFuncTests.ApiWrapper.f4)(3)("a")(6uy)(7y)  =  FSharpFuncTests.ApiWrapper.f4.Invoke(3, "a", 6uy, 7y))
     test "vkejhwew905" (FuncConvert.FromFunc(FSharpFuncTests.ApiWrapper.f5)(3)("a")(6uy)(7y)(7s)  =  FSharpFuncTests.ApiWrapper.f5.Invoke(3, "a", 6uy, 7y, 7s))
 
+module TestStructs =
+    open StructTests
+
+    let someFunc (s: NonReadOnlyStruct) = 
+        s.M(456)
+        s.X
+
+    let someByrefFunc (s: byref<NonReadOnlyStruct>) = 
+        s.M(456)
+        s.X
+
+    let someInrefFunc (s: inref<NonReadOnlyStruct>) = 
+        s.M(456)
+        s.X
+
+    let someFuncReturn (s: NonReadOnlyStruct) =
+        s.X
+
+    let someInrefFuncReturn (s: inref<NonReadOnlyStruct>) =
+        s.X
+
+    let test1 () =
+        let s = NonReadOnlyStruct()
+        check "hdlcjiklhen1" s.X 0
+        s.M(123)
+        check "hdlcjiklhen2" s.X 123
+        check "hdlcjiklhen3" (someFunc s) 456
+        check "hdlcjiklhen4" s.X 123
+
+
+    let test2 () =
+        let mutable s = NonReadOnlyStruct()
+        check "hdlcjiklhen5" s.X 0
+        s.M(123)
+        check "hdlcjiklhen6" s.X 123
+        check "hdlcjiklhen7" (someByrefFunc &s) 456
+        check "hdlcjiklhen8" s.X 456
+
+
+    let test3 () =
+        let s = NonReadOnlyStruct()
+        check "hdlcjiklhen9" s.X 0
+        s.M(123)
+        check "hdlcjiklhen10" s.X 123
+        check "hdlcjiklhen11" (someInrefFunc &s) 123
+        check "hdlcjiklhen12" s.X 123
+
+    let test4 () =
+        let s = NonReadOnlyStruct()
+        check "hdlcjiklhen13" s.X 0
+        s.M(123)
+        check "hdlcjiklhen14" s.X 123
+        check "hdlcjiklhen15" (someFuncReturn s) 123
+        check "hdlcjiklhen16" s.X 123
+
+    let test5 () =
+        let s = NonReadOnlyStruct()
+        check "hdlcjiklhen17" s.X 0
+        s.M(123)
+        check "hdlcjiklhen18" s.X 123
+        check "hdlcjiklhen19" (someInrefFuncReturn &s) 123
+        check "hdlcjiklhen20" s.X 123
+
+TestStructs.test1 ()
+TestStructs.test2 ()
+TestStructs.test3 () 
+TestStructs.test4 () 
+TestStructs.test5 () 
+
 #endif
 
 #if TESTS_AS_APP

--- a/tests/fsharp/core/fsfromfsviacs/test.fsx
+++ b/tests/fsharp/core/fsfromfsviacs/test.fsx
@@ -262,7 +262,7 @@ module TestStructs =
         check "hdlcjiklhen13" s.X 0
         s.M(123)
         check "hdlcjiklhen14" s.X 123
-        check "hdlcjiklhen15" (someFuncReturn s) 123
+        check "hdlcjiklhen15" (someFuncReturn s) 0 // Technically a bug today, but test is to verify current behavior.
         check "hdlcjiklhen16" s.X 123
 
     let test5 () =


### PR DESCRIPTION
This is to resolve: https://github.com/dotnet/fsharp/issues/7406

Gets rid of the immutability assumption for .NET structs when it's an `inref`.

Added awareness of `IsReadOnlyAttribute` on method calls from structs, only aware of IL method calls, not F# method calls. This is not a feature, but merely an optimization and will help mitigate extra warnings as a result of the immutability assumption change.

- [x] Find out if we can optimize the attribute lookup? Simple query, will only check on structs and when we must take an address.
- [x] Tests