### PR TITLE
re-enable end-to-end type provider tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,6 +86,8 @@ stages:
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                     /p:PublishToSymbolServer=true
                     /p:VisualStudioDropName=$(VisualStudioDropName)
+          - script: .\tests\EndToEndBuildTests\EndToEndBuildTests.cmd -c $(_BuildConfig)
+            displayName: End to end build tests
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:
@@ -265,6 +267,17 @@ stages:
               publishLocation: Container
             continueOnError: true
             condition: failed()
+
+        # End to end build
+        - job: EndToEndBuildTests
+          pool:
+            vmImage: windows-2019
+          steps:
+          - checkout: self
+            clean: true
+          - script: .\Build.cmd -c Release
+          - script: .\tests\EndToEndBuildTests\EndToEndBuildTests -c Release
+            displayName: End to end build tests
 
         # Source Build Linux
         - job: SourceBuild_Linux

--- a/tests/EndToEndBuildTests/BasicProvider/BasicProvider.Tests/BasicProvider.Tests.fsproj
+++ b/tests/EndToEndBuildTests/BasicProvider/BasicProvider.Tests/BasicProvider.Tests.fsproj
@@ -6,7 +6,6 @@
     <TargetFramework Condition=" '$(TestTargetFramework)' != '' ">$(TestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>NO_GENERATIVE</DefineConstants>
-    <DebugType>None</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +19,7 @@
         <PackagePath>content\myfiles\</PackagePath>
     </Content>
     <PackageReference Include="BasicProvider" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/EndToEndBuildTests/BasicProvider/TestBasicProvider.cmd
+++ b/tests/EndToEndBuildTests/BasicProvider/TestBasicProvider.cmd
@@ -8,6 +8,22 @@ rem
 
 setlocal
 set __scriptpath=%~dp0
+set configuration=Debug
+
+:parseargs
+if "%1" == "" goto argsdone
+if /i "%1" == "-c" goto set_configuration
+
+echo Unsupported argument: %1
+goto failure
+
+:set_configuration
+set configuration=%2
+shift
+shift
+goto parseargs
+
+:argsdone
 
 pushd %__scriptpath%
 rem
@@ -18,17 +34,17 @@ rem
 if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\BasicProvider /s /q
 taskkill /F /IM dotnet.exe
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40 -nr=false
-@if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+echo dotnet pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c %configuration% -v minimal -p:FSharpTestCompilerVersion=net40
+     dotnet pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c %configuration% -v minimal -p:FSharpTestCompilerVersion=net40
+if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-@if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+echo dotnet test BasicProvider.Tests\BasicProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+     dotnet test BasicProvider.Tests\BasicProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-@if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+echo dotnet test BasicProvider.Tests\BasicProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr
+     dotnet test BasicProvider.Tests\BasicProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr
+if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
 rem
 rem Build typeprovider package with coreclr compiler
@@ -36,17 +52,17 @@ rem Test it with both desktop and coreclr compilers
 rem
 if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\BasicProvider /s /q
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr -nr=false
-@if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+echo dotnet pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c %configuration% -v minimal -p:FSharpTestCompilerVersion=coreclr
+     dotnet pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c %configuration% -v minimal -p:FSharpTestCompilerVersion=coreclr
+if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-@if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+echo dotnet test BasicProvider.Tests\BasicProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+     dotnet test BasicProvider.Tests\BasicProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-@if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+echo dotnet test BasicProvider.Tests\BasicProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr
+     dotnet test BasicProvider.Tests\BasicProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr
+if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
 :success
 endlocal

--- a/tests/EndToEndBuildTests/ComboProvider/ComboProvider.Tests/ComboProvider.Tests.fsproj
+++ b/tests/EndToEndBuildTests/ComboProvider/ComboProvider.Tests/ComboProvider.Tests.fsproj
@@ -6,7 +6,6 @@
     <TargetFramework Condition=" '$(TestTargetFramework)' != '' ">$(TestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>NO_GENERATIVE</DefineConstants>
-    <DebugType>None</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +16,7 @@
     </None>
 
     <PackageReference Include="ComboProvider" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/EndToEndBuildTests/ComboProvider/TestComboProvider.cmd
+++ b/tests/EndToEndBuildTests/ComboProvider/TestComboProvider.cmd
@@ -8,7 +8,24 @@ rem
 
 setlocal
 set __scriptpath=%~dp0
+set configuration=Debug
 
+:parseargs
+if "%1" == "" goto argsdone
+if /i "%1" == "-c" goto set_configuration
+
+echo Unsupported argument: %1
+goto failure
+
+:set_configuration
+set configuration=%2
+shift
+shift
+goto parseargs
+
+:argsdone
+
+pushd %__scriptpath%
 rem
 rem Build typeprovider package with desktop compiler
 rem Test it with both desktop and coreclr compilers
@@ -17,17 +34,17 @@ rem
 if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\ComboProvider /s /q
 taskkill /F /IM dotnet.exe
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40 -nr=false
-@if ERRORLEVEL 1 echo Error: ComboProvider failed  && goto :failure
+echo dotnet pack ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c %configuration% -v minimal -p:FSharpTestCompilerVersion=net40
+     dotnet pack ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c %configuration% -v minimal -p:FSharpTestCompilerVersion=net40
+if ERRORLEVEL 1 echo Error: TestComboProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-@if ERRORLEVEL 1 echo Error: ComboProvider failed  && goto :failure
+echo dotnet test ComboProvider.Tests\ComboProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+     dotnet test ComboProvider.Tests\ComboProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+if ERRORLEVEL 1 echo Error: TestComboProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-@if ERRORLEVEL 1 echo Error: ComboProviderProvider failed  && goto :failure
+echo dotnet test ComboProvider.Tests\ComboProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr
+     dotnet test ComboProvider.Tests\ComboProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr
+if ERRORLEVEL 1 echo Error: TestComboProvider failed  && goto :failure
 
 rem
 rem Build typeprovider package with coreclr compiler
@@ -35,24 +52,26 @@ rem Test it with both desktop and coreclr compilers
 rem
 if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\ComboProvider /s /q
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr -nr=false
-@if ERRORLEVEL 1 echo Error: ComboProviderProvider failed  && goto :failure
+echo dotnet pack ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c %configuration% -v minimal -p:FSharpTestCompilerVersion=coreclr
+     dotnet pack ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c %configuration% -v minimal -p:FSharpTestCompilerVersion=coreclr
+if ERRORLEVEL 1 echo Error: TestComboProvider failed  && goto :failure
 
-@echo%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-@if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+echo dotnet test ComboProvider.Tests\ComboProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+     dotnet test ComboProvider.Tests\ComboProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+if ERRORLEVEL 1 echo Error: TestComboProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-@if ERRORLEVEL 1 echo Error: ComboProvider failed  && goto :failure
+echo dotnet test ComboProvider.Tests\ComboProvider.Tests.fsproj -v %configuration% -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr
+     dotnet test ComboProvider.Tests\ComboProvider.Tests.fsproj -c %configuration% -v minimal -p:TestTargetFramework=netcoreapp3.0 -p:FSharpTestCompilerVersion=coreclr
+if ERRORLEVEL 1 echo Error: TestComboProvider failed  && goto :failure
 
 :success
 endlocal
 echo Succeeded
+popd
 exit /b 0
 
 :failure
 endlocal
 echo Failed
+popd
 exit /b 1

--- a/tests/EndToEndBuildTests/EndToEndBuildTests.cmd
+++ b/tests/EndToEndBuildTests/EndToEndBuildTests.cmd
@@ -6,20 +6,35 @@ rem
 
 setlocal
 set __scriptpath=%~dp0
+set configuration=Debug
 
-@echo %__scriptpath%BasicProvider\TestBasicProvider.cmd
-call %__scriptpath%BasicProvider\TestBasicProvider.cmd
-@if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+:parseargs
+if "%1" == "" goto argsdone
+if /i "%1" == "-c" goto set_configuration
 
-@echo %__scriptpath%ComboProvider\TestComboProvider.cmd
-call %__scriptpath%ComboProvider\TestComboProvider.cmd
-@if ERRORLEVEL 1 echo Error: TestComboProvider failed  && goto :failure
+echo Unsupported argument: %1
+goto failure
+
+:set_configuration
+set configuration=%2
+shift
+shift
+goto parseargs
+
+:argsdone
+
+echo %__scriptpath%BasicProvider\TestBasicProvider.cmd -c %configuration%
+call %__scriptpath%BasicProvider\TestBasicProvider.cmd -c %configuration%
+if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
+
+echo %__scriptpath%ComboProvider\TestComboProvider.cmd -c %configuration%
+call %__scriptpath%ComboProvider\TestComboProvider.cmd -c %configuration%
+if ERRORLEVEL 1 echo Error: TestComboProvider failed  && goto :failure
 
 :success
 endlocal
 echo Succeeded
 exit /b 0
-
 
 :failure
 endlocal

--- a/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs
+++ b/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs
@@ -12373,7 +12373,7 @@ namespace ProviderImplementation.ProvidedTypes
 
         let writeBytes (os: BinaryWriter) (chunk:byte[]) = os.Write(chunk, 0, chunk.Length)  
 
-        let writeBinaryAndReportMappings (outfile, 
+        let writeBinaryAndReportMappings (outfile: string,
                                           ilg: ILGlobals, pdbfile: string option, (* signer: ILStrongNameSigner option, *) portablePDB, embeddedPDB, 
                                           embedAllSource, embedSourceList, sourceLink, emitTailcalls, deterministic, showTimes, dumpDebugInfo ) modul =
             let isDll = modul.IsDLL


### PR DESCRIPTION
Turns out the end-to-end type provider build tests aren't being run.  This is just some quick cleanup to re-enable them.  A one-off PR leg was added as well as a step in the official signed build.