### PR TITLE
cross-platform wrapper around memory-backed memorymappedfile creation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,6 +364,14 @@ stages:
             clean: true
           - script: ./fcs/build.sh Test
             displayName: Build / Test
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '*.xml'
+              searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
+            continueOnError: true
+            condition: always()
 
         - job: MacOS_FCS
           pool:
@@ -376,6 +384,14 @@ stages:
             clean: true
           - script: ./fcs/build.sh Test
             displayName: Build / Test
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '*.xml'
+              searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
+            continueOnError: true
+            condition: always()
 
 #---------------------------------------------------------------------------------------------------------------------#
 #                                                    Post Build                                                       #

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -342,6 +342,11 @@ stages:
           steps:
           - checkout: self
             clean: true
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core sdk'
+            inputs:
+              useGlobalJson: true
+              workingDirectory: fcs
           - script: fcs\build.cmd TestAndNuget
             displayName: Build / Test
           - task: PublishTestResults@2
@@ -362,6 +367,11 @@ stages:
           steps:
           - checkout: self
             clean: true
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core sdk'
+            inputs:
+              useGlobalJson: true
+              workingDirectory: fcs
           - script: ./fcs/build.sh Test
             displayName: Build / Test
           - task: PublishTestResults@2
@@ -382,6 +392,11 @@ stages:
           steps:
           - checkout: self
             clean: true
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core sdk'
+            inputs:
+              useGlobalJson: true
+              workingDirectory: fcs
           - script: ./fcs/build.sh Test
             displayName: Build / Test
           - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -373,7 +373,7 @@ stages:
             inputs:
               useGlobalJson: true
               workingDirectory: fcs
-          - script: ./fcs/build.sh Test
+          - script: ./fcs/build.sh
             displayName: Build / Test
           - task: PublishTestResults@2
             displayName: Publish Test Results
@@ -399,7 +399,7 @@ stages:
             inputs:
               useGlobalJson: true
               workingDirectory: fcs
-          - script: ./fcs/build.sh Test
+          - script: ./fcs/build.sh
             displayName: Build / Test
           - task: PublishTestResults@2
             displayName: Publish Test Results

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -355,6 +355,7 @@ stages:
               testResultsFormat: 'NUnit'
               testResultsFiles: '*.xml'
               searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
+              publishRunAttachments: true
             continueOnError: true
             condition: always()
 
@@ -380,6 +381,7 @@ stages:
               testResultsFormat: 'NUnit'
               testResultsFiles: '*.xml'
               searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
+              publishRunAttachments: true
             continueOnError: true
             condition: always()
 
@@ -405,6 +407,7 @@ stages:
               testResultsFormat: 'NUnit'
               testResultsFiles: '*.xml'
               searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
+              publishRunAttachments: true
             continueOnError: true
             condition: always()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -362,20 +362,20 @@ stages:
           steps:
           - checkout: self
             clean: true
-          - script: ./fcs/build.sh
-            displayName: Build
+          - script: ./fcs/build.sh Test
+            displayName: Build / Test
 
-        # - job: MacOS_FCS
-        #   pool:
-        #     vmImage: macOS-latest
-        #   variables:
-        #   - name: _SignType
-        #     value: Test
-        #   steps:
-        #   - checkout: self
-        #     clean: true
-        #   - script: ./fcs/build.sh
-        #     displayName: Build
+        - job: MacOS_FCS
+          pool:
+            vmImage: macOS-latest
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./fcs/build.sh Test
+            displayName: Build / Test
 
 #---------------------------------------------------------------------------------------------------------------------#
 #                                                    Post Build                                                       #

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -183,7 +183,7 @@
     <NUnitVersion>3.11.0</NUnitVersion>
     <NUnit3TestAdapterVersion>3.11.2</NUnit3TestAdapterVersion>
     <NUnitLiteVersion>3.11.0</NUnitLiteVersion>
-    <NunitXmlTestLoggerVersion>2.1.36</NunitXmlTestLoggerVersion>
+    <NunitXmlTestLoggerVersion>2.1.41</NunitXmlTestLoggerVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
     <StrawberryPerlVersion>5.28.0.1</StrawberryPerlVersion>
     <StreamJsonRpcVersion>2.0.187</StreamJsonRpcVersion>

--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -60,6 +60,9 @@
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\TreeVisitorTests.fs">
       <Link>TreeVisitorTests.fs</Link>
     </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\..\tests\service\ScriptOptionsTests.fs">
+      <Link>ScriptOptionsTests.fs</Link>
+    </Compile>
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\Program.fs" Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
       <Link>Program.fs</Link>
     </Compile>

--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
+  <Import Project="..\..\eng\Versions.props"/>   <!-- keep our test deps in line with the overall compiler -->
   <PropertyGroup>
     <TargetFrameworks>$(FcsTargetNetFxFramework);netcoreapp3.0</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
@@ -74,10 +75,10 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="$(FcsFSharpCorePkgVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.36" />
     <PackageReference Include="Dotnet.ProjInfo" Version="0.20.0" />
+    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterVersion)" />
+    <PackageReference Include="NunitXml.TestLogger" Version="$(NunitXmlTestLoggerVersion)" />
     <ProjectReference Include="..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(FcsTargetNetFxFramework)'">

--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -73,9 +73,9 @@ Target.create "Test" (fun _ ->
     // This project file is used for the netcoreapp2.0 tests to work out reference sets
     runDotnet __SOURCE_DIRECTORY__ "build" "../tests/projects/Sample_NETCoreSDK_FSharp_Library_netstandard2_0/Sample_NETCoreSDK_FSharp_Library_netstandard2_0.fsproj -nodereuse:false -v n /restore /p:DisableCompilerRedirection=true"
 
-    // Now run the tests
-    let logFilePath = Path.Combine(__SOURCE_DIRECTORY__, "..", "artifacts", "TestResults", "Release", "FSharp.Compiler.Service.Test.xml")
-    runDotnet __SOURCE_DIRECTORY__ "test" (sprintf "FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj --no-restore --no-build -nodereuse:false -v n -c Release --test-adapter-path . --logger \"nunit;LogFilePath=%s\"" logFilePath)
+    // Now run the tests (different output files per TFM)
+    let logFilePath = Path.Combine(__SOURCE_DIRECTORY__, "..", "artifacts", "TestResults", "Release", "FSharp.Compiler.Service.Test.{framework}.xml")
+    runDotnet __SOURCE_DIRECTORY__ "test" (sprintf "FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj --no-restore --no-build -nodereuse:false -v n -c Release --logger \"nunit;LogFilePath=%s\"" logFilePath)
 )
 
 Target.create "NuGet" (fun _ ->

--- a/fcs/samples/FscExe/FscMain.fs
+++ b/fcs/samples/FscExe/FscMain.fs
@@ -8,7 +8,7 @@ open System.IO
 open System.Reflection
 open System.Runtime.CompilerServices
 open FSharp.Compiler.SourceCodeServices
-open FSharp.Compiler.AbstractIL.IL // runningOnMono 
+open FSharp.Compiler.AbstractIL.Internal.Utils // runningOnMono
 open FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.ErrorLogger
 

--- a/src/absil/bytes.fsi
+++ b/src/absil/bytes.fsi
@@ -5,10 +5,11 @@ namespace FSharp.Compiler.AbstractIL.Internal
 
 open System.IO
 open Internal.Utilities
-
 open FSharp.Compiler.AbstractIL 
 open FSharp.Compiler.AbstractIL.Internal 
 
+module Utils =
+    val runningOnMono: bool
 
 module internal Bytes = 
     /// returned int will be 0 <= x <= 255

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -25,24 +25,6 @@ open Internal.Utilities
 
 let logging = false
 
-let runningOnMono =
-#if ENABLE_MONO_SUPPORT
-// Officially supported way to detect if we are running on Mono.
-// See http://www.mono-project.com/FAQ:_Technical
-// "How can I detect if am running in Mono?" section
-    try
-        System.Type.GetType ("Mono.Runtime") <> null
-    with e->
-        // Must be robust in the case that someone else has installed a handler into System.AppDomain.OnTypeResolveEvent
-        // that is not reliable.
-        // This is related to bug 5506--the issue is actually a bug in VSTypeResolutionService.EnsurePopulated which is
-        // called by OnTypeResolveEvent. The function throws a NullReferenceException. I'm working with that team to get
-        // their issue fixed but we need to be robust here anyway.
-        false
-#else
-    false
-#endif
-
 let _ = if logging then dprintn "* warning: Il.logging is on"
 
 let int_order = LanguagePrimitives.FastGenericComparer<int>

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -2012,8 +2012,6 @@ type ILPropertyRef =
      member Name: string
      interface System.IComparable
 
-val runningOnMono: bool
-
 type ILReferences = 
     { AssemblyReferences: ILAssemblyRef list 
       ModuleReferences: ILModuleRef list }

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -20,12 +20,13 @@ open System.Text
 open Internal.Utilities
 open Internal.Utilities.Collections
 open FSharp.NativeInterop
-open FSharp.Compiler.AbstractIL.Internal 
-open FSharp.Compiler.AbstractIL.Internal.Support
 open FSharp.Compiler.AbstractIL.Diagnostics 
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.Internal
 open FSharp.Compiler.AbstractIL.Internal.BinaryConstants 
-open FSharp.Compiler.AbstractIL.IL  
 open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.Internal.Support
+open FSharp.Compiler.AbstractIL.Internal.Utils
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Range
 open System.Reflection

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -17,6 +17,7 @@ open System.Collections.Generic
 open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.Internal
 open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.Internal.Utils
 open FSharp.Compiler.AbstractIL.Diagnostics 
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.ErrorLogger

--- a/src/absil/ilsupp.fs
+++ b/src/absil/ilsupp.fs
@@ -3,9 +3,9 @@
 module internal FSharp.Compiler.AbstractIL.Internal.Support
 
 open FSharp.Compiler.AbstractIL
-open FSharp.Compiler.AbstractIL.Internal
 open FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.AbstractIL.Internal.NativeRes
+open FSharp.Compiler.AbstractIL.Internal.Utils
 #if FX_NO_CORHOST_SIGNER
 open FSharp.Compiler.AbstractIL.Internal.StrongNameSign
 #endif
@@ -1287,7 +1287,7 @@ let getICLRStrongName () =
     | Some sn -> sn
 
 let signerGetPublicKeyForKeyPair kp =
- if IL.runningOnMono then
+ if runningOnMono then
     let snt = System.Type.GetType("Mono.Security.StrongName")
     let sn = System.Activator.CreateInstance(snt, [| box kp |])
     snt.InvokeMember("PublicKey", (BindingFlags.GetProperty ||| BindingFlags.Instance ||| BindingFlags.Public), null, sn, [| |], Globalization.CultureInfo.InvariantCulture) :?> byte[]
@@ -1319,7 +1319,7 @@ let signerCloseKeyContainer kc =
     iclrSN.StrongNameKeyDelete kc |> ignore
 
 let signerSignatureSize (pk: byte[]) =
- if IL.runningOnMono then
+ if runningOnMono then
    if pk.Length > 32 then pk.Length - 32 else 128
  else
     let mutable pSize =  0u
@@ -1328,7 +1328,7 @@ let signerSignatureSize (pk: byte[]) =
     int pSize
 
 let signerSignFileWithKeyPair fileName kp =
- if IL.runningOnMono then
+ if runningOnMono then
     let snt = System.Type.GetType("Mono.Security.StrongName")
     let sn = System.Activator.CreateInstance(snt, [| box kp |])
     let conv (x: obj) = if (unbox x: bool) then 0 else -1

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -6,12 +6,13 @@ open System.Collections.Generic
 open System.IO
 
 open Internal.Utilities
-open FSharp.Compiler.AbstractIL.IL 
-open FSharp.Compiler.AbstractIL.Diagnostics 
-open FSharp.Compiler.AbstractIL.Internal 
-open FSharp.Compiler.AbstractIL.Internal.BinaryConstants 
-open FSharp.Compiler.AbstractIL.Internal.Support 
-open FSharp.Compiler.AbstractIL.Internal.Library 
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.Diagnostics
+open FSharp.Compiler.AbstractIL.Internal
+open FSharp.Compiler.AbstractIL.Internal.BinaryConstants
+open FSharp.Compiler.AbstractIL.Internal.Support
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.Internal.Utils
 open FSharp.Compiler.AbstractIL.ILPdbWriter
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Range

--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -15,6 +15,7 @@ open Internal.Utilities
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.Internal.Support 
 open FSharp.Compiler.AbstractIL.Internal.Library 
+open FSharp.Compiler.AbstractIL.Internal.Utils
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Range
 
@@ -244,7 +245,7 @@ let pdbGetDebugInfo (contentId: byte[]) (timestamp: int32) (filepath: string)
 // This function takes output file name and returns debug file name.
 let getDebugFileName outfile (portablePDB: bool) =
 #if ENABLE_MONO_SUPPORT
-  if IL.runningOnMono && not portablePDB then
+  if runningOnMono && not portablePDB then
       outfile + ".mdb"
   else 
 #else

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -20,6 +20,7 @@ open FSharp.Compiler.AbstractIL.ILBinaryReader
 open FSharp.Compiler.AbstractIL.ILPdbWriter
 open FSharp.Compiler.AbstractIL.Internal
 open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.Internal.Utils
 open FSharp.Compiler.AbstractIL.Extensions.ILX
 open FSharp.Compiler.AbstractIL.Diagnostics
 

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -8,10 +8,11 @@ open Internal.Utilities
 open System
 open System.IO
 open FSharp.Compiler 
-open FSharp.Compiler.AbstractIL 
+open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILPdbWriter
 open FSharp.Compiler.AbstractIL.Internal.Library 
+open FSharp.Compiler.AbstractIL.Internal.Utils
 open FSharp.Compiler.AbstractIL.Extensions.ILX
 open FSharp.Compiler.AbstractIL.Diagnostics
 open FSharp.Compiler.CompileOps

--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -115,13 +115,19 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
         let desktopProductVersionMonikers = [|
             // major, minor, build, revision, moniker
                4,     8,      3815,     0,    "net48"
+               4,     8,      3761,     0,    "net48"
                4,     7,      3190,     0,    "net472"
+               4,     7,      3062,     0,    "net472"
                4,     7,      2600,     0,    "net471"
+               4,     7,      2558,     0,    "net471"
                4,     7,      2053,     0,    "net47"
+               4,     7,      2046,     0,    "net47"
                4,     6,      1590,     0,    "net462"
+               4,     6,        57,     0,    "net462"
                4,     6,      1055,     0,    "net461"
                4,     6,        81,     0,    "net46"
                4,     0,     30319, 34209,    "net452"
+               4,     0,     30319, 17020,    "net452"
                4,     0,     30319, 18408,    "net451"
                4,     0,     30319, 17929,    "net45"
                4,     0,     30319,     1,    "net4"
@@ -138,14 +144,17 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
             with _ -> defaultMscorlibVersion
 
         // Get the ProductVersion of this framework compare with table yield compatible monikers
-        let _, _, _, _, moniker =
-            desktopProductVersionMonikers
-            |> Array.find (fun (major, minor, build, revision, _) ->
-                (majorPart >= major) &&
-                (minorPart >= minor) &&
-                (buildPart >= build) &&
-                (privatePart >= revision))
-        moniker
+        match desktopProductVersionMonikers
+              |> Array.tryFind (fun (major, minor, build, revision, _) ->
+                    (majorPart >= major) &&
+                    (minorPart >= minor) &&
+                    (buildPart >= build) &&
+                    (privatePart >= revision)) with
+        | Some (_,_,_,_,moniker) ->
+            moniker
+        | None ->
+            // no TFM could be found, assume latest stable?
+            "net48"
 
     /// Gets the tfm E.g netcore3.0, net472
     let executionTfm =

--- a/src/fsharp/LegacyMSBuildReferenceResolver.fs
+++ b/src/fsharp/LegacyMSBuildReferenceResolver.fs
@@ -344,7 +344,7 @@ module LegacyMSBuildReferenceResolver
 #if ENABLE_MONO_SUPPORT
         // The properties TargetedRuntimeVersion and CopyLocalDependenciesWhenParentReferenceInGac 
         // are not available on Mono. So we only set them if available (to avoid a compile-time dependency). 
-        if not FSharp.Compiler.AbstractIL.IL.runningOnMono then  
+        if not FSharp.Compiler.AbstractIL.Internal.Utils.runningOnMono then
             typeof<ResolveAssemblyReference>.InvokeMember("TargetedRuntimeVersion",(BindingFlags.Instance ||| BindingFlags.SetProperty ||| BindingFlags.Public),null,rar,[| box targetedRuntimeVersionValue |])  |> ignore 
             typeof<ResolveAssemblyReference>.InvokeMember("CopyLocalDependenciesWhenParentReferenceInGac",(BindingFlags.Instance ||| BindingFlags.SetProperty ||| BindingFlags.Public),null,rar,[| box true |])  |> ignore 
 #else

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -29,8 +29,9 @@ open FSharp.Compiler
 open FSharp.Compiler.AbstractIL 
 open FSharp.Compiler.AbstractIL.IL 
 open FSharp.Compiler.AbstractIL.ILBinaryReader 
-open FSharp.Compiler.AbstractIL.Internal 
+open FSharp.Compiler.AbstractIL.Internal
 open FSharp.Compiler.AbstractIL.Internal.Library 
+open FSharp.Compiler.AbstractIL.Internal.Utils
 open FSharp.Compiler.AbstractIL.Diagnostics
 
 open FSharp.Compiler.IlxGen

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -29,6 +29,7 @@ open FSharp.Compiler.AbstractIL.Diagnostics
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILBinaryReader
 open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.Internal.Utils
 open FSharp.Compiler.AbstractIL.ILRuntimeWriter
 open FSharp.Compiler.Lib
 open FSharp.Compiler.AccessibilityLogic

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -12,7 +12,8 @@ open FSharp.Compiler
 open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILBinaryReader
-open FSharp.Compiler.AbstractIL.Internal.Library  
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.Internal.Utils
 
 open FSharp.Compiler.Ast
 open FSharp.Compiler.CompileOps

--- a/tests/service/ScriptOptionsTests.fs
+++ b/tests/service/ScriptOptionsTests.fs
@@ -1,0 +1,36 @@
+#if INTERACTIVE
+#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#load "FsUnit.fs"
+#load "Common.fs"
+#else
+module Tests.Service.ScriptOptions
+#endif
+
+open NUnit.Framework
+open FsUnit
+open System
+open FSharp.Compiler
+open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Service.Tests.Common
+
+// Add additional imports/constructs into this script text to verify that common scenarios
+// for FCS script typechecking can be supported
+let scriptSource = """
+open System
+let pi = Math.PI
+"""
+
+[<TestCase(true, false, [| "--targetprofile:mscorlib" |])>]
+[<TestCase(false, true, [| "--targetprofile:netcore" |])>]
+[<Test>]
+let ``can generate options for different frameworks regardless of execution environment``(assumeNetFx, useSdk, flags) =
+    let path = IO.Path.GetTempPath()
+    let file = IO.Path.GetTempFileName()
+    let tempFile = IO.Path.Combine(path, file)
+    let (options, errors) =
+        checker.GetProjectOptionsFromScript(tempFile, Text.SourceText.ofString scriptSource, assumeDotNetFramework = assumeNetFx, useSdkRefs = useSdk, otherFlags = flags)
+        |> Async.RunSynchronously
+    match errors with
+    | [] -> ()
+    | errors -> failwithf "Error while parsing script with assumeDotNetFramework:%b, useSdkRefs:%b, and otherFlags:%A:\n%A" assumeNetFx useSdk flags errors


### PR DESCRIPTION
While investigating #8357 I ran into a problem running the FCS tests for the net461 TFM caused by a [mono bug around memory-backed MemoryMappedFile creation](https://github.com/mono/mono/issues/10245).  This MR attempts to do a minimal workaround for this bug by giving MemoryMappedFiles names on Mono-on-Posix environments, while leaving the behavior on Mono-on-Windows, .Net Framework, and .Net Core untouched.  This issue will need to be worked around before FCS can be released for a net461 target again, as there are a number of dependent projects that still target net4x.