### PR TITLE
Remove unnecessary experimental add include events.

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2170,8 +2170,6 @@ type TcConfigBuilder =
       mutable pathMap: PathMap
 
       mutable langVersion: LanguageVersion
-
-      mutable includePathAdded: string -> unit
       }
 
     static member Initial =
@@ -2312,18 +2310,16 @@ type TcConfigBuilder =
           noConditionalErasure = false
           pathMap = PathMap.empty
           langVersion = LanguageVersion("default")
-          includePathAdded = ignore
         }
 
     static member CreateNew(legacyReferenceResolver, defaultFSharpBinariesDir, reduceMemoryUsage, implicitIncludeDir,
-                            isInteractive, isInvalidationSupported, defaultCopyFSharpCore, tryGetMetadataSnapshot, ?includePathAdded: string -> unit) =
+                            isInteractive, isInvalidationSupported, defaultCopyFSharpCore, tryGetMetadataSnapshot) =
 
         Debug.Assert(FileSystem.IsPathRootedShim implicitIncludeDir, sprintf "implicitIncludeDir should be absolute: '%s'" implicitIncludeDir)
 
         if (String.IsNullOrEmpty defaultFSharpBinariesDir) then
             failwith "Expected a valid defaultFSharpBinariesDir"
 
-        let includePathAdded = defaultArg includePathAdded ignore
         { TcConfigBuilder.Initial with 
             implicitIncludeDir = implicitIncludeDir
             defaultFSharpBinariesDir = defaultFSharpBinariesDir
@@ -2334,7 +2330,6 @@ type TcConfigBuilder =
             copyFSharpCore = defaultCopyFSharpCore
             tryGetMetadataSnapshot = tryGetMetadataSnapshot
             useFsiAuxLib = isInteractive
-            includePathAdded = includePathAdded
         }
 
     member tcConfigB.ResolveSourceFile(m, nm, pathLoadedFrom) = 
@@ -2410,7 +2405,6 @@ type TcConfigBuilder =
             | None -> false
         if ok && not (List.contains absolutePath tcConfigB.includes) then 
            tcConfigB.includes <- tcConfigB.includes ++ absolutePath
-           tcConfigB.includePathAdded absolutePath
 
     member tcConfigB.AddLoadedSource(m, originalPath, pathLoadedFrom) =
         if FileSystem.IsInvalidPathShim originalPath then

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -389,8 +389,6 @@ type TcConfigBuilder =
       mutable pathMap : PathMap
 
       mutable langVersion : LanguageVersion
-
-      mutable includePathAdded : string -> unit
     }
 
     static member Initial: TcConfigBuilder
@@ -403,8 +401,7 @@ type TcConfigBuilder =
         isInteractive: bool * 
         isInvalidationSupported: bool *
         defaultCopyFSharpCore: CopyFSharpCoreFlag *
-        tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot *
-        ?includePathAdded: (string -> unit)
+        tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot
           -> TcConfigBuilder
 
     member DecideNames: string list -> outfile: string * pdbfile: string option * assemblyName: string 
@@ -417,7 +414,7 @@ type TcConfigBuilder =
     member AddEmbeddedSourceFile: string -> unit
     member AddEmbeddedResource: string -> unit
     member AddPathMapping: oldPrefix: string * newPrefix: string -> unit
-    
+
     static member SplitCommandLineResourceInfo: string -> string * string * ILResourceAccess
 
 [<Sealed>]

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharpScript.fs
@@ -22,9 +22,6 @@ type FSharpScript(?additionalArgs: string[]) =
     member __.ValueBound = fsi.ValueBound
 
     [<CLIEvent>]
-    member __.IncludePathAdded = fsi.IncludePathAdded
-
-    [<CLIEvent>]
     member __.DependencyAdding = fsi.DependencyAdding
 
     [<CLIEvent>]

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2540,8 +2540,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         | None -> SimulatedMSBuildReferenceResolver.getResolver()
         | Some rr -> rr
 
-    let includePathAddedEvent = Control.Event<_>()
-
     let tcConfigB =
         TcConfigBuilder.CreateNew(legacyReferenceResolver, 
             defaultFSharpBinariesDir=defaultFSharpBinariesDir, 
@@ -2550,8 +2548,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
             isInteractive=true, 
             isInvalidationSupported=false, 
             defaultCopyFSharpCore=CopyFSharpCoreFlag.No, 
-            tryGetMetadataSnapshot=tryGetMetadataSnapshot,
-            includePathAdded=includePathAddedEvent.Trigger)
+            tryGetMetadataSnapshot=tryGetMetadataSnapshot)
 
     let tcConfigP = TcConfigProvider.BasedOnMutableBuilder(tcConfigB)
     do tcConfigB.resolutionEnvironment <- ResolutionEnvironment.CompilationAndEvaluation // See Bug 3608
@@ -2857,10 +2854,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     /// Event fires when a root-level value is bound to an identifier, e.g., via `let x = ...`.
     member __.ValueBound = fsiDynamicCompiler.ValueBound
-
-    [<CLIEvent>]
-    /// Event fires every time a path is added to the include search list, e.g., via `#I`.
-    member __.IncludePathAdded = includePathAddedEvent.Publish
 
     [<CLIEvent>]
     /// Event fires at the start of adding a dependency via the dependency manager.

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -235,10 +235,6 @@ type FsiEvaluationSession =
     member ReportUnhandledException : exn: exn -> unit
 
     [<CLIEvent>]
-    /// Event fires every time a path is added to the include search list, e.g., via `#I`.
-    member IncludePathAdded: IEvent<string>
-
-    [<CLIEvent>]
     /// Event fires at the start of adding a dependency via the dependency manager.
     member DependencyAdding: IEvent<string * string>
 

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -82,30 +82,6 @@ stacktype.Name = "Stack"
         Assert.AreEqual(1, errors.Length)
 
     [<Test>]
-    member __.``Add include path event successful``() =
-        use script = new FSharpScript()
-        let includePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
-        let mutable includePathEventCount = 0
-        let mutable foundIncludePath = false
-        Event.add (fun (inc: string) ->
-            includePathEventCount <- includePathEventCount + 1
-            foundIncludePath <- foundIncludePath || String.Compare(includePath, inc, StringComparison.OrdinalIgnoreCase) = 0)
-            script.IncludePathAdded
-        script.Eval(sprintf "#I @\"%s\"" includePath) |> ignoreValue
-        Assert.AreEqual(1, includePathEventCount)
-        Assert.True(foundIncludePath)
-
-    [<Test>]
-    member __.``Add include path event unsuccessful``() =
-        use script = new FSharpScript()
-        let includePath = Path.Combine("a", "path", "that", "can't", "be", "found")
-        let mutable foundIncludePath = false
-        Event.add (fun _ -> foundIncludePath <- true) script.IncludePathAdded
-        let _result, errors = script.Eval(sprintf "#I @\"%s\"" includePath)
-        Assert.AreEqual(1, errors.Length)
-        Assert.False(foundIncludePath)
-
-    [<Test>]
     member _.``Compilation errors report a specific exception``() =
         use script = new FSharpScript()
         let result, _errors = script.Eval("abc")
@@ -121,15 +97,6 @@ stacktype.Name = "Stack"
         match result with
         | Ok(_) -> Assert.Fail("expected a failure")
         | Error(ex) -> Assert.IsInstanceOf<FileNotFoundException>(ex)
-
-    [<Test>]
-    member __.``Nuget reference fires multiple events``() =
-        use script = new FSharpScript(additionalArgs=[|"/langversion:preview"|])
-        let mutable includeAddCount = 0
-        Event.add (fun _ -> includeAddCount <- includeAddCount + 1) script.IncludePathAdded
-        script.Eval("#r \"nuget:include=NUnitLite, version=3.11.0\"") |> ignoreValue
-        script.Eval("0") |> ignoreValue
-        Assert.GreaterOrEqual(includeAddCount, 1)
 
 /// Native dll resolution is not implemented on desktop
 #if NETSTANDARD


### PR DESCRIPTION
These were part of the original notebook integration mechanism.  They are no longer necessary and so I am removing them.

Kevin