### PR TITLE
Allow resource text to work with %x format strings

### DIFF
--- a/src/fsharp/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/fsharp/FSharp.Build/FSharpEmbedResourceText.fs
@@ -155,20 +155,23 @@ type FSharpEmbedResourceText() =
         let mutable holes = ResizeArray()  //  order
         let sb = new System.Text.StringBuilder()
         let AddHole holeType =
-            sb.Append(sprintf "{%d}" holeNumber) |> ignore
+            match holeType with
+            | "System.UInt32" -> sb.Append(sprintf "{%d:x}" holeNumber) |> ignore
+            | _ -> sb.Append(sprintf "{%d}" holeNumber) |> ignore
             holeNumber <- holeNumber + 1
             holes.Add(holeType)
         while i < txt.Length do
             if txt.[i] = '%' then
                 if i+1 = txt.Length then
-                    Err(filename, lineNum, "(at end of string) % must be followed by d, f, s, or %")
+                    Err(filename, lineNum, "(at end of string) % must be followed by d, x, f, s, or %")
                 else
                     match txt.[i+1] with
                     | 'd' -> AddHole "System.Int32"
+                    | 'x' -> AddHole "System.UInt32"
                     | 'f' -> AddHole "System.Double"
                     | 's' -> AddHole "System.String"
                     | '%' -> sb.Append('%') |> ignore
-                    | c -> Err(filename, lineNum, sprintf "'%%%c' is not a valid sequence, only %%d %%f %%s or %%%%" c)
+                    | c -> Err(filename, lineNum, sprintf "'%%%c' is not a valid sequence, only %%d %%x %%f %%s or %%%%" c)
                 i <- i + 2
             else
                 match txt.[i] with
@@ -279,6 +282,7 @@ open Printf
         match fmt.[i] with
         | '%' -> go args ty (i+1)
         | 'd'
+        | 'x'
         | 'f'
         | 's' -> buildFunctionForOneArgPat ty (fun rty n -> go (n :: args) rty (i+1))
         | _ -> failwith ""bad format specifier""
@@ -406,10 +410,11 @@ open Printf
                 fprintfn out "    /// %s" str
                 fprintfn out "    /// (Originally from %s:%d)" filename (lineNum+1)
                 let justPercentsFromFormatString = 
-                    (holes |> Array.fold (fun acc holeType -> 
-                        acc + match holeType with 
-                                | "System.Int32" -> ",,,%d" 
-                                | "System.Double" -> ",,,%f" 
+                    (holes |> Array.fold (fun acc holeType ->
+                        acc + match holeType with
+                                | "System.Int32" -> ",,,%d"
+                                | "System.UInt32" -> ",,,%x"
+                                | "System.Double" -> ",,,%f"
                                 | "System.String" -> ",,,%s"
                                 | _ -> failwith "unreachable") "") + ",,,"
                 let errPrefix = match optErrNum with


### PR DESCRIPTION
While working on something else I noticed that the imbedded resource routines do not work with %x format strings.

This PR makes a few minor modifications to allow the generation of resource strings that will do %x string formatting.

