### PR TITLE
apply hack to pre-restore FSharp.Core 4.6.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,11 @@ stages:
           steps:
           - checkout: self
             clean: true
+          - task: NuGetToolInstaller@0
+            inputs:
+              versionSpec: 5.1.0
+          - script: nuget.exe install FSharp.Core -Version 4.6.2 -Source https://api.nuget.org/v3/index.json
+            displayName: HACK - pre-restore FSharp.Core 4.6.2
           - script: eng\CIBuild.cmd
                     -configuration $(_BuildConfig)
                     -prepareMachine
@@ -169,6 +174,11 @@ stages:
           steps:
           - checkout: self
             clean: true
+          - task: NuGetToolInstaller@0
+            inputs:
+              versionSpec: 5.1.0
+          - script: nuget.exe install FSharp.Core -Version 4.6.2 -Source https://api.nuget.org/v3/index.json
+            displayName: HACK - pre-restore FSharp.Core 4.6.2
           - script: eng\CIBuild.cmd -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
           - task: PublishTestResults@2
@@ -247,6 +257,11 @@ stages:
           steps:
           - checkout: self
             clean: true
+          - task: NuGetToolInstaller@0
+            inputs:
+              versionSpec: 5.1.0
+          - script: nuget.exe install FSharp.Core -Version 4.6.2 -Source https://api.nuget.org/v3/index.json
+            displayName: HACK - pre-restore FSharp.Core 4.6.2
           - script: eng\CIBuild.cmd -configuration Release -noSign /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
             displayName: Build
 
@@ -257,6 +272,11 @@ stages:
           steps:
           - checkout: self
             clean: true
+          - task: NuGetToolInstaller@0
+            inputs:
+              versionSpec: 5.1.0
+          - script: nuget.exe install FSharp.Core -Version 4.6.2 -Source https://api.nuget.org/v3/index.json
+            displayName: HACK - pre-restore FSharp.Core 4.6.2
           - task: PowerShell@2
             displayName: Run up-to-date build check
             inputs:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -116,6 +116,8 @@
     <MicrosoftVisualStudioComponentModelHostVersion>16.1.89</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioEditorVersion>16.1.89</MicrosoftVisualStudioEditorVersion>
+    <MicrosoftVisualStudioEditorImplementationVersion>16.1.89</MicrosoftVisualStudioEditorImplementationVersion>
+    <MicrosoftVisualStudioGraphModelVersion>16.0.28226-alpha</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImageCatalogVersion>16.1.28916.169</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioImagingVersion>16.1.28917.181</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioLanguageServerClientVersion>16.1.3121</MicrosoftVisualStudioLanguageServerClientVersion>
@@ -125,6 +127,7 @@
     <MicrosoftVisualStudioManagedInterfacesVersion>8.0.50728</MicrosoftVisualStudioManagedInterfacesVersion>
     <MicrosoftVisualStudioOLEInteropVersion>7.10.6071</MicrosoftVisualStudioOLEInteropVersion>
     <MicrosoftVisualStudioPackageLanguageService150Version>16.1.28917.181</MicrosoftVisualStudioPackageLanguageService150Version>
+    <MicrosoftVisualStudioPlatformVSEditorVersion>16.1.89</MicrosoftVisualStudioPlatformVSEditorVersion>
     <MicrosoftVisualStudioProjectAggregatorVersion>8.0.50728</MicrosoftVisualStudioProjectAggregatorVersion>
     <MicrosoftVisualStudioProjectSystemVersion>16.0.201-pre-g7d366164d0</MicrosoftVisualStudioProjectSystemVersion>
     <MicrosoftVisualStudioProjectSystemManagedVersion>2.3.6152103</MicrosoftVisualStudioProjectSystemManagedVersion>
@@ -141,7 +144,9 @@
     <MicrosoftVisualStudioShellInterop100Version>10.0.30320</MicrosoftVisualStudioShellInterop100Version>
     <MicrosoftVisualStudioShellInterop110Version>11.0.61031</MicrosoftVisualStudioShellInterop110Version>
     <MicrosoftVisualStudioShellInterop120Version>12.0.30111</MicrosoftVisualStudioShellInterop120Version>
+    <MicrosoftVisualStudioShellInterop160DesignTimeVersion>16.0.0</MicrosoftVisualStudioShellInterop160DesignTimeVersion>
     <MicrosoftVisualStudioTextDataVersion>16.1.89</MicrosoftVisualStudioTextDataVersion>
+    <MicrosoftVisualStudioTextInternalVersion>16.1.89</MicrosoftVisualStudioTextInternalVersion>
     <MicrosoftVisualStudioTextManagerInteropVersion>7.10.6071</MicrosoftVisualStudioTextManagerInteropVersion>
     <MicrosoftVisualStudioTextManagerInterop80Version>8.0.50728</MicrosoftVisualStudioTextManagerInterop80Version>
     <MicrosoftVisualStudioTextManagerInterop100Version>10.0.30320</MicrosoftVisualStudioTextManagerInterop100Version>

--- a/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
+++ b/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
@@ -49,23 +49,30 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EnvDTE80" Version="$(EnvDTE80Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectAggregator" Version="$(MicrosoftVisualStudioProjectAggregatorVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop100Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop110Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.8.0" Version="$(MicrosoftVisualStudioTextManagerInterop80Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="EnvDTE80" Version="$(EnvDTE80Version)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor.Implementation" Version="$(MicrosoftVisualStudioEditorImplementationVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.GraphModel" Version="$(MicrosoftVisualStudioGraphModelVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectAggregator" Version="$(MicrosoftVisualStudioProjectAggregatorVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop100Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop110Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.16.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop160DesignTimeVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Internal" Version="$(MicrosoftVisualStudioTextInternalVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.8.0" Version="$(MicrosoftVisualStudioTextManagerInterop80Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
-    <PackageReference Include="VSSDK.VSHelp" Version="$(VSSDKVSHelpVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="VSSDK.VSLangProj.8" Version="$(VSSDKVSLangProj8Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="VSSDK.VSHelp" Version="$(VSSDKVSHelpVersion)" />
+    <PackageReference Include="VSSDK.VSLangProj.8" Version="$(VSSDKVSLangProj8Version)" />
   </ItemGroup>
 
 </Project>

--- a/vsintegration/tests/Salsa/VsMocks.fs
+++ b/vsintegration/tests/Salsa/VsMocks.fs
@@ -1657,41 +1657,27 @@ module internal VsActual =
 
     let CreateEditorCatalog() =
         let thisAssembly = Assembly.GetExecutingAssembly().Location
-        let editorAssemblyDir = Path.Combine(vsInstallDir, @"IDE\CommonExtensions\Microsoft\Editor")
-        let privateAssemblyDir = Path.Combine(vsInstallDir, @"IDE\PrivateAssemblies")
-        let publicAssemblyDir = Path.Combine(vsInstallDir, @"IDE\PublicAssemblies")
-
-        let CreateAssemblyCatalog(path, file) =
-            let fullPath = Path.GetFullPath(Path.Combine(path, file))
-            if File.Exists(fullPath) then
-                new AssemblyCatalog(fullPath)
-            else
-                failwith("could not find " + fullPath)
-
+        let thisAssemblyDir = Path.GetDirectoryName(thisAssembly)
         let list = new ResizeArray<ComposablePartCatalog>()
-
-        let addMovedFile originalDir alternateDir file =
-            let path = Path.Combine(originalDir, file)
-            if File.Exists(path) then
-                list.Add(CreateAssemblyCatalog(originalDir,  file))
+        let add p =
+            let fullPath = Path.GetFullPath(Path.Combine(thisAssemblyDir, p))
+            if File.Exists(fullPath) then
+                list.Add(new AssemblyCatalog(fullPath))
             else
-                list.Add(CreateAssemblyCatalog(alternateDir,  file))
+                failwith <| sprintf "unable to find assembly %s" p
 
         list.Add(new AssemblyCatalog(thisAssembly))
-        list.Add(CreateAssemblyCatalog(editorAssemblyDir,  "Microsoft.VisualStudio.Text.Data.dll"))
-        list.Add(CreateAssemblyCatalog(editorAssemblyDir,  "Microsoft.VisualStudio.Text.Logic.dll"))
-
-        // "Microsoft.VisualStudio.Text.Internal.dll" moved locations between dev15 and 16
-        // This ensures we can run in both Devs 15 and 16
-        addMovedFile privateAssemblyDir editorAssemblyDir "Microsoft.VisualStudio.Text.Internal.dll"
-
-        list.Add(CreateAssemblyCatalog(editorAssemblyDir,  "Microsoft.VisualStudio.Text.UI.dll"))
-        list.Add(CreateAssemblyCatalog(editorAssemblyDir,  "Microsoft.VisualStudio.Text.UI.Wpf.dll"))
-        list.Add(CreateAssemblyCatalog(privateAssemblyDir, "Microsoft.VisualStudio.Threading.dll"))
-        list.Add(CreateAssemblyCatalog(editorAssemblyDir,  "Microsoft.VisualStudio.Platform.VSEditor.dll"))
-        list.Add(CreateAssemblyCatalog(editorAssemblyDir,  "Microsoft.VisualStudio.Editor.Implementation.dll"))
-        list.Add(CreateAssemblyCatalog(publicAssemblyDir,  "Microsoft.VisualStudio.ComponentModelHost.dll"))
-        list.Add(CreateAssemblyCatalog(publicAssemblyDir,  "Microsoft.VisualStudio.Shell.15.0.dll"))
+        [ "Microsoft.VisualStudio.Text.Data.dll"
+          "Microsoft.VisualStudio.Text.Logic.dll"
+          "Microsoft.VisualStudio.Text.Internal.dll"
+          "Microsoft.VisualStudio.Text.UI.dll"
+          "Microsoft.VisualStudio.Text.UI.Wpf.dll"
+          "Microsoft.VisualStudio.Threading.dll"
+          "Microsoft.VisualStudio.Platform.VSEditor.dll"
+          "Microsoft.VisualStudio.Editor.Implementation.dll"
+          "Microsoft.VisualStudio.ComponentModelHost.dll"
+          "Microsoft.VisualStudio.Shell.15.0.dll" ]
+        |> List.iter add
         new AggregateCatalog(list)
 
     let exportProvider = new CompositionContainer(new AggregateCatalog(CreateEditorCatalog()), true, null)

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -234,6 +234,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
@@ -243,6 +244,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop90Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop100Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop110Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Internal" Version="$(MicrosoftVisualStudioTextInternalVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.8.0" Version="$(MicrosoftVisualStudioTextManagerInterop80Version)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropVersion)" />


### PR DESCRIPTION
For infrastructure reasons as yet unknown, the Windows builds do not restore FSharp.Core 4.6.2.  This hack pre-restores is so that it is present in the `%USERPROFILE%\.nuget\packages` directory.

Also includes cherry-picked #7378 to handle VM image changes.