### PR TITLE
Add fsi dependent Reference Testcase

### DIFF
--- a/VisualFSharp.sln
+++ b/VisualFSharp.sln
@@ -164,6 +164,10 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.Private.Scr
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.Private.Scripting.UnitTests", "tests\FSharp.Compiler.Private.Scripting.UnitTests\FSharp.Compiler.Private.Scripting.UnitTests.fsproj", "{09F56540-AFA5-4694-B7A6-0DBF6D4618C2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TopAssembly", "tests\FSharp.Compiler.Private.Scripting.UnitTests\TestProjects\DependentAssemblies\TopAssembly\TopAssembly.csproj", "{5313D5B9-01B1-44F5-8BA3-40910DCF693B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DependentAssembly", "tests\FSharp.Compiler.Private.Scripting.UnitTests\TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj", "{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -954,6 +958,30 @@ Global
 		{09F56540-AFA5-4694-B7A6-0DBF6D4618C2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{09F56540-AFA5-4694-B7A6-0DBF6D4618C2}.Release|x86.ActiveCfg = Release|Any CPU
 		{09F56540-AFA5-4694-B7A6-0DBF6D4618C2}.Release|x86.Build.0 = Release|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Debug|x86.Build.0 = Debug|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Proto|Any CPU.Build.0 = Debug|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Proto|x86.ActiveCfg = Debug|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Proto|x86.Build.0 = Debug|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Release|x86.ActiveCfg = Release|Any CPU
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B}.Release|x86.Build.0 = Release|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Debug|x86.Build.0 = Debug|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Proto|Any CPU.Build.0 = Debug|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Proto|x86.ActiveCfg = Debug|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Proto|x86.Build.0 = Debug|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Release|x86.ActiveCfg = Release|Any CPU
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1031,6 +1059,8 @@ Global
 		{79255A92-ED00-40BA-9D64-12FCC664A976} = {4C7B48D7-19AF-4AE7-9D1D-3BB289D5480D}
 		{20B7BC36-CF51-4D75-9E13-66681C07977F} = {B8DDA694-7939-42E3-95E5-265C2217C142}
 		{09F56540-AFA5-4694-B7A6-0DBF6D4618C2} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
+		{5313D5B9-01B1-44F5-8BA3-40910DCF693B} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
+		{6EFD1B2F-7CC3-49C1-994B-22EA52ACDFB1} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {48EDBBBE-C8EE-4E3C-8B19-97184A487B37}

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
@@ -17,11 +17,11 @@
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private.Scripting\FSharp.Compiler.Private.Scripting.fsproj" />
-    <ProjectReference Include="$(FSharpSourcesRoot)\..\tests\FSharp.Compiler.Private.Scripting.UnitTests\TestProjects\DependentAssemblies\TopAssembly\TopAssembly.csproj"><Private>false</Private></ProjectReference>
-    <ProjectReference Include="$(FSharpSourcesRoot)\..\tests\FSharp.Compiler.Private.Scripting.UnitTests\TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj"><Private>false</Private></ProjectReference>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)TestProjects\DependentAssemblies\TopAssembly\TopAssembly.csproj"><Private>false</Private></ProjectReference>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj"><Private>false</Private></ProjectReference>
   </ItemGroup>
 
-  <Target Name="MyCopyFilesToOutputDirectory" AfterTargets="CoreBuild">
+  <Target Name="MyCopyFilesToOutputDirectory" AfterTargets="Compile">
     <Copy SourceFiles="$(OutDir)..\..\..\TopAssembly\$(Configuration)\$(TargetFramework)\TopAssembly.dll" DestinationFolder="$(OutDir)TopAssemblyLocation\" />
     <Copy SourceFiles="$(OutDir)..\..\..\DependentAssembly\$(Configuration)\$(TargetFramework)\DependentAssembly.dll" DestinationFolder="$(OutDir)DependentAssemblyLocation\" />
   </Target>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
@@ -17,8 +17,8 @@
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private.Scripting\FSharp.Compiler.Private.Scripting.fsproj" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)TestProjects\DependentAssemblies\TopAssembly\TopAssembly.csproj"><Private>false</Private></ProjectReference>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj"><Private>false</Private></ProjectReference>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)TestProjects\DependentAssemblies\TopAssembly\TopAssembly.csproj"><Private>false</Private><ReferenceOutputAssembly>false</ReferenceOutputAssembly></ProjectReference>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj"><Private>false</Private><ReferenceOutputAssembly>false</ReferenceOutputAssembly></ProjectReference>
   </ItemGroup>
 
   <Target Name="MyCopyFilesToOutputDirectory" AfterTargets="Compile">

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
@@ -17,6 +17,13 @@
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private.Scripting\FSharp.Compiler.Private.Scripting.fsproj" />
+    <ProjectReference Include="$(FSharpSourcesRoot)\..\tests\FSharp.Compiler.Private.Scripting.UnitTests\TestProjects\DependentAssemblies\TopAssembly\TopAssembly.csproj"><Private>false</Private></ProjectReference>
+    <ProjectReference Include="$(FSharpSourcesRoot)\..\tests\FSharp.Compiler.Private.Scripting.UnitTests\TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj"><Private>false</Private></ProjectReference>
   </ItemGroup>
+
+  <Target Name="MyCopyFilesToOutputDirectory" AfterTargets="CoreBuild">
+    <Copy SourceFiles="$(OutDir)..\..\..\TopAssembly\$(Configuration)\$(TargetFramework)\TopAssembly.dll" DestinationFolder="$(OutDir)TopAssemblyLocation\" />
+    <Copy SourceFiles="$(OutDir)..\..\..\DependentAssembly\$(Configuration)\$(TargetFramework)\DependentAssembly.dll" DestinationFolder="$(OutDir)DependentAssemblyLocation\" />
+  </Target>
 
 </Project>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/DependentAssembly/DependentAssembly.cs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/DependentAssembly/DependentAssembly.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace DependentAssembly
+{
+    public class DependentAssemblyClass
+    {
+        public string GetTheString(string passedIn)
+        {
+            return $"Hello {passedIn}";
+        }
+    }
+}

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/DependentAssembly/DependentAssembly.csproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/DependentAssembly/DependentAssembly.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.0</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+
+</Project>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/DependentAssembly/DependentAssembly.csproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/DependentAssembly/DependentAssembly.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-    <Configuration>Release</Configuration>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
 </Project>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/TopAssembly/TopAssembly.csproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/TopAssembly/TopAssembly.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.0</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(FSharpSourcesRoot)\..\tests\FSharp.Compiler.Private.Scripting.UnitTests\TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj"><Private>false</Private></ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/TopAssembly/TopAssembly.csproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/TopAssembly/TopAssembly.csproj
@@ -5,10 +5,11 @@
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(FSharpSourcesRoot)\..\tests\FSharp.Compiler.Private.Scripting.UnitTests\TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj"><Private>false</Private></ProjectReference>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\TestProjects\DependentAssemblies\DependentAssembly\DependentAssembly.csproj"><Private>false</Private></ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/TopAssembly/TopAssemblyClass.cs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestProjects/DependentAssemblies/TopAssembly/TopAssemblyClass.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using DependentAssembly;
+
+namespace TopAssembly
+{
+    public class TopAssemblyClass
+    {
+        public string GetTheString(string s)
+        {
+            return new DependentAssemblyClass().GetTheString(s);
+        }
+    }
+}


### PR DESCRIPTION
The issue that this PR: https://github.com/dotnet/fsharp/pull/7598 addresses is: when fsi executes generated code on the coreclr it didn't follow transitive references.

Anyway the fix is in, this PR just has a simple repro that doesn't include 3rd part nuget packages and starting the browser.


