### PR TITLE
turn off broken source link validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -330,3 +330,5 @@ stages:
     parameters:
       # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
       enableSymbolValidation: false
+      # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
+      enableSourceLinkValidation: false


### PR DESCRIPTION
Internal builds generate a warning that various generated files (e.g., under `artifacts/obj/...` cannot be found in the repo.  Since this is by design I'm turning off SourceLink validation (similar to Roslyn) so we don't fill the logs with warnings that don't matter.