### PR TITLE
allow nuget references from script host

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.fsproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.DependencyManager\FSharp.DependencyManager.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.nuspec
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.nuspec
@@ -14,5 +14,7 @@
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.Scripting.xml" target="lib\netstandard2.0" />
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.dll" target="lib\netstandard2.0" />
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.xml" target="lib\netstandard2.0" />
+        <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.DependencyManager.dll" target="lib\netstandard2.0" />
+        <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.DependencyManager.xml" target="lib\netstandard2.0" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -5,7 +5,7 @@ namespace FSharp.Compiler.Scripting
 open System
 open FSharp.Compiler.Interactive.Shell
 
-type FSharpScript(?captureInput: bool, ?captureOutput: bool) as this =
+type FSharpScript(?captureInput: bool, ?captureOutput: bool, ?additionalArgs: string[]) as this =
     let outputProduced = Event<string>()
     let errorProduced = Event<string>()
 
@@ -17,6 +17,7 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool) as this =
     do stderr.LineWritten.Add errorProduced.Trigger
     let captureInput = defaultArg captureInput false
     let captureOutput = defaultArg captureOutput false
+    let additionalArgs = defaultArg additionalArgs [||]
     let savedInput = Console.In
     let savedOutput = Console.Out
     let savedError = Console.Error
@@ -29,7 +30,8 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool) as this =
         ())()
 
     let config = FsiEvaluationSession.GetDefaultConfiguration()
-    let argv = [| this.GetType().Assembly.Location; "--noninteractive"; "--targetprofile:netcore"; "--quiet" |]
+    let baseArgs = [| this.GetType().Assembly.Location; "--noninteractive"; "--targetprofile:netcore"; "--quiet" |]
+    let argv = Array.append baseArgs additionalArgs
     let fsi = FsiEvaluationSession.Create (config, argv, stdin, stdout, stderr, collectible=true)
 
     member __.AssemblyReferenceAdded = fsi.AssemblyReferenceAdded

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private.Scripting\FSharp.Compiler.Private.Scripting.fsproj" />
+    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.DependencyManager\FSharp.DependencyManager.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -90,3 +90,12 @@ type InteractiveTests() =
         let _result, errors = script.Eval(sprintf "#r \"%s\"" testAssembly)
         Assert.AreEqual(1, errors.Length)
         Assert.False(foundAssemblyReference)
+
+    [<Test>]
+    member __.``Nuget reference fires multiple events``() =
+        use script = new FSharpScript(additionalArgs=[|"/langversion:preview"|])
+        let mutable assemblyRefCount = 0;
+        Event.add (fun _ -> assemblyRefCount <- assemblyRefCount + 1) script.AssemblyReferenceAdded
+        script.Eval("#r \"nuget:include=NUnitLite, version=3.11.0\"") |> ignoreValue
+        script.Eval("0") |> ignoreValue
+        Assert.GreaterOrEqual(assemblyRefCount, 2)


### PR DESCRIPTION
Enable `#r "nuget:..."` from `FSharp.Compiler.Private.Scripting`.