### PR TITLE
Clarify what to do for working on the compiler only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ You're invited to contribute to future releases of the F# compiler, core library
 
 ### Quickstart on Windows
 
-Build from the command line:
+Build from the command line if you want to work on the **F# compiler only**:
+
+```
+build.cmd --noVisualStudio
+```
+
+After it's finished, open `FSharp.sln` in your editor of choice.
+
+----
+
+Build from the command line if you want to work on the **F# tools & F# compiler**:
 
 ```
 build.cmd


### PR DESCRIPTION
I noticed that with the current master it's only possible to use the command `build.cmd` alone if you run it in the `developer command prompt` for the Visual Studio 2019 preview.

As I only intended to work on the compiler this wasn't my plan and after investigating the build script further I noticed that the resolution of the build tools is different if the flag `--noVisualStudio` is used.
To lessen the pain for future contributors I thought adding a small tip/notice about that to the Readme would be good.