### PR TITLE
Clean up nuget project file

### DIFF
--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.Utilities.fs
@@ -237,7 +237,7 @@ $(PACKAGEREFERENCES)
 
   <Target Name='ComputePackageRootsForInteractivePackageManagement'
           BeforeTargets='CoreCompile'
-          DependsOnTargets='CollectPackageReferences'>
+          DependsOnTargets='ResolveAssemblyReferences;GenerateBuildDependencyFile;ResolvePackageAssets;CollectPackageReferences'>
       <ItemGroup>
         <InteractiveResolvedFile Remove='@(InteractiveResolvedFile)' />
         <InteractiveResolvedFile Include='@(ResolvedCompileFileDefinitions->ClearMetadata())' KeepDuplicates='false'>
@@ -268,7 +268,7 @@ $(PACKAGEREFERENCES)
       </ItemGroup>
   </Target>
 
-  <Target Name='InteractivePackageManagement' DependsOnTargets='ResolvePackageAssets;ComputePackageRootsForInteractivePackageManagement'>
+  <Target Name='InteractivePackageManagement' DependsOnTargets='ComputePackageRootsForInteractivePackageManagement'>
     <ItemGroup>
       <ReferenceLines Remove='@(ReferenceLines)' />
       <ReferenceLines Include='// Generated from #r ""nuget:Package References""' />

--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.Utilities.fs
@@ -221,12 +221,9 @@ module Utilities =
         let resultOutFile = if succeeded && File.Exists(outputFile) then Some outputFile else None
         succeeded, resultOutFile
 
-    // Generate a project files for dependencymanager projects
-    let generateLibrarySource = @"// Generated dependencymanager library
-namespace lib"
-
     let generateProjectBody = @"
 <Project Sdk='Microsoft.NET.Sdk'>
+
   <PropertyGroup>
     <TargetFramework>$(TARGETFRAMEWORK)</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -235,47 +232,8 @@ namespace lib"
     <FSharpCoreImplicitPackageVersion Condition=""'$(FSharpCoreImplicitPackageVersion)' == '{{FSharpCoreShippedPackageVersion}}'"">4.7.0</FSharpCoreImplicitPackageVersion>
     <FSharpCoreImplicitPackageVersion Condition=""'$(FSharpCoreImplicitPackageVersion)' == '{{FSharpCorePreviewPackageVersion}}'"">4.7.1-*</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include='Library.fs' />
-  </ItemGroup>
+
 $(PACKAGEREFERENCES)
-
-  <Target Name='CollectFSharpDesignTimeTools' BeforeTargets='BeforeCompile' DependsOnTargets='_GetFrameworkAssemblyReferences'>
-    <ItemGroup>
-      <PropertyNames Include = ""Pkg$([System.String]::Copy('%(PackageReference.FileName)').Replace('.','_'))"" Condition = "" '%(PackageReference.IsFSharpDesignTimeProvider)' == 'true' and '%(PackageReference.Extension)' == '' ""/>
-      <PropertyNames Include = ""Pkg$([System.String]::Copy('%(PackageReference.FileName)%(PackageReference.Extension)').Replace('.','_'))"" Condition = "" '%(PackageReference.IsFSharpDesignTimeProvider)' == 'true' and '%(PackageReference.Extension)' != '' ""/>
-      <FscCompilerTools Include = ""$(%(PropertyNames.Identity))"" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name=""PackageFSharpDesignTimeTools"" DependsOnTargets=""_GetFrameworkAssemblyReferences"">
-    <PropertyGroup>
-      <FSharpDesignTimeProtocol Condition = "" '$(FSharpDesignTimeProtocol)' == '' "">fsharp41</FSharpDesignTimeProtocol>
-      <FSharpToolsDirectory Condition = "" '$(FSharpToolsDirectory)' == '' "">tools</FSharpToolsDirectory>
-    </PropertyGroup>
-
-    <Error Text=""'$(FSharpToolsDirectory)' is an invalid value for 'FSharpToolsDirectory' valid values are 'typeproviders' and 'tools'."" Condition=""'$(FSharpToolsDirectory)' != 'typeproviders' and '$(FSharpToolsDirectory)' != 'tools'"" />
-    <Error Text=""The 'FSharpDesignTimeProtocol'  property can be only 'fsharp41'"" Condition=""'$(FSharpDesignTimeProtocol)' != 'fsharp41'"" />
-
-    <ItemGroup>
-      <_ResolvedOutputFiles
-          Include=""%(_ResolvedProjectReferencePaths.RootDir)%(_ResolvedProjectReferencePaths.Directory)/**/*""
-          Exclude=""%(_ResolvedProjectReferencePaths.RootDir)%(_ResolvedProjectReferencePaths.Directory)/**/FSharp.Core.dll;%(_ResolvedProjectReferencePaths.RootDir)%(_ResolvedProjectReferencePaths.Directory)/**/System.ValueTuple.dll""
-          Condition=""'%(_ResolvedProjectReferencePaths.IsFSharpDesignTimeProvider)' == 'true'"">
-        <NearestTargetFramework>%(_ResolvedProjectReferencePaths.NearestTargetFramework)</NearestTargetFramework>
-      </_ResolvedOutputFiles>
-
-      <_ResolvedOutputFiles
-          Include=""@(BuiltProjectOutputGroupKeyOutput)""
-          Condition=""'$(IsFSharpDesignTimeProvider)' == 'true' and '%(BuiltProjectOutputGroupKeyOutput->Filename)%(BuiltProjectOutputGroupKeyOutput->Extension)' != 'FSharp.Core.dll' and '%(BuiltProjectOutputGroupKeyOutput->Filename)%(BuiltProjectOutputGroupKeyOutput->Extension)' != 'System.ValueTuple.dll'"">
-        <NearestTargetFramework>$(TargetFramework)</NearestTargetFramework>
-      </_ResolvedOutputFiles>
-
-      <TfmSpecificPackageFile Include=""@(_ResolvedOutputFiles)"">
-         <PackagePath>$(FSharpToolsDirectory)/$(FSharpDesignTimeProtocol)/%(_ResolvedOutputFiles.NearestTargetFramework)/%(_ResolvedOutputFiles.FileName)%(_ResolvedOutputFiles.Extension)</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
-  </Target>
 
   <Target Name='ComputePackageRootsForInteractivePackageManagement'
           BeforeTargets='CoreCompile'
@@ -305,7 +263,7 @@ $(PACKAGEREFERENCES)
         <NativeIncludeRoots
             Include='@(RuntimeTargetsCopyLocalItems)'
             Condition=""'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'"">
-           <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))'))</Path>
+            <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))'))</Path>
         </NativeIncludeRoots>
       </ItemGroup>
   </Target>

--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.Utilities.fs
@@ -239,27 +239,19 @@ $(PACKAGEREFERENCES)
           BeforeTargets='CoreCompile'
           DependsOnTargets='ResolveAssemblyReferences;GenerateBuildDependencyFile;ResolvePackageAssets;CollectPackageReferences'>
       <ItemGroup>
-        <InteractiveResolvedFile Remove='@(InteractiveResolvedFile)' />
-        <InteractiveResolvedFile Include='@(ResolvedCompileFileDefinitions->ClearMetadata())' KeepDuplicates='false'>
+        <InteractiveReferencedAssembliesCopyLocal Include = ""@(RuntimeCopyLocalItems)"" Condition=""'$(TargetFrameworkIdentifier)'!='.NETFramework'"" />
+        <InteractiveReferencedAssembliesCopyLocal Include = ""@(ReferenceCopyLocalPaths)"" Condition=""'$(TargetFrameworkIdentifier)'=='.NETFramework'"" />
+        <InteractiveResolvedFile Include='@(InteractiveReferencedAssembliesCopyLocal)' KeepDuplicates='false'>
             <NormalizedIdentity Condition=""'%(Identity)'!=''"">$([System.String]::Copy('%(Identity)').Replace('\', '/'))</NormalizedIdentity>
-            <NormalizedPathInPackage Condition=""'%(ResolvedCompileFileDefinitions.PathInPackage)'!=''"">$([System.String]::Copy('%(ResolvedCompileFileDefinitions.PathInPackage)').Replace('\', '/'))</NormalizedPathInPackage>
+            <NormalizedPathInPackage Condition=""'%(InteractiveReferencedAssembliesCopyLocal.PathInPackage)'!=''"">$([System.String]::Copy('%(InteractiveReferencedAssembliesCopyLocal.PathInPackage)').Replace('\', '/'))</NormalizedPathInPackage>
             <PositionPathInPackage Condition=""'%(InteractiveResolvedFile.NormalizedPathInPackage)'!=''"">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').IndexOf('%(InteractiveResolvedFile.NormalizedPathInPackage)'))</PositionPathInPackage>
             <PackageRoot Condition=""'%(InteractiveResolvedFile.NormalizedPathInPackage)'!='' and '%(InteractiveResolvedFile.PositionPathInPackage)'!='-1'"">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').Substring(0, %(InteractiveResolvedFile.PositionPathInPackage)))</PackageRoot>
-            <InitializeSourcePath>%(InteractiveResolvedFile.PackageRoot)content\%(ResolvedCompileFileDefinitions.FileName)%(ResolvedCompileFileDefinitions.Extension).fsx</InitializeSourcePath>
-            <IsNotImplementationReference>$([System.String]::Copy('%(ResolvedCompileFileDefinitions.PathInPackage)').StartsWith('ref/'))</IsNotImplementationReference>
-            <NuGetPackageId>%(ResolvedCompileFileDefinitions.NuGetPackageId)</NuGetPackageId>
-            <NuGetPackageVersion>%(ResolvedCompileFileDefinitions.NuGetPackageVersion)</NuGetPackageVersion>
+            <InitializeSourcePath>%(InteractiveResolvedFile.PackageRoot)content\%(InteractiveReferencedAssembliesCopyLocal.FileName)%(InteractiveReferencedAssembliesCopyLocal.Extension).fsx</InitializeSourcePath>
+            <IsNotImplementationReference>$([System.String]::Copy('%(InteractiveReferencedAssembliesCopyLocal.PathInPackage)').StartsWith('ref/'))</IsNotImplementationReference>
+            <NuGetPackageId>%(InteractiveReferencedAssembliesCopyLocal.NuGetPackageId)</NuGetPackageId>
+            <NuGetPackageVersion>%(InteractiveReferencedAssembliesCopyLocal.NuGetPackageVersion)</NuGetPackageVersion>
         </InteractiveResolvedFile>
-        <InteractiveResolvedFile Include='@(RuntimeCopyLocalItems->ClearMetadata())' KeepDuplicates='false' >
-            <NormalizedIdentity Condition=""'%(Identity)'!=''"">$([System.String]::Copy('%(Identity)').Replace('\', '/'))</NormalizedIdentity>
-            <NormalizedPathInPackage Condition=""'%(RuntimeCopyLocalItems.PathInPackage)'!=''"">$([System.String]::Copy('%(RuntimeCopyLocalItems.PathInPackage)').Replace('\', '/'))</NormalizedPathInPackage>
-            <PositionPathInPackage Condition=""'%(InteractiveResolvedFile.NormalizedPathInPackage)'!=''"">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').IndexOf('%(InteractiveResolvedFile.NormalizedPathInPackage)'))</PositionPathInPackage>
-            <PackageRoot Condition=""'%(InteractiveResolvedFile.NormalizedPathInPackage)'!='' and '%(InteractiveResolvedFile.PositionPathInPackage)'!='-1'"">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').Substring(0, %(InteractiveResolvedFile.PositionPathInPackage)))</PackageRoot>
-            <InitializeSourcePath>%(InteractiveResolvedFile.PackageRoot)content\%(RuntimeCopyLocalItems.FileName)%(RuntimeCopyLocalItems.Extension).fsx</InitializeSourcePath>
-            <IsNotImplementationReference>$([System.String]::Copy('%(RuntimeCopyLocalItems.PathInPackage)').StartsWith('ref/'))</IsNotImplementationReference>
-            <NuGetPackageId>%(RuntimeCopyLocalItems.NuGetPackageId)</NuGetPackageId>
-            <NuGetPackageVersion>%(RuntimeCopyLocalItems.NuGetPackageVersion)</NuGetPackageVersion>
-        </InteractiveResolvedFile>
+
         <NativeIncludeRoots
             Include='@(RuntimeTargetsCopyLocalItems)'
             Condition=""'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'"">

--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.fs
@@ -28,10 +28,10 @@ module FSharpDependencyManager =
         let { Include=inc; Version=ver; RestoreSources=src; Script=script } = p
         seq {
             match not (String.IsNullOrEmpty(inc)), not (String.IsNullOrEmpty(ver)), not (String.IsNullOrEmpty(script)) with
-            | true, true, false  -> yield sprintf @"  <ItemGroup><PackageReference Include='%s' Version='%s'><GeneratePathProperty>true</GeneratePathProperty></PackageReference></ItemGroup>" inc ver
-            | true, true, true   -> yield sprintf @"  <ItemGroup><PackageReference Include='%s' Version='%s' Script='%s'><GeneratePathProperty>true</GeneratePathProperty></PackageReference></ItemGroup>" inc ver script
-            | true, false, false -> yield sprintf @"  <ItemGroup><PackageReference Include='%s'><GeneratePathProperty>true</GeneratePathProperty></PackageReference></ItemGroup>" inc
-            | true, false, true  -> yield sprintf @"  <ItemGroup><PackageReference Include='%s' Script='%s'><GeneratePathProperty>true</GeneratePathProperty></PackageReference></ItemGroup>" inc script
+            | true, true, false  -> yield sprintf @"  <ItemGroup><PackageReference Include='%s' Version='%s' /></ItemGroup>" inc ver
+            | true, true, true   -> yield sprintf @"  <ItemGroup><PackageReference Include='%s' Version='%s' Script='%s' /></ItemGroup>" inc ver script
+            | true, false, false -> yield sprintf @"  <ItemGroup><PackageReference Include='%s' /></ItemGroup>" inc
+            | true, false, true  -> yield sprintf @"  <ItemGroup><PackageReference Include='%s' Script='%s' /></ItemGroup>" inc script
             | _ -> ()
             match not (String.IsNullOrEmpty(src)) with
             | true -> yield sprintf @"  <PropertyGroup><RestoreAdditionalProjectSources>%s</RestoreAdditionalProjectSources></PropertyGroup>" (concat "$(RestoreAdditionalProjectSources)" src)
@@ -158,7 +158,6 @@ type [<DependencyManagerAttribute>] FSharpDependencyManager (outputDir:string op
                 generateProjectBody.Replace("$(TARGETFRAMEWORK)", tfm)
                                    .Replace("$(PACKAGEREFERENCES)", packageReferenceText)
 
-            writeFile (Path.Combine(scriptsPath, "Library.fs")) generateLibrarySource
             writeFile fsProjectPath generateProjBody
 
             let succeeded, resultingFsx = buildProject fsProjectPath binLogPath

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -27,14 +27,14 @@ type DependencyManagerInteractiveTests() =
     [<Test>]
     member __.``SmokeTest - #r nuget``() =
         let text = """
-#r @"nuget:System.Collections.Immutable, version=1.5.0"
+#r @"nuget:Newtonsoft.Json, Version=9.0.1"
 0"""
         use script = scriptHost()
         let mutable assemblyResolveEventCount = 0
         let mutable foundAssemblyReference = false
         Event.add (fun (assembly: string) ->
             assemblyResolveEventCount <- assemblyResolveEventCount + 1
-            foundAssemblyReference <- String.Compare("System.Collections.Immutable.dll", Path.GetFileName(assembly), StringComparison.OrdinalIgnoreCase) = 0)
+            foundAssemblyReference <- String.Compare("Newtonsoft.Json.dll", Path.GetFileName(assembly), StringComparison.OrdinalIgnoreCase) = 0)
             script.AssemblyReferenceAdded
         let opt = script.Eval(text) |> getValue
         let value = opt.Value
@@ -61,7 +61,7 @@ type DependencyManagerInteractiveTests() =
 
     [<Test>]
     member __.``Dependency add events successful``() =
-        let referenceText = "System.Collections.Immutable, version=1.5.0"
+        let referenceText = "Newtonsoft.Json, Version=9.0.1"
         let text = referenceText |> sprintf """
 #r @"nuget:%s"
 0"""
@@ -118,6 +118,6 @@ type DependencyManagerInteractiveTests() =
         use script = scriptHost()
         let mutable dependencyAddingEventCount = 0
         Event.add (fun _ -> dependencyAddingEventCount <- dependencyAddingEventCount + 1) script.DependencyAdding
-        script.Eval("#r \"nuget:System.Collections.Immutable, Version=1.5.0\"") |> ignoreValue
+        script.Eval("#r \"nuget:NUnit.ConsoleRunner, Version=3.10.0\"") |> ignoreValue
         script.Eval("#r \"nuget:Newtonsoft.Json, Version=9.0.1\"\n0") |> ignoreValue
         Assert.AreEqual(2, dependencyAddingEventCount)


### PR DESCRIPTION
1. The generated nuget project file had a couple of targets that were no longer used.
2. We generated a .fs file that was not used
3. GeneratePathProperty is no longer used to get package root.

Remove the targets, stop generating the fs file, stop including GeneratePathProperty .