### PR TITLE
FreeVars cache optimization on Expr.Let

### DIFF
--- a/src/fsharp/lib.fs
+++ b/src/fsharp/lib.fs
@@ -394,6 +394,10 @@ let inline cacheOptRef cache f =
        cache := Some res
        res 
 
+let inline tryGetCacheValue cache =
+    match box cache.cacheVal with
+    | null -> ValueNone
+    | _ -> ValueSome cache.cacheVal
 
 #if DUMPER
 type Dumper(x:obj) =


### PR DESCRIPTION
Hopefully this is the right thing to do and does not break anything.

We already had a free variables cache, but it would not immediately return if we had cached values for a let binding expression. This PR will now do that. Without the early return, it would always traverse through the expression even when we had a cached value ready.

In some cases, this optimization greatly affects compile time on expressions that are exceptionally large; I noticed this when providing a test for a large struct with 1000 fields in this PR: https://github.com/dotnet/fsharp/pull/7678
