### PR TITLE
Add  missing open declaration as possible issue when warning about uppercase pattern names

### DIFF
--- a/src/fsharp/FSStrings.resx
+++ b/src/fsharp/FSStrings.resx
@@ -154,7 +154,7 @@
     <value>Type constraint mismatch. The type \n    '{0}'    \nis not compatible with type\n    '{1}'    {2}\n</value>
   </data>
   <data name="UpperCaseIdentifierInPattern" xml:space="preserve">
-    <value>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</value>
+    <value>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</value>
   </data>
   <data name="NotUpperCaseConstructor" xml:space="preserve">
     <value>Discriminated union cases and exception labels must be uppercase identifiers</value>

--- a/src/fsharp/xlf/FSStrings.cs.xlf
+++ b/src/fsharp/xlf/FSStrings.cs.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">Identifikátory proměnných psané velkými písmeny se ve vzorech obecně nedoporučují. Můžou označovat špatně napsaný název vzoru.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">Identifikátory proměnných psané velkými písmeny se ve vzorech obecně nedoporučují. Můžou označovat špatně napsaný název vzoru.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.de.xlf
+++ b/src/fsharp/xlf/FSStrings.de.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">Variablenbezeichner in Großbuchstaben sollten im Allgemeinen nicht in Mustern verwendet werden und können ein Hinweis auf einen falsch geschriebenen Musternamen sein.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">Variablenbezeichner in Großbuchstaben sollten im Allgemeinen nicht in Mustern verwendet werden und können ein Hinweis auf einen falsch geschriebenen Musternamen sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.es.xlf
+++ b/src/fsharp/xlf/FSStrings.es.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">En general, los identificadores de variable en mayúscula no deben usarse en patrones y pueden indicar un nombre de patrón mal escrito.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">En general, los identificadores de variable en mayúscula no deben usarse en patrones y pueden indicar un nombre de patrón mal escrito.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.fr.xlf
+++ b/src/fsharp/xlf/FSStrings.fr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">En règle générale, les identificateurs de variable en majuscules ne doivent pas être utilisés dans les modèles. En outre, ils peuvent indiquer une erreur d'orthographe dans le nom du modèle.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">En règle générale, les identificateurs de variable en majuscules ne doivent pas être utilisés dans les modèles. En outre, ils peuvent indiquer une erreur d'orthographe dans le nom du modèle.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.it.xlf
+++ b/src/fsharp/xlf/FSStrings.it.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">In genere non è consigliabile usare identificatori di variabili in lettere maiuscole nei criteri perché potrebbero indicare un nome di criterio con ortografia errata.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">In genere non è consigliabile usare identificatori di variabili in lettere maiuscole nei criteri perché potrebbero indicare un nome di criterio con ortografia errata.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.ja.xlf
+++ b/src/fsharp/xlf/FSStrings.ja.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">通常、大文字の変数識別子はパターンに使用しません。また、つづりが間違っているパターン名を示す可能性があります。</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">通常、大文字の変数識別子はパターンに使用しません。また、つづりが間違っているパターン名を示す可能性があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.ko.xlf
+++ b/src/fsharp/xlf/FSStrings.ko.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">일반적으로 대문자 변수 식별자는 패턴에 사용하지 말아야 합니다. 이러한 식별자는 철자가 잘못된 패턴 이름을 나타낼 수 있습니다.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">일반적으로 대문자 변수 식별자는 패턴에 사용하지 말아야 합니다. 이러한 식별자는 철자가 잘못된 패턴 이름을 나타낼 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.pl.xlf
+++ b/src/fsharp/xlf/FSStrings.pl.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">Identyfikatory zmiennych pisane wielkimi literami nie powinny być używane we wzorcach i mogą oznaczać nazwę wzorca z błędami pisowni.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">Identyfikatory zmiennych pisane wielkimi literami nie powinny być używane we wzorcach i mogą oznaczać nazwę wzorca z błędami pisowni.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.pt-BR.xlf
+++ b/src/fsharp/xlf/FSStrings.pt-BR.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">Identificadores de variáveis maiúsculas geralmente não devem ser usados nos padrões, podendo indicar um nome de padrão escrito incorretamente.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">Identificadores de variáveis maiúsculas geralmente não devem ser usados nos padrões, podendo indicar um nome de padrão escrito incorretamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.ru.xlf
+++ b/src/fsharp/xlf/FSStrings.ru.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">Идентификаторы переменных в верхнем регистре обычно не должны использоваться в шаблонах, и могут указывать на неправильно написанное имя шаблона.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">Идентификаторы переменных в верхнем регистре обычно не должны использоваться в шаблонах, и могут указывать на неправильно написанное имя шаблона.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.tr.xlf
+++ b/src/fsharp/xlf/FSStrings.tr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">Büyük harfli değişken tanımlayıcıları desenlerde genel olarak kullanılmamalıdır, yanlış yazılmış bir desen adının göstergesi olabilirler.</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">Büyük harfli değişken tanımlayıcıları desenlerde genel olarak kullanılmamalıdır, yanlış yazılmış bir desen adının göstergesi olabilirler.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSStrings.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">通常不应在模式中使用大写的变量标识符，这可能标明某个模式名称存在拼写错误。</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">通常不应在模式中使用大写的变量标识符，这可能标明某个模式名称存在拼写错误。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/src/fsharp/xlf/FSStrings.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSStrings.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UpperCaseIdentifierInPattern">
-        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</source>
-        <target state="translated">模式中通常不應該使用大寫的變數識別項，這可能表示模式名稱拼字錯誤。</target>
+        <source>Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.</source>
+        <target state="needs-review-translation">模式中通常不應該使用大寫的變數識別項，這可能表示模式名稱拼字錯誤。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotUpperCaseConstructor">

--- a/tests/fsharp/typecheck/sigs/neg07.bsl
+++ b/tests/fsharp/typecheck/sigs/neg07.bsl
@@ -1,23 +1,23 @@
 
-neg07.fs(7,10,7,29): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.
+neg07.fs(7,10,7,29): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
 
-neg07.fs(7,10,7,29): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.
+neg07.fs(7,10,7,29): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
 
 neg07.fs(24,13,24,23): typecheck error FS0039: The value or constructor 'UnionCase1' is not defined. Maybe you want one of the following:
    X.UnionCase1
 
-neg07.fs(27,11,27,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.
+neg07.fs(27,11,27,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
 
-neg07.fs(28,11,28,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.
+neg07.fs(28,11,28,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
 
 neg07.fs(28,11,28,21): typecheck error FS0026: This rule will never be matched
 
 neg07.fs(31,18,31,28): typecheck error FS0039: The value or constructor 'UnionCase1' is not defined. Maybe you want one of the following:
    X.UnionCase1
 
-neg07.fs(35,11,35,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.
+neg07.fs(35,11,35,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
 
-neg07.fs(36,11,36,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.
+neg07.fs(36,11,36,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
 
 neg07.fs(36,11,36,21): typecheck error FS0026: This rule will never be matched
 

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/QueryExpressions/W_UppercaseIdentifier01.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/QueryExpressions/W_UppercaseIdentifier01.fs
@@ -1,7 +1,7 @@
 // Regression test for DevDiv:305886
 // [QueryExpressions] Identifiers for range variables in for-join queries cannot be uppercase!
 // We expect a simple warning.
-//<Expects status="warning" span="(10,9-10,18)" id="FS0049">Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name\.$</Expects>
+//<Expects status="warning" span="(10,9-10,18)" id="FS0049">Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name\.$</Expects>
 
 module M
 // Warning

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/QueryExpressions/W_UppercaseIdentifier02.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/QueryExpressions/W_UppercaseIdentifier02.fs
@@ -1,7 +1,7 @@
 // Regression test for DevDiv:305886
 // [QueryExpressions] Identifiers for range variables in for-join queries cannot be uppercase!
 // We expect a simple warning.
-//<Expects status="warning" span="(10,9-10,18)" id="FS0049">Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name\.$</Expects>
+//<Expects status="warning" span="(10,9-10,18)" id="FS0049">Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name\.$</Expects>
 
 module M
 // Warning

--- a/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/QueryExpressions/W_UppercaseIdentifier03.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/DataExpressions/QueryExpressions/W_UppercaseIdentifier03.fs
@@ -1,7 +1,7 @@
 // Regression test for DevDiv:305886
 // [QueryExpressions] Identifiers for range variables in for-join queries cannot be uppercase!
 // We expect a simple warning.
-//<Expects status="warning" span="(10,9-10,18)" id="FS0049">Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name\.$</Expects>
+//<Expects status="warning" span="(10,9-10,18)" id="FS0049">Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name\.$</Expects>
 
 module M
 // Warning

--- a/tests/fsharpqa/Source/Conformance/PatternMatching/Simple/W_BindCaptialIdent.fs
+++ b/tests/fsharpqa/Source/Conformance/PatternMatching/Simple/W_BindCaptialIdent.fs
@@ -2,8 +2,8 @@
 // Verify warning when capturing values with captial identifier
 // FSB 3954
 
-//<Expects id="FS0049" span="(9,16-9,19)" status="warning">Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name</Expects>
-//<Expects id="FS0049" span="(10,16-10,19)" status="warning">Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name</Expects>
+//<Expects id="FS0049" span="(9,16-9,19)" status="warning">Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name</Expects>
+//<Expects id="FS0049" span="(10,16-10,19)" status="warning">Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name</Expects>
 
 let test x = function 
              | Foo :: []      -> 1 


### PR DESCRIPTION
The following code:
```
module A =
    type A = Foo | Bar
module B =
    open A
    let a = Foo
module C =
    open B
    match a with
    | Bar -> Bar.ToString()
```
Will result in the following compiler warning:
```
      | Bar -> Bar.ToString()
  ------^^^

stdin(9,7): warning FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.
```

While a misspelling may be the culprit in the experience of our team it is also common for this to be due to a missing open declaration as in the example above. In the case where this is due to a missing open declaration the warning message does not help at all and has left team members quite confused.

This PR changes the warning resource string so that the the following warning is presented:
```
      | Bar -> "bar";;
  ------^^^

stdin(18,7): warning FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
```

Unfortunately I have no ability to contribute messages in the other languages supported. 

See https://github.com/dotnet/fsharp/issues/6712