### PR TITLE
better handle a `raise` expression at the top level of fsi

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -398,6 +398,8 @@ type NameResolutionEnv =
 
     member nenv.FindUnqualifiedItem nm = nenv.eUnqualifiedItems.[nm]
 
+    member nenv.TryFindUnqualifiedItem nm = nenv.eUnqualifiedItems.TryFind(nm)
+
     /// Get the table of types, indexed by name and arity
     member nenv.TyconsByDemangledNameAndArity fq =
         match fq with

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -163,6 +163,7 @@ type NameResolutionEnv =
     static member Empty : g:TcGlobals -> NameResolutionEnv
     member DisplayEnv : DisplayEnv
     member FindUnqualifiedItem : string -> Item
+    member TryFindUnqualifiedItem: string -> Item option
 
 type FullyQualifiedFlag =
   | FullyQualified

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1191,7 +1191,8 @@ type internal FsiDynamicCompiler
         // Construct the code that saves the 'it' value into the 'SaveIt' register.
         let defs =
             match expr with
-            | SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.Ident(i), _, m) when i.idText = "raise" -> [SynModuleDecl.DoExpr(NoSequencePointAtInvisibleBinding, expr, m)]
+            | SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.Ident(i), _, m)
+                when i.idText = "raise" || i.idText = "failwith" -> [SynModuleDecl.DoExpr(NoSequencePointAtInvisibleBinding, expr, m)]
             | _ -> fsiDynamicCompiler.BuildItBinding expr
 
         // Evaluate the overall definitions.

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -141,3 +141,12 @@ type InteractiveTests() =
         match result with
         | Ok(v) -> Assert.Fail(sprintf "expected a failure, got %A" v)
         | Error(ex) -> Assert.IsInstanceOf<NotImplementedException>(ex)
+
+    [<Test>]
+    member _.``Top level failwith is handled appropriately``() =
+        use script = new FSharpScript()
+        let result, errors = script.Eval("failwith \"fail\"")
+        Assert.IsEmpty(errors)
+        match result with
+        | Ok(v) -> Assert.Fail(sprintf "expected a failure, got %A" v)
+        | Error(ex) -> Assert.IsInstanceOf<Exception>(ex)

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -107,7 +107,7 @@ type InteractiveTests() =
         let result, errors = script.Eval("System.IO.File.ReadAllText(\"not-a-file-path-that-can-be-found-on-disk.txt\")")
         Assert.IsEmpty(errors)
         match result with
-        | Ok(_) -> Assert.Fail("expected a failure")
+        | Ok(v) -> Assert.Fail(sprintf "expected a failure, got %A" v)
         | Error(ex) -> Assert.IsInstanceOf<FileNotFoundException>(ex)
 
     [<Test>]
@@ -132,3 +132,12 @@ type InteractiveTests() =
         Assert.True(wasCancelled)
         Assert.LessOrEqual(sw.ElapsedMilliseconds, sleepTime)
         Assert.AreEqual(None, result)
+
+    [<Test>]
+    member _.``Top level thrown exceptions are returned appropriately``() =
+        use script = new FSharpScript()
+        let result, errors = script.Eval("raise (new System.NotImplementedException())")
+        Assert.IsEmpty(errors)
+        match result with
+        | Ok(v) -> Assert.Fail(sprintf "expected a failure, got %A" v)
+        | Error(ex) -> Assert.IsInstanceOf<NotImplementedException>(ex)


### PR DESCRIPTION
Previously the behavior was to complain that the artificial `let it = raise ...`
expression was invalid.  This special-cases that scenario and allows the raised
exception to be returned.