### PR TITLE
fix object expression on Language-Version-History.md

### DIFF
--- a/Language-Version-History.md
+++ b/Language-Version-History.md
@@ -8,6 +8,7 @@ Features Added in F# Language Versions
 - Tuples
 - Pattern matching
 - Type abbreviations
+- Object expressions
 - Structs
 - Signature files
 - Imperative programming
@@ -25,7 +26,6 @@ Features Added in F# Language Versions
 
 - Active patterns
 - Units of measure
-- Object expressions
 - Sequence expressions
 - Asynchronous programming
 - Agent programming


### PR DESCRIPTION
update object expression was target on F#1.1 while in dons blog it is on F# 1.0

