### PR TITLE
Make Log*FunctionId types internal

### DIFF
--- a/src/fsharp/Logger.fsi
+++ b/src/fsharp/Logger.fsi
@@ -4,9 +4,7 @@ namespace FSharp.Compiler
 
 open System
 
-// FIXME: We cannot make this internal yet until F# gets a compiler switch to make cases public when the type itself is internal.
-// https://github.com/Microsoft/visualfsharp/issues/4821
-type (* internal *) LogCompilerFunctionId =
+type internal LogCompilerFunctionId =
     | Service_ParseAndCheckFileInProject = 1
     | Service_CheckOneFile = 2
     | Service_IncrementalBuildersCache_BuildingNewCache = 3

--- a/vsintegration/src/FSharp.Editor/Common/Logger.fsi
+++ b/vsintegration/src/FSharp.Editor/Common/Logger.fsi
@@ -4,9 +4,7 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
 
-// FIXME: We cannot make this internal yet until F# gets a compiler switch to make cases public when the type itself is internal.
-// https://github.com/Microsoft/visualfsharp/issues/4821
-type (* internal *) LogEditorFunctionId =
+type internal LogEditorFunctionId =
     | Classification_Semantic = 1
     | Classification_Syntactic = 2
     | LanguageService_HandleCommandLineArgs = 3


### PR DESCRIPTION
As per the FIXME comments, the types can be internal now that #4821 has
been fixed.

Tested by:
- Making changes
- Building projects
- Ctrl+F5 launching a new Visual Studio Experimental instance
- Running perfview to capture ETW events and comparing before and after changes for "FSharp" events
- Ensured the Function Id's were strings in both cases.

PerfView launched by:

```ps
.\PerfView.exe collect C:\temp\ReproTrace.etl -CircularMB:4096 -BufferSizeMB:256 -Merge:true -Zip:true -Providers:641d7f6c-481c-42e8-ab7e-d18dc5e5cb9e,*FSharpCompiler,.NETTasks:0:0 -ThreadTime -NoV2Rundown -NoNGenRundown
```