### PR TITLE
fire events when script host resolves assembly reference

### DIFF
--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -672,7 +672,7 @@ val WriteOptimizationData: TcGlobals * filename: string * inMem: bool * CcuThunk
 
 /// Process #r in F# Interactive.
 /// Adds the reference to the tcImports and add the ccu to the type checking environment.
-val RequireDLL: CompilationThreadToken * TcImports * TcEnv * thisAssemblyName: string * referenceRange: range * file: string -> TcEnv * (ImportedBinary list * ImportedAssembly list)
+val RequireDLL: CompilationThreadToken * TcImports * TcEnv * thisAssemblyName: string * referenceRange: range * file: string * assemblyReferenceAdded: (string -> unit) -> TcEnv * (ImportedBinary list * ImportedAssembly list)
 
 /// Processing # commands
 val ProcessMetaCommandsFromInput: 

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -5,7 +5,7 @@ namespace FSharp.Compiler.Scripting
 open System
 open FSharp.Compiler.Interactive.Shell
 
-type FSharpScript(?captureInput: bool, ?captureOutput: bool) as this =
+type FSharpScript(?captureInput: bool, ?captureOutput: bool, ?additionalArgs: string[]) as this =
     let outputProduced = Event<string>()
     let errorProduced = Event<string>()
 
@@ -17,6 +17,7 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool) as this =
     do stderr.LineWritten.Add errorProduced.Trigger
     let captureInput = defaultArg captureInput false
     let captureOutput = defaultArg captureOutput false
+    let additionalArgs = defaultArg additionalArgs [||]
     let savedInput = Console.In
     let savedOutput = Console.Out
     let savedError = Console.Error
@@ -29,7 +30,8 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool) as this =
         ())()
 
     let config = FsiEvaluationSession.GetDefaultConfiguration()
-    let argv = [| this.GetType().Assembly.Location; "--noninteractive"; "--targetprofile:netcore"; "--quiet" |]
+    let baseArgs = [| this.GetType().Assembly.Location; "--noninteractive"; "--targetprofile:netcore"; "--quiet" |]
+    let argv = Array.append baseArgs additionalArgs
     let fsi = FsiEvaluationSession.Create (config, argv, stdin, stdout, stderr, collectible=true)
 
     member __.AssemblyReferenceAdded = fsi.AssemblyReferenceAdded

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -32,6 +32,8 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool) as this =
     let argv = [| this.GetType().Assembly.Location; "--noninteractive"; "--targetprofile:netcore"; "--quiet" |]
     let fsi = FsiEvaluationSession.Create (config, argv, stdin, stdout, stderr, collectible=true)
 
+    member __.AssemblyReferenceAdded = fsi.AssemblyReferenceAdded
+
     member __.ProvideInput = stdin.ProvideInput
 
     member __.OutputProduced = outputProduced.Publish

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -227,6 +227,9 @@ type FsiEvaluationSession =
     /// A host calls this to report an unhandled exception in a standard way, e.g. an exception on the GUI thread gets printed to stderr
     member ReportUnhandledException : exn: exn -> unit
 
+    /// Event fires every time an assembly reference is added to the execution environment, e.g., via `#r`.
+    member AssemblyReferenceAdded : IEvent<string>
+
     /// Load the dummy interaction, load the initial files, and,
     /// if interacting, start the background thread to read the standard input.
     ///


### PR DESCRIPTION
Cherry-picking relevant parts of #7537 and #7561 to `master`.

@KevinRansom and I decided that some of the scripting work that's been happening in the `feature/kernel` branch is useful in `master`, so the development story is changing such that any changes that can be made in `master` will be made there, and the `feature/kernel` branch will only contain changes that won't work in `master` or `release/fsharp5`.