### PR TITLE
Disallow attributes on type extensions

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1461,6 +1461,7 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3243,parsInvalidAnonRecdExpr,"Invalid anonymous record expression"
 3244,parsInvalidAnonRecdType,"Invalid anonymous record type"
 3245,tcCopyAndUpdateNeedsRecordType,"The input to a copy-and-update expression that creates an anonymous record must be either an anonymous record or a record"
+3245,tcAugmentationsCannotHaveAttributes,"Attributes cannot be assigned to type extensions."
 3300,chkInvalidFunctionParameterType,"The parameter '%s' has an invalid type '%s'. This is not permitted by the rules of Common IL."
 3301,chkInvalidFunctionReturnType,"The function or method has an invalid return type '%s'. This is not permitted by the rules of Common IL."
 useSdkRefs,"Use reference assemblies for .NET framework references when available (Enabled by default)."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1461,7 +1461,7 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3243,parsInvalidAnonRecdExpr,"Invalid anonymous record expression"
 3244,parsInvalidAnonRecdType,"Invalid anonymous record type"
 3245,tcCopyAndUpdateNeedsRecordType,"The input to a copy-and-update expression that creates an anonymous record must be either an anonymous record or a record"
-3245,tcAugmentationsCannotHaveAttributes,"Attributes cannot be assigned to type extensions."
+3246,tcAugmentationsCannotHaveAttributes,"Attributes cannot be applied to type extensions."
 3300,chkInvalidFunctionParameterType,"The parameter '%s' has an invalid type '%s'. This is not permitted by the rules of Common IL."
 3301,chkInvalidFunctionReturnType,"The function or method has an invalid return type '%s'. This is not permitted by the rules of Common IL."
 useSdkRefs,"Use reference assemblies for .NET framework references when available (Enabled by default)."

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -16429,6 +16429,11 @@ module TcDeclarations =
                 if not (isNil members) && tcref.IsTypeAbbrev then 
                     errorR(Error(FSComp.SR.tcTypeAbbreviationsCannotHaveAugmentations(), tyDeclRange))
 
+                let (ComponentInfo (attributes, _, _, _, _, _, _, _)) = synTyconInfo
+                if not (List.isEmpty attributes) && (declKind = ExtrinsicExtensionBinding || declKind = IntrinsicExtensionBinding) then
+                    let attributeRange = (List.head attributes).Range
+                    error(Error(FSComp.SR.tcAugmentationsCannotHaveAttributes(), attributeRange))
+
                 MutRecDefnsPhase2DataForTycon(tyconOpt, innerParent, declKind, tcref, baseValOpt, safeInitInfo, declaredTyconTypars, members, tyDeclRange, newslotsOK, fixupFinalAttrs))
 
         // By now we've established the full contents of type definitions apart from their

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">Není definovaný obor názvů {0}.</target>

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">Der Namespace "{0}" ist nicht definiert.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">El espacio de nombres "{0}" no está definido.</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">L'espace de noms '{0}' n'est pas défini.</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">Lo spazio dei nomi '{0}' non è definito.</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">名前空間 '{0}' が定義されていません。</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">'{0}' 네임스페이스가 정의되지 않았습니다.</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">Nie zdefiniowano przestrzeni nazw „{0}”.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">O namespace '{0}' não está definido.</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">Пространство имен "{0}" не определено.</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">'{0}' ad alanı tanımlı değil.</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">未定义命名空间“{0}”。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="new">Algorithm '{0}' is not supported</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAugmentationsCannotHaveAttributes">
+        <source>Attributes cannot be assigned to type extensions.</source>
+        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="undefinedNameNamespace">
         <source>The namespace '{0}' is not defined.</source>
         <target state="translated">未定義命名空間 '{0}'。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
-        <source>Attributes cannot be assigned to type extensions.</source>
-        <target state="new">Attributes cannot be assigned to type extensions.</target>
+        <source>Attributes cannot be applied to type extensions.</source>
+        <target state="new">Attributes cannot be applied to type extensions.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/tests/fsharp/Compiler/Language/TypeAttributeTests.fs
+++ b/tests/fsharp/Compiler/Language/TypeAttributeTests.fs
@@ -1,0 +1,44 @@
+﻿namespace FSharp.Compiler.UnitTests
+
+open NUnit.Framework
+open FSharp.Compiler.SourceCodeServices
+
+[<TestFixture>]
+module TypeAttributeTests = 
+
+    [<Test>]
+    let ``Attribute can be assigned to type definition``() = 
+        CompilerAssert.Pass
+            """
+[<Struct>]
+type Point = {x:int; y:int}
+            """
+    [<Test>]
+    let ``Attribute cannot be assigned to optional type extension``() = 
+        CompilerAssert.TypeCheckSingleError
+            """
+open System
+
+[<NoEquality>]
+type String with 
+    member this.test = 42
+            """
+            FSharpErrorSeverity.Error
+            3245
+            (4, 1, 4, 15)
+            "Attributes cannot be assigned to type extensions."
+
+    [<Test>]
+    let ``Attribute cannot be assigned to intrinsic type extension``() = 
+        CompilerAssert.TypeCheckSingleError
+            """
+type Point = {x:int; y:int}
+
+[<NoEquality>]
+type Point with 
+    member this.test = 42
+            """
+            FSharpErrorSeverity.Error
+            3245
+            (4, 1, 4, 15)
+            "Attributes cannot be assigned to type extensions."

--- a/tests/fsharp/Compiler/Language/TypeAttributeTests.fs
+++ b/tests/fsharp/Compiler/Language/TypeAttributeTests.fs
@@ -7,14 +7,14 @@ open FSharp.Compiler.SourceCodeServices
 module TypeAttributeTests = 
 
     [<Test>]
-    let ``Attribute can be assigned to type definition``() = 
+    let ``Attribute can be applied to type definition``() = 
         CompilerAssert.Pass
             """
 [<Struct>]
 type Point = {x:int; y:int}
             """
     [<Test>]
-    let ``Attribute cannot be assigned to optional type extension``() = 
+    let ``Attribute cannot be applied to optional type extension``() = 
         CompilerAssert.TypeCheckSingleError
             """
 open System
@@ -24,12 +24,12 @@ type String with
     member this.test = 42
             """
             FSharpErrorSeverity.Error
-            3245
+            3246
             (4, 1, 4, 15)
-            "Attributes cannot be assigned to type extensions."
+            "Attributes cannot be applied to type extensions."
 
     [<Test>]
-    let ``Attribute cannot be assigned to intrinsic type extension``() = 
+    let ``Attribute cannot be applied to intrinsic type extension``() = 
         CompilerAssert.TypeCheckSingleError
             """
 type Point = {x:int; y:int}
@@ -39,6 +39,6 @@ type Point with
     member this.test = 42
             """
             FSharpErrorSeverity.Error
-            3245
+            3246
             (4, 1, 4, 15)
-            "Attributes cannot be assigned to type extensions."
+            "Attributes cannot be applied to type extensions."

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -55,6 +55,7 @@
     <Compile Include="Compiler\Warnings\AssignmentWarningTests.fs" />
     <Compile Include="Compiler\Warnings\PatternMatchingWarningTests.fs" />
     <Compile Include="Compiler\SourceTextTests.fs" />
+    <Compile Include="Compiler\Language\TypeAttributeTests.fs" />
     <Compile Include="Compiler\Language\AnonRecordTests.fs" />
     <Compile Include="Compiler\Language\SpanOptimizationTests.fs" />
     <Compile Include="Compiler\Language\SpanTests.fs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/7394

Before, when attributes get added to type extensions, they can be parsed, no errors are thrown, but the attributes are silently dropped inside the type checker. This PR explicitly disallows that.
