### PR TITLE
skip flaky tests in official builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,9 @@ variables:
     value: .NETCore
   - name: VisualStudioDropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+  - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+    - name: RunningAsPullRequest
+      value: true
 
 # Variables defined in yml cannot be overridden at queue time; instead overridable variables must be defined in the web UI.
 # Commenting out until something like this is supported: https://github.com/Microsoft/azure-pipelines-yaml/pull/129

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -256,6 +256,10 @@ function TestUsingNUnit([string] $testProject, [string] $targetFramework) {
         $args += " --no-build"
     }
 
+    if ($env:RunningAsPullRequest -ne "true") {
+        $args += " --filter TestCategory!=PullRequest"
+    }
+
     Exec-Console $dotnetExe $args
 }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -181,10 +181,15 @@ function TestUsingNUnit() {
     exit 1
   fi
 
+  filterArgs=""
+  if [[ "${RunningAsPullRequest:-}" != "true" ]]; then
+    filterArgs=" --filter TestCategory!=PullRequest"
+  fi
+
   projectname=$(basename -- "$testproject")
   projectname="${projectname%.*}"
   testlogpath="$artifacts_dir/TestResults/$configuration/${projectname}_$targetframework.xml"
-  args="test \"$testproject\" --no-restore --no-build -c $configuration -f $targetframework --test-adapter-path . --logger \"nunit;LogFilePath=$testlogpath\""
+  args="test \"$testproject\" --no-restore --no-build -c $configuration -f $targetframework --test-adapter-path . --logger \"nunit;LogFilePath=$testlogpath\"$filterArgs"
   "$DOTNET_INSTALL_DIR/dotnet" $args || exit $?
 }
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/MailboxProcessorType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/MailboxProcessorType.fs
@@ -70,6 +70,7 @@ type MailboxProcessorType() =
         ()
 
     [<Test>]
+    [<Category("PullRequest")>]
     member this.``Receive handles cancellation token``() =
         let result = ref None
 
@@ -103,6 +104,7 @@ type MailboxProcessorType() =
         Assert.AreEqual(Some("Received 1 Disposed"), !result)
 
     [<Test>]
+    [<Category("PullRequest")>]
     member this.``Receive with timeout argument handles cancellation token``() =
         let result = ref None
 


### PR DESCRIPTION
Some MailBoxProcessor tests are flaky so we're skipping them on official builds, but keeping them alive on PRs. This way we'll definitely know when they break, but the inherent flakiness won't prevent official builds.