### PR TITLE
Optimize Seq.Last to behave like Seq.Length (incl. tests)

### DIFF
--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -9,6 +9,7 @@ namespace Microsoft.FSharp.Collections
     open Microsoft.FSharp.Collections
     open Microsoft.FSharp.Core.CompilerServices
     open System.Collections.Generic
+    
 
     [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
     [<RequireQualifiedAccess>]
@@ -24,18 +25,16 @@ namespace Microsoft.FSharp.Collections
         let length (list: 'T list) = list.Length
 
         [<CompiledName("Last")>]
-        let rec last (list: 'T list) =
-            match list with
-            | [x] -> x
-            | _ :: tail -> last tail
-            | [] -> invalidArg "list" (SR.GetString(SR.inputListWasEmpty))
+        let last (list: 'T list) =
+            match Microsoft.FSharp.Primitives.Basics.List.tryLast list with
+            | ValueSome x -> x
+            | ValueNone -> invalidArg "list" (SR.GetString(SR.inputListWasEmpty))
 
         [<CompiledName("TryLast")>]
         let rec tryLast (list: 'T list) =
-            match list with
-            | [x] -> Some x
-            | _ :: tail -> tryLast tail
-            | [] -> None
+            match Microsoft.FSharp.Primitives.Basics.List.tryLast list with
+            | ValueSome x -> Some x
+            | ValueNone -> None            
 
         [<CompiledName("Reverse")>]
         let rev list = Microsoft.FSharp.Primitives.Basics.List.rev list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -26,13 +26,13 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Last")>]
         let last (list: 'T list) =
-            match Microsoft.FSharp.Primitives.Basics.List.tryLast list with
+            match Microsoft.FSharp.Primitives.Basics.List.tryLastV list with
             | ValueSome x -> x
             | ValueNone -> invalidArg "list" (SR.GetString(SR.inputListWasEmpty))
 
         [<CompiledName("TryLast")>]
         let rec tryLast (list: 'T list) =
-            match Microsoft.FSharp.Primitives.Basics.List.tryLast list with
+            match Microsoft.FSharp.Primitives.Basics.List.tryLastV list with
             | ValueSome x -> Some x
             | ValueNone -> None            
 

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -988,6 +988,12 @@ module internal List =
             takeWhileFreshConsTail cons p xs
             cons
 
+    let rec tryLast (list: 'T list) = 
+        match list with
+        | [] -> ValueNone
+        | [x] -> ValueSome x        
+        | _ :: tail -> tryLast tail           
+
 module internal Array =
 
     open System
@@ -1187,3 +1193,26 @@ module internal Array =
                 res.[i] <- subUnchecked !startIndex minChunkSize array
                 startIndex := !startIndex + minChunkSize
             res
+
+module internal Seq =
+    let tryLast (source : seq<_>) =
+        //checkNonNull "source" source //done in main Seq.tryLast
+        match source with
+        | :? ('T[]) as a -> 
+            if a.Length = 0 then ValueNone
+            else ValueSome(a.[a.Length - 1])
+        
+        | :? ('T IList) as a -> //ResizeArray and other collections
+            if a.Count = 0 then ValueNone
+            else ValueSome(a.[a.Count - 1])
+        
+        | :? ('T list) as a -> List.tryLast a 
+        
+        | _ -> 
+            use e = source.GetEnumerator()
+            if e.MoveNext() then
+                let mutable res = e.Current
+                while (e.MoveNext()) do res <- e.Current
+                ValueSome(res)
+            else
+                ValueNone

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -988,11 +988,11 @@ module internal List =
             takeWhileFreshConsTail cons p xs
             cons
 
-    let rec tryLast (list: 'T list) = 
+    let rec tryLastV (list: 'T list) = 
         match list with
         | [] -> ValueNone
         | [x] -> ValueSome x        
-        | _ :: tail -> tryLast tail           
+        | _ :: tail -> tryLastV tail           
 
 module internal Array =
 
@@ -1195,7 +1195,7 @@ module internal Array =
             res
 
 module internal Seq =
-    let tryLast (source : seq<_>) =
+    let tryLastV (source : seq<_>) =
         //checkNonNull "source" source //done in main Seq.tryLast
         match source with
         | :? ('T[]) as a -> 
@@ -1206,7 +1206,7 @@ module internal Seq =
             if a.Count = 0 then ValueNone
             else ValueSome(a.[a.Count - 1])
         
-        | :? ('T list) as a -> List.tryLast a 
+        | :? ('T list) as a -> List.tryLastV a 
         
         | _ -> 
             use e = source.GetEnumerator()

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -65,6 +65,7 @@ module internal List =
     val splitAt : int -> 'T list -> ('T list * 'T list)
     val transpose : 'T list list -> 'T list list
     val truncate : int -> 'T list -> 'T list
+    val tryLast : 'T list -> 'T ValueOption
 
 module internal Array =
     // The input parameter should be checked by callers if necessary
@@ -101,3 +102,6 @@ module internal Array =
     val stableSortInPlaceWith: comparer:('T -> 'T -> int) -> array:'T[] -> unit
 
     val stableSortInPlace: array:'T[] -> unit when 'T : comparison 
+
+module internal Seq =
+    val tryLast : 'T seq -> 'T ValueOption

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -65,7 +65,7 @@ module internal List =
     val splitAt : int -> 'T list -> ('T list * 'T list)
     val transpose : 'T list list -> 'T list list
     val truncate : int -> 'T list -> 'T list
-    val tryLast : 'T list -> 'T ValueOption
+    val tryLastV : 'T list -> 'T ValueOption
 
 module internal Array =
     // The input parameter should be checked by callers if necessary
@@ -104,4 +104,4 @@ module internal Array =
     val stableSortInPlace: array:'T[] -> unit when 'T : comparison 
 
 module internal Seq =
-    val tryLast : 'T seq -> 'T ValueOption
+    val tryLastV : 'T seq -> 'T ValueOption

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1377,7 +1377,13 @@ namespace Microsoft.FSharp.Collections
                       invalidArg "source" (SR.GetString(SR.notEnoughElements))
                   while e.MoveNext() do
                       yield e.Current }
-
+        
+        let rec private listLast (list: 'T list) = // copied from List.last which is not available here (compilation order)
+            match list with
+            | [x] -> x
+            | _ :: tail -> listLast tail
+            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString 
+                    
         [<CompiledName("Last")>]
         let last (source : seq<_>) =
             checkNonNull "source" source
@@ -1388,10 +1394,8 @@ namespace Microsoft.FSharp.Collections
             | :? ('T IList) as a -> //ResizeArray and other collections 
                 if a.Count = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
                 else a.[a.Count - 1]
-            | :? ('T list) as a ->  
-                match a with 
-                |[] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
-                | _ -> List.last a             
+            | :? ('T list) as a ->
+                listLast a             
             | _ -> 
                 use e = source.GetEnumerator()
                 if e.MoveNext() then
@@ -1401,6 +1405,12 @@ namespace Microsoft.FSharp.Collections
                 else
                     invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
 
+        let rec private listTryLast (list: 'T list) = // copied from List.tryLast which is not available here (compilation order)
+            match list with
+            | [x] -> Some x
+            | _ :: tail -> listTryLast tail
+            | [] -> None
+        
         [<CompiledName("TryLast")>]
         let tryLast (source : seq<_>) =
             checkNonNull "source" source
@@ -1411,7 +1421,8 @@ namespace Microsoft.FSharp.Collections
             | :? ('T IList) as a -> //ResizeArray and other collections
                 if a.Count = 0 then None
                 else Some(a.[a.Count - 1])
-            | :? ('T list) as a -> List.tryLast a  
+            | :? ('T list) as a ->                 
+                listTryLast a  
             | _ -> 
                 use e = source.GetEnumerator()
                 if e.MoveNext() then

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1377,13 +1377,7 @@ namespace Microsoft.FSharp.Collections
                       invalidArg "source" (SR.GetString(SR.notEnoughElements))
                   while e.MoveNext() do
                       yield e.Current }
-        
-        let rec private listLast (list: 'T list) = // copied from List.last which is not available here (compilation order)
-            match list with
-            | [x] -> x
-            | _ :: tail -> listLast tail
-            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString 
-                    
+                           
         [<CompiledName("Last")>]
         let last (source : seq<_>) =
             checkNonNull "source" source
@@ -1395,6 +1389,11 @@ namespace Microsoft.FSharp.Collections
                 if a.Count = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
                 else a.[a.Count - 1]
             | :? ('T list) as a ->
+                let rec listLast (list: 'T list) = // copied from List.last which is not available here (compilation order)
+                    match list with
+                    | [x] -> x
+                    | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString  
+                    | _ :: tail -> listLast tail // inlined ? tail recursive?                                   
                 listLast a             
             | _ -> 
                 use e = source.GetEnumerator()
@@ -1404,12 +1403,6 @@ namespace Microsoft.FSharp.Collections
                     res
                 else
                     invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
-
-        let rec private listTryLast (list: 'T list) = // copied from List.tryLast which is not available here (compilation order)
-            match list with
-            | [x] -> Some x
-            | _ :: tail -> listTryLast tail
-            | [] -> None
         
         [<CompiledName("TryLast")>]
         let tryLast (source : seq<_>) =
@@ -1422,6 +1415,11 @@ namespace Microsoft.FSharp.Collections
                 if a.Count = 0 then None
                 else Some(a.[a.Count - 1])
             | :? ('T list) as a ->                 
+                let rec listTryLast (list: 'T list) = // copied from List.tryLast which is not available here (compilation order)
+                    match list with
+                    | [x] -> Some x
+                    | [] -> None
+                    | _ :: tail -> listTryLast tail //tail recursive? inlined?                    
                 listTryLast a  
             | _ -> 
                 use e = source.GetEnumerator()

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1384,10 +1384,10 @@ namespace Microsoft.FSharp.Collections
             match source with
             | :? ('T[]) as a -> 
                 if a.Length=0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
-                else a.[a.Length-1]
+                else a.[a.Length - 1]
             | :? IList<'T> as a -> 
                 if a.Count=0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
-                else a.[a.Count-1]
+                else a.[a.Count - 1]
             | _ -> 
                 use e = source.GetEnumerator()
                 if e.MoveNext() then
@@ -1403,10 +1403,10 @@ namespace Microsoft.FSharp.Collections
             match source with
             | :? ('T[]) as a -> 
                 if a.Length=0 then None
-                else Some(a.[a.Length-1])
+                else Some(a.[a.Length - 1])
             | :? IList<'T> as a -> 
                 if a.Count=0 then None
-                else Some(a.[a.Count-1])
+                else Some(a.[a.Count - 1])
             | _ -> 
                 use e = source.GetEnumerator()
                 if e.MoveNext() then

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1385,9 +1385,10 @@ namespace Microsoft.FSharp.Collections
             | :? ('T[]) as a -> 
                 if a.Length = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
                 else a.[a.Length - 1]
-            | :? IList<'T> as a -> 
+            | :? ('T IList) as a -> //ResizeArray and other collections 
                 if a.Count = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
                 else a.[a.Count - 1]
+            | :? list<'T> as a -> List.last a                
             | _ -> 
                 use e = source.GetEnumerator()
                 if e.MoveNext() then
@@ -1404,9 +1405,10 @@ namespace Microsoft.FSharp.Collections
             | :? ('T[]) as a -> 
                 if a.Length = 0 then None
                 else Some(a.[a.Length - 1])
-            | :? IList<'T> as a -> 
+            | :? ('T IList) as a -> //ResizeArray and other collections
                 if a.Count = 0 then None
                 else Some(a.[a.Count - 1])
+            | :? ('T list) as a -> List.tryLast a  
             | _ -> 
                 use e = source.GetEnumerator()
                 if e.MoveNext() then

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1381,24 +1381,40 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Last")>]
         let last (source : seq<_>) =
             checkNonNull "source" source
-            use e = source.GetEnumerator()
-            if e.MoveNext() then
-                let mutable res = e.Current
-                while (e.MoveNext()) do res <- e.Current
-                res
-            else
-                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
+            match source with
+            | :? ('T[]) as a -> 
+                if a.Length=0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
+                else a.[a.Length-1]
+            | :? IList<'T> as a -> 
+                if a.Count=0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
+                else a.[a.Count-1]
+            | _ -> 
+                use e = source.GetEnumerator()
+                if e.MoveNext() then
+                    let mutable res = e.Current
+                    while (e.MoveNext()) do res <- e.Current
+                    res
+                else
+                    invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
 
         [<CompiledName("TryLast")>]
         let tryLast (source : seq<_>) =
             checkNonNull "source" source
-            use e = source.GetEnumerator()
-            if e.MoveNext() then
-                let mutable res = e.Current
-                while (e.MoveNext()) do res <- e.Current
-                Some res
-            else
-                None
+            match source with
+            | :? ('T[]) as a -> 
+                if a.Length=0 then None
+                else Some(a.[a.Length-1])
+            | :? IList<'T> as a -> 
+                if a.Count=0 then None
+                else Some(a.[a.Count-1])
+            | _ -> 
+                use e = source.GetEnumerator()
+                if e.MoveNext() then
+                    let mutable res = e.Current
+                    while (e.MoveNext()) do res <- e.Current
+                    Some(res)
+                else
+                    None
 
         [<CompiledName("ExactlyOne")>]
         let exactlyOne (source : seq<_>) =

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1381,14 +1381,14 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Last")>]
         let last (source : seq<_>) =
             checkNonNull "source" source
-            match Microsoft.FSharp.Primitives.Basics.Seq.tryLast source with
+            match Microsoft.FSharp.Primitives.Basics.Seq.tryLastV source with
             | ValueSome x -> x
             | ValueNone -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
         
         [<CompiledName("TryLast")>]
         let tryLast (source : seq<_>) =
             checkNonNull "source" source
-            match Microsoft.FSharp.Primitives.Basics.Seq.tryLast source with
+            match Microsoft.FSharp.Primitives.Basics.Seq.tryLastV source with
             | ValueSome x -> Some x
             | ValueNone -> None
             

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1383,10 +1383,10 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source" source
             match source with
             | :? ('T[]) as a -> 
-                if a.Length=0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
+                if a.Length = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
                 else a.[a.Length - 1]
             | :? IList<'T> as a -> 
-                if a.Count=0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
+                if a.Count = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
                 else a.[a.Count - 1]
             | _ -> 
                 use e = source.GetEnumerator()
@@ -1402,10 +1402,10 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source" source
             match source with
             | :? ('T[]) as a -> 
-                if a.Length=0 then None
+                if a.Length = 0 then None
                 else Some(a.[a.Length - 1])
             | :? IList<'T> as a -> 
-                if a.Count=0 then None
+                if a.Count = 0 then None
                 else Some(a.[a.Count - 1])
             | _ -> 
                 use e = source.GetEnumerator()

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1388,7 +1388,10 @@ namespace Microsoft.FSharp.Collections
             | :? ('T IList) as a -> //ResizeArray and other collections 
                 if a.Count = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
                 else a.[a.Count - 1]
-            | :? list<'T> as a -> List.last a                
+            | :? ('T list) as a ->  
+                match a with 
+                |[] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
+                | _ -> List.last a.              
             | _ -> 
                 use e = source.GetEnumerator()
                 if e.MoveNext() then

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1381,55 +1381,17 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Last")>]
         let last (source : seq<_>) =
             checkNonNull "source" source
-            match source with
-            | :? ('T[]) as a -> 
-                if a.Length = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
-                else a.[a.Length - 1]
-            | :? ('T IList) as a -> //ResizeArray and other collections 
-                if a.Count = 0 then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
-                else a.[a.Count - 1]
-            | :? ('T list) as a ->
-                let rec listLast (list: 'T list) = // copied from List.last which is not available here (compilation order)
-                    match list with
-                    | [x] -> x
-                    | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString  
-                    | _ :: tail -> listLast tail // inlined ? tail recursive?                                   
-                listLast a             
-            | _ -> 
-                use e = source.GetEnumerator()
-                if e.MoveNext() then
-                    let mutable res = e.Current
-                    while (e.MoveNext()) do res <- e.Current
-                    res
-                else
-                    invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
+            match Microsoft.FSharp.Primitives.Basics.Seq.tryLast source with
+            | ValueSome x -> x
+            | ValueNone -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
         
         [<CompiledName("TryLast")>]
         let tryLast (source : seq<_>) =
             checkNonNull "source" source
-            match source with
-            | :? ('T[]) as a -> 
-                if a.Length = 0 then None
-                else Some(a.[a.Length - 1])
-            | :? ('T IList) as a -> //ResizeArray and other collections
-                if a.Count = 0 then None
-                else Some(a.[a.Count - 1])
-            | :? ('T list) as a ->                 
-                let rec listTryLast (list: 'T list) = // copied from List.tryLast which is not available here (compilation order)
-                    match list with
-                    | [x] -> Some x
-                    | [] -> None
-                    | _ :: tail -> listTryLast tail //tail recursive? inlined?                    
-                listTryLast a  
-            | _ -> 
-                use e = source.GetEnumerator()
-                if e.MoveNext() then
-                    let mutable res = e.Current
-                    while (e.MoveNext()) do res <- e.Current
-                    Some(res)
-                else
-                    None
-
+            match Microsoft.FSharp.Primitives.Basics.Seq.tryLast source with
+            | ValueSome x -> Some x
+            | ValueNone -> None
+            
         [<CompiledName("ExactlyOne")>]
         let exactlyOne (source : seq<_>) =
             checkNonNull "source" source

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1391,7 +1391,7 @@ namespace Microsoft.FSharp.Collections
             | :? ('T list) as a ->  
                 match a with 
                 |[] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
-                | _ -> List.last a.              
+                | _ -> List.last a             
             | _ -> 
                 use e = source.GetEnumerator()
                 if e.MoveNext() then

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
@@ -99,8 +99,7 @@ type SeqModule2() =
         // null Seq
         let nullSeq:seq<'a> = null
         CheckThrowsArgumentNullException (fun () ->Seq.last nullSeq) 
-        () 
-        
+                
         
         // ------ Test for Array -----
         let IntArr = Array.ofSeq IntSeq                     
@@ -117,8 +116,7 @@ type SeqModule2() =
         // null Array
         let nullArr: array<'a> = null
         CheckThrowsArgumentNullException (fun () ->Seq.last nullArr) 
-        () 
-
+        
         // ---- Test for IList -----
         let IntRarr = ResizeArray(IntSeq)
         if Seq.last IntRarr <> 9 then Assert.Fail()
@@ -134,7 +132,24 @@ type SeqModule2() =
         // null IList
         let nullRarr: ResizeArray<unit> = null
         CheckThrowsArgumentNullException (fun () ->Seq.last nullRarr) 
+        
+        // ---- Test for list -----
+        let Intlist = List.ofSeq(IntSeq)
+        if Seq.last Intlist <> 9 then Assert.Fail()
+                 
+        // string list
+        let strlist = List.ofSeq(strSeq) 
+        if Seq.last strlist <> "third" then Assert.Fail()
+         
+        // Empty list
+        let emptylist: list<unit> = []
+        CheckThrowsArgumentException ( fun() -> Seq.last emptyRlist)
+      
+        // null list
+        let nulllist: list<unit> = Unchecked.defaultof<list<unit>>
+        CheckThrowsArgumentNullException (fun () ->Seq.last nullRarr) 
         () 
+        
 
     [<Test>]
     member this.TryLast() =
@@ -155,8 +170,7 @@ type SeqModule2() =
       
         // null Seq
         let nullSeq:seq<'a> = null
-        CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullSeq |> ignore) 
-        () 
+        CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullSeq |> ignore)
 
         // ------ Test for Array -----
         let IntArr = Array.ofSeq IntSeq                     
@@ -164,7 +178,7 @@ type SeqModule2() =
         Assert.AreEqual(9, intResult.Value)
                  
         // string Array
-        let strResult = Seq.tryLast (Array.ofSeq (seq ["first"; "second";  "third"]))
+        let strResult = Seq.tryLast (Array.ofSeq (["first"; "second";  "third"]))
         Assert.AreEqual("third", strResult.Value)
          
         // Empty Array
@@ -174,7 +188,6 @@ type SeqModule2() =
         // null Array
         let nullArr:array<unit> = null
         CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullArr |> ignore) 
-        () 
 
 
         // ------ Test for IList -----
@@ -183,7 +196,7 @@ type SeqModule2() =
         Assert.AreEqual(9, intResult.Value)
                  
         // string IList
-        let strResult = Seq.tryLast (ResizeArray (seq ["first"; "second";  "third"]))
+        let strResult = Seq.tryLast (ResizeArray (["first"; "second";  "third"]))
         Assert.AreEqual("third", strResult.Value)
          
         // Empty IList
@@ -193,9 +206,25 @@ type SeqModule2() =
         // null IList
         let nullRarr:ResizeArray<unit> = null
         CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullRarr |> ignore) 
+        
+        // ------ Test for list -----
+        let Intlist= List.ofSeq( IntSeq )
+        let intResult = Seq.tryLast Intlist
+        Assert.AreEqual(9, intResult.Value)
+                 
+        // string list
+        let strResult = Seq.tryLast ["first"; "second";  "third"]
+        Assert.AreEqual("third", strResult.Value)
+         
+        // Empty list
+        let emptylist: list<unit> = []
+        let emptyResult = Seq.tryLast emptylist
+        Assert.IsTrue(emptyResult.IsNone)
+      
+        // null list
+        let nulllist: list<unit> = Unchecked.defaultof<list<unit>>
+        CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullList |> ignore) 
         () 
-
-
 
 
         

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
@@ -146,8 +146,8 @@ type SeqModule2() =
         CheckThrowsArgumentException ( fun() -> Seq.last emptylist)
       
         // null list
-        let nulllist: list<unit> = Unchecked.defaultof<list<unit>>
-        CheckThrowsArgumentNullException (fun () ->Seq.last nulllist) 
+        let nullList: list<unit> = Unchecked.defaultof<list<unit>>
+        CheckThrowsArgumentNullException (fun () ->Seq.last nullList) 
         () 
         
 
@@ -222,7 +222,7 @@ type SeqModule2() =
         Assert.IsTrue(emptyResult.IsNone)
       
         // null list
-        let nulllist: list<unit> = Unchecked.defaultof<list<unit>>
+        let nullList: list<unit> = Unchecked.defaultof<list<unit>>
         CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullList |> ignore) 
         () 
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
@@ -143,11 +143,11 @@ type SeqModule2() =
          
         // Empty list
         let emptylist: list<unit> = []
-        CheckThrowsArgumentException ( fun() -> Seq.last emptyRlist)
+        CheckThrowsArgumentException ( fun() -> Seq.last emptylist)
       
         // null list
         let nulllist: list<unit> = Unchecked.defaultof<list<unit>>
-        CheckThrowsArgumentNullException (fun () ->Seq.last nullRarr) 
+        CheckThrowsArgumentNullException (fun () ->Seq.last nulllist) 
         () 
         
 
@@ -187,7 +187,7 @@ type SeqModule2() =
       
         // null Array
         let nullArr:array<unit> = null
-        CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullArr |> ignore) 
+        CheckThrowsArgumentNullException (fun () -> Seq.tryLast nullArr |> ignore) 
 
 
         // ------ Test for IList -----

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
@@ -123,16 +123,16 @@ type SeqModule2() =
         let IntRarr = ResizeArray(IntSeq)
         if Seq.last IntRarr <> 9 then Assert.Fail()
                  
-        // string Array
+        // string IList
         let strRarr = ResizeArray(strSeq) 
         if Seq.last strRarr <> "third" then Assert.Fail()
          
-        // Empty Array
-        let emptyRarr = ResizeArray<'a>()
+        // Empty IList
+        let emptyRarr = ResizeArray<unit>()
         CheckThrowsArgumentException ( fun() -> Seq.last emptyRarr)
       
-        // null Array
-        let nullRarr: ResizeArray<'a> = null
+        // null IList
+        let nullRarr: ResizeArray<unit> = null
         CheckThrowsArgumentNullException (fun () ->Seq.last nullRarr) 
         () 
 
@@ -163,16 +163,16 @@ type SeqModule2() =
         let intResult = Seq.tryLast IntArr
         Assert.AreEqual(9, intResult.Value)
                  
-        // string Seq
+        // string Array
         let strResult = Seq.tryLast (Array.ofSeq (seq ["first"; "second";  "third"]))
         Assert.AreEqual("third", strResult.Value)
          
-        // Empty Seq
+        // Empty Array
         let emptyResult = Seq.tryLast Array.empty
         Assert.IsTrue(emptyResult.IsNone)
       
-        // null Seq
-        let nullArr:array<'a> = null
+        // null Array
+        let nullArr:array<unit> = null
         CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullArr |> ignore) 
         () 
 
@@ -182,16 +182,16 @@ type SeqModule2() =
         let intResult = Seq.tryLast IntRarr
         Assert.AreEqual(9, intResult.Value)
                  
-        // string Seq
+        // string IList
         let strResult = Seq.tryLast (ResizeArray (seq ["first"; "second";  "third"]))
         Assert.AreEqual("third", strResult.Value)
          
-        // Empty Seq
-        let emptyResult = Seq.tryLast (ResizeArray<'a>())
+        // Empty IList
+        let emptyResult = Seq.tryLast (ResizeArray<unit>())
         Assert.IsTrue(emptyResult.IsNone)
       
-        // null Seq
-        let nullRarr:ResizeArray<'a> = null
+        // null IList
+        let nullRarr:ResizeArray<unit> = null
         CheckThrowsArgumentNullException (fun () ->Seq.tryLast nullRarr |> ignore) 
         () 
 


### PR DESCRIPTION
Add type check to` Seq.Last` and `Seq.TryLast` to avoid full iteration if not necessary. [Like `Seq.Length` does it](https://github.com/dotnet/fsharp/blob/c18e1780b3f3f345364cb1ad8e510ea9f4590d3a/src/fsharp/FSharp.Core/seq.fs#L709). Test are added too, but I could not run them (or build the solution).

