### PR TITLE
Include System.Buffers in vsix

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -27,6 +27,7 @@
       <BuiltProjectOutputGroupKeyOutput Include="$(BuildOutputGroupLocation)\Microsoft.Build.Tasks.Core.dll" />
       <BuiltProjectOutputGroupKeyOutput Include="$(BuildOutputGroupLocation)\System.Reflection.Metadata.dll" />
       <BuiltProjectOutputGroupKeyOutput Include="$(BuildOutputGroupLocation)\System.Collections.Immutable.dll" />
+      <BuiltProjectOutputGroupKeyOutput Include="$(BuildOutputGroupLocation)\System.Buffers.dll" />
     </ItemGroup>
   </Target>
 

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.netcore.nuspec
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.netcore.nuspec
@@ -33,6 +33,7 @@
                 <dependency id="System.Threading.Thread" version="4.0.0" />
                 <dependency id="System.Threading.ThreadPool" version="4.0.10" />
                 <dependency id="System.ValueTuple" version="4.3.0" />
+                <dependency id="System.Buffers" version="4.5.0" />
             </group>
         </dependencies>
     </metadata>

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -22,6 +22,7 @@
                 <dependency id="System.Threading.Thread" version="4.3.0" />
                 <dependency id="System.Threading.ThreadPool" version="4.3.0" />
                 <dependency id="System.ValueTuple" version="4.4.0" />
+                <dependency id="System.Buffers" version="4.5.0" />
             </group>
         </dependencies>
         <contentFiles>

--- a/vsintegration/Directory.Build.targets
+++ b/vsintegration/Directory.Build.targets
@@ -18,6 +18,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
   </ItemGroup>
  
 </Project>


### PR DESCRIPTION
@KevinRansom I realized when I added System.Buffers as a dep, it is not being included in the VSIX. Also need to make sure it's in the nuspec.

Is this all the right way to do this? I keep trying to build and deploy and it's still not putting the `System.Buffers.dll` in the VSIX for some reason. Is there another place I am not aware of?