### PR TITLE
Remove assembly load notification

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -4835,10 +4835,10 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
         
 /// Process #r in F# Interactive.
 /// Adds the reference to the tcImports and add the ccu to the type checking environment.
-let RequireDLL (ctok, tcImports: TcImports, tcEnv, thisAssemblyName, m, file, assemblyReferenceAdded: string -> unit) =
+let RequireDLL (ctok, tcImports: TcImports, tcEnv, thisAssemblyName, m, file) =
     let resolutions = CommitOperationResult(tcImports.TryResolveAssemblyReference(ctok, AssemblyReference(m, file, None), ResolveAssemblyReferenceMode.ReportErrors))
     let dllinfos, ccuinfos = tcImports.RegisterAndImportReferencedAssemblies(ctok, resolutions) |> Cancellable.runWithoutCancellation
-   
+
     let asms = 
         ccuinfos |> List.map (function
             | ResolvedImportedAssembly asm -> asm
@@ -4847,11 +4847,7 @@ let RequireDLL (ctok, tcImports: TcImports, tcEnv, thisAssemblyName, m, file, as
     let g = tcImports.GetTcGlobals()
     let amap = tcImports.GetImportMap()
     let buildTcEnv tcEnv asm =
-        let tcEnv = AddCcuToTcEnv(g, amap, m, tcEnv, thisAssemblyName, asm.FSharpViewOfMetadata, asm.AssemblyAutoOpenAttributes, asm.AssemblyInternalsVisibleToAttributes)
-        match asm.FSharpViewOfMetadata.FileName with
-        | Some asmPath -> assemblyReferenceAdded asmPath
-        | None -> ()
-        tcEnv
+        AddCcuToTcEnv(g, amap, m, tcEnv, thisAssemblyName, asm.FSharpViewOfMetadata, asm.AssemblyAutoOpenAttributes, asm.AssemblyInternalsVisibleToAttributes)
     let tcEnv = (tcEnv, asms) ||> List.fold buildTcEnv
     tcEnv, (dllinfos, asms)
 

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -684,7 +684,7 @@ val WriteOptimizationData: TcGlobals * filename: string * inMem: bool * CcuThunk
 
 /// Process #r in F# Interactive.
 /// Adds the reference to the tcImports and add the ccu to the type checking environment.
-val RequireDLL: CompilationThreadToken * TcImports * TcEnv * thisAssemblyName: string * referenceRange: range * file: string * assemblyReferenceAdded: (string -> unit) -> TcEnv * (ImportedBinary list * ImportedAssembly list)
+val RequireDLL: CompilationThreadToken * TcImports * TcEnv * thisAssemblyName: string * referenceRange: range * file: string -> TcEnv * (ImportedBinary list * ImportedAssembly list)
 
 /// Processing # commands
 val ProcessMetaCommandsFromInput : 

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -19,9 +19,6 @@ type FSharpScript(?additionalArgs: string[]) =
     let argv = Array.append baseArgs additionalArgs
     let fsi = FsiEvaluationSession.Create (config, argv, stdin, stdout, stderr)
 
-    [<CLIEvent>]
-    member __.AssemblyReferenceAdded = fsi.AssemblyReferenceAdded
-
     member __.ValueBound = fsi.ValueBound
 
     [<CLIEvent>]

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -956,7 +956,6 @@ type internal FsiDynamicCompiler
     let outfile = "TMPFSCI.exe"
     let assemblyName = "FSI-ASSEMBLY"
 
-    let assemblyReferenceAddedEvent = Control.Event<string>()
     let valueBoundEvent = Control.Event<_>()
     let dependencyAddingEvent = Control.Event<string * string>()
     let dependencyAddedEvent = Control.Event<string * string>()
@@ -1260,7 +1259,7 @@ type internal FsiDynamicCompiler
         let tcState = istate.tcState 
         let tcEnv,(_dllinfos,ccuinfos) = 
             try
-                RequireDLL (ctok, tcImports, tcState.TcEnvFromImpls, assemblyName, m, path, assemblyReferenceAddedEvent.Trigger)
+                RequireDLL (ctok, tcImports, tcState.TcEnvFromImpls, assemblyName, m, path)
             with e ->
                 tcConfigB.RemoveReferencedAssemblyByPath(m,path)
                 reraise()
@@ -1401,8 +1400,6 @@ type internal FsiDynamicCompiler
 
     member __.FormatValue(obj:obj, objTy) = 
         valuePrinter.FormatValue(obj, objTy)
-
-    member __.AssemblyReferenceAdded = assemblyReferenceAddedEvent.Publish
 
     member __.ValueBound = valueBoundEvent.Publish
 
@@ -1908,8 +1905,6 @@ type internal FsiInteractionProcessor
                              initialInteractiveState) = 
 
     let referencedAssemblies = Dictionary<string, DateTime>()
-
-    let assemblyReferencedEvent = Control.Event<string>()
 
     let mutable currState = initialInteractiveState
     let event = Control.Event<unit>()
@@ -2451,8 +2446,6 @@ type internal FsiInteractionProcessor
         let fsiInteractiveChecker = FsiInteractiveChecker(legacyReferenceResolver, checker, tcConfig, istate.tcGlobals, istate.tcImports, istate.tcState)
         fsiInteractiveChecker.ParseAndCheckInteraction(ctok, SourceText.ofString text)
 
-    member __.AssemblyReferenceAdded = assemblyReferencedEvent.Publish
-
 
 //----------------------------------------------------------------------------
 // Server mode:
@@ -2861,10 +2854,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         fsiInteractionProcessor.EvalScript(ctok, scriptPath, errorLogger)
         |> commitResultNonThrowing errorOptions scriptPath errorLogger
         |> function Choice1Of2 (_), errs -> Choice1Of2 (), errs | Choice2Of2 exn, errs -> Choice2Of2 exn, errs
-
-    [<CLIEvent>]
-    /// Event fires every time an assembly reference is added to the execution environment, e.g., via `#r`.
-    member __.AssemblyReferenceAdded = fsiDynamicCompiler.AssemblyReferenceAdded
 
     /// Event fires when a root-level value is bound to an identifier, e.g., via `let x = ...`.
     member __.ValueBound = fsiDynamicCompiler.ValueBound

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -235,10 +235,6 @@ type FsiEvaluationSession =
     member ReportUnhandledException : exn: exn -> unit
 
     [<CLIEvent>]
-    /// Event fires every time an assembly reference is added to the execution environment, e.g., via `#r`.
-    member AssemblyReferenceAdded: IEvent<string>
-
-    [<CLIEvent>]
     /// Event fires every time a path is added to the include search list, e.g., via `#I`.
     member IncludePathAdded: IEvent<string>
 

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -30,18 +30,10 @@ type DependencyManagerInteractiveTests() =
 #r @"nuget:Newtonsoft.Json, Version=9.0.1"
 0"""
         use script = scriptHost()
-        let mutable assemblyResolveEventCount = 0
-        let mutable foundAssemblyReference = false
-        Event.add (fun (assembly: string) ->
-            assemblyResolveEventCount <- assemblyResolveEventCount + 1
-            foundAssemblyReference <- String.Compare("Newtonsoft.Json.dll", Path.GetFileName(assembly), StringComparison.OrdinalIgnoreCase) = 0)
-            script.AssemblyReferenceAdded
         let opt = script.Eval(text) |> getValue
         let value = opt.Value
         Assert.AreEqual(typeof<int>, value.ReflectionType)
         Assert.AreEqual(0, value.ReflectionValue :?> int)
-        Assert.Greater(assemblyResolveEventCount, 0)
-        Assert.AreEqual(true, foundAssemblyReference)
 
     [<Test>]
     member __.``SmokeTest - #r nuget package not found``() =

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -41,15 +41,10 @@ type DependencyManagerInteractiveTests() =
 #r @"nuget:System.Collections.Immutable.DoesNotExist, version=1.5.0"
 0"""
         use script = scriptHost()
-        let mutable assemblyResolveEventCount = 0
-        Event.add (fun (assembly: string) ->
-            assemblyResolveEventCount <- assemblyResolveEventCount + 1)
-            script.AssemblyReferenceAdded
         let opt = script.Eval(text) |> getValue
         let value = opt.Value
         Assert.AreEqual(typeof<int>, value.ReflectionType)
         Assert.AreEqual(0, value.ReflectionValue :?> int)
-        Assert.AreEqual(0, assemblyResolveEventCount)
 
     [<Test>]
     member __.``Dependency add events successful``() =

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -75,7 +75,7 @@ stacktype.Name = "Stack"
         Assert.AreEqual(true, value.ReflectionValue :?> bool)
 
     [<Test>]
-    member __.``Assembly reference event unsuccessful``() =
+    member __.``Assembly reference unsuccessful``() =
         use script = new FSharpScript()
         let testAssembly = "not-an-assembly-that-can-be-found.dll"
         let _result, errors = script.Eval(sprintf "#r \"%s\"" testAssembly)


### PR DESCRIPTION
Notebook had a scenario where they needed to know when a what assembly was loaded by a script.  So we added this notification.

That scenario has gone away, so I am removing this notification from our code since we don't need it any more.
