### PR TITLE
Compiler fix and tests for 8777

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -4999,9 +4999,6 @@ let ProcessMetaCommandsFromInput
                     let output = tcConfig.outputDir |> Option.defaultValue ""
                     let dm = tcConfig.dependencyProvider.TryFindDependencyManagerInPath(tcConfig.compilerToolPaths, output , reportError, path)
                     match dm with
-                    | dllpath, null when String.IsNullOrWhiteSpace(dllpath) ->
-                        state           // error already reported
-
                     | _, dependencyManager when not(isNull dependencyManager) ->
                         if tcConfig.langVersion.SupportsFeature(LanguageFeature.PackageManagement) then
                             packageRequireF state (dependencyManager, m, path)
@@ -5011,7 +5008,11 @@ let ProcessMetaCommandsFromInput
 
                     // #r "Assembly"
                     | path, _ ->
-                        dllRequireF state (m, path)
+                        let p =
+                            if String.IsNullOrWhiteSpace(path) then ""
+                            else path
+
+                        dllRequireF state (m, p)
 
                 | _ ->
                    errorR(Error(FSComp.SR.buildInvalidHashrDirective(), m))

--- a/tests/fsharp/Compiler/Language/CompilerDirectiveTests.fs
+++ b/tests/fsharp/Compiler/Language/CompilerDirectiveTests.fs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.UnitTests
+
+open NUnit.Framework
+open FSharp.Compiler.SourceCodeServices
+
+[<TestFixture>]
+module ``Test Compiler Directives`` =
+
+    [<Test>]
+    let ``compiler #r "" is invalid``() =
+        let source = """
+#r ""
+"""
+        CompilerAssert.CompileWithErrors(
+            Compilation.Create(source, Fsx, Library),
+            [|
+                FSharpErrorSeverity.Warning, 213, (2,1,2,6), "'' is not a valid assembly name"
+            |])
+
+    [<Test>]
+    let ``compiler #r "   " is invalid``() =
+        let source = """
+#r "    "
+"""
+        CompilerAssert.CompileWithErrors(
+            Compilation.Create(source, Fsx, Library),
+            [|
+                FSharpErrorSeverity.Warning, 213, (2,1,2,10), "'' is not a valid assembly name"
+            |])

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -60,6 +60,7 @@
     <Compile Include="Compiler\Warnings\ExperimentalAttributeTests.fs" />
     <Compile Include="Compiler\Warnings\PatternMatchingWarningTests.fs" />
     <Compile Include="Compiler\SourceTextTests.fs" />
+    <Compile Include="Compiler\Language\CompilerDirectiveTests.fs" />
     <Compile Include="Compiler\Language\DefaultInterfaceMemberTests.fs" />
     <Compile Include="Compiler\Language\OptionalInteropTests.fs" />
     <Compile Include="Compiler\Language\UIntTests.fs" />


### PR DESCRIPTION
It is possible for the compiler to compile .fsx files.  It has different code handling metacommands than fsi.  So #877 needs fixing for the compiler too.

Amusingly the compiler issues the error messages as warnings, whereas fsi issues them as errors.

Anyway this PR, doesn't address that, it merely ensures that the compiler warns like it used to.  And adds a couple of test cases.