### PR TITLE
Anon union experiment

### DIFF
--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1552,6 +1552,12 @@ type SynTypeDefnSimpleRepr =
         unionCases: SynUnionCase list *
         range: range
 
+    /// An anon union type definition, type X = (A | B)
+    | AnonUnion of
+        accessibility: SynAccess option *
+        anonUnionCases: SynAnonUnionCase list *
+        range: range
+
     /// An enum type definition, type X = A = 1 | B = 2
     | Enum of
         cases: SynEnumCase list *
@@ -1600,6 +1606,7 @@ type SynTypeDefnSimpleRepr =
     member this.Range =
         match this with
         | Union (range=m)
+        | AnonUnion (range=m)
         | Enum (range=m)
         | Record (range=m)
         | General (range=m)
@@ -1639,6 +1646,21 @@ type SynUnionCase =
     member this.Range =
         match this with
         | UnionCase (range=m) -> m
+
+[<NoEquality; NoComparison>]
+type SynAnonUnionCase =
+
+    /// The untyped, unchecked syntax tree for one case in a union definition.
+    | AnonUnionCase of
+        attributes: SynAttributes *
+        typ: SynType *
+        xmlDoc: PreXmlDoc *
+        accessibility: SynAccess option *
+        range: range
+    
+    member this.Range =
+        match this with
+        | AnonUnionCase (range=m) -> m
 
 /// Represents the syntax tree for the right-hand-side of union definition, excluding members,
 /// in either a signature or implementation.

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -455,6 +455,11 @@ type SynType =
         fields:(Ident * SynType) list *
         range: range
 
+    /// An anon union type definition, type X = (A | B)
+    | AnonUnion of
+        anonUnionCases: SynAnonUnionCase list *
+        range: range
+
     /// F# syntax: type[]
     | Array of
         rank: int *
@@ -523,6 +528,7 @@ type SynType =
         | SynType.Tuple (range=m)
         | SynType.Array (range=m)
         | SynType.AnonRecd (range=m)
+        | SynType.AnonUnion (range=m)
         | SynType.Fun (range=m)
         | SynType.Var (range=m)
         | SynType.Anon (range=m)
@@ -1552,12 +1558,6 @@ type SynTypeDefnSimpleRepr =
         unionCases: SynUnionCase list *
         range: range
 
-    /// An anon union type definition, type X = (A | B)
-    | AnonUnion of
-        accessibility: SynAccess option *
-        anonUnionCases: SynAnonUnionCase list *
-        range: range
-
     /// An enum type definition, type X = A = 1 | B = 2
     | Enum of
         cases: SynEnumCase list *
@@ -1606,7 +1606,6 @@ type SynTypeDefnSimpleRepr =
     member this.Range =
         match this with
         | Union (range=m)
-        | AnonUnion (range=m)
         | Enum (range=m)
         | Record (range=m)
         | General (range=m)

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1651,10 +1651,8 @@ type SynAnonUnionCase =
 
     /// The untyped, unchecked syntax tree for one case in a union definition.
     | AnonUnionCase of
-        attributes: SynAttributes *
         typ: SynType *
         xmlDoc: PreXmlDoc *
-        accessibility: SynAccess option *
         range: range
     
     member this.Range =

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4710,6 +4710,30 @@ and TcTypeOrMeasure optKind cenv newOk checkCxs occ env (tpenv: SyntacticUnscope
             else
                 let args',tpenv = TcTypesAsTuple cenv newOk checkCxs occ env tpenv args m
                 TType_tuple(tupInfo,args'),tpenv
+    
+    | SynType.AnonUnion(cases, m) ->
+        let types =
+            cases
+            |> List.map(fun (AnonUnionCase(typ=ty)) -> TcTypeAndRecover cenv NoNewTypars CheckCxs ItemOccurence.UseInType env tpenv ty |> fst)
+            |> List.fold(fun existing current -> current :: (existing |> List.filter (fun e -> typeEquiv g e current |> not))) []
+            |> List.sortBy(fun ty -> ty.ToString())
+        // Create a Choice
+        let mkChoiceTyconRef (g: TcGlobals) m n = 
+            match n with 
+            | 0 | 1 -> error(InternalError("mkChoiceTyconRef", m))
+            | 2 -> g.choice2_tcr
+            | 3 -> g.choice3_tcr
+            | 4 -> g.choice4_tcr
+            | 5 -> g.choice5_tcr
+            | 6 -> g.choice6_tcr
+            | 7 -> g.choice7_tcr
+            | _ -> error(Error(FSComp.SR.tastActivePatternsLimitedToSeven(), m))
+        let mkChoiceTy (g: TcGlobals) m tinst =
+            match List.length tinst with 
+            | 0 -> g.unit_ty
+            | 1 -> List.head tinst
+            | length -> mkAppTy (mkChoiceTyconRef g m length) tinst
+        mkChoiceTy g m types, tpenv
 
     | SynType.AnonRecd(isStruct, args,m) ->   
         let tupInfo = mkTupInfo isStruct
@@ -15499,7 +15523,7 @@ module EstablishTypeDefinitionCores =
             | SynTypeDefnSimpleRepr.Enum _
             | SynTypeDefnSimpleRepr.Exception _ -> None
             | SynTypeDefnSimpleRepr.Union (vis, _, _)
-            | SynTypeDefnSimpleRepr.AnonUnion(vis, _, _)
+            // | SynTypeDefnSimpleRepr.AnonUnion(vis, _, _)
             | SynTypeDefnSimpleRepr.Record (vis, _, _) -> vis
          
         let visOfRepr, _ = ComputeAccessAndCompPath env None id.idRange synVisOfRepr None parent
@@ -15552,7 +15576,6 @@ module EstablishTypeDefinitionCores =
 
         let repr = 
             match synTyconRepr with 
-            | SynTypeDefnSimpleRepr.AnonUnion(_attributes, _cases, _range) -> TNoRepr
             | SynTypeDefnSimpleRepr.Exception _ -> TNoRepr
             | SynTypeDefnSimpleRepr.None m -> 
                 // Run InferTyconKind to raise errors on inconsistent attribute sets
@@ -15928,7 +15951,6 @@ module EstablishTypeDefinitionCores =
                         // REVIEW: we could do the IComparable/IStructuralHash interface analysis here. 
                         // This would let the type satisfy more recursive IComparable/IStructuralHash constraints 
                         implementedTys, []
-                    | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> [], []
 
                 for (implementedTy, m) in implementedTys do
                     if firstPass && isErasedType cenv.g implementedTy then 
@@ -15981,7 +16003,6 @@ module EstablishTypeDefinitionCores =
 
                   | SynTypeDefnSimpleRepr.Enum _ -> 
                       Some(cenv.g.system_Enum_ty)
-                  | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> None
 
               // Allow super type to be a function type but convert back to FSharpFunc<A,B> to make sure it has metadata
               // (We don't apply the same rule to tuple types, i.e. no F#-declared inheritors of those are permitted)
@@ -16158,37 +16179,6 @@ module EstablishTypeDefinitionCores =
                     else 
                         TNoRepr, None, NoSafeInitInfo
                 
-                | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) ->
-                    noCLIMutableAttributeCheck()
-                    noMeasureAttributeCheck()
-                    noSealedAttributeCheck FSComp.SR.tcTypesAreAlwaysSealedDU
-                    noAbstractClassAttributeCheck()
-                    noAllowNullLiteralAttributeCheck()
-                    structLayoutAttributeCheck false
-                    let _types =
-                        _anonUnionCases
-                        |> List.map(fun (AnonUnionCase(typ=ty)) -> TcTypeAndRecover cenv NoNewTypars CheckCxs ItemOccurence.UseInType envinner tpenv ty |> fst)
-                        |> List.fold(fun existing current -> current :: (existing |> List.filter (fun e -> typeEquiv g e current |> not))) []
-                        |> List.sortBy(fun ty -> ty.ToString())
-                    // Create a Choice
-                    let mkChoiceTyconRef (g: TcGlobals) m n = 
-                        match n with 
-                        | 0 | 1 -> error(InternalError("mkChoiceTyconRef", m))
-                        | 2 -> g.choice2_tcr
-                        | 3 -> g.choice3_tcr
-                        | 4 -> g.choice4_tcr
-                        | 5 -> g.choice5_tcr
-                        | 6 -> g.choice6_tcr
-                        | 7 -> g.choice7_tcr
-                        | _ -> error(Error(FSComp.SR.tastActivePatternsLimitedToSeven(), m))
-                    let mkChoiceTy (g: TcGlobals) m tinst =
-                        match List.length tinst with 
-                        | 0 -> g.unit_ty
-                        | 1 -> List.head tinst
-                        | length -> mkAppTy (mkChoiceTyconRef g m length) tinst
-                    let ty = mkChoiceTy g _range _types
-                    TMeasureableRepr ty, None, NoSafeInitInfo
-                    // Construct.MakeAnonUnionRepr [ _anonUnionCases], None, NoSafeInitInfo
 
                 | SynTypeDefnSimpleRepr.Union (_, unionCases, _) -> 
                     noCLIMutableAttributeCheck()
@@ -16316,7 +16306,6 @@ module EstablishTypeDefinitionCores =
                             | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly _ -> None
                             | SynTypeDefnSimpleRepr.Record _ -> None
                             | SynTypeDefnSimpleRepr.Enum _ -> None
-                            | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> None
                             | SynTypeDefnSimpleRepr.General (_, inherits, _, _, _, _, _, _) ->
                                 match inherits with 
                                 | [] -> None

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -15492,14 +15492,15 @@ module EstablishTypeDefinitionCores =
         //      member x.P = x.f + x.f
         let synVisOfRepr = 
             match synTyconRepr with 
-            | SynTypeDefnSimpleRepr.None _ -> None
-            | SynTypeDefnSimpleRepr.TypeAbbrev _ -> None
-            | SynTypeDefnSimpleRepr.Union (vis, _, _) -> vis
-            | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly _ -> None
-            | SynTypeDefnSimpleRepr.Record (vis, _, _) -> vis
-            | SynTypeDefnSimpleRepr.General _ -> None
-            | SynTypeDefnSimpleRepr.Enum _ -> None
+            | SynTypeDefnSimpleRepr.None _
+            | SynTypeDefnSimpleRepr.TypeAbbrev _
+            | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly _
+            | SynTypeDefnSimpleRepr.General _
+            | SynTypeDefnSimpleRepr.Enum _
             | SynTypeDefnSimpleRepr.Exception _ -> None
+            | SynTypeDefnSimpleRepr.Union (vis, _, _)
+            | SynTypeDefnSimpleRepr.AnonUnion(vis, _, _)
+            | SynTypeDefnSimpleRepr.Record (vis, _, _) -> vis
          
         let visOfRepr, _ = ComputeAccessAndCompPath env None id.idRange synVisOfRepr None parent
         let visOfRepr = combineAccess vis visOfRepr 
@@ -15551,6 +15552,7 @@ module EstablishTypeDefinitionCores =
 
         let repr = 
             match synTyconRepr with 
+            | SynTypeDefnSimpleRepr.AnonUnion(_attributes, _cases, _range) -> failwithf "Not implemented!"
             | SynTypeDefnSimpleRepr.Exception _ -> TNoRepr
             | SynTypeDefnSimpleRepr.None m -> 
                 // Run InferTyconKind to raise errors on inconsistent attribute sets
@@ -15565,6 +15567,8 @@ module EstablishTypeDefinitionCores =
                     TNoRepr
 
             | TyconCoreAbbrevThatIsReallyAUnion (hasMeasureAttr, envinner, id) (_, m)
+            // | SynTypeDefnSimpleRepr.AnonUnion(_, _, m) ->
+            
             | SynTypeDefnSimpleRepr.Union (_, _, m) -> 
 
                 // Run InferTyconKind to raise errors on inconsistent attribute sets
@@ -15926,6 +15930,7 @@ module EstablishTypeDefinitionCores =
                         // REVIEW: we could do the IComparable/IStructuralHash interface analysis here. 
                         // This would let the type satisfy more recursive IComparable/IStructuralHash constraints 
                         implementedTys, []
+                    | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> failwith "Not Implemented"
 
                 for (implementedTy, m) in implementedTys do
                     if firstPass && isErasedType cenv.g implementedTy then 
@@ -15977,7 +15982,8 @@ module EstablishTypeDefinitionCores =
                           error(Error(FSComp.SR.tcTypesCannotInheritFromMultipleConcreteTypes(), m))
 
                   | SynTypeDefnSimpleRepr.Enum _ -> 
-                      Some(cenv.g.system_Enum_ty) 
+                      Some(cenv.g.system_Enum_ty)
+                  | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> failwith "Not Implemented" 
 
               // Allow super type to be a function type but convert back to FSharpFunc<A,B> to make sure it has metadata
               // (We don't apply the same rule to tuple types, i.e. no F#-declared inheritors of those are permitted)
@@ -16105,6 +16111,8 @@ module EstablishTypeDefinitionCores =
             
             let typeRepr, baseValOpt, safeInitInfo = 
                 match synTyconRepr with 
+                
+                | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> failwith "Not Implemented"
 
                 | SynTypeDefnSimpleRepr.Exception synExnDefnRepr -> 
                     let parent = Parent (mkLocalTyconRef tycon)
@@ -16280,6 +16288,7 @@ module EstablishTypeDefinitionCores =
                             | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly _ -> None
                             | SynTypeDefnSimpleRepr.Record _ -> None
                             | SynTypeDefnSimpleRepr.Enum _ -> None
+                            | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> failwith "Not Implemented"
                             | SynTypeDefnSimpleRepr.General (_, inherits, _, _, _, _, _, _) ->
                                 match inherits with 
                                 | [] -> None

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -2102,6 +2102,14 @@ tyconDefnOrSpfnSimpleRepr:
      { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(), rhs parseState 1))
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsTypeAbbreviationsCannotHaveVisibilityDeclarations(), rhs parseState 2))
        SynTypeDefnSimpleRepr.TypeAbbrev (ParserDetail.Ok, $3, unionRanges (rhs parseState 1) $3.Range) }
+  
+  /* A choice union type definition */
+  | opt_attributes opt_declVisibility anonUnionTypeRepr
+     { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(),rhs parseState 1))
+       let rangesOf3 = $3 |> List.map (fun (e: SynAnonUnionCase) -> e.Range)
+       let mWhole = (rhs2 parseState 1 2, rangesOf3) ||> List.fold unionRanges
+       SynTypeDefnSimpleRepr.AnonUnion($2, $3, mWhole)
+     }
 
   /* A union type definition */
   | opt_attributes opt_declVisibility unionTypeRepr
@@ -2323,6 +2331,25 @@ unionTypeRepr:
 
   | firstUnionCaseDecl 
      { [$1] } 
+
+/* The core of an anon union type definition */
+anonUnionTypeRepr:
+  /* Note the next three rules are required to disambiguate this from type x = y */
+  /* Attributes can only appear on a single constructor if you've used a | */
+  | LPAREN attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls rparen
+     { $4 $3 }
+    //  { ($2 (grabXmlDoc(parseState, 1))) :: $4 $3 }
+
+attrAnonUnionCaseDecls:
+  | attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls  { (fun xmlDoc -> $1 xmlDoc  :: $3 $2) }
+  | attrAnonUnionCaseDecl { (fun xmlDoc -> [ $1 xmlDoc ]) }
+
+/* The core of an anon union case definition */
+attrAnonUnionCaseDecl:
+  | opt_attributes opt_access typ opt_OBLOCKSEP
+      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(),rhs parseState 2))
+        let mDecl = rhs parseState 3
+        (fun xmlDoc -> AnonUnionCase ( $1, ($3 : SynType), xmlDoc,None,mDecl)) }
 
 barAndgrabXmlDoc : 
   | BAR

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -2103,14 +2103,6 @@ tyconDefnOrSpfnSimpleRepr:
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsTypeAbbreviationsCannotHaveVisibilityDeclarations(), rhs parseState 2))
        SynTypeDefnSimpleRepr.TypeAbbrev (ParserDetail.Ok, $3, unionRanges (rhs parseState 1) $3.Range) }
   
-  /* A choice union type definition */
-  | opt_attributes opt_declVisibility anonUnionTypeRepr
-     { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(),rhs parseState 1))
-       let rangesOf3 = $3 |> List.map (fun (e: SynAnonUnionCase) -> e.Range)
-       let mWhole = (rhs2 parseState 1 2, rangesOf3) ||> List.fold unionRanges
-       SynTypeDefnSimpleRepr.AnonUnion($2, $3, mWhole)
-     }
-
   /* A union type definition */
   | opt_attributes opt_declVisibility unionTypeRepr
      { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(), rhs parseState 1))
@@ -2171,6 +2163,24 @@ braceBarFieldDeclListCore:
 
   | LBRACE_BAR error bar_rbrace
      { [] }
+
+/* The core of an anon union type definition */
+anonUnionType:
+  /* Note the next three rules are required to disambiguate this from type x = y */
+  /* Attributes can only appear on a single constructor if you've used a | */
+  | LPAREN attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls rparen
+     { ($2 (grabXmlDoc(parseState, 1))) :: $4 $3 }
+
+attrAnonUnionCaseDecls:
+  | attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls  { (fun xmlDoc -> $1 xmlDoc  :: $3 $2) }
+  | attrAnonUnionCaseDecl { (fun xmlDoc -> [ $1 xmlDoc ]) }
+
+/* The core of an anon union case definition */
+attrAnonUnionCaseDecl:
+  | opt_attributes opt_access typ
+      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(),rhs parseState 2))
+        let mDecl = rhs parseState 3
+        (fun xmlDoc -> AnonUnionCase ( $1, ($3 : SynType), xmlDoc,None,mDecl)) }
 
 inlineAssemblyTyconRepr:
   | HASH stringOrKeywordString HASH 
@@ -2331,24 +2341,6 @@ unionTypeRepr:
 
   | firstUnionCaseDecl 
      { [$1] } 
-
-/* The core of an anon union type definition */
-anonUnionTypeRepr:
-  /* Note the next three rules are required to disambiguate this from type x = y */
-  /* Attributes can only appear on a single constructor if you've used a | */
-  | LPAREN attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls rparen
-     { ($2 (grabXmlDoc(parseState, 1))) :: $4 $3 }
-
-attrAnonUnionCaseDecls:
-  | attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls  { (fun xmlDoc -> $1 xmlDoc  :: $3 $2) }
-  | attrAnonUnionCaseDecl { (fun xmlDoc -> [ $1 xmlDoc ]) }
-
-/* The core of an anon union case definition */
-attrAnonUnionCaseDecl:
-  | opt_attributes opt_access typ opt_OBLOCKSEP
-      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(),rhs parseState 2))
-        let mDecl = rhs parseState 3
-        (fun xmlDoc -> AnonUnionCase ( $1, ($3 : SynType), xmlDoc,None,mDecl)) }
 
 barAndgrabXmlDoc : 
   | BAR
@@ -4826,6 +4818,8 @@ typ:
   | tupleType %prec prec_typ_prefix 
      { $1 }
 
+  | anonUnionType { SynType.AnonUnion ($1, (rhs parseState 1, $1 |> List.map(fun (AnonUnionCase(range = m)) -> m)) ||> List.fold unionRanges) }
+
 typEOF:
   | typ EOF { checkEndOfFileError $2; $1 }
 
@@ -4974,7 +4968,7 @@ atomType:
   | UNDERSCORE 
      { SynType.Anon (lhs parseState) }
 
-  | LPAREN typ rparen 
+  | LPAREN typ rparen
      {  $2 }
 
   | LPAREN typ recover      

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -2164,24 +2164,6 @@ braceBarFieldDeclListCore:
   | LBRACE_BAR error bar_rbrace
      { [] }
 
-/* The core of an anon union type definition */
-anonUnionType:
-  /* Note the next three rules are required to disambiguate this from type x = y */
-  /* Attributes can only appear on a single constructor if you've used a | */
-  | LPAREN attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls rparen
-     { ($2 (grabXmlDoc(parseState, 1))) :: $4 $3 }
-
-attrAnonUnionCaseDecls:
-  | attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls  { (fun xmlDoc -> $1 xmlDoc  :: $3 $2) }
-  | attrAnonUnionCaseDecl { (fun xmlDoc -> [ $1 xmlDoc ]) }
-
-/* The core of an anon union case definition */
-attrAnonUnionCaseDecl:
-  | opt_attributes opt_access typ
-      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(),rhs parseState 2))
-        let mDecl = rhs parseState 3
-        (fun xmlDoc -> AnonUnionCase ( $1, ($3 : SynType), xmlDoc,None,mDecl)) }
-
 inlineAssemblyTyconRepr:
   | HASH stringOrKeywordString HASH 
      { libraryOnlyError (lhs parseState)
@@ -4818,8 +4800,6 @@ typ:
   | tupleType %prec prec_typ_prefix 
      { $1 }
 
-  | anonUnionType { SynType.AnonUnion ($1, (rhs parseState 1, $1 |> List.map(fun (AnonUnionCase(range = m)) -> m)) ||> List.fold unionRanges) }
-
 typEOF:
   | typ EOF { checkEndOfFileError $2; $1 }
 
@@ -4954,7 +4934,9 @@ atomTypeOrAnonRecdType:
            flds |> List.choose (function 
              | (Field([], false, Some id, ty, false, _xmldoc, None, _m)) -> Some (id, ty) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None)
-       SynType.AnonRecd (isStruct, flds2, rhs parseState 1) }  
+       SynType.AnonRecd (isStruct, flds2, rhs parseState 1) }
+
+  | anonUnionType { SynType.AnonUnion ($1, (rhs parseState 1, $1 |> List.map(fun (AnonUnionCase(range = m)) -> m)) ||> List.fold unionRanges) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
@@ -5027,6 +5009,21 @@ atomType:
   | appTypeCon DOT ends_coming_soon_or_recover
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedNameAfterToken())
        $1 } 
+
+/* The core of an anon union type definition */
+anonUnionType:
+  /* Note the next three rules are required to disambiguate this from type x = y */
+  /* Attributes can only appear on a single constructor if you've used a | */
+  | LPAREN attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls rparen
+     { ($2 (grabXmlDoc(parseState, 1))) :: $4 $3 }
+
+attrAnonUnionCaseDecls:
+  | attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls { (fun xmlDoc -> $1 xmlDoc  :: $3 $2) }
+  | attrAnonUnionCaseDecl { (fun xmlDoc -> [ $1 xmlDoc ]) }
+
+/* The core of an anon union case definition */
+attrAnonUnionCaseDecl:
+  | typ { let mDecl = rhs parseState 3 in (fun xmlDoc -> AnonUnionCase ($1, xmlDoc, mDecl)) }
 
 typeArgsNoHpaDeprecated:
   | typeArgsActual

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -2337,8 +2337,7 @@ anonUnionTypeRepr:
   /* Note the next three rules are required to disambiguate this from type x = y */
   /* Attributes can only appear on a single constructor if you've used a | */
   | LPAREN attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls rparen
-     { $4 $3 }
-    //  { ($2 (grabXmlDoc(parseState, 1))) :: $4 $3 }
+     { ($2 (grabXmlDoc(parseState, 1))) :: $4 $3 }
 
 attrAnonUnionCaseDecls:
   | attrAnonUnionCaseDecl barAndgrabXmlDoc attrAnonUnionCaseDecls  { (fun xmlDoc -> $1 xmlDoc  :: $3 $2) }

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -690,7 +690,6 @@ module NavigateTo =
     
         and walkSynTypeDefnSimpleRepr(repr: SynTypeDefnSimpleRepr) isSig container = 
             match repr with
-            | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> failwith "Not Implemented"
             | SynTypeDefnSimpleRepr.Enum(enumCases, _) ->
                 for c in enumCases do
                     addEnumCase c isSig container

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -690,6 +690,7 @@ module NavigateTo =
     
         and walkSynTypeDefnSimpleRepr(repr: SynTypeDefnSimpleRepr) isSig container = 
             match repr with
+            | SynTypeDefnSimpleRepr.AnonUnion(_accessibility, _anonUnionCases, _range) -> failwith "Not Implemented"
             | SynTypeDefnSimpleRepr.Enum(enumCases, _) ->
                 for c in enumCases do
                     addEnumCase c isSig container


### PR DESCRIPTION
Currently implements basic simplification of `type Foo = (A_1 | A_2 | ... | A_n)` to `Choice<A_1, A_2, ..., A_n>`.

This is somehow an experiment of what can be done in the direction of non-tagged unions with F#.