### PR TITLE
Move Finalize from TcImports to another object

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3756,6 +3756,38 @@ type TcConfigProvider =
 // TcImports
 //--------------------------------------------------------------------------
 
+[<Sealed>]
+type TcImportsSafeDisposal
+    (disposeActions: (unit -> unit) list,
+#if !NO_EXTENSIONTYPING
+     disposeTypeProviderActions: (unit -> unit) list,
+#endif
+     compilationThread: ICompilationThread) =
+
+    let mutable isDisposed = false
+
+    let dispose () =
+        // disposing deliberately only closes this tcImports, not the ones up the chain 
+        isDisposed <- true        
+        if verbose then 
+            dprintf "disposing of TcImports, %d binaries\n" disposeActions.Length
+#if !NO_EXTENSIONTYPING
+        let actions = disposeTypeProviderActions
+        if actions.Length > 0 then
+            compilationThread.EnqueueWork (fun _ -> for action in actions do action())
+#endif
+        for action in disposeActions do action()
+
+    override _.Finalize() =
+        dispose ()
+
+    interface IDisposable with
+
+        member this.Dispose()  =
+            if not isDisposed then
+                GC.SuppressFinalize this
+                dispose ()
+
 #if !NO_EXTENSIONTYPING
 // These are hacks in order to allow TcImports to be held as a weak reference inside a type provider.
 // The reason is due to older type providers compiled using an older TypeProviderSDK, that SDK used reflection on fields and properties to determine the contract.
@@ -3809,25 +3841,15 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
     let mutable generatedTypeRoots = new System.Collections.Generic.Dictionary<ILTypeRef, int * ProviderGeneratedType>()
     let mutable tcImportsWeak = TcImportsWeakHack (WeakReference<_> this)
 #endif
+
+    let disposal = new TcImportsSafeDisposal(disposeActions, disposeTypeProviderActions, compilationThread)
     
     let CheckDisposed() =
         if disposed then assert false
 
     let dispose () =
         CheckDisposed()
-        // disposing deliberately only closes this tcImports, not the ones up the chain 
-        disposed <- true        
-        if verbose then 
-            dprintf "disposing of TcImports, %d binaries\n" disposeActions.Length
-#if !NO_EXTENSIONTYPING
-        let actions = disposeTypeProviderActions
-        disposeTypeProviderActions <- []
-        if actions.Length > 0 then
-            compilationThread.EnqueueWork (fun _ -> for action in actions do action())
-#endif
-        let actions = disposeActions
-        disposeActions <- []
-        for action in actions do action()
+        (disposal :> IDisposable).Dispose()
 
     static let ccuHasType (ccu: CcuThunk) (nsname: string list) (tname: string) =
         let matchNameSpace (entityOpt: Entity option) n =
@@ -4781,9 +4803,6 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
         knownUnresolved
         |> List.map (function UnresolvedAssemblyReference(file, originalReferences) -> file, originalReferences)
         |> List.iter reportAssemblyNotResolved
-
-    override tcImports.Finalize () =
-        dispose ()
         
     static member BuildNonFrameworkTcImports (ctok, tcConfigP: TcConfigProvider, tcGlobals: TcGlobals, baseTcImports, nonFrameworkReferences, knownUnresolved) = 
       cancellable {
@@ -4809,7 +4828,6 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
     interface System.IDisposable with 
         member tcImports.Dispose() = 
             dispose ()
-            GC.SuppressFinalize tcImports
 
     override tcImports.ToString() = "TcImports(...)"
         


### PR DESCRIPTION
This moves the disposal of some of the resources that `TcImports` uses to another object. The reason why is because we do not want `TcImports` itself to override `Finalize` as that causes `TcImports` to survive longer on collections. Instead, the object responsible for disposing will be surviving longer. Therefore, allows `TcImports` to be collected sooner.