### PR TITLE
ensure localized menu name is used for 'F# Interactive'

### DIFF
--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -60,7 +60,7 @@
 "CompanyName"="Microsoft Corp."
 
 [$RootKey$\Menus]
-"{91a04a73-4f2c-4e7c-ad38-c1a68e7da05c}"=", 1000_ctmenu, 1"
+"{91a04a73-4f2c-4e7c-ad38-c1a68e7da05c}"=", Menus.ctmenu, 1"
 
 [$RootKey$\CLSID\{e1194663-db3c-49eb-8b45-276fcdc440ea}]
 "InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/.gitignore
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/.gitignore
@@ -1,1 +1,0 @@
-ctofiles/

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
@@ -124,23 +124,4 @@
     <PackageReference Include="VSSDK.VSLangProj.8" Version="$(VSSDKVSLangProj8Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
   </ItemGroup>
 
-  <Target Name="CopyCtoFile" BeforeTargets="CopyLocalizationResources" DependsOnTargets="VSCTCompile">
-    <Copy SourceFiles="@(VSCTCompile->'$(IntermediateOutputPath)%(FileName).cto')" DestinationFiles="@(VSCTCompile->'ctofiles\%(FileName).cto')" />
-  </Target>
-
-  <Target Name="CopyLocalizationResources" BeforeTargets="CoreResGen">
-    <ItemGroup>
-      <LocalizationResources Include="MenusAndCommands.vsct" />
-    </ItemGroup>
-    <Copy SourceFiles="@(LocalizationResources)" DestinationFiles="@(LocalizationResources->'$(OutputPath)\%(Filename)%(Extension)')" />
-  </Target>
-
-  <Target Name="EnsureResourceNameHasCulture" BeforeTargets="MergeCtoResource">
-    <ItemGroup>
-      <_GeneratedCTOFilesWithCulture Update="%(Identity)">
-        <ResourceName>%(ResourceName).%(Culture)</ResourceName>
-      </_GeneratedCTOFilesWithCulture>
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
@@ -220,9 +220,6 @@
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\FSharpAboutBox.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="1000_ctmenu" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>ctofiles\MenusAndCommands.cto;System.Byte[], mscorlib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
   <data name="4000" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\FSharpWindowsApplication.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>


### PR DESCRIPTION
Before we were pulling in an unlocalized resource string for the menu item View -> Other Windows -> F# Interactive.  With this change we're inline with C#.

Local screenshot with Spanish:
![image](https://user-images.githubusercontent.com/926281/65791228-26eb5d80-e116-11e9-93ac-50d413c54ae7.png)
