### PR TITLE
Using ArrayPool for AssocTable

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -95,6 +95,7 @@
     <SystemThreadingThreadVersion>4.3.0</SystemThreadingThreadVersion>
     <SystemThreadingThreadPoolVersion>4.3.0</SystemThreadingThreadPoolVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
+    <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
     <!-- Roslyn packages -->
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>
     <MicrosoftCodeAnalysisEditorFeaturesTextVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesTextVersion>

--- a/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -680,6 +680,7 @@
     <PackageReference Include="FSharp.Core" Version="$(FcsFSharpCorePkgVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -743,6 +743,7 @@
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(SystemThreadingTasksParallelVersion)" />
     <PackageReference Include="System.Threading.Thread" Version="$(SystemThreadingThreadVersion)" />
     <PackageReference Include="System.Threading.ThreadPool" Version="$(SystemThreadingThreadPoolVersion)" />
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -6,6 +6,7 @@ namespace FSharp.Compiler.Text
 
 open System
 open System.IO
+open System.Buffers
 
 type ISourceText =
 

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -6,7 +6,6 @@ namespace FSharp.Compiler.Text
 
 open System
 open System.IO
-open System.Buffers
 
 type ISourceText =
 

--- a/src/utils/prim-parsing.fs
+++ b/src/utils/prim-parsing.fs
@@ -7,6 +7,7 @@ namespace  Internal.Utilities.Text.Parsing
 open Internal.Utilities.Text.Lexing
 
 open System
+open System.Buffers
 
 exception RecoverableParseError
 exception Accept of obj
@@ -131,11 +132,7 @@ module internal Implementation =
     //-------------------------------------------------------------------------
     // Read the tables written by FSYACC.  
 
-    type AssocTable(elemTab:uint16[], offsetTab:uint16[]) =
-        let cacheSize = 7919 // the 1000'th prime
-        // Use a simpler hash table with faster lookup, but only one
-        // hash bucket per key.
-        let cache = Array.zeroCreate<int> (cacheSize * 2)
+    type AssocTable(elemTab:uint16[], offsetTab:uint16[], cache:int[], cacheSize:int) =
 
         member t.ReadAssoc (minElemNum,maxElemNum,defaultValueOfAssoc,keyToFind) =     
             // do a binary chop on the table 
@@ -234,8 +231,14 @@ module internal Implementation =
         let ruleValues    = (Array.zeroCreate 100 : obj[])              
         let lhsPos        = (Array.zeroCreate 2 : Position[])                                            
         let reductions = tables.reductions
-        let actionTable = new AssocTable(tables.actionTableElements, tables.actionTableRowOffsets)
-        let gotoTable = new AssocTable(tables.gotos, tables.sparseGotoTableRowOffsets)
+        let cacheSize = 7919 // the 1000'th prime
+        // Use a simpler hash table with faster lookup, but only one
+        // hash bucket per key.
+        let actionTableCache = ArrayPool<int>.Shared.Rent(cacheSize * 2)
+        let gotoTableCache = ArrayPool<int>.Shared.Rent(cacheSize * 2)
+        use _cacheDisposal = { new IDisposable with member _.Dispose() = ArrayPool<int>.Shared.Return actionTableCache; ArrayPool<int>.Shared.Return gotoTableCache }
+        let actionTable = new AssocTable(tables.actionTableElements, tables.actionTableRowOffsets, actionTableCache, cacheSize)
+        let gotoTable = new AssocTable(tables.gotos, tables.sparseGotoTableRowOffsets, gotoTableCache, cacheSize)
         let stateToProdIdxsTable = new IdxToIdxListTable(tables.stateToProdIdxsTableElements, tables.stateToProdIdxsTableRowOffsets)
 
         let parseState =                                                                                            

--- a/src/utils/prim-parsing.fs
+++ b/src/utils/prim-parsing.fs
@@ -236,6 +236,9 @@ module internal Implementation =
         // hash bucket per key.
         let actionTableCache = ArrayPool<int>.Shared.Rent(cacheSize * 2)
         let gotoTableCache = ArrayPool<int>.Shared.Rent(cacheSize * 2)
+        // Clear the arrays since ArrayPool does not
+        Array.Clear(actionTableCache, 0, actionTableCache.Length)
+        Array.Clear(gotoTableCache, 0, gotoTableCache.Length)
         use _cacheDisposal = 
             { new IDisposable with 
                 member _.Dispose() = 

--- a/src/utils/prim-parsing.fs
+++ b/src/utils/prim-parsing.fs
@@ -132,7 +132,7 @@ module internal Implementation =
     //-------------------------------------------------------------------------
     // Read the tables written by FSYACC.  
 
-    type AssocTable(elemTab:uint16[], offsetTab:uint16[], cache:int[], cacheSize:int) =
+    type AssocTable(elemTab: uint16[], offsetTab: uint16[], cache: int[], cacheSize: int) =
 
         member t.ReadAssoc (minElemNum,maxElemNum,defaultValueOfAssoc,keyToFind) =     
             // do a binary chop on the table 
@@ -236,9 +236,13 @@ module internal Implementation =
         // hash bucket per key.
         let actionTableCache = ArrayPool<int>.Shared.Rent(cacheSize * 2)
         let gotoTableCache = ArrayPool<int>.Shared.Rent(cacheSize * 2)
-        use _cacheDisposal = { new IDisposable with member _.Dispose() = ArrayPool<int>.Shared.Return actionTableCache; ArrayPool<int>.Shared.Return gotoTableCache }
-        let actionTable = new AssocTable(tables.actionTableElements, tables.actionTableRowOffsets, actionTableCache, cacheSize)
-        let gotoTable = new AssocTable(tables.gotos, tables.sparseGotoTableRowOffsets, gotoTableCache, cacheSize)
+        use _cacheDisposal = 
+            { new IDisposable with 
+                member _.Dispose() = 
+                    ArrayPool<int>.Shared.Return actionTableCache
+                    ArrayPool<int>.Shared.Return gotoTableCache }
+        let actionTable = AssocTable(tables.actionTableElements, tables.actionTableRowOffsets, actionTableCache, cacheSize)
+        let gotoTable = AssocTable(tables.gotos, tables.sparseGotoTableRowOffsets, gotoTableCache, cacheSize)
         let stateToProdIdxsTable = new IdxToIdxListTable(tables.stateToProdIdxsTableElements, tables.stateToProdIdxsTableRowOffsets)
 
         let parseState =                                                                                            


### PR DESCRIPTION
Uses ArrayPool for AssocTable since we are allocating a large int array every time we want to parse anything.
![Untitled](https://user-images.githubusercontent.com/1278959/72563307-3d9ef700-3862-11ea-9469-ffecd17e991e.png)
