### PR TITLE
Ignore .DS_store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ msbuild.binlog
 /fcs/FSharp.Compiler.Service.netstandard/*.fs
 /fcs/FSharp.Compiler.Service.netstandard/*.fsi
 /.ionide/
+**/.DS_Store


### PR DESCRIPTION
Ignore .DS_store files that macOS creates.
<img width="766" alt="Screenshot 2019-10-15 at 01 45 19" src="https://user-images.githubusercontent.com/3923587/66787753-8656b500-eeed-11e9-9d79-5f4e439c3868.png">

