### PR TITLE
Don't store end pos in CapturedNameResolution

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1644,8 +1644,8 @@ let ItemsAreEffectivelyEqualHash (g: TcGlobals) orig =
     | _ -> 389329
 
 [<System.Diagnostics.DebuggerDisplay("{DebugToString()}")>]
-type CapturedNameResolution(p: pos, i: Item, tpinst, io: ItemOccurence, de: DisplayEnv, nre: NameResolutionEnv, ad: AccessorDomain, m: range) =
-    member this.Pos = p
+type CapturedNameResolution(i: Item, tpinst, io: ItemOccurence, de: DisplayEnv, nre: NameResolutionEnv, ad: AccessorDomain, m: range) =
+    member this.Pos = m.End
     member this.Item = i
     member this.ItemWithInst = ({ Item = i; TyparInst = tpinst } : ItemWithInst)
     member this.ItemOccurence = io
@@ -1654,7 +1654,7 @@ type CapturedNameResolution(p: pos, i: Item, tpinst, io: ItemOccurence, de: Disp
     member this.AccessorDomain = ad
     member this.Range = m
     member this.DebugToString() =
-        sprintf "%A: %+A" (p.Line, p.Column) i
+        sprintf "%A: %+A" (this.Pos.Line, this.Pos.Column) i
 
 /// Represents container for all name resolutions that were met so far when typechecking some particular file
 type TcResolutions
@@ -1794,8 +1794,8 @@ type TcResultsSinkImpl(g, ?sourceText: ISourceText) =
                             | _ -> false
 
                     if not alreadyDone then
-                        capturedNameResolutions.Add(CapturedNameResolution(endPos, item, tpinst, occurenceType, denv, nenv, ad, m))
-                        capturedMethodGroupResolutions.Add(CapturedNameResolution(endPos, itemMethodGroup, [], occurenceType, denv, nenv, ad, m))
+                        capturedNameResolutions.Add(CapturedNameResolution(item, tpinst, occurenceType, denv, nenv, ad, m))
+                        capturedMethodGroupResolutions.Add(CapturedNameResolution(itemMethodGroup, [], occurenceType, denv, nenv, ad, m))
 
         member sink.NotifyFormatSpecifierLocation(m, numArgs) =
             capturedFormatSpecifierLocations.Add((m, numArgs))

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -43,7 +43,7 @@ type SemanticClassificationType =
 module TcResolutionsExtensions =
 
     let (|CNR|) (cnr:CapturedNameResolution) =
-        (cnr.Pos, cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.NameResolutionEnv, cnr.AccessorDomain, cnr.Range)
+        (cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.NameResolutionEnv, cnr.AccessorDomain, cnr.Range)
 
     type TcResolutions with
 
@@ -114,15 +114,15 @@ module TcResolutionsExtensions =
                         results.Add struct(m, typ)
                 resolutions
                 |> Seq.iter (fun cnr ->
-                    match cnr.Pos, cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.NameResolutionEnv, cnr.AccessorDomain, cnr.Range with
+                    match cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.NameResolutionEnv, cnr.AccessorDomain, cnr.Range with
                     // 'seq' in 'seq { ... }' gets colored as keywords
-                    | _, (Item.Value vref), ItemOccurence.Use, _, _, _, m when valRefEq g g.seq_vref vref ->
+                    | (Item.Value vref), ItemOccurence.Use, _, _, _, m when valRefEq g g.seq_vref vref ->
                         add m SemanticClassificationType.ComputationExpression
-                    | _, (Item.Value vref), _, _, _, _, m when isValRefMutable vref ->
+                    | (Item.Value vref), _, _, _, _, m when isValRefMutable vref ->
                         add m SemanticClassificationType.MutableVar
-                    | _, Item.Value KeywordIntrinsicValue, ItemOccurence.Use, _, _, _, m ->
+                    | Item.Value KeywordIntrinsicValue, ItemOccurence.Use, _, _, _, m ->
                         add m SemanticClassificationType.IntrinsicFunction
-                    | _, (Item.Value vref), _, _, _, _, m when isFunction g vref.Type ->
+                    | (Item.Value vref), _, _, _, _, m when isFunction g vref.Type ->
                         if valRefEq g g.range_op_vref vref || valRefEq g g.range_step_op_vref vref then 
                             ()
                         elif vref.IsPropertyGetterMethod || vref.IsPropertySetterMethod then
@@ -131,46 +131,46 @@ module TcResolutionsExtensions =
                             add m SemanticClassificationType.Operator
                         else
                             add m SemanticClassificationType.Function
-                    | _, Item.RecdField rfinfo, _, _, _, _, m when isRecdFieldMutable rfinfo ->
+                    | Item.RecdField rfinfo, _, _, _, _, m when isRecdFieldMutable rfinfo ->
                         add m SemanticClassificationType.MutableVar
-                    | _, Item.RecdField rfinfo, _, _, _, _, m when isFunction g rfinfo.FieldType ->
+                    | Item.RecdField rfinfo, _, _, _, _, m when isFunction g rfinfo.FieldType ->
                         add m SemanticClassificationType.Function
-                    | _, Item.RecdField EnumCaseFieldInfo, _, _, _, _, m ->
+                    | Item.RecdField EnumCaseFieldInfo, _, _, _, _, m ->
                         add m SemanticClassificationType.Enumeration
-                    | _, Item.MethodGroup _, _, _, _, _, m ->
+                    | Item.MethodGroup _, _, _, _, _, m ->
                         add m SemanticClassificationType.Function
                     // custom builders, custom operations get colored as keywords
-                    | _, (Item.CustomBuilder _ | Item.CustomOperation _), ItemOccurence.Use, _, _, _, m ->
+                    | (Item.CustomBuilder _ | Item.CustomOperation _), ItemOccurence.Use, _, _, _, m ->
                         add m SemanticClassificationType.ComputationExpression
                     // types get colored as types when they occur in syntactic types or custom attributes
                     // type variables get colored as types when they occur in syntactic types custom builders, custom operations get colored as keywords
-                    | _, Item.Types (_, [OptionalArgumentAttribute]), LegitTypeOccurence, _, _, _, _ -> ()
-                    | _, Item.CtorGroup(_, [MethInfo.FSMeth(_, OptionalArgumentAttribute, _, _)]), LegitTypeOccurence, _, _, _, _ -> ()
-                    | _, Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists (isInterfaceTy g) -> 
+                    | Item.Types (_, [OptionalArgumentAttribute]), LegitTypeOccurence, _, _, _, _ -> ()
+                    | Item.CtorGroup(_, [MethInfo.FSMeth(_, OptionalArgumentAttribute, _, _)]), LegitTypeOccurence, _, _, _, _ -> ()
+                    | Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists (isInterfaceTy g) -> 
                         add m SemanticClassificationType.Interface
-                    | _, Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists (isStructTy g) -> 
+                    | Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists (isStructTy g) -> 
                         add m SemanticClassificationType.ValueType
-                    | _, Item.Types(_, TType_app(tyconRef, TType_measure _ :: _) :: _), LegitTypeOccurence, _, _, _, m when isStructTyconRef tyconRef ->
+                    | Item.Types(_, TType_app(tyconRef, TType_measure _ :: _) :: _), LegitTypeOccurence, _, _, _, m when isStructTyconRef tyconRef ->
                         add m SemanticClassificationType.ValueType
-                    | _, Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists isDisposableTy ->
+                    | Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists isDisposableTy ->
                         add m SemanticClassificationType.Disposable
-                    | _, Item.Types _, LegitTypeOccurence, _, _, _, m -> 
+                    | Item.Types _, LegitTypeOccurence, _, _, _, m -> 
                         add m SemanticClassificationType.ReferenceType
-                    | _, (Item.TypeVar _ ), LegitTypeOccurence, _, _, _, m ->
+                    | (Item.TypeVar _ ), LegitTypeOccurence, _, _, _, m ->
                         add m SemanticClassificationType.TypeArgument
-                    | _, Item.UnqualifiedType tyconRefs, LegitTypeOccurence, _, _, _, m ->
+                    | Item.UnqualifiedType tyconRefs, LegitTypeOccurence, _, _, _, m ->
                         if tyconRefs |> List.exists (fun tyconRef -> tyconRef.Deref.IsStructOrEnumTycon) then
                             add m SemanticClassificationType.ValueType
                         else add m SemanticClassificationType.ReferenceType
-                    | _, Item.CtorGroup(_, minfos), LegitTypeOccurence, _, _, _, m ->
+                    | Item.CtorGroup(_, minfos), LegitTypeOccurence, _, _, _, m ->
                         if minfos |> List.exists (fun minfo -> isStructTy g minfo.ApparentEnclosingType) then
                             add m SemanticClassificationType.ValueType
                         else add m SemanticClassificationType.ReferenceType
-                    | _, Item.ExnCase _, LegitTypeOccurence, _, _, _, m ->
+                    | Item.ExnCase _, LegitTypeOccurence, _, _, _, m ->
                         add m SemanticClassificationType.ReferenceType
-                    | _, Item.ModuleOrNamespaces refs, LegitTypeOccurence, _, _, _, m when refs |> List.exists (fun x -> x.IsModule) ->
+                    | Item.ModuleOrNamespaces refs, LegitTypeOccurence, _, _, _, m when refs |> List.exists (fun x -> x.IsModule) ->
                         add m SemanticClassificationType.Module
-                    | _, (Item.ActivePatternCase _ | Item.UnionCase _ | Item.ActivePatternResult _), _, _, _, _, m ->
+                    | (Item.ActivePatternCase _ | Item.UnionCase _ | Item.ActivePatternResult _), _, _, _, _, m ->
                         add m SemanticClassificationType.UnionCase
                     | _ -> ())
                 results.AddRange(formatSpecifierLocations |> Array.map (fun (m, _) -> struct(m, SemanticClassificationType.Printf)))

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -32,7 +32,7 @@ type SemanticClassificationType =
 [<AutoOpen>]
 module internal TcResolutionsExtensions =
 
-    val (|CNR|) : cnr: CapturedNameResolution -> (pos * Item * ItemOccurence * DisplayEnv * NameResolutionEnv * AccessorDomain * range)
+    val (|CNR|) : cnr: CapturedNameResolution -> (Item * ItemOccurence * DisplayEnv * NameResolutionEnv * AccessorDomain * range)
 
     type TcResolutions with
 


### PR DESCRIPTION
Saves 8 bytes in each captured item.