### PR TITLE
update package feed url

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -18,10 +18,9 @@
     <add key="interactive-window" value="https://dotnet.myget.org/F/interactive-window/api/v3/index.json" />
     <add key="vs-devcore" value="https://myget.org/F/vs-devcore/api/v3/index.json" />
     <add key="vs-editor" value="https://myget.org/F/vs-editor/api/v3/index.json" />
-    <add key="vssdk" value="https://vside.myget.org/F/vssdk/api/v3/index.json" />
-    <add key="vs-impl" value="https://vside.myget.org/F/vs-impl/api/v3/index.json" />
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="roslyn_concord" value="https://myget.org/F/roslyn_concord/api/v3/index.json" />
-    <add key="devcore" value="https://vside.myget.org/F/devcore/api/v3/index.json" />
     <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
     <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
     <add key="aspnet-aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,10 +60,9 @@
       https://dotnet.myget.org/F/interactive-window/api/v3/index.json;
       https://myget.org/F/vs-devcore/api/v3/index.json;
       https://myget.org/F/vs-editor/api/v3/index.json;
-      https://vside.myget.org/F/vssdk/api/v3/index.json;
-      https://vside.myget.org/F/vs-impl/api/v3/index.json;
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
       https://myget.org/F/roslyn_concord/api/v3/index.json;
-      https://vside.myget.org/F/devcore/api/v3/index.json;
     </RestoreSources>
     <!-- version numbers from files -->
     <RoslynVersion>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\RoslynPackageVersion.txt').Trim())</RoslynVersion>


### PR DESCRIPTION
The replaced MyGet feed has been deprecated and the packages have moved to an Azure DevOps feed.

This should fix a bunch of recent failing PRs.