### PR TITLE
Revert --- Fixed indexer with type annotation (#8850)

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -3756,6 +3756,9 @@ atomicExprQualification:
             mlCompatWarning (FSComp.SR.parsParenFormIsForML()) (lhs parseState) 
             mkSynDotParenGet lhsm dotm e $2) }
 
+  |   LBRACK  typedSeqExpr RBRACK
+      { (fun e lhsm dotm -> mkSynDotBrackGet lhsm dotm e $2 false) }
+
   |   LBRACK  typedSeqExpr recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
         (fun e lhsm dotm -> exprFromParseError (mkSynDotBrackGet lhsm dotm e $2 false)) }

--- a/tests/fsharp/Compiler/Regressions/IndexerRegressionTests.fs
+++ b/tests/fsharp/Compiler/Regressions/IndexerRegressionTests.fs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.UnitTests
+
+open System
+open NUnit.Framework
+
+[<TestFixture()>]
+module IndexerRegressionTests =
+
+    [<Test>]
+    let ``Indexer has qualified type value``() =
+        CompilerAssert.Pass 
+            """
+let a = [| 1 |]
+let f y = a.[y:int]
+            """

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -71,6 +71,7 @@
     <Compile Include="Compiler\Language\SpanTests.fs" />
     <Compile Include="Compiler\Language\StringConcatOptimizationTests.fs" />
     <Compile Include="Compiler\Stress\LargeExprTests.fs" />
+    <Compile Include="Compiler\Regressions\IndexerRegressionTests.fs" />
     <Compile Include="Compiler\Regressions\ForInDoMutableRegressionTest.fs" />
     <None Include="app.config" />
     <None Include="update.base.line.with.actuals.fsx" />


### PR DESCRIPTION
Revert  --- Fixed indexer with type annotation (#8850), not approved for release/dev6.5

This was inadvertently merged, prior to rebaseing.  Sorry for the confusion.