### PR TITLE
Add Range to FSharpErrorInfo, replace inner fields

### DIFF
--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -42,33 +42,47 @@ type FSharpErrorSeverity =
     | Warning 
     | Error
 
-type FSharpErrorInfo(fileName, s: pos, e: pos, severity: FSharpErrorSeverity, message: string, subcategory: string, errorNum: int) =
-    member __.Start = s
-    member __.End = e
+type FSharpErrorInfo(m: range, severity: FSharpErrorSeverity, message: string, subcategory: string, errorNum: int) =
+    member _.Start = m.Start
+    member _.End = m.End
 
-    member __.StartLine = Line.toZ s.Line
-    member __.StartLineAlternate = s.Line
-    member __.EndLine = Line.toZ e.Line
-    member __.EndLineAlternate = e.Line
-    member __.StartColumn = s.Column
-    member __.EndColumn = e.Column
+    member _.StartLine = Line.toZ m.Start.Line
+    member _.StartLineAlternate = m.Start.Line
+    member _.EndLine = Line.toZ m.End.Line
+    member _.EndLineAlternate = m.End.Line
+    member _.StartColumn = m.Start.Column
+    member _.EndColumn = m.End.Column
+    member _.FileName = m.FileName
 
-    member __.Severity = severity
-    member __.Message = message
-    member __.Subcategory = subcategory
-    member __.FileName = fileName
-    member __.ErrorNumber = errorNum
-    member __.WithStart newStart = FSharpErrorInfo(fileName, newStart, e, severity, message, subcategory, errorNum)
-    member __.WithEnd newEnd = FSharpErrorInfo(fileName, s, newEnd, severity, message, subcategory, errorNum)
-    override __.ToString()= sprintf "%s (%d,%d)-(%d,%d) %s %s %s" fileName (int s.Line) (s.Column + 1) (int e.Line) (e.Column + 1) subcategory (if severity=FSharpErrorSeverity.Warning then "warning" else "error")  message
-            
+    member _.Range = m
+    member _.Severity = severity
+    member _.Message = message
+    member _.Subcategory = subcategory
+    member _.ErrorNumber = errorNum
+
+    member _.WithStart newStart =
+        let m = mkFileIndexRange m.FileIndex newStart m.End
+        FSharpErrorInfo(m, severity, message, subcategory, errorNum)
+
+    member _.WithEnd newEnd =
+        let m = mkFileIndexRange m.FileIndex m.Start newEnd
+        FSharpErrorInfo(m, severity, message, subcategory, errorNum)
+
+    override _.ToString() =
+        let fileName = m.FileName
+        let s = m.Start
+        let e = m.End
+        let severity = if severity=FSharpErrorSeverity.Warning then "warning" else "error"
+        sprintf "%s (%d,%d)-(%d,%d) %s %s %s" fileName s.Line (s.Column + 1) e.Line (e.Column + 1) subcategory severity message
+
     /// Decompose a warning or error into parts: position, severity, message, error number
     static member CreateFromException(exn, isError, fallbackRange: range, suggestNames: bool) =
         let m = match GetRangeOfDiagnostic exn with Some m -> m | None -> fallbackRange 
+        let severity = if isError then FSharpErrorSeverity.Error else FSharpErrorSeverity.Warning
         let msg = bufs (fun buf -> OutputPhasedDiagnostic buf exn false suggestNames)
         let errorNum = GetDiagnosticNumber exn
-        FSharpErrorInfo(m.FileName, m.Start, m.End, (if isError then FSharpErrorSeverity.Error else FSharpErrorSeverity.Warning), msg, exn.Subcategory(), errorNum)
-        
+        FSharpErrorInfo(m, severity, msg, exn.Subcategory(), errorNum)
+
     /// Decompose a warning or error into parts: position, severity, message, error number
     static member CreateFromExceptionAndAdjustEof(exn, isError, fallbackRange: range, (linesCount: int, lastLength: int), suggestNames: bool) =
         let r = FSharpErrorInfo.CreateFromException(exn, isError, fallbackRange, suggestNames)

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -46,22 +46,22 @@ module FSharpErrorInfo =
     let [<Literal>] ObsoleteMessage = "Use FSharpErrorInfo.Range. This API will be removed in a future update."
 
 type FSharpErrorInfo(m: range, severity: FSharpErrorSeverity, message: string, subcategory: string, errorNum: int) =
-    member _.Start = m.Start
-    member _.End = m.End
-
-    member _.StartLine = Line.toZ m.Start.Line
-    member _.StartLineAlternate = m.Start.Line
-    member _.EndLine = Line.toZ m.End.Line
-    member _.EndLineAlternate = m.End.Line
-    member _.StartColumn = m.Start.Column
-    member _.EndColumn = m.End.Column
-    member _.FileName = m.FileName
-
     member _.Range = m
     member _.Severity = severity
     member _.Message = message
     member _.Subcategory = subcategory
     member _.ErrorNumber = errorNum
+
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.Start = m.Start
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.End = m.End
+
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.StartLine = Line.toZ m.Start.Line
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.StartLineAlternate = m.Start.Line
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.EndLine = Line.toZ m.End.Line
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.EndLineAlternate = m.End.Line
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.StartColumn = m.Start.Column
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.EndColumn = m.End.Column
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member _.FileName = m.FileName
 
     member _.WithStart newStart =
         let m = mkFileIndexRange m.FileIndex newStart m.End

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -42,6 +42,9 @@ type FSharpErrorSeverity =
     | Warning 
     | Error
 
+module FSharpErrorInfo =
+    let [<Literal>] ObsoleteMessage = "Use FSharpErrorInfo.Range. This API will be removed in a future update."
+
 type FSharpErrorInfo(m: range, severity: FSharpErrorSeverity, message: string, subcategory: string, errorNum: int) =
     member _.Start = m.Start
     member _.End = m.End
@@ -88,8 +91,8 @@ type FSharpErrorInfo(m: range, severity: FSharpErrorSeverity, message: string, s
         let r = FSharpErrorInfo.CreateFromException(exn, isError, fallbackRange, suggestNames)
 
         // Adjust to make sure that errors reported at Eof are shown at the linesCount
-        let startline, schange = min (r.StartLineAlternate, false) (linesCount, true)
-        let endline, echange = min (r.EndLineAlternate, false)   (linesCount, true)
+        let startline, schange = min (r.Range.StartLine, false) (linesCount, true)
+        let endline, echange = min (r.Range.EndLine, false)   (linesCount, true)
         
         if not (schange || echange) then r
         else
@@ -198,7 +201,8 @@ module ErrorHelpers =
                   // Not ideal, but it's hard to see what else to do.
                   let fallbackRange = rangeN mainInputFileName 1
                   let ei = FSharpErrorInfo.CreateFromExceptionAndAdjustEof (exn, isError, fallbackRange, fileInfo, suggestNames)
-                  if allErrors || (ei.FileName = mainInputFileName) || (ei.FileName = TcGlobals.DummyFileNameForRangesWithoutASpecificLocation) then
+                  let fileName = ei.Range.FileName
+                  if allErrors || fileName = mainInputFileName || fileName = TcGlobals.DummyFileNameForRangesWithoutASpecificLocation then
                       yield ei ]
 
             let mainError, relatedErrors = SplitRelatedDiagnostics exn 

--- a/src/fsharp/symbols/SymbolHelpers.fsi
+++ b/src/fsharp/symbols/SymbolHelpers.fsi
@@ -26,15 +26,18 @@ type public FSharpErrorSeverity =
 | Warning 
     | Error
 
+module FSharpErrorInfo =
+    [<Literal>] val ObsoleteMessage: string = "Use FSharpErrorInfo.Range. This API will be removed in a future update."
+
 [<Class>]
 type public FSharpErrorInfo = 
-    member FileName: string
-    member Start: pos
-    member End: pos
-    member StartLineAlternate: int
-    member EndLineAlternate: int
-    member StartColumn: int
-    member EndColumn: int
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member FileName: string
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member Start: pos
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member End: pos
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member StartLineAlternate: int
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member EndLineAlternate: int
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member StartColumn: int
+    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member EndColumn: int
 
     member Range: range
     member Severity: FSharpErrorSeverity

--- a/src/fsharp/symbols/SymbolHelpers.fsi
+++ b/src/fsharp/symbols/SymbolHelpers.fsi
@@ -26,18 +26,15 @@ type public FSharpErrorSeverity =
 | Warning 
     | Error
 
-module FSharpErrorInfo =
-    [<Literal>] val ObsoleteMessage: string = "Use FSharpErrorInfo.Range. This API will be removed in a future update."
-
 [<Class>]
 type public FSharpErrorInfo = 
-    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member FileName: string
-    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member Start: pos
-    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member End: pos
-    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member StartLineAlternate: int
-    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member EndLineAlternate: int
-    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member StartColumn: int
-    [<Obsolete(FSharpErrorInfo.ObsoleteMessage)>] member EndColumn: int
+    member FileName: string
+    member Start: pos
+    member End: pos
+    member StartLineAlternate: int
+    member EndLineAlternate: int
+    member StartColumn: int
+    member EndColumn: int
 
     member Range: range
     member Severity: FSharpErrorSeverity

--- a/src/fsharp/symbols/SymbolHelpers.fsi
+++ b/src/fsharp/symbols/SymbolHelpers.fsi
@@ -31,16 +31,19 @@ type public FSharpErrorInfo =
     member FileName: string
     member Start: pos
     member End: pos
-    member StartLineAlternate:int
-    member EndLineAlternate:int
-    member StartColumn:int
-    member EndColumn:int
-    member Severity:FSharpErrorSeverity
-    member Message:string
-    member Subcategory:string
-    member ErrorNumber:int
-    static member internal CreateFromExceptionAndAdjustEof : PhasedDiagnostic * isError: bool * range * lastPosInFile:(int*int) * suggestNames: bool -> FSharpErrorInfo
-    static member internal CreateFromException : PhasedDiagnostic * isError: bool * range * suggestNames: bool -> FSharpErrorInfo
+    member StartLineAlternate: int
+    member EndLineAlternate: int
+    member StartColumn: int
+    member EndColumn: int
+
+    member Range: range
+    member Severity: FSharpErrorSeverity
+    member Message: string
+    member Subcategory: string
+    member ErrorNumber: int
+
+    static member internal CreateFromExceptionAndAdjustEof: PhasedDiagnostic * isError: bool * range * lastPosInFile: (int*int) * suggestNames: bool -> FSharpErrorInfo
+    static member internal CreateFromException: PhasedDiagnostic * isError: bool * range * suggestNames: bool -> FSharpErrorInfo
 
 //----------------------------------------------------------------------------
 // Object model for quick info

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -312,12 +312,11 @@ let getParseAndCheckResults (source: string) =
 let inline dumpErrors results =
     (^TResults: (member Errors: FSharpErrorInfo[]) results)
     |> Array.map (fun e ->
-        let range = mkRange e.FileName e.Start e.End
         let message =
             e.Message.Split('\n')
             |> Array.map (fun s -> s.Trim())
             |> String.concat " "
-        sprintf "%s: %s" (range.ToShortString()) message)
+        sprintf "%s: %s" (e.Range.ToShortString()) message)
     |> List.ofArray
 
 

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -99,10 +99,10 @@ let ``Test project1 whole project errors`` () =
     wholeProjectResults.Errors.[1].Message.Contains("Incomplete pattern matches on this expression") |> shouldEqual true // yes it does
     wholeProjectResults.Errors.[1].ErrorNumber |> shouldEqual 25
 
-    wholeProjectResults.Errors.[0].StartLineAlternate |> shouldEqual 10
-    wholeProjectResults.Errors.[0].EndLineAlternate |> shouldEqual 10
-    wholeProjectResults.Errors.[0].StartColumn |> shouldEqual 43
-    wholeProjectResults.Errors.[0].EndColumn |> shouldEqual 44
+    wholeProjectResults.Errors.[0].Range.StartLine |> shouldEqual 10
+    wholeProjectResults.Errors.[0].Range.EndLine |> shouldEqual 10
+    wholeProjectResults.Errors.[0].Range.StartColumn |> shouldEqual 43
+    wholeProjectResults.Errors.[0].Range.EndColumn |> shouldEqual 44
 
 [<Test;NonParallelizable>]
 let ``Test project1 and make sure TcImports gets cleaned up`` () = 
@@ -5222,9 +5222,9 @@ let ``Test line directives in foreground analysis`` () = // see https://github.c
     // In background analysis and normal compiler checking, the errors are reported w.r.t. the line directives
     let wholeProjectResults = checker.ParseAndCheckProject(ProjectLineDirectives.options) |> Async.RunSynchronously
     for e in wholeProjectResults.Errors do 
-        printfn "ProjectLineDirectives wholeProjectResults error file: <<<%s>>>" e.FileName
+        printfn "ProjectLineDirectives wholeProjectResults error file: <<<%s>>>" e.Range.FileName
 
-    [ for e in wholeProjectResults.Errors -> e.StartLineAlternate, e.EndLineAlternate, e.FileName ] |> shouldEqual [(10, 10, "Test.fsy")]
+    [ for e in wholeProjectResults.Errors -> e.Range.StartLine, e.Range.EndLine, e.Range.FileName ] |> shouldEqual [(10, 10, "Test.fsy")]
 
     // In foreground analysis routines, used by visual editing tools, the errors are reported w.r.t. the source
     // file, which is assumed to be in the editor, not the other files referred to by line directives.
@@ -5234,9 +5234,9 @@ let ``Test line directives in foreground analysis`` () = // see https://github.c
         |> function (_,FSharpCheckFileAnswer.Succeeded x) ->  x | _ -> failwith "unexpected aborted"
 
     for e in checkResults1.Errors do 
-        printfn "ProjectLineDirectives checkResults1 error file: <<<%s>>>" e.FileName
+        printfn "ProjectLineDirectives checkResults1 error file: <<<%s>>>" e.Range.FileName
 
-    [ for e in checkResults1.Errors -> e.StartLineAlternate, e.EndLineAlternate, e.FileName ] |> shouldEqual [(5, 5, ProjectLineDirectives.fileName1)]
+    [ for e in checkResults1.Errors -> e.Range.StartLine, e.Range.EndLine, e.Range.FileName ] |> shouldEqual [(5, 5, ProjectLineDirectives.fileName1)]
 
 //------------------------------------------------------
 


### PR DESCRIPTION
Adds `Range` property to `FSharpErrorInfo` which has the same type as in other FCS APIs and is commonly used. Replaces other fields which were previosly extracted from the range.