### PR TITLE
Update desktop templates to 4.7.1

### DIFF
--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
@@ -27,7 +27,7 @@
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharpTemplates">
       <package id="System.ValueTuple" version="4.4.0" />
-      <package id="FSharp.Core" version="4.7.0" />
+      <package id="FSharp.Core" version="4.7.1" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
@@ -27,7 +27,7 @@
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharpTemplates">
       <package id="System.ValueTuple" version="4.4.0" />
-      <package id="FSharp.Core" version="4.7.0" />
+      <package id="FSharp.Core" version="4.7.1" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
@@ -25,7 +25,7 @@
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharpTemplates">
       <package id="System.ValueTuple" version="4.4.0" />
-      <package id="FSharp.Core" version="4.7.0" />
+      <package id="FSharp.Core" version="4.7.1" />
      </packages>
   </WizardData>
 </VSTemplate>


### PR DESCRIPTION
The new project dialogue for new NetFramework, console, Library and Tutorial projects with Dev16.6 will fail with this message

![image](https://user-images.githubusercontent.com/5175830/79270047-45b30680-7e52-11ea-82b5-92030a198296.png)

This happens because the Wizard, uses FSharp.Core 4.7.0 which is not re-distributed with Dev 16.6.

The fix is to update the package reference in the wizard template.

In master branch we will provide a better fix, that is parameterized by the build.
