### PR TITLE
Fixed destNullableTy internal error

### DIFF
--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -189,7 +189,7 @@ let AdjustCalledArgTypeForOptionals (g: TcGlobals) enforceNullableOptionalsKnown
         // CSharpMethod(x = arg), optional C#-style argument, may have type Nullable<ty>. 
         // The arg should have type ty. However for backwards compat, we also allow arg to have type Nullable<ty>
         | CallerSide _ ->
-            if isNullableTy g calledArgTy  && g.langVersion.SupportsFeature LanguageFeature.NullableOptionalInterop  then 
+            if isNullableTy g calledArgTy && g.langVersion.SupportsFeature LanguageFeature.NullableOptionalInterop then 
                 // If inference has worked out it's a nullable then use this
                 if isNullableTy g callerArg.CallerArgumentType then
                     calledArgTy
@@ -1186,11 +1186,6 @@ let AdjustCallerArgForOptional tcFieldInit eCallerMemberName (infoReader: InfoRe
                             let minfo = GetIntrinsicConstructorInfosOfType infoReader m calledArgTy |> List.head
                             let callerArgExprCoerced = mkCoerceIfNeeded g calledNonOptTy callerArgTy callerArgExpr
                             MakeMethInfoCall amap m minfo [] [callerArgExprCoerced]
-                    elif isOptionTy g calledArgTy then 
-                        // CSharpMethod(x=b) when 'b' has nullable type and 'x' has optional type --> CSharpMethod(Some b.Value)
-                        let calledNonOptTy = destOptionTy g calledArgTy 
-                        let callerArgExprCoerced = mkCoerceIfNeeded g calledNonOptTy callerArgTy callerArgExpr
-                        mkSome g (destNullableTy g callerArgTy) callerArgExprCoerced m
                     else 
                         // CSharpMethod(x=b) --> CSharpMethod(?x=b)
                         callerArgExpr

--- a/tests/fsharp/Compiler/Language/OptionalInteropTests.fs
+++ b/tests/fsharp/Compiler/Language/OptionalInteropTests.fs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.UnitTests
+
+open System.Collections.Immutable
+open NUnit.Framework
+open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.UnitTests.Utilities
+open Microsoft.CodeAnalysis
+
+[<TestFixture>]
+module OptionalInteropTests =
+
+    [<Test>]
+    let ``C# method with an optional parameter and called with an option type should compile`` () =
+        let csSrc =
+            """
+using Microsoft.FSharp.Core;
+
+namespace CSharpTest
+{
+    public static class Test
+    {
+        public static void M(FSharpOption<int> x = null) { }
+    }
+}
+            """
+
+        let fsSrc =
+            """
+open System
+open CSharpTest
+
+Test.M(x = Some 1)
+            """
+
+        let fsharpCoreAssembly =
+            typeof<_ list>.Assembly.Location
+            |> MetadataReference.CreateFromFile
+
+        let cs =
+            CompilationUtil.CreateCSharpCompilation(csSrc, CSharpLanguageVersion.CSharp8, TargetFramework.NetStandard20, additionalReferences = ImmutableArray.CreateRange [fsharpCoreAssembly])
+            |> CompilationReference.Create
+
+        let fs = Compilation.Create(fsSrc, SourceKind.Fsx, CompileOutput.Exe, options = [|"--langversion:preview"|], cmplRefs = [cs])
+        CompilerAssert.Compile fs

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -60,6 +60,7 @@
     <Compile Include="Compiler\Warnings\ExperimentalAttributeTests.fs" />
     <Compile Include="Compiler\Warnings\PatternMatchingWarningTests.fs" />
     <Compile Include="Compiler\SourceTextTests.fs" />
+    <Compile Include="Compiler\Language\OptionalInteropTests.fs" />
     <Compile Include="Compiler\Language\UIntTests.fs" />
     <Compile Include="Compiler\Language\FixedIndexSliceTests.fs" />
     <Compile Include="Compiler\Language\SlicingQuotationTests.fs" />


### PR DESCRIPTION
Should resolve this: https://github.com/dotnet/fsharp/issues/8646

Before this fix, you could cause an internal error with `destNullableTy` - this was a result of the optionals interop changes that were made.

Here is an example of how to trigger the error without this fix:
```csharp
using Microsoft.FSharp.Core;

namespace CSharpTest
{
    public static class Test
    {
        public static void M(FSharpOption<int> x = null) { }
    }
}
```

```fsharp
open System
open CSharpTest

Test.M(x = 1) // or Test.M(x = Some 1) which should compile
```

Before optionals interop, this would give an error saying `Option<int>` and `int` are different. With the optionals interop change, even without turning langversion to the appropriate version that enabled optionals interop, this would give us an internal error. 

Based on this comment in code,
```fsharp
// CSharpMethod(x=b) when 'b' has nullable type and 'x' has optional type --> CSharpMethod(Some b.Value)
```
I think the intent was to allow this behavior and also allow a `Nullable<int>` to passed in as well, instead of `int` in the example. But, the RFC does not describe this calling behavior for C#/IL methods with optional args of type `FSharpOption<_>`.

Will need @dsyme 's input.

