### PR TITLE
Add FSharpUnionCase.HasFields

### DIFF
--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -781,9 +781,13 @@ and FSharpUnionCase(cenv, v: UnionCaseRef) =
         checkIsResolved()
         v.Range
 
+    member __.HasFields =
+        if isUnresolved() then false else
+        v.UnionCase.RecdFieldsArray.Length <> 0
+
     member __.UnionCaseFields = 
         if isUnresolved() then makeReadOnlyCollection [] else
-        v.UnionCase.RecdFields |> List.mapi (fun i _ ->  FSharpField(cenv, FSharpFieldData.Union (v, i))) |> makeReadOnlyCollection
+        v.UnionCase.RecdFieldsArray |> Array.mapi (fun i _ ->  FSharpField(cenv, FSharpFieldData.Union (v, i))) |> makeReadOnlyCollection
 
     member __.ReturnType = 
         checkIsResolved()

--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -382,6 +382,9 @@ and [<Class>] public FSharpUnionCase =
     /// Get the range of the name of the case 
     member DeclarationLocation : range
 
+    /// Indicates if the union case has field definitions
+    member HasFields: bool
+
     /// Get the data carried by the case. 
     member UnionCaseFields: IList<FSharpField>
 


### PR DESCRIPTION
An extracted part from #7840. See https://github.com/dotnet/fsharp/pull/7840#discussion_r344523305.

Adds an FCS API to check if a union case has fields without converting the TAST array into FCS symbols list first.