### PR TITLE
Fixed exception that prevented creating a memory mapped file that sha…

### DIFF
--- a/src/absil/bytes.fs
+++ b/src/absil/bytes.fs
@@ -306,10 +306,11 @@ type ByteMemory with
                         leaveOpen=false)
             mmf, mmf.CreateViewAccessor(0L, length, memoryMappedFileAccess), length
 
+        // Validate MMF with the access that was intended.
         match access with
-        | FileAccess.Read when not accessor.CanRead -> failwith "Cannot read file"
-        | FileAccess.Write when not accessor.CanWrite -> failwith "Cannot write file"
-        | _ when not accessor.CanRead || not accessor.CanWrite -> failwith "Cannot read or write file"
+        | FileAccess.Read when not accessor.CanRead -> invalidOp "Cannot read file"
+        | FileAccess.Write when not accessor.CanWrite -> invalidOp "Cannot write file"
+        | FileAccess.ReadWrite when not accessor.CanRead || not accessor.CanWrite -> invalidOp "Cannot read or write file"
         | _ -> ()
 
         let safeHolder =

--- a/tests/projects/Sample_VS2017_FSharp_ConsoleApp_net35_old_fsharp_core/Program.fs
+++ b/tests/projects/Sample_VS2017_FSharp_ConsoleApp_net35_old_fsharp_core/Program.fs
@@ -1,0 +1,9 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+
+[<EntryPoint>]
+let main argv =
+    printfn "Hello World from F#!"
+    0 // return an integer exit code

--- a/tests/projects/Sample_VS2017_FSharp_ConsoleApp_net35_old_fsharp_core/Sample_VS2017_FSharp_ConsoleApp_net35_old_fsharp_core.fsproj
+++ b/tests/projects/Sample_VS2017_FSharp_ConsoleApp_net35_old_fsharp_core/Sample_VS2017_FSharp_ConsoleApp_net35_old_fsharp_core.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net35</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="3.0.2" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
…dow copies a file on-disk (#8238)

* Fixed exception that prevented creating a memory mapped file that is shadow copied

* Update bytes.fs

Fixes regression https://github.com/dotnet/fsharp/issues/8739 for dev16.5.

Seems we already had the fix in master, it just wasn't in 16.5.