### PR TITLE
[WIP] (Maybe) detuple struct tuples

### DIFF
--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="Compiler\ILChecker.fs" />
     <Compile Include="Compiler\Utilities.fs" />
     <Compile Include="Compiler\CompilerAssert.fs" />
+    <Compile Include="Compiler\CodeGen\EmittedIL\StructTupleElimination.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\StaticLinkTests.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\LiteralValue.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\Mutation.fs" />


### PR DESCRIPTION
This is inspired by the following code:

```fsharp
let rec runWithTuple t offset times =
    let offsetValues x y z offset =
        (x + offset, y + offset, z + offset)
    if times <= 0 then
        t
    else
        let (x, y, z) = t
        let r = offsetValues x y z offset
        runWithTuple r offset (times - 1)
let rec runWithStructTuple t offset times =
    let offsetValues x y z offset =
        struct(x + offset, y + offset, z + offset)
    if times <= 0 then
        t
    else
        let struct(x, y, z) = t
        let r = offsetValues x y z offset
        runWithStructTuple r offset (times - 1)
```

`runWithStructTuple ` is faster than `runWithTuple ` for any decently large value of `times` by about 40% in benchmarking. But if you mark the inner functions as `inline`, then `runWithTuple ` is actually marginally faster because some optimizations kick in.

Maybe this fixes it, maybe it doesn't. Let's see what CI says