### PR TITLE
Add dependencymanager to scripting project

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.fsproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.DependencyManager\FSharp.DependencyManager.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.nuspec
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.nuspec
@@ -14,5 +14,7 @@
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.Scripting.xml" target="lib\netstandard2.0" />
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.dll" target="lib\netstandard2.0" />
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.xml" target="lib\netstandard2.0" />
+        <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.DependencyManager.dll" target="lib\netstandard2.0" />
+        <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.DependencyManager.xml" target="lib\netstandard2.0" />
     </files>
 </package>


### PR DESCRIPTION
notebooks need access to the dependency manager.  This ensures that the nuget package and tests relying on FSharp.Compiler.Private.Scripting get access to it.
