### PR TITLE
Opt out of PLM (partial load mode)

### DIFF
--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -7,6 +7,9 @@
 "Name"="F#"
 @="{871d2a70-12a2-4e42-9440-425dd92a4116}"
 
+[$RootKey$\Editors\{8a5aa6cf-46e3-4520-a70a-7393d15233e9}]
+"DeferUntilIntellisenseIsReady"=dword:00000000
+
 [$RootKey$\Editors\{8a5aa6cf-46e3-4520-a70a-7393d15233e9}\LogicalViews]
 "{7651a700-06e5-11d1-8ebd-00a0c90f26ea}"=""
 "{7651a701-06e5-11d1-8ebd-00a0c90f26ea}"=""


### PR DESCRIPTION
This opts us out of PLM (partial load mode) until it becomes stable. We had to opt in to opt out. :)

Otherwise, large solutions will experience odd behavior on already open documents, such as white text and no tooling activated. Very reproducible. Using this fix, no more problems.