### PR TITLE
Type check: recover in Set expressions when left side value is not mutable

### DIFF
--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -1638,5 +1638,6 @@ let MethInfoChecks g amap isInstance tyargsOpt objArgs ad m (minfo: MethInfo)  =
 exception FieldNotMutable of DisplayEnv * Tast.RecdFieldRef * range
 
 let CheckRecdFieldMutation m denv (rfinfo: RecdFieldInfo) = 
-    if not rfinfo.RecdField.IsMutable then error (FieldNotMutable(denv, rfinfo.RecdFieldRef, m))
+    if not rfinfo.RecdField.IsMutable then
+        errorR (FieldNotMutable (denv, rfinfo.RecdFieldRef, m))
 

--- a/tests/fsharp/core/span/test3.bsl
+++ b/tests/fsharp/core/span/test3.bsl
@@ -10,5 +10,5 @@ test3.fsx(47,21,47,27): typecheck error FS0027: This value is not mutable. Consi
 test3.fsx(46,26,46,27): typecheck error FS0193: Type constraint mismatch. The type 
     'Span<int>'    
 is not compatible with type
-    'seq<'a>'    
+    'seq<int>'    
 

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -298,6 +298,29 @@ let rec allSymbolsInEntities compGen (entities: IList<FSharpEntity>) =
           yield! allSymbolsInEntities compGen e.NestedEntities ]
 
 
+let getSymbolUses (source: string) =
+    let _, typeCheckResults = parseAndCheckScript("/home/user/Test.fsx", source) 
+    typeCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunSynchronously
+
+let getSymbols (source: string) =
+    getSymbolUses source
+    |> Array.map (fun symbolUse -> symbolUse.Symbol)
+
+
+let [<Literal>] missingName = "???"
+
+let getSymbolName (symbol: FSharpSymbol) =
+    match symbol with
+    | :? FSharpMemberOrFunctionOrValue as mfv -> mfv.LogicalName
+    | :? FSharpEntity as entity -> entity.LogicalName
+    | :? FSharpGenericParameter as parameter -> parameter.Name
+    | :? FSharpParameter as parameter -> Option.defaultValue missingName parameter.Name
+    | :? FSharpStaticParameter as parameter -> parameter.Name
+    | :? FSharpActivePatternCase as case -> case.Name
+    | :? FSharpUnionCase as case -> case.Name
+    | _ -> missingName
+
+
 let coreLibAssemblyName =
 #if NETCOREAPP2_0
     "System.Runtime"

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -1329,10 +1329,7 @@ x <-
     let y = 1
     y
 """
-    getSymbols source
-    |> Array.map getSymbolName
-    |> Array.contains "y"
-    |> shouldEqual true
+    assertContainsSymbolWithName "y" source
 
 
 [<Test>]
@@ -1345,10 +1342,7 @@ T.P <-
     let y = 1
     y
 """
-    getSymbols source
-    |> Array.map getSymbolName
-    |> Array.contains "y"
-    |> shouldEqual true
+    assertContainsSymbolWithName "y" source
 
 
 [<Test>]
@@ -1361,7 +1355,4 @@ type R =
     let y = 1
     y
 """
-    getSymbols source
-    |> Array.map getSymbolName
-    |> Array.contains "y"
-    |> shouldEqual true
+    assertContainsSymbolWithName "y" source

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -1329,14 +1329,9 @@ x <-
     let y = 1
     y
 """
-    let _, typeCheckResults = parseAndCheckScript("/home/user/Test.fsx", source) 
-    let symbols = typeCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunSynchronously
-
-    symbols
-    |> Array.exists (fun su ->
-        match su.Symbol with
-        | :? FSharpMemberOrFunctionOrValue as mfv -> mfv.DisplayName = "y"
-        | _ -> false)
+    getSymbols source
+    |> Array.map getSymbolName
+    |> Array.contains "y"
     |> shouldEqual true
 
 
@@ -1350,14 +1345,9 @@ T.P <-
     let y = 1
     y
 """
-    let _, typeCheckResults = parseAndCheckScript("/home/user/Test.fsx", source) 
-    let symbols = typeCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunSynchronously
-
-    symbols
-    |> Array.exists (fun su ->
-        match su.Symbol with
-        | :? FSharpMemberOrFunctionOrValue as mfv -> mfv.DisplayName = "y"
-        | _ -> false)
+    getSymbols source
+    |> Array.map getSymbolName
+    |> Array.contains "y"
     |> shouldEqual true
 
 
@@ -1371,12 +1361,7 @@ type R =
     let y = 1
     y
 """
-    let _, typeCheckResults = parseAndCheckScript("/home/user/Test.fsx", source) 
-    let symbols = typeCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunSynchronously
-
-    symbols
-    |> Array.exists (fun su ->
-        match su.Symbol with
-        | :? FSharpMemberOrFunctionOrValue as mfv -> mfv.DisplayName = "y"
-        | _ -> false)
+    getSymbols source
+    |> Array.map getSymbolName
+    |> Array.contains "y"
     |> shouldEqual true

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -1359,3 +1359,24 @@ T.P <-
         | :? FSharpMemberOrFunctionOrValue as mfv -> mfv.DisplayName = "y"
         | _ -> false)
     |> shouldEqual true
+
+
+[<Test>]
+let ``FieldNotMutable recovery`` () =
+    let source = """
+type R =
+    { F: int }
+
+{ F = 1 }.F <-
+    let y = 1
+    y
+"""
+    let _, typeCheckResults = parseAndCheckScript("/home/user/Test.fsx", source) 
+    let symbols = typeCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunSynchronously
+
+    symbols
+    |> Array.exists (fun su ->
+        match su.Symbol with
+        | :? FSharpMemberOrFunctionOrValue as mfv -> mfv.DisplayName = "y"
+        | _ -> false)
+    |> shouldEqual true


### PR DESCRIPTION
Don't skip type checking of right side expression of Set expression when its left side value/property cannot be set.