### PR TITLE
return the last-computed value when evaluating script code

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1171,7 +1171,7 @@ type internal FsiDynamicCompiler
                         lastValue <- None
                     | FSharpImplementationFileDeclaration.InitAction _ ->
                         // Top level 'do' bindings are not reported as incremental declarations
-                        ()
+                        lastValue <- None
             | _ -> ()
         with _ -> ()
 

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -30,6 +30,14 @@ type InteractiveTests() =
         Assert.AreEqual(2, value.ReflectionValue :?> int)
 
     [<Test>]
+    member __.``Declare and eval object value``() =
+        use script = new FSharpScript()
+        let opt = script.Eval("let x = 1 + 2\r\nx") |> getValue
+        let value = opt.Value
+        Assert.AreEqual(typeof<int>, value.ReflectionType)
+        Assert.AreEqual(3, value.ReflectionValue :?> int)
+
+    [<Test>]
     member __.``Capture console input``() =
         use script = new FSharpScript(captureInput=true)
         script.ProvideInput "stdin:1234\r\n"


### PR DESCRIPTION
As it currently stands, evaluating a single expression via `FsiEvaluationSession.EvalInteractionNonThrowing()` returns the result of the expression.  See [here](https://github.com/dotnet/fsharp/blob/f890daf066ded9233128525f36f69ae80c9a116c/src/fsharp/fsi/fsi.fs#L1791-L1792) and [here](https://github.com/dotnet/fsharp/blob/f890daf066ded9233128525f36f69ae80c9a116c/src/fsharp/fsi/fsi.fs#L1204).

However, when evaluating a multi-expression code segment like

``` f#
let x = 1 + 2
x
```

the last computed value is returned as [`None`](https://github.com/dotnet/fsharp/blob/f890daf066ded9233128525f36f69ae80c9a116c/src/fsharp/fsi/fsi.fs#L1794), specifically this part:

``` f#
fsiDynamicCompiler.EvalParsedDefinitions (ctok, errorLogger, istate, true, false, defs),Completed None
//                                                                                      ^^^^^^^^^^^^^^
```

The purpose of this PR is to return the last evaluated value.

~~The initial attempt explicitly pulls out the special `it` value, mimicking the code path taken when evaluating a single expression [here](https://github.com/dotnet/fsharp/blob/f890daf066ded9233128525f36f69ae80c9a116c/src/fsharp/fsi/fsi.fs#L1189-L1205).~~

~~This does, however, lead to the question of whether or not is is actually correct.~~

~~The other option I considered was to track the last value produced, like so (this is a highly simplified version of [this](https://github.com/dotnet/fsharp/blob/f890daf066ded9233128525f36f69ae80c9a116c/src/fsharp/fsi/fsi.fs#L1128-L1175)):~~

``` diff
 // ...
+let mutable lastValue = None
 try
     // ...
     match contentFile.Declarations with
     | [FSharpImplementationFileDeclaration.Entity (_eFakeModule,modDecls) ] ->
         // ...
         for decl in modDecls do
             match decl with
             | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (v,_,_) ->
                 // ...
                 let fsiValueOpt =
                     // ...
+                lastValue <- fsiValueOpt
             | FSharpImplementationFileDeclaration.Entity (e,_) ->
                 // ...
+                lastValue <- None
             | FSharpImplementationFileDeclaration.InitAction _ ->
+                // should `lastValue` also be set to `None` here?
 // ...
-newState
+newState, Completed lastValue
```

~~As it stands, I'm certainly open to either method, or something else entirely.~~

The first method of extracting `it` caused a bunch of (probably foreseeable) test failures, so I've added a commit that uses the `lastValue` approach.  My questions about the validity of this method remain.