### PR TITLE
only dump package list if the run failed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,6 +187,9 @@ stages:
               publishLocation: Container
             continueOnError: true
             condition: eq(variables['_testKind'], 'testFSharpQA')
+          - script: dotnet build $(Build.SourcesDirectory)/eng/DumpPackageRoot/DumpPackageRoot.csproj
+            displayName: Dump NuGet cache contents
+            condition: failed()
           - task: PublishBuildArtifacts@1
             displayName: Publish NuGet cache contents
             inputs:
@@ -194,7 +197,7 @@ stages:
               ArtifactName: 'NuGetPackageContents Windows $(_testKind)'
               publishLocation: Container
             continueOnError: true
-            condition: always()
+            condition: failed()
 
         # Linux
         - job: Linux
@@ -216,6 +219,9 @@ stages:
               searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
             continueOnError: true
             condition: always()
+          - script: dotnet build $(Build.SourcesDirectory)/eng/DumpPackageRoot/DumpPackageRoot.csproj
+            displayName: Dump NuGet cache contents
+            condition: failed()
           - task: PublishBuildArtifacts@1
             displayName: Publish NuGet cache contents
             inputs:
@@ -223,7 +229,7 @@ stages:
               ArtifactName: 'NuGetPackageContents Linux'
               publishLocation: Container
             continueOnError: true
-            condition: always()
+            condition: failed()
 
         # MacOS
         - job: MacOS
@@ -245,6 +251,9 @@ stages:
               searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
             continueOnError: true
             condition: always()
+          - script: dotnet build $(Build.SourcesDirectory)/eng/DumpPackageRoot/DumpPackageRoot.csproj
+            displayName: Dump NuGet cache contents
+            condition: failed()
           - task: PublishBuildArtifacts@1
             displayName: Publish NuGet cache contents
             inputs:
@@ -252,7 +261,7 @@ stages:
               ArtifactName: 'NuGetPackageContents Mac'
               publishLocation: Container
             continueOnError: true
-            condition: always()
+            condition: failed()
 
         # Source Build Linux
         - job: SourceBuild_Linux
@@ -263,6 +272,9 @@ stages:
             clean: true
           - script: ./eng/cibuild.sh --configuration Release /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
             displayName: Build
+          - script: dotnet build $(Build.SourcesDirectory)/eng/DumpPackageRoot/DumpPackageRoot.csproj
+            displayName: Dump NuGet cache contents
+            condition: failed()
           - task: PublishBuildArtifacts@1
             displayName: Publish NuGet cache contents
             inputs:
@@ -270,7 +282,7 @@ stages:
               ArtifactName: 'NuGetPackageContents SourceBuild_Linux'
               publishLocation: Container
             continueOnError: true
-            condition: always()
+            condition: failed()
 
         # Source Build Windows
         - job: SourceBuild_Windows
@@ -281,6 +293,9 @@ stages:
             clean: true
           - script: eng\CIBuild.cmd -configuration Release -noSign /p:DotNetBuildFromSource=true /p:FSharpSourceBuild=true
             displayName: Build
+          - script: dotnet build $(Build.SourcesDirectory)/eng/DumpPackageRoot/DumpPackageRoot.csproj
+            displayName: Dump NuGet cache contents
+            condition: failed()
           - task: PublishBuildArtifacts@1
             displayName: Publish NuGet cache contents
             inputs:
@@ -288,7 +303,7 @@ stages:
               ArtifactName: 'NuGetPackageContents SourceBuild_Windows'
               publishLocation: Container
             continueOnError: true
-            condition: always()
+            condition: failed()
 
         # Up-to-date
         - job: UpToDate_Windows

--- a/eng/DumpPackageRoot/DumpPackageRoot.csproj
+++ b/eng/DumpPackageRoot/DumpPackageRoot.csproj
@@ -1,6 +1,10 @@
-<Project>
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Used as a diagnostic tool to view the state of the NuGet package cache as it existed immediately after a restore/build. -->
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageRootFiles Include="$(NuGetPackageRoot)/**" />


### PR DESCRIPTION
Building on #8303, this ensures the package dump always has a chance to run, but only does so if something failed.

~~**PR includes a purposeful break to ensure the correct thing happens.  Once that behavior has been observed, I'll remove the failure.**~~

Build contained the expected artifacts.