### PR TITLE
fix whitespace in resource

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/Microsoft.VisualStudio.Editors.Designer.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/Microsoft.VisualStudio.Editors.Designer.resx
@@ -1276,7 +1276,6 @@ CONSIDER: get this from CodeDom</comment>
   <data name="RSE_GraphicSizeFormat" xml:space="preserve">
     <value>{0} x {1}</value>
     <comment>Format string for showing a graphic's size
-
 #  {0} = width (as an integer)
 #  {1} = height (as an integer)
 #Example, for a bitmap of width=123, height = 456, the English version of this string would be "123x456"</comment>


### PR DESCRIPTION
There's a blank line in the `<comment>` field of one of our `.resx` files, and whenever the localization team gives us string translations, that line is removed from the `<note>` field of the generated `.xlf` files.  Since the actual format of that string doesn't matter, I have no idea what tool that team uses to do translations, and even if I did it's not worth fixing, I've decided to simply remove the extra line in our `.resx` file so that local builds don't keep changing `.xlf` files and pretending like something meaningful happened.  You've all seen that after building you suddenly have 13 changed files.