### PR TITLE
Phillips original PR --- Add type name to error, if it's known, to undefined name error 

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -4,6 +4,7 @@
 undefinedNameNamespace,"The namespace '%s' is not defined."
 undefinedNameNamespaceOrModule,"The namespace or module '%s' is not defined."
 undefinedNameFieldConstructorOrMember,"The field, constructor or member '%s' is not defined."
+undefinedNameFieldConstructorOrMemberWhenTypeIsKnown,"The type '%s' does not define the field, constructor or member '%s'."
 undefinedNameValueConstructorNamespaceOrType,"The value, constructor, namespace or type '%s' is not defined."
 undefinedNameValueOfConstructor,"The value or constructor '%s' is not defined."
 undefinedNameValueNamespaceTypeOrModule,"The value, namespace, type or module '%s' is not defined."

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -2362,7 +2362,7 @@ let rec ResolveLongIdentInTypePrim (ncenv: NameResolver) nenv lookupKind (resInf
         let errorTextF s =
             if isAppTy g ty then
                 let tcref = tcrefOfAppTy g ty
-                FSComp.SR.undefinedNameFieldConstructorOrMemberWhenTypeIsKnown(tcref.DisplayName, s)
+                FSComp.SR.undefinedNameFieldConstructorOrMemberWhenTypeIsKnown(tcref.DisplayNameWithStaticParametersAndTypars, s)
             else
                 FSComp.SR.undefinedNameFieldConstructorOrMember(s)
 

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -2359,7 +2359,14 @@ let rec ResolveLongIdentInTypePrim (ncenv: NameResolver) nenv lookupKind (resInf
                 | _ -> ()
             | _ -> ()
 
-        raze (UndefinedName (depth, FSComp.SR.undefinedNameFieldConstructorOrMember, id, suggestMembers))
+        let errorTextF s =
+            if isAppTy g ty then
+                let tcref = tcrefOfAppTy g ty
+                FSComp.SR.undefinedNameFieldConstructorOrMemberWhenTypeIsKnown(tcref.DisplayName, s)
+            else
+                FSComp.SR.undefinedNameFieldConstructorOrMember(s)
+
+        raze (UndefinedName (depth, errorTextF, id, suggestMembers))
 
 and ResolveLongIdentInNestedTypes (ncenv: NameResolver) nenv lookupKind resInfo depth id m ad (id2: Ident) (rest: Ident list) findFlag typeNameResInfo tys =
     tys

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -702,13 +702,16 @@ and /// Represents a type definition, exception definition, module definition or
         | _ -> x.entity_opt_data <- Some { Entity.NewEmptyEntityOptData() with entity_compiled_name = name }
 
     /// The display name of the namespace, module or type, e.g. List instead of List`1, and no static parameters
-    member x.DisplayName = x.GetDisplayName(false, false)
+    member x.DisplayName = x.GetDisplayName()
+
+    /// The display name of the namespace, module or type with <'T, 'U, 'V> added for generic types, plus static parameters if any
+    member x.DisplayNameWithStaticParametersAndTypars = x.GetDisplayName(withStaticParameters=true, withTypars=true, withUnderscoreTypars=false)
 
     /// The display name of the namespace, module or type with <_, _, _> added for generic types, plus static parameters if any
-    member x.DisplayNameWithStaticParametersAndUnderscoreTypars = x.GetDisplayName(true, true)
+    member x.DisplayNameWithStaticParametersAndUnderscoreTypars = x.GetDisplayName(withStaticParameters=true, withTypars=false, withUnderscoreTypars=true)
 
     /// The display name of the namespace, module or type, e.g. List instead of List`1, including static parameters if any
-    member x.DisplayNameWithStaticParameters = x.GetDisplayName(true, false)
+    member x.DisplayNameWithStaticParameters = x.GetDisplayName(withStaticParameters=true, withTypars=false, withUnderscoreTypars=false)
 
 #if !NO_EXTENSIONTYPING
     member x.IsStaticInstantiationTycon = 
@@ -717,15 +720,20 @@ and /// Represents a type definition, exception definition, module definition or
             args.Length > 0 
 #endif
 
-    member x.GetDisplayName(withStaticParameters, withUnderscoreTypars) = 
+    member x.GetDisplayName(?withStaticParameters, ?withTypars, ?withUnderscoreTypars) =
+        let withStaticParameters = defaultArg withStaticParameters false
+        let withTypars = defaultArg withTypars false
+        let withUnderscoreTypars = defaultArg withUnderscoreTypars false
         let nm = x.LogicalName
+
         let getName () =
             match x.TyparsNoRange with 
             | [] -> nm
             | tps -> 
                 let nm = DemangleGenericTypeName nm
-                if withUnderscoreTypars && not (List.isEmpty tps) then 
-                    nm + "<" + String.concat "," (Array.create tps.Length "_") + ">"
+                if (withUnderscoreTypars || withTypars) && not (List.isEmpty tps) then
+                    let typearNames = tps |> List.map (fun typar -> if withUnderscoreTypars then "_" else typar.Name)
+                    nm + "<" + String.concat "," typearNames + ">"
                 else
                     nm
 
@@ -854,7 +862,7 @@ and /// Represents a type definition, exception definition, module definition or
     member x.Typars m = x.entity_typars.Force m
 
     /// Get the type parameters for an entity that is a type declaration, otherwise return the empty list.
-    member x.TyparsNoRange = x.Typars x.Range
+    member x.TyparsNoRange: Typars = x.Typars x.Range
 
     /// Get the type abbreviated by this type definition, if it is an F# type abbreviation definition
     member x.TypeAbbrev = 
@@ -3361,6 +3369,9 @@ and
 
     /// The display name of the namespace, module or type, e.g. List instead of List`1, not including static parameters
     member x.DisplayName = x.Deref.DisplayName
+
+    /// The display name of the namespace, module or type with <'T, 'U, 'V> added for generic types, including static parameters
+    member x.DisplayNameWithStaticParametersAndTypars = x.Deref.DisplayNameWithStaticParametersAndTypars
 
     /// The display name of the namespace, module or type with <_, _, _> added for generic types, including static parameters
     member x.DisplayNameWithStaticParametersAndUnderscoreTypars = x.Deref.DisplayNameWithStaticParametersAndUnderscoreTypars

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Algoritmus {0} není podporovaný.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Atributy nejde použít pro rozšíření typů.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Algoritmus {0} není podporovaný.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Atributy nejde použít pro rozšíření typů.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Algorithmus "{0}" wird nicht unterstützt</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Attribute können nicht auf Typerweiterungen angewendet werden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Algorithmus "{0}" wird nicht unterstützt</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Attribute können nicht auf Typerweiterungen angewendet werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -57,11 +57,6 @@
         <target state="translated">No se admite el algoritmo '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Los atributos no se pueden aplicar a las extensiones de tipo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">No se admite el algoritmo '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Los atributos no se pueden aplicar a las extensiones de tipo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Algorithme '{0}' non pris en charge</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Impossible d'appliquer des attributs aux extensions de type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Algorithme '{0}' non pris en charge</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Impossible d'appliquer des attributs aux extensions de type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">L'algoritmo '{0}' non è supportato</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Gli attributi non possono essere applicati a estensioni di tipo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -57,11 +57,6 @@
         <target state="translated">L'algoritmo '{0}' non è supportato</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Gli attributi non possono essere applicati a estensioni di tipo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">アルゴリズム '{0}' はサポートされていません</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">属性を型拡張に適用することはできません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -57,11 +57,6 @@
         <target state="translated">アルゴリズム '{0}' はサポートされていません</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">属性を型拡張に適用することはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0}' 알고리즘은 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">형식 확장에 특성을 적용할 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -57,11 +57,6 @@
         <target state="translated">{0}' 알고리즘은 지원되지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">형식 확장에 특성을 적용할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Algorytm „{0}” nie jest obsługiwany</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Atrybutów nie można stosować do rozszerzeń typu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Algorytm „{0}” nie jest obsługiwany</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Atrybutów nie można stosować do rozszerzeń typu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Algoritmo '{0}' sem suporte</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Os atributos não podem ser aplicados às extensões de tipo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Algoritmo '{0}' sem suporte</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Os atributos não podem ser aplicados às extensões de tipo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Алгоритм "{0}" не поддерживается</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Атрибуты не могут быть применены к расширениям типа.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Алгоритм "{0}" не поддерживается</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Атрибуты не могут быть применены к расширениям типа.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -57,11 +57,6 @@
         <target state="translated">{0}' algoritması desteklenmiyor</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">Öznitelikler tür uzantılarına uygulanamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">{0}' algoritması desteklenmiyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Öznitelikler tür uzantılarına uygulanamaz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -57,11 +57,6 @@
         <target state="translated">不支持算法“{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">属性不可应用于类型扩展。</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">不支持算法“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">属性不可应用于类型扩展。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -57,11 +57,6 @@
         <target state="translated">不支援演算法 '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcAndBangNotSupported">
-        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
-        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -82,14 +77,9 @@
         <target state="translated">屬性無法套用到類型延伸模組。</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
-        <source>use! may not be combined with and!</source>
-        <target state="new">use! may not be combined with and!</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="tcRequireMergeSourcesOrBindN">
-        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
-        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
+      <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">
+        <source>The type '{0}' does not define the field, constructor or member '{1}'.</source>
+        <target state="new">The type '{0}' does not define the field, constructor or member '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameNamespace">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">不支援演算法 '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcAndBangNotSupported">
+        <source>This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</source>
+        <target state="new">This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcAnonRecdFieldNameDifferent">
         <source>This is the wrong anonymous record. It should have the fields {0}.</source>
         <target state="new">This is the wrong anonymous record. It should have the fields {0}.</target>
@@ -75,6 +80,16 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">屬性無法套用到類型延伸模組。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcInvalidUseBangBindingNoAndBangs">
+        <source>use! may not be combined with and!</source>
+        <target state="new">use! may not be combined with and!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRequireMergeSourcesOrBindN">
+        <source>The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</source>
+        <target state="new">The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a '{0}' method or appropriate 'MergeSource' and 'Bind' methods</target>
         <note />
       </trans-unit>
       <trans-unit id="undefinedNameFieldConstructorOrMemberWhenTypeIsKnown">

--- a/tests/fsharp/Compiler/ErrorMessages/SuggestionsTests.fs
+++ b/tests/fsharp/Compiler/ErrorMessages/SuggestionsTests.fs
@@ -19,7 +19,7 @@ let x = { Person.Names = "Isaac" }
             FSharpErrorSeverity.Error
             39
             (4, 18, 4, 23)
-            "The field, constructor or member 'Names' is not defined. Maybe you want one of the following:\r\n   Name"
+            "The type 'Person' does not define the field, constructor or member 'Names'. Maybe you want one of the following:\r\n   Name"
 
 
     [<Test>]
@@ -94,7 +94,7 @@ let x = N.MyUnion.``My Case2``
             FSharpErrorSeverity.Error
             39
             (9, 19, 9,31)
-            "The field, constructor or member 'My Case2' is not defined. Maybe you want one of the following:\r\n   My Case1\r\n   Case2"
+            "The type 'MyUnion' does not define the field, constructor or member 'My Case2'. Maybe you want one of the following:\r\n   My Case1\r\n   Case2"
 
 
     [<Test>]
@@ -142,7 +142,7 @@ module Test2 =
             FSharpErrorSeverity.Error
             39
             (9, 7, 9, 14)
-            "The field, constructor or member 'Method2' is not defined. Maybe you want one of the following:\r\n   Method1"
+            "The type 'D' does not define the field, constructor or member 'Method2'. Maybe you want one of the following:\r\n   Method1"
 
 
     [<Test>]
@@ -186,7 +186,7 @@ let x = r.ello
             FSharpErrorSeverity.Error
             39
             (6, 11, 6, 15)
-            "The field, constructor or member 'ello' is not defined. Maybe you want one of the following:\r\n   Hello"
+            "The type 'MyRecord' does not define the field, constructor or member 'ello'. Maybe you want one of the following:\r\n   Hello"
 
 
     [<Test>]
@@ -278,7 +278,7 @@ let u = MyUnion.AntherCase
             FSharpErrorSeverity.Error
             39
             (6, 17, 6, 27)
-            "The field, constructor or member 'AntherCase' is not defined. Maybe you want one of the following:\r\n   AnotherCase"
+            "The type 'MyUnion' does not define the field, constructor or member 'AntherCase'. Maybe you want one of the following:\r\n   AnotherCase"
 
 
     [<Test>]
@@ -317,4 +317,4 @@ let x =
             FSharpErrorSeverity.Error
             39
             (11, 15, 11, 19)
-            "The field, constructor or member 'Cas1' is not defined. Maybe you want one of the following:\r\n   Case1\r\n   Case2"
+            "The type 'MyUnion' does not define the field, constructor or member 'Cas1'. Maybe you want one of the following:\r\n   Case1\r\n   Case2"

--- a/tests/fsharp/Compiler/Language/CustomCollectionTests.fs
+++ b/tests/fsharp/Compiler/Language/CustomCollectionTests.fs
@@ -101,8 +101,7 @@ if a.[^2] <> 12 then failwith "expected 12"
             FSharpErrorSeverity.Error
             39
             (9,7,9,9)
-            "The field, constructor or member 'GetReverseIndex' is not defined."
-
+            "The type 'foo' does not define the field, constructor or member 'GetReverseIndex'."
 
     [<Test>]
     let ``Custom collection with GetSlice and GetReverseIndex should support reverse index slicing``() =
@@ -142,4 +141,4 @@ if a.[^2..1] <> 13 then failwith "expected 13"
             FSharpErrorSeverity.Error
             39
             (12,7,12,9)
-            "The field, constructor or member 'GetReverseIndex' is not defined."
+            "The type 'foo' does not define the field, constructor or member 'GetReverseIndex'."

--- a/tests/fsharp/Compiler/Language/FixedIndexSliceTests.fs
+++ b/tests/fsharp/Compiler/Language/FixedIndexSliceTests.fs
@@ -83,7 +83,7 @@ arr3.[*, 1, *] <- arr1
 arr3.[*, 1, 1] <- arr1
             """
             [|
-                FSharpErrorSeverity.Error, 39, (7,1,7,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice"
+                FSharpErrorSeverity.Error, 39, (7,1,7,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."
                 FSharpErrorSeverity.Error, 39, (8,1,8,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."
                 FSharpErrorSeverity.Error, 39, (9,1,9,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."
                 FSharpErrorSeverity.Error, 39, (10,1,10,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."

--- a/tests/fsharp/Compiler/Language/FixedIndexSliceTests.fs
+++ b/tests/fsharp/Compiler/Language/FixedIndexSliceTests.fs
@@ -21,12 +21,12 @@ arr3.[*, 1, *]
 arr3.[*, 1, 1]
             """
             [|
-                FSharpErrorSeverity.Error, 39, (5,1,5,15), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (6,1,6,15), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (7,1,7,15), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (8,1,8,15), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (9,1,9,15), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (10,1,10,15), "The field, constructor or member 'GetSlice' is not defined."
+                FSharpErrorSeverity.Error, 39, (5,1,5,15), "The type '[,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (6,1,6,15), "The type '[,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (7,1,7,15), "The type '[,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (8,1,8,15), "The type '[,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (9,1,9,15), "The type '[,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (10,1,10,15), "The type '[,,]<T>' does not define the field, constructor or member 'GetSlice'."
             |]
 
     [<Test>]
@@ -51,19 +51,19 @@ arr4.[1, 1, 1, *]
 arr4.[*, 1, 1, 1]
             """
             [|
-                FSharpErrorSeverity.Error, 39, (5,1,5,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (6,1,6,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (7,1,7,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (8,1,8,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (9,1,9,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (10,1,10,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (11,1,11,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (12,1,12,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (13,1,13,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (14,1,14,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (15,1,15,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (16,1,16,18), "The field, constructor or member 'GetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (17,1,17,18), "The field, constructor or member 'GetSlice' is not defined."
+                FSharpErrorSeverity.Error, 39, (5,1,5,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (6,1,6,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (7,1,7,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (8,1,8,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (9,1,9,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (10,1,10,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (11,1,11,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (12,1,12,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (13,1,13,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (14,1,14,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (15,1,15,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (16,1,16,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
+                FSharpErrorSeverity.Error, 39, (17,1,17,18), "The type '[,,,]<T>' does not define the field, constructor or member 'GetSlice'."
             |]
             
     [<Test>]
@@ -83,12 +83,12 @@ arr3.[*, 1, *] <- arr1
 arr3.[*, 1, 1] <- arr1
             """
             [|
-                FSharpErrorSeverity.Error, 39, (7,1,7,15), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (8,1,8,15), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (9,1,9,15), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (10,1,10,15), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (11,1,11,15), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (12,1,12,15), "The field, constructor or member 'SetSlice' is not defined."
+                FSharpErrorSeverity.Error, 39, (7,1,7,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice"
+                FSharpErrorSeverity.Error, 39, (8,1,8,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (9,1,9,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (10,1,10,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (11,1,11,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (12,1,12,15), "The type '[,,]<T>' does not define the field, constructor or member 'SetSlice'."
             |]
 
     [<Test>]
@@ -117,23 +117,18 @@ arr4.[1, 1, 1, *] <- arr1
 arr4.[*, 1, 1, 1] <- arr1
             """
             [|
-                FSharpErrorSeverity.Error, 39, (8,1,8,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (9,1,9,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (10,1,10,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (11,1,11,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (12,1,12,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (13,1,13,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (14,1,14,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (15,1,15,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (16,1,16,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (17,1,17,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (18,1,18,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (19,1,19,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (20,1,20,18), "The field, constructor or member 'SetSlice' is not defined."
-                FSharpErrorSeverity.Error, 39, (21,1,21,18), "The field, constructor or member 'SetSlice' is not defined."
+                FSharpErrorSeverity.Error, 39, (8,1,8,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (9,1,9,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (10,1,10,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (11,1,11,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (12,1,12,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (13,1,13,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (14,1,14,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (15,1,15,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (16,1,16,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (17,1,17,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (18,1,18,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (19,1,19,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (20,1,20,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
+                FSharpErrorSeverity.Error, 39, (21,1,21,18), "The type '[,,,]<T>' does not define the field, constructor or member 'SetSlice'."
             |]
-
-
-
-
-

--- a/tests/fsharp/conformance/expressions/syntacticsugar/E_Slices01.bsl
+++ b/tests/fsharp/conformance/expressions/syntacticsugar/E_Slices01.bsl
@@ -7,7 +7,7 @@ E_Slices01.fsx(24,9,24,19): typecheck error FS0041: A unique overload for method
 
 E_Slices01.fsx(25,9,25,17): typecheck error FS0041: A unique overload for method 'GetSlice' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: member Foo.GetSlice : x1:float option * x2:int option * y:int -> unit, member Foo.GetSlice : x1:int option * x2:int option * y:int -> unit
 
-E_Slices01.fsx(26,9,26,17): typecheck error FS0039: The type 'Foo' does not define the field, constructor or member 'Item'.
+E_Slices01.fsx(26,9,26,17): typecheck error FS0039: The type 'Foo<a>' does not define the field, constructor or member 'Item'.
 
 E_Slices01.fsx(27,9,27,26): typecheck error FS0503: A member or object constructor 'GetSlice' taking 4 arguments is not accessible from this code location. All accessible versions of method 'GetSlice' take 3 arguments.
 

--- a/tests/fsharp/conformance/expressions/syntacticsugar/E_Slices01.bsl
+++ b/tests/fsharp/conformance/expressions/syntacticsugar/E_Slices01.bsl
@@ -7,7 +7,7 @@ E_Slices01.fsx(24,9,24,19): typecheck error FS0041: A unique overload for method
 
 E_Slices01.fsx(25,9,25,17): typecheck error FS0041: A unique overload for method 'GetSlice' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: member Foo.GetSlice : x1:float option * x2:int option * y:int -> unit, member Foo.GetSlice : x1:int option * x2:int option * y:int -> unit
 
-E_Slices01.fsx(26,9,26,17): typecheck error FS0039: The field, constructor or member 'Item' is not defined.
+E_Slices01.fsx(26,9,26,17): typecheck error FS0039: The type 'Foo' does not define the field, constructor or member 'Item'.
 
 E_Slices01.fsx(27,9,27,26): typecheck error FS0503: A member or object constructor 'GetSlice' taking 4 arguments is not accessible from this code location. All accessible versions of method 'GetSlice' take 3 arguments.
 

--- a/tests/fsharp/typecheck/sigs/neg04.bsl
+++ b/tests/fsharp/typecheck/sigs/neg04.bsl
@@ -12,7 +12,6 @@ neg04.fs(22,8,22,17): typecheck error FS0912: This declaration element is not pe
 neg04.fs(26,8,26,17): typecheck error FS0912: This declaration element is not permitted in an augmentation
 
 neg04.fs(32,8,32,11): typecheck error FS0039: The type 'Double' does not define the field, constructor or member 'Nan'. Maybe you want one of the following:
-
    IsNaN
 
 neg04.fs(46,69,46,94): typecheck error FS0001: Type mismatch. Expecting a

--- a/tests/fsharp/typecheck/sigs/neg04.bsl
+++ b/tests/fsharp/typecheck/sigs/neg04.bsl
@@ -11,7 +11,8 @@ neg04.fs(22,8,22,17): typecheck error FS0912: This declaration element is not pe
 
 neg04.fs(26,8,26,17): typecheck error FS0912: This declaration element is not permitted in an augmentation
 
-neg04.fs(32,8,32,11): typecheck error FS0039: The field, constructor or member 'Nan' is not defined. Maybe you want one of the following:
+neg04.fs(32,8,32,11): typecheck error FS0039: The type 'Double' does not define the field, constructor or member 'Nan'. Maybe you want one of the following:
+
    IsNaN
 
 neg04.fs(46,69,46,94): typecheck error FS0001: Type mismatch. Expecting a
@@ -68,7 +69,7 @@ but here has type
 
 neg04.fs(83,39,83,46): typecheck error FS0752: The operator 'expr.[idx]' has been used on an object of indeterminate type based on information prior to this program point. Consider adding further type constraints
 
-neg04.fs(85,47,85,52): typecheck error FS0039: The field, constructor or member 'Item' is not defined.
+neg04.fs(85,47,85,52): typecheck error FS0039: The type 'Int32' does not define the field, constructor or member 'Item'.
 
 neg04.fs(87,73,87,78): typecheck error FS0752: The operator 'expr.[idx]' has been used on an object of indeterminate type based on information prior to this program point. Consider adding further type constraints
 

--- a/tests/fsharp/typecheck/sigs/neg06.bsl
+++ b/tests/fsharp/typecheck/sigs/neg06.bsl
@@ -1,5 +1,6 @@
 
-neg06.fs(3,40,3,45): typecheck error FS0039: The field, constructor or member 'Ascii' is not defined. Maybe you want one of the following:
+neg06.fs(3,40,3,45): typecheck error FS0039: The type 'Encoding' does not define the field, constructor or member 'Ascii'. Maybe you want one of the following:
+
    ASCII
 
 neg06.fs(12,6,12,31): typecheck error FS0942: Struct types are always sealed

--- a/tests/fsharp/typecheck/sigs/neg06.bsl
+++ b/tests/fsharp/typecheck/sigs/neg06.bsl
@@ -1,6 +1,5 @@
 
 neg06.fs(3,40,3,45): typecheck error FS0039: The type 'Encoding' does not define the field, constructor or member 'Ascii'. Maybe you want one of the following:
-
    ASCII
 
 neg06.fs(12,6,12,31): typecheck error FS0942: Struct types are always sealed

--- a/tests/fsharp/typecheck/sigs/neg08.bsl
+++ b/tests/fsharp/typecheck/sigs/neg08.bsl
@@ -19,6 +19,6 @@ neg08.fs(55,7,55,14): typecheck error FS0773: Cannot create an extension of a se
 
 neg08.fs(55,7,55,14): typecheck error FS0776: Object construction expressions may only be used to implement constructors in class types
 
-neg08.fs(61,19,61,26): typecheck error FS0039: The field, constructor or member 'value__' is not defined.
+neg08.fs(61,19,61,26): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'value__'.
 
 neg08.fs(79,5,79,44): typecheck error FS0502: The member or object constructor 'Random' takes 0 type argument(s) but is here given 1. The required signature is 'static member Variable.Random : y:Variable<'a> -> Variable<'a>'.

--- a/tests/fsharp/typecheck/sigs/neg101.bsl
+++ b/tests/fsharp/typecheck/sigs/neg101.bsl
@@ -1,5 +1,5 @@
 
-neg101.fs(7,11,7,14): typecheck error FS0039: The field, constructor or member 'Foo' is not defined.
+neg101.fs(7,11,7,14): typecheck error FS0039: The type 'Int32' does not define the field, constructor or member 'Foo'.
 
 neg101.fs(14,6,14,17): typecheck error FS3220: This method or property is not normally used from F# code, use an explicit tuple pattern for deconstruction instead.
 

--- a/tests/fsharp/typecheck/sigs/neg17.bsl
+++ b/tests/fsharp/typecheck/sigs/neg17.bsl
@@ -8,13 +8,11 @@ neg17b.fs(8,18,8,43): typecheck error FS1092: The type 'PrivateUnionType' is not
 neg17b.fs(11,26,11,41): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'PrivateProperty'.
 
 neg17b.fs(12,24,12,45): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'PrivateStaticProperty'. Maybe you want one of the following:
-
    InternalStaticProperty
 
 neg17b.fs(13,26,13,39): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'PrivateMethod'.
 
 neg17b.fs(14,24,14,43): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'PrivateStaticMethod'. Maybe you want one of the following:
-
    InternalStaticMethod
 
 neg17b.fs(15,17,15,52): typecheck error FS1092: The type 'PrivateRecordType' is not accessible from this code location

--- a/tests/fsharp/typecheck/sigs/neg17.bsl
+++ b/tests/fsharp/typecheck/sigs/neg17.bsl
@@ -5,14 +5,16 @@ neg17b.fs(7,17,7,31): typecheck error FS1094: The value 'privateValue' is not ac
 
 neg17b.fs(8,18,8,43): typecheck error FS1092: The type 'PrivateUnionType' is not accessible from this code location
 
-neg17b.fs(11,26,11,41): typecheck error FS0039: The field, constructor or member 'PrivateProperty' is not defined.
+neg17b.fs(11,26,11,41): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'PrivateProperty'.
 
-neg17b.fs(12,24,12,45): typecheck error FS0039: The field, constructor or member 'PrivateStaticProperty' is not defined. Maybe you want one of the following:
+neg17b.fs(12,24,12,45): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'PrivateStaticProperty'. Maybe you want one of the following:
+
    InternalStaticProperty
 
-neg17b.fs(13,26,13,39): typecheck error FS0039: The field, constructor or member 'PrivateMethod' is not defined.
+neg17b.fs(13,26,13,39): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'PrivateMethod'.
 
-neg17b.fs(14,24,14,43): typecheck error FS0039: The field, constructor or member 'PrivateStaticMethod' is not defined. Maybe you want one of the following:
+neg17b.fs(14,24,14,43): typecheck error FS0039: The type 'Type' does not define the field, constructor or member 'PrivateStaticMethod'. Maybe you want one of the following:
+
    InternalStaticMethod
 
 neg17b.fs(15,17,15,52): typecheck error FS1092: The type 'PrivateRecordType' is not accessible from this code location

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -407,10 +407,10 @@ neg20.fs(373,22,373,41): typecheck error FS1124: Multiple types exist called 'Ov
 
 neg20.fs(382,19,382,40): typecheck error FS1124: Multiple types exist called 'OverloadedClassName', taking different numbers of generic parameters. Provide a type instantiation to disambiguate the type resolution, e.g. 'OverloadedClassName<_>'.
 
-neg20.fs(383,39,383,41): typecheck error FS0039: The field, constructor or member 'S2' is not defined.
+neg20.fs(383,39,383,41): typecheck error FS0039: The type 'OverloadedClassName' does not define the field, constructor or member 'S2'
 
 neg20.fs(428,19,428,38): typecheck error FS1133: No constructors are available for the type 'OverloadedClassName<'a,'b>'
 
 neg20.fs(430,22,430,41): typecheck error FS1133: No constructors are available for the type 'OverloadedClassName<'a,'b>'
 
-neg20.fs(444,39,444,41): typecheck error FS0039: The field, constructor or member 'S2' is not defined.
+neg20.fs(444,39,444,41): typecheck error FS0039: The type 'OverloadedClassName' does not define the field, constructor or member 'S2'

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -407,10 +407,10 @@ neg20.fs(373,22,373,41): typecheck error FS1124: Multiple types exist called 'Ov
 
 neg20.fs(382,19,382,40): typecheck error FS1124: Multiple types exist called 'OverloadedClassName', taking different numbers of generic parameters. Provide a type instantiation to disambiguate the type resolution, e.g. 'OverloadedClassName<_>'.
 
-neg20.fs(383,39,383,41): typecheck error FS0039: The type 'OverloadedClassName' does not define the field, constructor or member 'S2'
+neg20.fs(383,39,383,41): typecheck error FS0039: The type 'OverloadedClassName<T>' does not define the field, constructor or member 'S2'.
 
 neg20.fs(428,19,428,38): typecheck error FS1133: No constructors are available for the type 'OverloadedClassName<'a,'b>'
 
 neg20.fs(430,22,430,41): typecheck error FS1133: No constructors are available for the type 'OverloadedClassName<'a,'b>'
 
-neg20.fs(444,39,444,41): typecheck error FS0039: The type 'OverloadedClassName' does not define the field, constructor or member 'S2'
+neg20.fs(444,39,444,41): typecheck error FS0039: The type 'OverloadedClassName' does not define the field, constructor or member 'S2'.

--- a/tests/fsharp/typecheck/sigs/neg45.bsl
+++ b/tests/fsharp/typecheck/sigs/neg45.bsl
@@ -11,7 +11,7 @@ neg45.fs(34,25,34,26): typecheck error FS0465: Type inference problem too compli
 
 neg45.fs(41,23,41,41): typecheck error FS0827: This is not a valid name for an active pattern
 
-neg45.fs(52,14,52,17): typecheck error FS0039: The field, constructor or member 'Foo' is not defined.
+neg45.fs(52,14,52,17): typecheck error FS0039: The type 'FooBir' does not define the field, constructor or member 'Foo'.
 
 neg45.fs(56,16,56,31): typecheck error FS0827: This is not a valid name for an active pattern
 

--- a/tests/fsharp/typecheck/sigs/neg55.bsl
+++ b/tests/fsharp/typecheck/sigs/neg55.bsl
@@ -1,6 +1,6 @@
 
 neg55.fs(10,5,10,19): typecheck error FS0491: The member or object constructor '.cctor' is not accessible. Private members may only be accessed from within the declaring type. Protected members may only be accessed from an extending type and cannot be accessed from inner lambda expressions.
 
-neg55.fs(19,7,19,16): typecheck error FS0039: The field, constructor or member '.ctor' is not defined.
+neg55.fs(19,7,19,16): typecheck error FS0039: The type 'D' does not define the field, constructor or member '.ctor'.
 
 neg55.fs(24,22,24,31): typecheck error FS3066: Invalid member name. Members may not have name '.ctor' or '.cctor'

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/MethodsAndProperties/E_ActivePatternMember01.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/MethodsAndProperties/E_ActivePatternMember01.fs
@@ -2,7 +2,7 @@
 // Regression for FSHARP1.0:6168
 // Active patterns should not be allowed as members - they don't work , but currently can be defined
 //<Expects status="error" id="FS0827" span="(10,19-10,37)">This is not a valid name for an active pattern</Expects>
-//<Expects status="error" id="FS0039" span="(21,10-21,13)">The type 'FaaBor' does not define a field, constructor or member 'Foo'</Expects>
+//<Expects status="error" id="FS0039" span="(21,10-21,13)">The type 'FaaBor' does not define the field, constructor or member 'Foo'</Expects>
 
 module M
 

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/MethodsAndProperties/E_ActivePatternMember01.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/MethodsAndProperties/E_ActivePatternMember01.fs
@@ -2,7 +2,7 @@
 // Regression for FSHARP1.0:6168
 // Active patterns should not be allowed as members - they don't work , but currently can be defined
 //<Expects status="error" id="FS0827" span="(10,19-10,37)">This is not a valid name for an active pattern</Expects>
-//<Expects status="error" id="FS0039" span="(21,10-21,13)">The field, constructor or member 'Foo' is not defined</Expects>
+//<Expects status="error" id="FS0039" span="(21,10-21,13)">The type 'FaaBor' does not define a field, constructor or member 'Foo'</Expects>
 
 module M
 
@@ -18,7 +18,7 @@ type FaaBor() =
         | Bar -> ()
 
 match 1,2 with
-| FaaBor.Foo -> printfn "hi"  // The field, constructor or member 'Foo' is not defined
+| FaaBor.Foo -> printfn "hi"  // The type 'FaaBor' does not define a field, constructor or member 'Foo'
 | _ -> ()
 
 exit 1

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/MethodsAndProperties/E_IndexerNotSpecified01.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/MethodsAndProperties/E_IndexerNotSpecified01.fs
@@ -2,7 +2,7 @@
 #light
 
 // Verify error if the type doesn't support an indexer
-//<Expects id="FS0039" status="error">The field, constructor or member 'Item' is not defined</Expects>
+//<Expects id="FS0039" status="error">The type 'Foo' does not define a field, constructor or member 'Item'</Expects>
 
 type Foo(x : int) =
     member this.Value = x

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/MethodsAndProperties/E_IndexerNotSpecified01.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/MethodsAndProperties/E_IndexerNotSpecified01.fs
@@ -2,7 +2,7 @@
 #light
 
 // Verify error if the type doesn't support an indexer
-//<Expects id="FS0039" status="error">The type 'Foo' does not define a field, constructor or member 'Item'</Expects>
+//<Expects id="FS0039" status="error">The type 'Foo' does not define the field, constructor or member 'Item'</Expects>
 
 type Foo(x : int) =
     member this.Value = x

--- a/tests/fsharpqa/Source/Conformance/Expressions/ApplicationExpressions/ObjectConstruction/E_ObjectConstruction01.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/ApplicationExpressions/ObjectConstruction/E_ObjectConstruction01.fs
@@ -1,6 +1,6 @@
 // #Regression #Conformance #ApplicationExpressions #ObjectConstructors 
 // Verify error for inaccessible constructor
-//<Expects id="FS0039" status="error" span="(5,37)">The type 'BitArray' does not define a field, constructor or member 'BitArrayEnumeratorSimple'</Expects>
+//<Expects id="FS0039" status="error" span="(5,37)">The type 'BitArray' does not define the field, constructor or member 'BitArrayEnumeratorSimple'</Expects>
 
 let y = System.Collections.BitArray.BitArrayEnumeratorSimple
 ()

--- a/tests/fsharpqa/Source/Conformance/Expressions/ApplicationExpressions/ObjectConstruction/E_ObjectConstruction01.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/ApplicationExpressions/ObjectConstruction/E_ObjectConstruction01.fs
@@ -1,6 +1,6 @@
 // #Regression #Conformance #ApplicationExpressions #ObjectConstructors 
 // Verify error for inaccessible constructor
-//<Expects id="FS0039" status="error" span="(5,37)">The field, constructor or member 'BitArrayEnumeratorSimple' is not defined</Expects>
+//<Expects id="FS0039" status="error" span="(5,37)">The type 'BitArray' does not define a field, constructor or member 'BitArrayEnumeratorSimple'</Expects>
 
 let y = System.Collections.BitArray.BitArrayEnumeratorSimple
 ()

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
@@ -2,7 +2,6 @@
 // FSB 6350, Compiler crash on invalid code: Crash by invalid type definition
 
 //<Expects status="error" span="(19,39)" id="FS0658">Structs may only bind a 'this' parameter at member declarations$</Expects>
-//<Expects status="error" span="(20,14)" id="FS0039">The type 'X' does not define the field, constructor or member 'dt'</Expects>
 //<Expects status="error" span="(20,9)" id="FS0696">This is not a valid object construction expression\. Explicit object constructors must either call an alternate constructor or initialize all fields of the object and specify a call to a super class constructor\.$</Expects>
 
 module mod6350

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
@@ -2,7 +2,7 @@
 // FSB 6350, Compiler crash on invalid code: Crash by invalid type definition
 
 //<Expects status="error" span="(19,39)" id="FS0658">Structs may only bind a 'this' parameter at member declarations$</Expects>
-//<Expects status="error" span="(20,14)" id="FS0039">The field, constructor or member 'dt' is not defined</Expects>
+//<Expects status="error" span="(20,14)" id="FS0039">The type 'X' does not define a field, constructor or member 'dt'</Expects>
 //<Expects status="error" span="(20,9)" id="FS0696">This is not a valid object construction expression\. Explicit object constructors must either call an alternate constructor or initialize all fields of the object and specify a call to a super class constructor\.$</Expects>
 
 module mod6350

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
@@ -3,7 +3,7 @@
 
 //<Expects status="error" span="(19,39)" id="FS0658">Structs may only bind a 'this' parameter at member declarations$</Expects>
 //<Expects status="error" span="(20,9)" id="FS0696">This is not a valid object construction expression\. Explicit object constructors must either call an alternate constructor or initialize all fields of the object and specify a call to a super class constructor\.$</Expects>
-//<Expects status="error" span="(20,14)" id="FS0039">The type byref<T,Kind> does not define the field, constructor or member 'dt'</Expects>
+//<Expects status="error" span="(20,14)" id="FS0039">The type 'byref<T,Kind>' does not define the field, constructor or member 'dt'</Expects>
 
 module mod6350
 

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
@@ -3,6 +3,7 @@
 
 //<Expects status="error" span="(19,39)" id="FS0658">Structs may only bind a 'this' parameter at member declarations$</Expects>
 //<Expects status="error" span="(20,9)" id="FS0696">This is not a valid object construction expression\. Explicit object constructors must either call an alternate constructor or initialize all fields of the object and specify a call to a super class constructor\.$</Expects>
+//<Expects status="error" span="(20,14)" id="FS0039">The type byref<T,Kind> does not define the field, constructor or member 'dt'</Expects>
 
 module mod6350
 

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/ObjectExpressions/E_InvalidSelfReferentialStructConstructor.fs
@@ -2,7 +2,7 @@
 // FSB 6350, Compiler crash on invalid code: Crash by invalid type definition
 
 //<Expects status="error" span="(19,39)" id="FS0658">Structs may only bind a 'this' parameter at member declarations$</Expects>
-//<Expects status="error" span="(20,14)" id="FS0039">The type 'X' does not define a field, constructor or member 'dt'</Expects>
+//<Expects status="error" span="(20,14)" id="FS0039">The type 'X' does not define the field, constructor or member 'dt'</Expects>
 //<Expects status="error" span="(20,9)" id="FS0696">This is not a valid object construction expression\. Explicit object constructors must either call an alternate constructor or initialize all fields of the object and specify a call to a super class constructor\.$</Expects>
 
 module mod6350

--- a/tests/fsharpqa/Source/Conformance/Expressions/SyntacticSugar/E_GetSliceNotDef01.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/SyntacticSugar/E_GetSliceNotDef01.fs
@@ -2,7 +2,7 @@
 #light
 
 // Verify error if GetSlice is not defined
-//<Expects id="FS0039" status="error">The field, constructor or member 'GetSlice' is not defined</Expects>
+//<Expects id="FS0039" status="error">The type 'DU' does not define a field, constructor or member 'GetSlice'</Expects>
 
 type DU = A | B of int | C
 

--- a/tests/fsharpqa/Source/Conformance/Expressions/SyntacticSugar/E_GetSliceNotDef01.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/SyntacticSugar/E_GetSliceNotDef01.fs
@@ -2,7 +2,7 @@
 #light
 
 // Verify error if GetSlice is not defined
-//<Expects id="FS0039" status="error">The type 'DU' does not define a field, constructor or member 'GetSlice'</Expects>
+//<Expects id="FS0039" status="error">The type 'DU' does not define the field, constructor or member 'GetSlice'</Expects>
 
 type DU = A | B of int | C
 

--- a/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/EnumTypes/E_NoValueFieldOnEnum.fs
+++ b/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/EnumTypes/E_NoValueFieldOnEnum.fs
@@ -1,6 +1,6 @@
 // #Regression #Conformance #ObjectOrientedTypes #Enums 
 // FS1 992: ilreflect error triggered with Enum value__ calls.
-//<Expects id="FS0039" status="error">The type 'EnumType' does not define a field, constructor or member 'value__'</Expects>
+//<Expects id="FS0039" status="error">The type 'EnumType' does not define the field, constructor or member 'value__'</Expects>
 
 type EnumType = 
     | A = 1

--- a/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/EnumTypes/E_NoValueFieldOnEnum.fs
+++ b/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/EnumTypes/E_NoValueFieldOnEnum.fs
@@ -1,6 +1,6 @@
 // #Regression #Conformance #ObjectOrientedTypes #Enums 
 // FS1 992: ilreflect error triggered with Enum value__ calls.
-//<Expects id="FS0039" status="error">The field, constructor or member 'value__' is not defined</Expects>
+//<Expects id="FS0039" status="error">The type 'EnumType' does not define a field, constructor or member 'value__'</Expects>
 
 type EnumType = 
     | A = 1

--- a/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/InterfaceTypes/E_MultipleInterfaceInheritance.fs
+++ b/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/InterfaceTypes/E_MultipleInterfaceInheritance.fs
@@ -60,9 +60,9 @@ if ( {new I_003<int> with
             System.Console.WriteLine("I_003.Home failed")         
             res <- false
 
-//<Expects id="FS0039" status="error" span="(41,7-41,9)">The type 'T' does not define a field, constructor or member 'Me'</Expects>
-//<Expects id="FS0039" status="error" span="(45,7-45,9)">The type 'T' does not define a field, constructor or member 'Me'</Expects>
-//<Expects id="FS0039" status="error" span="(49,7-49,11)">The type 'T' does not define a field, constructor or member 'Home'</Expects>
+//<Expects id="FS0039" status="error" span="(41,7-41,9)">The type 'T' does not define the field, constructor or member 'Me'</Expects>
+//<Expects id="FS0039" status="error" span="(45,7-45,9)">The type 'T' does not define the field, constructor or member 'Me'</Expects>
+//<Expects id="FS0039" status="error" span="(49,7-49,11)">The type 'T' does not define the field, constructor or member 'Home'</Expects>
 //<Expects id="FS0366" status="error" span="(53,6-55,8)">No implementation was given for those members: </Expects>
 //<Expects span="(53,6-55,8)">'abstract member I_002\.Me : 'a -> int'\.</Expects>
 //<Expects span="(53,6-55,8)">'abstract member I_002\.Me : 'a -> int'\.</Expects>

--- a/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/InterfaceTypes/E_MultipleInterfaceInheritance.fs
+++ b/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/InterfaceTypes/E_MultipleInterfaceInheritance.fs
@@ -60,9 +60,9 @@ if ( {new I_003<int> with
             System.Console.WriteLine("I_003.Home failed")         
             res <- false
 
-//<Expects id="FS0039" status="error" span="(41,7-41,9)">The field, constructor or member 'Me' is not defined</Expects>
-//<Expects id="FS0039" status="error" span="(45,7-45,9)">The field, constructor or member 'Me' is not defined</Expects>
-//<Expects id="FS0039" status="error" span="(49,7-49,11)">The field, constructor or member 'Home' is not defined</Expects>
+//<Expects id="FS0039" status="error" span="(41,7-41,9)">The type 'T' does not define a field, constructor or member 'Me'</Expects>
+//<Expects id="FS0039" status="error" span="(45,7-45,9)">The type 'T' does not define a field, constructor or member 'Me'</Expects>
+//<Expects id="FS0039" status="error" span="(49,7-49,11)">The type 'T' does not define a field, constructor or member 'Home'</Expects>
 //<Expects id="FS0366" status="error" span="(53,6-55,8)">No implementation was given for those members: </Expects>
 //<Expects span="(53,6-55,8)">'abstract member I_002\.Me : 'a -> int'\.</Expects>
 //<Expects span="(53,6-55,8)">'abstract member I_002\.Me : 'a -> int'\.</Expects>

--- a/tests/fsharpqa/Source/Conformance/Signatures/SignatureConformance/E_StructWithNameConflict02.fsi
+++ b/tests/fsharpqa/Source/Conformance/Signatures/SignatureConformance/E_StructWithNameConflict02.fsi
@@ -1,6 +1,6 @@
 // #Conformance #Signatures #Structs #Regression
 // Regression for Dev11:137942, structs used to not give errors on when member names conflicted with interface members
-//<Expects status="error" span="(18,13-18,26)" id="FS0039">The field, constructor or member 'GetEnumerator' is not defined</Expects>
+//<Expects status="error" span="(18,13-18,26)" id="FS0039">The type 'Foo<T>' does not define the field, constructor or member 'GetEnumerator'</Expects>
 //<Expects status="notin" span="(14,21-14,34)" id="FS0034">Module 'M' contains     override Foo\.GetEnumerator : unit -> IEnumerator<'T>     but its signature specifies     member Foo\.GetEnumerator : unit -> IEnumerator<'T>     The compiled names differ</Expects>
 module M
 

--- a/tests/fsharpqa/Source/Import/E_InternalsConsumer.fs
+++ b/tests/fsharpqa/Source/Import/E_InternalsConsumer.fs
@@ -4,7 +4,7 @@
 // Test that even if we have InternalsVisibleTo() attribute for this friendly assembly, private members won't be still accessible
 //<Expects status="error" span="(8,6)" id="FS1092">The type 'CalcBeta' is not accessible from this code location$</Expects>
 //<Expects status="error" span="(8,2)" id="FS0509">Method or object constructor 'CalcBeta' not found$</Expects>
-//<Expects status="error" span="(8,18)" id="FS0039">The field, constructor or member 'Mod' is not defined</Expects>
+//<Expects status="error" span="(8,18)" id="FS0039">The type 'CalcBeta' does not define a field, constructor or member 'Mod'</Expects>
 (new CalcBeta()).Mod(1,1) |> ignore
 
 exit 1

--- a/tests/fsharpqa/Source/Import/E_InternalsConsumer.fs
+++ b/tests/fsharpqa/Source/Import/E_InternalsConsumer.fs
@@ -4,7 +4,7 @@
 // Test that even if we have InternalsVisibleTo() attribute for this friendly assembly, private members won't be still accessible
 //<Expects status="error" span="(8,6)" id="FS1092">The type 'CalcBeta' is not accessible from this code location$</Expects>
 //<Expects status="error" span="(8,2)" id="FS0509">Method or object constructor 'CalcBeta' not found$</Expects>
-//<Expects status="error" span="(8,18)" id="FS0039">The type 'CalcBeta' does not define a field, constructor or member 'Mod'</Expects>
+//<Expects status="error" span="(8,18)" id="FS0039">The type 'CalcBeta' does not define the field, constructor or member 'Mod'</Expects>
 (new CalcBeta()).Mod(1,1) |> ignore
 
 exit 1

--- a/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
+++ b/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
@@ -1,5 +1,5 @@
 // #Regression #NoMT #Import 
-//<Expects status="error" span="(7,13)" id="FS1092">The type 'Accessibility' is not defined</Expects>
+//<Expects status="error" span="(8,28)" id="FS0039">The type 'Accessibility' does not define the field, constructor or member 'FamAndAssembly'. Maybe you want one of the following:</Expects>
 namespace NS
 
 type T() =

--- a/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
+++ b/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
@@ -1,5 +1,6 @@
 // #Regression #NoMT #Import 
-//<Expects status="error" span="(7,13)" id="FS0039">The type 'Accessibility' is not defined</Expects>
+//<Expects status="error" span="(8,5)" id="FS0509">Method or object constructor 'Accessibility' not found</Expects>
+//<Expects status="error" span="(8,13)" id="FS1092">The type 'Accessibility' is not defined</Expects>
 namespace NS
 
 type T() =

--- a/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
+++ b/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
@@ -1,5 +1,5 @@
 // #Regression #NoMT #Import 
-//<Expects status="error" span="(8,28)" id="FS0039">The type 'T' does not define the field, constructor or member 'FamAndAssembly'</Expects>
+//<Expects status="error" span="(8,23)" id="FS0039">The field, constructor or member 'FamAndAssembly' is not defined</Expects>
 namespace NS
 
 type T() =

--- a/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
+++ b/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
@@ -1,5 +1,5 @@
 // #Regression #NoMT #Import 
-//<Expects status="error" span="(8,13)" id="FS1092">The type 'Accessibility' is not defined</Expects>
+//<Expects status="error" span="(7,13)" id="FS1092">The type 'Accessibility' is not defined</Expects>
 namespace NS
 
 type T() =

--- a/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
+++ b/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
@@ -1,5 +1,4 @@
 // #Regression #NoMT #Import 
-//<Expects status="error" span="(8,5)" id="FS0509">Method or object constructor 'Accessibility' not found</Expects>
 //<Expects status="error" span="(8,13)" id="FS1092">The type 'Accessibility' is not defined</Expects>
 namespace NS
 

--- a/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
+++ b/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
@@ -1,5 +1,5 @@
 // #Regression #NoMT #Import 
-//<Expects status="error" span="(8,23)" id="FS0039">The field, constructor or member 'FamAndAssembly' is not defined</Expects>
+//<Expects status="error" span="(7,13)" id="FS0039">The type 'Accessibility' is not defined</Expects>
 namespace NS
 
 type T() =

--- a/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
+++ b/tests/fsharpqa/Source/Import/FamAndAssembly_NoIVT.fs
@@ -1,5 +1,5 @@
 // #Regression #NoMT #Import 
-//<Expects status="error" span="(8,28)" id="FS0039">The field, constructor or member 'FamAndAssembly' is not defined.</Expects>
+//<Expects status="error" span="(8,28)" id="FS0039">The type 'T' does not define the field, constructor or member 'FamAndAssembly'</Expects>
 namespace NS
 
 type T() =


### PR DESCRIPTION
The original branch seems to have disappeared, so I had to merge it in this cack-handed way.

Original PR:    https://github.com/dotnet/fsharp/pull/7478

