### PR TITLE
ngen dependency manager

### DIFF
--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -19,6 +19,7 @@
       <Action Type="Ngen" Path="FSharp.Compiler.Interactive.Settings.dll" />
       <Action Type="Ngen" Path="FSharp.Compiler.Server.Shared.dll" />
       <Action Type="Ngen" Path="FSharp.Core.dll" />
+      <Action Type="Ngen" Path="FSharp.DependencyManager.dll" />
       <Action Type="Ngen" Path="FSharp.Editor.dll" />
       <Action Type="Ngen" Path="FSharp.Editor.Helpers.dll" />
       <Action Type="Ngen" Path="FSharp.UIResources.dll" />


### PR DESCRIPTION
1. Ensure that dependency manager library is ngened in vs.
2. remove #if to select build engine
3. Select msbuild when running on desktop and dotnet build on dotnet