### PR TITLE
Revert "Small LOH fix for Dictionary (#8024)"

### DIFF
--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -3435,7 +3435,7 @@ let OptimizeImplFile (settings, ccu, tcGlobals, tcVal, importMap, optEnv, isIncr
           g=tcGlobals 
           amap=importMap
           optimizing=true
-          localInternalVals=Dictionary<Stamp, ValInfo>()
+          localInternalVals=Dictionary<Stamp, ValInfo>(10000)
           emitTailcalls=emitTailcalls
           casApplied=new Dictionary<Stamp, bool>() }
     let (optEnvNew, _, _, _ as results) = OptimizeImplFileInternal cenv optEnv isIncrementalFragment hidden mimpls  


### PR DESCRIPTION
This reverts commit f1747487cd632a57fd149e7ce38c7d0a3c3d28cf.

This actually doesn't help LOH. The capacity was 10,000, but the size allocated would be 80k which is under the LOH size. This means it showed up in the trace on the LOH because it actually went over that amount. We'll have to resolve this another way.