### PR TITLE
Make resolutions assembly netstandard 2.0

### DIFF
--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -10,6 +10,7 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
     open System.IO
     open System.Reflection
     open Internal.Utilities
+    open Internal.Utilities.FSharpEnvironment
 
     type private TypeInThisAssembly = class end
 
@@ -29,7 +30,6 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
     let getDefaultFSharpCoreLocation = Path.Combine(fSharpCompilerLocation, getFSharpCoreLibraryName + ".dll")
     let getDefaultFsiLibraryLocation = Path.Combine(fSharpCompilerLocation, getFsiLibraryName + ".dll")
     let implementationAssemblyDir = Path.GetDirectoryName(typeof<obj>.Assembly.Location)
-    let isRunningOnCoreClr = (typeof<obj>.Assembly).FullName.StartsWith("System.Private.CoreLib", StringComparison.InvariantCultureIgnoreCase)
 
     // Use the ValueTuple that is executing with the compiler if it is from System.ValueTuple
     // or the System.ValueTuple.dll that sits alongside the compiler.  (Note we always ship one with the compiler)

--- a/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fs
+++ b/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fs
@@ -8,11 +8,13 @@ open System.IO
 open System.Reflection
 open Internal.Utilities.FSharpEnvironment
 
-open System.Runtime.Loader
-
 /// Signature for ResolutionProbe callback
 /// host implements this, it's job is to return a list of assembly paths to probe.
 type AssemblyResolutionProbe = delegate of Unit -> IEnumerable<string>
+
+#if NETSTANDARD
+
+open System.Runtime.Loader
 
 /// Type that encapsulates AssemblyResolveHandler for managed packages
 type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProbe) =
@@ -45,6 +47,8 @@ type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProb
     interface IDisposable with
         member _x.Dispose() =
             AssemblyLoadContext.Default.remove_Resolving(handler)
+
+#endif
 
 /// Type that encapsulates AssemblyResolveHandler for managed packages
 type AssemblyResolveHandlerDeskTop (assemblyProbingPaths: AssemblyResolutionProbe) =
@@ -81,9 +85,11 @@ type AssemblyResolveHandlerDeskTop (assemblyProbingPaths: AssemblyResolutionProb
 type AssemblyResolveHandler (assemblyProbingPaths: AssemblyResolutionProbe) =
 
     let handler =
+#if NETSTANDARD
         if isRunningOnCoreClr then
             new AssemblyResolveHandlerCoreclr(assemblyProbingPaths) :> IDisposable
         else
+#endif
             new AssemblyResolveHandlerDeskTop(assemblyProbingPaths) :> IDisposable
 
     interface IDisposable with

--- a/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fs
+++ b/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fs
@@ -93,4 +93,4 @@ type AssemblyResolveHandler (assemblyProbingPaths: AssemblyResolutionProbe) =
             new AssemblyResolveHandlerDeskTop(assemblyProbingPaths) :> IDisposable
 
     interface IDisposable with
-        member _x.Dispose() = handler.Dispose()
+        member _.Dispose() = handler.Dispose()

--- a/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fs
+++ b/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fs
@@ -6,32 +6,21 @@ open System
 open System.Collections.Generic
 open System.IO
 open System.Reflection
+open Internal.Utilities.FSharpEnvironment
 
-#if NETSTANDARD
 open System.Runtime.Loader
-#endif
 
 /// Signature for ResolutionProbe callback
 /// host implements this, it's job is to return a list of assembly paths to probe.
 type AssemblyResolutionProbe = delegate of Unit -> IEnumerable<string>
 
-
 /// Type that encapsulates AssemblyResolveHandler for managed packages
-type AssemblyResolveHandler (assemblyProbingPaths: AssemblyResolutionProbe) =
+type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProbe) =
 
-#if NETSTANDARD
     let resolveAssemblyNetStandard (ctxt: AssemblyLoadContext) (assemblyName: AssemblyName): Assembly =
 
         let loadAssembly path =
             ctxt.LoadFromAssemblyPath(path)
-
-#else
-    let resolveAssemblyNET (assemblyName: AssemblyName): Assembly =
-
-        let loadAssembly assemblyPath =
-            Assembly.LoadFrom(assemblyPath)
-
-#endif
 
         let assemblyPaths =
             match assemblyProbingPaths with
@@ -50,7 +39,6 @@ type AssemblyResolveHandler (assemblyProbingPaths: AssemblyResolutionProbe) =
 
         with | _ -> Unchecked.defaultof<Assembly>
 
-#if NETSTANDARD
     let handler = Func<AssemblyLoadContext, AssemblyName, Assembly>(resolveAssemblyNetStandard)
     do AssemblyLoadContext.Default.add_Resolving(handler)
 
@@ -58,7 +46,31 @@ type AssemblyResolveHandler (assemblyProbingPaths: AssemblyResolutionProbe) =
         member _x.Dispose() =
             AssemblyLoadContext.Default.remove_Resolving(handler)
 
-#else
+/// Type that encapsulates AssemblyResolveHandler for managed packages
+type AssemblyResolveHandlerDeskTop (assemblyProbingPaths: AssemblyResolutionProbe) =
+
+    let resolveAssemblyNET (assemblyName: AssemblyName): Assembly =
+
+        let loadAssembly assemblyPath =
+            Assembly.LoadFrom(assemblyPath)
+
+        let assemblyPaths =
+            match assemblyProbingPaths with
+            | null -> Seq.empty<string>
+            | _ ->  assemblyProbingPaths.Invoke()
+
+        try
+            // args.Name is a displayname formatted assembly version.
+            // E.g:  "System.IO.FileSystem, Version=4.1.1.0, Culture=en-US, PublicKeyToken=b03f5f7f11d50a3a"
+            let simpleName = assemblyName.Name
+            let assemblyPathOpt = assemblyPaths |> Seq.tryFind(fun path -> Path.GetFileNameWithoutExtension(path) = simpleName)
+            match assemblyPathOpt with
+            | Some path ->
+                loadAssembly path
+            | None -> Unchecked.defaultof<Assembly>
+
+        with | _ -> Unchecked.defaultof<Assembly>
+
     let handler = new ResolveEventHandler(fun _ (args: ResolveEventArgs) -> resolveAssemblyNET (new AssemblyName(args.Name)))
     do AppDomain.CurrentDomain.add_AssemblyResolve(handler)
 
@@ -66,4 +78,13 @@ type AssemblyResolveHandler (assemblyProbingPaths: AssemblyResolutionProbe) =
         member _x.Dispose() =
             AppDomain.CurrentDomain.remove_AssemblyResolve(handler)
 
-#endif
+type AssemblyResolveHandler (assemblyProbingPaths: AssemblyResolutionProbe) =
+
+    let handler =
+        if isRunningOnCoreClr then
+            new AssemblyResolveHandlerCoreclr(assemblyProbingPaths) :> IDisposable
+        else
+            new AssemblyResolveHandlerDeskTop(assemblyProbingPaths) :> IDisposable
+
+    interface IDisposable with
+        member _x.Dispose() = handler.Dispose()

--- a/src/fsharp/Interactive.DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/Interactive.DependencyManager/DependencyProvider.fs
@@ -235,6 +235,7 @@ type ReflectionDependencyManagerProvider(theType: Type, nameProperty: PropertyIn
 type DependencyProvider (assemblyProbingPaths: AssemblyResolutionProbe, nativeProbingRoots: NativeResolutionProbe) =
 
     let dllResolveHandler = new NativeDllResolveHandler(nativeProbingRoots) :> IDisposable
+
     let assemblyResolveHandler = new AssemblyResolveHandler(assemblyProbingPaths) :> IDisposable
 
     // Resolution Path = Location of FSharp.Compiler.Private.dll

--- a/src/fsharp/Interactive.DependencyManager/Interactive.DependencyManager.fsproj
+++ b/src/fsharp/Interactive.DependencyManager/Interactive.DependencyManager.fsproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Interactive.DependencyManager</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>

--- a/src/fsharp/Interactive.DependencyManager/Interactive.DependencyManager.fsproj
+++ b/src/fsharp/Interactive.DependencyManager/Interactive.DependencyManager.fsproj
@@ -4,13 +4,11 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Interactive.DependencyManager</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
-    <DefineConstants>$(DefineConstants);COMPILER</DefineConstants>
-    <DefineConstants>$(DefineConstants);MSBUILD_AT_LEAST_15</DefineConstants>
     <OtherFlags>$(OtherFlags) --warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
   </PropertyGroup>

--- a/src/fsharp/Interactive.DependencyManager/NativeDllResolveHandler.fs
+++ b/src/fsharp/Interactive.DependencyManager/NativeDllResolveHandler.fs
@@ -137,7 +137,7 @@ type NativeDllResolveHandler (_nativeProbingRoots: NativeResolutionProbe) =
             None
 
     interface IDisposable with
-        member _x.Dispose() =
+        member _.Dispose() =
             match handler with
             | None -> ()
             | Some handler -> handler.Dispose()

--- a/src/fsharp/Interactive.DependencyManager/NativeDllResolveHandler.fs
+++ b/src/fsharp/Interactive.DependencyManager/NativeDllResolveHandler.fs
@@ -7,9 +7,9 @@ open System.Collections.Generic
 open System.IO
 open System.Reflection
 open System.Runtime.InteropServices
-
-#if NETSTANDARD
 open System.Runtime.Loader
+
+open Internal.Utilities.FSharpEnvironment
 
 // Cut down AssemblyLoadContext, for loading native libraries
 type NativeAssemblyLoadContext () =
@@ -22,7 +22,6 @@ type NativeAssemblyLoadContext () =
         raise (NotImplementedException())
 
     static member NativeLoadContext = new NativeAssemblyLoadContext()
-#endif
 
 
 /// Signature for Native library resolution probe callback
@@ -31,8 +30,7 @@ type NativeResolutionProbe = delegate of Unit -> IEnumerable<string>
 
 
 /// Type that encapsulates Native library probing for managed packages
-type NativeDllResolveHandler (_nativeProbingRoots: NativeResolutionProbe) =
-#if NETSTANDARD
+type NativeDllResolveHandlerCoreClr (_nativeProbingRoots: NativeResolutionProbe) =
     let probingFileNames (name: string) =
         // coreclr native library probing algorithm: https://github.com/dotnet/coreclr/blob/9773db1e7b1acb3ec75c9cc0e36bd62dcbacd6d5/src/System.Private.CoreLib/shared/System/Runtime/Loader/LibraryNameVariation.Unix.cs
         let isRooted = Path.IsPathRooted name
@@ -118,12 +116,23 @@ type NativeDllResolveHandler (_nativeProbingRoots: NativeResolutionProbe) =
     let handler = Func<Assembly, string, IntPtr> (_resolveUnmanagedDll)
 
     do if not (isNull eventInfo) then eventInfo.AddEventHandler(AssemblyLoadContext.Default, handler)
-#endif
 
     interface IDisposable with
         member _x.Dispose() =
-#if NETSTANDARD
             if not (isNull eventInfo) then
                 eventInfo.RemoveEventHandler(AssemblyLoadContext.Default, handler)
-#endif
             ()
+
+
+type NativeDllResolveHandler (_nativeProbingRoots: NativeResolutionProbe) =
+
+    let handler =
+        if isRunningOnCoreClr then
+            Some (new NativeDllResolveHandlerCoreClr(_nativeProbingRoots) :> IDisposable)
+        else    None
+
+    interface IDisposable with
+        member _x.Dispose() =
+            match handler with
+            | None -> ()
+            | Some handler -> handler.Dispose()

--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -41,6 +41,9 @@ module internal FSharpEnvironment =
     // WARNING: Do not change this revision number unless you absolutely know what you're doing.
     let FSharpBinaryMetadataFormatRevision = "2.0.0.0"
 
+    let isRunningOnCoreClr = (typeof<obj>.Assembly).FullName.StartsWith("System.Private.CoreLib", StringComparison.InvariantCultureIgnoreCase)
+
+
 #if FX_NO_WIN_REGISTRY
 #else
     [<DllImport("Advapi32.dll", CharSet = CharSet.Unicode, BestFitMapping = false)>]
@@ -62,6 +65,7 @@ module internal FSharpEnvironment =
     // See: ndp\clr\src\BCL\System\IO\Path.cs
     let maxPath = 260;
     let maxDataLength = (new System.Text.UTF32Encoding()).GetMaxByteCount(maxPath)
+
 #if FX_NO_WIN_REGISTRY
 #else
     let KEY_WOW64_DEFAULT = 0x0000


### PR DESCRIPTION
Fixes:  https://github.com/dotnet/fsharp/issues/8676

Make the Assembly Resolution code target netstandard2.0 only.

Create shims for AssemblyResolutionHandler and NativeResolution handler.

Detect execution platform and choose either the handler that matches that platform.

@auduchinok, we only build netstandard2.0 now, and both desktop and coreclr work.  So I believe this will work well for fcs too.

Could you give it a whirl and let me know if it suits tou.