### PR TITLE
[WIP] Chunked array for ByteBuffer

### DIFF
--- a/src/absil/bytes.fs
+++ b/src/absil/bytes.fs
@@ -102,7 +102,8 @@ type ChunkedArrayBuilder<'T> private (minChunkSize: int, buffer: 'T []) =
         data.CopyTo(reserved)
 
     member x.Add(data: 'T) =
-        x.AddSpan(ReadOnlySpan(Unsafe.AsPointer(&Unsafe.AsRef(&data)), 1))
+        let reserved = x.Reserve 1
+        reserved.[0] <- data
 
     member x.ForEachBuilder f =
         match box x.NextOrPrevious with

--- a/src/absil/bytes.fs
+++ b/src/absil/bytes.fs
@@ -247,6 +247,23 @@ module ChunkedArray =
                     | _ -> ())
             res.ToChunkedArray()
 
+    let distinctBy projection (chunkedArr: ChunkedArray<_>) =
+        if chunkedArr.IsEmpty then ChunkedArray<_>.Empty
+        else
+            let hashSet = Collections.Generic.HashSet<_>(HashIdentity.Structural<_>)
+            let res = ChunkedArrayBuilder<_>.Create(MinChunkSize, DefaultChunkSize)
+            chunkedArr.ForEachChunk(fun chunk ->
+                for item in chunk do
+                    if hashSet.Add(projection item) then
+                        res.Add item)
+            res.ToChunkedArray()
+
+    let concat (chunkedArrs: ChunkedArray<_> seq) =
+        let res = ChunkedArrayBuilder<_>.Create(MinChunkSize, DefaultChunkSize)
+        chunkedArrs
+        |> Seq.iter (fun chunkedArr -> chunkedArr |> iter res.Add)
+        res.ToChunkedArray()
+
     let toArray (chunkedArr: ChunkedArray<_>) =
         chunkedArr.ToArray()
 

--- a/src/absil/bytes.fs
+++ b/src/absil/bytes.fs
@@ -65,7 +65,9 @@ type internal ByteBuffer =
     { mutable bbArray: ChunkedArrayBuilder<byte> 
       mutable bbCurrent: int }
 
-    member buf.Reserve length = buf.bbArray.Reserve length
+    member buf.Reserve length = 
+        buf.bbCurrent <- buf.bbCurrent + length
+        buf.bbArray.Reserve length
 
     member buf.Close () = buf.bbArray.ToChunkedArray().ToArray()
 
@@ -73,7 +75,7 @@ type internal ByteBuffer =
         buf.EmitByte (byte i)
 
     member buf.EmitByte (b:byte) =
-        (buf.bbArray.Reserve 1).WriteByte b
+        (buf.bbArray.Reserve 1).WriteByte (0, b)
         buf.bbCurrent <- buf.bbCurrent + 1
 
     member buf.EmitIntsAsBytes (arr:int[]) = 
@@ -87,7 +89,7 @@ type internal ByteBuffer =
             buf.EmitInt32 arr.[i]
 
     member buf.EmitInt32 n = 
-        (buf.bbArray.Reserve 4).WriteUInt32(uint32 n)
+        (buf.bbArray.Reserve 4).WriteUInt32(0, uint32 n)
         buf.bbCurrent <- buf.bbCurrent + 4
 
     member buf.EmitBytes (i:byte[]) = 
@@ -95,7 +97,7 @@ type internal ByteBuffer =
         buf.bbCurrent <- buf.bbCurrent + i.Length
 
     member buf.EmitInt32AsUInt16 n = 
-        (buf.bbArray.Reserve 2).WriteInt32AsUInt16 n
+        (buf.bbArray.Reserve 2).WriteInt32AsUInt16 (0, n)
         buf.bbCurrent <- buf.bbCurrent + 2
     
     member buf.EmitBoolAsByte (b:bool) = buf.EmitIntAsByte (if b then 1 else 0)

--- a/src/absil/bytes.fs
+++ b/src/absil/bytes.fs
@@ -60,6 +60,18 @@ type internal ByteStream =
     member b.Skip = b.pos <- b.pos + n
 #endif
 
+[<RequireQualifiedAccess>]
+module ByteBufferConstants =
+
+    // From System.Reflection.Metadata.BlobBuilder as the DefaultChunkSize.
+    [<Literal>]
+    let MaxStartingCapacity = 256
+
+    // From System.Reflection.Metadata.BlobBuilder
+    // Reasoning was the smallest atomic data was a Guid.
+    // Therefore, it should be a reasonable minimum value.
+    [<Literal>]
+    let MinChunkSize = 16
 
 type internal ByteBuffer = 
     { mutable bbArray: ChunkedArrayBuilder<byte> 
@@ -111,13 +123,12 @@ type internal ByteBuffer =
     member buf.Position = buf.bbCurrent
 
     static member Create startingCapacity = 
-        let maxStartingCapacity = 1024 * 8 // 8k
         let startingCapacity =
-            if startingCapacity > maxStartingCapacity then
-                maxStartingCapacity
+            if startingCapacity > ByteBufferConstants.MaxStartingCapacity then
+                ByteBufferConstants.MaxStartingCapacity
             else
                 startingCapacity
-        { bbArray = ChunkedArrayBuilder.Create(16, startingCapacity)  
+        { bbArray = ChunkedArrayBuilder.Create(ByteBufferConstants.MinChunkSize, startingCapacity)  
           bbCurrent = 0 }
 
 

--- a/src/absil/bytes.fsi
+++ b/src/absil/bytes.fsi
@@ -19,10 +19,10 @@ module internal Bytes =
     val stringAsUnicodeNullTerminated: string -> byte[]
     val stringAsUtf8NullTerminated: string -> byte[]
 
-type ChunkedArrayForEachDelegate<'T> = delegate of Span<'T> -> unit
+type internal ChunkedArrayForEachDelegate<'T> = delegate of Span<'T> -> unit
 
 [<Struct;NoEquality;NoComparison>]
-type ChunkedArray<'T> =
+type internal ChunkedArray<'T> =
 
     member Length: int
 
@@ -36,7 +36,7 @@ type ChunkedArray<'T> =
 
 /// Not thread safe.
 [<Sealed>]
-type ChunkedArrayBuilder<'T> =
+type internal ChunkedArrayBuilder<'T> =
 
     member Reserve: length: int -> Span<'T>
 
@@ -54,7 +54,7 @@ type ChunkedArrayBuilder<'T> =
     static member Create: minChunkSize: int * startingCapacity: int -> ChunkedArrayBuilder<'T>
 
 [<RequireQualifiedAccess>]
-module ChunkedArray =
+module internal ChunkedArray =
 
     val iter: ('T -> unit) -> ChunkedArray<'T> -> unit
 
@@ -76,10 +76,6 @@ type internal ByteMemory =
 
     abstract Length: int
 
-    abstract Span: Span<byte>
-
-    abstract ReadOnlySpan: ReadOnlySpan<byte>
-
     abstract ReadBytes: pos: int * count: int -> byte[]
 
     abstract ReadInt32: pos: int -> int
@@ -91,6 +87,8 @@ type internal ByteMemory =
     abstract Slice: pos: int * count: int -> ByteMemory
 
     abstract CopyTo: Stream -> unit
+
+    abstract CopyTo: Span<byte> -> unit
 
     abstract Copy: srcOffset: int * dest: byte[] * destOffset: int * count: int -> unit
 
@@ -114,8 +112,6 @@ type internal ReadOnlyByteMemory =
 
     member Length: int
 
-    member Span: ReadOnlySpan<byte>
-
     member ReadBytes: pos: int * count: int -> byte[]
 
     member ReadInt32: pos: int -> int
@@ -128,6 +124,8 @@ type internal ReadOnlyByteMemory =
 
     member CopyTo: Stream -> unit
 
+    member CopyTo: Span<byte> -> unit
+
     member Copy: srcOffset: int * dest: byte[] * destOffset: int * count: int -> unit
 
     member ToArray: unit -> byte[]
@@ -137,7 +135,7 @@ type internal ReadOnlyByteMemory =
     /// Stream cannot be written to.
     member AsStream: unit -> Stream
 
-type ByteMemory with
+type internal ByteMemory with
 
     member AsReadOnly: unit -> ReadOnlyByteMemory
 
@@ -167,7 +165,7 @@ type internal ByteBuffer =
     member EmitInt32s : int32[] -> unit
     member EmitByte : byte -> unit
     member EmitBytes : byte[] -> unit
-    member EmitByteSpan : ReadOnlySpan<byte> -> unit
+    member EmitByteMemory : ReadOnlyByteMemory -> unit
     member EmitInt32 : int32 -> unit
     member EmitInt64 : int64 -> unit
     member EmitInt32AsUInt16 : int32 -> unit

--- a/src/absil/bytes.fsi
+++ b/src/absil/bytes.fsi
@@ -64,6 +64,10 @@ module internal ChunkedArray =
 
     val choose: ('T -> 'U option) -> ChunkedArray<'T> -> ChunkedArray<'U>
 
+    val distinctBy: ('T -> 'Key) -> ChunkedArray<'T> -> ChunkedArray<'T> when 'Key : equality
+
+    val concat: ChunkedArray<'T> seq -> ChunkedArray<'T>
+
     val toArray: ChunkedArray<'T> -> 'T[]
 
     val toReversedList: ChunkedArray<'T> -> 'T list

--- a/src/absil/bytes.fsi
+++ b/src/absil/bytes.fsi
@@ -3,10 +3,12 @@
 /// Blobs of bytes, cross-compiling 
 namespace FSharp.Compiler.AbstractIL.Internal
 
+open System
 open Internal.Utilities
 
 open FSharp.Compiler.AbstractIL 
-open FSharp.Compiler.AbstractIL.Internal 
+open FSharp.Compiler.AbstractIL.Internal
+open FSharp.Compiler.AbstractIL.Internal.Library 
 
 
 module internal Bytes = 
@@ -26,19 +28,20 @@ module internal Bytes =
 /// Imperative buffers and streams of byte[]
 [<Sealed>]
 type internal ByteBuffer = 
+    member Reserve : int -> Span<byte>
     member Close : unit -> byte[] 
     member EmitIntAsByte : int -> unit
     member EmitIntsAsBytes : int[] -> unit
+    member EmitInt32s : int32[] -> unit
     member EmitByte : byte -> unit
     member EmitBytes : byte[] -> unit
     member EmitInt32 : int32 -> unit
     member EmitInt64 : int64 -> unit
-    member FixupInt32 : pos: int -> value: int32 -> unit
     member EmitInt32AsUInt16 : int32 -> unit
     member EmitBoolAsByte : bool -> unit
     member EmitUInt16 : uint16 -> unit
     member Position : int
-    static member Create : int -> ByteBuffer
+    static member Create : startingCapacity: int -> ByteBuffer
 
 
 [<Sealed>]

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -436,30 +436,30 @@ module List =
 
     let mapiFoldSquared f z xss = mapFoldSquared f z (xss |> mapiSquared (fun i j x -> (i, j, x)))
 
-[<System.Runtime.CompilerServices.Extension;AbstractClass;Sealed>]
+[<Extension;AbstractClass;Sealed>]
 type SpanExtensions =
 
-    [<System.Runtime.CompilerServices.Extension>]
+    [<Extension>]
     static member inline WriteByte(data: Span<byte>, offset, value: byte) =
         data.[0 + offset] <- byte value
 
-    [<System.Runtime.CompilerServices.Extension>]
+    [<Extension>]
     static member inline WriteUInt16(data: Span<byte>, offset, value: uint16) =
         data.[0 + offset] <- byte value
         data.[1 + offset] <- byte (value >>> 8)
 
-    [<System.Runtime.CompilerServices.Extension>]
+    [<Extension>]
     static member inline WriteUInt32(data: Span<byte>, offset, value: uint32) =
         data.[0 + offset] <- byte value
         data.[1 + offset] <- byte (value >>> 8)
         data.[2 + offset] <- byte (value >>> 16)
         data.[3 + offset] <- byte (value >>> 24)
 
-    [<System.Runtime.CompilerServices.Extension>]
+    [<Extension>]
     static member inline WriteInt32(data: Span<byte>, offset, value: int32) =
         data.WriteUInt32(offset, uint32 value)
 
-    [<System.Runtime.CompilerServices.Extension>]
+    [<Extension>]
     static member inline WriteInt32AsUInt16(data: Span<byte>, offset, value: int32) =
         data.[0 + offset] <- byte value
         data.[1 + offset] <- byte (value >>> 8)

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -440,32 +440,31 @@ module List =
 type SpanExtensions =
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member inline WriteByte(data: Span<byte>, value: byte) =
-        data.[0] <- byte value
+    static member inline WriteByte(data: Span<byte>, offset, value: byte) =
+        data.[0 + offset] <- byte value
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member inline WriteUInt16(data: Span<byte>, value: uint16) =
-        data.[0] <- byte value
-        data.[1] <- byte (value >>> 8)
+    static member inline WriteUInt16(data: Span<byte>, offset, value: uint16) =
+        data.[0 + offset] <- byte value
+        data.[1 + offset] <- byte (value >>> 8)
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member inline WriteUInt32(data: Span<byte>, value: uint32) =
-        data.[0] <- byte value
-        data.[1] <- byte (value >>> 8)
-        data.[2] <- byte (value >>> 16)
-        data.[3] <- byte (value >>> 24)
+    static member inline WriteUInt32(data: Span<byte>, offset, value: uint32) =
+        data.[0 + offset] <- byte value
+        data.[1 + offset] <- byte (value >>> 8)
+        data.[2 + offset] <- byte (value >>> 16)
+        data.[3 + offset] <- byte (value >>> 24)
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member inline WriteInt32AsUInt16(data: Span<byte>, value: int32) =
-        data.[0] <- byte value
-        data.[1] <- byte (value >>> 8)
+    static member inline WriteInt32(data: Span<byte>, offset, value: int32) =
+        data.WriteUInt32(offset, uint32 value)
 
     [<System.Runtime.CompilerServices.Extension>]
-    static member inline WriteInt32s(data: Span<byte>, values: int32 []) =
-        let mutable data = data
-        for value in values do
-            data.WriteUInt32 (uint32 value)
-            data <- data.Slice 4
+    static member inline WriteInt32AsUInt16(data: Span<byte>, offset, value: int32) =
+        data.[0 + offset] <- byte value
+        data.[1 + offset] <- byte (value >>> 8)
+
+    
 
 /// Not thread safe.
 /// Loosely based on StringBuilder/BlobBuilder

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2698,7 +2698,7 @@ let rec GetResourceAsManifestResourceRow cenv r =
             let resourceSize = bytes.Length 
             cenv.resources.EmitPadding pad 
             cenv.resources.EmitInt32 resourceSize 
-            cenv.resources.EmitByteSpan bytes.Span 
+            cenv.resources.EmitByteMemory bytes 
             Data (alignedOffset, true), (i_File, 0)  
 
         match r.Location with 

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -721,10 +721,10 @@
 
   <ItemGroup Condition="$(TargetFramework.Startswith('netstandard'))">
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemDiagnosticsTraceSourceVersion)" />

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -721,11 +721,11 @@
 
   <ItemGroup Condition="$(TargetFramework.Startswith('netstandard'))">
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemDiagnosticsTraceSourceVersion)" />
     <PackageReference Include="System.Linq.Expressions" Version="$(SystemLinqExpressionsVersion)" />

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -725,6 +725,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="$(SystemDiagnosticsTraceSourceVersion)" />
     <PackageReference Include="System.Linq.Expressions" Version="$(SystemLinqExpressionsVersion)" />

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -12,6 +12,7 @@ open FSharp.Compiler.InfoReader
 open FSharp.Compiler.Tast
 open FSharp.Compiler.Tastops
 open FSharp.Compiler.TcGlobals
+open FSharp.Compiler.AbstractIL.Internal
 open FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.PrettyNaming
 open FSharp.Compiler.Text
@@ -297,10 +298,10 @@ type internal TcResolutions =
     member CapturedExpressionTypings : ResizeArray<pos * TType * DisplayEnv * NameResolutionEnv * AccessorDomain * range>
 
     /// Exact name resolutions
-    member CapturedNameResolutions : ResizeArray<CapturedNameResolution>
+    member CapturedNameResolutions : ChunkedArray<CapturedNameResolution>
 
     /// Represents all the resolutions of names to groups of methods.
-    member CapturedMethodGroupResolutions : ResizeArray<CapturedNameResolution>
+    member CapturedMethodGroupResolutions : ChunkedArray<CapturedNameResolution>
 
     /// Represents the empty set of resolutions 
     static member Empty : TcResolutions
@@ -318,10 +319,10 @@ type TcSymbolUseData =
 type internal TcSymbolUses = 
 
     /// Get all the uses of a particular item within the file
-    member GetUsesOfSymbol : Item -> TcSymbolUseData[]
+    member GetUsesOfSymbol : Item -> ChunkedArray<TcSymbolUseData>
 
     /// All the uses of all items within the file
-    member AllUsesOfSymbols : TcSymbolUseData[][]
+    member AllUsesOfSymbols : ChunkedArray<TcSymbolUseData>
 
     /// Get the locations of all the printf format specifiers in the file
     member GetFormatSpecifierLocationsAndArity : unit -> (range * int)[]

--- a/src/fsharp/TastPickle.fs
+++ b/src/fsharp/TastPickle.fs
@@ -510,9 +510,7 @@ let p_option f x st =
 // OSGN nodes.
 let private p_lazy_impl p v st =
     // We fix these up after
-    let fixupArr = Array.zeroCreate<int32> 7
-    let fixup = st.os.Reserve (fixupArr.Length * sizeof<int32>)
-    st.os.EmitInt32s fixupArr
+    let fixup = st.os.Reserve (7 * sizeof<int32>)
     let idx1 = st.os.Position
     let otyconsIdx1 = st.oentities.Size
     let otyparsIdx1 = st.otypars.Size
@@ -525,14 +523,13 @@ let private p_lazy_impl p v st =
     let otyconsIdx2 = st.oentities.Size
     let otyparsIdx2 = st.otypars.Size
     let ovalsIdx2 = st.ovals.Size
-    fixupArr.[0] <- (idx2-idx1)
-    fixupArr.[1] <- otyconsIdx1
-    fixupArr.[2] <- otyconsIdx2
-    fixupArr.[3] <- otyparsIdx1
-    fixupArr.[4] <- otyparsIdx2
-    fixupArr.[5] <- ovalsIdx1
-    fixupArr.[6] <- ovalsIdx2
-    fixup.WriteInt32s fixupArr
+    fixup.WriteInt32 (0, (idx2-idx1))
+    fixup.WriteInt32 (4, otyconsIdx1)
+    fixup.WriteInt32 (8, otyconsIdx2)
+    fixup.WriteInt32 (12, otyparsIdx1)
+    fixup.WriteInt32 (16, otyparsIdx2)
+    fixup.WriteInt32 (20, ovalsIdx1)
+    fixup.WriteInt32 (24, ovalsIdx2)
 
 let p_lazy p x st =
     p_lazy_impl p (Lazy.force x) st

--- a/src/fsharp/TastPickle.fs
+++ b/src/fsharp/TastPickle.fs
@@ -523,13 +523,13 @@ let private p_lazy_impl p v st =
     let otyconsIdx2 = st.oentities.Size
     let otyparsIdx2 = st.otypars.Size
     let ovalsIdx2 = st.ovals.Size
-    fixup.WriteInt32 (0, (idx2-idx1))
-    fixup.WriteInt32 (4, otyconsIdx1)
-    fixup.WriteInt32 (8, otyconsIdx2)
-    fixup.WriteInt32 (12, otyparsIdx1)
-    fixup.WriteInt32 (16, otyparsIdx2)
-    fixup.WriteInt32 (20, ovalsIdx1)
-    fixup.WriteInt32 (24, ovalsIdx2)
+    fixup.WriteInt32 (0                , (idx2-idx1))
+    fixup.WriteInt32 (1 * sizeof<int32>, otyconsIdx1)
+    fixup.WriteInt32 (2 * sizeof<int32>, otyconsIdx2)
+    fixup.WriteInt32 (3 * sizeof<int32>, otyparsIdx1)
+    fixup.WriteInt32 (4 * sizeof<int32>, otyparsIdx2)
+    fixup.WriteInt32 (5 * sizeof<int32>, ovalsIdx1)
+    fixup.WriteInt32 (6 * sizeof<int32>, ovalsIdx2)
 
 let p_lazy p x st =
     p_lazy_impl p (Lazy.force x) st

--- a/src/fsharp/TastPickle.fs
+++ b/src/fsharp/TastPickle.fs
@@ -509,21 +509,10 @@ let p_option f x st =
 // lazily. However, a lazy reader is not used in this version because the value may contain the definitions of some
 // OSGN nodes.
 let private p_lazy_impl p v st =
-    let fixupPos1 = st.os.Position
     // We fix these up after
-    prim_p_int32 0 st
-    let fixupPos2 = st.os.Position
-    prim_p_int32 0 st
-    let fixupPos3 = st.os.Position
-    prim_p_int32 0 st
-    let fixupPos4 = st.os.Position
-    prim_p_int32 0 st
-    let fixupPos5 = st.os.Position
-    prim_p_int32 0 st
-    let fixupPos6 = st.os.Position
-    prim_p_int32 0 st
-    let fixupPos7 = st.os.Position
-    prim_p_int32 0 st
+    let fixupArr = Array.zeroCreate<int32> 7
+    let fixup = st.os.Reserve (fixupArr.Length * sizeof<int32>)
+    st.os.EmitInt32s fixupArr
     let idx1 = st.os.Position
     let otyconsIdx1 = st.oentities.Size
     let otyparsIdx1 = st.otypars.Size
@@ -532,17 +521,18 @@ let private p_lazy_impl p v st =
     p v st
     // Determine and fixup the length of the pickled data
     let idx2 = st.os.Position
-    st.os.FixupInt32 fixupPos1 (idx2-idx1)
     // Determine and fixup the ranges of OSGN nodes defined within the lazy portion
     let otyconsIdx2 = st.oentities.Size
     let otyparsIdx2 = st.otypars.Size
     let ovalsIdx2 = st.ovals.Size
-    st.os.FixupInt32 fixupPos2 otyconsIdx1
-    st.os.FixupInt32 fixupPos3 otyconsIdx2
-    st.os.FixupInt32 fixupPos4 otyparsIdx1
-    st.os.FixupInt32 fixupPos5 otyparsIdx2
-    st.os.FixupInt32 fixupPos6 ovalsIdx1
-    st.os.FixupInt32 fixupPos7 ovalsIdx2
+    fixupArr.[0] <- (idx2-idx1)
+    fixupArr.[1] <- otyconsIdx1
+    fixupArr.[2] <- otyconsIdx2
+    fixupArr.[3] <- otyparsIdx1
+    fixupArr.[4] <- otyparsIdx2
+    fixupArr.[5] <- ovalsIdx1
+    fixupArr.[6] <- ovalsIdx2
+    fixup.WriteInt32s fixupArr
 
 let p_lazy p x st =
     p_lazy_impl p (Lazy.force x) st


### PR DESCRIPTION
Still a work in progress for this issue: https://github.com/dotnet/fsharp/issues/7982

This one is a bit tricky. Effectively it's writing data to a memory stream that is constantly getting resized and re-allocated when the buffer size limit is reached. Therefore, we need to solve this by having a memory stream backed by chunked byte arrays. There is nothing built into the core libraries that solve this for us; we need to build it ourselves.

Right now I'm using Span for part of it as it helped me reduce some cognitive load. We can take it out if it's an issue. I know I'm having some trouble with the System.Memory package and the compiler.

- [ ] Decide whether or not to use Span (Could use ArraySegment instead)
- [ ] Remove use of `ToArray` on the `ChunkedArray` in places we know have the ability to go passed the LOH. `ByteMemory` https://github.com/dotnet/fsharp/pull/7971 may need to get merged first before we figure this out.
- [x] Cleanup - figure out what's public and private for members on `ChunkedArray` and `ChunkedArrayBuilder`

Possible Alternatives:
- Investigate and use https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream instead
- Use `System.Reflection.Metadata.BlobBuilder` (I don't know if this is a good idea because it might be specific for reading assembly metadata and not for general use, @tmat could tell us.)
- Write to disk

Current impl is based on ideas from `System.Reflection.Metadata.BlobBuilder`.