### PR TITLE
Cherry pick Fix for #8827 --- Invalid floating point number for dotless exponential.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -212,7 +212,7 @@ stages:
         # MacOS
         - job: MacOS
           pool:
-            vmImage: macOS-10.13
+            vmImage: macOS-latest
           variables:
           - name: _SignType
             value: Test
@@ -312,7 +312,7 @@ stages:
 
         # - job: MacOS_FCS
         #   pool:
-        #     vmImage: macOS-10.13
+        #     vmImage: macOS-latest
         #   variables:
         #   - name: _SignType
         #     value: Test

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -154,6 +154,12 @@ let evalIfDefExpression startPos isFeatureSupported args (lookup:string->bool) (
     let expr            = FSharp.Compiler.PPParser.start tokenStream lexbuf
     LexerIfdefEval lookup expr
 
+let evalFloat args lexbuf =
+    try
+        float32(removeUnderscores (lexemeTrimRight lexbuf 1))
+    with _ ->
+        fail args lexbuf (FSComp.SR.lexInvalidFloat()) 0.0f
+
 }
 let letter = '\Lu' | '\Ll' | '\Lt' | '\Lm' | '\Lo' | '\Nl'
 let surrogateChar = '\Cs'
@@ -193,7 +199,11 @@ let floate = digit ((digit | separator)* digit)? ('.' (digit ((digit | separator
 let float = floatp | floate 
 let bignum =  integer ('I'  | 'N' | 'Z' | 'Q' | 'R' | 'G')
 let ieee64 = float
-let ieee32 = (float | integer) ('f' | 'F')
+
+let ieee32 = float ('f' | 'F') 
+
+let ieee32_dotless_no_exponent = integer ('f' | 'F')
+
 let decimal = (float | integer) ('m' | 'M')
 let xieee32 = xinteger 'l' 'f'
 let xieee64 = xinteger 'L' 'F'
@@ -336,16 +346,16 @@ rule token args skip = parse
        with _ ->  fail args lexbuf (FSComp.SR.lexOutsideNativeUnsigned())  (UNATIVEINT(0UL)) }
 
  | ieee32
-     { let s = lexemeTrimRight lexbuf 1
-       if lexbuf.SupportsFeature LanguageFeature.DotlessFloat32Literal || s.Contains "." then
-          try
-             IEEE32 (float32 (removeUnderscores s))
-          with _ -> fail args lexbuf (FSComp.SR.lexInvalidFloat()) (IEEE32 0.0f)
+     { IEEE32 (evalFloat args lexbuf) }
+
+ | ieee32_dotless_no_exponent
+     { if lexbuf.SupportsFeature LanguageFeature.DotlessFloat32Literal then
+          IEEE32 (evalFloat args lexbuf)
        else
           fail args lexbuf (FSComp.SR.lexInvalidFloat()) (IEEE32 0.0f)
      }
 
- | ieee64     
+ | ieee64
      { IEEE64 (try float(lexeme lexbuf) with _ -> fail args lexbuf (FSComp.SR.lexInvalidFloat()) 0.0) }
 
  | decimal    

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/BasicConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/BasicConstants.fs
@@ -175,24 +175,52 @@ if x14 <> 0o52 then failwith "Wrong parsing"
 printfn "%A" x14
             """
     [<Test>]
-    let ``float without dot``() = 
+    let ``dotless float``() = 
         CompilerAssert.CompileExeWithOptions [|"--langversion:preview"|]
             """
 let x = 42f
 printfn "%A" x
             """
-    
+
     [<Test>]
-    let ``float with dot``() = 
-        CompilerAssert.CompileExeWithOptions [|"--langversion:preview"|]
+    let ``dotted float``() = 
+        CompilerAssert.CompileExe
             """
 let x = 42.f
 printfn "%A" x
             """
-    
+
     [<Test>]
-    let ``floats with dot should be equal to floats without dot``() = 
+    let ``dotted floats should be equal to dotless floats``() = 
         CompilerAssert.CompileExeAndRunWithOptions [|"--langversion:preview"|]
             """
-if 1.0f <> 1f then failwith "1.0f is not equal to 1f" 
+if 1.0f <> 1f then failwith "1.0f <> 1f"
+            """
+
+    [<Test>]
+    let ``exponent dotted floats should be equal to dotted floats``() =
+        CompilerAssert.CompileExeAndRun
+            """
+if 1.0e1f <> 10.f then failwith "1.0e1f <> 10.f"
+            """
+
+    [<Test>]
+    let ``exponent dotless floats should be equal to dotted floats``() = 
+        CompilerAssert.CompileExeAndRun
+            """
+if 1e1f <> 10.f then failwith "1e1f <> 10.f" 
+            """
+
+    [<Test>]
+    let ``exponent dotted floats should be equal to dotless floats``() = 
+        CompilerAssert.CompileExeAndRunWithOptions [|"--langversion:preview"|]
+            """
+if 1.0e1f <> 10f then failwith "1.0e1f <> 10f" 
+            """
+
+    [<Test>]
+    let ``exponent dotless floats should be equal to dotless floats``() = 
+        CompilerAssert.CompileExeAndRunWithOptions [|"--langversion:preview"|]
+            """
+if 1e1f <> 10f then failwith "1e1f <> 10f" 
             """


### PR DESCRIPTION
Cherry pick fix for 8802 into servicing branch.

--------

Fixes: #8802
The recent preview feature to enable dotless floats introduced a bug with floats with exponents.
E.g

> 1e4f

  1e4f
  ^^^^

stdin(1,1): error FS1153: Invalid floating point number
The issue arose because this line:

   if lexbuf.SupportsFeature LanguageFeature.DotlessFloat32Literal || s.Contains "." then
validates that the float contained a "." and exponents are floats with an e or E, effectively trying to distinguish between float(f) and integer (f). By letting the pattern match do it, we are lucky to be out of that business.

The fix is to separator the lexing of 32 bit float literals into 2 bits.
The first handling dotted floats, the second handling dotless floats.

The dotless floats can be correctly protected under the language feature flag. And everything else is handled exactly as before.

The original error got through because of a test hole. Nowhere in our test suites did we have a float of the format: 7e4f. we had 7.e4f and 7e4 but not the exact form for the issue.

Added a couple of additional tests.