### PR TITLE
[release/fsharp5] update TargetFramework values

### DIFF
--- a/FSharpTests.Directory.Build.props
+++ b/FSharpTests.Directory.Build.props
@@ -22,18 +22,18 @@
     <FscToolPath>$([System.IO.Path]::GetDirectoryName('$(DOTNET_HOST_PATH)'))</FscToolPath>
     <FscToolExe Condition="'$(OS)' != 'Unix'">dotnet.exe</FscToolExe>
     <FscToolExe Condition="'$(OS)' == 'Unix'">dotnet</FscToolExe>
-    <DotnetFscCompilerPath>$(MSBuildThisFileDirectory)artifacts\bin\fsc\$(Configuration)\netcoreapp2.1\fsc.exe</DotnetFscCompilerPath>
+    <DotnetFscCompilerPath>$(MSBuildThisFileDirectory)artifacts\bin\fsc\$(Configuration)\netcoreapp3.0\fsc.exe</DotnetFscCompilerPath>
 
     <FsiToolPath>$([System.IO.Path]::GetDirectoryName('$(DOTNET_HOST_PATH)'))</FsiToolPath>
     <FsiToolExe Condition="'$(OS)' != 'Unix'">dotnet.exe</FsiToolExe>
     <FsiToolExe Condition="'$(OS)' == 'Unix'">dotnet</FsiToolExe>
-    <DotnetFsiCompilerPath>$(MSBuildThisFileDirectory)artifacts\bin\fsi\$(Configuration)\netcoreapp2.1\fsi.exe</DotnetFsiCompilerPath>
+    <DotnetFsiCompilerPath>$(MSBuildThisFileDirectory)artifacts\bin\fsi\$(Configuration)\netcoreapp3.0\fsi.exe</DotnetFsiCompilerPath>
   </PropertyGroup>
 
   <!-- SDK targets override -->
   <PropertyGroup>
     <_FSharpBuildTargetFramework Condition="'$(MSBuildRuntimeType)'!='Core'">net472</_FSharpBuildTargetFramework>
-    <_FSharpBuildTargetFramework Condition="'$(MSBuildRuntimeType)'=='Core'">netcoreapp2.1</_FSharpBuildTargetFramework>
+    <_FSharpBuildTargetFramework Condition="'$(MSBuildRuntimeType)'=='Core'">netcoreapp3.0</_FSharpBuildTargetFramework>
     <_FSharpBuildBinPath>$(MSBuildThisFileDirectory)artifacts\bin\fsc\$(Configuration)\$(_FSharpBuildTargetFramework)</_FSharpBuildBinPath>
 
     <FSharpBuildAssemblyFile>$(_FSharpBuildBinPath)\FSharp.Build.dll</FSharpBuildAssemblyFile>

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ proto: tools
 	$(DotNetExe) restore src/fsharp/fsc/fsc.fsproj
 	$(DotNetExe) build src/buildtools/buildtools.proj -c Proto
 	$(DotNetExe) build src/fsharp/FSharp.Build/FSharp.Build.fsproj -f netstandard2.0 -c Proto
-	$(DotNetExe) build src/fsharp/fsc/fsc.fsproj -f netcoreapp2.1 -c Proto
+	$(DotNetExe) build src/fsharp/fsc/fsc.fsproj -f netcoreapp3.0 -c Proto
 
 restore:
 	$(DotNetExe) restore src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -32,15 +32,15 @@ build: proto restore
 	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Core/FSharp.Core.fsproj
 	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Build/FSharp.Build.fsproj
 	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.1 src/fsharp/fsc/fsc.fsproj
+	$(DotNetExe) build -c $(Configuration) -f netcoreapp3.0 src/fsharp/fsc/fsc.fsproj
 	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.1 src/fsharp/fsi/fsi.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.0 tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.0 tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
+	$(DotNetExe) build -c $(Configuration) -f netcoreapp3.0 src/fsharp/fsi/fsi.fsproj
+	$(DotNetExe) build -c $(Configuration) -f netcoreapp3.0 tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
+	$(DotNetExe) build -c $(Configuration) -f netcoreapp3.0 tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
 
 test: build
-	$(DotNetExe) test -f netcoreapp2.0 -c $(Configuration) --no-restore --no-build tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Core.UnitTests.coreclr.trx"
-	$(DotNetExe) test -f netcoreapp2.0 -c $(Configuration) --no-restore --no-build tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Build.UnitTests.coreclr.trx"
+	$(DotNetExe) test -f netcoreapp3.0 -c $(Configuration) --no-restore --no-build tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Core.UnitTests.coreclr.trx"
+	$(DotNetExe) test -f netcoreapp3.0 -c $(Configuration) --no-restore --no-build tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj -l "trx;LogFileName=$(CURDIR)/tests/TestResults/FSharp.Build.UnitTests.coreclr.trx"
 
 clean:
 	rm -rf $(CURDIR)/artifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -289,6 +289,14 @@ stages:
             clean: true
           - script: fcs\build.cmd TestAndNuget
             displayName: Build / Test
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Logs
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log'
+              ArtifactName: 'Windows FCS logs'
+              publishLocation: Container
+            continueOnError: true
+            condition: not(succeeded())
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:
@@ -309,6 +317,14 @@ stages:
         #    clean: true
         #  - script: ./fcs/build.sh Build
         #    displayName: Build
+        #  - task: PublishBuildArtifacts@1
+        #    displayName: Publish Logs
+        #    inputs:
+        #      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log'
+        #      ArtifactName: 'Linux FCS logs'
+        #      publishLocation: Container
+        #    continueOnError: true
+        #    condition: not(succeeded())
 
         - job: MacOS_FCS
           pool:
@@ -321,6 +337,14 @@ stages:
             clean: true
           - script: ./fcs/build.sh Build
             displayName: Build
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Logs
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log'
+              ArtifactName: 'Mac FCS logs'
+              publishLocation: Container
+            continueOnError: true
+            condition: not(succeeded())
 
 #---------------------------------------------------------------------------------------------------------------------#
 #                                                    Post Build                                                       #

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -151,11 +151,11 @@ function Process-Arguments() {
 
 function Update-Arguments() {
     if ($script:noVisualStudio) {
-        $script:bootstrapTfm = "netcoreapp2.1"
+        $script:bootstrapTfm = "netcoreapp3.0"
         $script:msbuildEngine = "dotnet"
     }
 
-    if ($bootstrapTfm -eq "netcoreapp2.1") {
+    if ($bootstrapTfm -eq "netcoreapp3.0") {
         if (-Not (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.runtimeconfig.json")) {
             $script:bootstrap = $True
         }
@@ -259,7 +259,7 @@ function TestUsingNUnit([string] $testProject, [string] $targetFramework) {
 }
 
 function BuildCompiler() {
-    if ($bootstrapTfm -eq "netcoreapp2.1") {
+    if ($bootstrapTfm -eq "netcoreapp3.0") {
         $dotnetPath = InitializeDotNetCli
         $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
         $fscProject = "$RepoRoot\src\fsharp\fsc\fsc.fsproj"
@@ -268,10 +268,10 @@ function BuildCompiler() {
         $argNoRestore = if ($norestore) { " --no-restore" } else { "" }
         $argNoIncremental = if ($rebuild) { " --no-incremental" } else { "" }
 
-        $args = "build $fscProject -c $configuration -v $verbosity -f netcoreapp2.1" + $argNoRestore + $argNoIncremental
+        $args = "build $fscProject -c $configuration -v $verbosity -f netcoreapp3.0" + $argNoRestore + $argNoIncremental
         Exec-Console $dotnetExe $args
 
-        $args = "build $fsiProject -c $configuration -v $verbosity -f netcoreapp2.1" + $argNoRestore + $argNoIncremental
+        $args = "build $fsiProject -c $configuration -v $verbosity -f netcoreapp3.0" + $argNoRestore + $argNoIncremental
         Exec-Console $dotnetExe $args
     }
 }
@@ -312,11 +312,6 @@ try {
     if ($ci) {
         Prepare-TempDir
         EnablePreviewSdks
-
-        # enable us to build netcoreapp2.1 product binaries
-        $global:_DotNetInstallDir = Join-Path $RepoRoot ".dotnet"
-        InstallDotNetSdk $global:_DotNetInstallDir $GlobalJson.tools.dotnet
-        InstallDotNetSdk $global:_DotNetInstallDir "2.1.503"
     }
 
     if ($bootstrap) {

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -238,9 +238,9 @@ function Make-BootstrapBuild() {
 
     # prepare FsLex and Fsyacc and AssemblyCheck
     Run-MSBuild "$RepoRoot\src\buildtools\buildtools.proj" "/restore /t:Publish" -logFileName "BuildTools" -configuration $bootstrapConfiguration
-    Copy-Item "$ArtifactsDir\bin\fslex\$bootstrapConfiguration\netcoreapp2.1\publish" -Destination "$dir\fslex" -Force -Recurse
-    Copy-Item "$ArtifactsDir\bin\fsyacc\$bootstrapConfiguration\netcoreapp2.1\publish" -Destination "$dir\fsyacc" -Force  -Recurse
-    Copy-Item "$ArtifactsDir\bin\AssemblyCheck\$bootstrapConfiguration\netcoreapp2.1\publish" -Destination "$dir\AssemblyCheck" -Force  -Recurse
+    Copy-Item "$ArtifactsDir\bin\fslex\$bootstrapConfiguration\netcoreapp3.0\publish" -Destination "$dir\fslex" -Force -Recurse
+    Copy-Item "$ArtifactsDir\bin\fsyacc\$bootstrapConfiguration\netcoreapp3.0\publish" -Destination "$dir\fsyacc" -Force  -Recurse
+    Copy-Item "$ArtifactsDir\bin\AssemblyCheck\$bootstrapConfiguration\netcoreapp3.0\publish" -Destination "$dir\AssemblyCheck" -Force  -Recurse
 
     # prepare compiler
     $projectPath = "$RepoRoot\proto.proj"

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -239,8 +239,8 @@ function BuildSolution {
       }
 
     mkdir -p "$bootstrap_dir"
-    cp -pr $artifacts_dir/bin/fslex/$bootstrap_config/netcoreapp2.1/publish $bootstrap_dir/fslex
-    cp -pr $artifacts_dir/bin/fsyacc/$bootstrap_config/netcoreapp2.1/publish $bootstrap_dir/fsyacc
+    cp -pr $artifacts_dir/bin/fslex/$bootstrap_config/netcoreapp3.0/publish $bootstrap_dir/fslex
+    cp -pr $artifacts_dir/bin/fsyacc/$bootstrap_config/netcoreapp3.0/publish $bootstrap_dir/fsyacc
   fi
   if [ ! -f "$bootstrap_dir/fsc.exe" ]; then
     MSBuild "$repo_root/proto.proj" \
@@ -252,7 +252,7 @@ function BuildSolution {
         ExitWithExitCode $exit_code
       }
 
-    cp -pr $artifacts_dir/bin/fsc/$bootstrap_config/netcoreapp2.1/publish $bootstrap_dir/fsc
+    cp -pr $artifacts_dir/bin/fsc/$bootstrap_config/netcoreapp3.0/publish $bootstrap_dir/fsc
   fi
 
   # do real build
@@ -279,11 +279,6 @@ function BuildSolution {
 }
 
 InitializeDotNetCli $restore
-
-# enable us to build netcoreapp2.1 binaries
-if [[ "$source_build" != true ]]; then
-  InstallDotNetSdk $_InitializeDotNetCli 2.1.503
-fi
 
 BuildSolution
 

--- a/fcs/Directory.Build.targets
+++ b/fcs/Directory.Build.targets
@@ -29,7 +29,7 @@
   </Target>
 
   <Target Name="_GenerateBuildPropertiesFile"
-          Outputs="$(IntermediateOutputPath)$(ProjectName)\buildproperties.fs"
+          Outputs="$(IntermediateOutputPath)$(ProjectName).BuildProperties.fs"
           BeforeTargets="BeforeBuild"
           Condition="'$(Language)'=='F#'">
 
@@ -44,15 +44,12 @@
       <_BuildPropertyLines Include="let fsLanguageVersion = &quot;$(FSLANGUAGEVERSION)&quot;" />
     </ItemGroup>
 
-    <MakeDir
-      Directories="$(IntermediateOutputPath)$(ProjectName)"
-      Condition="!Exists('$(IntermediateOutputPath)$(ProjectName)')" />
-    <WriteLinesToFile File="$(IntermediateOutputPath)$(ProjectName)\buildproperties.fs" Lines="@(_BuildPropertyLines)" Overwrite="true"  WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(IntermediateOutputPath)$(ProjectName).BuildProperties.fs" Lines="@(_BuildPropertyLines)" Overwrite="true"  WriteOnlyWhenDifferent="true" />
 
     <!-- Make sure it will get cleaned  -->
     <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)$(ProjectName)\buildproperties.fs" />
-      <CompileBefore Include="$(IntermediateOutputPath)$(ProjectName)\buildproperties.fs" />
+      <FileWrites Include="$(IntermediateOutputPath)$(ProjectName).BuildProperties.fs" />
+      <CompileBefore Include="$(IntermediateOutputPath)$(ProjectName).BuildProperties.fs" />
     </ItemGroup>
   </Target>
 

--- a/fcs/FSharp.Compiler.Service.ProjectCrackerTool/Program.fs
+++ b/fcs/FSharp.Compiler.Service.ProjectCrackerTool/Program.fs
@@ -6,7 +6,7 @@ open System.Runtime.Serialization.Json
 
 module Program =
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP
     let addMSBuildv14BackupResolution () =
         let onResolveEvent = new ResolveEventHandler(fun sender evArgs ->
             let requestedAssembly = AssemblyName(evArgs.Name)
@@ -40,7 +40,7 @@ module Program =
         let asText = Array.exists (fun (s: string) -> s = "--text") argv
         let argv = Array.filter (fun (s: string) -> s <> "--text") argv
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP
         addMSBuildv14BackupResolution ()
 #endif
         crackAndSendOutput asText argv

--- a/fcs/FSharp.Compiler.Service.ProjectCrackerTool/ProjectCrackerTool.fs
+++ b/fcs/FSharp.Compiler.Service.ProjectCrackerTool/ProjectCrackerTool.fs
@@ -11,7 +11,7 @@ module internal ProjectCrackerTool =
   open Microsoft.Build.Evaluation
 
   let runningOnMono =
-#if NETCOREAPP2_0
+#if NETCOREAPP
     false
 #else
     try match System.Type.GetType("Mono.Runtime") with null -> false | _ -> true
@@ -128,7 +128,7 @@ module internal ProjectCrackerTool =
 
     outFileOpt, directory, getItems, references, projectReferences, getprop project, project.FullPath
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP
   let CrackProjectUsingOldBuildAPI (fsprojFile:string) properties logOpt = 
     let engine = new Microsoft.Build.BuildEngine.Engine()
     Option.iter (fun l -> engine.RegisterLogger(l)) logOpt
@@ -201,7 +201,7 @@ module internal ProjectCrackerTool =
   
       let outFileOpt, directory, getItems, references, projectReferences, getProp, fsprojFullPath =
         try
-#if NETCOREAPP2_0
+#if NETCOREAPP
           CrackProjectUsingNewBuildAPI fsprojFileName properties logOpt
         with
 #else

--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>$(FcsTargetNetFxFramework);netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>$(FcsTargetNetFxFramework);netcoreapp3.0</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DefaultFSharpPackageVersion>4.1.19</DefaultFSharpPackageVersion>
     <NoWarn>$(NoWarn);44;75;</NoWarn>
@@ -11,7 +11,7 @@
     <IsTestProject>true</IsTestProject>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> <!-- Tests won't run without this, at least on OSX, see https://github.com/NuGet/Home/issues/4837#issuecomment-354536302 -->
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <DefineConstants>$(DefineConstants);NO_PROJECTCRACKER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
@@ -66,7 +66,7 @@
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\TreeVisitorTests.fs">
       <Link>TreeVisitorTests.fs</Link>
     </Compile>
-    <Compile Include="$(FSharpSourcesRoot)\..\tests\service\Program.fs" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <Compile Include="$(FSharpSourcesRoot)\..\tests\service\Program.fs" Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
       <Link>Program.fs</Link>
     </Compile>
     <NoneSubstituteText Include="App.config">

--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -94,7 +94,8 @@ Target "Build" (fun _ ->
     runDotnet __SOURCE_DIRECTORY__ "build ../src/buildtools/buildtools.proj -v n -c Proto"
     let fslexPath = __SOURCE_DIRECTORY__ + "/../artifacts/bin/fslex/Proto/netcoreapp3.0/fslex.dll"
     let fsyaccPath = __SOURCE_DIRECTORY__ + "/../artifacts/bin/fsyacc/Proto/netcoreapp3.0/fsyacc.dll"
-    runDotnet __SOURCE_DIRECTORY__ (sprintf "build FSharp.Compiler.Service.sln -v n -c Release /p:FsLexPath=%s /p:FsYaccPath=%s" fslexPath fsyaccPath)
+    let binLogPath = __SOURCE_DIRECTORY__ + "/../artifacts/log/Release/fcs-build.binlog"
+    runDotnet __SOURCE_DIRECTORY__ (sprintf "build FSharp.Compiler.Service.sln -v n -c Release /p:FsLexPath=%s /p:FsYaccPath=%s /bl:%s" fslexPath fsyaccPath binLogPath)
 )
 
 Target "Test" (fun _ ->

--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -31,7 +31,7 @@ let dotnetExePath =
     if File.Exists(pathToCli) then
         pathToCli
     else
-        DotNetCli.InstallDotNetSDK "2.2.105"
+        DotNetCli.InstallDotNetSDK "3.0.100"
 
 let runDotnet workingDir args =
     let result =
@@ -92,8 +92,8 @@ Target "BuildVersion" (fun _ ->
 
 Target "Build" (fun _ ->
     runDotnet __SOURCE_DIRECTORY__ "build ../src/buildtools/buildtools.proj -v n -c Proto"
-    let fslexPath = __SOURCE_DIRECTORY__ + "/../artifacts/bin/fslex/Proto/netcoreapp2.1/fslex.dll"
-    let fsyaccPath = __SOURCE_DIRECTORY__ + "/../artifacts/bin/fsyacc/Proto/netcoreapp2.1/fsyacc.dll"
+    let fslexPath = __SOURCE_DIRECTORY__ + "/../artifacts/bin/fslex/Proto/netcoreapp3.0/fslex.dll"
+    let fsyaccPath = __SOURCE_DIRECTORY__ + "/../artifacts/bin/fsyacc/Proto/netcoreapp3.0/fsyacc.dll"
     runDotnet __SOURCE_DIRECTORY__ (sprintf "build FSharp.Compiler.Service.sln -v n -c Release /p:FsLexPath=%s /p:FsYaccPath=%s" fslexPath fsyaccPath)
 )
 

--- a/fcs/samples/EditorService/EditorService.fsproj
+++ b/fcs/samples/EditorService/EditorService.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>$(FcsTargetNetFxFramework);netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>$(FcsTargetNetFxFramework);netcoreapp3.0</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>

--- a/global.json
+++ b/global.json
@@ -4,7 +4,6 @@
     "vs": {
       "version": "16.3",
       "components": [
-        "Microsoft.Net.Core.Component.SDK.2.1",
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     }

--- a/proto.proj
+++ b/proto.proj
@@ -7,13 +7,13 @@
 
   <ItemGroup>
     <Projects Include="src\fsharp\FSharp.Build\FSharp.Build.fsproj">
-      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
+      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp3.0</AdditionalProperties>
     </Projects>
     <Projects Include="src\fsharp\fsc\fsc.fsproj">
-      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
+      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp3.0</AdditionalProperties>
     </Projects>
     <Projects Include="src\fsharp\fsi\fsi.fsproj">
-      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
+      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp3.0</AdditionalProperties>
     </Projects>
   </ItemGroup>
 

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 

--- a/src/buildtools/fslex/fslex.fsproj
+++ b/src/buildtools/fslex/fslex.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DefineConstants>INTERNALIZED_FSLEXYACC_RUNTIME;$(DefineConstant)</DefineConstants>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>

--- a/src/buildtools/fsyacc/fsyacc.fsproj
+++ b/src/buildtools/fsyacc/fsyacc.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DefineConstants>INTERNALIZED_FSLEXYACC_RUNTIME;$(DefineConstant)</DefineConstants>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks Condition="'$(ProtoTargetFramework)' != ''">$(ProtoTargetFramework)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.0</TargetFrameworks>
     <AssemblyName>FSharp.Build</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.csproj
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PreRelease>true</PreRelease>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <NuspecFile>Microsoft.FSharp.Compiler.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>
     <PackageDescription>.NET Core compatible version of the F# compiler fsc.exe.</PackageDescription>
@@ -10,13 +10,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\fsc\fsc.fsproj">
-      <AdditionalProperties>TargetFramework=netcoreapp2.1</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=netcoreapp3.0</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\fsi\fsi.fsproj">
-      <AdditionalProperties>TargetFramework=netcoreapp2.1</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=netcoreapp3.0</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\FSharp.Build\FSharp.Build.fsproj">
-      <AdditionalProperties>TargetFramework=netcoreapp2.1</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=netcoreapp3.0</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj">
       <AdditionalProperties>TargetFramework=netstandard2.0</AdditionalProperties>

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -4,7 +4,7 @@
         $CommonMetadataElements$
         <language>en-US</language>
         <dependencies>
-            <group targetFramework=".NETCoreApp2.1">
+            <group targetFramework=".NETCoreApp3.0">
                 <dependency id="Microsoft.NETCore.Platforms" version="2.0.0" />
                 <dependency id="NETStandard.Library" version="2.0.0" />
                 <dependency id="System.Collections.Immutable" version="1.5.0" />
@@ -43,30 +43,30 @@
             this approach gives a very small deployment. Which is kind of necessary.
         -->
         <!-- assemblies -->
-        <file src="fsc\$Configuration$\netcoreapp2.1\fsc.exe"                                             target="lib\netcoreapp2.1" />
-        <file src="fsi\$Configuration$\netcoreapp2.1\fsi.exe"                                             target="lib\netcoreapp2.1" />
-        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.dll"                            target="lib\netcoreapp2.1" />
-        <file src="FSharp.Compiler.Private\$Configuration$\netstandard2.0\FSharp.Compiler.Private.dll"    target="lib\netcoreapp2.1" />
-        <file src="FSharp.Build\$Configuration$\netcoreapp2.1\FSharp.Build.dll"                           target="lib\netcoreapp2.1" />
-        <file src="FSharp.DependencyManager\$configuration$\netstandard2.0\FSharp.DependencyManager.dll"  target="lib\netcoreapp2.1" />
+        <file src="fsc\$Configuration$\netcoreapp3.0\fsc.exe"                                             target="lib\netcoreapp3.0" />
+        <file src="fsi\$Configuration$\netcoreapp3.0\fsi.exe"                                             target="lib\netcoreapp3.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.dll"                            target="lib\netcoreapp3.0" />
+        <file src="FSharp.Compiler.Private\$Configuration$\netstandard2.0\FSharp.Compiler.Private.dll"    target="lib\netcoreapp3.0" />
+        <file src="FSharp.Build\$Configuration$\netcoreapp3.0\FSharp.Build.dll"                           target="lib\netcoreapp3.0" />
+        <file src="FSharp.DependencyManager\$configuration$\netstandard2.0\FSharp.DependencyManager.dll"  target="lib\netcoreapp3.0" />
         <file src="FSharp.Compiler.Interactive.Settings\$Configuration$\netstandard2.0\FSharp.Compiler.Interactive.Settings.dll"
-                                                                                                          target="lib\netcoreapp2.1" />
+                                                                                                          target="lib\netcoreapp3.0" />
         <!-- additional files -->
-        <file src="fsc\$Configuration$\netcoreapp2.1\default.win32manifest"                               target="contentFiles\any\any" />
-        <file src="FSharp.Build\$Configuration$\netcoreapp2.1\Microsoft.FSharp.Targets"                   target="contentFiles\any\any" />
-        <file src="FSharp.Build\$Configuration$\netcoreapp2.1\Microsoft.Portable.FSharp.Targets"          target="contentFiles\any\any" />
-        <file src="FSharp.Build\$Configuration$\netcoreapp2.1\Microsoft.FSharp.NetSdk.props"              target="contentFiles\any\any" />
-        <file src="FSharp.Build\$Configuration$\netcoreapp2.1\Microsoft.FSharp.NetSdk.targets"            target="contentFiles\any\any" />
-        <file src="FSharp.Build\$Configuration$\netcoreapp2.1\Microsoft.FSharp.Overrides.NetSdk.targets"  target="contentFiles\any\any" />
+        <file src="fsc\$Configuration$\netcoreapp3.0\default.win32manifest"                               target="contentFiles\any\any" />
+        <file src="FSharp.Build\$Configuration$\netcoreapp3.0\Microsoft.FSharp.Targets"                   target="contentFiles\any\any" />
+        <file src="FSharp.Build\$Configuration$\netcoreapp3.0\Microsoft.Portable.FSharp.Targets"          target="contentFiles\any\any" />
+        <file src="FSharp.Build\$Configuration$\netcoreapp3.0\Microsoft.FSharp.NetSdk.props"              target="contentFiles\any\any" />
+        <file src="FSharp.Build\$Configuration$\netcoreapp3.0\Microsoft.FSharp.NetSdk.targets"            target="contentFiles\any\any" />
+        <file src="FSharp.Build\$Configuration$\netcoreapp3.0\Microsoft.FSharp.Overrides.NetSdk.targets"  target="contentFiles\any\any" />
 
         <!-- resources -->
-        <file src="FSharp.Core\$Configuration$\netstandard2.0\**\FSharp.Core.resources.dll"               target="lib\netcoreapp2.1" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\**\FSharp.Core.resources.dll"               target="lib\netcoreapp3.0" />
         <file src="FSharp.Compiler.Private\$Configuration$\netstandard2.0\**\FSharp.Compiler.Private.resources.dll"
-                                                                                                          target="lib\netcoreapp2.1" />
+                                                                                                          target="lib\netcoreapp3.0" />
         <file src="FSharp.Compiler.Interactive.Settings\$Configuration$\netstandard2.0\**\FSharp.Compiler.Interactive.Settings.resources.dll"
-                                                                                                          target="lib\netcoreapp2.1" />
-        <file src="FSharp.Build\$Configuration$\netcoreapp2.1\**\FSharp.Build.resources.dll"              target="lib\netcoreapp2.1" />
+                                                                                                          target="lib\netcoreapp3.0" />
+        <file src="FSharp.Build\$Configuration$\netcoreapp3.0\**\FSharp.Build.resources.dll"              target="lib\netcoreapp3.0" />
         <file src="FSharp.DependencyManager\$configuration$\netstandard2.0\**\FSharp.DependencyManager.resources.dll"
-                                                                                                          target="lib\netcoreapp2.1" />
+                                                                                                          target="lib\netcoreapp3.0" />
     </files>
 </package>

--- a/src/fsharp/fsc/fsc.fsproj
+++ b/src/fsharp/fsc/fsc.fsproj
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks Condition="'$(ProtoTargetFramework)' != ''">$(ProtoTargetFramework)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.0</TargetFrameworks>
     <TargetExt>.exe</TargetExt>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
@@ -40,11 +40,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Console" Version="$(SystemConsoleVersion)" />
-    <PackageReference Include="System.Linq.Expressions" Version="$(SystemLinqExpressionsVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
-    <PackageReference Include="System.Security.Principal" Version="$(SystemSecurityPrincipalVersion)" />
     <PackageReference Include="System.Console" Version="$(SystemConsoleVersion)" />
     <PackageReference Include="System.Linq.Expressions" Version="$(SystemLinqExpressionsVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks Condition="'$(ProtoTargetFramework)' != ''">$(ProtoTargetFramework)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.0</TargetFrameworks>
     <TargetExt>.exe</TargetExt>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
@@ -50,7 +50,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
     <PackageReference Include="System.Linq.Expressions" Version="$(SystemLinqExpressionsVersion)" />
     <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />

--- a/tests/EndToEndBuildTests/BasicProvider/BasicProvider.DesignTime/BasicProvider.DesignTime.fsproj
+++ b/tests/EndToEndBuildTests/BasicProvider/BasicProvider.DesignTime/BasicProvider.DesignTime.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <FSharpToolsDirectory>typeproviders</FSharpToolsDirectory>
     <DefineConstants>NO_GENERATIVE</DefineConstants>
     <DefineConstants>IS_DESIGNTIME</DefineConstants>

--- a/tests/EndToEndBuildTests/BasicProvider/BasicProvider.Tests/BasicProvider.Tests.fsproj
+++ b/tests/EndToEndBuildTests/BasicProvider/BasicProvider.Tests/BasicProvider.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework Condition=" '$(TestTargetFramework)' == '' ">netcoreapp2.0</TargetFramework>
+    <TargetFramework Condition=" '$(TestTargetFramework)' == '' ">netcoreapp3.0</TargetFramework>
     <TargetFramework Condition=" '$(TestTargetFramework)' != '' ">$(TestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>NO_GENERATIVE</DefineConstants>

--- a/tests/EndToEndBuildTests/BasicProvider/BasicProvider/BasicProvider.fsproj
+++ b/tests/EndToEndBuildTests/BasicProvider/BasicProvider/BasicProvider.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <FSharpToolsDirectory>typeproviders</FSharpToolsDirectory>
     <PackagePath>typeproviders</PackagePath>
   </PropertyGroup>

--- a/tests/EndToEndBuildTests/BasicProvider/TestBasicProvider.cmd
+++ b/tests/EndToEndBuildTests/BasicProvider/TestBasicProvider.cmd
@@ -26,8 +26,8 @@ taskkill /F /IM dotnet.exe
 %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
 rem
@@ -44,8 +44,8 @@ if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\BasicProvider /s /q
 %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
 :success

--- a/tests/EndToEndBuildTests/ComboProvider/ComboProvider.Tests/ComboProvider.Tests.fsproj
+++ b/tests/EndToEndBuildTests/ComboProvider/ComboProvider.Tests/ComboProvider.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework Condition=" '$(TestTargetFramework)' == '' ">netcoreapp2.0</TargetFramework>
+    <TargetFramework Condition=" '$(TestTargetFramework)' == '' ">3.0</TargetFramework>
     <TargetFramework Condition=" '$(TestTargetFramework)' != '' ">$(TestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>NO_GENERATIVE</DefineConstants>

--- a/tests/EndToEndBuildTests/ComboProvider/ComboProvider.Tests/ComboProvider.Tests.fsproj
+++ b/tests/EndToEndBuildTests/ComboProvider/ComboProvider.Tests/ComboProvider.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework Condition=" '$(TestTargetFramework)' == '' ">3.0</TargetFramework>
+    <TargetFramework Condition=" '$(TestTargetFramework)' == '' ">netcoreapp3.0</TargetFramework>
     <TargetFramework Condition=" '$(TestTargetFramework)' != '' ">$(TestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>NO_GENERATIVE</DefineConstants>

--- a/tests/EndToEndBuildTests/ComboProvider/ComboProvider/ComboProvider.fsproj
+++ b/tests/EndToEndBuildTests/ComboProvider/ComboProvider/ComboProvider.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/EndToEndBuildTests/ComboProvider/TestComboProvider.cmd
+++ b/tests/EndToEndBuildTests/ComboProvider/TestComboProvider.cmd
@@ -25,8 +25,8 @@ taskkill /F /IM dotnet.exe
 %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
 @if ERRORLEVEL 1 echo Error: ComboProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
 @if ERRORLEVEL 1 echo Error: ComboProviderProvider failed  && goto :failure
 
 rem
@@ -43,8 +43,8 @@ if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\ComboProvider /s /q
 %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
 @if ERRORLEVEL 1 echo Error: ComboProvider failed  && goto :failure
 
 :success

--- a/tests/FSharp.Compiler.LanguageServer.UnitTests/ProtocolTests.fs
+++ b/tests/FSharp.Compiler.LanguageServer.UnitTests/ProtocolTests.fs
@@ -12,7 +12,7 @@ open StreamJsonRpc
 type ProtocolTests() =
 
 #if !NETCOREAPP
-    // The `netcoreapp2.1` version of `FSharp.Compiler.LanguageServer.exe` can't be run without a `publish` step so
+    // The `netcoreapp` version of `FSharp.Compiler.LanguageServer.exe` can't be run without a `publish` step so
     // we're artificially restricting this test to the full framework.
     [<Test>]
 #endif

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -168,10 +168,10 @@ let config configurationName envVars =
     let fsharpBuildArchitecture = "net472"
     let fsharpCompilerInteractiveSettingsArchitecture = "net472"
 #else
-    let fscArchitecture = "netcoreapp2.1"
-    let fsiArchitecture = "netcoreapp2.1"
+    let fscArchitecture = "netcoreapp3.0"
+    let fsiArchitecture = "netcoreapp3.0"
     let fsharpCoreArchitecture = "netstandard2.0"
-    let fsharpBuildArchitecture = "netcoreapp2.1"
+    let fsharpBuildArchitecture = "netcoreapp3.0"
     let fsharpCompilerInteractiveSettingsArchitecture = "netstandard2.0"
 #endif
     let repoRoot = SCRIPT_ROOT ++ ".." ++ ".."

--- a/tests/service/CSharpProjectAnalysis.fs
+++ b/tests/service/CSharpProjectAnalysis.fs
@@ -61,7 +61,7 @@ let internal getProjectReferences (content, dllFiles, libDirs, otherFlags) =
     results, assemblies
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Test that csharp references are recognized as such`` () = 
@@ -99,7 +99,7 @@ let ``Test that csharp references are recognized as such`` () =
     members.["InterfaceEvent"].XmlDocSig |> shouldEqual "E:FSharp.Compiler.Service.Tests.CSharpClass.InterfaceEvent"
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Test that symbols of csharp inner classes/enums are reported`` () = 
@@ -122,7 +122,7 @@ let _ = CSharpOuterClass.InnerClass.StaticMember()
             "member StaticMember"; "NestedEnumClass"|]
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Ctor test`` () =
@@ -158,7 +158,7 @@ let getEntitiesUses source =
     |> List.ofSeq
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Different types with the same short name equality check`` () =
@@ -178,7 +178,7 @@ let (s2: FSharp.Compiler.Service.Tests.String) = null
     | _ -> sprintf "Expecting two symbols, got %A" stringSymbols |> failwith
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Different namespaces with the same short name equality check`` () =

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -6,7 +6,7 @@ open System.Collections.Generic
 open FSharp.Compiler
 open FSharp.Compiler.SourceCodeServices
 
-#if NETCOREAPP2_0
+#if NETCOREAPP
 let readRefs (folder : string) (projectFile: string) =
     let runProcess (workingDir: string) (exePath: string) (args: string) =
         let psi = System.Diagnostics.ProcessStartInfo()
@@ -64,7 +64,7 @@ let getBackgroundCheckResultsForScriptText (input) =
 
 
 let sysLib nm = 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP
     if System.Environment.OSVersion.Platform = System.PlatformID.Win32NT then // file references only valid on Windows 
         let programFilesx86Folder = System.Environment.GetEnvironmentVariable("PROGRAMFILES(X86)")
         programFilesx86Folder + @"\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\" + nm + ".dll"
@@ -84,7 +84,7 @@ let fsCoreDefaultReference() =
     PathRelativeToTestAssembly "FSharp.Core.dll"
 
 let mkStandardProjectReferences () = 
-#if NETCOREAPP2_0
+#if NETCOREAPP
             let file = "Sample_NETCoreSDK_FSharp_Library_netstandard2_0.fsproj"
             let projDir = Path.Combine(__SOURCE_DIRECTORY__, "../projects/Sample_NETCoreSDK_FSharp_Library_netstandard2_0")
             readRefs projDir file
@@ -124,7 +124,7 @@ let mkProjectCommandLineArgs (dllName, fileNames) =
   printfn "dllName = %A, args = %A" dllName args
   args
 
-#if NETCOREAPP2_0
+#if NETCOREAPP
 let mkProjectCommandLineArgsForScript (dllName, fileNames) = 
     [|  yield "--simpleresolution" 
         yield "--noframework" 
@@ -165,7 +165,7 @@ let parseAndCheckFile fileName source options =
 
 let parseAndCheckScript (file, input) = 
 
-#if NETCOREAPP2_0
+#if NETCOREAPP
     let dllName = Path.ChangeExtension(file, ".dll")
     let projName = Path.ChangeExtension(file, ".fsproj")
     let args = mkProjectCommandLineArgsForScript (dllName, [file])
@@ -299,7 +299,7 @@ let rec allSymbolsInEntities compGen (entities: IList<FSharpEntity>) =
 
 
 let coreLibAssemblyName =
-#if NETCOREAPP2_0
+#if NETCOREAPP
     "System.Runtime"
 #else
     "mscorlib"

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -103,14 +103,14 @@ let ``Intro test`` () =
                ("Concat", ["str0: string"; "str1: string"]);
                ("Concat", ["arg0: obj"; "arg1: obj"; "arg2: obj"]);
                ("Concat", ["str0: string"; "str1: string"; "str2: string"]);
-#if !NETCOREAPP2_0 // TODO: check why this is needed for .NET Core testing of FSharp.Compiler.Service
+#if !NETCOREAPP // TODO: check why this is needed for .NET Core testing of FSharp.Compiler.Service
                ("Concat", ["arg0: obj"; "arg1: obj"; "arg2: obj"; "arg3: obj"]);
 #endif               
                ("Concat", ["str0: string"; "str1: string"; "str2: string"; "str3: string"])]
 
 
 // TODO: check if this can be enabled in .NET Core testing of FSharp.Compiler.Service
-#if !INTERACTIVE && !NETCOREAPP2_0 // InternalsVisibleTo on IncrementalBuild.LocallyInjectCancellationFault not working for some reason?
+#if !INTERACTIVE && !NETCOREAPP // InternalsVisibleTo on IncrementalBuild.LocallyInjectCancellationFault not working for some reason?
 [<Test>]
 let ``Basic cancellation test`` () = 
    try 
@@ -162,7 +162,7 @@ let ``GetMethodsAsSymbols should return all overloads of a method as FSharpSymbo
              ("Concat", [("str0", "string"); ("str1", "string")]);
              ("Concat", [("arg0", "obj"); ("arg1", "obj"); ("arg2", "obj")]);
              ("Concat", [("str0", "string"); ("str1", "string"); ("str2", "string")]);
-#if !NETCOREAPP2_0 // TODO: check why this is needed for .NET Core testing of FSharp.Compiler.Service
+#if !NETCOREAPP // TODO: check why this is needed for .NET Core testing of FSharp.Compiler.Service
              ("Concat", [("arg0", "obj"); ("arg1", "obj"); ("arg2", "obj"); ("arg3", "obj")]);
 #endif
              ("Concat", [("str0", "string"); ("str1", "string"); ("str2", "string"); ("str3", "string")])]

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -784,7 +784,7 @@ let ``Test Unoptimized Declarations Project1`` () =
 
 
 [<Test>]
-//#if NETCOREAPP2_0
+//#if NETCOREAPP
 //[<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 //#endif
 let ``Test Optimized Declarations Project1`` () =
@@ -2897,7 +2897,7 @@ let ``Test expressions of optimized declarations stress big expressions`` () =
 
 #if NOT_YET_ENABLED
 
-#if !NO_PROJECTCRACKER && !NETCOREAPP2_0
+#if !NO_PROJECTCRACKER && !NETCOREAPP
 
 [<Test>]
 let ``Check use of type provider that provides calls to F# code`` () = 

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -76,7 +76,7 @@ let UseMyFileSystem() =
 
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``FileSystem compilation test``() = 

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -37,7 +37,7 @@ type PEVerifier () =
     static let runsOnMono = try System.Type.GetType("Mono.Runtime") <> null with _ -> false
 
     let verifierInfo =
-#if NETCOREAPP2_0
+#if NETCOREAPP
         None
 #else           
         if runsOnMono then
@@ -92,7 +92,7 @@ let checker = FSharpChecker.Create()
 /// Ensures the default FSharp.Core referenced by the F# compiler service (if none is 
 /// provided explicitly) is available in the output directory.
 let ensureDefaultFSharpCoreAvailable tmpDir  =
-#if NETCOREAPP2_0
+#if NETCOREAPP
     ignore tmpDir
 #else
     // FSharp.Compiler.Service references FSharp.Core 4.3.0.0 by default.  That's wrong? But the output won't verify

--- a/tests/service/FsiTests.fs
+++ b/tests/service/FsiTests.fs
@@ -27,7 +27,7 @@ let errStream = new CompilerOutputStream()
 let argv = [| "C:\\fsi.exe" |]
 let allArgs = Array.append argv [|"--noninteractive"|]
 
-#if NETCOREAPP2_0
+#if NETCOREAPP
 let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration()
 #else
 let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration(fsi)

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -129,7 +129,7 @@ let u = Case1 3
 
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Test multi project 1 whole project errors`` () = 
@@ -314,7 +314,7 @@ let p = ("""
         FSharpChecker.Create(projectCacheSize=size)
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Test ManyProjectsStressTest whole project errors`` () = 
@@ -834,7 +834,7 @@ let ``Test max memory gets triggered`` () =
 
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Type provider project references should not throw exceptions`` () =
@@ -924,7 +924,7 @@ let ``Type provider project references should not throw exceptions`` () =
 //------------------------------------------------------------------------------------
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #else
 [<Ignore("Getting vsunit tests passing again")>]

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -3212,7 +3212,7 @@ let ``Test Project22 IList properties`` () =
 
     attribsOfSymbol ilistTypeDefn |> shouldEqual ["interface"]
 
-#if !NETCOREAPP2_0 // TODO: check if this can be enabled in .NET Core testing of FSharp.Compiler.Service
+#if !NETCOREAPP // TODO: check if this can be enabled in .NET Core testing of FSharp.Compiler.Service
     ilistTypeDefn.Assembly.SimpleName |> shouldEqual coreLibAssemblyName
 #endif
 
@@ -3674,7 +3674,7 @@ let _ = XmlProvider<"<root><value>1</value><value>3</value></root>">.GetSample()
     let options = checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore "SKIPPED: Disabled until FSharp.Data.dll is build for dotnet core.">]
 #endif
 let ``Test Project25 whole project errors`` () = 
@@ -3684,7 +3684,7 @@ let ``Test Project25 whole project errors`` () =
     wholeProjectResults.Errors.Length |> shouldEqual 0
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore "SKIPPED: Disabled until FSharp.Data.dll is build for dotnet core.">]
 #endif
 let ``Test Project25 symbol uses of type-provided members`` () = 
@@ -3743,7 +3743,7 @@ let ``Test Project25 symbol uses of type-provided members`` () =
     usesOfGetSampleSymbol |> shouldEqual [|("file1", ((5, 8), (5, 25))); ("file1", ((10, 8), (10, 78)))|]
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore "SKIPPED: Disabled until FSharp.Data.dll is build for dotnet core.">]
 #endif
 let ``Test symbol uses of type-provided types`` () = 
@@ -4174,7 +4174,7 @@ let ``Test project31 whole project errors`` () =
     wholeProjectResults.Errors.Length |> shouldEqual 0
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: Fails on .NET Core - DebuggerTypeProxyAttribute and DebuggerDisplayAttribute note being emitted?")>]
 #endif
 let ``Test project31 C# type attributes`` () =
@@ -4217,13 +4217,13 @@ let ``Test project31 C# method attributes`` () =
         |> set
         |> shouldEqual 
               (set [
-#if !NETCOREAPP2_0 
+#if !NETCOREAPP
                    "(SecuritySafeCriticalAttribute, [], [])";
 #endif
                    "(CLSCompliantAttribute, [(type Microsoft.FSharp.Core.bool, false)], [])"])
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: Fails on .NET Core - DebuggerTypeProxyAttribute and DebuggerDisplayAttribute note being emitted?")>]
 #endif
 let ``Test project31 Format C# type attributes`` () =
@@ -4258,7 +4258,7 @@ let ``Test project31 Format C# method attributes`` () =
         |> set
         |> shouldEqual 
               (set ["[<CLSCompliantAttribute (false)>]";
-#if !NETCOREAPP2_0
+#if !NETCOREAPP
                     "[<Security.SecuritySafeCriticalAttribute ()>]";
 #endif
                     ])
@@ -4413,7 +4413,7 @@ let ``Test Project34 whole project errors`` () =
     wholeProjectResults.Errors.Length |> shouldEqual 0
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Test project34 should report correct accessibility for System.Data.Listeners`` () =
@@ -4538,7 +4538,7 @@ module internal Project35b =
     let cleanFileName a = if a = fileName1 then "file1" else "??"
 
     let fileNames = [fileName1]
-#if NETCOREAPP2_0
+#if NETCOREAPP
     let projPath = Path.ChangeExtension(fileName1, ".fsproj")
     let dllPath = Path.ChangeExtension(fileName1, ".dll")
     let args = mkProjectCommandLineArgs(dllPath, fileNames)

--- a/tests/service/ProjectOptionsTests.fs
+++ b/tests/service/ProjectOptionsTests.fs
@@ -520,7 +520,7 @@ let ``Test SourceFiles order for GetProjectOptionsFromScript`` () = // See #594
     test "MainBad" [|"MainBad"|] 
 
 [<Test>]
-#if NETCOREAPP2_0
+#if NETCOREAPP
 [<Ignore("SKIPPED: no project options cracker for .NET Core?")>]
 #endif
 let ``Script load closure project`` () =


### PR DESCRIPTION
Given that we require .NET SDK 3.0.100 and VS 16.3 to build, there's no requirement dependency that would prevent us from updating TFM values throughout the codebase.  This will make the eventual removal of the desktop frameworks (e.g., `net472`) much easier as ~~`netstandard2.1`/~~`netcoreapp3.0` should have all of the APIs we need.

In general:

- ~~`netstandard2.0` -> `netstandard2.1`, FSharp.Core excluded~~
- `netcoreapp2.x` -> `netcoreapp3.0`

TODO:
- [ ] Fix tests.
- ~~Test insertion with full-signed build.~~
