### PR TITLE
cleanup FX_LCIDFROMCODEPAGE

### DIFF
--- a/FSharp.Profiles.props
+++ b/FSharp.Profiles.props
@@ -6,7 +6,6 @@
     <DefineConstants Condition="'$(MonoPackaging)' == 'true'">$(DefineConstants);CROSS_PLATFORM_COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);ENABLE_MONO_SUPPORT</DefineConstants>
     <DefineConstants>$(DefineConstants);BE_SECURITY_TRANSPARENT</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_LCIDFROMCODEPAGE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1774,15 +1774,13 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
           exiter: Exiter, errorLoggerProvider : ErrorLoggerProvider, disposables : DisposablesTracker) = 
 
     // See Bug 735819 
-    let lcidFromCodePage = 
-#if FX_LCIDFROMCODEPAGE
+    let lcidFromCodePage =
         if (Console.OutputEncoding.CodePage <> 65001) &&
            (Console.OutputEncoding.CodePage <> Thread.CurrentThread.CurrentUICulture.TextInfo.OEMCodePage) &&
            (Console.OutputEncoding.CodePage <> Thread.CurrentThread.CurrentUICulture.TextInfo.ANSICodePage) then
                 Thread.CurrentThread.CurrentUICulture <- new CultureInfo("en-US")
                 Some 1033
         else
-#endif
             None
 
     let directoryBuildingFrom = Directory.GetCurrentDirectory()

--- a/src/fsharp/fsi/fsimain.fs
+++ b/src/fsharp/fsi/fsimain.fs
@@ -40,14 +40,12 @@ do()
 
 
 /// Set the current ui culture for the current thread.
-#if FX_LCIDFROMCODEPAGE
 let internal SetCurrentUICultureForThread (lcid : int option) =
     let culture = Thread.CurrentThread.CurrentUICulture
     match lcid with
     | Some n -> Thread.CurrentThread.CurrentUICulture <- new CultureInfo(n)
     | None -> ()
     { new IDisposable with member x.Dispose() = Thread.CurrentThread.CurrentUICulture <- culture }
-#endif
 
 let callStaticMethod (ty:Type) name args =
     ty.InvokeMember(name, (BindingFlags.InvokeMethod ||| BindingFlags.Static ||| BindingFlags.Public ||| BindingFlags.NonPublic), null, null, Array.ofList args,Globalization.CultureInfo.InvariantCulture)
@@ -95,11 +93,7 @@ type WinFormsEventLoop() =
                                            try 
                                               // When we get called back, someone may jack our culture
                                               // So we must reset our UI culture every time
-#if FX_LCIDFROMCODEPAGE
                                               use _scope = SetCurrentUICultureForThread lcid
-#else
-                                              ignore lcid
-#endif
                                               mainFormInvokeResultHolder := Some(f ())
                                            finally 
                                               doneSignal.Set() |> ignore)) |> ignore

--- a/vsintegration/Utils/LanguageServiceProfiling/Options.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Options.fs
@@ -212,9 +212,8 @@ let FCS (repositoryDir: string) : Options =
             @"--define:FX_ATLEAST_40"; "--define:BE_SECURITY_TRANSPARENT";
             @"--define:COMPILER";
             @"--define:ENABLE_MONO_SUPPORT"; "--define:FX_MSBUILDRESOLVER_RUNTIMELIKE";
-            @"--define:FX_LCIDFROMCODEPAGE"; "--define:FX_RESX_RESOURCE_READER";
-            @"--define:FX_RESIDENT_COMPILER"; "--define:SHADOW_COPY_REFERENCES";
-            @"--define:EXTENSIONTYPING";
+            @"--define:FX_RESX_RESOURCE_READER"; "--define:FX_RESIDENT_COMPILER";
+            @"--define:SHADOW_COPY_REFERENCES"; "--define:EXTENSIONTYPING";
             @"--define:COMPILER_SERVICE_DLL_ASSUMES_FSHARP_CORE_4_4_0_0";
             @"--define:COMPILER_SERVICE_DLL"; "--define:NO_STRONG_NAMES"; "--define:TRACE";
             @"--doc:..\..\..\bin\v4.5\FSharp.Compiler.Service.xml"; "--optimize-";


### PR DESCRIPTION
Remove remaining few FX_LCIDFROMCODEPAGE customizations.  coreclr now handles the lcid apis cross platform.