### PR TITLE
fix IMAGE_DEBUG_TYPE_CHECKSUMPDB minor version in pdb writer

### DIFF
--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -203,7 +203,7 @@ let pdbChecksumDebugInfo timestamp (checksumPdbChunk: BinaryChunk) (algorithmNam
         buffer
     { iddCharacteristics = 0                                                    // Reserved
       iddMajorVersion = 1                                                       // VersionMajor should be 1
-      iddMinorVersion = 0x0100                                                  // VersionMinor should be 0x0100
+      iddMinorVersion = 0                                                       // VersionMinor should be 0
       iddType = 19                                                              // IMAGE_DEBUG_TYPE_CHECKSUMPDB
       iddTimestamp = timestamp
       iddData = iddBuffer                                                       // Path name to the pdb file when built


### PR DESCRIPTION
F# Compiler is emitting the incorrect minor version number for Debug Directory entry type #19 (PDB Checksum). This bug seems like either a copy/paste error or human error. 0x0100 is the correct minor version number for embedded pdb info, but 0 is the correct minor version number for pdb checksum as spec'd here: https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PE-COFF.md#pdb-checksum-debug-directory-entry-type-19

This issues causes the VS Debugger to ignore PDB Checksum entries in F# pdbs, which breaks NuGet.org Symbol Server scenarios for F#.