### PR TITLE
remove package restore hack and don't allow package fallback folders

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -32,4 +32,7 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,11 +63,6 @@ stages:
           steps:
           - checkout: self
             clean: true
-          - task: NuGetToolInstaller@0
-            inputs:
-              versionSpec: 5.1.0
-          - script: nuget.exe install FSharp.Core -Version 4.6.2 -Source https://api.nuget.org/v3/index.json
-            displayName: HACK - pre-restore FSharp.Core 4.6.2
           - script: eng\CIBuild.cmd
                     -configuration $(_BuildConfig)
                     -prepareMachine
@@ -174,11 +169,6 @@ stages:
           steps:
           - checkout: self
             clean: true
-          - task: NuGetToolInstaller@0
-            inputs:
-              versionSpec: 5.1.0
-          - script: nuget.exe install FSharp.Core -Version 4.6.2 -Source https://api.nuget.org/v3/index.json
-            displayName: HACK - pre-restore FSharp.Core 4.6.2
           - script: eng\CIBuild.cmd -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
           - task: PublishTestResults@2
@@ -257,11 +247,6 @@ stages:
           steps:
           - checkout: self
             clean: true
-          - task: NuGetToolInstaller@0
-            inputs:
-              versionSpec: 5.1.0
-          - script: nuget.exe install FSharp.Core -Version 4.6.2 -Source https://api.nuget.org/v3/index.json
-            displayName: HACK - pre-restore FSharp.Core 4.6.2
           - script: eng\CIBuild.cmd -configuration Release -noSign /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
             displayName: Build
 
@@ -272,11 +257,6 @@ stages:
           steps:
           - checkout: self
             clean: true
-          - task: NuGetToolInstaller@0
-            inputs:
-              versionSpec: 5.1.0
-          - script: nuget.exe install FSharp.Core -Version 4.6.2 -Source https://api.nuget.org/v3/index.json
-            displayName: HACK - pre-restore FSharp.Core 4.6.2
           - task: PowerShell@2
             displayName: Run up-to-date build check
             inputs:


### PR DESCRIPTION
Follow up to #7424.

The issue causing the recent build failures is that the CI/PR machines have the Xamarin Visual Studio workload installed which adds a NuGet fallback package folder at `C:\Microsoft\Xamarin\NuGet` which contains a copy of FSharp.Core 4.6.2 which means that the restore of that package from `VisualFSharpTemplates.csproj` was a successful noop, but that lead to the reading of the actual `.nupkg` file to fail since it wasn't at the expected location.

The proper fix is to disable all fallback folders so that only the one at `%USERPROFILE%\.nuget\packages` is allowed.