### PR TITLE
improve argument parsing in #r nuget

### DIFF
--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.Utilities.fs
@@ -177,11 +177,15 @@ module Utilities =
             p.ExitCode = 0
         | None -> false
 
-    let buildProject projectPath binLogging =
+    let buildProject projectPath binLogPath =
         let binLoggingArguments =
-            match binLogging with
-            | true -> "/bl"
-            | _ -> ""
+            match binLogPath with
+            | Some(path) ->
+                let path = match path with
+                           | Some path -> path // specific file
+                           | None -> Path.Combine(projectPath, "msbuild.binlog") // auto-generated file
+                sprintf "/bl:\"%s\"" path
+            | None -> ""
 
         let arguments prefix =
             sprintf "%s -restore %s %c%s%c /t:FSI-PackageManagement" prefix binLoggingArguments '\"' projectPath '\"'

--- a/tests/FSharp.DependencyManager.UnitTests/DependencyManagerLineParserTests.fs
+++ b/tests/FSharp.DependencyManager.UnitTests/DependencyManagerLineParserTests.fs
@@ -38,6 +38,37 @@ type DependencyManagerLineParserTests() =
         Assert.AreEqual(Some(Some "path/to/file.binlog"), binLogPath)
 
     [<Test>]
+    member __.``Bare binary log argument isn't parsed as a package name: before``() =
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["bl, MyPackage"]
+        Assert.AreEqual("MyPackage", packageReferences.Single().Include)
+        Assert.AreEqual(Some (None: string option), binLogPath)
+
+    [<Test>]
+    member __.``Bare binary log argument isn't parsed as a package name: middle``() =
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["MyPackage, bl, 1.2.3.4"]
+        Assert.AreEqual("MyPackage", packageReferences.Single().Include)
+        Assert.AreEqual("1.2.3.4", packageReferences.Single().Version)
+        Assert.AreEqual(Some (None: string option), binLogPath)
+
+    [<Test>]
+    member __.``Bare binary log argument isn't parsed as a package name: after``() =
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["MyPackage, bl"]
+        Assert.AreEqual("MyPackage", packageReferences.Single().Include)
+        Assert.AreEqual(Some (None: string option), binLogPath)
+
+    [<Test>]
+    member __.``Package named 'bl' can be explicitly referenced``() =
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["Include=bl"]
+        Assert.AreEqual("bl", packageReferences.Single().Include)
+        Assert.AreEqual(None, binLogPath)
+
+    [<Test>]
+    member __.``Package named 'bl' can be explicitly referenced with binary logging``() =
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["Include=bl,bl"]
+        Assert.AreEqual("bl", packageReferences.Single().Include)
+        Assert.AreEqual(Some (None: string option), binLogPath)
+
+    [<Test>]
     member __.``Parse explicitly specified package name``() =
         let pr = parseSingleReference "Include=MyPackage"
         Assert.AreEqual("MyPackage", pr.Include)

--- a/tests/FSharp.DependencyManager.UnitTests/DependencyManagerLineParserTests.fs
+++ b/tests/FSharp.DependencyManager.UnitTests/DependencyManagerLineParserTests.fs
@@ -9,28 +9,33 @@ open NUnit.Framework
 [<TestFixture>]
 type DependencyManagerLineParserTests() =
 
-    let parseBinLoggingFlag text =
-        let _, binLogging = FSharpDependencyManager.parsePackageReference [text]
-        binLogging
+    let parseBinLogPath text =
+        let _, binLogPath = FSharpDependencyManager.parsePackageReference [text]
+        binLogPath
 
     let parseSingleReference text =
         let packageReferences, _ = FSharpDependencyManager.parsePackageReference [text]
         packageReferences.Single()
 
     [<Test>]
-    member __.``Binary logging defaults to false``() =
-        let _, binLogging = FSharpDependencyManager.parsePackageReference []
-        Assert.False(binLogging)
+    member __.``Binary logging defaults to disabled``() =
+        let _, binLogPath = FSharpDependencyManager.parsePackageReference []
+        Assert.AreEqual(None, binLogPath)
 
     [<Test>]
-    member __.``Binary logging can be set to true``() =
-        let binLogging = parseBinLoggingFlag "bl=true"
-        Assert.True(binLogging)
+    member __.``Binary logging can be set to default path``() =
+        let binLogPath = parseBinLogPath "bl=true"
+        Assert.AreEqual(Some (None: string option), binLogPath)
 
     [<Test>]
-    member __.``Binary logging can be set to false``() =
-        let binLogging = parseBinLoggingFlag "bl=false"
-        Assert.False(binLogging)
+    member __.``Binary logging can be disabled``() =
+        let binLogPath = parseBinLogPath "bl=false"
+        Assert.AreEqual(None, binLogPath)
+
+    [<Test>]
+    member __.``Binary logging can be set to specific location``() =
+        let binLogPath = parseBinLogPath "bl=path/to/file.binlog"
+        Assert.AreEqual(Some(Some "path/to/file.binlog"), binLogPath)
 
     [<Test>]
     member __.``Parse explicitly specified package name``() =


### PR DESCRIPTION
- Improves the `bl` option of the `#r "nuget:..."` syntax with the following:

  - Allow explicit path to be set to the binary log via `bl=path/to/msbuild.binlog` syntax.  This is meant to mimic the command-line form of `/bl=path/to/msbuild.binlog`.
  - Allow implicit path to be generated to the binary log via `bl` syntax.  This is meant to mimic the command-line form of `/bl`.
    - Note that this has the potential to collide with the syntax where `Include=` isn't required to specify a package name.  I resolved this by explicitly disallowing a package named `bl` to be specified without the `Include=` key and a test covering this exact scenario has been added.
  - Allow implicit path to be generated to the binary log with a boolean argument via `bl=true` syntax.  This is a departure from the command-line syntax, but is meant to mimic `.fsproj` attribute usage of other features.  On the off-chance that the user wants to write the binary log to a file named `true` (or `false`, see below), then they're out of luck.
  - Explicitly turn off binary logging via `bl=false` syntax.  Similar to above, this is meant to mimic `.fsproj` attribute usage.

- ~~Adds `v=` and `verbosity=` parameters with the valid value being `diag` or `diagnostic`.  This is meant to mimic the msbuild command-line form of `/v:diag`, etc.  When this is enabled, the path of the auto-generated project, script, and binary log (if relevant) will be printed to the console.  This will be particularly useful when a `#r "nuget:..."` invocation doesn't behave as expected by making diagnostic information much easier to find and attach to GitHub issues.~~ Internal discussion resulted in a different design for specifying debug/diagnostic/verbose output that will be a second PR, but the `bl=` stuff is still valid.