### PR TITLE
run Linux tests on latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,7 @@ stages:
         # Linux
         - job: Linux
           pool:
-            vmImage: ubuntu-16.04
+            vmImage: ubuntu-latest
           variables:
           - name: _SignType
             value: Test
@@ -283,7 +283,7 @@ stages:
         # - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         #   - job: SourceBuild_Linux
         #     pool:
-        #       vmImage: ubuntu-16.04
+        #       vmImage: ubuntu-latest
         #     steps:
         #     - checkout: self
         #       clean: true
@@ -379,7 +379,7 @@ stages:
 
         - job: Linux_FCS
           pool:
-            vmImage: ubuntu-16.04
+            vmImage: ubuntu-latest
           variables:
           - name: _SignType
             value: Test


### PR DESCRIPTION
An attempt to prevent future work when 16.04 is eventually dropped.  This change is inline with #8405 to always run Mac builds on latest.