### PR TITLE
[source-build] Don't install 2.1.x SDK for source-build.

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -277,7 +277,9 @@ function BuildSolution {
 InitializeDotNetCli $restore
 
 # enable us to build netcoreapp2.1 binaries
-InstallDotNetSdk $_InitializeDotNetCli 2.1.503
+if [[ "$DotNetBuildFromSource" != "true" ]]; then
+  InstallDotNetSdk $_InitializeDotNetCli 2.1.503
+fi
 
 BuildSolution
 


### PR DESCRIPTION
Source-build only uses one SDK to bootstrap its build, and we are apparently not building the projects this is required for (we are currently [patching it out](https://github.com/dotnet/source-build/blob/release/3.0/patches/fsharp/0001-Don-t-install-old-SDK.patch)).