### PR TITLE
Remove redundent reference from FCS TestProj

### DIFF
--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -101,6 +101,5 @@
     <Reference Include="UIAutomationTypes" />
     <ProjectReference Include="CSharp_Analysis\CSharp_Analysis.csproj" />
     <ProjectReference Include="..\FSharp.Compiler.Service.ProjectCracker\FSharp.Compiler.Service.ProjectCracker.fsproj" />
-    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
@dsyme  noticed a redundent file reference in the FCSTest proj.

Just checking what happens when we remove it.

