### PR TITLE
update flaky test to only execute on PRs, not official builds

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/MailboxProcessorType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/MailboxProcessorType.fs
@@ -138,6 +138,7 @@ type MailboxProcessorType() =
         Assert.AreEqual(Some("Received 1 Disposed"),!result)
 
     [<Test>]
+    [<Category("PullRequest")>]
     member this.``Scan handles cancellation token``() =
         let result = ref None
 


### PR DESCRIPTION
I missed a flaky `MailboxProcessor` test in #8497.