### PR TITLE
save the contents of the NuGet package cache as a build artifact

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,6 +187,14 @@ stages:
               publishLocation: Container
             continueOnError: true
             condition: eq(variables['_testKind'], 'testFSharpQA')
+          - task: PublishBuildArtifacts@1
+            displayName: Publish NuGet cache contents
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\NugetPackageRootContents'
+              ArtifactName: 'NuGetPackageContents Windows $(_testKind)'
+              publishLocation: Container
+            continueOnError: true
+            condition: always()
 
         # Linux
         - job: Linux
@@ -206,6 +214,14 @@ stages:
               testResultsFormat: 'NUnit'
               testResultsFiles: '*.xml'
               searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+            continueOnError: true
+            condition: always()
+          - task: PublishBuildArtifacts@1
+            displayName: Publish NuGet cache contents
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/NugetPackageRootContents'
+              ArtifactName: 'NuGetPackageContents Linux'
+              publishLocation: Container
             continueOnError: true
             condition: always()
 
@@ -229,6 +245,14 @@ stages:
               searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
             continueOnError: true
             condition: always()
+          - task: PublishBuildArtifacts@1
+            displayName: Publish NuGet cache contents
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/NugetPackageRootContents'
+              ArtifactName: 'NuGetPackageContents Mac'
+              publishLocation: Container
+            continueOnError: true
+            condition: always()
 
         # Source Build Linux
         - job: SourceBuild_Linux
@@ -239,6 +263,14 @@ stages:
             clean: true
           - script: ./eng/cibuild.sh --configuration Release /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
             displayName: Build
+          - task: PublishBuildArtifacts@1
+            displayName: Publish NuGet cache contents
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/NugetPackageRootContents'
+              ArtifactName: 'NuGetPackageContents SourceBuild_Linux'
+              publishLocation: Container
+            continueOnError: true
+            condition: always()
 
         # Source Build Windows
         - job: SourceBuild_Windows
@@ -249,6 +281,14 @@ stages:
             clean: true
           - script: eng\CIBuild.cmd -configuration Release -noSign /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
             displayName: Build
+          - task: PublishBuildArtifacts@1
+            displayName: Publish NuGet cache contents
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\NugetPackageRootContents'
+              ArtifactName: 'NuGetPackageContents SourceBuild_Windows'
+              publishLocation: Container
+            continueOnError: true
+            condition: always()
 
         # Up-to-date
         - job: UpToDate_Windows

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,0 +1,18 @@
+<Project>
+
+  <!-- Used as a diagnostic tool to view the state of the NuGet package cache as it existed immediately after a restore/build. -->
+
+  <ItemGroup>
+    <PackageRootFiles Include="$(NuGetPackageRoot)/**" />
+  </ItemGroup>
+
+  <Target Name="_DumpPackageRootDirectoryListing"
+          AfterTargets="Build">
+    <PropertyGroup>
+      <PackageRootArtifactDirectory>$(ArtifactsDir)NugetPackageRootContents</PackageRootArtifactDirectory>
+      <PackageRootContentsFile>$(PackageRootArtifactDirectory)/package_contents.txt</PackageRootContentsFile>
+    </PropertyGroup>
+    <MakeDir Directories="$(PackageRootArtifactDirectory)" Condition="!Exists('$(PackageRootArtifactDirectory)')" />
+    <WriteLinesToFile File="$(PackageRootContentsFile)" Lines="@(PackageRootFiles)" />
+  </Target>
+</Project>


### PR DESCRIPTION
There are several internal build bugs that appear to be related to NuGet packages not being fully restored at the time of the build.  To help diagnose this, the contents of the NuGet cache are being written to a text file and appended to the build as an artifact.