### PR TITLE
Remove IsModuleRef/IsAssemblyRef/ModuleRef/AssemblyRef properties

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -493,14 +493,6 @@ type ILScopeRef =
 
     member x.IsLocalRef = match x with ILScopeRef.Local -> true | _ -> false
 
-    member x.IsModuleRef = match x with ILScopeRef.Module _ -> true | _ -> false
-
-    member x.IsAssemblyRef= match x with ILScopeRef.Assembly _ -> true | _ -> false
-
-    member x.ModuleRef = match x with ILScopeRef.Module x -> x | _ -> failwith "not a module reference"
-
-    member x.AssemblyRef = match x with ILScopeRef.Assembly x -> x | _ -> failwith "not an assembly reference"
-
     member x.QualifiedName =
         match x with
         | ILScopeRef.Local -> ""
@@ -2627,7 +2619,10 @@ type ILGlobals(primaryScopeRef) =
     let m_typ_UIntPtr = ILType.Value (mkILNonGenericTySpec (m_mkSysILTypeRef tname_UIntPtr))
 
     member x.primaryAssemblyScopeRef = m_typ_Object.TypeRef.Scope
-    member x.primaryAssemblyName = m_typ_Object.TypeRef.Scope.AssemblyRef.Name
+    member x.primaryAssemblyName = 
+        match primaryScopeRef with 
+        | ILScopeRef.Assembly aref -> aref.Name 
+        | _ -> failwith "Invalid primary assembly"
     member x.typ_Object = m_typ_Object
     member x.typ_String = m_typ_String
     member x.typ_Array = m_typ_Array

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -2620,7 +2620,7 @@ type ILGlobals(primaryScopeRef) =
 
     member x.primaryAssemblyScopeRef = m_typ_Object.TypeRef.Scope
     member x.primaryAssemblyName = 
-        match primaryScopeRef with 
+        match m_typ_Object.TypeRef.Scope with 
         | ILScopeRef.Assembly aref -> aref.Name 
         | _ -> failwith "Invalid primary assembly"
     member x.typ_Object = m_typ_Object

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -99,10 +99,6 @@ type ILScopeRef =
     /// A reference to a type in another assembly
     | Assembly of ILAssemblyRef  
     member IsLocalRef: bool
-    member IsModuleRef: bool
-    member IsAssemblyRef: bool
-    member ModuleRef: ILModuleRef
-    member AssemblyRef: ILAssemblyRef
     member QualifiedName: string
 
 // Calling conventions.  

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -2070,9 +2070,7 @@ and OptimizeExprOp cenv env (op, tyargs, args, m) =
    // guarantees to optimize.
   
     | TOp.ILCall (_, _, _, _, _, _, _, mref, _enclTypeArgs, _methTypeArgs, _tys), _, [arg]
-        when (mref.DeclaringTypeRef.Scope.IsAssemblyRef &&
-              mref.DeclaringTypeRef.Scope.AssemblyRef.Name = cenv.g.ilg.typ_Array.TypeRef.Scope.AssemblyRef.Name &&
-              mref.DeclaringTypeRef.Name = cenv.g.ilg.typ_Array.TypeRef.Name &&
+        when (mref.DeclaringTypeRef.Name = cenv.g.ilg.typ_Array.TypeRef.Name &&
               mref.Name = "get_Length" &&
               isArray1DTy cenv.g (tyOfExpr cenv.g arg)) -> 
          OptimizeExpr cenv env (Expr.Op (TOp.ILAsm (i_ldlen, [cenv.g.int_ty]), [], [arg], m))
@@ -2785,7 +2783,10 @@ and TryInlineApplication cenv env finfo (tyargs: TType list, args: Expr list, m)
                     match vref.ApparentEnclosingEntity with
                     | Parent tcr when (tyconRefEq cenv.g cenv.g.lazy_tcr_canon tcr) ->
                             match tcr.CompiledRepresentation with
-                            | CompiledTypeRepr.ILAsmNamed(iltr, _, _) -> iltr.Scope.AssemblyRef.Name = "FSharp.Core"
+                            | CompiledTypeRepr.ILAsmNamed(iltr, _, _) -> 
+                                match iltr.Scope with
+                                | ILScopeRef.Assembly aref -> aref.Name = "FSharp.Core"
+                                | _ -> false
                             | _ -> false
                     | _ -> false
                 | _ -> false                                          

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1397,7 +1397,10 @@ module StaticLinker =
     // Add all provider-generated assemblies into the static linking set
     let FindProviderGeneratedILModules (ctok, tcImports: TcImports, providerGeneratedAssemblies: (ImportedBinary * _) list) = 
         [ for (importedBinary, provAssemStaticLinkInfo) in providerGeneratedAssemblies do 
-              let ilAssemRef  = importedBinary.ILScopeRef.AssemblyRef
+              let ilAssemRef =
+                match importedBinary.ILScopeRef with
+                | ILScopeRef.Assembly aref -> aref
+                | _ -> failwith "Invalid ILScopeRef, expected ILScopeRef.Assembly"
               if debugStaticLinking then printfn "adding provider-generated assembly '%s' into static linking set" ilAssemRef.Name
               match tcImports.TryFindDllInfo(ctok, Range.rangeStartup, ilAssemRef.Name, lookupOnly=false) with 
               | Some dllInfo ->

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -5775,10 +5775,7 @@ let NewTycon (cpath, nm, m, access, reprAccess, kind, typars, docOption, usesPre
 
 
 let NewILTycon nlpath (nm, m) tps (scoref: ILScopeRef, enc, tdef: ILTypeDef) mtyp =
-
-    // NOTE: hasSelfReferentialCtor=false is an assumption about mscorlib
-    let hasSelfReferentialCtor = tdef.IsClass && (not scoref.IsAssemblyRef && scoref.AssemblyRef.Name = "mscorlib")
-    let tycon = NewTycon(nlpath, nm, m, taccessPublic, taccessPublic, TyparKind.Type, tps, XmlDoc.Empty, true, false, hasSelfReferentialCtor, mtyp)
+    let tycon = NewTycon(nlpath, nm, m, taccessPublic, taccessPublic, TyparKind.Type, tps, XmlDoc.Empty, true, false, false, mtyp)
 
     tycon.entity_tycon_repr <- TILObjectRepr (TILObjectReprData (scoref, enc, tdef))
     tycon.TypeContents.tcaug_closed <- true


### PR DESCRIPTION
This removes `IsModuleRef`/`IsAssemblyRef`/`ModuleRef`/`AssemblyRef` properties on `ILScopeRef`.

Reason being, `IsModuleRef` and `ModuleRef` are never used. `IsAssemblyRef` and `AssemblyRef` are only used in a handful of places; it is better to do pattern matching on the scope.

The one behavior difference would be how it optimizes `get_Length` for an array as we skip the assembly check. This is fine considering we are skipping the assembly check when doing the `String.Concat` optimizations.

Another weird piece of code was this:
```fsharp
let hasSelfReferentialCtor = tdef.IsClass && (not scoref.IsAssemblyRef && scoref.AssemblyRef.Name = "mscorlib")
```
This is definitely never returning `true` as it would be impossible. It would either be `false` or throw an exception. I have not seen this throw an exception ever; therefore, this should always be `false`.