### PR TITLE
Fix fsi dotnet implementation references

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -32,7 +32,11 @@ type FSharpScript(?captureInput: bool, ?captureOutput: bool, ?additionalArgs: st
         ())()
 
     let config = FsiEvaluationSession.GetDefaultConfiguration()
-    let baseArgs = [| this.GetType().Assembly.Location; "--noninteractive"; "--targetprofile:netcore"; "--quiet" |]
+    let computedProfile =
+        // If we are being executed on the desktop framework (we can tell because the assembly containing int is mscorlib) then profile must be mscorlib otherwise use netcore
+        if typeof<int>.Assembly.GetName().Name = "mscorlib" then "mscorlib"
+        else "netcore"
+    let baseArgs = [| this.GetType().Assembly.Location; "--noninteractive"; "--targetprofile:" + computedProfile; "--quiet" |]
     let argv = Array.append baseArgs additionalArgs
     let fsi = FsiEvaluationSession.Create (config, argv, stdin, stdout, stderr, collectible=true)
 


### PR DESCRIPTION
When using **dotnet fsi** with **--usesdkrefs-** fsi references only a subset of dotnet assemblies, ignoring for example System.Text.Json.dll.

````fsharp
dotnet fsi --usesdkrefs-

Microsoft (R) F# Interactive version 10.7.0.0 for F# 4.7
Copyright (c) Microsoft Corporation. All Rights Reserved.

For help type #help;;

> open System.Text.Json;
- let jsonException = JsonException()
- let location = jsonException.GetType().Assembly.Location
- printfn "%s" location;;

  open System.Text.Json;
  -----------------^^^^

stdin(1,18): error FS0039: The namespace 'Json' is not defined.

>
````
This change causes all of the implementation assemblies to be referenced.
