### PR TITLE
Minor pickle optimization for Map and list

### DIFF
--- a/src/fsharp/TastPickle.fs
+++ b/src/fsharp/TastPickle.fs
@@ -581,8 +581,7 @@ let u_array_ext extraf f st =
     extraItem, arr
 
 let u_list_core f n st =
-    [ for _ in 1..n do
-         yield f st ]
+    List.init n (fun _ -> f st)
 
 let u_list f st =
     let n = u_int st
@@ -1305,11 +1304,27 @@ let u_ILInstr st =
 // Pickle/unpickle for F# types and module signatures
 //---------------------------------------------------------------------------
 
-let p_Map pk pv = p_wrap Map.toList (p_list (p_tup2 pk pv))
+let p_Map_core pk pv (xs: Map<_, _>) st =
+    for x in xs do
+        pk x.Key st
+        pv x.Value st
+
+let p_Map pk pv x st =
+    p_int (Map.count x) st
+    p_Map_core pk pv x st
+
 let p_qlist pv = p_wrap QueueList.toList (p_list pv)
 let p_namemap p = p_Map p_string p
 
-let u_Map uk uv = u_wrap Map.ofList (u_list (u_tup2 uk uv))
+let u_Map_core uk uv n st =
+    Map.ofSeq (seq {
+        for _ in 1..n do
+            yield (uk st, uv st) })
+
+let u_Map uk uv st = 
+    let n = u_int st
+    u_Map_core uk uv n st
+
 let u_qlist uv = u_wrap QueueList.ofList (u_list uv)
 let u_namemap u = u_Map u_string u
 

--- a/src/fsharp/TastPickle.fs
+++ b/src/fsharp/TastPickle.fs
@@ -1304,7 +1304,7 @@ let u_ILInstr st =
 // Pickle/unpickle for F# types and module signatures
 //---------------------------------------------------------------------------
 
-let p_Map_core pk pv (xs: Map<_, _>) st =
+let p_Map_core pk pv xs st =
     xs |> Map.iter (fun k v -> pk k st; pv v st)
 
 let p_Map pk pv x st =

--- a/src/fsharp/TastPickle.fs
+++ b/src/fsharp/TastPickle.fs
@@ -1305,9 +1305,7 @@ let u_ILInstr st =
 //---------------------------------------------------------------------------
 
 let p_Map_core pk pv (xs: Map<_, _>) st =
-    for x in xs do
-        pk x.Key st
-        pv x.Value st
+    xs |> Map.iter (fun k v -> pk k st; pv v st)
 
 let p_Map pk pv x st =
     p_int (Map.count x) st
@@ -1317,9 +1315,7 @@ let p_qlist pv = p_wrap QueueList.toList (p_list pv)
 let p_namemap p = p_Map p_string p
 
 let u_Map_core uk uv n st =
-    Map.ofSeq (seq {
-        for _ in 1..n do
-            yield (uk st, uv st) })
+    Map.ofSeq (seq { for _ in 1..n -> (uk st, uv st) })
 
 let u_Map uk uv st = 
     let n = u_int st


### PR DESCRIPTION
- Pickling and unpickling a `Map` will not convert to a `list` only then to unpickle/pickle the `list`. Will use a `seq` for unpickling and a `for` loop for pickling.
- Unpickling a `list` will use `List.init`. (technically faster than using a list comprehension)

The optimization's impact is very very small and only affects importing/exporting optimization metadata which can have an effect on compile time and interactivity (loading F# DLLs). Nonetheless, perfview gives some insight with CPU Stacks:

Before:
![image](https://user-images.githubusercontent.com/1278959/68080644-cad2c380-fdbc-11e9-8851-77d0e7ee978c.png)

![image](https://user-images.githubusercontent.com/1278959/68080654-fe155280-fdbc-11e9-8896-48d28ade1ddd.png)

After:
![image](https://user-images.githubusercontent.com/1278959/68080659-1d13e480-fdbd-11e9-828a-23e6e58a540b.png)