### PR TITLE
safely delete test files and directories

### DIFF
--- a/vsintegration/tests/UnitTests/ProjectOptionsBuilder.fs
+++ b/vsintegration/tests/UnitTests/ProjectOptionsBuilder.fs
@@ -5,6 +5,19 @@ open System.IO
 open System.Xml.Linq
 open FSharp.Compiler.SourceCodeServices
 
+module FileSystemHelpers =
+    let safeDeleteFile (path: string) =
+        try
+            File.Delete(path)
+        with
+        | _ -> ()
+
+    let safeDeleteDirectory (path: string) =
+        try
+            Directory.Delete(path)
+        with
+        | _ -> ()
+
 type FSharpProject =
     {
         Directory: string
@@ -29,9 +42,10 @@ type FSharpProject =
         member this.Dispose() =
             // delete each source file
             this.Files
-            |> List.iter (fun (path, _contents) -> File.Delete(path))
+            |> List.map fst
+            |> List.iter FileSystemHelpers.safeDeleteFile
             // delete the directory
-            Directory.Delete(this.Directory)
+            FileSystemHelpers.safeDeleteDirectory (this.Directory)
             // project file doesn't really exist, nothing to delete
             ()
 


### PR DESCRIPTION
Some QuickInfo tests are failing on cleanup because the temporary file can't be accessed.