### PR TITLE
update tool requirement to VS 16.3

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "tools": {
     "dotnet": "3.0.100",
     "vs": {
-      "version": "16.1",
+      "version": "16.3",
       "components": [
         "Microsoft.Net.Core.Component.SDK.2.1",
         "Microsoft.VisualStudio.Component.FSharp"


### PR DESCRIPTION
With the release of VS 16.3, make the build explicitly need this version.