### PR TITLE
Allow reraising unexpected exception in debug

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -55,12 +55,6 @@ open FSharp.Compiler.ExtensionTyping
 open Microsoft.FSharp.Core.CompilerServices
 #endif
 
-#if DEBUG
-[<AutoOpen>]
-module internal CompilerService =
-    let showAssertForUnexpectedException = ref true
-#endif // DEBUG
-
 //----------------------------------------------------------------------------
 // Some Globals
 //--------------------------------------------------------------------------
@@ -1392,8 +1386,7 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
           | _ -> os.Append(Failure4E().Format s) |> ignore
 #if DEBUG
           Printf.bprintf os "\nStack Trace\n%s\n" (exn.ToString())
-          if !showAssertForUnexpectedException then 
-              System.Diagnostics.Debug.Assert(false, sprintf "Unexpected exception seen in compiler: %s\n%s" s (exn.ToString()))
+          reportUnexpectedException s exn
 #endif
 
       | FullAbstraction(s, _) -> os.Append(FullAbstractionE().Format s) |> ignore
@@ -1582,8 +1575,7 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
           os.Append(TargetInvocationExceptionWrapperE().Format e.Message) |> ignore
 #if DEBUG
           Printf.bprintf os "\nStack Trace\n%s\n" (e.ToString())
-          if !showAssertForUnexpectedException then 
-              System.Diagnostics.Debug.Assert(false, sprintf "Unknown exception seen in compiler: %s" (e.ToString()))
+          reportUnexpectedException "" e
 #endif
 
     OutputExceptionR os err.Exception

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -26,13 +26,6 @@ open Microsoft.FSharp.Core.CompilerServices
 open FSharp.Compiler.ExtensionTyping
 #endif
 
-
-#if DEBUG
-
-module internal CompilerService =
-    val showAssertForUnexpectedException: bool ref
-#endif
-
 //----------------------------------------------------------------------------
 // File names and known file suffixes
 //--------------------------------------------------------------------------


### PR DESCRIPTION
It's quite difficult to work with these obtrusive windows when debugging tests, so an option to just raise an exception is added.

<img width="463" alt="Screenshot 2019-10-04 at 14 36 58" src="https://user-images.githubusercontent.com/3923587/66208668-56720b00-e6be-11e9-9733-d7a14fa8a258.png">
