### PR TITLE
add event every time `#r` is invoked

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -32,6 +32,8 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool) as this =
     let argv = [| this.GetType().Assembly.Location; "--noninteractive"; "--targetprofile:netcore"; "--quiet" |]
     let fsi = FsiEvaluationSession.Create (config, argv, stdin, stdout, stderr, collectible=true)
 
+    member __.AssemblyReferenceAdded = fsi.AssemblyReferenceAdded
+
     member __.ProvideInput = stdin.ProvideInput
 
     member __.OutputProduced = outputProduced.Publish

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1713,6 +1713,8 @@ type internal FsiInteractionProcessor
 
     let referencedAssemblies = Dictionary<string, DateTime>()
 
+    let assemblyReferencedEvent = Control.Event<string>()
+
     let mutable currState = initialInteractiveState
     let event = Control.Event<unit>()
     let setCurrState s = currState <- s; event.Trigger()
@@ -1815,6 +1817,7 @@ type internal FsiInteractionProcessor
                                 FSIstrings.SR.fsiDidAHashr(ar.resolvedPath)
                         else
                             FSIstrings.SR.fsiDidAHashrWithLockWarning(ar.resolvedPath)
+                    assemblyReferencedEvent.Trigger(ar.resolvedPath)
                     fsiConsoleOutput.uprintnfnn "%s" format)
                 istate,Completed None
 
@@ -2230,6 +2233,8 @@ type internal FsiInteractionProcessor
         let fsiInteractiveChecker = FsiInteractiveChecker(legacyReferenceResolver, checker, tcConfig, istate.tcGlobals, istate.tcImports, istate.tcState)
         fsiInteractiveChecker.ParseAndCheckInteraction(ctok, SourceText.ofString text)
 
+    member __.AssemblyReferenceAdded = assemblyReferencedEvent.Publish
+
 
 //----------------------------------------------------------------------------
 // Server mode:
@@ -2628,6 +2633,9 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         fsiInteractionProcessor.EvalScript(ctok, scriptPath, errorLogger)
         |> commitResultNonThrowing errorOptions scriptPath errorLogger
         |> function Choice1Of2 (_), errs -> Choice1Of2 (), errs | Choice2Of2 exn, errs -> Choice2Of2 exn, errs
+
+    /// Event fires every time an assembly reference is added to the execution environment, e.g., via `#r`.
+    member __.AssemblyReferenceAdded = fsiInteractionProcessor.AssemblyReferenceAdded
  
     /// Performs these steps:
     ///    - Load the dummy interaction, if any

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -227,6 +227,9 @@ type FsiEvaluationSession =
     /// A host calls this to report an unhandled exception in a standard way, e.g. an exception on the GUI thread gets printed to stderr
     member ReportUnhandledException : exn: exn -> unit
 
+    /// Event fires every time an assembly reference is added to the execution environment, e.g., via `#r`.
+    member AssemblyReferenceAdded : IEvent<string>
+
     /// Load the dummy interaction, load the initial files, and,
     /// if interacting, start the background thread to read the standard input.
     ///

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -68,10 +68,20 @@ type InteractiveTests() =
         Assert.AreEqual(5, value.ReflectionValue :?> int)
 
     [<Test>]
-    member __.``Assembly reference events``() =
+    member __.``Assembly reference event successful``() =
         use script = new FSharpScript()
         let testAssembly = "System.dll"
         let mutable foundAssemblyReference = false
         Event.add (fun (assembly: string) -> foundAssemblyReference <- String.Compare(testAssembly, Path.GetFileName(assembly), StringComparison.OrdinalIgnoreCase) = 0) script.AssemblyReferenceAdded
         script.Eval(sprintf "#r \"%s\"" testAssembly) |> ignoreValue
         Assert.True(foundAssemblyReference)
+
+    [<Test>]
+    member __.``Assembly reference event unsuccessful``() =
+        use script = new FSharpScript()
+        let testAssembly = "not-an-assembly-that-can-be-found.dll"
+        let mutable foundAssemblyReference = false
+        Event.add (fun (assembly: string) -> foundAssemblyReference <- String.Compare(testAssembly, Path.GetFileName(assembly), StringComparison.OrdinalIgnoreCase) = 0) script.AssemblyReferenceAdded
+        let _result, errors = script.Eval(sprintf "#r \"%s\"" testAssembly)
+        Assert.AreEqual(1, errors.Length)
+        Assert.False(foundAssemblyReference)

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.Scripting.UnitTests
 
 open System
+open System.IO
 open System.Threading
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.Scripting
@@ -65,3 +66,12 @@ type InteractiveTests() =
         let value = opt.Value
         Assert.AreEqual(typeof<int>, value.ReflectionType)
         Assert.AreEqual(5, value.ReflectionValue :?> int)
+
+    [<Test>]
+    member __.``Assembly reference events``() =
+        use script = new FSharpScript()
+        let testAssembly = "System.dll"
+        let mutable foundAssemblyReference = false
+        Event.add (fun (assembly: string) -> foundAssemblyReference <- String.Compare(testAssembly, Path.GetFileName(assembly), StringComparison.OrdinalIgnoreCase) = 0) script.AssemblyReferenceAdded
+        script.Eval(sprintf "#r \"%s\"" testAssembly) |> ignoreValue
+        Assert.True(foundAssemblyReference)


### PR DESCRIPTION
This adds an event to `FsiInteractionProcessor` that fires every time `#r` is invoked.  Since this type is internal, the event is resurfaced in `FsiEvaluationsession` and it is resurfaced again in `FSharpScript`, although as discussed previously, the `FSharpScript` type will eventually go away; it's just currently a handy place to see all consumed APIs for the Jupyter kernel work in [dotnet/try](https://github.com/dotnet/try), so there will eventually only be the one resurfacing in `FsiEvaluationSession`.

There is [one other location](https://github.com/dotnet/fsharp/blob/f525717ee80c996287c7ffb8e47e26de06fd9848/src/fsharp/CompileOps.fs#L4835) where `#r` commands are handled, but due to how those functions are called, it's not interesting to fire an event because there's no way to consume them.