### PR TITLE
Do not check assembly for string concat optimization

### DIFF
--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1830,22 +1830,27 @@ let TryDetectQueryQuoteAndRun cenv (expr: Expr) =
         //printfn "Not eliminating because no Run found"
         None
 
-let IsILMethodRefDeclaringTypeSystemString (ilg: ILGlobals) (mref: ILMethodRef) =
-    mref.DeclaringTypeRef.Scope.IsAssemblyRef &&
-    mref.DeclaringTypeRef.Scope.AssemblyRef.Name = ilg.typ_String.TypeRef.Scope.AssemblyRef.Name &&
-    mref.DeclaringTypeRef.BasicQualifiedName = ilg.typ_String.BasicQualifiedName
-                
-let IsILMethodRefSystemStringConcatOverload (ilg: ILGlobals) (mref: ILMethodRef) =
-    IsILMethodRefDeclaringTypeSystemString ilg mref &&
+let IsILMethodRefSystemStringConcat (mref: ILMethodRef) =
     mref.Name = "Concat" &&
-    mref.ReturnType.BasicQualifiedName = ilg.typ_String.BasicQualifiedName &&
-    mref.ArgCount >= 2 && mref.ArgCount <= 4 && mref.ArgTypes |> List.forall(fun ilty -> ilty.BasicQualifiedName = ilg.typ_String.BasicQualifiedName)
+    mref.DeclaringTypeRef.Name = "System.String" &&
+    (mref.ReturnType.IsNominal && mref.ReturnType.TypeRef.Name = "System.String") &&
+    (mref.ArgCount >= 2 && mref.ArgCount <= 4 &&
+        mref.ArgTypes 
+        |> List.forall (fun ilTy ->
+            ilTy.IsNominal && ilTy.TypeRef.Name = "System.String"))
 
-let IsILMethodRefSystemStringConcatArray (ilg: ILGlobals) (mref: ILMethodRef) =
-    IsILMethodRefDeclaringTypeSystemString ilg mref &&
+let IsILMethodRefSystemStringConcatArray (mref: ILMethodRef) =
     mref.Name = "Concat" &&
-    mref.ReturnType.BasicQualifiedName = ilg.typ_String.BasicQualifiedName &&
-    mref.ArgCount = 1 && mref.ArgTypes.Head.BasicQualifiedName = "System.String[]"
+    mref.DeclaringTypeRef.Name = "System.String" &&
+    (mref.ReturnType.IsNominal && mref.ReturnType.TypeRef.Name = "System.String") &&
+    (mref.ArgCount = 1 && 
+        mref.ArgTypes
+        |> List.forall (fun ilTy ->          
+            match ilTy with
+            | ILType.Array (shape, ilTy) when shape = ILArrayShape.SingleDimensional &&
+                                              ilTy.IsNominal &&
+                                              ilTy.TypeRef.Name = "System.String" -> true
+            | _ -> false))
     
 /// Optimize/analyze an expression
 let rec OptimizeExpr cenv (env: IncrementalOptimizationEnv) expr =
@@ -1972,10 +1977,12 @@ and OptimizeInterfaceImpl cenv env baseValOpt (ty, overrides) =
 and MakeOptimizedSystemStringConcatCall cenv env m args =
     let rec optimizeArg argExpr accArgs =
         match argExpr, accArgs with
-        | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, methRef, _, _, _), _, [ Expr.Op(TOp.Array, _, args, _) ], _), _ when IsILMethodRefSystemStringConcatArray cenv.g.ilg methRef ->
+        | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, [ Expr.Op(TOp.Array, _, args, _) ], _), _ 
+          when IsILMethodRefSystemStringConcatArray mref ->
             optimizeArgs args accArgs
 
-        | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, args, _), _ when IsILMethodRefSystemStringConcatOverload cenv.g.ilg mref ->
+        | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, args, _), _ 
+          when IsILMethodRefSystemStringConcat mref ->
             optimizeArgs args accArgs
 
         // Optimize string constants, e.g. "1" + "2" will turn into "12"
@@ -2005,7 +2012,8 @@ and MakeOptimizedSystemStringConcatCall cenv env m args =
             mkStaticCall_String_Concat_Array cenv.g m arg
 
     match expr with
-    | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, methRef, _, _, _) as op, tyargs, args, m) when IsILMethodRefSystemStringConcatOverload cenv.g.ilg methRef || IsILMethodRefSystemStringConcatArray cenv.g.ilg methRef ->
+    | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _) as op, tyargs, args, m) 
+      when IsILMethodRefSystemStringConcat mref || IsILMethodRefSystemStringConcatArray mref ->
         OptimizeExprOpReductions cenv env (op, tyargs, args, m)
     | _ ->
         OptimizeExpr cenv env expr
@@ -2074,9 +2082,11 @@ and OptimizeExprOp cenv env (op, tyargs, args, m) =
     | TOp.ILAsm ([], [ty]), _, [a] when typeEquiv cenv.g (tyOfExpr cenv.g a) ty -> OptimizeExpr cenv env a
 
     // Optimize calls when concatenating strings, e.g. "1" + "2" + "3" + "4" .. etc.
-    | TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, [ Expr.Op(TOp.Array, _, args, _) ] when IsILMethodRefSystemStringConcatArray cenv.g.ilg mref ->
+    | TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, [ Expr.Op(TOp.Array, _, args, _) ] 
+      when IsILMethodRefSystemStringConcatArray mref ->
         MakeOptimizedSystemStringConcatCall cenv env m args
-    | TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, args when IsILMethodRefSystemStringConcatOverload cenv.g.ilg mref ->
+    | TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, args 
+      when IsILMethodRefSystemStringConcat mref ->
         MakeOptimizedSystemStringConcatCall cenv env m args
 
     | _ -> 


### PR DESCRIPTION
This stops checking for the assembly for string concat optimizations. We need to remove this as the optimization breaks when we have forwarded types. 

An alternative to this fix: 
- Check `ILTypeRef`'s imported `TyconRef` instead. Retrieving the corresponding `TyconRef` for an `ILTypeRef` is done by trying to import an `ILTypeRef` (`Import.ImportILTyperef`) which is also cached. I'm not sure the performance implications of that though.

I'm not super concerned about the performance, but in the future we could start adding flags for special methods so we only do the check once.

// cc @KevinRansom 