### PR TITLE
Simplify langversion code

### DIFF
--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -79,11 +79,11 @@ type LanguageVersion (specifiedVersionAsString) =
     member __.ValidOptions = validOptions
 
     /// Get a list of valid versions for help text
-    member __.ValidVersions = [|
-        for v in languageVersions |> Seq.sort do
-            let label = if v = defaultVersion then " (Default)" else ""
-            yield sprintf "%M%s" v label
-            |]
+    member __.ValidVersions =
+        [|
+            for v in languageVersions |> Seq.sort ->
+                sprintf "%M%s" v (if v = defaultVersion then " (Default)" else "")
+        |]
 
     /// Get the specified LanguageVersion
     member __.SpecifiedVersion = specified

--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -16,18 +16,14 @@ open System
 //   *  When a feature is assigned a release language, we will scrub the code of feature references and apply
 //      the Release Language version.
 
-/// LanguageFeature enumeration
 [<RequireQualifiedAccess>]
 type LanguageFeature =
-    | PreviewVersion = 0
-    | LanguageVersion46 = 1
-    | LanguageVersion47 = 2
-    | SingleUnderscorePattern = 3
-    | WildCardInForLoop = 4
-    | RelaxWhitespace = 5
-    | NameOf = 6
-    | ImplicitYield = 7
-    | OpenStaticClasses = 8
+    | SingleUnderscorePattern
+    | WildCardInForLoop
+    | RelaxWhitespace
+    | NameOf
+    | ImplicitYield
+    | OpenStaticClasses
 
 /// LanguageVersion management
 type LanguageVersion (specifiedVersionAsString) =
@@ -45,18 +41,13 @@ type LanguageVersion (specifiedVersionAsString) =
 
     static let features =
         dict [
-            // Add new LanguageVersions here ...
-            LanguageFeature.LanguageVersion46, languageVersion46
-            LanguageFeature.LanguageVersion47, languageVersion47
-            LanguageFeature.PreviewVersion, previewVersion
-        
             // F# 4.7
             LanguageFeature.SingleUnderscorePattern, languageVersion47
             LanguageFeature.WildCardInForLoop, languageVersion47
             LanguageFeature.RelaxWhitespace, languageVersion47
             LanguageFeature.ImplicitYield, languageVersion47
 
-            // Add new Language Features here...
+            // F# preview
             LanguageFeature.NameOf, previewVersion
             LanguageFeature.OpenStaticClasses, previewVersion
         ]

--- a/src/fsharp/LanguageFeatures.fsi
+++ b/src/fsharp/LanguageFeatures.fsi
@@ -6,16 +6,12 @@ module internal FSharp.Compiler.Features
 /// LanguageFeature enumeration
 [<RequireQualifiedAccess>]
 type LanguageFeature =
-    | PreviewVersion = 0
-    | LanguageVersion46 = 1
-    | LanguageVersion47 = 2
-    | SingleUnderscorePattern = 3
-    | WildCardInForLoop = 4
-    | RelaxWhitespace = 5
-    | NameOf = 6
-    | ImplicitYield = 7
-    | OpenStaticClasses = 8
-
+    | SingleUnderscorePattern
+    | WildCardInForLoop
+    | RelaxWhitespace
+    | NameOf
+    | ImplicitYield
+    | OpenStaticClasses
 
 /// LanguageVersion management
 type LanguageVersion =


### PR DESCRIPTION
We don't appear to be using ` LanguageFeature.LanguageVersion*` and friends anywhere, so let's try to remove it.

Also there does not appear to be a use for the type being an enum, so I made it a DU