### PR TITLE
Simple changes to make it compatible with WASM

### DIFF
--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -25,11 +25,13 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
             // Use the location of this dll
             location
 
+    let inline ifEmptyUse alternative filename = if String.IsNullOrEmpty filename then alternative else filename
+    
     let getFSharpCoreLibraryName = "FSharp.Core"
     let getFsiLibraryName = "FSharp.Compiler.Interactive.Settings"
     let getDefaultFSharpCoreLocation = Path.Combine(fSharpCompilerLocation, getFSharpCoreLibraryName + ".dll")
     let getDefaultFsiLibraryLocation = Path.Combine(fSharpCompilerLocation, getFsiLibraryName + ".dll")
-    let implementationAssemblyDir = Path.GetDirectoryName(typeof<obj>.Assembly.Location)
+    let implementationAssemblyDir = Path.GetDirectoryName(typeof<obj>.Assembly.Location) |> ifEmptyUse fSharpCompilerLocation
 
     // Use the ValueTuple that is executing with the compiler if it is from System.ValueTuple
     // or the System.ValueTuple.dll that sits alongside the compiler.  (Note we always ship one with the compiler)

--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -25,7 +25,7 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
             // Use the location of this dll
             location
 
-    let inline ifEmptyUse alternative filename = if String.IsNullOrEmpty filename then alternative else filename
+    let inline ifEmptyUse alternative filename = if String.IsNullOrWhiteSpace filename then alternative else filename
     
     let getFSharpCoreLibraryName = "FSharp.Core"
     let getFsiLibraryName = "FSharp.Compiler.Interactive.Settings"

--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -189,6 +189,10 @@ module internal FSharpEnvironment =
         // Check for an app.config setting to redirect the default compiler location
         // Like fsharp-compiler-location
         try
+            // We let you set FSHARP_COMPILER_BIN. I've rarely seen this used and its not documented in the install instructions.
+            match Environment.GetEnvironmentVariable("FSHARP_COMPILER_BIN") with
+            | result when not (String.IsNullOrWhiteSpace result) -> Some result
+            |_->
             // FSharp.Compiler support setting an appKey for compiler location. I've never seen this used.
             let result = tryAppConfig "fsharp-compiler-location"
             match result with
@@ -201,11 +205,6 @@ module internal FSharpEnvironment =
             match probePoint with 
             | Some p when safeExists (Path.Combine(p,"FSharp.Core.dll")) -> Some p 
             | _ ->
-                // We let you set FSHARP_COMPILER_BIN. I've rarely seen this used and its not documented in the install instructions.
-                let result = Environment.GetEnvironmentVariable("FSHARP_COMPILER_BIN")
-                if not (String.IsNullOrEmpty(result)) then
-                    Some result
-                else
                     // For the prototype compiler, we can just use the current domain
                     tryCurrentDomain()
         with e -> None


### PR DESCRIPTION
In WASM assemblies reside in memory, therefore `Assembly.Location` returns no directory path. That creates some problems. These 2 changes are to fix that.