### PR TITLE
cleanup compilingFsLib

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2015,9 +2015,6 @@ type TcConfigBuilder =
       mutable openDebugInformationForLaterStaticLinking: bool (* only for --standalone *)
       defaultFSharpBinariesDir: string
       mutable compilingFslib: bool
-      mutable compilingFslib20: string option
-      mutable compilingFslib40: bool
-      mutable compilingFslibNoBigInt: bool
       mutable useIncrementalBuilder: bool
       mutable includes: string list
       mutable implicitOpens: string list
@@ -2180,9 +2177,6 @@ type TcConfigBuilder =
           openDebugInformationForLaterStaticLinking = false
           defaultFSharpBinariesDir = String.Empty
           compilingFslib = false
-          compilingFslib20 = None
-          compilingFslib40 = false
-          compilingFslibNoBigInt = false
           useIncrementalBuilder = false
           useFsiAuxLib = false
           implicitOpens = []
@@ -2665,9 +2659,6 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
     member x.openDebugInformationForLaterStaticLinking = data.openDebugInformationForLaterStaticLinking
     member x.fsharpBinariesDir = fsharpBinariesDirValue
     member x.compilingFslib = data.compilingFslib
-    member x.compilingFslib20 = data.compilingFslib20
-    member x.compilingFslib40 = data.compilingFslib40
-    member x.compilingFslibNoBigInt = data.compilingFslibNoBigInt
     member x.useIncrementalBuilder = data.useIncrementalBuilder
     member x.includes = data.includes
     member x.implicitOpens = data.implicitOpens

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -256,9 +256,6 @@ type TcConfigBuilder =
       mutable openDebugInformationForLaterStaticLinking: bool
       defaultFSharpBinariesDir: string
       mutable compilingFslib: bool
-      mutable compilingFslib20: string option
-      mutable compilingFslib40: bool
-      mutable compilingFslibNoBigInt: bool
       mutable useIncrementalBuilder: bool
       mutable includes: string list
       mutable implicitOpens: string list
@@ -424,9 +421,6 @@ type TcConfig =
     member openDebugInformationForLaterStaticLinking: bool
     member fsharpBinariesDir: string
     member compilingFslib: bool
-    member compilingFslib20: string option
-    member compilingFslib40: bool
-    member compilingFslibNoBigInt: bool
     member useIncrementalBuilder: bool
     member includes: string list
     member implicitOpens: string list

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -1217,10 +1217,9 @@ let internalFlags (tcConfigB:TcConfigBuilder) =
         Some(InternalCommandLineOption("metadataversion", rangeCmdArgs)), None)
   ]
 
-  
 // OptionBlock: Deprecated flags (fsc, service only)
 //--------------------------------------------------
-    
+
 let compilingFsLibFlag (tcConfigB: TcConfigBuilder) = 
     CompilerOption
         ("compiling-fslib", tagNone,
@@ -1231,23 +1230,14 @@ let compilingFsLibFlag (tcConfigB: TcConfigBuilder) =
             IlxSettings.ilxCompilingFSharpCoreLib := true),
          Some(InternalCommandLineOption("--compiling-fslib", rangeCmdArgs)), None)
 
-let compilingFsLib20Flag (tcConfigB: TcConfigBuilder) = 
-    CompilerOption
-        ("compiling-fslib-20", tagNone,
-         OptionString (fun s -> tcConfigB.compilingFslib20 <- Some s ),
-         Some(InternalCommandLineOption("--compiling-fslib-20", rangeCmdArgs)), None)
+let compilingFsLib20Flag =
+    CompilerOption ("compiling-fslib-20", tagNone, OptionString (fun _ -> () ), None, None)
 
-let compilingFsLib40Flag (tcConfigB: TcConfigBuilder) = 
-    CompilerOption
-        ("compiling-fslib-40", tagNone,
-         OptionUnit (fun () -> tcConfigB.compilingFslib40 <- true ),
-         Some(InternalCommandLineOption("--compiling-fslib-40", rangeCmdArgs)), None)
+let compilingFsLib40Flag =
+    CompilerOption ("compiling-fslib-40", tagNone, OptionUnit (fun () -> ()), None, None)
 
-let compilingFsLibNoBigIntFlag (tcConfigB: TcConfigBuilder) = 
-    CompilerOption
-        ("compiling-fslib-nobigint", tagNone,
-         OptionUnit (fun () -> tcConfigB.compilingFslibNoBigInt <- true ),
-         Some(InternalCommandLineOption("--compiling-fslib-nobigint", rangeCmdArgs)), None)
+let compilingFsLibNoBigIntFlag =
+    CompilerOption ("compiling-fslib-nobigint", tagNone, OptionUnit (fun () -> () ), None, None)
 
 let mlKeywordsFlag = 
     CompilerOption
@@ -1262,7 +1252,7 @@ let gnuStyleErrorsFlag tcConfigB =
          Some(DeprecatedCommandLineOptionNoDescription("--gnu-style-errors", rangeCmdArgs)), None)
 
 let deprecatedFlagsBoth tcConfigB =
-    [ 
+    [
       CompilerOption
          ("light", tagNone,
           OptionUnit (fun () -> tcConfigB.light <- Some true),
@@ -1278,7 +1268,7 @@ let deprecatedFlagsBoth tcConfigB =
           OptionUnit (fun () -> tcConfigB.light <- Some false),
           Some(DeprecatedCommandLineOptionNoDescription("--no-indentation-syntax", rangeCmdArgs)), None) 
     ]
-          
+
 let deprecatedFlagsFsi tcConfigB = deprecatedFlagsBoth tcConfigB
 
 let deprecatedFlagsFsc tcConfigB =
@@ -1311,9 +1301,9 @@ let deprecatedFlagsFsc tcConfigB =
         Some(DeprecatedCommandLineOptionNoDescription("--progress", rangeCmdArgs)), None)
 
     compilingFsLibFlag tcConfigB
-    compilingFsLib20Flag tcConfigB 
-    compilingFsLib40Flag tcConfigB
-    compilingFsLibNoBigIntFlag tcConfigB
+    compilingFsLib20Flag
+    compilingFsLib40Flag
+    compilingFsLibNoBigIntFlag
 
     CompilerOption
        ("version", tagString,

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -869,11 +869,9 @@ module MainModuleBuilder =
               error(Error(FSComp.SR.fscAssemblyCultureAttributeError(), rangeCmdArgs))
 
             // Add the type forwarders to any .NET DLL post-.NET-2.0, to give binary compatibility
-            let exportedTypesList = 
-                if (tcConfig.compilingFslib && tcConfig.compilingFslib40) then 
-                   (List.append (createMscorlibExportList tcGlobals)
-                                (if tcConfig.compilingFslibNoBigInt then [] else (createSystemNumericsExportList tcConfig tcImports))
-                   )
+            let exportedTypesList =
+                if tcConfig.compilingFslib then
+                   List.append (createMscorlibExportList tcGlobals) (createSystemNumericsExportList tcConfig tcImports)
                 else
                     []
 
@@ -1279,64 +1277,6 @@ module StaticLinker =
 
             ilxMainModule, rewriteExternalRefsToLocalRefs
 
-
-    // LEGACY: This is only used when compiling an FSharp.Core for .NET 2.0 (FSharp.Core 2.3.0.0). We no longer
-    // build new FSharp.Core for that configuration.
-    //
-    // Find all IL modules that are to be statically linked given the static linking roots.
-    let LegacyFindAndAddMscorlibTypesForStaticLinkingIntoFSharpCoreLibraryForNet20 (tcConfig: TcConfig, ilGlobals: ILGlobals, ilxMainModule) = 
-        let mscorlib40 = tcConfig.compilingFslib20.Value 
-              
-        let ilBinaryReader = 
-            let ilGlobals = mkILGlobals ILScopeRef.Local
-            let opts : ILReaderOptions = 
-                { ilGlobals = ilGlobals
-                  reduceMemoryUsage = tcConfig.reduceMemoryUsage
-                  metadataOnly = MetadataOnlyFlag.No
-                  tryGetMetadataSnapshot = (fun _ -> None)
-                  pdbDirPath = None  } 
-            ILBinaryReader.OpenILModuleReader mscorlib40 opts
-              
-        let tdefs1 = ilxMainModule.TypeDefs.AsList  |> List.filter (fun td -> not (MainModuleBuilder.injectedCompatTypes.Contains(td.Name)))
-        let tdefs2 = ilBinaryReader.ILModuleDef.TypeDefs.AsList |> List.filter (fun td -> MainModuleBuilder.injectedCompatTypes.Contains(td.Name))
-        //printfn "tdefs2 = %A" (tdefs2 |> List.map (fun tdef -> tdef.Name))
-
-        // rewrite the mscorlib references 
-        let tdefs2 = 
-            let fakeModule = mkILSimpleModule "" "" true (4, 0) false (mkILTypeDefs tdefs2) None None 0 (mkILExportedTypes []) ""
-            let fakeModule = 
-                  fakeModule |> Morphs.morphILTypeRefsInILModuleMemoized ilGlobals (fun tref -> 
-                      if MainModuleBuilder.injectedCompatTypes.Contains(tref.Name)  || (tref.Enclosing  |> List.exists (fun x -> MainModuleBuilder.injectedCompatTypes.Contains x)) then 
-                          tref
-                          //|> Morphs.morphILScopeRefsInILTypeRef (function ILScopeRef.Local -> ilGlobals.mscorlibScopeRef | x -> x) 
-                      // The implementations of Tuple use two private methods from System.Environment to get a resource string. Remap it
-                      elif tref.Name = "System.Environment" then 
-                          ILTypeRef.Create(ILScopeRef.Local, [], "Microsoft.FSharp.Core.PrivateEnvironment")  //|> Morphs.morphILScopeRefsInILTypeRef (function ILScopeRef.Local -> ilGlobals.mscorlibScopeRef | x -> x) 
-                      else 
-                          tref |> Morphs.morphILScopeRefsInILTypeRef (fun _ -> ilGlobals.primaryAssemblyScopeRef) )
-                  
-            // strip out System.Runtime.TargetedPatchingOptOutAttribute, which doesn't exist for 2.0
-            let fakeModule = 
-              {fakeModule with 
-                TypeDefs = 
-                  mkILTypeDefs 
-                      ([ for td in fakeModule.TypeDefs do 
-                             let meths = td.Methods.AsList
-                                            |> List.map (fun md ->
-                                                md.With(customAttrs = 
-                                                              mkILCustomAttrs (td.CustomAttrs.AsList |> List.filter (fun ilattr ->
-                                                                ilattr.Method.DeclaringType.TypeRef.FullName <> "System.Runtime.TargetedPatchingOptOutAttribute")))) 
-                                            |> mkILMethods
-                             let td = td.With(methods=meths)
-                             yield td.With(methods=meths) ])}
-            //ILAsciiWriter.output_module stdout fakeModule
-            fakeModule.TypeDefs.AsList
-
-        let ilxMainModule = 
-            { ilxMainModule with 
-                TypeDefs = mkILTypeDefs (tdefs1 @ tdefs2) }
-        ilxMainModule
-
     [<NoEquality; NoComparison>]
     type Node = 
         { name: string
@@ -1481,7 +1421,7 @@ module StaticLinker =
     let StaticLink (ctok, tcConfig: TcConfig, tcImports: TcImports, ilGlobals: ILGlobals) = 
 
 #if !NO_EXTENSIONTYPING
-        let providerGeneratedAssemblies = 
+        let providerGeneratedAssemblies =
 
             [ // Add all EST-generated assemblies into the static linking set
                 for KeyValue(_, importedBinary: ImportedBinary) in tcImports.DllTable do
@@ -1490,10 +1430,7 @@ module StaticLinker =
                         | None -> ()
                         | Some provAssemStaticLinkInfo -> yield (importedBinary, provAssemStaticLinkInfo) ]
 #endif
-        if tcConfig.compilingFslib && tcConfig.compilingFslib20.IsSome then 
-            (fun ilxMainModule -> LegacyFindAndAddMscorlibTypesForStaticLinkingIntoFSharpCoreLibraryForNet20 (tcConfig, ilGlobals, ilxMainModule))
-          
-        elif not tcConfig.standalone && tcConfig.extraStaticLinkRoots.IsEmpty 
+        if not tcConfig.standalone && tcConfig.extraStaticLinkRoots.IsEmpty 
 #if !NO_EXTENSIONTYPING
              && providerGeneratedAssemblies.IsEmpty 
 #endif


### PR DESCRIPTION
With this PR we will no longer support building fsharp.core version 2.0.  It's very likely we didn't anyway, we haven't built and tested it in more than 3 years.

This PR:
- disables the command line switches:**compiling-fslib-20**, **compiling-fslib-40**,**compiling-fslib-nobigint**
- Removes the special cases for fslib-20 and fslib-no-bigint.