### PR TITLE
Provided types RawType encapsulation

### DIFF
--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -282,7 +282,7 @@ module internal ExtensionTyping =
     [<AllowNullLiteral; Sealed>]
     type ProvidedType (x: System.Type, ctxt: ProvidedTypeContext) =
         inherit ProvidedMemberInfo(x, ctxt)
-        let measureAttibuteFullname = typeof<Microsoft.FSharp.Core.MeasureAttribute>.FullName;
+        let measureAttibuteFullname = typeof<Microsoft.FSharp.Core.MeasureAttribute>.FullName
         let provide () = ProvidedCustomAttributeProvider.Create (fun _provider -> x.CustomAttributes)
         interface IProvidedCustomAttributeProvider with 
             member __.GetHasTypeProviderEditorHideMethodsAttribute provider = provide().GetHasTypeProviderEditorHideMethodsAttribute provider
@@ -346,8 +346,7 @@ module internal ExtensionTyping =
         /// Type.GetEnumUnderlyingType either returns type or raises exception, null is not permitted
         member __.GetEnumUnderlyingType() = 
             x.GetEnumUnderlyingType() 
-            |> ProvidedType.CreateWithNullCheck ctxt "EnumUnderlyingType"
-            
+            |> ProvidedType.CreateWithNullCheck ctxt "EnumUnderlyingType"    
         member __.MakePointerType() = ProvidedType.CreateNoContext(x.MakePointerType())
         member __.MakeByRefType() = ProvidedType.CreateNoContext(x.MakeByRefType())
         member __.MakeArrayType() = ProvidedType.CreateNoContext(x.MakeArrayType())

--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -351,9 +351,9 @@ module internal ExtensionTyping =
         member __.MakeByRefType() = ProvidedType.CreateNoContext(x.MakeByRefType())
         member __.MakeArrayType() = ProvidedType.CreateNoContext(x.MakeArrayType())
         member __.MakeArrayType rank = ProvidedType.CreateNoContext(x.MakeArrayType(rank))
-        member __.MakeGenericType genericArgNames =
-            let argsToMake = x.GetGenericArguments() |> Array.filter (fun arg -> genericArgNames |> Array.contains arg.FullName)
-            ProvidedType.CreateNoContext(x.MakeGenericType(argsToMake))
+        member __.MakeGenericType (args: ProvidedType[]) =
+            let argTypes = args |> Array.map (fun arg -> arg.RawSystemType)
+            ProvidedType.CreateNoContext(x.MakeGenericType(argTypes))
         static member Create ctxt x = match x with null -> null | t -> ProvidedType (t, ctxt)
         static member CreateWithNullCheck ctxt name x = match x with null -> nullArg name | t -> ProvidedType (t, ctxt)
         static member CreateArray ctxt xs = match xs with null -> null | _ -> xs |> Array.map (ProvidedType.Create ctxt)

--- a/src/fsharp/ExtensionTyping.fsi
+++ b/src/fsharp/ExtensionTyping.fsi
@@ -135,7 +135,7 @@ module internal ExtensionTyping =
         member MakeByRefType: unit -> ProvidedType
         member MakeArrayType: unit -> ProvidedType
         member MakeArrayType: rank: int -> ProvidedType
-        member MakeGenericType: genericArgNames: string[] -> ProvidedType
+        member MakeGenericType: args: ProvidedType[] -> ProvidedType
         static member Void : ProvidedType
         static member CreateNoContext : Type -> ProvidedType
         member TryGetILTypeRef : unit -> ILTypeRef option

--- a/src/fsharp/ExtensionTyping.fsi
+++ b/src/fsharp/ExtensionTyping.fsi
@@ -120,6 +120,7 @@ module internal ExtensionTyping =
         member IsEnum : bool
         member IsInterface : bool
         member IsClass : bool
+        member IsMeasure: bool
         member IsSealed : bool
         member IsAbstract : bool
         member IsPublic : bool
@@ -130,6 +131,11 @@ module internal ExtensionTyping =
         member GetArrayRank : unit -> int
         member RawSystemType : System.Type
         member GetEnumUnderlyingType : unit -> ProvidedType
+        member MakePointerType: unit -> ProvidedType
+        member MakeByRefType: unit -> ProvidedType
+        member MakeArrayType: unit -> ProvidedType
+        member MakeArrayType: rank: int -> ProvidedType
+        member MakeGenericType: genericArgNames: string[] -> ProvidedType
         static member Void : ProvidedType
         static member CreateNoContext : Type -> ProvidedType
         member TryGetILTypeRef : unit -> ILTypeRef option

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -1433,8 +1433,10 @@ module ProvidedMethodCalls =
                         if genericArgs.Length = 0 then
                             headType
                         else
-                            let erasedArgTys = genericArgs |> Array.map (fun x -> x.PUntaintNoFailure(fun st -> st.FullName))
-                            headType.PApply((fun st -> st.MakeGenericType erasedArgTys), m)
+                            let erasedArgTys = genericArgs |> Array.map loop
+                            headType.PApply((fun st -> 
+                                let erasedArgTys = erasedArgTys |> Array.map (fun a -> a.PUntaintNoFailure(id))
+                                st.MakeGenericType erasedArgTys), m)
                     else   
                         st
         loop inputType

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -2058,12 +2058,9 @@ and Construct =
         let id = ident (name, m)
         let kind = 
             let isMeasure = 
-                st.PApplyWithProvider((fun (st, provider) -> 
-                    let findAttrib (ty: System.Type) (a: CustomAttributeData) = (a.Constructor.DeclaringType.FullName = ty.FullName)  
-                    let ty = st.RawSystemType
+                st.PApplyWithProvider((fun (st, provider) ->
                     ignore provider
-                    ty.CustomAttributes
-                        |> Seq.exists (findAttrib typeof<Microsoft.FSharp.Core.MeasureAttribute>)), m)
+                    st.IsMeasure), m)
                   .PUntaintNoFailure(fun x -> x)
             if isMeasure then TyparKind.Measure else TyparKind.Type
 


### PR DESCRIPTION
Now System.Reflection.Type's which are wrapped by the provided types 
can be passed out as properties, what increases coupling between ProvidedType and FCS code.
This pull request encapsulates most of logic that works with raw types within provided types.