### PR TITLE
[Performance] Use TokenTup object pool to reduce allocations in LexFilter

### DIFF
--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -400,6 +400,7 @@ type LexbufState(startPos: Position,
     member x.PastEOF = pastEOF
 
 /// Used to save the state related to a token
+/// Treat as though this is read-only.
 [<Class>]
 type TokenTup = 
     // This is mutable for performance reasons.

--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -934,7 +934,7 @@ type LexFilterImpl (lightSyntaxStatus: LightSyntaxStatus, compilingFsLib, lexer,
                         let hasAfterOp = (match lookaheadToken with GREATER _ -> false | _ -> true)
                         if nParen > 0 then 
                             // Don't smash the token if there is an after op and we're in a nested paren
-                            stack := (pool.Copy(lookaheadTokenTup), not hasAfterOp) :: (!stack).Tail
+                            stack := (lookaheadTokenTup, not hasAfterOp) :: (!stack).Tail
                             scanAhead nParen 
                         else 
                             // On successful parse of a set of type parameters, look for an adjacent (, e.g. 
@@ -948,7 +948,7 @@ type LexFilterImpl (lightSyntaxStatus: LightSyntaxStatus, compilingFsLib, lexer,
                         let nParen = nParen - greaters.Length
                         if nParen > 0 then 
                             // Don't smash the token if there is an after op and we're in a nested paren
-                            stack := (pool.Copy(lookaheadTokenTup), not afterOp.IsSome) :: (!stack).Tail
+                            stack := (lookaheadTokenTup, not afterOp.IsSome) :: (!stack).Tail
                             scanAhead nParen 
                         else 
                             // On successful parse of a set of type parameters, look for an adjacent (, e.g. 
@@ -2266,6 +2266,7 @@ type LexFilterImpl (lightSyntaxStatus: LightSyntaxStatus, compilingFsLib, lexer,
                   let token = ADJACENT_PREFIX_OP tokenName
                   delayToken nextTokenTup 
                   delayToken (pool.UseLocation(tokenTup, token))
+                  pool.Return tokenTup
 
               if plusOrMinus then 
                   match nextTokenTup.Token with 

--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -421,15 +421,20 @@ type TokenTupPool() =
     let stack = System.Collections.Generic.Stack(Array.init maxSize (fun _ -> TokenTup(Unchecked.defaultof<_>, Unchecked.defaultof<_>, Unchecked.defaultof<_>)))
 
     member _.Rent() = 
-        stack.Pop()
+        if stack.Count = 0 then
+            assert false
+            TokenTup(Unchecked.defaultof<_>, Unchecked.defaultof<_>, Unchecked.defaultof<_>)
+        else
+            stack.Pop()
 
     member _.Return(x: TokenTup) =
-        if stack.Count >= maxSize then
-            invalidOp "pool larger than max size"
         x.Token <- Unchecked.defaultof<_>
         x.LexbufState <- Unchecked.defaultof<_>
         x.LastTokenPos <- Unchecked.defaultof<_>
-        stack.Push x
+        if stack.Count >= maxSize then
+            assert false
+        else
+            stack.Push x
 
     /// Returns a token 'tok' with the same position as this token
     member pool.UseLocation(x: TokenTup, tok) = 

--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -415,6 +415,9 @@ type TokenTup =
         
 type TokenTupPool() =
 
+    /// Arbitrary.
+    /// When parsing the compiler's source files, the pool didn't come close to reaching this limit.
+    /// Therefore, this seems like a reasonable limit to handle 99% of cases.
     [<Literal>]
     let maxSize = 100
 


### PR DESCRIPTION
We were getting a ton of `TokenTup` allocations when parsing.

Image below is just a small sample of allocations of parsing one file, `TypeChecker.fs`.
![Untitled3](https://user-images.githubusercontent.com/1278959/71564893-eaa10380-2a5c-11ea-8744-c439fc071641.png)

There are never many `TokenTup` objects being used at the same time. They are created and thrown away very quickly. But, they are very large.

To handle this problem, we can use an object pool. Below is the impact it had.

Before:
![Untitled (Recovered)2](https://user-images.githubusercontent.com/1278959/71564920-466b8c80-2a5d-11ea-858c-0c3fe01a7a8b.png)

After:
![Untitled2](https://user-images.githubusercontent.com/1278959/71564929-669b4b80-2a5d-11ea-8192-f627f2143abf.png)

Makes the parser faster and doesn't push objects into Gen2 so quickly. The downside is that we have to care about the lifetime of `TokenTup` in the `LexFilter`, so it increases complexity and more prone to error - but should be caught quickly.

Alternatives:

- Make `TokenTup` a struct.
    - Making `TokenTup` a struct may eliminate heap allocations, but there are a ton of copying. To fix that problem we could pass it `byref`. However, this requires much larger changes and ergonomically speaking, is a lot harder to deal with.

