### PR TITLE
Added SafeUnmanagedMemoryStream for AsStream/AsReadOnlyStream 

### DIFF
--- a/src/absil/bytes.fs
+++ b/src/absil/bytes.fs
@@ -144,6 +144,7 @@ type SafeUnmanagedMemoryStream =
         base.Dispose disposing
         if not x.isDisposed then
             x.hold <- null // Null out so it can be collected.
+            x.isDisposed <- true
 
 [<Sealed>]
 type RawByteMemory(addr: nativeptr<byte>, length: int, hold: obj) =


### PR DESCRIPTION
Quickly fixes this bug: https://github.com/dotnet/fsharp/issues/7998

Need this to keep the pointer valid by holding onto the object.