### PR TITLE
Don't check isFunction for every captured type, don't store end pos

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1446,7 +1446,7 @@ type FormatStringCheckContext =
 /// An abstract type for reporting the results of name resolution and type checking.
 type ITypecheckResultsSink =
     abstract NotifyEnvWithScope: range * NameResolutionEnv * AccessorDomain -> unit
-    abstract NotifyExprHasType: pos * TType * NameResolutionEnv * AccessorDomain * range -> unit
+    abstract NotifyExprHasType: TType * NameResolutionEnv * AccessorDomain * range -> unit
     abstract NotifyNameResolution: pos * item: Item * TyparInst * ItemOccurence * NameResolutionEnv * AccessorDomain * range * replace: bool -> unit
     abstract NotifyMethodGroupNameResolution : pos * item: Item * itemMethodGroup: Item * TyparInst * ItemOccurence * NameResolutionEnv * AccessorDomain * range * replace: bool -> unit
     abstract NotifyFormatSpecifierLocation: range * int -> unit
@@ -1674,7 +1674,7 @@ type CapturedNameResolution(i: Item, tpinst, io: ItemOccurence, nre: NameResolut
 /// Represents container for all name resolutions that were met so far when typechecking some particular file
 type TcResolutions
     (capturedEnvs: ResizeArray<range * NameResolutionEnv * AccessorDomain>,
-     capturedExprTypes: ResizeArray<pos * TType * NameResolutionEnv * AccessorDomain * range>,
+     capturedExprTypes: ResizeArray<TType * NameResolutionEnv * AccessorDomain * range>,
      capturedNameResolutions: ResizeArray<CapturedNameResolution>,
      capturedMethodGroupResolutions: ResizeArray<CapturedNameResolution>) =
 
@@ -1805,9 +1805,9 @@ type TcResultsSinkImpl(g, ?sourceText: ISourceText) =
             if allowedRange m then
                 capturedEnvs.Add((m, nenv, ad))
 
-        member sink.NotifyExprHasType(endPos, ty, nenv, ad, m) =
+        member sink.NotifyExprHasType(ty, nenv, ad, m) =
             if allowedRange m then
-                capturedExprTypings.Add((endPos, ty, nenv, ad, m))
+                capturedExprTypings.Add((ty, nenv, ad, m))
 
         member sink.NotifyNameResolution(endPos, item, tpinst, occurenceType, nenv, ad, m, replace) =
             if allowedRange m then
@@ -1880,7 +1880,7 @@ let CallNameResolutionSinkReplacing (sink: TcResultsSink) (m: range, nenv, item,
 let CallExprHasTypeSink (sink: TcResultsSink) (m: range, nenv, ty, ad) =
     match sink.CurrentSink with
     | None -> ()
-    | Some sink -> sink.NotifyExprHasType(m.End, ty, nenv, ad, m)
+    | Some sink -> sink.NotifyExprHasType(ty, nenv, ad, m)
 
 let CallOpenDeclarationSink (sink: TcResultsSink) (openDeclaration: OpenDeclaration) =
     match sink.CurrentSink with

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -338,7 +338,7 @@ type internal TcResolutions =
 
     /// Information of exact types found for expressions, that can be to the left of a dot.
     /// typ - the inferred type for an expression
-    member CapturedExpressionTypings : ResizeArray<pos * TType * NameResolutionEnv * AccessorDomain * range>
+    member CapturedExpressionTypings : ResizeArray<TType * NameResolutionEnv * AccessorDomain * range>
 
     /// Exact name resolutions
     member CapturedNameResolutions : ResizeArray<CapturedNameResolution>
@@ -409,7 +409,7 @@ type ITypecheckResultsSink =
     abstract NotifyEnvWithScope   : range * NameResolutionEnv * AccessorDomain -> unit
 
     /// Record that an expression has a specific type at the given range.
-    abstract NotifyExprHasType    : pos * TType * NameResolutionEnv * AccessorDomain * range -> unit
+    abstract NotifyExprHasType    : TType * NameResolutionEnv * AccessorDomain * range -> unit
 
     /// Record that a name resolution occurred at a specific location in the source
     abstract NotifyNameResolution : pos * Item * TyparInst * ItemOccurence * NameResolutionEnv * AccessorDomain * range * bool -> unit

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -1880,7 +1880,7 @@ let MakeAndPublishSimpleValsForMergedScope cenv env m (names: NameMap<_>) =
                         member this.NotifyMethodGroupNameResolution(pos, item, itemGroup, itemTyparInst, occurence, nenv, ad, m, replacing) =
                             notifyNameResolution (pos, item, itemGroup, itemTyparInst, occurence, nenv, ad, m, replacing)
 
-                        member this.NotifyExprHasType(_, _, _, _, _) = assert false // no expr typings in MakeAndPublishSimpleVals
+                        member this.NotifyExprHasType(_, _, _, _) = assert false // no expr typings in MakeAndPublishSimpleVals
                         member this.NotifyFormatSpecifierLocation(_, _) = ()
                         member this.NotifyOpenDeclaration(_) = ()
                         member this.CurrentSourceText = None 

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -366,12 +366,14 @@ type internal TypeCheckInfo
             sResolutions.CapturedExpressionTypings 
             |> Seq.filter (fun (pos,ty,nenv,_,_) -> 
                     // We only want expression types that end at the particular position in the file we are looking at.
-                    let isLocationWeCareAbout = posEq pos endOfExprPos
-                    // Get rid of function types.  True, given a 2-arg curried function "f x y", it is legal to do "(f x).GetType()",
-                    // but you almost never want to do this in practice, and we choose not to offer up any intellisense for 
-                    // F# function types.
-                    let isFunction = isFunTy nenv.DisplayEnv.g ty
-                    isLocationWeCareAbout && not isFunction)
+                    if not (posEq pos endOfExprPos) then
+                        false
+                    else
+                        // Get rid of function types.  True, given a 2-arg curried function "f x y", it is legal to do "(f x).GetType()",
+                        // but you almost never want to do this in practice, and we choose not to offer up any intellisense for 
+                        // F# function types.
+                        let isFunction = isFunTy nenv.DisplayEnv.g ty
+                        not isFunction)
             |> Seq.toArray
 
         let thereWereSomeQuals = not (Array.isEmpty quals)

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -366,14 +366,12 @@ type internal TypeCheckInfo
             sResolutions.CapturedExpressionTypings 
             |> Seq.filter (fun (ty,nenv,_,m) -> 
                     // We only want expression types that end at the particular position in the file we are looking at.
-                    if not (posEq m.End endOfExprPos) then
-                        false
-                    else
-                        // Get rid of function types.  True, given a 2-arg curried function "f x y", it is legal to do "(f x).GetType()",
-                        // but you almost never want to do this in practice, and we choose not to offer up any intellisense for 
-                        // F# function types.
-                        let isFunction = isFunTy nenv.DisplayEnv.g ty
-                        not isFunction)
+                    posEq m.End endOfExprPos &&
+
+                    // Get rid of function types.  True, given a 2-arg curried function "f x y", it is legal to do "(f x).GetType()",
+                    // but you almost never want to do this in practice, and we choose not to offer up any intellisense for 
+                    // F# function types.
+                    not (isFunTy nenv.DisplayEnv.g ty))
             |> Seq.toArray
 
         let thereWereSomeQuals = not (Array.isEmpty quals)


### PR DESCRIPTION
* Prevents `isFunction` check for every captured type in a file when we're only interested in types at particular location
* Removes `endPos` from captured types, saves 8 bytes in each captured type