### PR TITLE
Enums are always read-only

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -5951,12 +5951,15 @@ let isRecdOrStructTyconRefAssumedImmutable (g: TcGlobals) (tcref: TyconRef) =
 
 let isTyconRefReadOnly g m (tcref: TyconRef) =
     tcref.CanDeref &&
-    ((match tcref.TryIsReadOnly with 
-      | ValueSome res -> res
-      | _ ->
-        let res = TyconRefHasAttribute g m g.attrib_IsReadOnlyAttribute tcref
-        tcref.SetIsReadOnly res
-        res) || tcref.IsEnumTycon)
+    if
+        match tcref.TryIsReadOnly with 
+        | ValueSome res -> res
+        | _ ->
+            let res = TyconRefHasAttribute g m g.attrib_IsReadOnlyAttribute tcref
+            tcref.SetIsReadOnly res
+            res 
+    then true
+    else tcref.IsEnumTycon
 
 let isTyconRefAssumedReadOnly g (tcref: TyconRef) =
     tcref.CanDeref &&

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -5951,12 +5951,12 @@ let isRecdOrStructTyconRefAssumedImmutable (g: TcGlobals) (tcref: TyconRef) =
 
 let isTyconRefReadOnly g m (tcref: TyconRef) =
     tcref.CanDeref &&
-    match tcref.TryIsReadOnly with 
-    | ValueSome res -> res
-    | _ ->
+    ((match tcref.TryIsReadOnly with 
+      | ValueSome res -> res
+      | _ ->
         let res = TyconRefHasAttribute g m g.attrib_IsReadOnlyAttribute tcref
         tcref.SetIsReadOnly res
-        res
+        res) || tcref.IsEnumTycon)
 
 let isTyconRefAssumedReadOnly g (tcref: TyconRef) =
     tcref.CanDeref &&


### PR DESCRIPTION
Just a quick change. We should treat enums as read-only.