### PR TITLE
FCS Doc update - SourceText

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -128,7 +128,7 @@ VSIXInstaller.exe /u:"VisualFSharp"
 VSIXInstaller.exe artifacts\VSSetup\Release\VisualFSharpFull.vsix
 ```
 
-It's important to use `Release` if you want to see if your changes have had a noticable performance impact.
+It's important to use `Release` if you want to see if your changes have had a noticeable performance impact.
 
 ### Performance and debugging
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You're invited to contribute to future releases of the F# compiler, core library
 
 Build from the command line:
 
-```bash
+```
 build.cmd
 ```
 
@@ -18,8 +18,8 @@ After it's finished, open either `FSharp.sln` or `VisualFSharp.sln` in your edit
 
 Build from the command line:
 
-```bash
-sh ./build.sh
+```
+./build.sh
 ```
 
 After it's finished, open `FSharp.sln` in your editor of choice.

--- a/fcs/README.md
+++ b/fcs/README.md
@@ -99,5 +99,5 @@ FSharp.Compiler.Service is a somewhat awkward component. There are some things w
 1. Remove the use of Paket and FAKE
 1. Move all projects under fcs\... to new .NET SDK project file format
 1. Drop the use of ``dotnet mergenupkg`` since we should be able to use cross targeting
-1. Make FCS a DLL similar ot the rest of the build and make this an official component from Microsoft (signed etc.)
+1. Make FCS a DLL similar to the rest of the build and make this an official component from Microsoft (signed etc.)
 1. Replace FSharp.Compiler.Private by FSharp.Compiler.Service

--- a/fcs/docsrc/content/devnotes.md
+++ b/fcs/docsrc/content/devnotes.md
@@ -20,7 +20,7 @@ This repo should be _identical_ to 'fsharp' except:
     - No bootstrap or proto compiler is used - an installed F# compiler is assumed
 
   - Build script using FAKE that builds everything, produces NuGet package and 
-    generates documentation, files for publising NuGet packages etc.
+    generates documentation, files for publishing NuGet packages etc.
     (following [F# project scaffold](https://github.com/fsprojects/FSharp.ProjectScaffold))
 
   - Changes to compiler source code to expose new functionality; Changes to the
@@ -30,7 +30,7 @@ This repo should be _identical_ to 'fsharp' except:
 
   - Additions to compiler source code which add new functionality to the compiler service API
 
-If language or compiler addiitons are committed to `fsharp/fsharp`, they should be merged into 
+If language or compiler additions are committed to `fsharp/fsharp`, they should be merged into
 this repo and a new NuGet package released.
 
 ## Building and NuGet

--- a/fcs/docsrc/content/editor.fsx
+++ b/fcs/docsrc/content/editor.fsx
@@ -27,6 +27,7 @@ of `InteractiveChecker`:
 
 open System
 open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Text
 
 // Create an interactive checker instance 
 let checker = FSharpChecker.Create()
@@ -53,7 +54,7 @@ let inputLines = input.Split('\n')
 let file = "/home/user/Test.fsx"
 
 let projOptions, errors = 
-    checker.GetProjectOptionsFromScript(file, input)
+    checker.GetProjectOptionsFromScript(file, SourceText.ofString input)
     |> Async.RunSynchronously
 
 let parsingOptions, _errors = checker.GetParsingOptionsFromProjectOptions(projOptions)
@@ -68,7 +69,7 @@ together.
 // Perform parsing  
 
 let parseFileResults = 
-    checker.ParseFile(file, input, parsingOptions) 
+    checker.ParseFile(file, SourceText.ofString input, parsingOptions)
     |> Async.RunSynchronously
 (**
 Before we look at the interesting operations provided by `TypeCheckResults`, we 
@@ -78,7 +79,7 @@ result (but it may contain incorrectly "guessed" results).
 
 // Perform type checking
 let checkFileAnswer = 
-    checker.CheckFileInProject(parseFileResults, file, 0, input, projOptions) 
+    checker.CheckFileInProject(parseFileResults, file, 0, SourceText.ofString input, projOptions)
     |> Async.RunSynchronously
 
 (**
@@ -86,7 +87,7 @@ Alternatively you can use `ParseAndCheckFileInProject` to check both in one step
 *)
 
 let parseResults2, checkFileAnswer2 = 
-    checker.ParseAndCheckFileInProject(file, 0, input, projOptions) 
+    checker.ParseAndCheckFileInProject(file, 0, SourceText.ofString input, projOptions)
     |> Async.RunSynchronously
 
 (**

--- a/fcs/docsrc/content/interactive.fsx
+++ b/fcs/docsrc/content/interactive.fsx
@@ -44,8 +44,8 @@ open System.IO
 open System.Text
 
 // Intialize output and input streams
-let sbOut = new StringBuilder()
-let sbErr = new StringBuilder()
+let sbOut = StringBuilder()
+let sbErr = StringBuilder()
 let inStream = new StringReader("")
 let outStream = new StringWriter(sbOut)
 let errStream = new StringWriter(sbErr)
@@ -242,7 +242,7 @@ If you want your scripting code to be able to access the 'fsi' object, you shoul
 Normally the one fromm FSharp.Compiler.Interactive.Settings.dll is used.
 *)
 
-let fsiConfig2 = FsiEvaluationSession.GetDefaultConfiguration(fsi)
+let fsiConfig2 = FsiEvaluationSession.GetDefaultConfiguration(fsiSession)
 
 (**
 Collectible code generation

--- a/fcs/docsrc/content/project.fsx
+++ b/fcs/docsrc/content/project.fsx
@@ -28,6 +28,7 @@ of `InteractiveChecker`:
 open System
 open System.Collections.Generic
 open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Text
 
 // Create an interactive checker instance 
 let checker = FSharpChecker.Create()
@@ -220,7 +221,7 @@ in the project are still read from disk, unless you are using the [FileSystem AP
 *)
 
 let parseResults1, checkAnswer1 = 
-    checker.ParseAndCheckFileInProject(Inputs.fileName1, 0, Inputs.fileSource1, projectOptions) 
+    checker.ParseAndCheckFileInProject(Inputs.fileName1, 0, SourceText.ofString Inputs.fileSource1, projectOptions)
     |> Async.RunSynchronously
 
 let checkResults1 = 
@@ -229,7 +230,7 @@ let checkResults1 =
     | _ -> failwith "unexpected aborted"
 
 let parseResults2, checkAnswer2 = 
-    checker.ParseAndCheckFileInProject(Inputs.fileName2, 0, Inputs.fileSource2, projectOptions)
+    checker.ParseAndCheckFileInProject(Inputs.fileName2, 0, SourceText.ofString Inputs.fileSource2, projectOptions)
     |> Async.RunSynchronously
 
 let checkResults2 = 

--- a/fcs/docsrc/content/symbols.fsx
+++ b/fcs/docsrc/content/symbols.fsx
@@ -19,6 +19,7 @@ of `FSharpChecker`:
 open System
 open System.IO
 open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Text
 
 // Create an interactive checker instance 
 let checker = FSharpChecker.Create()
@@ -72,7 +73,7 @@ type C() =
     member x.P = 1
       """
 let parseFileResults, checkFileResults = 
-    parseAndTypeCheckSingleFile(file, input2)
+    parseAndTypeCheckSingleFile(file, SourceText.ofString input2)
 
 (**
 Now get the partial assembly signature for the code:

--- a/fcs/docsrc/content/typedtree.fsx
+++ b/fcs/docsrc/content/typedtree.fsx
@@ -26,6 +26,7 @@ To use the interactive checker, reference `FSharp.Compiler.Service.dll` and open
 open System
 open System.IO
 open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Text
 (**
 
 ### Checking code
@@ -42,7 +43,7 @@ let parseAndCheckSingleFile (input) =
     File.WriteAllText(file, input)
     // Get context representing a stand-alone (script) file
     let projOptions, _errors = 
-        checker.GetProjectOptionsFromScript(file, input)
+        checker.GetProjectOptionsFromScript(file, SourceText.ofString input)
         |> Async.RunSynchronously
 
     checker.ParseAndCheckProject(projOptions) 

--- a/fcs/docsrc/content/untypedtree.fsx
+++ b/fcs/docsrc/content/untypedtree.fsx
@@ -31,6 +31,7 @@ To use the interactive checker, reference `FSharp.Compiler.Service.dll` and open
 #r "FSharp.Compiler.Service.dll"
 open System
 open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Text
 (**
 
 ### Performing untyped parse
@@ -201,16 +202,19 @@ with location of the file. The location does not have to exist (it is used only 
 information) and it can be in both Unix and Windows formats:
 *)
 // Sample input for the compiler service
-let input = """
+let input =
+  """
   let foo() = 
     let msg = "Hello world"
     if true then 
-      printfn "%s" msg """
+      printfn "%s" msg
+  """
+
 // File name in Unix format
 let file = "/home/user/Test.fsx"
 
 // Get the AST of sample F# code
-let tree = getUntypedTree(file, input) 
+let tree = getUntypedTree(file, SourceText.ofString input)
 (**
 When you run the code in F# interactive, you can enter `tree;;` in the interactive console and
 see pretty printed representation of the data structure - the tree contains a lot of information,


### PR DESCRIPTION
There are a couple small fixes in this PR.

1) Fixed FCS code examples that incorrectly sent a String type into a function expecting a SourceText type (causing compile errors). I assume when the underlying methods changed from accepting String to SourceText these examples weren't updated; I believe this rectifies this.

2) Modified dev notes for `sh build.sh`.  It doesn't work if sh isn't linked to `bash`, removing the explicit `sh` resolves the issue and makes it consistent with other parts of the documentation.

3) Fixed misc. typos.
 