### PR TITLE
add VS insertion logic to build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -332,3 +332,14 @@ stages:
       enableSymbolValidation: false
       # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
       enableSourceLinkValidation: false
+
+#---------------------------------------------------------------------------------------------------------------------#
+#                                                   VS Insertion                                                      #
+#---------------------------------------------------------------------------------------------------------------------#
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng/release/insert-into-vs.yml
+    parameters:
+      componentBranchName: refs/heads/release/dev16.4
+      insertTargetBranch: master
+      insertTeamEmail: fsharpteam@microsoft.com
+      insertTeamName: 'F#'

--- a/eng/release/insert-into-vs.yml
+++ b/eng/release/insert-into-vs.yml
@@ -1,0 +1,54 @@
+parameters:
+  componentBranchName: ''
+  insertBuildPolicy: 'CloudBuild - Request RPS'
+  insertTargetBranch: ''
+  insertTeamEmail: ''
+  insertTeamName: ''
+  dependsOn: [build]
+
+stages:
+- stage: insert
+  dependsOn: build
+  displayName: Insert into VS
+  jobs:
+  - job: Insert_VS
+    pool:
+      vmImage: vs2017-win2016
+    variables:
+    - group: DotNet-VSTS-Infra-Access
+    - name: InsertAccessToken
+      value: $(dn-bot-devdiv-build-rw-code-rw-release-rw)
+    - name: InsertBuildPolicy
+      value: ${{ parameters.insertBuildPolicy }}
+    - name: InsertTargetBranch
+      value: ${{ parameters.insertTargetBranch }}
+    - name: InsertTeamEmail
+      value: ${{ parameters.insertTeamEmail }}
+    - name: InsertTeamName
+      value: ${{ parameters.insertTeamName }}
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Insertion Artifacts
+      inputs:
+        buildType: current
+        artifactName: VSSetup
+    - task: PowerShell@2
+      displayName: Get Publish URLs
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/release/scripts/GetPublishUrls.ps1
+        arguments: -accessToken $(System.AccessToken) -buildId $(Build.BuildId) -insertionDir $(Build.ArtifactStagingDirectory)\VSSetup
+    - task: PowerShell@2
+      displayName: Get versions for default.config
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/release/scripts/GetDefaultConfigVersions.ps1
+        arguments: -packagesDir $(Build.ArtifactStagingDirectory)\VSSetup\DevDivPackages
+    - task: PowerShell@2
+      displayName: Get versions for AssemblyVersions.tt
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/release/scripts/GetAssemblyVersions.ps1
+        arguments: -assemblyVersionsPath $(Build.ArtifactStagingDirectory)\VSSetup\DevDivPackages\DependentAssemblyVersions.csv
+    - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@2
+      displayName: 'Insert VS Payload'
+      inputs:
+        LinkWorkItemsToPR: false
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], '${{ parameters.componentBranchName }}'))

--- a/eng/release/scripts/GetAssemblyVersions.ps1
+++ b/eng/release/scripts/GetAssemblyVersions.ps1
@@ -1,0 +1,28 @@
+[CmdletBinding(PositionalBinding=$false)]
+param (
+    [string]$assemblyVersionsPath
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    [string[]]$lines = Get-Content -Path $assemblyVersionsPath | ForEach-Object {
+        $parts = $_ -Split ",",2
+        $asm = $parts[0]
+        $ver = $parts[1]
+        $asmConst = ($asm -Replace "\.","") + "Version"
+        $output = "$asmConst=$ver"
+        $output
+    }
+
+    $final = $lines -Join ","
+    Write-Host "Setting InsertVersionsValues to $final"
+    Write-Host "##vso[task.setvariable variable=InsertVersionsValues]$final"
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/eng/release/scripts/GetDefaultConfigVersions.ps1
+++ b/eng/release/scripts/GetDefaultConfigVersions.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding(PositionalBinding=$false)]
+param (
+    [string]$packagesDir
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    $packages = @()
+    $regex = "^(.*?)\.((?:\.?[0-9]+){3,}(?:[-a-z0-9]+)?)\.nupkg$"
+    Get-Item -Path "$packagesDir\*" -Filter "*.nupkg" | ForEach-Object {
+        $fileName = Split-Path $_ -Leaf
+        If ($fileName -Match $regex) {
+            $entry = $Matches[1] + "=" + $Matches[2]
+            $packages += $entry
+        }
+    }
+
+    $final = $packages -Join ","
+    Write-Host "Setting InsertConfigValues to $final"
+    Write-Host "##vso[task.setvariable variable=InsertConfigValues]$final"
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/eng/release/scripts/GetPublishUrls.ps1
+++ b/eng/release/scripts/GetPublishUrls.ps1
@@ -1,0 +1,57 @@
+[CmdletBinding(PositionalBinding=$false)]
+param (
+    [string]$accessToken,
+    [string]$buildId,
+    [string]$insertionDir
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    # build map of all *.vsman files to their `info.buildVersion` values
+    $manifestVersionMap = @{}
+    Get-ChildItem -Path "$insertionDir\*" -Filter "*.vsman" | ForEach-Object {
+        $manifestName = Split-Path $_ -Leaf
+        $vsmanContents = Get-Content $_ | ConvertFrom-Json
+        $buildVersion = $vsmanContents.info.buildVersion
+        $manifestVersionMap.Add($manifestName, $buildVersion)
+    }
+
+    # find all publish URLs
+    $manifests = @()
+    $seenManifests = @{}
+    $url = "https://dev.azure.com/dnceng/internal/_apis/build/builds/$buildId/logs?api-version=5.1"
+    $base64 = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$accessToken"))
+    $headers = @{
+        Authorization = "Basic $base64"
+    }
+    Write-Host "Fetching log from $url"
+    $json = Invoke-WebRequest -Method Get -Uri $url -Headers $headers -UseBasicParsing | ConvertFrom-Json
+    foreach ($l in $json.value) {
+        $logUrl = $l.url
+        Write-Host "Fetching log from $logUrl"
+        $log = (Invoke-WebRequest -Method Get -Uri $logUrl -Headers $headers -UseBasicParsing).Content
+        If ($log -Match "(https://vsdrop\.corp\.microsoft\.com/[^\r\n;]+);([^\r\n]+)\r?\n") {
+            $manifestShortUrl = $Matches[1]
+            $manifestName = $Matches[2]
+            $manifestUrl = "$manifestShortUrl;$manifestName"
+            If (-Not $seenManifests.Contains($manifestUrl)) {
+                $seenManifests.Add($manifestUrl, $true)
+                $buildVersion = $manifestVersionMap[$manifestName]
+                $manifestEntry = "$manifestName{$buildVersion}=$manifestUrl"
+                $manifests += $manifestEntry
+            }
+        }
+    }
+
+    $final = $manifests -Join ","
+    Write-Host "Setting InsertJsonValues to $final"
+    Write-Host "##vso[task.setvariable variable=InsertJsonValues]$final"
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}


### PR DESCRIPTION
Simply a cherry-pick of #7499 to `master`.

Since `master` doesn't produce any officially inserted builds, this has no effect here, but it sets us up for easy insertions from any new branches.