### PR TITLE
Clean up some compiler location redundancies

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2586,7 +2586,7 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
         let dllReference, fileNameOpt = computeKnownDllReference getFSharpCoreLibraryName
         match fileNameOpt with
         | Some _ -> dllReference
-        | None -> AssemblyReference(range0, getDefaultFSharpCoreReference, None)
+        | None -> AssemblyReference(range0, getDefaultFSharpCoreLocation, None)
 
     // clrRoot: the location of the primary assembly (mscorlib.dll or netstandard.dll or System.Runtime.dll)
     //
@@ -3513,12 +3513,8 @@ type TcAssemblyResolutions(tcConfig: TcConfig, results: AssemblyResolution list,
 
             let assumeDotNetFramework = primaryReference.SimpleAssemblyNameIs("mscorlib")
             if tcConfig.framework then
-                for s in defaultReferencesForScriptsAndOutOfProjectSources assumeDotNetFramework tcConfig.useSdkRefs do
+                for s in defaultReferencesForScriptsAndOutOfProjectSources tcConfig.useFsiAuxLib assumeDotNetFramework tcConfig.useSdkRefs do
                     yield AssemblyReference(rangeStartup, (if s.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) then s else s+".dll"), None)
-
-            if tcConfig.useFsiAuxLib then
-                let name = Path.Combine(tcConfig.fsharpBinariesDir, getFsiLibraryName + ".dll")
-                yield AssemblyReference(rangeStartup, name, None)
 
             yield! tcConfig.referencedDLLs
         ]
@@ -5555,4 +5551,4 @@ let TypeCheckClosedInputSet (ctok, checkForErrors, tcConfig, tcImports, tcGlobal
 
 // Existing public APIs delegate to newer implementations
 let GetFSharpCoreLibraryName () = getFSharpCoreLibraryName
-let DefaultReferencesForScriptsAndOutOfProjectSources assumeDotNetFramework = defaultReferencesForScriptsAndOutOfProjectSources assumeDotNetFramework false
+let DefaultReferencesForScriptsAndOutOfProjectSources assumeDotNetFramework = defaultReferencesForScriptsAndOutOfProjectSources (*useFsiAuxLib*)false assumeDotNetFramework (*useSdkRefs*)false

--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -1,22 +1,34 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
 // Functions to retrieve framework dependencies
-
 module internal FSharp.Compiler.DotNetFrameworkDependencies
 
     open System
     open System.Collections.Generic
+    open System.Diagnostics
     open System.Globalization
     open System.IO
     open System.Reflection
+    open Internal.Utilities
 
     type private TypeInThisAssembly = class end
 
+    let implementationAssemblyDir = Path.GetDirectoryName(typeof<obj>.Assembly.Location)
+    let fSharpCompilerLocation =
+        let location = Path.GetDirectoryName(typeof<TypeInThisAssembly>.Assembly.Location)
+        match FSharpEnvironment.BinFolderOfDefaultFSharpCompiler (Some location) with
+        | Some path -> path
+        | None ->
+#if DEBUG
+            Debug.Print(sprintf "FSharpEnvironment.BinFolderOfDefaultFSharpCompiler (Some '%s') returned None Location customized incorrectly: algorithm here: https://github.com/dotnet/fsharp/blob/03f3f1c35f82af26593d025dabca57a6ef3ea9a1/src/utils/CompilerLocationUtils.fs#L171" location)
+#endif
+            // Use the location of this dll
+            location
+
     let getFSharpCoreLibraryName = "FSharp.Core"
     let getFsiLibraryName = "FSharp.Compiler.Interactive.Settings"
-    let implementationAssemblyDir = Path.GetDirectoryName(typeof<obj>.Assembly.Location)
-    let getDefaultFSharpCoreReference = typeof<Microsoft.FSharp.Core.Unit>.Assembly.Location
-    let getFSharpCompilerLocation = Path.GetDirectoryName(typeof<TypeInThisAssembly>.Assembly.Location)
+    let getDefaultFSharpCoreLocation = Path.Combine(fSharpCompilerLocation, getFSharpCoreLibraryName + ".dll")
+    let getDefaultFsiLibraryLocation = Path.Combine(fSharpCompilerLocation, getFsiLibraryName + ".dll")
 
     // Use the ValueTuple that is executing with the compiler if it is from System.ValueTuple
     // or the System.ValueTuple.dll that sits alongside the compiler.  (Note we always ship one with the compiler)
@@ -26,14 +38,12 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
             if asm.FullName.StartsWith("System.ValueTuple", StringComparison.OrdinalIgnoreCase) then
                 Some asm.Location
             else
-                let location = Path.GetDirectoryName(typeof<TypeInThisAssembly>.Assembly.Location)
-                let valueTuplePath = Path.Combine(location, "System.ValueTuple.dll")
+                let valueTuplePath = Path.Combine(fSharpCompilerLocation, "System.ValueTuple.dll")
                 if File.Exists(valueTuplePath) then
                     Some valueTuplePath
                 else
                     None
         with _ -> None
-
 
     // Algorithm:
     //     use implementation location of obj type, on shared frameworks it will always be in:
@@ -161,11 +171,12 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
         yield "System.Data"
         yield "System.Drawing"
         yield "System.Core"
-        yield getDefaultFSharpCoreReference
+
+        yield getFSharpCoreLibraryName
         if useFsiAuxLib then yield getFsiLibraryName
 
         // always include a default reference to System.ValueTuple.dll in scripts and out-of-project sources 
-        match getDefaultSystemValueTupleReference() with
+        match getDefaultSystemValueTupleReference () with
         | None -> ()
         | Some v -> yield v
 
@@ -199,8 +210,8 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
                         // Coreclr supports netstandard assemblies only for now
                         (getDependenciesOf [
                             yield! Directory.GetFiles(implementationAssemblyDir, "*.dll")
-                            yield getDefaultFSharpCoreReference
-                            if useFsiAuxLib then yield getFsiLibraryName
+                            yield getDefaultFSharpCoreLocation
+                            if useFsiAuxLib then yield getDefaultFsiLibraryLocation
                         ]).Values |> Seq.toList
 
                     if useSdkRefs then
@@ -208,8 +219,8 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
                         match frameworkRefsPackDirectory with
                         | Some path ->
                             try [ yield! Directory.GetFiles(path, "*.dll")
-                                  yield getDefaultFSharpCoreReference
-                                  if useFsiAuxLib then yield getFsiLibraryName
+                                  yield getDefaultFSharpCoreLocation
+                                  if useFsiAuxLib then yield getDefaultFsiLibraryLocation
                                 ]
                             with | _ -> List.empty<string>
                         | None ->
@@ -219,8 +230,8 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
                 dependencies
         results
 
-    let defaultReferencesForScriptsAndOutOfProjectSources assumeDotNetFramework useSdkRefs =
-        fetchPathsForDefaultReferencesForScriptsAndOutOfProjectSources false useSdkRefs assumeDotNetFramework
+    let defaultReferencesForScriptsAndOutOfProjectSources useFsiAuxLib assumeDotNetFramework useSdkRefs =
+        fetchPathsForDefaultReferencesForScriptsAndOutOfProjectSources useFsiAuxLib useSdkRefs assumeDotNetFramework
 
     // A set of assemblies to always consider to be system assemblies.  A common set of these can be used a shared 
     // resources between projects in the compiler services.  Also all assemblies where well-known system types exist

--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -2,6 +2,7 @@
 
 namespace Internal.Utilities
 open System
+open System.Diagnostics
 open System.IO
 open Microsoft.Win32
 open System.Runtime.InteropServices
@@ -71,9 +72,10 @@ module internal FSharpEnvironment =
             (try
                 downcast Microsoft.Win32.Registry.GetValue("HKEY_LOCAL_MACHINE\\"+subKey,null,null)
              with e->
-                System.Diagnostics.Debug.Assert(false, sprintf "Failed in GetDefaultRegistryStringValueViaDotNet: %s" (e.ToString()))
+#if DEBUG
+                Debug.Assert(false, sprintf "Failed in GetDefaultRegistryStringValueViaDotNet: %s" (e.ToString()))
+#endif
                 null)
-
 
     let Get32BitRegistryStringValueViaPInvoke(subKey:string) = 
         Option.ofString
@@ -114,11 +116,13 @@ module internal FSharpEnvironment =
                     if pathResult <> IntPtr.Zero then
                         Marshal.FreeCoTaskMem(pathResult)
              with e->
-                System.Diagnostics.Debug.Assert(false, sprintf "Failed in Get32BitRegistryStringValueViaPInvoke: %s" (e.ToString()))
+#if DEBUG
+                Debug.Assert(false, sprintf "Failed in Get32BitRegistryStringValueViaPInvoke: %s" (e.ToString()))
+#endif
                 null)
 
     let is32Bit = IntPtr.Size = 4
-    
+
     let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e-> false
 
     let tryRegKey(subKey:string) = 
@@ -133,7 +137,7 @@ module internal FSharpEnvironment =
             // by comparing against the result from GetDefaultRegistryStringValueViaDotNet(...)
 #if DEBUG
             let viaPinvoke = Get32BitRegistryStringValueViaPInvoke(subKey)
-            System.Diagnostics.Debug.Assert((s = viaPinvoke), sprintf "32bit path: pi=%A def=%A" viaPinvoke s)
+            Debug.Assert((s = viaPinvoke), sprintf "32bit path: pi=%A def=%A" viaPinvoke s)
 #endif
             s
         else
@@ -141,13 +145,9 @@ module internal FSharpEnvironment =
 #endif
 
     let internal tryCurrentDomain() =
-        let pathFromCurrentDomain = 
-#if FX_NO_APP_DOMAINS
-            System.AppContext.BaseDirectory
-#else
-            System.AppDomain.CurrentDomain.BaseDirectory
-#endif
-        if not(String.IsNullOrEmpty(pathFromCurrentDomain)) then 
+        let pathFromCurrentDomain =
+            AppDomain.CurrentDomain.BaseDirectory
+        if not(String.IsNullOrEmpty(pathFromCurrentDomain)) then
             Some pathFromCurrentDomain
         else
             None
@@ -157,14 +157,17 @@ module internal FSharpEnvironment =
 #else
     let internal tryAppConfig (_appConfigKey:string) = 
         let locationFromAppConfig = System.Configuration.ConfigurationSettings.AppSettings.[_appConfigKey]
-        System.Diagnostics.Debug.Print(sprintf "Considering _appConfigKey %s which has value '%s'" _appConfigKey locationFromAppConfig) 
-
+#if DEBUG
+        Debug.Print(sprintf "Considering _appConfigKey %s which has value '%s'" _appConfigKey locationFromAppConfig) 
+#endif
         if String.IsNullOrEmpty(locationFromAppConfig) then 
             None
         else
             let exeAssemblyFolder = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)
             let locationFromAppConfig = locationFromAppConfig.Replace("{exepath}", exeAssemblyFolder)
-            System.Diagnostics.Debug.Print(sprintf "Using path %s" locationFromAppConfig) 
+#if DEBUG
+            Debug.Print(sprintf "Using path %s" locationFromAppConfig)
+#endif
             Some locationFromAppConfig
 #endif
 
@@ -175,14 +178,10 @@ module internal FSharpEnvironment =
     //     - default F# binaries directory in service.fs (REVIEW: check this)
     //     - default location of fsi.exe in FSharp.VS.FSI.dll (REVIEW: check this)
     //     - default F# binaries directory in (project system) Project.fs
-    let BinFolderOfDefaultFSharpCompiler(probePoint:string option) = 
+    let BinFolderOfDefaultFSharpCompiler(probePoint:string option) =
 #if FX_NO_WIN_REGISTRY
         ignore probePoint
-#if FX_NO_APP_DOMAINS
-        Some System.AppContext.BaseDirectory
-#else
-        Some System.AppDomain.CurrentDomain.BaseDirectory
-#endif
+        Some AppDomain.CurrentDomain.BaseDirectory
 #else
         // Check for an app.config setting to redirect the default compiler location
         // Like fsharp-compiler-location
@@ -199,7 +198,7 @@ module internal FSharpEnvironment =
             | Some p when safeExists (Path.Combine(p,"FSharp.Core.dll")) -> Some p 
             | _ -> 
             // We let you set FSHARP_COMPILER_BIN. I've rarely seen this used and its not documented in the install instructions.
-            let result = System.Environment.GetEnvironmentVariable("FSHARP_COMPILER_BIN")
+            let result = Environment.GetEnvironmentVariable("FSHARP_COMPILER_BIN")
             if not (String.IsNullOrEmpty(result)) then
                 Some result
             else


### PR DESCRIPTION
1. Some small tweaks naming things in DotNetFrameworkDependencies
2. use 'FSharpEnvironment.BinFolderOfDefaultFSharpCompiler' to find compiler location
3. Resolve fsiLibrary consistently with FSharp.Core.
4. Place a few Debug asserts under #ifdef