### PR TITLE
Dynamic compiling in Unity Player (2019.1.6f1)

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1894,12 +1894,12 @@ let rec ResolveLongIndentAsModuleOrNamespace sink atMostOne amap m first fullyQu
         | _ -> raze (namespaceNotFound.Force())
 
 
-let ResolveLongIndentAsModuleOrNamespaceThen sink atMostOne amap m fullyQualified (nenv: NameResolutionEnv) ad id rest isOpenDecl f =
+let ResolveLongIndentAsModuleOrNamespaceThen sink atMostOne amap m fullyQualified (nenv: NameResolutionEnv) ad id (rest: Ident list) isOpenDecl f =
     match ResolveLongIndentAsModuleOrNamespace sink ResultCollectionSettings.AllResults amap m true fullyQualified nenv ad id [] isOpenDecl with
     | Result modrefs ->
         match rest with
         | [] -> error(Error(FSComp.SR.nrUnexpectedEmptyLongId(), id.idRange))
-        | (id2:Ident) :: rest2 ->
+        | id2 :: rest2 ->
             modrefs
             |> CollectResults2 atMostOne (fun (depth, modref, mty) ->
                 let resInfo = ResolutionInfo.Empty.AddEntity(id.idRange, modref)

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1899,7 +1899,7 @@ let ResolveLongIndentAsModuleOrNamespaceThen sink atMostOne amap m fullyQualifie
     | Result modrefs ->
         match rest with
         | [] -> error(Error(FSComp.SR.nrUnexpectedEmptyLongId(), id.idRange))
-        | id2 :: rest2 ->
+        | (id2:Ident) :: rest2 ->
             modrefs
             |> CollectResults2 atMostOne (fun (depth, modref, mty) ->
                 let resInfo = ResolutionInfo.Empty.AddEntity(id.idRange, modref)

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1894,6 +1894,7 @@ let rec ResolveLongIndentAsModuleOrNamespace sink atMostOne amap m first fullyQu
         | _ -> raze (namespaceNotFound.Force())
 
 
+// Note - 'rest' is annotated due to a bug currently in Unity (see: https://github.com/dotnet/fsharp/pull/7427)
 let ResolveLongIndentAsModuleOrNamespaceThen sink atMostOne amap m fullyQualified (nenv: NameResolutionEnv) ad id (rest: Ident list) isOpenDecl f =
     match ResolveLongIndentAsModuleOrNamespace sink ResultCollectionSettings.AllResults amap m true fullyQualified nenv ad id [] isOpenDecl with
     | Result modrefs ->


### PR DESCRIPTION
Dynamically compiling an F# script in Unity3D Editor works using the following code.

    let checker = FSharpChecker.Create()
    let (_, _, asm) = checker.CompileToDynamicAssembly( [|
        "fsc.exe"
        "--target:exe"
        "--noframework"
        "--reference:" + System_DllPath
        "--reference:" + SystemIO_DllPath
        "--reference:" + FSharp_DllPath
        fsxPath
    |] )
    let main = asm |> findMainFunction // dynamic assembly doesn't set the EntryPoint
    main.Invoke(null, null)

But when building (a Windows) Player it crashes with a weird `NullReferenceException` from function `FSharp.Compiler.PrettyNaming.TryDemangleGenericNameAndPos`. The parameter `n:string` seems to be uninitialized memory (every run a random string length, most of the time negative).

This happens when [`ResolveLongIndentAsModuleOrNamespaceThen`](https://github.com/dotnet/fsharp/blob/master/src/fsharp/NameResolution.fs#L1897) is called from [here](https://github.com/dotnet/fsharp/blob/master/src/fsharp/NameResolution.fs#L2526).

Turns out the actual problem has something to do with the parameter `rest` of function `ResolveLongIndentAsModuleOrNamespaceThen` being generic. Before variable `id2` is passed into `f` it is valid, but inside [`ResolveExprLongIdentInModuleOrNamespace`](https://github.com/dotnet/fsharp/blob/master/src/fsharp/NameResolution.fs#L2295) parameter `id` is uninitialized.

The fix is to not make parameter `rest` generic, so a simple type-annotation is sufficient.

I'm pretty sure this is actually a Unity Runtime problem, but it's A LOT easier to fix it here.

PS: I know `FsiEvaluationSession` exists, but that throws an exception in it's constructor. I searched for the error and the only results I got were really old and related to some very outdated Mono version.