### PR TITLE
ProvidedExpr handles encapsulation

### DIFF
--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -631,179 +631,102 @@ module internal ExtensionTyping =
         override __.Equals y = assert false; match y with :? ProvidedConstructorInfo as y -> x.Equals y.Handle | _ -> false
         override __.GetHashCode() = assert false; x.GetHashCode()
 
-    [<RequireQualifiedAccess; Class; AllowNullLiteral; Sealed>]
-    type ProvidedExpr (x: Quotations.Expr, ctxt) =
+    type ProvidedExprType =
+        | ProvidedNewArrayExpr of ProvidedType * ProvidedExpr[]
+#if PROVIDED_ADDRESS_OF
+        | ProvidedAddressOfExpr of ProvidedExpr
+#endif
+        | ProvidedNewObjectExpr of ProvidedConstructorInfo * ProvidedExpr[]
+        | ProvidedWhileLoopExpr of ProvidedExpr * ProvidedExpr
+        | ProvidedNewDelegateExpr of ProvidedType * ProvidedVar[] * ProvidedExpr
+        | ProvidedForIntegerRangeLoopExpr of ProvidedVar * ProvidedExpr * ProvidedExpr * ProvidedExpr
+        | ProvidedSequentialExpr of ProvidedExpr * ProvidedExpr
+        | ProvidedTryWithExpr of ProvidedExpr * ProvidedVar * ProvidedExpr * ProvidedVar * ProvidedExpr
+        | ProvidedTryFinallyExpr of ProvidedExpr * ProvidedExpr
+        | ProvidedLambdaExpr of ProvidedVar * ProvidedExpr
+        | ProvidedCallExpr of ProvidedExpr option * ProvidedMethodInfo * ProvidedExpr[] 
+        | ProvidedConstantExpr of obj * ProvidedType
+        | ProvidedDefaultExpr of ProvidedType
+        | ProvidedNewTupleExpr of ProvidedExpr[]
+        | ProvidedTupleGetExpr of ProvidedExpr * int
+        | ProvidedTypeAsExpr of ProvidedExpr * ProvidedType
+        | ProvidedTypeTestExpr of ProvidedExpr * ProvidedType
+        | ProvidedLetExpr of ProvidedVar * ProvidedExpr * ProvidedExpr
+        | ProvidedVarSetExpr of ProvidedVar * ProvidedExpr
+        | ProvidedIfThenElseExpr of ProvidedExpr * ProvidedExpr * ProvidedExpr
+        | ProvidedVarExpr of ProvidedVar
+
+    and [<RequireQualifiedAccess; Class; AllowNullLiteral; Sealed>]
+        ProvidedExpr (x: Quotations.Expr, ctxt) =
         member __.Type = x.Type |> ProvidedType.Create ctxt
         member __.Handle = x
         member __.Context = ctxt
         member __.UnderlyingExpressionString = x.ToString()
+        member __.GetExprType() =
+            match x with
+            | Quotations.Patterns.NewObject(ctor, args) ->
+                Some (ProvidedNewObjectExpr (ProvidedConstructorInfo.Create ctxt ctor, [| for a in args -> ProvidedExpr.Create ctxt a |]))
+            | Quotations.Patterns.WhileLoop(guardExpr, bodyExpr) ->
+                Some (ProvidedWhileLoopExpr (ProvidedExpr.Create ctxt guardExpr, ProvidedExpr.Create ctxt bodyExpr))
+            | Quotations.Patterns.NewDelegate(ty, vs, expr) ->
+                Some (ProvidedNewDelegateExpr(ProvidedType.Create ctxt ty, ProvidedVar.CreateArray ctxt (List.toArray vs), ProvidedExpr.Create ctxt expr))
+            | Quotations.Patterns.Call(objOpt, meth, args) ->
+                Some (ProvidedCallExpr((match objOpt with None -> None | Some obj -> Some (ProvidedExpr.Create ctxt obj)), 
+                        ProvidedMethodInfo.Create ctxt meth, [| for a in args -> ProvidedExpr.Create ctxt a |]))
+            | Quotations.Patterns.DefaultValue ty ->
+                Some (ProvidedDefaultExpr (ProvidedType.Create ctxt ty))
+            | Quotations.Patterns.Value(obj, ty) ->
+                Some (ProvidedConstantExpr (obj, ProvidedType.Create ctxt ty))
+            | Quotations.Patterns.Coerce(arg, ty) ->
+                Some (ProvidedTypeAsExpr (ProvidedExpr.Create ctxt arg, ProvidedType.Create ctxt ty))
+            | Quotations.Patterns.NewTuple args ->
+                Some (ProvidedNewTupleExpr(ProvidedExpr.CreateArray ctxt (Array.ofList args)))
+            | Quotations.Patterns.TupleGet(arg, n) ->
+                Some (ProvidedTupleGetExpr (ProvidedExpr.Create ctxt arg, n))
+            | Quotations.Patterns.NewArray(ty, args) ->
+                Some (ProvidedNewArrayExpr(ProvidedType.Create ctxt ty, ProvidedExpr.CreateArray ctxt (Array.ofList args)))
+            | Quotations.Patterns.Sequential(e1, e2) ->
+                Some (ProvidedSequentialExpr(ProvidedExpr.Create ctxt e1, ProvidedExpr.Create ctxt e2))
+            | Quotations.Patterns.Lambda(v, body) ->
+                Some (ProvidedLambdaExpr (ProvidedVar.Create ctxt v,  ProvidedExpr.Create ctxt body))
+            | Quotations.Patterns.TryFinally(b1, b2) ->
+                Some (ProvidedTryFinallyExpr (ProvidedExpr.Create ctxt b1, ProvidedExpr.Create ctxt b2))
+            | Quotations.Patterns.TryWith(b, v1, e1, v2, e2) ->
+                Some (ProvidedTryWithExpr (ProvidedExpr.Create ctxt b, ProvidedVar.Create ctxt v1, ProvidedExpr.Create ctxt e1, ProvidedVar.Create ctxt v2, ProvidedExpr.Create ctxt e2))
+            | _ -> None
+#if PROVIDED_ADDRESS_OF
+            | Quotations.Patterns.AddressOf e -> Some (ProvidedAddressOfExpr (ProvidedExpr.Create ctxt e))
+#endif
+            | Quotations.Patterns.TypeTest(e, ty) ->
+                Some (ProvidedTypeTestExpr(ProvidedExpr.Create ctxt e, ProvidedType.Create ctxt ty))
+            | Quotations.Patterns.Let(v, e, b) ->
+                Some (ProvidedLetExpr (ProvidedVar.Create ctxt v, ProvidedExpr.Create ctxt e, ProvidedExpr.Create ctxt b))
+            | Quotations.Patterns.ForIntegerRangeLoop (v, e1, e2, e3) ->
+                Some (ProvidedForIntegerRangeLoopExpr (ProvidedVar.Create ctxt v, ProvidedExpr.Create ctxt e1, ProvidedExpr.Create ctxt e2, ProvidedExpr.Create ctxt e3))
+            | Quotations.Patterns.VarSet(v, e) ->
+                Some (ProvidedVarSetExpr (ProvidedVar.Create ctxt v, ProvidedExpr.Create ctxt e))
+            | Quotations.Patterns.IfThenElse(g, t, e) ->
+                Some (ProvidedIfThenElseExpr (ProvidedExpr.Create ctxt g, ProvidedExpr.Create ctxt t, ProvidedExpr.Create ctxt e))
+            | Quotations.Patterns.Var v ->
+                Some (ProvidedVarExpr (ProvidedVar.Create ctxt v))
+            | _ -> None
         static member Create ctxt t = match box t with null -> null | _ -> ProvidedExpr (t, ctxt)
         static member CreateArray ctxt xs = match xs with null -> null | _ -> xs |> Array.map (ProvidedExpr.Create ctxt)
         override __.Equals y = match y with :? ProvidedExpr as y -> x.Equals y.Handle | _ -> false
         override __.GetHashCode() = x.GetHashCode()
 
-    [<RequireQualifiedAccess; Class; AllowNullLiteral; Sealed>]
-    type ProvidedVar (x: Quotations.Var, ctxt) =
+    and [<RequireQualifiedAccess; Class; AllowNullLiteral; Sealed>]
+        ProvidedVar (x: Quotations.Var, ctxt) =
         member __.Type = x.Type |> ProvidedType.Create ctxt
         member __.Name = x.Name
         member __.IsMutable = x.IsMutable
         member __.Handle = x
         member __.Context = ctxt
         static member Create ctxt t = match box t with null -> null | _ -> ProvidedVar (t, ctxt)
-        static member Fresh (nm, ty: ProvidedType) = ProvidedVar.Create ty.Context (new Quotations.Var(nm, ty.Handle))
+        static member Fresh (nm, ty: ProvidedType) = ProvidedVar.Create ty.Context (Quotations.Var(nm, ty.Handle))
         static member CreateArray ctxt xs = match xs with null -> null | _ -> xs |> Array.map (ProvidedVar.Create ctxt)
         override __.Equals y = match y with :? ProvidedVar as y -> x.Equals y.Handle | _ -> false
         override __.GetHashCode() = x.GetHashCode()
-
-
-    /// Detect a provided new-object expression 
-    let (|ProvidedNewObjectExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.NewObject(ctor, args)  -> 
-            Some (ProvidedConstructorInfo.Create x.Context ctor, [| for a in args -> ProvidedExpr.Create x.Context a |])
-        | _ -> None
-
-    /// Detect a provided while-loop expression 
-    let (|ProvidedWhileLoopExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.WhileLoop(guardExpr, bodyExpr)  -> 
-            Some (ProvidedExpr.Create x.Context guardExpr, ProvidedExpr.Create x.Context bodyExpr)
-        | _ -> None
-
-    /// Detect a provided new-delegate expression 
-    let (|ProvidedNewDelegateExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.NewDelegate(ty, vs, expr)  -> 
-            Some (ProvidedType.Create x.Context ty, ProvidedVar.CreateArray x.Context (List.toArray vs), ProvidedExpr.Create x.Context expr)
-        | _ -> None
-
-    /// Detect a provided call expression 
-    let (|ProvidedCallExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.Call(objOpt, meth, args) -> 
-            Some ((match objOpt with None -> None | Some obj -> Some (ProvidedExpr.Create  x.Context obj)), 
-                  ProvidedMethodInfo.Create x.Context meth, 
-                  [| for a in args -> ProvidedExpr.Create  x.Context a |])
-        | _ -> None
-
-    /// Detect a provided default-value expression 
-    let (|ProvidedDefaultExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.DefaultValue ty   -> Some (ProvidedType.Create x.Context ty)
-        | _ -> None
-
-    /// Detect a provided constant expression 
-    let (|ProvidedConstantExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.Value(obj, ty)   -> Some (obj, ProvidedType.Create x.Context ty)
-        | _ -> None
-
-    /// Detect a provided type-as expression 
-    let (|ProvidedTypeAsExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.Coerce(arg, ty) ->
-            Some (ProvidedExpr.Create x.Context arg, ProvidedType.Create  x.Context ty)
-        | _ -> None
-
-    /// Detect a provided new-tuple expression 
-    let (|ProvidedNewTupleExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.NewTuple args -> Some (ProvidedExpr.CreateArray x.Context (Array.ofList args))
-        | _ -> None
-
-    /// Detect a provided tuple-get expression 
-    let (|ProvidedTupleGetExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.TupleGet(arg, n) -> Some (ProvidedExpr.Create x.Context arg, n)
-        | _ -> None
-
-    /// Detect a provided new-array expression 
-    let (|ProvidedNewArrayExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.NewArray(ty, args) ->
-            Some (ProvidedType.Create  x.Context ty, ProvidedExpr.CreateArray x.Context (Array.ofList args))
-        | _ -> None
-
-    /// Detect a provided sequential expression 
-    let (|ProvidedSequentialExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.Sequential(e1, e2) ->
-            Some (ProvidedExpr.Create x.Context e1, ProvidedExpr.Create x.Context e2)
-        | _ -> None
-
-    /// Detect a provided lambda expression 
-    let (|ProvidedLambdaExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.Lambda(v, body) ->
-            Some (ProvidedVar.Create x.Context v,  ProvidedExpr.Create x.Context body)
-        | _ -> None
-
-    /// Detect a provided try/finally expression 
-    let (|ProvidedTryFinallyExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.TryFinally(b1, b2) ->
-            Some (ProvidedExpr.Create x.Context b1, ProvidedExpr.Create x.Context b2)
-        | _ -> None
-
-    /// Detect a provided try/with expression 
-    let (|ProvidedTryWithExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.TryWith(b, v1, e1, v2, e2) ->
-            Some (ProvidedExpr.Create x.Context b, ProvidedVar.Create x.Context v1, ProvidedExpr.Create x.Context e1,
-                  ProvidedVar.Create x.Context v2, ProvidedExpr.Create x.Context e2)
-        | _ -> None
-
-#if PROVIDED_ADDRESS_OF
-    let (|ProvidedAddressOfExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.AddressOf e -> Some (ProvidedExpr.Create x.Context e)
-        | _ -> None
-#endif
-
-    /// Detect a provided type-test expression 
-    let (|ProvidedTypeTestExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.TypeTest(e, ty) ->
-            Some (ProvidedExpr.Create x.Context e, ProvidedType.Create x.Context ty)
-        | _ -> None
-
-    /// Detect a provided 'let' expression 
-    let (|ProvidedLetExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.Let(v, e, b) ->
-            Some (ProvidedVar.Create x.Context v, ProvidedExpr.Create x.Context e, ProvidedExpr.Create x.Context b)
-        | _ -> None
-
-
-    /// Detect a provided expression which is a for-loop over integers
-    let (|ProvidedForIntegerRangeLoopExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.ForIntegerRangeLoop (v, e1, e2, e3) -> 
-            Some (ProvidedVar.Create x.Context v, 
-                  ProvidedExpr.Create x.Context e1, 
-                  ProvidedExpr.Create x.Context e2, 
-                  ProvidedExpr.Create x.Context e3)
-        | _ -> None
-
-    /// Detect a provided 'set variable' expression 
-    let (|ProvidedVarSetExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.VarSet(v, e) ->
-            Some (ProvidedVar.Create x.Context v, ProvidedExpr.Create x.Context e)
-        | _ -> None
-
-    /// Detect a provided 'IfThenElse' expression 
-    let (|ProvidedIfThenElseExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.IfThenElse(g, t, e) ->
-            Some (ProvidedExpr.Create x.Context g, ProvidedExpr.Create x.Context t, ProvidedExpr.Create x.Context e)
-        | _ -> None
-
-    /// Detect a provided 'Var' expression 
-    let (|ProvidedVarExpr|_|) (x: ProvidedExpr) = 
-        match x.Handle with 
-        | Quotations.Patterns.Var v  -> Some (ProvidedVar.Create x.Context v)
-        | _ -> None
 
     /// Get the provided invoker expression for a particular use of a method.
     let GetInvokerExpression (provider: ITypeProvider, methodBase: ProvidedMethodBase, paramExprs: ProvidedVar[]) = 

--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -693,7 +693,6 @@ module internal ExtensionTyping =
                 Some (ProvidedTryFinallyExpr (ProvidedExpr.Create ctxt b1, ProvidedExpr.Create ctxt b2))
             | Quotations.Patterns.TryWith(b, v1, e1, v2, e2) ->
                 Some (ProvidedTryWithExpr (ProvidedExpr.Create ctxt b, ProvidedVar.Create ctxt v1, ProvidedExpr.Create ctxt e1, ProvidedVar.Create ctxt v2, ProvidedExpr.Create ctxt e2))
-            | _ -> None
 #if PROVIDED_ADDRESS_OF
             | Quotations.Patterns.AddressOf e -> Some (ProvidedAddressOfExpr (ProvidedExpr.Create ctxt e))
 #endif

--- a/src/fsharp/ExtensionTyping.fsi
+++ b/src/fsharp/ExtensionTyping.fsi
@@ -242,85 +242,47 @@ module internal ExtensionTyping =
     and [<AllowNullLiteral; Class; Sealed>] 
         ProvidedConstructorInfo = 
         inherit ProvidedMethodBase
+      
+    type ProvidedExprType =
+        | ProvidedNewArrayExpr of ProvidedType * ProvidedExpr[]
+#if PROVIDED_ADDRESS_OF
+        | ProvidedAddressOfExpr of ProvidedExpr
+#endif
+        | ProvidedNewObjectExpr of ProvidedConstructorInfo * ProvidedExpr[]
+        | ProvidedWhileLoopExpr of ProvidedExpr * ProvidedExpr
+        | ProvidedNewDelegateExpr of ProvidedType * ProvidedVar[] * ProvidedExpr
+        | ProvidedForIntegerRangeLoopExpr of ProvidedVar * ProvidedExpr * ProvidedExpr * ProvidedExpr
+        | ProvidedSequentialExpr of ProvidedExpr * ProvidedExpr
+        | ProvidedTryWithExpr of ProvidedExpr * ProvidedVar * ProvidedExpr * ProvidedVar * ProvidedExpr
+        | ProvidedTryFinallyExpr of ProvidedExpr * ProvidedExpr
+        | ProvidedLambdaExpr of ProvidedVar * ProvidedExpr
+        | ProvidedCallExpr of ProvidedExpr option * ProvidedMethodInfo * ProvidedExpr[]
+        | ProvidedConstantExpr of obj * ProvidedType
+        | ProvidedDefaultExpr of ProvidedType
+        | ProvidedNewTupleExpr of ProvidedExpr[]
+        | ProvidedTupleGetExpr of ProvidedExpr * int
+        | ProvidedTypeAsExpr of ProvidedExpr * ProvidedType
+        | ProvidedTypeTestExpr of ProvidedExpr * ProvidedType
+        | ProvidedLetExpr of ProvidedVar * ProvidedExpr * ProvidedExpr
+        | ProvidedVarSetExpr of ProvidedVar * ProvidedExpr
+        | ProvidedIfThenElseExpr of ProvidedExpr * ProvidedExpr * ProvidedExpr
+        | ProvidedVarExpr of ProvidedVar
         
-    [<RequireQualifiedAccess; Class; Sealed; AllowNullLiteral>]
-    type ProvidedExpr =
+    and [<RequireQualifiedAccess; Class; Sealed; AllowNullLiteral>]
+        ProvidedExpr =
         member Type : ProvidedType
         /// Convert the expression to a string for diagnostics
         member UnderlyingExpressionString : string
+        member GetExprType : unit -> ProvidedExprType option
 
-    [<RequireQualifiedAccess; Class; Sealed; AllowNullLiteral>]
-    type ProvidedVar =
+    and [<RequireQualifiedAccess; Class; Sealed; AllowNullLiteral>]
+        ProvidedVar =
         member Type : ProvidedType
         member Name : string
         member IsMutable : bool
         static member Fresh : string * ProvidedType -> ProvidedVar
         override Equals : obj -> bool
         override GetHashCode : unit -> int
-
-    /// Detect a provided new-array expression 
-    val (|ProvidedNewArrayExpr|_|)   : ProvidedExpr -> (ProvidedType * ProvidedExpr[]) option
-
-#if PROVIDED_ADDRESS_OF
-    val (|ProvidedAddressOfExpr|_|)  : ProvidedExpr -> ProvidedExpr option
-#endif
-
-    /// Detect a provided new-object expression 
-    val (|ProvidedNewObjectExpr|_|)     : ProvidedExpr -> (ProvidedConstructorInfo * ProvidedExpr[]) option
-
-    /// Detect a provided while-loop expression 
-    val (|ProvidedWhileLoopExpr|_|) : ProvidedExpr -> (ProvidedExpr * ProvidedExpr) option
-
-    /// Detect a provided new-delegate expression 
-    val (|ProvidedNewDelegateExpr|_|) : ProvidedExpr -> (ProvidedType * ProvidedVar[] * ProvidedExpr) option
-
-    /// Detect a provided expression which is a for-loop over integers
-    val (|ProvidedForIntegerRangeLoopExpr|_|) : ProvidedExpr -> (ProvidedVar * ProvidedExpr * ProvidedExpr * ProvidedExpr) option
-
-    /// Detect a provided sequential expression 
-    val (|ProvidedSequentialExpr|_|)    : ProvidedExpr -> (ProvidedExpr * ProvidedExpr) option
-
-    /// Detect a provided try/with expression 
-    val (|ProvidedTryWithExpr|_|)       : ProvidedExpr -> (ProvidedExpr * ProvidedVar * ProvidedExpr * ProvidedVar * ProvidedExpr) option
-
-    /// Detect a provided try/finally expression 
-    val (|ProvidedTryFinallyExpr|_|)    : ProvidedExpr -> (ProvidedExpr * ProvidedExpr) option
-
-    /// Detect a provided lambda expression 
-    val (|ProvidedLambdaExpr|_|)     : ProvidedExpr -> (ProvidedVar * ProvidedExpr) option
-
-    /// Detect a provided call expression 
-    val (|ProvidedCallExpr|_|) : ProvidedExpr -> (ProvidedExpr option * ProvidedMethodInfo * ProvidedExpr[]) option
-
-    /// Detect a provided constant expression 
-    val (|ProvidedConstantExpr|_|)   : ProvidedExpr -> (obj * ProvidedType) option
-
-    /// Detect a provided default-value expression 
-    val (|ProvidedDefaultExpr|_|)    : ProvidedExpr -> ProvidedType option
-
-    /// Detect a provided new-tuple expression 
-    val (|ProvidedNewTupleExpr|_|)   : ProvidedExpr -> ProvidedExpr[] option
-
-    /// Detect a provided tuple-get expression 
-    val (|ProvidedTupleGetExpr|_|)   : ProvidedExpr -> (ProvidedExpr * int) option
-
-    /// Detect a provided type-as expression 
-    val (|ProvidedTypeAsExpr|_|)      : ProvidedExpr -> (ProvidedExpr * ProvidedType) option
-
-    /// Detect a provided type-test expression 
-    val (|ProvidedTypeTestExpr|_|)      : ProvidedExpr -> (ProvidedExpr * ProvidedType) option
-
-    /// Detect a provided 'let' expression 
-    val (|ProvidedLetExpr|_|)      : ProvidedExpr -> (ProvidedVar * ProvidedExpr * ProvidedExpr) option
-
-    /// Detect a provided 'set variable' expression 
-    val (|ProvidedVarSetExpr|_|)      : ProvidedExpr -> (ProvidedVar * ProvidedExpr) option
-
-    /// Detect a provided 'IfThenElse' expression 
-    val (|ProvidedIfThenElseExpr|_|) : ProvidedExpr -> (ProvidedExpr * ProvidedExpr * ProvidedExpr) option
-
-    /// Detect a provided 'Var' expression 
-    val (|ProvidedVarExpr|_|)  : ProvidedExpr -> ProvidedVar option
 
     /// Get the provided expression for a particular use of a method.
     val GetInvokerExpression : ITypeProvider * ProvidedMethodBase * ProvidedVar[] ->  ProvidedExpr

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -1466,112 +1466,90 @@ module ProvidedMethodCalls =
             match ea with
             | Tainted.Null -> error(Error(FSComp.SR.etNullProvidedExpression(ea.TypeProviderDesignation), m))
             |  _ ->
-            match ea.PApplyOption((function ProvidedTypeAsExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let (expr, targetTy) = info.PApply2(id, m)
+            let exprType = ea.PApplyOption((fun x -> x.GetExprType()), m)
+            let exprType = match exprType with | Some exprType -> exprType | None -> fail()
+            match exprType.PUntaint(id, m) with
+            | ProvidedTypeAsExpr (expr, targetTy) ->
+                let (expr, targetTy) = exprType.PApply2((fun _ -> (expr, targetTy)), m)
                 let srcExpr = exprToExpr expr
                 let targetTy = Import.ImportProvidedType amap m (targetTy.PApply(id, m)) 
                 let sourceTy = Import.ImportProvidedType amap m (expr.PApply ((fun e -> e.Type), m)) 
                 let te = mkCoerceIfNeeded g targetTy sourceTy srcExpr
                 None, (te, tyOfExpr g te)
-            | None -> 
-            match ea.PApplyOption((function ProvidedTypeTestExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let (expr, targetTy) = info.PApply2(id, m)
+            | ProvidedTypeTestExpr (expr, targetTy) ->
+                let (expr, targetTy) = exprType.PApply2((fun _ -> (expr, targetTy)), m)
                 let srcExpr = exprToExpr expr
                 let targetTy = Import.ImportProvidedType amap m (targetTy.PApply(id, m)) 
                 let te = mkCallTypeTest g m targetTy srcExpr
                 None, (te, tyOfExpr g te)
-            | None -> 
-            match ea.PApplyOption((function ProvidedIfThenElseExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let test, thenBranch, elseBranch = info.PApply3(id, m)
+            | ProvidedIfThenElseExpr (test, thenBranch, elseBranch) ->
+                let test, thenBranch, elseBranch = exprType.PApply3((fun _ -> (test, thenBranch, elseBranch)), m)
                 let testExpr = exprToExpr test
                 let ifTrueExpr = exprToExpr thenBranch
                 let ifFalseExpr = exprToExpr elseBranch
                 let te = mkCond NoDebugPointAtStickyBinding DebugPointForTarget.No m (tyOfExpr g ifTrueExpr) testExpr ifTrueExpr ifFalseExpr
                 None, (te, tyOfExpr g te)
-            | None -> 
-            match ea.PApplyOption((function ProvidedVarExpr x -> Some x | _ -> None), m) with
-            | Some info ->  
-                let _, vTe = varToExpr info
+            | ProvidedVarExpr providedVar ->
+                let _, vTe = varToExpr (exprType.PApply((fun _ -> providedVar), m))
                 None, (vTe, tyOfExpr g vTe)
-            | None -> 
-            match ea.PApplyOption((function ProvidedConstantExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let ce = convertConstExpr g amap m info
+            | ProvidedConstantExpr (obj, prType) ->
+                let ce = convertConstExpr g amap m (exprType.PApply((fun _ -> (obj, prType)), m))
                 None, (ce, tyOfExpr g ce)
-            | None -> 
-            match ea.PApplyOption((function ProvidedNewTupleExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let elems = info.PApplyArray(id, "GetInvokerExpression", m)
+            | ProvidedNewTupleExpr info ->
+                let elems = exprType.PApplyArray((fun _ -> info), "GetInvokerExpression", m)
                 let elemsT = elems |> Array.map exprToExpr |> Array.toList
                 let exprT = mkRefTupledNoTypes g m elemsT
                 None, (exprT, tyOfExpr g exprT)
-            | None -> 
-            match ea.PApplyOption((function ProvidedNewArrayExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let ty, elems = info.PApply2(id, m)
+            | ProvidedNewArrayExpr (ty, elems) ->
+                let ty, elems = exprType.PApply2((fun _ -> (ty, elems)), m)
                 let tyT = Import.ImportProvidedType amap m ty
                 let elems = elems.PApplyArray(id, "GetInvokerExpression", m)
                 let elemsT = elems |> Array.map exprToExpr |> Array.toList
                 let exprT = Expr.Op (TOp.Array, [tyT], elemsT, m)
                 None, (exprT, tyOfExpr g exprT)
-            | None -> 
-            match ea.PApplyOption((function ProvidedTupleGetExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let inp, n = info.PApply2(id, m)
+            | ProvidedTupleGetExpr (inp, n) -> 
+                let inp, n = exprType.PApply2((fun _ -> (inp, n)), m)
                 let inpT = inp |> exprToExpr 
                 // if type of expression is erased type then we need convert it to the underlying base type
-                let typeOfExpr = 
+                let typeOfExpr =
                     let t = tyOfExpr g inpT
                     stripTyEqnsWrtErasure EraseMeasures g t
                 let tupInfo, tysT = tryDestAnyTupleTy g typeOfExpr
                 let exprT = mkTupleFieldGet g (tupInfo, inpT, tysT, n.PUntaint(id, m), m)
                 None, (exprT, tyOfExpr g exprT)
-            | None -> 
-            match ea.PApplyOption((function ProvidedLambdaExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let v, b = info.PApply2(id, m)
+            | ProvidedLambdaExpr (v, b) ->
+                let v, b = exprType.PApply2((fun _ -> (v, b)), m)
                 let vT = addVar v
                 let bT = exprToExpr b
                 removeVar v
                 let exprT = mkLambda m vT (bT, tyOfExpr g bT)
                 None, (exprT, tyOfExpr g exprT)
-            | None -> 
-            match ea.PApplyOption((function ProvidedLetExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let v, e, b = info.PApply3(id, m)
+            | ProvidedLetExpr (v, e, b) ->
+                let v, e, b = exprType.PApply3((fun _ -> (v, e, b)), m)
                 let eT = exprToExpr  e
                 let vT = addVar v
                 let bT = exprToExpr  b
                 removeVar v
                 let exprT = mkCompGenLet m vT eT bT
                 None, (exprT, tyOfExpr g exprT)
-            | None -> 
-            match ea.PApplyOption((function ProvidedVarSetExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let v, e = info.PApply2(id, m)
+            | ProvidedVarSetExpr (v, e) ->
+                let v, e = exprType.PApply2((fun _ -> (v, e)), m)
                 let eT = exprToExpr  e
                 let vTopt, _ = varToExpr v
                 match vTopt with 
                 | None -> 
                     fail()
-                | Some vT -> 
+                | Some vT ->
                     let exprT = mkValSet m (mkLocalValRef vT) eT 
                     None, (exprT, tyOfExpr g exprT)
-            | None -> 
-            match ea.PApplyOption((function ProvidedWhileLoopExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let guardExpr, bodyExpr = info.PApply2(id, m)
+            | ProvidedWhileLoopExpr (guardExpr, bodyExpr) ->
+                let guardExpr, bodyExpr = (exprType.PApply2((fun _ -> (guardExpr, bodyExpr)), m))
                 let guardExprT = exprToExpr guardExpr
                 let bodyExprT = exprToExpr bodyExpr
                 let exprT = mkWhile g (DebugPointAtWhile.No, SpecialWhileLoopMarker.NoSpecialWhileLoopMarker, guardExprT, bodyExprT, m)
                 None, (exprT, tyOfExpr g exprT)
-            | None -> 
-            match ea.PApplyOption((function ProvidedForIntegerRangeLoopExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let v, e1, e2, e3 = info.PApply4(id, m)
+            | ProvidedForIntegerRangeLoopExpr (v, e1, e2, e3) -> 
+                let v, e1, e2, e3 = exprType.PApply4((fun _ -> (v, e1, e2, e3)), m)
                 let e1T = exprToExpr  e1
                 let e2T = exprToExpr  e2
                 let vT = addVar v
@@ -1579,10 +1557,8 @@ module ProvidedMethodCalls =
                 removeVar v
                 let exprT = mkFastForLoop g (DebugPointAtFor.No, m, vT, e1T, true, e2T, e3T)
                 None, (exprT, tyOfExpr g exprT)
-            | None -> 
-            match ea.PApplyOption((function ProvidedNewDelegateExpr x -> Some x | _ -> None), m) with
-            | Some info -> 
-                let delegateTy, boundVars, delegateBodyExpr = info.PApply3(id, m)
+            | ProvidedNewDelegateExpr (delegateTy, boundVars, delegateBodyExpr) ->
+                let delegateTy, boundVars, delegateBodyExpr = exprType.PApply3((fun _ -> (delegateTy, boundVars, delegateBodyExpr)), m)
                 let delegateTyT = Import.ImportProvidedType amap m delegateTy
                 let vs = boundVars.PApplyArray(id, "GetInvokerExpression", m) |> Array.toList 
                 let vsT = List.map addVar vs
@@ -1593,44 +1569,33 @@ module ProvidedMethodCalls =
                 let infoReader = InfoReader(g, amap)
                 let exprT = CoerceFromFSharpFuncToDelegate g amap infoReader AccessorDomain.AccessibleFromSomewhere lambdaExprTy m lambdaExpr delegateTyT
                 None, (exprT, tyOfExpr g exprT)
-            | None -> 
 #if PROVIDED_ADDRESS_OF
-            match ea.PApplyOption((function ProvidedAddressOfExpr x -> Some x | _ -> None), m) with
-            | Some e -> 
-                let eT =  exprToExpr e
+            | ProvidedAddressOfExpr e ->
+                let eT =  exprToExpr (exprType.PApply((fun _ -> e), m))
                 let wrap,ce, _readonly, _writeonly = mkExprAddrOfExpr g true false DefinitelyMutates eT None m
                 let ce = wrap ce
                 None, (ce, tyOfExpr g ce)
-            | None -> 
 #endif
-            match ea.PApplyOption((function ProvidedDefaultExpr x -> Some x | _ -> None), m) with
-            | Some pty -> 
-                let ty = Import.ImportProvidedType amap m pty
+            | ProvidedDefaultExpr pty ->
+                let ty = Import.ImportProvidedType amap m (exprType.PApply((fun _ -> pty), m))
                 let ce = mkDefault (m, ty)
                 None, (ce, tyOfExpr g ce)
-            | None -> 
-            match ea.PApplyOption((function ProvidedCallExpr c -> Some c | _ -> None), m) with 
-            | Some info ->
-                methodCallToExpr top ea info
-            | None -> 
-            match ea.PApplyOption((function ProvidedSequentialExpr c -> Some c | _ -> None), m) with 
-            | Some info ->
-                let e1, e2 = info.PApply2(id, m)
+            | ProvidedCallExpr (e1, e2, e3) ->
+                methodCallToExpr top ea (exprType.PApply((fun _ -> (e1, e2, e3)), m))
+            | ProvidedSequentialExpr (e1, e2) ->
+                let e1, e2 = exprType.PApply2((fun _ -> (e1, e2)), m)
                 let e1T = exprToExpr e1
                 let e2T = exprToExpr e2
                 let ce = mkCompGenSequential m e1T e2T
                 None, (ce, tyOfExpr g ce)
-            | None -> 
-            match ea.PApplyOption((function ProvidedTryFinallyExpr c -> Some c | _ -> None), m) with 
-            | Some info ->
-                let e1, e2 = info.PApply2(id, m)
+            | ProvidedTryFinallyExpr (e1, e2) ->
+                let e1, e2 = exprType.PApply2((fun _ -> (e1, e2)), m)
                 let e1T = exprToExpr e1
                 let e2T = exprToExpr e2
                 let ce = mkTryFinally g (e1T, e2T, m, tyOfExpr g e1T, DebugPointAtTry.No, DebugPointAtFinally.No)
                 None, (ce, tyOfExpr g ce)
-            | None -> 
-            match ea.PApplyOption((function ProvidedTryWithExpr c -> Some c | _ -> None), m) with 
-            | Some info ->
+            | ProvidedTryWithExpr (e1, e2, e3, e4, e5) ->
+                let info = exprType.PApply((fun _ -> (e1, e2, e3, e4, e5)), m)
                 let bT = exprToExpr (info.PApply((fun (x, _, _, _, _) -> x), m))
                 let v1 = info.PApply((fun (_, x, _, _, _) -> x), m)
                 let v1T = addVar v1
@@ -1642,12 +1607,8 @@ module ProvidedMethodCalls =
                 removeVar v2
                 let ce = mkTryWith g (bT, v1T, e1T, v2T, e2T, m, tyOfExpr g bT, DebugPointAtTry.No, DebugPointAtWith.No)
                 None, (ce, tyOfExpr g ce)
-            | None -> 
-            match ea.PApplyOption((function ProvidedNewObjectExpr c -> Some c | _ -> None), m) with 
-            | Some info -> 
-                None, ctorCallToExpr info
-            | None -> 
-                fail()
+            | ProvidedNewObjectExpr (e1, e2) ->
+                None, ctorCallToExpr (exprType.PApply((fun _ -> (e1, e2)), m))
 
 
         and ctorCallToExpr (ne: Tainted<_>) =    


### PR DESCRIPTION
Now Quotation.Expr's which are wrapped by the provided expr's can be passed out as properties.
This is used by several static active patterns, which, in addition, statically create Provided members, increasing coupling between ProvidedExpr's/Members and FCS code.
This pull request encapsulates most of logic working with Quotation.Expr Handles and Provided members within ProvidedExpr's.