### PR TITLE
Add FSharpDisplayContext.WithShortTypeNames(bool)

### DIFF
--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -188,7 +188,11 @@ module Impl =
 
 type FSharpDisplayContext(denv: TcGlobals -> DisplayEnv) = 
     member x.Contents g = denv g
+
     static member Empty = FSharpDisplayContext(fun g -> DisplayEnv.Empty g)
+
+    member x.WithShortTypeNames shortNames =
+         FSharpDisplayContext(fun g -> { denv g with shortTypeNames = shortNames })
 
 
 // delay the realization of 'item' in case it is unresolved

--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -50,6 +50,8 @@ type [<Class>] public FSharpDisplayContext =
     internal new : denv: (TcGlobals -> Tastops.DisplayEnv) -> FSharpDisplayContext
     static member Empty: FSharpDisplayContext
 
+    member WithShortTypeNames: bool -> FSharpDisplayContext
+
 /// Represents a symbol in checked F# source code or a compiled .NET component. 
 ///
 /// The subtype of the symbol may reveal further information and can be one of FSharpEntity, FSharpUnionCase


### PR DESCRIPTION
Added method allows getting display context that would use unqualified type names even when they are not imported in the context.