### PR TITLE
Fixed type abbreviation from bypassing ByRefLike rules

### DIFF
--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -357,6 +357,10 @@ let rec CheckTypeDeep (cenv: cenv) ((visitTy, visitTyconRefOpt, visitAppTyOpt, v
         match visitAppTyOpt with 
         | Some visitAppTy -> visitAppTy (tcref, tinst)
         | None -> ()
+
+        match tcref.TypeAbbrev with
+        | Some tya -> CheckTypeDeep cenv f g env isInner tya
+        | _ -> ()
     | TType_anon (anonInfo, tys) -> 
         RecordAnonRecdInfo cenv anonInfo
         CheckTypesDeep cenv f g env tys

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -332,7 +332,7 @@ let rec CheckTypeDeep (cenv: cenv) ((visitTy, visitTyconRefOpt, visitAppTyOpt, v
             | _ -> ())
     | _ -> ()
     
-    let ty = stripTyparEqns ty 
+    let ty = stripTyEqns g ty
     visitTy ty
 
     match ty with
@@ -357,10 +357,6 @@ let rec CheckTypeDeep (cenv: cenv) ((visitTy, visitTyconRefOpt, visitAppTyOpt, v
         match visitAppTyOpt with 
         | Some visitAppTy -> visitAppTy (tcref, tinst)
         | None -> ()
-
-        match tcref.TypeAbbrev with
-        | Some tya -> CheckTypeDeep cenv f g env isInner tya
-        | _ -> ()
     | TType_anon (anonInfo, tys) -> 
         RecordAnonRecdInfo cenv anonInfo
         CheckTypesDeep cenv f g env tys

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -464,7 +464,7 @@ let CheckEscapes cenv allowProtected m syntacticArgs body = (* m is a range suit
 let AccessInternalsVisibleToAsInternal thisCompPath internalsVisibleToPaths access =
     // Each internalsVisibleToPath is a compPath for the internals of some assembly.
     // Replace those by the compPath for the internals of this assembly.
-    // This makes those internals visible here, but still internal. Bug://3737bui
+    // This makes those internals visible here, but still internal. Bug://3737
     (access, internalsVisibleToPaths) ||> List.fold (fun access internalsVisibleToPath -> 
         accessSubstPaths (thisCompPath, internalsVisibleToPath) access)
     

--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -211,7 +211,7 @@ let main argv = 0"""
                 typeCheckResults.Errors
                 |> Array.distinctBy (fun e -> e.Severity, e.ErrorNumber, e.StartLineAlternate, e.StartColumn, e.EndLineAlternate, e.EndColumn, e.Message)
 
-            Assert.AreEqual(Array.length expectedTypeErrors, errors.Length, sprintf "Type check errors: %A" typeCheckResults.Errors)
+            Assert.AreEqual(Array.length expectedTypeErrors, errors.Length, sprintf "Type check errors: %A" errors)
 
             Array.zip errors expectedTypeErrors
             |> Array.iter (fun (info, expectedError) ->

--- a/tests/fsharp/Compiler/Language/SpanTests.fs
+++ b/tests/fsharp/Compiler/Language/SpanTests.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open System
+open FSharp.Compiler.SourceCodeServices
 open NUnit.Framework
 
 #if NETCOREAPP
@@ -50,4 +51,55 @@ test ()
         // We expect this error until System.Reflection.Emit gets fixed for emitting `modreq` on method calls.
         // See: https://github.com/dotnet/corefx/issues/29254
         CompilerAssert.RunScript script [ "Method not found: '!0 ByRef System.ReadOnlySpan`1.get_Item(Int32)'." ]
+
+
+    [<Test>]
+    let ``Should fail to compile on a type abbreviation``() =
+        CompilerAssert.TypeCheckWithErrors """
+open System
+
+type Bytes = ReadOnlySpan<byte>
+
+type Test() =
+
+    member _.M1 (data: Bytes) =
+        let x = 
+            if false then
+                failwith ""
+            else
+                data
+        x
+
+    member _.M2 (data: Bytes) =
+        let x = 
+            if false then
+                failwithf ""
+            else
+                data
+        x
+
+let test () =
+    let span = ReadOnlySpan<_>(Array.empty)
+    let result = Test().M1(span)
+    let result = Test().M2(span)
+    0
+            """
+            [|
+                FSharpErrorSeverity.Error, 412, (11, 17, 11, 28), "A type instantiation involves a byref type. This is not permitted by the rules of Common IL."
+                FSharpErrorSeverity.Error, 412, (19, 17, 19, 29), "A type instantiation involves a byref type. This is not permitted by the rules of Common IL."
+                FSharpErrorSeverity.Error, 412, (19, 27, 19, 29), "A type instantiation involves a byref type. This is not permitted by the rules of Common IL."
+            |]
+
+    [<Test>]
+    let ``Should fail to compile on a type abbreviation 2``() =
+        CompilerAssert.TypeCheckWithErrors """
+open System
+
+type TA = Span<int> * Span<int>
+
+let f (x: TA) = ()
+            """
+            [|
+                FSharpErrorSeverity.Error, 3300, (6, 8, 6, 9), "The parameter 'x' has an invalid type 'TA'. This is not permitted by the rules of Common IL."
+            |]
 #endif

--- a/tests/fsharp/Compiler/Language/SpanTests.fs
+++ b/tests/fsharp/Compiler/Language/SpanTests.fs
@@ -54,7 +54,7 @@ test ()
 
 
     [<Test>]
-    let ``Should fail to compile on a type abbreviation``() =
+    let ``Invalid usage of type abbreviated span should fail to compile``() =
         CompilerAssert.TypeCheckWithErrors """
 open System
 
@@ -91,7 +91,7 @@ let test () =
             |]
 
     [<Test>]
-    let ``Should fail to compile on a type abbreviation 2``() =
+    let ``Type abbreviation that boxes a span should fail to compile``() =
         CompilerAssert.TypeCheckWithErrors """
 open System
 

--- a/tests/fsharp/typecheck/sigs/neg_byref_13.bsl
+++ b/tests/fsharp/typecheck/sigs/neg_byref_13.bsl
@@ -1,2 +1,8 @@
 
 neg_byref_13.fs(2,6,2,8): typecheck error FS0445: The type abbreviation contains byrefs. This is not permitted by F#.
+
+neg_byref_13.fs(3,12,3,13): typecheck error FS3300: The parameter 'x' has an invalid type 'M5'. This is not permitted by the rules of Common IL.
+
+neg_byref_13.fs(3,5,3,10): typecheck error FS3301: The function or method has an invalid return type 'M5'. This is not permitted by the rules of Common IL.
+
+neg_byref_13.fs(3,20,3,21): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.


### PR DESCRIPTION
This should be a simple fix. Resolves https://github.com/dotnet/fsharp/issues/6133 and https://github.com/dotnet/fsharp/issues/6133.  Looks like this PR: https://github.com/dotnet/fsharp/pull/6135 was intended to do the same thing too.