### PR TITLE
Refactor dependency manager for notebooks and C#

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -5158,7 +5158,7 @@ module ScriptPreprocessClosure =
             let tcConfigB = tcConfig.CloneOfOriginalBuilder 
             TcConfig.Create(tcConfigB, validate=false), nowarns
     
-    let FindClosureFiles(mainFile, _m, closureSources, origTcConfig:TcConfig, codeContext, lexResourceManager: Lexhelp.LexResourceManager) =
+    let FindClosureFiles(_mainFile, _m, closureSources, origTcConfig:TcConfig, codeContext, lexResourceManager: Lexhelp.LexResourceManager) =
         let mutable tcConfig = origTcConfig
         
         let observedSources = Observed()
@@ -5182,7 +5182,7 @@ module ScriptPreprocessClosure =
                                 let inline snd3 (_, b, _) = b
                                 let packageManagerTextLines = packageManagerLines |> List.map snd3
 
-                                match DependencyManagerIntegration.resolve packageManager tcConfig.implicitIncludeDir mainFile scriptName m packageManagerTextLines with
+                                match DependencyManagerIntegration.resolve packageManager ".fsx" m packageManagerTextLines with
                                 | None -> () // error already reported
                                 | Some (succeeded, generatedScripts, additionalIncludeFolders) ->  //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
                                     // This may incrementally update tcConfig too with new #r references

--- a/src/fsharp/DependencyManager.Integration.fsi
+++ b/src/fsharp/DependencyManager.Integration.fsi
@@ -8,7 +8,7 @@ open FSharp.Compiler.Range
 type IDependencyManagerProvider =
     abstract Name: string
     abstract Key: string
-    abstract ResolveDependencies: scriptDir: string * mainScriptName: string * scriptName: string * packageManagerTextLines: string seq * tfm: string -> bool * string list * string list
+    abstract ResolveDependencies: scriptExt: string * packageManagerTextLines: string seq * tfm: string -> bool * string list * string list
     abstract DependencyAdding: IEvent<string * string>
     abstract DependencyAdded: IEvent<string * string>
     abstract DependencyFailed: IEvent<string * string>
@@ -23,4 +23,4 @@ val tryFindDependencyManagerInPath: string list -> string option -> range -> str
 val tryFindDependencyManagerByKey: string list -> string option -> range -> string -> IDependencyManagerProvider option
 val removeDependencyManagerKey: string -> string -> string
 val createPackageManagerUnknownError: string list -> string option -> string -> range -> exn
-val resolve: IDependencyManagerProvider -> string -> string -> string -> range -> string seq -> (bool * string list * string list) option
+val resolve: IDependencyManagerProvider -> string -> range -> string seq -> (bool * string list * string list) option

--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.ProjectFile.fs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+namespace FSharp.DependencyManager
+
+open System
+open System.Collections
+open System.Collections.Generic
+open System.Diagnostics
+open System.IO
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.Versioning
+
+open Internal.Utilities.FSharpEnvironment
+
+// Package reference information
+type PackageReference = {
+    Include:string
+    Version:string
+    RestoreSources:string
+    Script:string }
+
+
+// Resolved assembly information
+type Resolution = {
+    NugetPackageId : string
+    NugetPackageVersion : string
+    PackageRoot : string
+    FullPath : string
+    IsNotImplementationReference: string
+    NativePath : string
+    AppHostRuntimeIdentifier : string
+    InitializeSourcePath : string }
+
+
+module ProjectFile =
+
+    let findLoadsFromResolutions (resolutions:Resolution array) =
+        resolutions
+        |> Array.filter(fun r -> not(String.IsNullOrEmpty(r.NugetPackageId) ||
+                                     String.IsNullOrEmpty(r.InitializeSourcePath)) &&
+                                     File.Exists(r.InitializeSourcePath))
+        |> Array.map(fun r -> r.InitializeSourcePath)
+        |> Array.distinct
+
+    let findIncludesFromResolutions (resolutions:Resolution array) =
+        let managedRoots =
+            resolutions
+            |> Array.filter(fun r -> not(String.IsNullOrEmpty(r.NugetPackageId) ||
+                                         String.IsNullOrEmpty(r.PackageRoot)) &&
+                                         Directory.Exists(r.PackageRoot))
+            |> Array.map(fun r -> r.PackageRoot)
+            |> Array.distinct
+
+        let nativeRoots =
+            resolutions
+            |> Array.filter(fun r -> not(String.IsNullOrEmpty(r.NugetPackageId) ||
+                                         String.IsNullOrEmpty(r.NativePath)) &&
+                                       Directory.Exists(r.NativePath))
+            |> Array.map(fun r -> r.NativePath)
+            |> Array.distinct
+
+        Array.concat [|managedRoots; nativeRoots|]
+
+    let getResolutionsFromFile resolutionsFile =
+
+        let lines =
+            try
+                File.ReadAllText(resolutionsFile).Split([| '\r'; '\n'|], StringSplitOptions.None)
+                     |> Array.filter(fun line -> not(String.IsNullOrEmpty(line)))
+            with
+            | _ -> [||]
+
+        [| for line in lines do
+            let fields = line.Split(',')
+            if fields.Length < 8 then raise (new System.InvalidOperationException(sprintf "Internal error - Invalid resolutions file format '%s'" line))
+            else {
+                NugetPackageId = fields.[0]
+                NugetPackageVersion = fields.[1]
+                PackageRoot = fields.[2]
+                FullPath = fields.[3]
+                IsNotImplementationReference = fields.[4]
+                InitializeSourcePath = fields.[5]
+                NativePath = fields.[6]
+                AppHostRuntimeIdentifier = fields.[7]
+            }
+        |]
+
+    let makeScriptFromResolutions (resolutions:Resolution array) poundRprefix =
+        let expandReferences =
+            resolutions
+            |> Array.filter(fun r -> not(String.IsNullOrEmpty(r.NugetPackageId) ||
+                                         String.IsNullOrEmpty(r.FullPath)) &&
+                                         String.Compare(r.IsNotImplementationReference, "true", StringComparison.InvariantCultureIgnoreCase) <> 0 &&
+                                         File.Exists(r.FullPath)) 
+            |> Array.fold(fun acc r -> acc + poundRprefix + r.FullPath + "\"" + Environment.NewLine) ""
+
+        let fsxTemplate ="""
+// Generated from #r "nuget:Package References"
+// ============================================
+//
+// DOTNET_HOST_PATH:(C:\Program Files\dotnet\dotnet.exe)
+// MSBuildSDKsPath:(C:\Program Files\dotnet\sdk\3.1.200-preview-014883\Sdks)
+// MSBuildExtensionsPath:(C:\Program Files\dotnet\sdk\3.1.200-preview-014883\)
+//
+// References
+//
+$(POUND_R)
+
+"""
+        fsxTemplate.Replace("$(POUND_R)", expandReferences)
+
+    let generateProjectBody = """
+<Project Sdk='Microsoft.NET.Sdk'>
+
+  <PropertyGroup>
+    <TargetFramework>$(TARGETFRAMEWORK)</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+
+    <!-- Temporary fix some sdks, shipped internally with broken parameterization -->
+    <FSharpCoreImplicitPackageVersion Condition="'$(FSharpCoreImplicitPackageVersion)' == '{{FSharpCoreShippedPackageVersion}}'">4.7.0</FSharpCoreImplicitPackageVersion>
+    <FSharpCoreImplicitPackageVersion Condition="'$(FSharpCoreImplicitPackageVersion)' == '{{FSharpCorePreviewPackageVersion}}'">4.7.1-*</FSharpCoreImplicitPackageVersion>
+  </PropertyGroup>
+
+$(PACKAGEREFERENCES)
+
+  <Target Name="ComputePackageRootsForInteractivePackageManagement"
+          DependsOnTargets="ResolveReferences;ResolveSdkReferences;ResolveTargetingPackAssets;ResolveSDKReferences;GenerateBuildDependencyFile">
+
+      <ItemGroup>
+        <__InteractiveReferencedAssemblies Include = "@(ReferencePath)" />
+        <__InteractiveReferencedAssembliesCopyLocal Include = "@(RuntimeCopyLocalItems)" Condition="'$(TargetFrameworkIdentifier)'!='.NETFramework'" />
+        <__InteractiveReferencedAssembliesCopyLocal Include = "@(ReferenceCopyLocalPaths)" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
+        <__ConflictsList Include="%(_ConflictPackageFiles.ConflictItemType)=%(_ConflictPackageFiles.Filename)%(_ConflictPackageFiles.Extension)" />
+      </ItemGroup>
+
+      <PropertyGroup>
+        <__Conflicts>@(__ConflictsList, ';');</__Conflicts>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <InteractiveResolvedFile Include="@(__InteractiveReferencedAssemblies)"
+                                 Condition="$([System.String]::new($(__Conflicts)).Contains($([System.String]::new('Reference=%(__InteractiveReferencedAssemblies.Filename)%(__InteractiveReferencedAssemblies.Extension);'))))"
+                                 KeepDuplicates="false">
+            <NormalizedIdentity Condition="'%(Identity)'!=''">$([System.String]::Copy('%(Identity)').Replace('\', '/'))</NormalizedIdentity>
+            <NormalizedPathInPackage Condition="'%(__InteractiveReferencedAssemblies.PathInPackage)'!=''">$([System.String]::Copy('%(__InteractiveReferencedAssemblies.PathInPackage)').Replace('\', '/'))</NormalizedPathInPackage>
+            <PositionPathInPackage Condition="'%(InteractiveResolvedFile.NormalizedPathInPackage)'!=''">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').IndexOf('%(InteractiveResolvedFile.NormalizedPathInPackage)'))</PositionPathInPackage>
+            <PackageRoot Condition="'%(InteractiveResolvedFile.NormalizedPathInPackage)'!='' and '%(InteractiveResolvedFile.PositionPathInPackage)'!='-1'">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').Substring(0, %(InteractiveResolvedFile.PositionPathInPackage)))</PackageRoot>
+            <InitializeSourcePath>%(InteractiveResolvedFile.PackageRoot)content\%(__InteractiveReferencedAssemblies.FileName)%(__InteractiveReferencedAssemblies.Extension)$(SCRIPTEXTENSION)</InitializeSourcePath>
+            <IsNotImplementationReference>$([System.String]::Copy('%(__InteractiveReferencedAssemblies.PathInPackage)').StartsWith('ref/'))</IsNotImplementationReference>
+            <NuGetPackageId>%(__InteractiveReferencedAssemblies.NuGetPackageId)</NuGetPackageId>
+            <NuGetPackageVersion>%(__InteractiveReferencedAssemblies.NuGetPackageVersion)</NuGetPackageVersion>
+        </InteractiveResolvedFile>
+
+        <InteractiveResolvedFile Include="@(__InteractiveReferencedAssembliesCopyLocal)" KeepDuplicates="false">
+            <NormalizedIdentity Condition="'%(Identity)'!=''">$([System.String]::Copy('%(Identity)').Replace('\', '/'))</NormalizedIdentity>
+            <NormalizedPathInPackage Condition="'%(__InteractiveReferencedAssembliesCopyLocal.PathInPackage)'!=''">$([System.String]::Copy('%(__InteractiveReferencedAssembliesCopyLocal.PathInPackage)').Replace('\', '/'))</NormalizedPathInPackage>
+            <PositionPathInPackage Condition="'%(InteractiveResolvedFile.NormalizedPathInPackage)'!=''">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').IndexOf('%(InteractiveResolvedFile.NormalizedPathInPackage)'))</PositionPathInPackage>
+            <PackageRoot Condition="'%(InteractiveResolvedFile.NormalizedPathInPackage)'!='' and '%(InteractiveResolvedFile.PositionPathInPackage)'!='-1'">$([System.String]::Copy('%(InteractiveResolvedFile.NormalizedIdentity)').Substring(0, %(InteractiveResolvedFile.PositionPathInPackage)))</PackageRoot>
+            <InitializeSourcePath>%(InteractiveResolvedFile.PackageRoot)content\%(__InteractiveReferencedAssembliesCopyLocal.FileName)%(__InteractiveReferencedAssembliesCopyLocal.Extension)$(SCRIPTEXTENSION)</InitializeSourcePath>
+            <IsNotImplementationReference>$([System.String]::Copy('%(__InteractiveReferencedAssembliesCopyLocal.PathInPackage)').StartsWith('ref/'))</IsNotImplementationReference>
+            <NuGetPackageId>%(__InteractiveReferencedAssembliesCopyLocal.NuGetPackageId)</NuGetPackageId>
+            <NuGetPackageVersion>%(__InteractiveReferencedAssembliesCopyLocal.NuGetPackageVersion)</NuGetPackageVersion>
+        </InteractiveResolvedFile>
+
+        <NativeIncludeRoots
+            Include="@(RuntimeTargetsCopyLocalItems)"
+            Condition="'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'">
+            <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))'))</Path>
+        </NativeIncludeRoots>
+      </ItemGroup>
+  </Target>
+
+  <Target Name="InteractivePackageManagement"
+          DependsOnTargets="ComputePackageRootsForInteractivePackageManagement"
+          BeforeTargets="CoreCompile"
+          AfterTargets="PrepareForBuild">
+
+    <ItemGroup>
+      <ResolvedReferenceLines Remove='*' />
+      <ResolvedReferenceLines Include='%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.PackageRoot),%(InteractiveResolvedFile.FullPath),%(InteractiveResolvedFile.IsNotImplementationReference),%(InteractiveResolvedFile.InitializeSourcePath),%(NativeIncludeRoots.Path),$(AppHostRuntimeIdentifier)' KeepDuplicates="false" />
+    </ItemGroup>
+
+    <WriteLinesToFile Lines='@(ResolvedReferenceLines)' 
+                      File='$(MSBuildProjectFullPath).resolvedReferences.paths' 
+                      Overwrite='True' WriteOnlyWhenDifferent='True' />
+  </Target>
+
+</Project>"""

--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.ProjectFile.fs
@@ -94,7 +94,7 @@ module ProjectFile =
                                          File.Exists(r.FullPath)) 
             |> Array.fold(fun acc r -> acc + poundRprefix + r.FullPath + "\"" + Environment.NewLine) ""
 
-        let fsxTemplate ="""
+        let projectTemplate ="""
 // Generated from #r "nuget:Package References"
 // ============================================
 //
@@ -107,7 +107,7 @@ module ProjectFile =
 $(POUND_R)
 
 """
-        fsxTemplate.Replace("$(POUND_R)", expandReferences)
+        projectTemplate.Replace("$(POUND_R)", expandReferences)
 
     let generateProjectBody = """
 <Project Sdk='Microsoft.NET.Sdk'>

--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.fs
@@ -8,14 +8,13 @@ open System.Diagnostics
 open System.IO
 open FSharp.DependencyManager
 open FSharp.DependencyManager.Utilities
+open FSharp.DependencyManager.ProjectFile
 
-module Attributes =
-    [<assembly: DependencyManagerAttribute()>]
-    do ()
-
-type PackageReference = { Include:string; Version:string; RestoreSources:string; Script:string }
 
 module FSharpDependencyManager =
+
+    [<assembly: DependencyManagerAttribute()>]
+    do ()
 
     let private concat (s:string) (v:string) : string =
         match String.IsNullOrEmpty(s), String.IsNullOrEmpty(v) with
@@ -107,7 +106,9 @@ type [<DependencyManagerAttribute>] FSharpDependencyManager (outputDir:string op
         match outputDir with
         | None -> path
         | Some v -> Path.Combine(path, v)
+
     let generatedScripts = new ConcurrentDictionary<string,string>()
+
     let deleteScripts () =
         try
             if Directory.Exists(scriptsPath) then
@@ -134,8 +135,12 @@ type [<DependencyManagerAttribute>] FSharpDependencyManager (outputDir:string op
 
     member __.Key = key
 
-    member __.ResolveDependencies(_scriptDir:string, _mainScriptName:string, _scriptName:string, packageManagerTextLines:string seq, tfm: string) : bool * string list * string list =
+    member __.ResolveDependencies(scriptExt:string, packageManagerTextLines:string seq, tfm: string) : bool * string list * string list =
 
+        let scriptExt, poundRprefix  =
+            match scriptExt with
+            | ".csx" -> ".csx", "#r \"" 
+            | _ -> ".fsx", "#r @\"" 
         let packageReferences, binLogPath =
             packageManagerTextLines
             |> List.ofSeq
@@ -152,20 +157,28 @@ type [<DependencyManagerAttribute>] FSharpDependencyManager (outputDir:string op
                 if not (generatedScripts.ContainsKey(body.GetHashCode().ToString())) then
                     emitFile path  body
 
-            let fsProjectPath = Path.Combine(scriptsPath, "Project.fsproj")
+            let projectPath = Path.Combine(scriptsPath, "Project.fsproj")
 
             let generateProjBody =
                 generateProjectBody.Replace("$(TARGETFRAMEWORK)", tfm)
                                    .Replace("$(PACKAGEREFERENCES)", packageReferenceText)
+                                   .Replace("$(SCRIPTEXTENSION)", scriptExt)
 
-            writeFile fsProjectPath generateProjBody
+            writeFile projectPath generateProjBody
 
-            let succeeded, resultingFsx = buildProject fsProjectPath binLogPath
-            let fsx =
-                match resultingFsx with
-                | Some fsx -> [fsx]
-                | None -> []
+            let result, resolutionsFile = buildProject projectPath binLogPath
+            match resolutionsFile with
+            | Some file ->
+                let resolutions = getResolutionsFromFile file
+                let scripts =
+                    let scriptPath = projectPath + scriptExt
+                    let scriptBody =  makeScriptFromResolutions resolutions poundRprefix
+                    emitFile scriptPath scriptBody
+                    let loads = (findLoadsFromResolutions resolutions) |> Array.toList
+                    List.concat [ [scriptPath]; loads]
+                let includes = (findIncludesFromResolutions resolutions) |> Array.toList
 
-            succeeded, fsx, List.empty<string>
+                result, scripts, includes
+            | None -> result, [], []
 
         generateAndBuildProjectArtifacts

--- a/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.fsproj
+++ b/src/fsharp/FSharp.DependencyManager/FSharp.DependencyManager.fsproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <EmbeddedText Include="FSDependencyManager.txt" />
     <Compile Include="$(FSharpSourcesRoot)\utils\CompilerLocationUtils.fs" />
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.DependencyManager\FSharp.DependencyManager.ProjectFile.fs" />
     <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.DependencyManager\FSharp.DependencyManager.Utilities.fs" />
     <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.DependencyManager\FSharp.DependencyManager.fs" />
   </ItemGroup>

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1302,7 +1302,7 @@ type internal FsiDynamicCompiler
                             Event.add dependencyAddingEvent.Trigger packageManager.DependencyAdding
                             Event.add dependencyAddedEvent.Trigger packageManager.DependencyAdded
                             Event.add dependencyFailedEvent.Trigger packageManager.DependencyFailed
-                        match DependencyManagerIntegration.resolve packageManager tcConfigB.implicitIncludeDir "stdin.fsx" "stdin.fsx" m packageManagerTextLines with
+                        match DependencyManagerIntegration.resolve packageManager ".fsx" m packageManagerTextLines with
                         | None -> istate // error already reported
                         | Some (succeeded, generatedScripts, additionalIncludeFolders) ->    //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
                             if succeeded then


### PR DESCRIPTION
So ...
the notebooks are going to take a dependency on this for C# packet management.  So, we need to do a few things a bit differently internally.

1.  We need to not generate #I and #load for script and package roots.  Instead we now return them using the lists returned from the method.  The mechanism was always there, however, we used to do it in the generated script.
2.  The script is no longer generated by msbuild, instead the dependency manager generates it.
3.  We no longer pass in the names and directory of the scripts, since they were never used.
4.  We pass in the script extension, to allow us to distinguish between CSX files and FSX files in nuget packages that contain initialization scripts.
5.  We used to spill the msbuild text to a file, and leave it on disk for diagnosis, now if there is a build error we spill them to the console too.
6.  A lot of the change is to move the projectfile text out of blah.utilities.fs into blah.ProjectFile.fs which makes things slightly less confusing.
7. Note:
C# syntax for #r looks like: #r "nuget:Somestuff"
F# syntax for #r looks like: #r @"nuget:Somestuff"

Kevin