### PR TITLE
Remove unnecessary diagnostics

### DIFF
--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -292,7 +292,6 @@ module internal FSharpEnvironment =
         // We look in the directories stepping up from the location of the runtime assembly.
         let loadFromLocation designTimeAssemblyPath =
             try
-                printfn "Using: %s" designTimeAssemblyPath
                 Some (Assembly.UnsafeLoadFrom designTimeAssemblyPath)
             with e ->
                 raiseError e
@@ -315,8 +314,6 @@ module internal FSharpEnvironment =
             let runTimeAssemblyPath = Path.GetDirectoryName runTimeAssemblyFileName
             let paths = searchParentDirChain (Some runTimeAssemblyPath) designTimeAssemblyName
             paths
-            |> Seq.iter(function res -> printfn ">>>> %s" res)
-            paths
             |> Seq.tryHead
             |> function
                | Some res -> loadFromLocation res
@@ -325,7 +322,6 @@ module internal FSharpEnvironment =
                     let runTimeAssemblyPath = Path.GetDirectoryName runTimeAssemblyFileName
                     loadFromLocation (Path.Combine (runTimeAssemblyPath, designTimeAssemblyName))
 
-        printfn "=============== S T A R T =========================================="
         if designTimeAssemblyName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) then
             loadFromParentDirRelativeToRuntimeAssemblyLocation designTimeAssemblyName
         else


### PR DESCRIPTION
When referencing type providers there are a couple of unnecesssary diagnostic logging messages that appear.  They came along for the ride with the fsharp5 merge.

This PR removes them.

Kevin

````
=============== S T A R T ==========================================
>>>> C:\Users\kevinr\.nuget\packages\fsharp.data\3.3.3\typeproviders\fsharp41\net45\FSharp.Data.DesignTime.dll
>>>> C:\Users\kevinr\.nuget\packages\fsharp.data\3.3.3\typeproviders\fsharp41\netstandard2.0\FSharp.Data.DesignTime.dll
>>>> C:\Users\kevinr\.nuget\packages\fsharp.data\3.3.3\lib\net45\FSharp.Data.DesignTime.dll
Using: C:\Users\kevinr\.nuget\packages\fsharp.data\3.3.3\typeproviders\fsharp41\net45\FSharp.Data.DesignTime.dll
````