### PR TITLE
Fix unique ID

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -354,8 +354,17 @@ let isMscorlib data =
 
 [<Sealed>]
 type ILAssemblyRef(data) =
-    let uniqueStamp = AssemblyRefUniqueStampGenerator.Encode data
-    let uniqueIgnoringVersionStamp = AssemblyRefUniqueStampGenerator.Encode { data with assemRefVersion = None }
+    let pkToken key =
+        match key with
+        | Some (PublicKey bytes) -> Some (PublicKey (SHA1.sha1HashBytes bytes))
+        | Some (PublicKeyToken token) -> Some (PublicKey (token))
+        | None -> None
+
+    let uniqueStamp =
+        AssemblyRefUniqueStampGenerator.Encode { data with assemRefPublicKeyInfo = pkToken (data.assemRefPublicKeyInfo) }
+
+    let uniqueIgnoringVersionStamp =
+        AssemblyRefUniqueStampGenerator.Encode { data with assemRefVersion = None; assemRefPublicKeyInfo = pkToken (data.assemRefPublicKeyInfo) }
 
     member x.Name=data.assemRefName
 


### PR DESCRIPTION
Fixes #8881 and #8743 

This occurred because when we load an assembly reference from a local dll we get it including the public key, but when it is an imported assembly ref, it contains just the pktoken.  The code that we use to determine reference equality When writing the assembly was using the full PublicKey information, I.e PublicKey and PublicKeyToken.  This resulted in references from imported assemblies not matching references from local assemblies.

Anyway the fix was fairly straightforward, always use the public key token for testing assembly equality,

/cc @kerams , @cartermp 