### PR TITLE
change the type of completion item returned for scripts

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -44,6 +44,8 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool, ?additionalArgs: st
 
     member __.ErrorProduced = errorProduced.Publish
 
+    member __.Fsi = fsi
+
     member __.Eval(code: string, ?cancellationToken: CancellationToken) =
         let cancellationToken = defaultArg cancellationToken CancellationToken.None
         let ch, errors = fsi.EvalInteractionNonThrowing(code, cancellationToken)
@@ -51,21 +53,18 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool, ?additionalArgs: st
         | Choice1Of2 v -> Ok(v), errors
         | Choice2Of2 ex -> Error(ex), errors
 
-    /// Get the available completion symbols from the code at the specified location.
+    /// Get the available completion items from the code at the specified location.
     ///
     /// <param name="text">The input text on which completions will be calculated</param>
     /// <param name="line">The 1-based line index</param>
     /// <param name="column">The 0-based column index</param>
-    member __.GetCompletionSymbols(text: string, line: int, column: int) =
+    member __.GetCompletionItems(text: string, line: int, column: int) =
         async {
             let! parseResults, checkResults, _projectResults = fsi.ParseAndCheckInteraction(text)
             let lineText = text.Split('\n').[line - 1]
             let partialName = QuickParse.GetPartialLongNameEx(lineText, column - 1)
-            let! symbolUses = checkResults.GetDeclarationListSymbols(Some parseResults, line, lineText, partialName)
-            let symbols = symbolUses
-                          |> List.concat
-                          |> List.map (fun s -> s.Symbol)
-            return symbols
+            let! declarationListInfos = checkResults.GetDeclarationListInfo(Some parseResults, line, lineText, partialName)
+            return declarationListInfos.Items
         }
 
     interface IDisposable with

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/CompletionTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/CompletionTests.fs
@@ -16,9 +16,9 @@ type CompletionTests() =
             use script = new FSharpScript()
             let lines = [ "let x = 1"
                           "x." ]
-            let! completions = script.GetCompletionSymbols(String.Join("\n", lines), 2, 2)
-            let matchingCompletions = completions |> List.filter (fun s -> s.DisplayName = "CompareTo")
-            Assert.AreEqual(1, List.length matchingCompletions)
+            let! completions = script.GetCompletionItems(String.Join("\n", lines), 2, 2)
+            let matchingCompletions = completions |> Array.filter (fun d -> d.Name = "CompareTo")
+            Assert.AreEqual(1, matchingCompletions.Length)
         } |> Async.StartAsTask :> Task
 
     [<Test>]
@@ -26,36 +26,36 @@ type CompletionTests() =
         async {
             use script = new FSharpScript()
             script.Eval("let x = 1") |> ignoreValue
-            let! completions = script.GetCompletionSymbols("x.", 1, 2)
-            let matchingCompletions = completions |> List.filter (fun s -> s.DisplayName = "CompareTo")
-            Assert.AreEqual(1, List.length matchingCompletions)
+            let! completions = script.GetCompletionItems("x.", 1, 2)
+            let matchingCompletions = completions |> Array.filter (fun d -> d.Name = "CompareTo")
+            Assert.AreEqual(1, matchingCompletions.Length)
         } |> Async.StartAsTask :> Task
 
     [<Test>]
     member _.``Static member completions``() =
         async {
             use script = new FSharpScript()
-            let! completions = script.GetCompletionSymbols("System.String.", 1, 14)
-            let matchingCompletions = completions |> List.filter (fun s -> s.DisplayName = "Join")
-            Assert.GreaterOrEqual(List.length matchingCompletions, 1)
+            let! completions = script.GetCompletionItems("System.String.", 1, 14)
+            let matchingCompletions = completions |> Array.filter (fun d -> d.Name = "Join")
+            Assert.GreaterOrEqual(matchingCompletions.Length, 1)
         } |> Async.StartAsTask :> Task
 
     [<Test>]
     member _.``Type completions from namespace``() =
         async {
             use script = new FSharpScript()
-            let! completions = script.GetCompletionSymbols("System.", 1, 7)
-            let matchingCompletions = completions |> List.filter (fun s -> s.DisplayName = "String")
-            Assert.GreaterOrEqual(List.length matchingCompletions, 1)
+            let! completions = script.GetCompletionItems("System.", 1, 7)
+            let matchingCompletions = completions |> Array.filter (fun d -> d.Name = "String")
+            Assert.GreaterOrEqual(matchingCompletions.Length, 1)
         } |> Async.StartAsTask :> Task
 
     [<Test>]
     member _.``Namespace completions``() =
         async {
             use script = new FSharpScript()
-            let! completions = script.GetCompletionSymbols("System.", 1, 7)
-            let matchingCompletions = completions |> List.filter (fun s -> s.DisplayName = "Collections")
-            Assert.AreEqual(1, List.length matchingCompletions)
+            let! completions = script.GetCompletionItems("System.", 1, 7)
+            let matchingCompletions = completions |> Array.filter (fun d -> d.Name = "Collections")
+            Assert.AreEqual(1, matchingCompletions.Length)
         } |> Async.StartAsTask :> Task
 
     [<Test>]
@@ -65,7 +65,7 @@ type CompletionTests() =
             let lines = [ "open System.Linq"
                           "let list = new System.Collections.Generic.List<int>()"
                           "list." ]
-            let! completions = script.GetCompletionSymbols(String.Join("\n", lines), 3, 5)
-            let matchingCompletions = completions |> List.filter (fun s -> s.DisplayName = "Select")
-            Assert.AreEqual(1, List.length matchingCompletions)
+            let! completions = script.GetCompletionItems(String.Join("\n", lines), 3, 5)
+            let matchingCompletions = completions |> Array.filter (fun d -> d.Name = "Select")
+            Assert.AreEqual(1, matchingCompletions.Length)
         } |> Async.StartAsTask :> Task


### PR DESCRIPTION
I've found that rather than returning a collection of `FSharpSymbol`s, it's much more useful to return a collection of `FSharpDeclarationListItem`s because it already contains what type of item it is (method, property, etc.) as well as it doc comments.