### PR TITLE
Fix wild self id pat range

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1942,8 +1942,8 @@ atomicPatternLongIdent:
   | pathOp { (None,$1) }
   | access UNDERSCORE DOT pathOp {
     if not (parseState.LexBuffer.SupportsFeature LanguageFeature.SingleUnderscorePattern) then
-        raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedSymbolDot())
-    let (LongIdentWithDots(lid,dotms)) = $4 in (Some($1),LongIdentWithDots(ident("_",rhs parseState 1)::lid, rhs parseState 2::dotms))
+        raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedSymbolDot())
+    let (LongIdentWithDots(lid,dotms)) = $4 in (Some($1),LongIdentWithDots(ident("_",rhs parseState 2)::lid, rhs parseState 3::dotms))
     }  
   | access pathOp { (Some($1), $2) }
 


### PR DESCRIPTION
Fixes problems with `_` self id ranges in members (from #7631). The added rule was copied from existing one and some of its parts didn't have indices properly updated.