### PR TITLE
Move ProvidedVar.Fresh to the more suitable place

### DIFF
--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -362,6 +362,7 @@ module internal ExtensionTyping =
         member __.MakeGenericType (args: ProvidedType[]) =
             let argTypes = args |> Array.map (fun arg -> arg.RawSystemType)
             ProvidedType.CreateNoContext(x.MakeGenericType(argTypes))
+        member __.AsProvidedVar name = ProvidedVar.Create ctxt (Quotations.Var(name, x))
         static member Create ctxt x = match x with null -> null | t -> ProvidedType (t, ctxt)
         static member CreateWithNullCheck ctxt name x = match x with null -> nullArg name | t -> ProvidedType (t, ctxt)
         static member CreateArray ctxt xs = match xs with null -> null | _ -> xs |> Array.map (ProvidedType.Create ctxt)
@@ -631,7 +632,7 @@ module internal ExtensionTyping =
         override __.Equals y = assert false; match y with :? ProvidedConstructorInfo as y -> x.Equals y.Handle | _ -> false
         override __.GetHashCode() = assert false; x.GetHashCode()
 
-    type ProvidedExprType =
+    and ProvidedExprType =
         | ProvidedNewArrayExpr of ProvidedType * ProvidedExpr[]
 #if PROVIDED_ADDRESS_OF
         | ProvidedAddressOfExpr of ProvidedExpr
@@ -722,7 +723,6 @@ module internal ExtensionTyping =
         member __.Handle = x
         member __.Context = ctxt
         static member Create ctxt t = match box t with null -> null | _ -> ProvidedVar (t, ctxt)
-        static member Fresh (nm, ty: ProvidedType) = ProvidedVar.Create ty.Context (Quotations.Var(nm, ty.Handle))
         static member CreateArray ctxt xs = match xs with null -> null | _ -> xs |> Array.map (ProvidedVar.Create ctxt)
         override __.Equals y = match y with :? ProvidedVar as y -> x.Equals y.Handle | _ -> false
         override __.GetHashCode() = x.GetHashCode()

--- a/src/fsharp/ExtensionTyping.fsi
+++ b/src/fsharp/ExtensionTyping.fsi
@@ -136,6 +136,7 @@ module internal ExtensionTyping =
         member MakeArrayType: unit -> ProvidedType
         member MakeArrayType: rank: int -> ProvidedType
         member MakeGenericType: args: ProvidedType[] -> ProvidedType
+        member AsProvidedVar : name: string -> ProvidedVar
         static member Void : ProvidedType
         static member CreateNoContext : Type -> ProvidedType
         member TryGetILTypeRef : unit -> ILTypeRef option
@@ -243,7 +244,7 @@ module internal ExtensionTyping =
         ProvidedConstructorInfo = 
         inherit ProvidedMethodBase
       
-    type ProvidedExprType =
+    and ProvidedExprType =
         | ProvidedNewArrayExpr of ProvidedType * ProvidedExpr[]
 #if PROVIDED_ADDRESS_OF
         | ProvidedAddressOfExpr of ProvidedExpr
@@ -280,7 +281,6 @@ module internal ExtensionTyping =
         member Type : ProvidedType
         member Name : string
         member IsMutable : bool
-        static member Fresh : string * ProvidedType -> ProvidedVar
         override Equals : obj -> bool
         override GetHashCode : unit -> int
 

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -1685,7 +1685,7 @@ module ProvidedMethodCalls =
             |> Array.map (fun pty -> eraseSystemType (amap, m, pty))
         let paramVars = 
             erasedParamTys
-            |> Array.mapi (fun i erasedParamTy -> erasedParamTy.PApply((fun ty -> ProvidedVar.Fresh("arg" + i.ToString(), ty)), m))
+            |> Array.mapi (fun i erasedParamTy -> erasedParamTy.PApply((fun ty -> ty.AsProvidedVar("arg" + i.ToString())), m))
 
 
         // encode "this" as the first ParameterExpression, if applicable
@@ -1693,7 +1693,7 @@ module ProvidedMethodCalls =
             match objArgs with
             | [objArg] -> 
                 let erasedThisTy = eraseSystemType (amap, m, mi.PApply((fun mi -> mi.DeclaringType), m))
-                let thisVar = erasedThisTy.PApply((fun ty -> ProvidedVar.Fresh("this", ty)), m)
+                let thisVar = erasedThisTy.PApply((fun ty -> ty.AsProvidedVar("this")), m)
                 Some objArg, Array.append [| thisVar |] paramVars
             | [] -> None, paramVars
             | _ -> failwith "multiple objArgs?"


### PR DESCRIPTION
ProvidedVar.Fresh is the static method with two problems: it is static and it explicitly uses ProvidedType.Handle

This pull request moves ProvidedVar.Fresh to the more suitable place