### PR TITLE
Fix attribute list range for list ending with semicolon

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1364,7 +1364,7 @@ attributes:
 /* One set of custom attributes, including [< ... >] */
 attributeList:
   | LBRACK_LESS attributeListElements opt_seps GREATER_RBRACK opt_OBLOCKSEP
-      { mkAttributeList $2 (rhs2 parseState 1 3) }
+      { mkAttributeList $2 (rhs2 parseState 1 4) }
 
   | LBRACK_LESS error GREATER_RBRACK opt_OBLOCKSEP
       { mkAttributeList [] (rhs2 parseState 1 3) }

--- a/tests/service/ServiceUntypedParseTests.fs
+++ b/tests/service/ServiceUntypedParseTests.fs
@@ -126,6 +126,9 @@ let foo6 = ()
 
 [<>]
 let foo7 = ()
+
+[<A;>]
+let foo8 = ()
 """
     let (SynModuleOrNamespace (_, _, _, decls, _, _, _, _)) = parseSourceCodeAndGetModule source
     decls |> List.map (fun decl ->
@@ -145,7 +148,8 @@ let foo7 = ()
           [ (1, ((12, 0), (13, 0))) ]
           [ (1, ((15, 0), (15, 4))) ]
           [ (0, ((18, 0), (18, 2))) ]
-          [ (0, ((21, 0), (21, 4))) ] ]
+          [ (0, ((21, 0), (21, 4))) ]
+          [ (1, ((24, 0), (24, 6))) ] ]
 
 
 module TypeMemberRanges =


### PR DESCRIPTION
Fixes a case where attribute list ends with `;` and range doesn't include `>]`.
```fsharp
[<A;>]
 let foo8 = ()
```