### PR TITLE
Fix SynExpr.ImplicitZero doc comment

### DIFF
--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -748,7 +748,7 @@ and
     /// Computation expressions only, based on JOIN_IN token from lex filter
     | JoinIn of SynExpr * range * SynExpr * range: range
 
-    /// Used internally during type checking for translating computation expressions.
+    /// Used in parser error recovery and internally during type checking for translating computation expressions.
     | ImplicitZero of range: range
 
     /// Used internally during type checking for translating computation expressions.


### PR DESCRIPTION
ImplicitZero is also used in error recovery during parsing and the current comment doesn't mention it.