### PR TITLE
Re-enable sdktests

### DIFF
--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -229,6 +229,11 @@ module CoreTests =
     [<Test>]
     let ``recordResolution-FSI_BASIC`` () = singleTestBuildAndRun "core/recordResolution" FSI_BASIC
 
+    [<Test>]
+    let ``SDKTests`` () =
+        let cfg = testConfig "SDKTests"
+        exec cfg cfg.DotNetExe ("msbuild " + Path.Combine(cfg.Directory, "AllSdkTargetsTests.proj"))
+
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
     [<Test>]
     let ``attributes-FSC_BASIC`` () = singleTestBuildAndRun "core/attributes" FSC_BASIC


### PR DESCRIPTION
These are a couple of tests that verify certain FSharp behaviours for the netsdk props and targets.

Somehow these tests got disconnected probably due to build script rewrite.  Anyway, ths PR adds them back.

I found this whilst doing this PR: https://github.com/dotnet/fsharp/pull/8750

Since we don't yet know whether that is the way we want to resolve that issue, I broke out the test reactivation part of the PR.

