### PR TITLE
set insertion payload name

### DIFF
--- a/eng/release/insert-into-vs.yml
+++ b/eng/release/insert-into-vs.yml
@@ -26,6 +26,8 @@ stages:
       value: ${{ parameters.insertTeamEmail }}
     - name: InsertTeamName
       value: ${{ parameters.insertTeamName }}
+    - name: InsertPayloadName
+      value: 'F# $(Build.SourceBranchName) $(Build.BuildNumber)'
     steps:
     - task: DownloadBuildArtifacts@0
       displayName: Download Insertion Artifacts


### PR DESCRIPTION
With this change VS insertion PR titles change from e.g., `Insert F# Payload into master` to a much more helpful `Insert F# dev16.5 20191107.1 Payload into master`.  Verified via internal build.