### PR TITLE
always run mac tests on latest os

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,7 +234,7 @@ stages:
         # MacOS
         - job: MacOS
           pool:
-            vmImage: macOS-10.13
+            vmImage: macOS-latest
           variables:
           - name: _SignType
             value: Test
@@ -367,7 +367,7 @@ stages:
 
         # - job: MacOS_FCS
         #   pool:
-        #     vmImage: macOS-10.13
+        #     vmImage: macOS-latest
         #   variables:
         #   - name: _SignType
         #     value: Test


### PR DESCRIPTION
We have no requirement for specific macos versions, so to avoid any pain when lab machines are updated, we'll just always run on latest.