### PR TITLE
Optimize PrettyNaming.IsActivePatternName

### DIFF
--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -591,17 +591,20 @@ module public FSharp.Compiler.PrettyNaming
     let IsActivePatternName (name: string) =
         // The name must contain at least one character between the starting and ending delimiters.
         let nameLen = name.Length
-        if nameLen < 3 || name.[0] <> '|' || name.[nameLen - 1] <> '|' then false else
+        if nameLen < 3 || name.[0] <> '|' || name.[nameLen - 1] <> '|' then
+            false
+        else
+            let rec isCoreActivePatternName (name: string) idx seenNonOpChar =
+                if idx = name.Length - 1 then
+                    seenNonOpChar
+                else
+                    let c = name.[idx]
+                    if opCharSet.Contains(c) && c <> '|' && c <> ' ' then
+                        false
+                    else
+                        isCoreActivePatternName name (idx + 1) (seenNonOpChar || c <> '|')
 
-        let rec isCoreActivePatternName (name: string) idx seenNonOpChar =
-            if idx = name.Length - 1 then seenNonOpChar else
-
-            let c = name.[idx]
-            if opCharSet.Contains(c) && c <> '|' && c <> ' ' then false else
-
-            isCoreActivePatternName name (idx + 1) (seenNonOpChar || c <> '|')
-
-        isCoreActivePatternName name 1 false
+            isCoreActivePatternName name 1 false
 
     //IsActivePatternName "|+|" = false
     //IsActivePatternName "|ABC|" = true

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -588,20 +588,20 @@ module public FSharp.Compiler.PrettyNaming
     let IllegalCharactersInTypeAndNamespaceNames = [| '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '\"'; '`'  |]
 
     /// Determines if the specified name is a valid name for an active pattern.
-    let IsActivePatternName (nm: string) =
-        let nameLen = nm.Length
-        // The name must start and end with '|'
-        (nm.IndexOf '|' = 0) &&
-        (nm.LastIndexOf '|' = nameLen - 1) &&
+    let IsActivePatternName (name: string) =
         // The name must contain at least one character between the starting and ending delimiters.
-        nameLen >= 3 &&
-        (
-           let core = nm.Substring(1, nameLen - 2)
-           // no operator characters except '|' and ' '
-           core |> String.forall (fun c -> c = '|' || c = ' ' || not (opCharSet.Contains c)) &&
-           // at least one non-operator or space character
-           core |> String.exists (fun c -> c = ' ' || not (opCharSet.Contains c))
-        )
+        let nameLen = name.Length
+        if nameLen < 3 || name.[0] <> '|' || name.[nameLen - 1] <> '|' then false else
+
+        let rec isCoreActivePatternName (name: string) idx seenNonOpChar =
+            if idx = name.Length - 1 then seenNonOpChar else
+
+            let c = name.[idx]
+            if opCharSet.Contains(c) && c <> '|' && c <> ' ' then false else
+
+            isCoreActivePatternName name (idx + 1) (seenNonOpChar || c <> '|')
+
+        isCoreActivePatternName name 1 false
 
     //IsActivePatternName "|+|" = false
     //IsActivePatternName "|ABC|" = true


### PR DESCRIPTION
For each valref item name in completion lookup items filtering:

* don't try scanning whole string name for start/end `|` twice
* don't create a substring for further checks (if the name looks like an active pattern one)
* don't scan the inner name twice
* don't create two lambda/closure objects