### PR TITLE
Update namespace for Interactive.DependencyManager

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -51,7 +51,7 @@ open FSharp.Compiler.Text
 
 open FSharp.Compiler.DotNetFrameworkDependencies
 
-open Interactive.DependencyManager
+open Microsoft.Interactive.DependencyManager
 
 #if !NO_EXTENSIONTYPING
 open FSharp.Compiler.ExtensionTyping

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -27,7 +27,7 @@ open Microsoft.FSharp.Core.CompilerServices
 open FSharp.Compiler.ExtensionTyping
 #endif
 
-open Interactive.DependencyManager
+open Microsoft.Interactive.DependencyManager
 
 #if DEBUG
 

--- a/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fs
+++ b/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Interactive.DependencyManager
+namespace Microsoft.Interactive.DependencyManager
 
 open System
 open System.Collections.Generic

--- a/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fsi
+++ b/src/fsharp/Interactive.DependencyManager/AssemblyResolveHandler.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Interactive.DependencyManager
+namespace Microsoft.Interactive.DependencyManager
 
 open System
 open System.Collections.Generic

--- a/src/fsharp/Interactive.DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/Interactive.DependencyManager/DependencyProvider.fs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Interactive.DependencyManager
+namespace Microsoft.Interactive.DependencyManager
 
 open System
 open System.IO

--- a/src/fsharp/Interactive.DependencyManager/DependencyProvider.fsi
+++ b/src/fsharp/Interactive.DependencyManager/DependencyProvider.fsi
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 /// Helper members to integrate DependencyManagers into F# codebase
-namespace Interactive.DependencyManager
+namespace Microsoft.Interactive.DependencyManager
 
 open System
 open System.Runtime.InteropServices

--- a/src/fsharp/Interactive.DependencyManager/NativeDllResolveHandler.fs
+++ b/src/fsharp/Interactive.DependencyManager/NativeDllResolveHandler.fs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Interactive.DependencyManager
+namespace Microsoft.Interactive.DependencyManager
 
 open System
 open System.Collections.Generic

--- a/src/fsharp/Interactive.DependencyManager/NativeDllResolveHandler.fsi
+++ b/src/fsharp/Interactive.DependencyManager/NativeDllResolveHandler.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Interactive.DependencyManager
+namespace Microsoft.Interactive.DependencyManager
 
 open System
 open System.Collections.Generic

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -53,7 +53,7 @@ open FSharp.Compiler.DotNetFrameworkDependencies
 open Internal.Utilities
 open Internal.Utilities.StructuredFormat
 
-open Interactive.DependencyManager
+open Microsoft.Interactive.DependencyManager
 
 //----------------------------------------------------------------------------
 // For the FSI as a service methods...

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -12,7 +12,7 @@ open FSharp.Compiler.SourceCodeServices
 open System.Runtime.InteropServices
 open NUnit.Framework
 
-open Interactive.DependencyManager
+open Microsoft.Interactive.DependencyManager
 
 module Native =
     [<DllImport("NoneExistentDll")>]


### PR DESCRIPTION
Because the types in this assembly are public and used by more than just F# we need to apply an approved managed namespace, so types in this assembly are exposed in the:

Microsoft.Interactive.DependencyManager namespace.