### PR TITLE
Fix 8884 - Cannot build the repo on fresh windows install

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -3,7 +3,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\targets\Imports.targets" />
   <Import Project="eng\targets\NuGet.targets" />
-  <Import Project="eng\targets\NGenBinaries.targets" />
   <Import Project="FSharp.Profiles.props" />
 
   <Target Name="NoneSubstituteTextFiles"

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -324,6 +324,7 @@ try {
 
     if ($bootstrap) {
         $script:BuildMessage = "Failure building bootstrap compiler"
+        $toolsetBuildProj = InitializeToolset
         $bootstrapDir = Make-BootstrapBuild
     }
 

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -237,16 +237,30 @@ function Make-BootstrapBuild() {
     Create-Directory $dir
 
     # prepare FsLex and Fsyacc and AssemblyCheck
-    Run-MSBuild "$RepoRoot\src\buildtools\buildtools.proj" "/restore /t:Publish /p:PublishWindowsPdb=false" -logFileName "BuildTools" -configuration $bootstrapConfiguration
-    Copy-Item "$ArtifactsDir\bin\fslex\$bootstrapConfiguration\netcoreapp3.0\publish" -Destination "$dir\fslex" -Force -Recurse
-    Copy-Item "$ArtifactsDir\bin\fsyacc\$bootstrapConfiguration\netcoreapp3.0\publish" -Destination "$dir\fsyacc" -Force  -Recurse
-    Copy-Item "$ArtifactsDir\bin\AssemblyCheck\$bootstrapConfiguration\netcoreapp3.0\publish" -Destination "$dir\AssemblyCheck" -Force  -Recurse
+    $dotnetPath = InitializeDotNetCli
+    $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
+    $buildToolsProject = "$RepoRoot\src\buildtools\buildtools.proj"
+
+    $argNoRestore = if ($norestore) { " --no-restore" } else { "" }
+    $argNoIncremental = if ($rebuild) { " --no-incremental" } else { "" }
+
+    $args = "build $buildToolsProject -c $bootstrapConfiguration -v $verbosity -f netcoreapp3.0" + $argNoRestore + $argNoIncremental
+    Exec-Console $dotnetExe $args
+
+    Copy-Item "$ArtifactsDir\bin\fslex\$bootstrapConfiguration\netcoreapp3.0" -Destination "$dir\fslex" -Force -Recurse
+    Copy-Item "$ArtifactsDir\bin\fsyacc\$bootstrapConfiguration\netcoreapp3.0" -Destination "$dir\fsyacc" -Force  -Recurse
+    Copy-Item "$ArtifactsDir\bin\AssemblyCheck\$bootstrapConfiguration\netcoreapp3.0" -Destination "$dir\AssemblyCheck" -Force  -Recurse
 
     # prepare compiler
-    $projectPath = "$RepoRoot\proto.proj"
-    Run-MSBuild $projectPath "/restore /t:Publish /p:TargetFramework=$bootstrapTfm;ProtoTargetFramework=$bootstrapTfm /p:PublishWindowsPdb=false" -logFileName "Bootstrap" -configuration $bootstrapConfiguration
-    Copy-Item "$ArtifactsDir\bin\fsc\$bootstrapConfiguration\$bootstrapTfm\publish" -Destination "$dir\fsc" -Force -Recurse
-    Copy-Item "$ArtifactsDir\bin\fsi\$bootstrapConfiguration\$bootstrapTfm\publish" -Destination "$dir\fsi" -Force -Recurse
+    $protoProject = "$RepoRoot\proto.proj"
+    $args = "build $protoProject -c $bootstrapConfiguration -v $verbosity -f $bootstrapTfm" + $argNoRestore + $argNoIncremental
+    Exec-Console $dotnetExe $args
+
+    Copy-Item "$ArtifactsDir\bin\fsc\$bootstrapConfiguration\$bootstrapTfm" -Destination "$dir\fsc" -Force -Recurse
+    Copy-Item "$ArtifactsDir\bin\fsi\$bootstrapConfiguration\$bootstrapTfm" -Destination "$dir\fsi" -Force -Recurse
 
     return $dir
 }
+
+
+


### PR DESCRIPTION
#8884

The build incorrectly required a dotnet sdk installed in order to successfully build the bootstrap compiler and tools.

This PR changes the bootstrap build so that it uses the sdk downloaded to support arcade.

It also changes, ngen step so that it doesn't ngen dependencies, because desktop builds don't copy System.Runtime.dll into the target directory even though it is a dependency of Interactive.DependencyManager.dll.