### PR TITLE
Add char to types resolvable by GenericZero

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1219,7 +1219,7 @@ and SolveMemberConstraint (csenv: ConstraintSolverEnv) ignoreUnresolvedOverload 
       // We pretend for uniformity that the numeric types have a static property called Zero and One 
       // As with constants, only zero is polymorphic in its units
       | [], [ty], false, "get_Zero", [] 
-          when IsNumericType g ty -> 
+          when IsNumericType g ty || isCharTy g ty -> 
           do! SolveTypeEqualsTypeKeepAbbrevs csenv ndeep m2 trace rty ty
           return TTraitBuiltIn
 

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -2349,6 +2349,7 @@ namespace Microsoft.FSharp.Core
                 elif aty.Equals(typeof<nativeint>)  then unboxPrim<'T> (box 0n)
                 elif aty.Equals(typeof<byte>)       then unboxPrim<'T> (box 0uy)
                 elif aty.Equals(typeof<uint16>)     then unboxPrim<'T> (box 0us)
+                elif aty.Equals(typeof<char>)       then unboxPrim<'T> (box '\000')
                 elif aty.Equals(typeof<uint32>)     then unboxPrim<'T> (box 0u)
                 elif aty.Equals(typeof<uint64>)     then unboxPrim<'T> (box 0UL)
                 elif aty.Equals(typeof<unativeint>) then unboxPrim<'T> (box 0un)
@@ -2372,7 +2373,7 @@ namespace Microsoft.FSharp.Core
                 elif aty.Equals(typeof<nativeint>)  then unboxPrim<'T> (box 1n)
                 elif aty.Equals(typeof<byte>)       then unboxPrim<'T> (box 1uy)
                 elif aty.Equals(typeof<uint16>)     then unboxPrim<'T> (box 1us)
-                elif aty.Equals(typeof<char>)       then unboxPrim<'T> (box (retype 1us : char))
+                elif aty.Equals(typeof<char>)       then unboxPrim<'T> (box '\001')
                 elif aty.Equals(typeof<uint32>)     then unboxPrim<'T> (box 1u)
                 elif aty.Equals(typeof<uint64>)     then unboxPrim<'T> (box 1UL)
                 elif aty.Equals(typeof<unativeint>) then unboxPrim<'T> (box 1un)
@@ -2400,6 +2401,7 @@ namespace Microsoft.FSharp.Core
             when ^T : unativeint  = 0un
             when ^T : int16       = 0s
             when ^T : uint16      = 0us
+            when ^T : char        = '\000'
             when ^T : sbyte       = 0y
             when ^T : byte        = 0uy
             when ^T : decimal     = 0M
@@ -2420,7 +2422,7 @@ namespace Microsoft.FSharp.Core
             when ^T : unativeint  = 1un
             when ^T : int16       = 1s
             when ^T : uint16      = 1us
-            when ^T : char        = (retype 1us : char)
+            when ^T : char        = '\001'
             when ^T : sbyte       = 1y
             when ^T : byte        = 1uy
             when ^T : decimal     = 1M

--- a/tests/fsharp/core/members/basics/test.fs
+++ b/tests/fsharp/core/members/basics/test.fs
@@ -3052,7 +3052,8 @@ module ContraintTest = begin
     do check "d3oc003k" (LanguagePrimitives.GenericZero<sbyte> = 0y)
     do check "d3oc003l" (LanguagePrimitives.GenericZero<decimal> = 0M)
 
-    do check "d3oc001q" (LanguagePrimitives.GenericOne<BigInteger> = 1I)
+    do check "d3oc113q" (LanguagePrimitives.GenericOne<BigInteger> = 1I)
+    do check "d3oc113w" (LanguagePrimitives.GenericOne<char> = '\001')
     do check "d3oc113e" (LanguagePrimitives.GenericOne<int> = 1)
     do check "d3oc113r" (LanguagePrimitives.GenericOne<unativeint> = 1un)
     do check "d3oc113t" (LanguagePrimitives.GenericOne<uint64> = 1UL)

--- a/tests/fsharp/core/members/basics/test.fs
+++ b/tests/fsharp/core/members/basics/test.fs
@@ -3038,6 +3038,7 @@ module ContraintTest = begin
     open System.Numerics
     let check s p = printf "Test %s: %s\n" s (if p then "pass" else "fail")
     do check "d3oc001" (LanguagePrimitives.GenericZero<BigInteger> = 0I)
+    do check "d3oc002" (LanguagePrimitives.GenericZero<char> = '\000')
     do check "d3oc003a" (LanguagePrimitives.GenericZero<int> = 0)
     do check "d3oc003b" (LanguagePrimitives.GenericZero<unativeint> = 0un)
     do check "d3oc003c" (LanguagePrimitives.GenericZero<uint64> = 0UL)

--- a/tests/fsharp/tools/eval/test.fsx
+++ b/tests/fsharp/tools/eval/test.fsx
@@ -1193,36 +1193,35 @@ module EvaluationTests =
 
     module InlinedOperationsStillDynamicallyAvailableTests = 
 
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<chat> @>)  '\000'
-        checkEval "vroievr093" (<@ LanguagePrimitives.GenericZero<sbyte> @>)  0y
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<int16> @>)  0s
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<int32> @>)  0
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<int64> @>)  0L
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<nativeint> @>)  0n
-        checkEval "vroievr093" (<@ LanguagePrimitives.GenericZero<byte> @>)  0uy
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<uint16> @>)  0us
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<uint32> @>)  0u
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<uint64> @>)  0UL
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<unativeint> @>)  0un
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<float> @>)  0.0
-        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<float32> @>)  0.0f
-        checkEval "vroievr092" (<@ LanguagePrimitives.GenericZero<decimal> @>)  0M
+        checkEval "vroievr091a" (<@ LanguagePrimitives.GenericZero<char> @>)  '\000'
+        checkEval "vroievr091b" (<@ LanguagePrimitives.GenericZero<sbyte> @>)  0y
+        checkEval "vroievr091c" (<@ LanguagePrimitives.GenericZero<int16> @>)  0s
+        checkEval "vroievr091d" (<@ LanguagePrimitives.GenericZero<int32> @>)  0
+        checkEval "vroievr091e" (<@ LanguagePrimitives.GenericZero<int64> @>)  0L
+        checkEval "vroievr091f" (<@ LanguagePrimitives.GenericZero<nativeint> @>)  0n
+        checkEval "vroievr091g" (<@ LanguagePrimitives.GenericZero<byte> @>)  0uy
+        checkEval "vroievr091h" (<@ LanguagePrimitives.GenericZero<uint16> @>)  0us
+        checkEval "vroievr091i" (<@ LanguagePrimitives.GenericZero<uint32> @>)  0u
+        checkEval "vroievr091j" (<@ LanguagePrimitives.GenericZero<uint64> @>)  0UL
+        checkEval "vroievr091k" (<@ LanguagePrimitives.GenericZero<unativeint> @>)  0un
+        checkEval "vroievr091l" (<@ LanguagePrimitives.GenericZero<float> @>)  0.0
+        checkEval "vroievr091m" (<@ LanguagePrimitives.GenericZero<float32> @>)  0.0f
+        checkEval "vroievr091n" (<@ LanguagePrimitives.GenericZero<decimal> @>)  0M
 
-
-
-        checkEval "vroievr093" (<@ LanguagePrimitives.GenericOne<sbyte> @>)  1y
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<int16> @>)  1s
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<int32> @>)  1
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<int64> @>)  1L
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<nativeint> @>)  1n
-        checkEval "vroievr193" (<@ LanguagePrimitives.GenericOne<byte> @>)  1uy
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<uint16> @>)  1us
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<uint32> @>)  1u
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<uint64> @>)  1UL
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<unativeint> @>)  1un
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<float> @>)  1.0
-        checkEval "vroievr191" (<@ LanguagePrimitives.GenericOne<float32> @>)  1.0f
-        checkEval "vroievr192" (<@ LanguagePrimitives.GenericOne<decimal> @>)  1M
+        checkEval "vroievr092a" (<@ LanguagePrimitives.GenericOne<char> @>)  '\001'
+        checkEval "vroievr092b" (<@ LanguagePrimitives.GenericOne<sbyte> @>)  1y
+        checkEval "vroievr092c" (<@ LanguagePrimitives.GenericOne<int16> @>)  1s
+        checkEval "vroievr092d" (<@ LanguagePrimitives.GenericOne<int32> @>)  1
+        checkEval "vroievr092e" (<@ LanguagePrimitives.GenericOne<int64> @>)  1L
+        checkEval "vroievr092f" (<@ LanguagePrimitives.GenericOne<nativeint> @>)  1n
+        checkEval "vroievr092g" (<@ LanguagePrimitives.GenericOne<byte> @>)  1uy
+        checkEval "vroievr092h" (<@ LanguagePrimitives.GenericOne<uint16> @>)  1us
+        checkEval "vroievr092i" (<@ LanguagePrimitives.GenericOne<uint32> @>)  1u
+        checkEval "vroievr092j" (<@ LanguagePrimitives.GenericOne<uint64> @>)  1UL
+        checkEval "vroievr092k" (<@ LanguagePrimitives.GenericOne<unativeint> @>)  1un
+        checkEval "vroievr092l" (<@ LanguagePrimitives.GenericOne<float> @>)  1.0
+        checkEval "vroievr092m" (<@ LanguagePrimitives.GenericOne<float32> @>)  1.0f
+        checkEval "vroievr092n" (<@ LanguagePrimitives.GenericOne<decimal> @>)  1M
 
         check "vroievr0971" (LanguagePrimitives.AdditionDynamic 3y 4y) 7y
         check "vroievr0972" (LanguagePrimitives.AdditionDynamic 3s 4s) 7s

--- a/tests/fsharp/tools/eval/test.fsx
+++ b/tests/fsharp/tools/eval/test.fsx
@@ -1193,6 +1193,7 @@ module EvaluationTests =
 
     module InlinedOperationsStillDynamicallyAvailableTests = 
 
+        checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<chat> @>)  '\000'
         checkEval "vroievr093" (<@ LanguagePrimitives.GenericZero<sbyte> @>)  0y
         checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<int16> @>)  0s
         checkEval "vroievr091" (<@ LanguagePrimitives.GenericZero<int32> @>)  0


### PR DESCRIPTION
It's resolvable by GenericOne already. Why not add it to GenericZero?