### PR TITLE
Recover type checking inherit ctor arg expression

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -13982,7 +13982,12 @@ module MutRecBindingChecking =
                         | Phase2AInherit (synBaseTy, arg, baseValOpt, m) ->
                             let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.Use envInstance tpenv synBaseTy
                             let baseTy = baseTy |> convertToTypeWithMetadataIfPossible g
-                            let inheritsExpr, tpenv = TcNewExpr cenv envInstance tpenv baseTy (Some synBaseTy.Range) true arg m
+                            let inheritsExpr, tpenv =
+                                try 
+                                   TcNewExpr cenv envInstance tpenv baseTy (Some synBaseTy.Range) true arg m
+                                with e ->
+                                    errorRecovery e m
+                                    mkUnit g m, tpenv
                             let envInstance = match baseValOpt with Some baseVal -> AddLocalVal cenv.tcSink scopem baseVal envInstance | None -> envInstance
                             let envNonRec = match baseValOpt with Some baseVal -> AddLocalVal cenv.tcSink scopem baseVal envNonRec | None -> envNonRec
                             let innerState = (tpenv, envInstance, envStatic, envNonRec, generalizedRecBinds, preGeneralizationRecBinds, uncheckedRecBindsTable)

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -312,8 +312,8 @@ let getSymbolUses (source: string) =
     typeCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunSynchronously
 
 let getSymbols (source: string) =
-    getSymbolUses source
-    |> Array.map (fun symbolUse -> symbolUse.Symbol)
+    let symbolUses = getSymbolUses source
+    symbolUses |> Array.map (fun symbolUse -> symbolUse.Symbol)
 
 
 let getSymbolName (symbol: FSharpSymbol) =
@@ -329,8 +329,10 @@ let getSymbolName (symbol: FSharpSymbol) =
 
 
 let assertContainsSymbolWithName name source =
-    getSymbols source
-    |> Array.choose getSymbolName
+    let symbols = getSymbols source
+    let names = symbols |> Array.choose getSymbolName
+
+    names
     |> Array.contains name
     |> shouldEqual true
 

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -1361,3 +1361,14 @@ type R =
     y
 """
     assertContainsSymbolWithName "y" source
+
+
+[<Test>]
+let ``Inherit ctor arg recovery`` () =
+    let source = """
+    type T() as this =
+        inherit System.Exception('a', 'a')
+
+        let x = this
+    """
+    assertContainsSymbolWithName "x" source


### PR DESCRIPTION
Adds recovery to the base type argument expression type check.

Without recovery the whole implicit constructor block (i.e. let bindings and do expressions) type check is skipped on error.

Before:
<img width="340" alt="Screenshot 2020-03-03 at 18 15 50" src="https://user-images.githubusercontent.com/3923587/75789712-261cbe80-5d7b-11ea-8f93-deb6216c4637.png">

After:
<img width="341" alt="Screenshot 2020-03-03 at 18 16 28" src="https://user-images.githubusercontent.com/3923587/75789751-36cd3480-5d7b-11ea-9f11-af71d0a8b817.png">