### PR TITLE
fire event when a value is bound at the root of a script evaluation

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -69,8 +69,6 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool, ?additionalArgs: st
             return declarationListInfos.Items
         }
 
-    member __.GetIdentifierValueType(identifier: string) = fsi.GetIdentifierValueType identifier
-
     interface IDisposable with
         member __.Dispose() =
             if captureInput then

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -38,6 +38,8 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool, ?additionalArgs: st
 
     member __.AssemblyReferenceAdded = fsi.AssemblyReferenceAdded
 
+    member __.ValueBound = fsi.ValueBound
+
     member __.ProvideInput = stdin.ProvideInput
 
     member __.OutputProduced = outputProduced.Publish
@@ -66,6 +68,8 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool, ?additionalArgs: st
             let! declarationListInfos = checkResults.GetDeclarationListInfo(Some parseResults, line, lineText, partialName)
             return declarationListInfos.Items
         }
+
+    member __.GetIdentifierValueType(identifier: string) = fsi.GetIdentifierValueType identifier
 
     interface IDisposable with
         member __.Dispose() =

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -950,6 +950,7 @@ type internal FsiDynamicCompiler
     let assemblyName = "FSI-ASSEMBLY"
 
     let assemblyReferenceAddedEvent = Control.Event<string>()
+    let valueBoundEvent = Control.Event<_>()
 
     let mutable fragmentId = 0
     let mutable prevIt : ValRef option = None
@@ -1155,6 +1156,10 @@ type internal FsiDynamicCompiler
                             if v.CompiledName = "it" then
                                 itValue <- fsiValueOpt
 
+                            match fsiValueOpt with
+                            | Some fsiValue -> valueBoundEvent.Trigger(fsiValue.ReflectionValue, fsiValue.ReflectionType, v.CompiledName)
+                            | None -> ()
+
                             let symbol = FSharpSymbol.Create(cenv, v.Item)
                             let symbolUse = FSharpSymbolUse(tcGlobals, newState.tcState.TcEnvFromImpls.DisplayEnv, symbol, ItemOccurence.Binding, v.DeclarationLocation)
                             fsi.TriggerEvaluation (fsiValueOpt, symbolUse, decl)
@@ -1172,11 +1177,6 @@ type internal FsiDynamicCompiler
         with _ -> ()
 
         newState, Completed itValue
-
-    member __.GetIdentifierValueType(istate, identifier) =
-        match istate.tcState.TcEnvFromImpls.NameEnv.FindUnqualifiedItem identifier with
-        | NameResolution.Item.Value vref -> istate.ilxGenerator.LookupGeneratedValue(valuePrinter.GetEvaluationContext istate.emEnv, vref.Deref)
-        | _ -> None
 
     /// Evaluate the given expression and produce a new interactive state.
     member fsiDynamicCompiler.EvalParsedExpression (ctok, errorLogger: ErrorLogger, istate, expr: SynExpr) =
@@ -1335,6 +1335,8 @@ type internal FsiDynamicCompiler
         valuePrinter.FormatValue(obj, objTy)
 
     member __.AssemblyReferenceAdded = assemblyReferenceAddedEvent.Publish
+
+    member __.ValueBound = valueBoundEvent.Publish
 
 //----------------------------------------------------------------------------
 // ctrl-c handling
@@ -1708,8 +1710,6 @@ type internal FsiInteractionProcessor
 
     let referencedAssemblies = Dictionary<string, DateTime>()
 
-    let valueBoundEvent = Control.Event<_>()
-
     let mutable currState = initialInteractiveState
     let event = Control.Event<unit>()
     let setCurrState s = currState <- s; event.Trigger()
@@ -1790,17 +1790,7 @@ type internal FsiInteractionProcessor
             | IDefns ([  SynModuleDecl.DoExpr(_,expr,_)],_) ->
                 fsiDynamicCompiler.EvalParsedExpression(ctok, errorLogger, istate, expr)
             | IDefns (defs,_) -> 
-                let istate, status = fsiDynamicCompiler.EvalParsedDefinitions (ctok, errorLogger, istate, true, false, defs)
-                defs
-                |> List.iter (fun d ->
-                                match d with
-                                | SynModuleDecl.Let (_, SynBinding.Binding(_, _, _, _, _, _, SynValData(_, _, Some ident), _, _, _, _, _) :: _, _)
-                                | SynModuleDecl.Let (_, SynBinding.Binding(_, _, _, _, _, _, _, SynPat.Named(_, ident, _, _, _), _, _, _, _) :: _, _) ->
-                                    match fsiDynamicCompiler.GetIdentifierValueType(istate, ident.idText) with
-                                    | Some (value, typ) -> valueBoundEvent.Trigger (value, typ, ident.idText)
-                                    | _ -> ()
-                                | _ -> ())
-                istate, status
+                fsiDynamicCompiler.EvalParsedDefinitions (ctok, errorLogger, istate, true, false, defs)
 
             | IHash (ParsedHashDirective("load",sourceFiles,m),_) -> 
                 fsiDynamicCompiler.EvalSourceFiles (ctok, istate, m, sourceFiles, lexResourceManager, errorLogger),Completed None
@@ -2239,10 +2229,6 @@ type internal FsiInteractionProcessor
         let fsiInteractiveChecker = FsiInteractiveChecker(legacyReferenceResolver, checker, tcConfig, istate.tcGlobals, istate.tcImports, istate.tcState)
         fsiInteractiveChecker.ParseAndCheckInteraction(ctok, SourceText.ofString text)
 
-    member __.GetIdentifierValueType identifier = fsiDynamicCompiler.GetIdentifierValueType(currState, identifier)
-
-    member __.ValueBound = valueBoundEvent.Publish
-
 //----------------------------------------------------------------------------
 // Server mode:
 //----------------------------------------------------------------------------
@@ -2648,14 +2634,11 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         |> commitResultNonThrowing errorOptions scriptPath errorLogger
         |> function Choice1Of2 (_), errs -> Choice1Of2 (), errs | Choice2Of2 exn, errs -> Choice2Of2 exn, errs
 
-    /// Gets the value and runtime type bound to the specified identifier text.
-    member __.GetIdentifierValueType identifier = fsiInteractionProcessor.GetIdentifierValueType identifier
-
     /// Event fires every time an assembly reference is added to the execution environment, e.g., via `#r`.
     member __.AssemblyReferenceAdded = fsiDynamicCompiler.AssemblyReferenceAdded
 
     /// Event fires when a root-level value is bound to an identifier, e.g., via `let x = ...`.
-    member __.ValueBound = fsiInteractionProcessor.ValueBound
+    member __.ValueBound = fsiDynamicCompiler.ValueBound
  
     /// Performs these steps:
     ///    - Load the dummy interaction, if any

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -234,9 +234,6 @@ type FsiEvaluationSession =
     /// A host calls this to report an unhandled exception in a standard way, e.g. an exception on the GUI thread gets printed to stderr
     member ReportUnhandledException : exn: exn -> unit
 
-    /// Gets the value and runtime type bound to the specified identifier text.
-    member GetIdentifierValueType : string -> (obj * System.Type) option
-
     /// Event fires every time an assembly reference is added to the execution environment, e.g., via `#r`.
     member AssemblyReferenceAdded : IEvent<string>
 

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -234,8 +234,14 @@ type FsiEvaluationSession =
     /// A host calls this to report an unhandled exception in a standard way, e.g. an exception on the GUI thread gets printed to stderr
     member ReportUnhandledException : exn: exn -> unit
 
+    /// Gets the value and runtime type bound to the specified identifier text.
+    member GetIdentifierValueType : string -> (obj * System.Type) option
+
     /// Event fires every time an assembly reference is added to the execution environment, e.g., via `#r`.
     member AssemblyReferenceAdded : IEvent<string>
+
+    /// Event fires when a root-level value is bound to an identifier, e.g., via `let x = ...`.
+    member ValueBound : IEvent<obj * System.Type * string>
 
     /// Load the dummy interaction, load the initial files, and,
     /// if interacting, start the background thread to read the standard input.

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -168,15 +168,3 @@ let x =
 "
         script.Eval(code) |> ignoreValue
         Assert.False(foundInner)
-
-    [<Test>]
-    member _.``Retrieve value from runtime``() =
-        use script = new FSharpScript()
-        let code = @"
-let x = 1
-let y = 2
-"
-        script.Eval(code) |> ignoreValue
-        let (value, typ) = (script.GetIdentifierValueType "x").Value
-        Assert.AreEqual(typeof<int>, typ)
-        Assert.AreEqual(1, value :?> int)

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -122,3 +122,61 @@ type InteractiveTests() =
         Assert.True(wasCancelled)
         Assert.LessOrEqual(sw.ElapsedMilliseconds, sleepTime)
         Assert.AreEqual(None, result)
+
+    [<Test>]
+    member _.``Values bound at the root trigger an event``() =
+        let mutable foundX = false
+        let mutable foundY = false
+        let mutable foundCount = 0
+        use script = new FSharpScript()
+        script.ValueBound
+        |> Event.add (fun (value, typ, name) ->
+            foundX <- foundX || (name = "x" && typ = typeof<int> && value :?> int = 1)
+            foundY <- foundY || (name = "y" && typ = typeof<int> && value :?> int = 2)
+            foundCount <- foundCount + 1)
+        let code = @"
+let x = 1
+let y = 2
+"
+        script.Eval(code) |> ignoreValue
+        Assert.True(foundX)
+        Assert.True(foundY)
+        Assert.AreEqual(2, foundCount)
+
+    [<Test>]
+    member _.``Values re-bound trigger an event``() =
+        let mutable foundXCount = 0
+        use script = new FSharpScript()
+        script.ValueBound
+        |> Event.add (fun (_value, typ, name) ->
+            if name = "x" && typ = typeof<int> then foundXCount <- foundXCount + 1)
+        script.Eval("let x = 1") |> ignoreValue
+        script.Eval("let x = 2") |> ignoreValue
+        Assert.AreEqual(2, foundXCount)
+
+    [<Test>]
+    member _.``Nested let bindings don't trigger event``() =
+        let mutable foundInner = false
+        use script = new FSharpScript()
+        script.ValueBound
+        |> Event.add (fun (_value, _typ, name) ->
+            foundInner <- foundInner || name = "inner")
+        let code = @"
+let x =
+    let inner = 1
+    ()
+"
+        script.Eval(code) |> ignoreValue
+        Assert.False(foundInner)
+
+    [<Test>]
+    member _.``Retrieve value from runtime``() =
+        use script = new FSharpScript()
+        let code = @"
+let x = 1
+let y = 2
+"
+        script.Eval(code) |> ignoreValue
+        let (value, typ) = (script.GetIdentifierValueType "x").Value
+        Assert.AreEqual(typeof<int>, typ)
+        Assert.AreEqual(1, value :?> int)


### PR DESCRIPTION
~~Also adds a function to get runtime type and value given a (root) identifier's name.~~

This is to enable a hypothetical "watch" or "locals" window in notebooks.