### PR TITLE
Fixed exception that prevented creating a memory mapped file that shadow copies a file on-disk

### DIFF
--- a/src/absil/bytes.fs
+++ b/src/absil/bytes.fs
@@ -307,10 +307,10 @@ type ByteMemory with
             mmf, mmf.CreateViewAccessor(0L, length, memoryMappedFileAccess), length
 
         match access with
-        | FileAccess.Read when not accessor.CanRead -> failwith "Cannot read file"
-        | FileAccess.Write when not accessor.CanWrite -> failwith "Cannot write file"
-        | _ when not accessor.CanRead || not accessor.CanWrite -> failwith "Cannot read or write file"
-        | _ -> ()
+        | FileAccess.Read when not accessor.CanRead -> invalidOp "Cannot read file"
+        | FileAccess.Write when not accessor.CanWrite -> invalidOp "Cannot write file"
+        | FileAccess.ReadWrite when not accessor.CanRead || not accessor.CanWrite -> invalidOp "Cannot read or write file"
+        | _ -> invalidOp "Invalid file access"
 
         let safeHolder =
             { new obj() with

--- a/src/absil/bytes.fs
+++ b/src/absil/bytes.fs
@@ -306,11 +306,12 @@ type ByteMemory with
                         leaveOpen=false)
             mmf, mmf.CreateViewAccessor(0L, length, memoryMappedFileAccess), length
 
+        // Validate MMF with the access that was intended.
         match access with
         | FileAccess.Read when not accessor.CanRead -> invalidOp "Cannot read file"
         | FileAccess.Write when not accessor.CanWrite -> invalidOp "Cannot write file"
         | FileAccess.ReadWrite when not accessor.CanRead || not accessor.CanWrite -> invalidOp "Cannot read or write file"
-        | _ -> invalidOp "Invalid file access"
+        | _ -> ()
 
         let safeHolder =
             { new obj() with


### PR DESCRIPTION
This was a logic bug that would raise an exception if you tried to create a memory mapped file that shadow copies a file on-disk. We currently do not use shadow copy yet, but we will in the future.