### PR TITLE
[release/dev16.6] update dev16.6 insertion target

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -447,6 +447,6 @@ stages:
   - template: eng/release/insert-into-vs.yml
     parameters:
       componentBranchName: refs/heads/release/dev16.6
-      insertTargetBranch: master
+      insertTargetBranch: rel/d16.6
       insertTeamEmail: fsharpteam@microsoft.com
       insertTeamName: 'F#'


### PR DESCRIPTION
All future changes to `release/dev16.6` need to be directly inserted into VS `rel/d16.6`.