### PR TITLE
Don't try to print predefined ranges contents in debug

### DIFF
--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -26,7 +26,7 @@ open FSharp.Compiler.Features
 
 open Internal.Utilities
 
-let internal DummyFileNameForRangesWithoutASpecificLocation = "startup"
+let internal DummyFileNameForRangesWithoutASpecificLocation = startupFileName
 let private envRange = rangeN DummyFileNameForRangesWithoutASpecificLocation 0
 
 /// Represents an intrinsic value from FSharp.Core known to the compiler

--- a/src/fsharp/range.fs
+++ b/src/fsharp/range.fs
@@ -200,6 +200,10 @@ let fileOfFileIndex idx = fileIndexTable.IndexToFile idx
 
 let mkPos l c = pos (l, c)
 
+let unknownFileName = "unknown"
+let startupFileName = "startup"
+let commandLineArgsFileName = "commandLineArgs"
+
 [<Struct; CustomEquality; NoComparison>]
 #if DEBUG
 [<System.Diagnostics.DebuggerDisplay("({StartLine},{StartColumn}-{EndLine},{EndColumn}) {FileName} IsSynthetic={IsSynthetic} -> {DebugCode}")>]
@@ -249,6 +253,9 @@ type range(code1:int64, code2: int64) =
 
 #if DEBUG
     member r.DebugCode =
+        let name = r.FileName
+        if name = unknownFileName || name = startupFileName || name = commandLineArgsFileName then name else
+
         try
             let endCol = r.EndColumn - 1
             let startCol = r.StartColumn - 1
@@ -323,11 +330,11 @@ let rangeN filename line = mkRange filename (mkPos line 0) (mkPos line 0)
 
 let pos0 = mkPos 1 0
 
-let range0 =  rangeN "unknown" 1
+let range0 =  rangeN unknownFileName 1
 
-let rangeStartup = rangeN "startup" 1
+let rangeStartup = rangeN startupFileName 1
 
-let rangeCmdArgs = rangeN "commandLineArgs" 0
+let rangeCmdArgs = rangeN commandLineArgsFileName 0
 
 let trimRangeToLine (r:range) =
     let startL, startC = r.StartLine, r.StartColumn

--- a/src/fsharp/range.fsi
+++ b/src/fsharp/range.fsi
@@ -44,6 +44,10 @@ val mkPos : line:int -> column:int -> pos
 /// Ordering on positions
 val posOrder : IComparer<pos>
 
+val unknownFileName: string
+val startupFileName: string
+val commandLineArgsFileName: string
+
 /// Represents a range within a known file
 [<Struct; CustomEquality; NoComparison>]
 type range =


### PR DESCRIPTION
`range` type has `DebuggerDisplay` defined to show file contents when possible.
It shouldn't, however, try to do this for predefined ranges, like `rangeStartup` or `range0` as it fails to find such file:
<img width="1440" alt="Screenshot 2019-11-22 at 19 28 00" src="https://user-images.githubusercontent.com/3923587/69450792-a2f4d100-0d66-11ea-8642-c2fe4f051c9f.png">

This PR makes it print the predefined ranges file names instead:
<img width="1440" alt="Screenshot 2019-11-22 at 20 26 42" src="https://user-images.githubusercontent.com/3923587/69450909-d20b4280-0d66-11ea-88bb-368f7eb94c29.png">