### PR TITLE
Fix #8853

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
@@ -33,6 +33,10 @@ type internal Resolution =
 
 module internal ProjectFile =
 
+    let fsxExt = ".fsx"
+
+    let csxExt = ".csx"
+
     let findLoadsFromResolutions (resolutions:Resolution[]) =
         resolutions
         |> Array.filter(fun r ->
@@ -129,7 +133,9 @@ $(POUND_R)
     <TargetFramework>$(TARGETFRAMEWORK)</TargetFramework>
     <RuntimeIdentifier>$(RUNTIMEIDENTIFIER)</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+
+    <!-- Disable automagic FSharp.Core resolution when not using with FSharp scripts -->
+    <DisableImplicitFSharpCoreReference Condition="'$(SCRIPTEXTENSION)' != '.fsx'">true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -37,7 +37,7 @@ module FSharpDependencyManager =
             | _ -> ()
         }
 
-    let parsePackageReference (lines: string list) =
+    let parsePackageReference scriptExt (lines: string list) =
         let mutable binLogPath = None
         let parsePackageReferenceOption (line: string) =
             let validatePackageName package packageName =
@@ -53,7 +53,8 @@ module FSharpDependencyManager =
                 | opt :: rest ->
                     let addInclude v =
                         validatePackageName v "mscorlib"
-                        validatePackageName v "FSharp.Core"
+                        if scriptExt = fsxExt then
+                            validatePackageName v "FSharp.Core"
                         validatePackageName v "System.ValueTuple"
                         validatePackageName v "NETStandard.Library"
                         Some { current with Include = v }
@@ -166,13 +167,13 @@ type FSharpDependencyManager (outputDir:string option) =
 
         let scriptExt, poundRprefix  =
             match scriptExt with
-            | ".csx" -> ".csx", "#r \"" 
-            | _ -> ".fsx", "#r @\"" 
+            | ".csx" -> csxExt, "#r \"" 
+            | _ -> fsxExt, "#r @\"" 
 
         let packageReferences, binLogPath =
             packageManagerTextLines
             |> List.ofSeq
-            |> FSharpDependencyManager.parsePackageReference
+            |> FSharpDependencyManager.parsePackageReference scriptExt
 
         let packageReferenceLines =
             packageReferences

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
@@ -4,7 +4,7 @@ namespace FSharp.DependencyManager.Nuget
 
 module internal FSharpDependencyManager =
     val formatPackageReference: PackageReference -> seq<string>
-    val parsePackageReference: string list -> PackageReference list * string option option
+    val parsePackageReference: scriptExt: string -> string list -> PackageReference list * string option option
 
 /// The results of ResolveDependencies
 [<Class>]

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -461,6 +461,57 @@ x |> Seq.iter(fun r ->
         let value = opt.Value
         Assert.AreEqual(123, value.ReflectionValue :?> int32)
 
+    [<Test>]
+    member __.``Verify that referencing FSharp.Core fails with FSharp Scripts``() =
+        let packagemanagerlines = [| "FSharp.Core,version=4.7.1" |]
+
+        let reportError =
+            let report errorType code message =
+                match errorType with
+                | ErrorReportType.Error -> printfn "PackageManagementError %d : %s" code message
+                | ErrorReportType.Warning -> printfn "PackageManagementWarning %d : %s" code message
+            ResolvingErrorReport (report)
+
+        let mutable resolverPackageRoots = Seq.empty<string>
+        let mutable resolverReferences = Seq.empty<string>
+
+        let nativeProbingRoots () = resolverPackageRoots
+        let assemblyProbingPaths () = resolverReferences
+
+        // Restore packages, Get Reference dll paths and package roots
+        let result =
+            use dp = new DependencyProvider(NativeResolutionProbe(nativeProbingRoots))
+            let idm = dp.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
+            dp.Resolve(idm, ".fsx", packagemanagerlines, reportError, "netcoreapp3.0")
+
+        // Expected: error FS3217: PackageManager can not reference the System Package 'FSharp.Core'
+        Assert.IsFalse(result.Success, "resolve succeeded but should have failed")
+
+    [<Test>]
+    member __.``Verify that referencing FSharp.Core succeeds with CSharp Scripts``() =
+        let packagemanagerlines = [| "FSharp.Core,version=4.7.1" |]
+
+        let reportError =
+            let report errorType code message =
+                match errorType with
+                | ErrorReportType.Error -> printfn "PackageManagementError %d : %s" code message
+                | ErrorReportType.Warning -> printfn "PackageManagementWarning %d : %s" code message
+            ResolvingErrorReport (report)
+
+        let mutable resolverPackageRoots = Seq.empty<string>
+        let mutable resolverReferences = Seq.empty<string>
+
+        let nativeProbingRoots () = resolverPackageRoots
+        let assemblyProbingPaths () = resolverReferences
+
+        // Restore packages, Get Reference dll paths and package roots
+        let result =
+            use dp = new DependencyProvider(NativeResolutionProbe(nativeProbingRoots))
+            let idm = dp.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
+            dp.Resolve(idm, ".csx", packagemanagerlines, reportError, "netcoreapp3.0")
+
+        Assert.IsTrue(result.Success, "resolve failed but should have succeeded")
+
 
     [<Test>]
     member __.``Verify that Dispose on DependencyProvider unhooks ResolvingUnmanagedDll event handler``() =

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerLineParserTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerLineParserTests.fs
@@ -10,16 +10,16 @@ open NUnit.Framework
 type DependencyManagerLineParserTests() =
 
     let parseBinLogPath text =
-        let _, binLogPath = FSharpDependencyManager.parsePackageReference [text]
+        let _, binLogPath = FSharpDependencyManager.parsePackageReference ".fsx" [text]
         binLogPath
 
     let parseSingleReference text =
-        let packageReferences, _ = FSharpDependencyManager.parsePackageReference [text]
+        let packageReferences, _ = FSharpDependencyManager.parsePackageReference ".fsx" [text]
         packageReferences.Single()
 
     [<Test>]
     member __.``Binary logging defaults to disabled``() =
-        let _, binLogPath = FSharpDependencyManager.parsePackageReference []
+        let _, binLogPath = FSharpDependencyManager.parsePackageReference ".fsx" []
         Assert.AreEqual(None, binLogPath)
 
     [<Test>]
@@ -39,32 +39,32 @@ type DependencyManagerLineParserTests() =
 
     [<Test>]
     member __.``Bare binary log argument isn't parsed as a package name: before``() =
-        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["bl, MyPackage"]
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ".fsx" ["bl, MyPackage"]
         Assert.AreEqual("MyPackage", packageReferences.Single().Include)
         Assert.AreEqual(Some (None: string option), binLogPath)
 
     [<Test>]
     member __.``Bare binary log argument isn't parsed as a package name: middle``() =
-        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["MyPackage, bl, 1.2.3.4"]
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ".fsx" ["MyPackage, bl, 1.2.3.4"]
         Assert.AreEqual("MyPackage", packageReferences.Single().Include)
         Assert.AreEqual("1.2.3.4", packageReferences.Single().Version)
         Assert.AreEqual(Some (None: string option), binLogPath)
 
     [<Test>]
     member __.``Bare binary log argument isn't parsed as a package name: after``() =
-        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["MyPackage, bl"]
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ".fsx" ["MyPackage, bl"]
         Assert.AreEqual("MyPackage", packageReferences.Single().Include)
         Assert.AreEqual(Some (None: string option), binLogPath)
 
     [<Test>]
     member __.``Package named 'bl' can be explicitly referenced``() =
-        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["Include=bl"]
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ".fsx" ["Include=bl"]
         Assert.AreEqual("bl", packageReferences.Single().Include)
         Assert.AreEqual(None, binLogPath)
 
     [<Test>]
     member __.``Package named 'bl' can be explicitly referenced with binary logging``() =
-        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ["Include=bl,bl"]
+        let packageReferences, binLogPath = FSharpDependencyManager.parsePackageReference ".fsx" ["Include=bl,bl"]
         Assert.AreEqual("bl", packageReferences.Single().Include)
         Assert.AreEqual(Some (None: string option), binLogPath)
 
@@ -109,6 +109,6 @@ type DependencyManagerLineParserTests() =
         let prs, _ =
             [ "MyPackage, Version=1.2.3.4"
               "Include=MyPackage, Version=1.2.3.4" ]
-            |> FSharpDependencyManager.parsePackageReference
+            |> FSharpDependencyManager.parsePackageReference ".fsx" 
         let pr = prs.Single()
         Assert.AreEqual("MyPackage", pr.Include)


### PR DESCRIPTION
In F# scripts, fail if a developer specifies an FSharp.Core as a nuget package reference.
In C# scripts, succeed if a developer specifies an FSharp.Core as a nuget package reference.

F# has an opinion about what the right FSharp.Core to use, because it has it's own.
C# is just another managed app and has no opinion on FSharp.Core.
