### PR TITLE
[WIP] Add range-based scopes for captured items

### DIFF
--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\netfx.props" />
   <Import Project="..\..\eng\Versions.props"/>   <!-- keep our test deps in line with the overall compiler -->
   <PropertyGroup>
@@ -18,6 +18,9 @@
     </Compile>
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\Common.fs">
       <Link>Common.fs</Link>
+    </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\..\tests\service\RangeScopedCollectionTests.fs">
+      <Link>RangeScopedCollectionTests.fs</Link>
     </Compile>
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\AssemblyReaderShim.fs">
       <Link>AssemblyReaderShim.fs</Link>

--- a/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -187,6 +187,9 @@
     <Compile Include="$(FSharpSourcesRoot)/fsharp/range.fs">
       <Link>ErrorLogging/range.fs</Link>
     </Compile>
+    <Compile Include="$(FSharpSourcesRoot)/fsharp/RangeScopedCollection.fs">
+      <Link>ErrorLogging/RangeScopedCollection.fs</Link>
+    </Compile>
     <Compile Include="$(FSharpSourcesRoot)/fsharp/ErrorLogger.fs">
       <Link>ErrorLogging/ErrorLogger.fs</Link>
     </Compile>

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -935,6 +935,8 @@ type EventuallyBuilder() =
 
     member x.TryWith(e, handler) = Eventually.tryWith e handler
 
+    member x.Using(resource, e) = Eventually.tryFinally (e resource) (fun () -> (resource :> IDisposable).Dispose())
+
     member x.TryFinally(e, compensation) = Eventually.tryFinally e compensation
 
     member x.Delay f = Eventually.delay f

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -174,6 +174,9 @@
     <Compile Include="..\range.fs">
       <Link>ErrorLogging\range.fs</Link>
     </Compile>
+    <Compile Include="..\RangeScopedCollection.fs">
+      <Link>ErrorLogging\RangeScopedCollection.fs</Link>
+    </Compile>
     <Compile Include="..\ErrorLogger.fs">
       <Link>ErrorLogging\ErrorLogger.fs</Link>
     </Compile>

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1904,6 +1904,11 @@ let CallOpenDeclarationSink (sink: TcResultsSink) (openDeclaration: OpenDeclarat
     | None -> ()
     | Some sink -> sink.NotifyOpenDeclaration openDeclaration
 
+let CreateScope (sink: TcResultsSink) (m: range) =
+    match sink.CurrentSink with
+    | None -> Disposable.Empty
+    | Some sink -> sink.CreateScope(m)
+
 //-------------------------------------------------------------------------
 // Check inferability of type parameters in resolved items.
 //-------------------------------------------------------------------------

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -494,6 +494,8 @@ val internal CallExprHasTypeSink        : TcResultsSink -> range * NameResolutio
 /// Report an open declaration
 val internal CallOpenDeclarationSink    : TcResultsSink -> OpenDeclaration -> unit
 
+val internal CreateScope: TcResultsSink -> range -> IDisposable
+
 /// Get all the available properties of a type (both intrinsic and extension)
 val internal AllPropInfosOfTypeInScope : ResultCollectionSettings -> InfoReader -> NameResolutionEnv -> string option -> AccessorDomain -> FindMemberFlag -> range -> TType -> PropInfo list
 

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -2,6 +2,7 @@
 
 module internal FSharp.Compiler.NameResolution
 
+open System
 open FSharp.Compiler
 open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.AbstractSyntax
@@ -325,6 +326,14 @@ type internal CapturedNameResolution =
     /// The starting and ending position
     member Range : range
 
+    interface IRangeOwner
+
+
+type CapturedExpressionType =
+    | CET of ty: TType * nenv: NameResolutionEnv * ad: AccessorDomain * m: range
+    interface IRangeOwner
+
+
 [<Class>]
 type internal TcResolutions = 
 
@@ -334,7 +343,7 @@ type internal TcResolutions =
 
     /// Information of exact types found for expressions, that can be to the left of a dot.
     /// typ - the inferred type for an expression
-    member CapturedExpressionTypings : ResizeArray<TType * NameResolutionEnv * AccessorDomain * range>
+    member CapturedExpressionTypings : RangeScopedCollection<CapturedExpressionType>
 
     /// Exact name resolutions
     member CapturedNameResolutions : ResizeArray<CapturedNameResolution>
@@ -418,6 +427,8 @@ type ITypecheckResultsSink =
 
     /// Record that an open declaration occured in a given scope range
     abstract NotifyOpenDeclaration : OpenDeclaration -> unit
+
+    abstract CreateScope: range -> IDisposable
 
     /// Get the current source
     abstract CurrentSourceText : ISourceText option

--- a/src/fsharp/RangeScopedCollection.fs
+++ b/src/fsharp/RangeScopedCollection.fs
@@ -1,0 +1,53 @@
+namespace FSharp.Compiler
+
+open System
+open System.Collections.Generic
+open FSharp.Compiler.Range
+
+type IRangeOwner =
+    abstract Range: range
+
+type Disposable() =
+    static member val Empty: IDisposable = new Disposable() :> _
+
+    interface IDisposable with
+        member _.Dispose() = ()
+
+type RangeScopedCollection<'T when 'T :> IRangeOwner>() as this =
+    let mutable currentScope = this
+
+    member val Items = ResizeArray<'T>()
+    member val NestedScopes = ResizeArray<range * RangeScopedCollection<'T>>()
+
+    member _.AddItem(item: 'T) =
+        currentScope.Items.Add(item)
+
+    member _.CreateScope(m: range) =
+        let newScope = RangeScopedCollection()
+        currentScope.NestedScopes.Add(m, newScope)
+
+        let parentScope = currentScope
+        currentScope <- newScope
+
+        { new IDisposable with
+            member x.Dispose() =
+                // todo: remove scopes without items 
+                currentScope <- parentScope }
+
+
+[<RequireQualifiedAccess>]
+module RangeScopedCollection =
+    let itemsByEndPos (endPos: pos) (rsc: RangeScopedCollection<_>): IList<_> =
+        let rec loop (result: ResizeArray<_>) endPos (rsc: RangeScopedCollection<_>) =
+            for item in rsc.Items do
+                if rangeEndsAtPos endPos item.Range then
+                    result.Add(item)
+
+            for range, scope in rsc.NestedScopes do
+                if rangeContainsPos range endPos then
+                    loop result endPos scope 
+
+        let result = ResizeArray()
+        loop result endPos rsc
+
+        result :> _

--- a/src/fsharp/RangeScopedCollection.fs
+++ b/src/fsharp/RangeScopedCollection.fs
@@ -13,18 +13,65 @@ type Disposable() =
     interface IDisposable with
         member _.Dispose() = ()
 
-type RangeScopedCollection<'T when 'T :> IRangeOwner>() as this =
-    let mutable currentScope = this
 
+type ScopeData<'T when 'T :> IRangeOwner>() =
     member val Items = ResizeArray<'T>()
-    member val NestedScopes = ResizeArray<range * RangeScopedCollection<'T>>()
+    member val NestedScopes = ResizeArray<RangedScope<'T>>()
+
+and RangedScope<'T when 'T :> IRangeOwner> =
+    private
+        | Global of ScopeData<'T>
+        | Nested of range * ScopeData<'T>
+
+    member private scope.Data =
+        match scope with
+        | Global data
+        | Nested (_, data) -> data
+
+    member scope.NestedScopes =
+        scope.Data.NestedScopes
+
+    member scope.Items =
+        scope.Data.Items
+
+    member scope.Range =
+        match scope with
+        | Global _ -> None
+        | Nested (scopeRange, _) -> Some scopeRange
+
+    member scope.Contains(m: range) =
+        match scope with
+        | Global _ -> true
+        | Nested (scopeRange, _) -> rangeContainsRange scopeRange m
+
+    member scope.Contains(p: pos) =
+        match scope with
+        | Global _ -> true
+        | Nested (scopeRange, _) -> rangeContainsPos scopeRange p
+
+    member x.CreateNestedScope(m: range) =
+        match x with
+        | Global _ -> ()
+        | Nested (currentScopeRange, _) ->
+            assert rangeContainsRange currentScopeRange m
+
+        let scope = Nested(m, ScopeData())
+        x.NestedScopes.Add(scope)
+
+        scope
+
+    static member CreateGlobalScope<'T>() =
+        RangedScope.Global(ScopeData<'T>())
+
+type RangeScopedCollection<'T when 'T :> IRangeOwner>() =
+    let globalScope = RangedScope.CreateGlobalScope()
+    let mutable currentScope = globalScope
 
     member _.AddItem(item: 'T) =
         currentScope.Items.Add(item)
 
     member _.CreateScope(m: range) =
-        let newScope = RangeScopedCollection()
-        currentScope.NestedScopes.Add(m, newScope)
+        let newScope = currentScope.CreateNestedScope(m)
 
         let parentScope = currentScope
         currentScope <- newScope
@@ -34,20 +81,21 @@ type RangeScopedCollection<'T when 'T :> IRangeOwner>() as this =
                 // todo: remove scopes without items 
                 currentScope <- parentScope }
 
+    member x.GlobalScope = globalScope
 
 [<RequireQualifiedAccess>]
 module RangeScopedCollection =
     let itemsByEndPos (endPos: pos) (rsc: RangeScopedCollection<_>): IList<_> =
-        let rec loop (result: ResizeArray<_>) endPos (rsc: RangeScopedCollection<_>) =
-            for item in rsc.Items do
+        let rec loop (result: ResizeArray<_>) endPos (scope: RangedScope<_>) =
+            for item in scope.Items do
                 if rangeEndsAtPos endPos item.Range then
                     result.Add(item)
 
-            for range, scope in rsc.NestedScopes do
-                if rangeContainsPos range endPos then
-                    loop result endPos scope 
+            for scope in scope.NestedScopes do
+                if scope.Contains(endPos) then
+                    loop result endPos scope
 
         let result = ResizeArray()
-        loop result endPos rsc
+        loop result endPos rsc.GlobalScope
 
         result :> _

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -17510,8 +17510,10 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
 
     //printfn "----------\nCHECKING, e = %+A\n------------------\n" e
     try 
-      match ElimModuleDoBinding synDecl with 
+      let synDecl = ElimModuleDoBinding synDecl
+      use _ = CreateScope cenv.tcSink synDecl.Range
 
+      match synDecl with
       | SynModuleDecl.ModuleAbbrev (id, p, m) -> 
           let env = MutRecBindingChecking.TcModuleAbbrevDecl cenv scopem env (id, p, m)
           return ((fun e -> e), []), env, env

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -1883,6 +1883,7 @@ let MakeAndPublishSimpleValsForMergedScope cenv env m (names: NameMap<_>) =
                         member this.NotifyExprHasType(_, _, _, _) = assert false // no expr typings in MakeAndPublishSimpleVals
                         member this.NotifyFormatSpecifierLocation(_, _) = ()
                         member this.NotifyOpenDeclaration(_) = ()
+                        member this.CreateScope _ = Disposable.Empty
                         member this.CurrentSourceText = None 
                         member this.FormatStringCheckContext = None } 
 

--- a/src/fsharp/range.fs
+++ b/src/fsharp/range.fs
@@ -330,6 +330,9 @@ let rangeContainsPos (m1:range) p =
 let rangeBeforePos (m1:range) p =
     posGeq p m1.End
 
+let rangeEndsAtPos (pos: pos) (m: range) =
+    m.EndLine = pos.Line && m.EndColumn = pos.Column
+
 let rangeN filename line = mkRange filename (mkPos line 0) (mkPos line 0)
 
 let pos0 = mkPos 1 0

--- a/src/fsharp/range.fsi
+++ b/src/fsharp/range.fsi
@@ -140,6 +140,8 @@ val rangeContainsPos : range -> pos -> bool
 /// Test to see if a range occurs fully before a position
 val rangeBeforePos : range -> pos -> bool
 
+val rangeEndsAtPos: pos: pos -> m: range -> bool
+
 /// Make a dummy range for a file
 val rangeN : string -> int -> range
 

--- a/tests/service/RangeScopedCollectionTests.fs
+++ b/tests/service/RangeScopedCollectionTests.fs
@@ -91,16 +91,21 @@ let ``Filter - End pos 01`` () =
 let dumpCollection (rsc: RangeScopedCollection<_>) =
     let writer = new StringWriter()
 
-    let rec loop indent (rsc: RangeScopedCollection<_>) =
-        for item in rsc.Items do
+    let rec loop indent (scope: RangedScope<_>) =
+        for item in scope.Items do
             writer.WriteLine(indent + item.ToString())
 
-        for range, rsc in rsc.NestedScopes do
-            writer.WriteLine()
-            writer.WriteLine(indent + "Nested scope: " + range.ToShortString())
-            loop (indent + "  ") rsc
+        for nestedScope in scope.NestedScopes do
+            let scopeRangeString =
+                nestedScope.Range
+                |> Option.map (fun m -> m.ToShortString())
+                |> Option.defaultWith (fun _ -> failwithf "Expecting nested scope")
 
-    loop "" rsc
+            writer.WriteLine()
+            writer.WriteLine(indent + "Nested scope: " + scopeRangeString)
+            loop (indent + "  ") nestedScope
+
+    loop "" rsc.GlobalScope
     writer.ToString()
 
 let (|Trim|) (s: string) =

--- a/tests/service/RangeScopedCollectionTests.fs
+++ b/tests/service/RangeScopedCollectionTests.fs
@@ -1,0 +1,156 @@
+module FSharp.Compiler.Service.Tests.RangeScopedCollectionTest
+
+open System.IO
+open FSharp.Compiler
+open FSharp.Compiler.Range
+open FsUnit
+open NUnit.Framework
+
+type NumberedItems() =
+    let mutable itemsCount = 0
+
+    member val RequestedRangeNumbers = ResizeArray()
+
+    member x.Create(m: range) =
+        itemsCount <- itemsCount + 1
+        NumberedItem(itemsCount, m, x)
+
+    member x.Create() =
+        x.Create(rangeStartup)
+
+and NumberedItem(number: int, m: range, items) =
+    member val Number = number
+
+    override x.ToString() =
+        x.Number.ToString() + ": " + m.ToShortString()
+
+    interface IRangeOwner with
+        member x.Range =
+            items.RequestedRangeNumbers.Add(number)
+            m
+
+
+type RangeScopedCollection<'T when 'T :> IRangeOwner> with
+    member x.WithScope(m, f) =
+        use scope = x.CreateScope(m)
+        f ()
+
+    member x.WithScope(f) =
+        x.WithScope(rangeStartup, f)
+
+
+let mkRange s e =
+    mkRange unknownFileName s e
+
+let mkSimplePos c =
+    mkPos 0 c
+
+let mkSimpleRange (s, e) =
+    let s = mkSimplePos s
+    let e = mkSimplePos e
+    mkRange s e
+
+
+[<Test>]
+let ``Filter - End pos 01`` () =
+    let expectedPos = mkSimplePos 3
+    let expectedRange = mkRange expectedPos expectedPos
+
+    let nestedScopeRange = mkSimpleRange (1, 5)
+    let innerNestedScopeRange = mkSimpleRange (1, 2)
+    let otherNestedScopeRange = mkSimpleRange (4, 5)
+
+    let items = NumberedItems()
+    let rsc = RangeScopedCollection<_>()
+
+    rsc.AddItem(items.Create(expectedRange))
+    rsc.AddItem(items.Create())
+
+    rsc.WithScope(nestedScopeRange, fun _ ->
+        rsc.AddItem(items.Create())
+        rsc.AddItem(items.Create(expectedRange))
+
+        rsc.WithScope(innerNestedScopeRange, fun _ ->
+            rsc.AddItem(items.Create(innerNestedScopeRange))))
+
+    rsc.WithScope(otherNestedScopeRange, fun _ ->
+        rsc.AddItem(items.Create(otherNestedScopeRange)))
+
+    rsc.AddItem(items.Create(expectedRange))
+
+    RangeScopedCollection.itemsByEndPos expectedPos rsc
+    |> Seq.map (fun o -> o.Number)
+    |> Array.ofSeq
+    |> shouldEqual [| 1; 7; 4 |]
+
+    items.RequestedRangeNumbers
+    |> Array.ofSeq
+    |> shouldEqual [| 1; 2; 7; 3; 4 |]
+
+
+let dumpCollection (rsc: RangeScopedCollection<_>) =
+    let writer = new StringWriter()
+
+    let rec loop indent (rsc: RangeScopedCollection<_>) =
+        for item in rsc.Items do
+            writer.WriteLine(indent + item.ToString())
+
+        for range, rsc in rsc.NestedScopes do
+            writer.WriteLine()
+            writer.WriteLine(indent + "Nested scope: " + range.ToShortString())
+            loop (indent + "  ") rsc
+
+    loop "" rsc
+    writer.ToString()
+
+let (|Trim|) (s: string) =
+    s.Trim()
+
+let assertDumpEquals rsc (Trim expected) =
+    let (Trim dump) = dumpCollection rsc
+    dump |> shouldEqual expected
+
+
+[<Test>]
+let ``Scopes 01`` () =
+    let items = NumberedItems()
+    let rsc = RangeScopedCollection<_>()
+
+    rsc.AddItem(items.Create())
+    rsc.WithScope(fun _ ->
+        rsc.AddItem(items.Create()))
+    rsc.AddItem(items.Create())
+
+    assertDumpEquals rsc """
+1: (1,0--1,0)
+3: (1,0--1,0)
+
+Nested scope: (1,0--1,0)
+  2: (1,0--1,0)
+"""
+
+
+[<Test>]
+let ``Scopes 02 - Nested`` () =
+    let items = NumberedItems()
+    let rsc = RangeScopedCollection<_>()
+
+    rsc.AddItem(items.Create())
+    rsc.WithScope(fun _ ->
+        rsc.AddItem(items.Create())
+        rsc.WithScope(fun _ ->
+            rsc.AddItem(items.Create()))
+        rsc.AddItem(items.Create()))
+    rsc.AddItem(items.Create())
+
+    assertDumpEquals rsc """
+1: (1,0--1,0)
+5: (1,0--1,0)
+
+Nested scope: (1,0--1,0)
+  2: (1,0--1,0)
+  4: (1,0--1,0)
+
+  Nested scope: (1,0--1,0)
+    3: (1,0--1,0)
+"""


### PR DESCRIPTION
The compiler uses ranges when capturing various info during a file type check. These ranges and/or end positions are then used to filter/lookup the infos at particular locations. An example feature using ranges is code completion where FCS looks for expressions types before a `.` and filters the previously captured expression types based on the expression end position.

This PR introduces range-based scopes that group items in a range and allow to skip the whole scopes when they don't contain the requested range. The scopes are currently used for captured expression types only and it would be great to extend it to other captured items in future PRs.

The scopes can also be used for working with scoped items in parallel which can be an interesting way for future optimizations.

At the moment of PR creation not many scopes are created, namely there are scopes for top level module member declarations in implementation files. Ideally there should be separate scopes for each type, type member, and top level binding which is probably going to be coarse- and even-enough for most features.

This is a prototype and I expect things to change. I'm opening the PR since I'm looking for feedback and/or suggestions of better names or places for the things. I'm also interested to see if there are any failing tests with the change.