### PR TITLE
[WIP] Improve type inference for non-sealed types

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -805,15 +805,6 @@ and solveTypMeetsTyparConstraints (csenv: ConstraintSolverEnv) ndeep m2 trace ty
     for e in r.Constraints do
       do!
       match e with
-      | TyparConstraint.DefaultsTo (priority, dty, m) -> 
-          if typeEquiv g ty dty then 
-              CompleteD
-          else
-              match tryDestTyparTy g ty with
-              | ValueNone -> CompleteD
-              | ValueSome destTypar ->
-                  AddConstraint csenv ndeep m2 trace destTypar (TyparConstraint.DefaultsTo(priority, dty, m))
-          
       | TyparConstraint.SupportsNull m2                -> SolveTypeSupportsNull               csenv ndeep m2 trace ty
       | TyparConstraint.IsEnum(underlying, m2)         -> SolveTypeIsEnum                     csenv ndeep m2 trace ty underlying
       | TyparConstraint.SupportsComparison(m2)         -> SolveTypeSupportsComparison         csenv ndeep m2 trace ty
@@ -827,6 +818,14 @@ and solveTypMeetsTyparConstraints (csenv: ConstraintSolverEnv) ndeep m2 trace ty
       | TyparConstraint.CoercesTo(ty2, m2)             -> SolveTypeSubsumesTypeKeepAbbrevs    csenv ndeep m2 trace None ty2 ty
       | TyparConstraint.MayResolveMember(traitInfo, m2) -> 
           SolveMemberConstraint csenv false false ndeep m2 trace traitInfo |> OperationResult.ignore
+      | TyparConstraint.DefaultsTo (priority, dty, m) -> 
+          if typeEquiv g ty dty then 
+              CompleteD
+          else
+              match tryDestTyparTy g ty with
+              | ValueNone -> CompleteD
+              | ValueSome destTypar ->
+                  AddConstraint csenv ndeep m2 trace destTypar (TyparConstraint.DefaultsTo(priority, dty, m))          
   }
 
         


### PR DESCRIPTION
I'm trying to fix a problem I find frequently, when I have a set of overloads and only those for types that are sealed get properly inferred while the rest fail to compile.