### PR TITLE
Respect env variable NUGET_PACKAGES in additonal locations

### DIFF
--- a/tests/fsharp/core/span/common-pre.fsx
+++ b/tests/fsharp/core/span/common-pre.fsx
@@ -1,4 +1,8 @@
 open System
 open System.IO
 
-File.WriteAllText("refs.generated.fsx", sprintf @"#r @""%s\.nuget\packages\System.Memory\4.5.3\lib\netstandard2.0\System.Memory.dll""" (Environment.GetEnvironmentVariable("USERPROFILE")))
+let packagesDir = 
+    match Environment.GetEnvironmentVariable("NUGET_PACKAGES") with
+    | null -> Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), ".nuget", "packages")
+    | path -> path
+File.WriteAllText("refs.generated.fsx", sprintf @"#r @""%s\System.Memory\4.5.3\lib\netstandard2.0\System.Memory.dll""" packagesDir)

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -156,7 +156,10 @@ type FSLibPaths =
 let requireFile nm = 
     if Commands.fileExists __SOURCE_DIRECTORY__ nm |> Option.isSome then nm else failwith (sprintf "couldn't find %s. Running 'build test' once might solve this issue" nm)
 
-let packagesDir = Environment.GetEnvironmentVariable("USERPROFILE") ++ ".nuget" ++ "packages"
+let packagesDir = 
+    match Environment.GetEnvironmentVariable("NUGET_PACKAGES") with
+    | null -> Environment.GetEnvironmentVariable("USERPROFILE") ++ ".nuget" ++ "packages"
+    | path -> path
 
 let config configurationName envVars =
 

--- a/tests/fsharp/typecheck/sigs/neg107-pre.fsx
+++ b/tests/fsharp/typecheck/sigs/neg107-pre.fsx
@@ -1,4 +1,8 @@
 open System
 open System.IO
 
-File.WriteAllText("neg107.generated.fsx", sprintf @"#r @""%s\.nuget\packages\System.Memory\4.5.3\lib\netstandard2.0\System.Memory.dll""" (Environment.GetEnvironmentVariable("USERPROFILE")))
+let packagesDir = 
+    match Environment.GetEnvironmentVariable("NUGET_PACKAGES") with
+    | null -> Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), ".nuget", "packages")
+    | path -> path
+File.WriteAllText("neg107.generated.fsx", sprintf @"#r @""%s\System.Memory\4.5.3\lib\netstandard2.0\System.Memory.dll""" packagesDir)

--- a/tests/fsharpqa/run.fsharpqa.test.fsx
+++ b/tests/fsharpqa/run.fsharpqa.test.fsx
@@ -15,7 +15,10 @@ let addToPath path =
     if not(Array.contains path splits) then
         setEnvVar "PATH" (path + (string Path.PathSeparator) + currentPath)
 
-let nugetCache = Path.Combine(System.Environment.GetEnvironmentVariable "USERPROFILE", ".nuget", "packages")
+let nugetCache = 
+    match System.Environment.GetEnvironmentVariable("NUGET_PACKAGES") with
+    | null -> Path.Combine(System.Environment.GetEnvironmentVariable "USERPROFILE", ".nuget", "packages")
+    | path -> path
 let rootFolder = Path.Combine(__SOURCE_DIRECTORY__, "..", "..")
 let compilerBinFolder = Path.Combine(rootFolder, "artifacts", "bin", "fsc", releaseOrDebug, "net472")
 setEnvVar "CSC_PIPE"      (Path.Combine(nugetCache, "Microsoft.Net.Compilers", "2.7.0", "tools", "csc.exe"))

--- a/tests/scripts/fscc.fsx
+++ b/tests/scripts/fscc.fsx
@@ -8,12 +8,6 @@ open System.IO
 
 let root            = Path.GetFullPath                   (__SOURCE_DIRECTORY__ ++ ".." ++ "..")
 
-// %USERPROFILE%/.nuget/packages
-let defaultPackagesDir =
-    match System.Environment.GetEnvironmentVariable("USERPROFILE") with
-    | p -> p ++ @".nuget\packages"
-    | _ -> root ++ "packages"
-
 let Platform        = getCmdLineArg "--platform:"        "win7-x64"
 let ProjectJsonLock = getCmdLineArg "--projectJsonLock:" (root ++ "tests" ++ "fsharp" ++ "FSharp.Tests.FSharpSuite.DrivingCoreCLR" ++ "project.lock.json")
 let PackagesDir     = getCmdLineArg "--packagesDir:"     (root ++ "packages")

--- a/tests/scripts/fsci.fsx
+++ b/tests/scripts/fsci.fsx
@@ -6,11 +6,6 @@ open System.IO
 open System.Diagnostics
 
 let root            = Path.GetFullPath                   (__SOURCE_DIRECTORY__ ++ ".." ++ "..")
-// %USERPROFILE%/.nuget/packages
-let defaultPackagesDir =
-    match System.Environment.GetEnvironmentVariable("USERPROFILE") with
-    | p -> p ++ @".nuget\packages"
-    | _ -> root ++ "packages"
 
 let Platform        = getCmdLineArg "--platform:"        "win7-x64"
 let ProjectJsonLock = getCmdLineArg "--projectJsonLock:" (root ++ "tests" ++ "fsharp" ++ "FSharp.Tests.FSharpSuite.DrivingCoreCLR" ++ "project.lock.json")


### PR DESCRIPTION
Follow up to issue #8620 and pr #8622.


There are some additional locations that use `%userprofile%/.nuget/packages` without looking for `NUGET_PACKAGES`:
* [test-framework.fs](https://github.com/dotnet/fsharp/blob/468f5a48e8d9181cdd15369c474ef9d9a9128b46/tests/fsharp/test-framework.fs#L159) in FSharp Test Suite (which results in failing the Cambridge tests)
* [common-pre.fsx](https://github.com/dotnet/fsharp/blob/468f5a48e8d9181cdd15369c474ef9d9a9128b46/tests/fsharp/core/span/common-pre.fsx#L4) in FSharp Test Suite (testing Spans)
* [neg107-pre.fsx](https://github.com/dotnet/fsharp/blob/468f5a48e8d9181cdd15369c474ef9d9a9128b46/tests/fsharp/typecheck/sigs/neg107-pre.fsx#L4) in FSharp Test Suite (testing typechecks)
* [run.fsharpqa.test.fsx](https://github.com/dotnet/fsharp/blob/468f5a48e8d9181cdd15369c474ef9d9a9128b46/tests/fsharpqa/run.fsharpqa.test.fsx#L18) in FSharpQA
* [fscc.fsx](https://github.com/dotnet/fsharp/blob/468f5a48e8d9181cdd15369c474ef9d9a9128b46/tests/scripts/fscc.fsx#L14) and [fsci.fsx](https://github.com/dotnet/fsharp/blob/468f5a48e8d9181cdd15369c474ef9d9a9128b46/tests/scripts/fsci.fsx#L12) in `/tests/scripts`.  
But the usage (via variable `defaultPackagesDir`) was removed quite a while ago (#2099). Instead a local packages directory is always used. So I completely removed that part in both files.