### PR TITLE
Consider '_' for members with access modifiers

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1924,6 +1924,11 @@ atomicPatternLongIdent:
     }
   | GLOBAL DOT pathOp  { let (LongIdentWithDots(lid,dotms)) = $3 in (None,LongIdentWithDots(ident(MangledGlobalName,rhs parseState 1) :: lid, rhs parseState 2 :: dotms)) }
   | pathOp { (None,$1) }
+  | access UNDERSCORE DOT pathOp {
+    if not (parseState.LexBuffer.SupportsFeature LanguageFeature.SingleUnderscorePattern) then
+        raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedSymbolDot())
+    let (LongIdentWithDots(lid,dotms)) = $4 in (Some($1),LongIdentWithDots(ident("_",rhs parseState 1)::lid, rhs parseState 2::dotms))
+    }  
   | access pathOp { (Some($1), $2) }
 
 

--- a/tests/fsharp/core/members/basics/test.fs
+++ b/tests/fsharp/core/members/basics/test.fs
@@ -18,6 +18,15 @@ let test (s : string) b =
 let check s b1 b2 = test s (b1 = b2)
 
 //--------------------------------------------------------------
+// Test defining a type using wildcard self identifiers
+
+type ClassType0 () =
+    member _.myNumber () = 0
+    member private _.myPrivateNumber () = 1
+    member inline _.myInlineNumber () = 2
+    member inline private _.myPrivateInlineNumber () = 3
+
+//--------------------------------------------------------------
 // Test defining a record using object-expression syntax
 
 type RecordType = { a: int; mutable b: int }

--- a/tests/fsharp/core/members/basics/test.fs
+++ b/tests/fsharp/core/members/basics/test.fs
@@ -18,15 +18,6 @@ let test (s : string) b =
 let check s b1 b2 = test s (b1 = b2)
 
 //--------------------------------------------------------------
-// Test defining a type using wildcard self identifiers
-
-type ClassType0 () =
-    member _.myNumber () = 0
-    member private _.myPrivateNumber () = 1
-    member inline _.myInlineNumber () = 2
-    member inline private _.myPrivateInlineNumber () = 3
-
-//--------------------------------------------------------------
 // Test defining a record using object-expression syntax
 
 type RecordType = { a: int; mutable b: int }

--- a/tests/fsharp/core/members/self-identifier/version47/test.fs
+++ b/tests/fsharp/core/members/self-identifier/version47/test.fs
@@ -26,12 +26,30 @@ type MyStructWithUnderscoreIdentifier =
     member _.MethodWithUnderscoreSelf() = true
     member __.MethodWithDoubleUnderscoreSelf() = true
     member _E.MethodWithUnderscoreESelf() = true
+    member private _.PrivateMethodWithUnderscoreSelf() = true
+    member private __.PrivateMethodWithDoubleUnderscoreSelf() = true
+    member private _E.PrivateMethodWithUnderscoreESelf() = true
+    member inline _.InlineMethodWithUnderscoreSelf() = true
+    member inline __.InlineMethodWithDoubleUnderscoreSelf() = true
+    member inline _E.InlineMethodWithUnderscoreESelf() = true
+    member inline private _.InlinePrivateMethodWithUnderscoreSelf() = true
+    member inline private __.InlinePrivateMethodWithDoubleUnderscoreSelf() = true
+    member inline private _E.InlinePrivateMethodWithUnderscoreESelf() = true
 
 type MyClassWithUnderscoreIdentifier () =
     class
         member _.MethodWithUnderscoreSelf() = true
         member __.MethodWithDoubleUnderscoreSelf() = true
         member _E.MethodWithUnderscoreESelf() = true
+        member private _.PrivateMethodWithUnderscoreSelf() = true
+        member private __.PrivateMethodWithDoubleUnderscoreSelf() = true
+        member private _E.PrivateMethodWithUnderscoreESelf() = true
+        member inline _.InlineMethodWithUnderscoreSelf() = true
+        member inline __.InlineMethodWithDoubleUnderscoreSelf() = true
+        member inline _E.InlineMethodWithUnderscoreESelf() = true
+        member inline private _.InlinePrivateMethodWithUnderscoreSelf() = true
+        member inline private __.InlinePrivateMethodWithDoubleUnderscoreSelf() = true
+        member inline private _E.InlinePrivateMethodWithUnderscoreESelf() = true
     end
 
 type MyStructTypeWithUnderscoreIdentifier =
@@ -39,6 +57,15 @@ type MyStructTypeWithUnderscoreIdentifier =
         member _.MethodWithUnderscoreSelf() = true
         member __.MethodWithDoubleUnderscoreSelf() = true
         member _E.MethodWithUnderscoreESelf() = true
+        member private _.PrivateMethodWithUnderscoreSelf() = true
+        member private __.PrivateMethodWithDoubleUnderscoreSelf() = true
+        member private _E.PrivateMethodWithUnderscoreESelf() = true
+        member inline _.InlineMethodWithUnderscoreSelf() = true
+        member inline __.InlineMethodWithDoubleUnderscoreSelf() = true
+        member inline _E.InlineMethodWithUnderscoreESelf() = true
+        member inline private _.InlinePrivateMethodWithUnderscoreSelf() = true
+        member inline private __.InlinePrivateMethodWithDoubleUnderscoreSelf() = true
+        member inline private _E.InlinePrivateMethodWithUnderscoreESelf() = true
     end
 
 


### PR DESCRIPTION
This will allow the use of the '_' for members with access modifiers like:

     type X() = member private _.PrintSomething () = printfn "something"