### PR TITLE
Pick correct dependencies when scripting on coreclr

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2816,7 +2816,11 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
                         let facades = Path.Combine(frameworkRootVersion, "Facades")
                         if Directory.Exists facades then
                             yield facades
-                  ]                    
+                        match frameworkRefsPackDirectory with
+                        | Some path when Directory.Exists(path) ->
+                            yield path
+                        | _ -> ()
+                  ]
         with e -> 
             errorRecovery e range0; [] 
 

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -2209,7 +2209,7 @@ type FsiInteractiveChecker(legacyReferenceResolver,
             
             let backgroundDiagnostics = [| |]
             let reduceMemoryUsage = ReduceMemoryFlag.Yes
-            let assumeDotNetFramework = true
+            let assumeDotNetFramework = tcConfig.primaryAssembly = PrimaryAssembly.Mscorlib
 
             let applyCompilerOptions tcConfigB  = 
                 let fsiCompilerOptions = CompileOptions.GetCoreFsiCompilerOptions tcConfigB 


### PR DESCRIPTION
FsiInteractiveChecker would set the dependencies incorrectly when run on the coreclr.

This uses the primaryAssembly to set the value for assumeDotNetFramework which tells it use desktop framework references on the desktop, and coreclr ones on the coreclr.

Also adds net sdk packs directory to the list of TargetFrameworkDirectories