### PR TITLE
[release/dev16.6] update Microsoft.VSSDK.BuildTools version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,7 +158,7 @@
     <MicrosoftVisualStudioUtilitiesVersion>16.1.28917.181</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>15.3.58</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioWCFReferenceInteropVersion>9.0.30729</MicrosoftVisualStudioWCFReferenceInteropVersion>
-    <MicrosoftVSSDKBuildToolsVersion>16.3.2099</MicrosoftVSSDKBuildToolsVersion>
+    <MicrosoftVSSDKBuildToolsVersion>16.5.2044</MicrosoftVSSDKBuildToolsVersion>
     <VSSDKDebuggerVisualizersVersion>12.0.4</VSSDKDebuggerVisualizersVersion>
     <VSSDKVSLangProjVersion>7.0.4</VSSDKVSLangProjVersion>
     <VSSDKVSLangProj8Version>8.0.4</VSSDKVSLangProj8Version>


### PR DESCRIPTION
As per an internal email, package references to Microsoft.VSSDK.BuildTools need to be updated to >= 16.4 to ensure the editor can properly load extension.

This PR is identical to #8869, just into `release/dev16.6` since auto-merges from `master` have been turned off.