### PR TITLE
Optimize PrettyNaming.IsOperator and prefix operator checks

### DIFF
--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -132,12 +132,26 @@ module public FSharp.Compiler.PrettyNaming
 
     /// Returns `true` if given string is an operator display name, e.g. ( |>> )
     let IsOperatorName (name: string) =
-        let name =
+        let rec isOperatorName (name: string) idx lastIdx =
+            if idx = lastIdx then
+                true
+            else
+                let c = name.[idx]
+                if not (opCharSet.Contains(c)) || c = ' ' then
+                    false
+                else
+                    isOperatorName name (idx + 1) lastIdx
+
+        let skipParens =
             if name.StartsWithOrdinal("( ") && name.EndsWithOrdinal(" )") then
-                name.[2 .. name.Length - 3]
-            else name
-        // there is single operator containing a space - range operator with step: `.. ..`
-        name = ".. .." || name |> Seq.forall (fun c -> c <> ' ' && opCharSet.Contains c)
+                true
+            else
+                false
+
+        let startIndex = if skipParens then 2 else 0
+        let lastIndex = if skipParens then name.Length - 1 else name.Length - 3
+
+        isOperatorName name startIndex lastIndex || name = ".. .."
 
     let IsMangledOpName (n: string) =
         n.StartsWithOrdinal(opNamePrefix)

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -365,36 +365,34 @@ module public FSharp.Compiler.PrettyNaming
         c = '.'
         || IsIdentifierPartCharacter c
 
+    let rec isTildaOnlyString (s: string) =
+        let rec loop (s: string) idx =
+            if idx >= s.Length then
+                true
+            elif s.[idx] <> '~' then
+                false
+            else
+                loop s (idx + 1)
+        loop s 0
+
     let IsValidPrefixOperatorUse s =
         if String.IsNullOrEmpty s then false else
         match s with 
         | "?+" | "?-" | "+" | "-" | "+." | "-." | "%" | "%%" | "&" | "&&" -> true
-        | _ ->
-            s.[0] = '!'
-            // The check for the first character here could be eliminated since it's covered
-            // by the call to String.forall; it is a fast check used to avoid the call if possible.
-            || (s.[0] = '~' && String.forall (fun c -> c = '~') s)
-    
+        | _ -> s.[0] = '!' || isTildaOnlyString s
+
     let IsValidPrefixOperatorDefinitionName s = 
         if String.IsNullOrEmpty s then false else
         match s with 
         | "~?+" | "~?-" | "~+" | "~-" | "~+." | "~-." | "~%" | "~%%" | "~&" | "~&&" -> true
-        | _ ->
-            (s.[0] = '!' && s <> "!=")
-            // The check for the first character here could be eliminated since it's covered
-            // by the call to String.forall; it is a fast check used to avoid the call if possible.
-            || (s.[0] = '~' && String.forall (fun c -> c = '~') s)
-        
+        | _ -> (s.[0] = '!' && s <> "!=") || isTildaOnlyString s
+
     let IsPrefixOperator s =
         if String.IsNullOrEmpty s then false else
         let s = DecompileOpName s
         match s with 
         | "~?+" | "~?-" | "~+" | "~-" | "~+." | "~-." | "~%" | "~%%" | "~&" | "~&&" -> true
-        | _ ->
-            (s.[0] = '!' && s <> "!=")
-            // The check for the first character here could be eliminated since it's covered
-            // by the call to String.forall; it is a fast check used to avoid the call if possible.
-            || (s.[0] = '~' && String.forall (fun c -> c = '~') s)
+        | _ -> (s.[0] = '!' && s <> "!=") || isTildaOnlyString s
 
     let IsPunctuation s =
         if String.IsNullOrEmpty s then false else

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -132,26 +132,21 @@ module public FSharp.Compiler.PrettyNaming
 
     /// Returns `true` if given string is an operator display name, e.g. ( |>> )
     let IsOperatorName (name: string) =
-        let rec isOperatorName (name: string) idx len =
-            if idx = len then
+        let rec isOperatorName (name: string) idx endIndex =
+            if idx = endIndex then
                 true
             else
                 let c = name.[idx]
                 if not (opCharSet.Contains(c)) || c = ' ' then
                     false
                 else
-                    isOperatorName name (idx + 1) len
+                    isOperatorName name (idx + 1) endIndex
 
-        let skipParens =
-            if name.StartsWithOrdinal("( ") && name.EndsWithOrdinal(" )") then
-                true
-            else
-                false
-
+        let skipParens = if name.StartsWithOrdinal("( ") && name.EndsWithOrdinal(" )") then true else false
         let startIndex = if skipParens then 2 else 0
-        let lastIndex = if skipParens then name.Length - 2 else name.Length
+        let endIndex = if skipParens then name.Length - 2 else name.Length
 
-        isOperatorName name startIndex lastIndex || name = ".. .."
+        isOperatorName name startIndex endIndex || name = ".. .."
 
     let IsMangledOpName (n: string) =
         n.StartsWithOrdinal(opNamePrefix)
@@ -365,7 +360,7 @@ module public FSharp.Compiler.PrettyNaming
         c = '.'
         || IsIdentifierPartCharacter c
 
-    let rec isTildaOnlyString (s: string) =
+    let isTildaOnlyString (s: string) =
         let rec loop (s: string) idx =
             if idx >= s.Length then
                 true

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -133,7 +133,7 @@ module public FSharp.Compiler.PrettyNaming
     /// Returns `true` if given string is an operator display name, e.g. ( |>> )
     let IsOperatorName (name: string) =
         let rec isOperatorName (name: string) idx lastIdx =
-            if idx = lastIdx then
+            if idx > lastIdx then
                 true
             else
                 let c = name.[idx]

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -149,7 +149,7 @@ module public FSharp.Compiler.PrettyNaming
                 false
 
         let startIndex = if skipParens then 2 else 0
-        let lastIndex = if skipParens then name.Length else name.Length - 2
+        let lastIndex = if skipParens then name.Length - 2 else name.Length
 
         isOperatorName name startIndex lastIndex || name = ".. .."
 

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -385,14 +385,14 @@ module public FSharp.Compiler.PrettyNaming
         if String.IsNullOrEmpty s then false else
         match s with 
         | "~?+" | "~?-" | "~+" | "~-" | "~+." | "~-." | "~%" | "~%%" | "~&" | "~&&" -> true
-        | _ -> (s.[0] = '!' && s <> "!=") || isTildaOnlyString s
+        | _ -> s.[0] = '!' && s <> "!=" || isTildaOnlyString s
 
     let IsPrefixOperator s =
         if String.IsNullOrEmpty s then false else
         let s = DecompileOpName s
         match s with 
         | "~?+" | "~?-" | "~+" | "~-" | "~+." | "~-." | "~%" | "~%%" | "~&" | "~&&" -> true
-        | _ -> (s.[0] = '!' && s <> "!=") || isTildaOnlyString s
+        | _ -> s.[0] = '!' && s <> "!=" || isTildaOnlyString s
 
     let IsPunctuation s =
         if String.IsNullOrEmpty s then false else

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -383,16 +383,22 @@ module public FSharp.Compiler.PrettyNaming
 
     let IsValidPrefixOperatorDefinitionName s = 
         if String.IsNullOrEmpty s then false else
-        match s with 
-        | "~?+" | "~?-" | "~+" | "~-" | "~+." | "~-." | "~%" | "~%%" | "~&" | "~&&" -> true
-        | _ -> s.[0] = '!' && s <> "!=" || isTildaOnlyString s
+
+        match s.[0] with
+        | '~' ->
+            isTildaOnlyString s ||
+
+            match s with
+            | "~?+" | "~?-" | "~+" | "~-" | "~+." | "~-." | "~%" | "~%%" | "~&" | "~&&" -> true
+            | _ -> false
+
+        | '!' -> s <> "!="
+        | _ -> false
 
     let IsPrefixOperator s =
         if String.IsNullOrEmpty s then false else
         let s = DecompileOpName s
-        match s with 
-        | "~?+" | "~?-" | "~+" | "~-" | "~+." | "~-." | "~%" | "~%%" | "~&" | "~&&" -> true
-        | _ -> s.[0] = '!' && s <> "!=" || isTildaOnlyString s
+        IsValidPrefixOperatorDefinitionName s
 
     let IsPunctuation s =
         if String.IsNullOrEmpty s then false else

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -132,15 +132,15 @@ module public FSharp.Compiler.PrettyNaming
 
     /// Returns `true` if given string is an operator display name, e.g. ( |>> )
     let IsOperatorName (name: string) =
-        let rec isOperatorName (name: string) idx lastIdx =
-            if idx > lastIdx then
+        let rec isOperatorName (name: string) idx len =
+            if idx = len then
                 true
             else
                 let c = name.[idx]
                 if not (opCharSet.Contains(c)) || c = ' ' then
                     false
                 else
-                    isOperatorName name (idx + 1) lastIdx
+                    isOperatorName name (idx + 1) len
 
         let skipParens =
             if name.StartsWithOrdinal("( ") && name.EndsWithOrdinal(" )") then
@@ -149,7 +149,7 @@ module public FSharp.Compiler.PrettyNaming
                 false
 
         let startIndex = if skipParens then 2 else 0
-        let lastIndex = if skipParens then name.Length - 1 else name.Length - 3
+        let lastIndex = if skipParens then name.Length else name.Length - 2
 
         isOperatorName name startIndex lastIndex || name = ".. .."
 


### PR DESCRIPTION
* Don't create another string to check escaped name
* Don't create lambda/closure objects, use tail rec functions instead
* Prevent many extra string equality checks
* Remove logic duplication in prefix op checks