### PR TITLE
Fixed consuming CSharp interface with an inref parameter

### DIFF
--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1536,7 +1536,7 @@ type MethInfo =
                     let formalRetTy = ImportReturnTypeFromMetadata amap m ilminfo.RawMetadata.Return.Type ilminfo.RawMetadata.Return.CustomAttrs ftinfo.ILScopeRef ftinfo.TypeInstOfRawMetadata formalMethTyparTys
                     let formalParams =
                         [ [ for p in ilminfo.RawMetadata.Parameters do
-                                let paramType = ImportILTypeFromMetadata amap m ftinfo.ILScopeRef ftinfo.TypeInstOfRawMetadata formalMethTyparTys p.Type
+                                let paramType = ImportILTypeFromMetadataWithAttributes amap m ftinfo.ILScopeRef ftinfo.TypeInstOfRawMetadata formalMethTyparTys p.Type p.CustomAttrs
                                 yield TSlotParam(p.Name, paramType, p.IsIn, p.IsOut, p.IsOptional, []) ] ]
                     formalRetTy, formalParams
 #if !NO_EXTENSIONTYPING

--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -92,7 +92,7 @@ type CompilerAssert private () =
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseFSharpPreview>true</UseFSharpPreview>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>

--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -8,6 +8,7 @@ open System.Diagnostics
 open System.IO
 open System.Text
 open System.Diagnostics
+open System.Collections.Generic
 open System.Reflection
 open FSharp.Compiler.Text
 open FSharp.Compiler.SourceCodeServices
@@ -17,6 +18,9 @@ open System.Runtime.Loader
 #endif
 open NUnit.Framework
 open System.Reflection.Emit
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.CSharp
+open FSharp.Compiler.UnitTests.Utilities
 
 [<Sealed>]
 type ILVerifier (dllFilePath: string) =
@@ -52,11 +56,17 @@ type CompileOutput =
     | Library
     | Exe
 
-type CompilationReference = private CompilationReference of Compilation * staticLink: bool with
+type CompilationReference = 
+    private 
+    | CompilationReference of Compilation * staticLink: bool 
+    | TestCompilationReference of TestCompilation
 
     static member CreateFSharp(cmpl: Compilation, ?staticLink) =
         let staticLink = defaultArg staticLink false
         CompilationReference(cmpl, staticLink)
+
+    static member Create(cmpl: TestCompilation) =
+        TestCompilationReference cmpl
 
 and Compilation = private Compilation of string * SourceKind * CompileOutput * options: string[] * CompilationReference list with
 
@@ -82,7 +92,7 @@ type CompilerAssert private () =
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseFSharpPreview>true</UseFSharpPreview>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
@@ -257,7 +267,14 @@ let main argv = 0"""
                     |> List.map (fun cmpl ->
                             match cmpl with
                             | CompilationReference (cmpl, staticLink) ->
-                                compileCompilationAux disposals ignoreWarnings cmpl, staticLink)
+                                compileCompilationAux disposals ignoreWarnings cmpl, staticLink
+                            | TestCompilationReference (cmpl) -> 
+                                let tmp = Path.GetTempFileName()
+                                disposals.Add({ new IDisposable with 
+                                                    member _.Dispose() = 
+                                                        try File.Delete tmp with | _ -> () })
+                                cmpl.EmitAsFile tmp
+                                (([||], tmp), []), false)
 
                 let compilationRefs =
                     compiledRefs

--- a/tests/fsharp/Compiler/Utilities.fs
+++ b/tests/fsharp/Compiler/Utilities.fs
@@ -120,7 +120,7 @@ type CompilationUtil private () =
                 [ CSharpSyntaxTree.ParseText (source, CSharpParseOptions lv) ],
                 references.As<MetadataReference>().AddRange additionalReferences,
                 CSharpCompilationOptions (OutputKind.DynamicallyLinkedLibrary))
-        Some (TestCompilation.CSharp (c, flags))
+        TestCompilation.CSharp (c, flags)
 
     static member CreateILCompilation (source: string) =
         let compute =
@@ -139,4 +139,4 @@ type CompilationUtil private () =
                     try File.Delete ilFilePath with | _ -> ()
                     try File.Delete tmp with | _ -> ()
                     try File.Delete dllFilePath with | _ -> ()
-        Some (TestCompilation.IL (source, compute))
+        TestCompilation.IL (source, compute)


### PR DESCRIPTION
Should resolve this: https://github.com/davidfowl/BedrockFramework/issues/48

Fix was easy, hardest part was making the test.
When importing an ILType when creating a TSlotParam, we didn't take into account the attributes, which there is a specific function for that. The attributes will dictate what kind of type we have, such as a `byref` parameter type with a `ReadOnlyAttribute`; turns into `inref`.