### PR TITLE
Compiler can generate delegate with direct pointer when referencing static members

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -4396,7 +4396,15 @@ and GenClosureTypeDefs cenv (tref: ILTypeRef, ilGenParams, attrs, ilCloAllFreeVa
 
   let tdefs = EraseClosures.convIlxClosureDef g.ilxPubCloEnv tref.Enclosing tdef cloInfo
   tdefs
-      
+
+and GenStaticClosureTypeDefs cenv (tref: ILTypeRef, ilGenParams, attrs, ilCloAllFreeVars, ilCloLambdas, ilCtorBody, mdefs, mimpls, ext, ilIntfTys) =
+    let tdefs = GenClosureTypeDefs cenv (tref, ilGenParams, attrs, ilCloAllFreeVars, ilCloLambdas, ilCtorBody, mdefs, mimpls, ext, ilIntfTys)
+
+    // Apply the abstract attribute, turning the sealed class into abstract sealed (i.e. static class).
+    // Remove the redundant constructor.
+    tdefs |> List.map (fun td -> td.WithAbstract(true)
+                                   .With(methods= mkILMethodsFromArray (td.Methods.AsArray |> Array.filter (fun m -> not m.IsConstructor))))
+
 and GenGenericParams cenv eenv tps = 
     tps |> DropErasedTypars |> List.map (GenGenericParam cenv eenv)
 
@@ -4781,7 +4789,7 @@ and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod((TSlotSig(_, deleg
                 false
          with _ ->
             false
-    
+
     // Work out the free type variables for the morphing thunk
     let takenNames = List.map nameOfVal tmvs
     let (cloAttribs, _, _, cloFreeTyvars, cloFreeVars, ilDelegeeTypeRef, ilCloFreeVars, eenvinner) =
@@ -4789,46 +4797,64 @@ and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod((TSlotSig(_, deleg
     let ilDelegeeGenericParams = GenGenericParams cenv eenvinner cloFreeTyvars
     let ilDelegeeGenericActualsInner = mkILFormalGenericArgs 0 ilDelegeeGenericParams
 
+    // When creating a delegate that does not capture any variables, we can instead create a static closure and directly reference the method.
+    let useStaticClosure = cloFreeVars.IsEmpty
+
     // Create a new closure class with a single "delegee" method that implements the delegate.
     let delegeeMethName = "Invoke"
     let ilDelegeeTyInner = mkILBoxedTy ilDelegeeTypeRef ilDelegeeGenericActualsInner
-
+    
     let envForDelegeeUnderTypars = AddTyparsToEnv methTyparsOfOverridingMethod eenvinner
-
-    let numthis = 1
+    
+    let numthis = if useStaticClosure then 0 else 1
     let tmvs, body = BindUnitVars g (tmvs, List.replicate (List.concat slotsig.FormalParams).Length ValReprInfo.unnamedTopArg1, body)
-
+    
     // The slot sig contains a formal instantiation. When creating delegates we're only
     // interested in the actual instantiation since we don't have to emit a method impl.
     let ilDelegeeParams, ilDelegeeRet = GenActualSlotsig m cenv envForDelegeeUnderTypars slotsig methTyparsOfOverridingMethod tmvs
-
+    
     let envForDelegeeMeth = AddStorageForLocalVals g (List.mapi (fun i v -> (v, Arg (i+numthis))) tmvs) envForDelegeeUnderTypars
     let ilMethodBody = CodeGenMethodForExpr cenv cgbuf.mgbuf (SPAlways, [], delegeeMethName, envForDelegeeMeth, 1, body, (if slotSigHasVoidReturnTy slotsig then discardAndReturnVoid else Return))
     let delegeeInvokeMeth =
-        mkILNonGenericInstanceMethod
-            (delegeeMethName, ILMemberAccess.Assembly,
+        (if useStaticClosure then mkILNonGenericStaticMethod else mkILNonGenericInstanceMethod)
+            (delegeeMethName,
+             ILMemberAccess.Assembly,
              ilDelegeeParams,
              ilDelegeeRet,
              MethodBody.IL ilMethodBody)
     let delegeeCtorMeth = mkILSimpleStorageCtor(None, Some g.ilg.typ_Object.TypeSpec, ilDelegeeTyInner, [], [], ILMemberAccess.Assembly)
     let ilCtorBody = delegeeCtorMeth.MethodBody
-
+    
     let ilCloLambdas = Lambdas_return ilCtxtDelTy
     let ilAttribs = GenAttrs cenv eenvinner cloAttribs
-    let cloTypeDefs = GenClosureTypeDefs cenv (ilDelegeeTypeRef, ilDelegeeGenericParams, ilAttribs, ilCloFreeVars, ilCloLambdas, ilCtorBody, [delegeeInvokeMeth], [], g.ilg.typ_Object, [])
+    let cloTypeDefs =
+        (if useStaticClosure then GenStaticClosureTypeDefs else GenClosureTypeDefs)
+            cenv (ilDelegeeTypeRef, ilDelegeeGenericParams, ilAttribs, ilCloFreeVars, ilCloLambdas, ilCtorBody, [delegeeInvokeMeth], [], g.ilg.typ_Object, [])
     for cloTypeDef in cloTypeDefs do
         cgbuf.mgbuf.AddTypeDef(ilDelegeeTypeRef, cloTypeDef, false, false, None)
     CountClosure()
 
+    // Push the constructor for the delegee
     let ctxtGenericArgsForDelegee = GenGenericArgs m eenvouter.tyenv cloFreeTyvars
-    let ilxCloSpec = IlxClosureSpec.Create(IlxClosureRef(ilDelegeeTypeRef, ilCloLambdas, ilCloFreeVars), ctxtGenericArgsForDelegee)
-    GenGetLocalVals cenv cgbuf eenvouter m cloFreeVars
-    CG.EmitInstr cgbuf (pop ilCloFreeVars.Length) (Push [EraseClosures.mkTyOfLambdas g.ilxPubCloEnv ilCloLambdas]) (I_newobj (ilxCloSpec.Constructor, None))
-
+    if useStaticClosure then
+        GenUnit cenv eenvouter m cgbuf
+    else
+        let ilxCloSpec = IlxClosureSpec.Create(IlxClosureRef(ilDelegeeTypeRef, ilCloLambdas, ilCloFreeVars), ctxtGenericArgsForDelegee)
+        GenGetLocalVals cenv cgbuf eenvouter m cloFreeVars
+        CG.EmitInstr cgbuf (pop ilCloFreeVars.Length) (Push [EraseClosures.mkTyOfLambdas g.ilxPubCloEnv ilCloLambdas]) (I_newobj (ilxCloSpec.Constructor, None))
+    
+    // Push the function pointer to the Invoke method of the delegee
     let ilDelegeeTyOuter = mkILBoxedTy ilDelegeeTypeRef ctxtGenericArgsForDelegee
-    let ilDelegeeInvokeMethOuter = mkILNonGenericInstanceMethSpecInTy (ilDelegeeTyOuter, "Invoke", typesOfILParams ilDelegeeParams, ilDelegeeRet.Type)
-    let ilDelegeeCtorMethOuter = mkCtorMethSpecForDelegate g.ilg (ilCtxtDelTy, useUIntPtrForDelegateCtor)
+    let ilDelegeeInvokeMethOuter =
+        (if useStaticClosure then mkILNonGenericStaticMethSpecInTy else mkILNonGenericInstanceMethSpecInTy)
+            (ilDelegeeTyOuter,
+             "Invoke",
+             typesOfILParams ilDelegeeParams,
+             ilDelegeeRet.Type)
     CG.EmitInstr cgbuf (pop 0) (Push [g.ilg.typ_IntPtr]) (I_ldftn ilDelegeeInvokeMethOuter)
+
+    // Instantiate the delegate
+    let ilDelegeeCtorMethOuter = mkCtorMethSpecForDelegate g.ilg (ilCtxtDelTy, useUIntPtrForDelegateCtor)
     CG.EmitInstr cgbuf (pop 2) (Push [ilCtxtDelTy]) (I_newobj(ilDelegeeCtorMethOuter, None))
     GenSequel cenv eenvouter.cloc cgbuf sequel
 

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
+
+open FSharp.Compiler.UnitTests
+open NUnit.Framework
+
+[<TestFixture>]
+module ``Static Member`` =
+
+    [<Test>]
+    let ``Action on Static Member``() =
+        CompilerAssert.CompileLibraryAndVerifyIL
+            """
+module StaticMember01
+
+open System
+type C =
+    static member M() = ()
+    static member CreateAction() =
+        new Action(C.M)
+            """
+            (fun verifier -> verifier.VerifyIL [
+            """
+.method public static class [runtime]System.Action 
+        CreateAction() cil managed
+{
+
+  .maxstack  8
+  IL_0000:  newobj     instance void StaticMember01/CreateAction@8::.ctor()
+  IL_0005:  ldftn      instance void StaticMember01/CreateAction@8::Invoke()
+  IL_000b:  newobj     instance void [runtime]System.Action::.ctor(object,
+                                                                   native int)
+  IL_0010:  ret
+}
+            """
+            """
+.class auto autochar serializable sealed nested assembly beforefieldinit specialname CreateAction@8
+       extends [runtime]System.Object
+            """
+            ])
+
+    [<Test>]
+    let ``Action on Static Member with lambda``() =
+        CompilerAssert.CompileLibraryAndVerifyIL
+            """
+module StaticMember02
+
+open System
+type C =
+    static member M(x : int32) = ()
+    static member CreateAction() =
+        new Action<int32>(fun x -> C.M x)
+            """
+            (fun verifier -> verifier.VerifyIL [
+            """
+.method public static class [runtime]System.Action`1<int32> 
+        CreateAction() cil managed
+{
+
+  .maxstack  8
+  IL_0000:  newobj     instance void StaticMember02/CreateAction@8::.ctor()
+  IL_0005:  ldftn      instance void StaticMember02/CreateAction@8::Invoke(int32)
+  IL_000b:  newobj     instance void class [runtime]System.Action`1<int32>::.ctor(object,
+                                                                                  native int)
+  IL_0010:  ret
+}
+            """
+            """
+.class auto autochar serializable sealed nested assembly beforefieldinit specialname CreateAction@8
+       extends [runtime]System.Object
+            """
+            ])
+
+    [<Test>]
+    let ``Action on Static Member with closure``() =
+        CompilerAssert.CompileLibraryAndVerifyIL
+            """
+module StaticMember03
+
+open System
+
+type C =
+    static member M(x: int32) = ()
+
+type MyClass(x: int32) =
+    member this.X = x
+
+[<EntryPoint>]
+let main _ =
+let input = new MyClass(7)
+let func = new Action<int32>(fun x -> C.M input.X)
+0
+            """
+            (fun verifier -> verifier.VerifyIL [
+            """
+.method public static int32  main(string[] _arg1) cil managed
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.EntryPointAttribute::.ctor() = ( 01 00 00 00 ) 
+
+  .maxstack  4
+  .locals init (class StaticMember03/MyClass V_0,
+           class [runtime]System.Action`1<int32> V_1)
+  IL_0000:  ldc.i4.7
+  IL_0001:  newobj     instance void StaticMember03/MyClass::.ctor(int32)
+  IL_0006:  stloc.0
+  IL_0007:  newobj     instance void StaticMember03/func@15::.ctor()
+  IL_000c:  ldftn      instance void StaticMember03/func@15::Invoke(int32)
+  IL_0012:  newobj     instance void class [runtime]System.Action`1<int32>::.ctor(object,
+                                                                                  native int)
+  IL_0017:  stloc.1
+  IL_0018:  ldc.i4.0
+  IL_0019:  ret
+}
+            """
+            """
+.class auto autochar serializable sealed nested assembly beforefieldinit specialname func@15
+       extends [runtime]System.Object
+            """
+            ])
+
+    [<Test>]
+    let ``Func on Static Member``() =
+        CompilerAssert.CompileLibraryAndVerifyIL
+            """
+module StaticMember04
+
+open System
+type C =
+    static member M(x: int32) =
+        x + 1
+    static member CreateFunc() =
+        new Func<int32, int32>(C.M)
+            """
+            (fun verifier -> verifier.VerifyIL [
+            """
+.method public static class [runtime]System.Func`2<int32,int32> 
+        CreateFunc() cil managed
+{
+
+  .maxstack  8
+  IL_0000:  newobj     instance void StaticMember04/CreateFunc@9::.ctor()
+  IL_0005:  ldftn      instance int32 StaticMember04/CreateFunc@9::Invoke(int32)
+  IL_000b:  newobj     instance void class [runtime]System.Func`2<int32,int32>::.ctor(object,
+                                                                                      native int)
+  IL_0010:  ret
+}
+            """
+            """
+.class auto autochar serializable sealed nested assembly beforefieldinit specialname CreateFunc@9
+       extends [runtime]System.Object
+            """
+            ])
+
+    [<Test>]
+    let ``Func on Static Member with lambda``() =
+        CompilerAssert.CompileLibraryAndVerifyIL
+            """
+module StaticMember05
+
+open System
+type C =
+    static member M(x: int32) =
+        x + 43
+    static member CreateFunc() =
+        new Func<int32, int32>(fun x -> C.M x)
+            """
+            (fun verifier -> verifier.VerifyIL [
+            """
+.method public static class [runtime]System.Func`2<int32,int32> 
+        CreateFunc() cil managed
+{
+
+  .maxstack  8
+  IL_0000:  newobj     instance void StaticMember05/CreateFunc@9::.ctor()
+  IL_0005:  ldftn      instance int32 StaticMember05/CreateFunc@9::Invoke(int32)
+  IL_000b:  newobj     instance void class [runtime]System.Func`2<int32,int32>::.ctor(object,
+                                                                                      native int)
+  IL_0010:  ret
+}
+            """
+            """
+.class auto autochar serializable sealed nested assembly beforefieldinit specialname CreateFunc@9
+       extends [runtime]System.Object
+            """
+            ])
+
+    [<Test>]
+    let ``Func on Static Member with closure``() =
+        CompilerAssert.CompileLibraryAndVerifyIL
+            """
+module StaticMember06
+
+open System
+
+type C =
+    static member M(x: int32) =
+        x + 43
+
+type MyClass(x: int32) =
+    member this.X = x
+
+[<EntryPoint>]
+let main _ =
+    let input = new MyClass(7)
+    let func = new Func<int32, int32>(fun x -> C.M input.X)
+    0
+            """
+            (fun verifier -> verifier.VerifyIL [
+            """
+.method public static int32  main(string[] _arg1) cil managed
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.EntryPointAttribute::.ctor() = ( 01 00 00 00 ) 
+
+  .maxstack  4
+  .locals init (class StaticMember06/MyClass V_0,
+           class [runtime]System.Func`2<int32,int32> V_1)
+  IL_0000:  ldc.i4.7
+  IL_0001:  newobj     instance void StaticMember06/MyClass::.ctor(int32)
+  IL_0006:  stloc.0
+  IL_0007:  ldloc.0
+  IL_0008:  newobj     instance void StaticMember06/func@16::.ctor(class StaticMember06/MyClass)
+  IL_000d:  ldftn      instance int32 StaticMember06/func@16::Invoke(int32)
+  IL_0013:  newobj     instance void class [runtime]System.Func`2<int32,int32>::.ctor(object,
+                                                                                      native int)
+  IL_0018:  stloc.1
+  IL_0019:  ldc.i4.0
+  IL_001a:  ret
+}
+            """
+            """
+.class auto autochar serializable sealed nested assembly beforefieldinit specialname func@16
+       extends [runtime]System.Object
+            """
+            ])
+
+#if !FX_NO_WINFORMS
+    [<Test>]
+    let ``EventHandler from Regression/83``() =
+        CompilerAssert.CompileLibraryAndVerifyIL
+            """
+module StaticMember07
+
+// #Regression 
+let failures = ref false
+let report_failure () = 
+  System.Console.Error.WriteLine " NO"; failures := true
+
+open System
+open System.Windows.Forms
+
+let form = new Form()
+
+let lblHello = new Label()
+let btnSay = new Button()
+
+let btnSay_Click(sender, e) =
+    lblHello.Text <- "Hello"
+
+let form_Load(sender, e) =
+    btnSay.add_Click(new EventHandler(fun sender e -> btnSay_Click(sender, e)))
+
+
+
+let _ = lblHello.Location <- new System.Drawing.Point(16, 16)
+let _ = lblHello.Name <- "lblHello"
+let _ = lblHello.Size <- new System.Drawing.Size(72, 23)
+let _ = lblHello.TabIndex <- 0
+
+let _ = btnSay.Location <- new System.Drawing.Point(216, 16)
+let _ = btnSay.Name <- "btnApply"
+let _ = btnSay.TabIndex <- 1
+let _ = btnSay.Text <- "Apply"
+
+let _ = form.Text <- "1st F# App"
+let _ = form.add_Load(new EventHandler(fun sender e -> form_Load(sender, e)))
+let _ = form.Controls.AddRange(Array.ofList [(upcast (lblHello) : Control);
+                                            (upcast (btnSay) : Control);
+                                                        ])
+ 
+(* let _ = Application.Run(form) *)
+
+let _ = 
+  if !failures then (System.Console.Out.WriteLine "Test Failed"; exit 1) 
+
+do (System.Console.Out.WriteLine "Test Passed"; 
+    System.IO.File.WriteAllText("test.ok", "ok"); 
+    exit 0)
+            """
+            (fun verifier -> verifier.VerifyIL [
+            """
+IL_00bc:  newobj     instance void StaticMember07/clo@36::.ctor()
+IL_00c1:  ldftn      instance void StaticMember07/clo@36::Invoke(object,
+                                                                 class [runtime]System.EventArgs)
+IL_00c7:  newobj     instance void [runtime]System.EventHandler::.ctor(object,
+                                                                       native int)
+IL_00cc:  callvirt   instance void [System.Windows.Forms]System.Windows.Forms.Form::add_Load(class [runtime]System.EventHandler)
+            """
+            """
+.class auto autochar serializable sealed nested assembly beforefieldinit specialname clo@36
+       extends [runtime]System.Object
+            """
+            ])
+#endif

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
@@ -27,15 +27,15 @@ type C =
 {
 
   .maxstack  8
-  IL_0000:  newobj     instance void StaticMember01/CreateAction@8::.ctor()
-  IL_0005:  ldftn      instance void StaticMember01/CreateAction@8::Invoke()
-  IL_000b:  newobj     instance void [runtime]System.Action::.ctor(object,
-                                                                   native int)
-  IL_0010:  ret
+  IL_0000:  ldnull
+  IL_0001:  ldftn      void StaticMember01/CreateAction@8::Invoke()
+  IL_0007:  newobj     instance void [runtime]System.Action::.ctor(object,
+                                                                    native int)
+  IL_000c:  ret
 }
             """
             """
-.class auto autochar serializable sealed nested assembly beforefieldinit specialname CreateAction@8
+.class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname CreateAction@8
        extends [runtime]System.Object
             """
             ])
@@ -59,15 +59,15 @@ type C =
 {
 
   .maxstack  8
-  IL_0000:  newobj     instance void StaticMember02/CreateAction@8::.ctor()
-  IL_0005:  ldftn      instance void StaticMember02/CreateAction@8::Invoke(int32)
-  IL_000b:  newobj     instance void class [runtime]System.Action`1<int32>::.ctor(object,
-                                                                                  native int)
-  IL_0010:  ret
+  IL_0000:  ldnull
+  IL_0001:  ldftn      void StaticMember02/CreateAction@8::Invoke(int32)
+  IL_0007:  newobj     instance void class [runtime]System.Action`1<int32>::.ctor(object,
+                                                                                   native int)
+  IL_000c:  ret
 }
             """
             """
-.class auto autochar serializable sealed nested assembly beforefieldinit specialname CreateAction@8
+.class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname CreateAction@8
        extends [runtime]System.Object
             """
             ])
@@ -104,17 +104,17 @@ let func = new Action<int32>(fun x -> C.M input.X)
   IL_0000:  ldc.i4.7
   IL_0001:  newobj     instance void StaticMember03/MyClass::.ctor(int32)
   IL_0006:  stloc.0
-  IL_0007:  newobj     instance void StaticMember03/func@15::.ctor()
-  IL_000c:  ldftn      instance void StaticMember03/func@15::Invoke(int32)
-  IL_0012:  newobj     instance void class [runtime]System.Action`1<int32>::.ctor(object,
-                                                                                  native int)
-  IL_0017:  stloc.1
-  IL_0018:  ldc.i4.0
-  IL_0019:  ret
+  IL_0007:  ldnull
+  IL_0008:  ldftn      void StaticMember03/func@15::Invoke(int32)
+  IL_000e:  newobj     instance void class [runtime]System.Action`1<int32>::.ctor(object,
+                                                                                   native int)
+  IL_0013:  stloc.1
+  IL_0014:  ldc.i4.0
+  IL_0015:  ret
 }
             """
             """
-.class auto autochar serializable sealed nested assembly beforefieldinit specialname func@15
+.class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname func@15
        extends [runtime]System.Object
             """
             ])
@@ -139,15 +139,15 @@ type C =
 {
 
   .maxstack  8
-  IL_0000:  newobj     instance void StaticMember04/CreateFunc@9::.ctor()
-  IL_0005:  ldftn      instance int32 StaticMember04/CreateFunc@9::Invoke(int32)
-  IL_000b:  newobj     instance void class [runtime]System.Func`2<int32,int32>::.ctor(object,
-                                                                                      native int)
-  IL_0010:  ret
+  IL_0000:  ldnull
+  IL_0001:  ldftn      int32 StaticMember04/CreateFunc@9::Invoke(int32)
+  IL_0007:  newobj     instance void class [runtime]System.Func`2<int32,int32>::.ctor(object,
+                                                                                       native int)
+  IL_000c:  ret
 }
             """
             """
-.class auto autochar serializable sealed nested assembly beforefieldinit specialname CreateFunc@9
+.class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname CreateFunc@9
        extends [runtime]System.Object
             """
             ])
@@ -172,15 +172,15 @@ type C =
 {
 
   .maxstack  8
-  IL_0000:  newobj     instance void StaticMember05/CreateFunc@9::.ctor()
-  IL_0005:  ldftn      instance int32 StaticMember05/CreateFunc@9::Invoke(int32)
-  IL_000b:  newobj     instance void class [runtime]System.Func`2<int32,int32>::.ctor(object,
-                                                                                      native int)
-  IL_0010:  ret
+  IL_0000:  ldnull
+  IL_0001:  ldftn      int32 StaticMember05/CreateFunc@9::Invoke(int32)
+  IL_0007:  newobj     instance void class [runtime]System.Func`2<int32,int32>::.ctor(object,
+                                                                                       native int)
+  IL_000c:  ret
 }
             """
             """
-.class auto autochar serializable sealed nested assembly beforefieldinit specialname CreateFunc@9
+.class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname CreateFunc@9
        extends [runtime]System.Object
             """
             ])
@@ -289,15 +289,15 @@ do (System.Console.Out.WriteLine "Test Passed";
             """
             (fun verifier -> verifier.VerifyIL [
             """
-IL_00bc:  newobj     instance void StaticMember07/clo@36::.ctor()
-IL_00c1:  ldftn      instance void StaticMember07/clo@36::Invoke(object,
-                                                                 class [runtime]System.EventArgs)
-IL_00c7:  newobj     instance void [runtime]System.EventHandler::.ctor(object,
+IL_00bc:  ldnull
+IL_00bd:  ldftn      void StaticMember07/clo@36::Invoke(object,
+                                                        class [runtime]System.EventArgs)
+IL_00c3:  newobj     instance void [runtime]System.EventHandler::.ctor(object,
                                                                        native int)
-IL_00cc:  callvirt   instance void [System.Windows.Forms]System.Windows.Forms.Form::add_Load(class [runtime]System.EventHandler)
+IL_00c8:  callvirt   instance void [System.Windows.Forms]System.Windows.Forms.Form::add_Load(class [runtime]System.EventHandler)
             """
             """
-.class auto autochar serializable sealed nested assembly beforefieldinit specialname clo@36
+.class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname clo@36
        extends [runtime]System.Object
             """
             ])

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="Compiler\ILChecker.fs" />
     <Compile Include="Compiler\Utilities.fs" />
     <Compile Include="Compiler\CompilerAssert.fs" />
+    <Compile Include="Compiler\CodeGen\EmittedIL\StaticMember.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\StaticLinkTests.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\LiteralValue.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\Mutation.fs" />

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x00000291
+  // Offset: 0x00000000 Length: 0x0000027A
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000298 Length: 0x000000BA
+  // Offset: 0x00000280 Length: 0x000000BA
 }
 .module DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.exe
-// MVID: {59B1920A-1475-D984-A745-03830A92B159}
+// MVID: {5EAD3E33-1475-D984-A745-0383333EAD5E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x015B0000
+// Image base: 0x00B10000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -51,30 +51,19 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname F@6
+  .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname F@6
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-            instance void  .ctor() cil managed
-    {
-      // Code size       7 (0x7)
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-      IL_0006:  ret
-    } // end of method F@6::.ctor
-
-    .method assembly hidebysig instance void 
-            Invoke(object x,
-                   int32 _arg1) cil managed
+    .method assembly static void  Invoke(object x,
+                                         int32 _arg1) cil managed
     {
       // Code size       3 (0x3)
       .maxstack  5
       .locals init ([0] int32 V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.fs'
-      IL_0000:  ldarg.2
+      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.fs'
+      IL_0000:  ldarg.1
       IL_0001:  stloc.0
       .line 6,6 : 80,82 ''
       IL_0002:  ret
@@ -84,7 +73,7 @@
 
   .method public static void  F<(class [FSharp.Core]Microsoft.FSharp.Control.IEvent`2<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>,int32>) T>(!!T[][] x) cil managed
   {
-    // Code size       44 (0x2c)
+    // Code size       40 (0x28)
     .maxstack  8
     .line 6,6 : 48,83 ''
     IL_0000:  ldarg.0
@@ -93,15 +82,15 @@
     IL_0007:  ldc.i4.0
     IL_0008:  readonly.
     IL_000a:  ldelema    !!T
-    IL_000f:  newobj     instance void DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth/F@6::.ctor()
-    IL_0014:  ldftn      instance void DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth/F@6::Invoke(object,
-                                                                                                     int32)
-    IL_001a:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
+    IL_000f:  ldnull
+    IL_0010:  ldftn      void DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth/F@6::Invoke(object,
+                                                                                            int32)
+    IL_0016:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
                                                                                                                  native int)
-    IL_001f:  constrained. !!T
-    IL_0025:  callvirt   instance void class [FSharp.Core]Microsoft.FSharp.Control.IDelegateEvent`1<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>>::AddHandler(!0)
-    IL_002a:  nop
-    IL_002b:  ret
+    IL_001b:  constrained. !!T
+    IL_0021:  callvirt   instance void class [FSharp.Core]Microsoft.FSharp.Control.IDelegateEvent`1<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>>::AddHandler(!0)
+    IL_0026:  nop
+    IL_0027:  ret
   } // end of method DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth::F
 
 } // end of class DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_Array_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_Array_FSInterface_NoExtMeth.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x00000278
+  // Offset: 0x00000000 Length: 0x00000261
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000280 Length: 0x000000AC
+  // Offset: 0x00000268 Length: 0x000000AC
 }
 .module DoNotBoxStruct_Array_FSInterface_NoExtMeth.exe
-// MVID: {59B1920A-8127-3EE3-A745-03830A92B159}
+// MVID: {5EAD3E33-8127-3EE3-A745-0383333EAD5E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00740000
+// Image base: 0x00AF0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -51,55 +51,44 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'F@6-1'
+  .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname F@6
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-            instance void  .ctor() cil managed
-    {
-      // Code size       7 (0x7)
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-      IL_0006:  ret
-    } // end of method 'F@6-1'::.ctor
-
-    .method assembly hidebysig instance void 
-            Invoke(object x,
-                   int32 _arg1) cil managed
+    .method assembly static void  Invoke(object x,
+                                         int32 _arg1) cil managed
     {
       // Code size       3 (0x3)
       .maxstack  5
       .locals init ([0] int32 V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_Array_FSInterface_NoExtMeth.fs'
-      IL_0000:  ldarg.2
+      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_Array_FSInterface_NoExtMeth.fs'
+      IL_0000:  ldarg.1
       IL_0001:  stloc.0
       .line 6,6 : 74,76 ''
       IL_0002:  ret
-    } // end of method 'F@6-1'::Invoke
+    } // end of method F@6::Invoke
 
-  } // end of class 'F@6-1'
+  } // end of class F@6
 
   .method public static void  F<(class [FSharp.Core]Microsoft.FSharp.Control.IEvent`2<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>,int32>) T>(!!T[] x) cil managed
   {
-    // Code size       38 (0x26)
+    // Code size       34 (0x22)
     .maxstack  8
     .line 6,6 : 46,77 ''
     IL_0000:  ldarg.0
     IL_0001:  ldc.i4.0
     IL_0002:  readonly.
     IL_0004:  ldelema    !!T
-    IL_0009:  newobj     instance void DoNotBoxStruct_Array_FSInterface_NoExtMeth/'F@6-1'::.ctor()
-    IL_000e:  ldftn      instance void DoNotBoxStruct_Array_FSInterface_NoExtMeth/'F@6-1'::Invoke(object,
-                                                                                                  int32)
-    IL_0014:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
+    IL_0009:  ldnull
+    IL_000a:  ldftn      void DoNotBoxStruct_Array_FSInterface_NoExtMeth/F@6::Invoke(object,
+                                                                                     int32)
+    IL_0010:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
                                                                                                                  native int)
-    IL_0019:  constrained. !!T
-    IL_001f:  callvirt   instance void class [FSharp.Core]Microsoft.FSharp.Control.IDelegateEvent`1<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>>::AddHandler(!0)
-    IL_0024:  nop
-    IL_0025:  ret
+    IL_0015:  constrained. !!T
+    IL_001b:  callvirt   instance void class [FSharp.Core]Microsoft.FSharp.Control.IDelegateEvent`1<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>>::AddHandler(!0)
+    IL_0020:  nop
+    IL_0021:  ret
   } // end of method DoNotBoxStruct_Array_FSInterface_NoExtMeth::F
 
 } // end of class DoNotBoxStruct_Array_FSInterface_NoExtMeth

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x0000027F
+  // Offset: 0x00000000 Length: 0x00000268
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000288 Length: 0x000000B0
+  // Offset: 0x00000270 Length: 0x000000B0
 }
 .module DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.exe
-// MVID: {59B1920A-A67D-867A-A745-03830A92B159}
+// MVID: {5EAD3E33-A67D-867A-A745-0383333EAD5E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x010C0000
+// Image base: 0x06A00000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -51,40 +51,29 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'F@6-2'
+  .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname F@6
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-            instance void  .ctor() cil managed
-    {
-      // Code size       7 (0x7)
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-      IL_0006:  ret
-    } // end of method 'F@6-2'::.ctor
-
-    .method assembly hidebysig instance void 
-            Invoke(object x,
-                   int32 _arg1) cil managed
+    .method assembly static void  Invoke(object x,
+                                         int32 _arg1) cil managed
     {
       // Code size       3 (0x3)
       .maxstack  5
       .locals init ([0] int32 V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.fs'
-      IL_0000:  ldarg.2
+      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.fs'
+      IL_0000:  ldarg.1
       IL_0001:  stloc.0
       .line 6,6 : 77,79 ''
       IL_0002:  ret
-    } // end of method 'F@6-2'::Invoke
+    } // end of method F@6::Invoke
 
-  } // end of class 'F@6-2'
+  } // end of class F@6
 
   .method public static void  F<(class [FSharp.Core]Microsoft.FSharp.Control.IEvent`2<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>,int32>) T>(!!T[0...,0...] x) cil managed
   {
-    // Code size       39 (0x27)
+    // Code size       35 (0x23)
     .maxstack  8
     .line 6,6 : 47,80 ''
     IL_0000:  ldarg.0
@@ -93,15 +82,15 @@
     IL_0003:  readonly.
     IL_0005:  call       instance !!T& !!T[0...,0...]::Address(int32,
                                                                int32)
-    IL_000a:  newobj     instance void DoNotBoxStruct_MDArray_FSInterface_NoExtMeth/'F@6-2'::.ctor()
-    IL_000f:  ldftn      instance void DoNotBoxStruct_MDArray_FSInterface_NoExtMeth/'F@6-2'::Invoke(object,
-                                                                                                    int32)
-    IL_0015:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
+    IL_000a:  ldnull
+    IL_000b:  ldftn      void DoNotBoxStruct_MDArray_FSInterface_NoExtMeth/F@6::Invoke(object,
+                                                                                       int32)
+    IL_0011:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
                                                                                                                  native int)
-    IL_001a:  constrained. !!T
-    IL_0020:  callvirt   instance void class [FSharp.Core]Microsoft.FSharp.Control.IDelegateEvent`1<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>>::AddHandler(!0)
-    IL_0025:  nop
-    IL_0026:  ret
+    IL_0016:  constrained. !!T
+    IL_001c:  callvirt   instance void class [FSharp.Core]Microsoft.FSharp.Control.IDelegateEvent`1<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>>::AddHandler(!0)
+    IL_0021:  nop
+    IL_0022:  ret
   } // end of method DoNotBoxStruct_MDArray_FSInterface_NoExtMeth::F
 
 } // end of class DoNotBoxStruct_MDArray_FSInterface_NoExtMeth

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x0000026F
+  // Offset: 0x00000000 Length: 0x00000258
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000278 Length: 0x000000B0
+  // Offset: 0x00000260 Length: 0x000000B0
 }
 .module DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.exe
-// MVID: {59B1920A-CD0A-F713-A745-03830A92B159}
+// MVID: {5EAD3E33-CD0A-F713-A745-0383333EAD5E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00720000
+// Image base: 0x05780000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -51,55 +51,44 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'F@6-3'
+  .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname F@6
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-            instance void  .ctor() cil managed
-    {
-      // Code size       7 (0x7)
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-      IL_0006:  ret
-    } // end of method 'F@6-3'::.ctor
-
-    .method assembly hidebysig instance void 
-            Invoke(object x,
-                   int32 _arg1) cil managed
+    .method assembly static void  Invoke(object x,
+                                         int32 _arg1) cil managed
     {
       // Code size       3 (0x3)
       .maxstack  5
       .locals init ([0] int32 V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.fs'
-      IL_0000:  ldarg.2
+      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.fs'
+      IL_0000:  ldarg.1
       IL_0001:  stloc.0
       .line 6,6 : 68,70 ''
       IL_0002:  ret
-    } // end of method 'F@6-3'::Invoke
+    } // end of method F@6::Invoke
 
-  } // end of class 'F@6-3'
+  } // end of class F@6
 
   .method public static void  F<(class [FSharp.Core]Microsoft.FSharp.Control.IEvent`2<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>,int32>) T>(!!T x) cil managed
   {
-    // Code size       33 (0x21)
+    // Code size       29 (0x1d)
     .maxstack  5
     .locals init ([0] !!T V_0)
     .line 6,6 : 44,71 ''
     IL_0000:  ldarg.0
     IL_0001:  stloc.0
     IL_0002:  ldloca.s   V_0
-    IL_0004:  newobj     instance void DoNotBoxStruct_NoArray_FSInterface_NoExtMeth/'F@6-3'::.ctor()
-    IL_0009:  ldftn      instance void DoNotBoxStruct_NoArray_FSInterface_NoExtMeth/'F@6-3'::Invoke(object,
-                                                                                                    int32)
-    IL_000f:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
+    IL_0004:  ldnull
+    IL_0005:  ldftn      void DoNotBoxStruct_NoArray_FSInterface_NoExtMeth/F@6::Invoke(object,
+                                                                                       int32)
+    IL_000b:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
                                                                                                                  native int)
-    IL_0014:  constrained. !!T
-    IL_001a:  callvirt   instance void class [FSharp.Core]Microsoft.FSharp.Control.IDelegateEvent`1<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>>::AddHandler(!0)
-    IL_001f:  nop
-    IL_0020:  ret
+    IL_0010:  constrained. !!T
+    IL_0016:  callvirt   instance void class [FSharp.Core]Microsoft.FSharp.Control.IDelegateEvent`1<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>>::AddHandler(!0)
+    IL_001b:  nop
+    IL_001c:  ret
   } // end of method DoNotBoxStruct_NoArray_FSInterface_NoExtMeth::F
 
 } // end of class DoNotBoxStruct_NoArray_FSInterface_NoExtMeth

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Aggregates01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Aggregates01.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:5:0:0
+  .ver 4:7:0:0
 }
 .assembly extern Utils
 {
@@ -38,20 +38,20 @@
 }
 .mresource public FSharpSignatureData.Linq101Aggregates01
 {
-  // Offset: 0x00000000 Length: 0x00000614
+  // Offset: 0x00000000 Length: 0x000005F6
 }
 .mresource public FSharpOptimizationData.Linq101Aggregates01
 {
-  // Offset: 0x00000618 Length: 0x00000211
+  // Offset: 0x00000600 Length: 0x00000211
 }
 .module Linq101Aggregates01.exe
-// MVID: {5B9A632A-D281-4783-A745-03832A639A5B}
+// MVID: {5EAD3E37-D281-4783-A745-0383373EAD5E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x026B0000
+// Image base: 0x04D10000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -105,7 +105,7 @@
       .locals init ([0] int32 V_0,
                [1] int32 n)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Aggregates01.fs'
+      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Aggregates01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
       IL_0006:  ldc.i4.1
@@ -3119,27 +3119,17 @@
 
   } // end of class 'categories3@67-2'
 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'min@68-2'
+  .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname 'min@68-2'
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-            instance void  .ctor() cil managed
-    {
-      // Code size       7 (0x7)
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-      IL_0006:  ret
-    } // end of method 'min@68-2'::.ctor
-
-    .method assembly hidebysig instance valuetype [mscorlib]System.Decimal 
+    .method assembly static valuetype [mscorlib]System.Decimal 
             Invoke(class [Utils]Utils/Product p) cil managed
     {
       // Code size       9 (0x9)
       .maxstack  8
       .line 68,68 : 46,57 ''
-      IL_0000:  ldarg.1
+      IL_0000:  ldarg.0
       IL_0001:  tail.
       IL_0003:  callvirt   instance valuetype [mscorlib]System.Decimal [Utils]Utils/Product::get_UnitPrice()
       IL_0008:  ret
@@ -3547,7 +3537,7 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object> 
             Invoke(class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> _arg2) cil managed
     {
-      // Code size       85 (0x55)
+      // Code size       81 (0x51)
       .maxstack  9
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> g,
                [1] valuetype [mscorlib]System.Decimal min,
@@ -3558,44 +3548,44 @@
       IL_0001:  stloc.0
       .line 68,68 : 9,58 ''
       IL_0002:  ldloc.0
-      IL_0003:  newobj     instance void Linq101Aggregates01/'min@68-2'::.ctor()
-      IL_0008:  ldftn      instance valuetype [mscorlib]System.Decimal Linq101Aggregates01/'min@68-2'::Invoke(class [Utils]Utils/Product)
-      IL_000e:  newobj     instance void class [mscorlib]System.Func`2<class [Utils]Utils/Product,valuetype [mscorlib]System.Decimal>::.ctor(object,
+      IL_0003:  ldnull
+      IL_0004:  ldftn      valuetype [mscorlib]System.Decimal Linq101Aggregates01/'min@68-2'::Invoke(class [Utils]Utils/Product)
+      IL_000a:  newobj     instance void class [mscorlib]System.Func`2<class [Utils]Utils/Product,valuetype [mscorlib]System.Decimal>::.ctor(object,
                                                                                                                                              native int)
-      IL_0013:  call       valuetype [mscorlib]System.Decimal [System.Core]System.Linq.Enumerable::Min<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+      IL_000f:  call       valuetype [mscorlib]System.Decimal [System.Core]System.Linq.Enumerable::Min<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                                                    class [mscorlib]System.Func`2<!!0,valuetype [mscorlib]System.Decimal>)
-      IL_0018:  stloc.1
+      IL_0014:  stloc.1
       .line 70,70 : 9,41 ''
-      IL_0019:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-      IL_001e:  stloc.3
-      IL_001f:  ldloc.3
-      IL_0020:  ldloc.0
-      IL_0021:  ldnull
-      IL_0022:  ldc.i4.0
-      IL_0023:  ldnull
-      IL_0024:  newobj     instance void Linq101Aggregates01/cheapestProducts@69::.ctor(class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,
+      IL_0015:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+      IL_001a:  stloc.3
+      IL_001b:  ldloc.3
+      IL_001c:  ldloc.0
+      IL_001d:  ldnull
+      IL_001e:  ldc.i4.0
+      IL_001f:  ldnull
+      IL_0020:  newobj     instance void Linq101Aggregates01/cheapestProducts@69::.ctor(class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,
                                                                                         class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>,
                                                                                         int32,
                                                                                         class [Utils]Utils/Product)
-      IL_0029:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-      IL_002e:  ldloc.1
-      IL_002f:  newobj     instance void Linq101Aggregates01/'cheapestProducts@69-1'::.ctor(valuetype [mscorlib]System.Decimal)
-      IL_0034:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0025:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+      IL_002a:  ldloc.1
+      IL_002b:  newobj     instance void Linq101Aggregates01/'cheapestProducts@69-1'::.ctor(valuetype [mscorlib]System.Decimal)
+      IL_0030:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-      IL_003e:  stloc.2
+      IL_0035:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+      IL_003a:  stloc.2
       .line 70,70 : 9,41 ''
-      IL_003f:  ldarg.0
-      IL_0040:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Aggregates01/'categories3@67-3'::builder@
-      IL_0045:  ldloc.0
-      IL_0046:  ldloc.1
-      IL_0047:  ldloc.2
-      IL_0048:  newobj     instance void class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>::.ctor(!0,
+      IL_003b:  ldarg.0
+      IL_003c:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Aggregates01/'categories3@67-3'::builder@
+      IL_0041:  ldloc.0
+      IL_0042:  ldloc.1
+      IL_0043:  ldloc.2
+      IL_0044:  newobj     instance void class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>::.ctor(!0,
                                                                                                                                                                                                                                                                                       !1,
                                                                                                                                                                                                                                                                                       !2)
-      IL_004d:  tail.
-      IL_004f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Yield<class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object>(!!0)
-      IL_0054:  ret
+      IL_0049:  tail.
+      IL_004b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Yield<class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object>(!!0)
+      IL_0050:  ret
     } // end of method 'categories3@67-3'::Invoke
 
   } // end of class 'categories3@67-3'

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Quantifiers01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Quantifiers01.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:5:0:0
+  .ver 4:7:0:0
 }
 .assembly extern Utils
 {
@@ -38,20 +38,20 @@
 }
 .mresource public FSharpSignatureData.Linq101Quantifiers01
 {
-  // Offset: 0x00000000 Length: 0x0000039F
+  // Offset: 0x00000000 Length: 0x00000381
 }
 .mresource public FSharpOptimizationData.Linq101Quantifiers01
 {
-  // Offset: 0x000003A8 Length: 0x000000FF
+  // Offset: 0x00000388 Length: 0x000000FF
 }
 .module Linq101Quantifiers01.exe
-// MVID: {5B9A632A-76DD-E373-A745-03832A639A5B}
+// MVID: {5EAD3E37-76DD-E373-A745-0383373EAD5E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x025D0000
+// Image base: 0x05120000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -105,7 +105,7 @@
       .locals init ([0] string V_0,
                [1] string w)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Quantifiers01.fs'
+      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Quantifiers01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Quantifiers01/iAfterE@12::pc
       IL_0006:  ldc.i4.1
@@ -559,27 +559,16 @@
 
   } // end of class 'productGroups@22-3'
 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'productGroups@23-5'
+  .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname 'productGroups@23-5'
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-            instance void  .ctor() cil managed
-    {
-      // Code size       7 (0x7)
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-      IL_0006:  ret
-    } // end of method 'productGroups@23-5'::.ctor
-
-    .method assembly hidebysig instance bool 
-            Invoke(class [Utils]Utils/Product x) cil managed
+    .method assembly static bool  Invoke(class [Utils]Utils/Product x) cil managed
     {
       // Code size       10 (0xa)
       .maxstack  8
       .line 23,23 : 31,49 ''
-      IL_0000:  ldarg.1
+      IL_0000:  ldarg.0
       IL_0001:  callvirt   instance int32 [Utils]Utils/Product::get_UnitsInStock()
       IL_0006:  ldc.i4.0
       IL_0007:  ceq
@@ -606,17 +595,17 @@
     .method public strict virtual instance bool 
             Invoke(class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> g) cil managed
     {
-      // Code size       23 (0x17)
+      // Code size       19 (0x13)
       .maxstack  8
       .line 23,23 : 16,50 ''
       IL_0000:  ldarg.1
-      IL_0001:  newobj     instance void Linq101Quantifiers01/'productGroups@23-5'::.ctor()
-      IL_0006:  ldftn      instance bool Linq101Quantifiers01/'productGroups@23-5'::Invoke(class [Utils]Utils/Product)
-      IL_000c:  newobj     instance void class [mscorlib]System.Func`2<class [Utils]Utils/Product,bool>::.ctor(object,
+      IL_0001:  ldnull
+      IL_0002:  ldftn      bool Linq101Quantifiers01/'productGroups@23-5'::Invoke(class [Utils]Utils/Product)
+      IL_0008:  newobj     instance void class [mscorlib]System.Func`2<class [Utils]Utils/Product,bool>::.ctor(object,
                                                                                                                native int)
-      IL_0011:  call       bool [System.Core]System.Linq.Enumerable::Any<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+      IL_000d:  call       bool [System.Core]System.Linq.Enumerable::Any<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                      class [mscorlib]System.Func`2<!!0,bool>)
-      IL_0016:  ret
+      IL_0012:  ret
     } // end of method 'productGroups@23-4'::Invoke
 
   } // end of class 'productGroups@23-4'
@@ -1152,27 +1141,16 @@
 
   } // end of class 'productGroups2@40-3'
 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'productGroups2@41-5'
+  .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname 'productGroups2@41-5'
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-            instance void  .ctor() cil managed
-    {
-      // Code size       7 (0x7)
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
-      IL_0006:  ret
-    } // end of method 'productGroups2@41-5'::.ctor
-
-    .method assembly hidebysig instance bool 
-            Invoke(class [Utils]Utils/Product x) cil managed
+    .method assembly static bool  Invoke(class [Utils]Utils/Product x) cil managed
     {
       // Code size       10 (0xa)
       .maxstack  8
       .line 41,41 : 31,49 ''
-      IL_0000:  ldarg.1
+      IL_0000:  ldarg.0
       IL_0001:  callvirt   instance int32 [Utils]Utils/Product::get_UnitsInStock()
       IL_0006:  ldc.i4.0
       IL_0007:  cgt
@@ -1199,17 +1177,17 @@
     .method public strict virtual instance bool 
             Invoke(class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> g) cil managed
     {
-      // Code size       23 (0x17)
+      // Code size       19 (0x13)
       .maxstack  8
       .line 41,41 : 16,50 ''
       IL_0000:  ldarg.1
-      IL_0001:  newobj     instance void Linq101Quantifiers01/'productGroups2@41-5'::.ctor()
-      IL_0006:  ldftn      instance bool Linq101Quantifiers01/'productGroups2@41-5'::Invoke(class [Utils]Utils/Product)
-      IL_000c:  newobj     instance void class [mscorlib]System.Func`2<class [Utils]Utils/Product,bool>::.ctor(object,
+      IL_0001:  ldnull
+      IL_0002:  ldftn      bool Linq101Quantifiers01/'productGroups2@41-5'::Invoke(class [Utils]Utils/Product)
+      IL_0008:  newobj     instance void class [mscorlib]System.Func`2<class [Utils]Utils/Product,bool>::.ctor(object,
                                                                                                                native int)
-      IL_0011:  call       bool [System.Core]System.Linq.Enumerable::All<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+      IL_000d:  call       bool [System.Core]System.Linq.Enumerable::All<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                      class [mscorlib]System.Func`2<!!0,bool>)
-      IL_0016:  ret
+      IL_0012:  ret
     } // end of method 'productGroups2@41-4'::Invoke
 
   } // end of class 'productGroups2@41-4'
@@ -1250,7 +1228,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'words@8-6'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::words@8
     IL_0005:  ret
   } // end of method Linq101Quantifiers01::get_words
 
@@ -1268,7 +1246,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'products@17-10'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::products@17
     IL_0005:  ret
   } // end of method Linq101Quantifiers01::get_products
 
@@ -1286,7 +1264,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'numbers@28-7'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::numbers@28
     IL_0005:  ret
   } // end of method Linq101Quantifiers01::get_numbers
 
@@ -1353,15 +1331,15 @@
 .class private abstract auto ansi sealed '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01
        extends [mscorlib]System.Object
 {
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'words@8-6'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> words@8
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly bool iAfterE@10
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@17-10'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> products@17
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>[] productGroups@19
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@28-7'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numbers@28
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly bool onlyOdd@30
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -1400,7 +1378,7 @@
     IL_0028:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_002d:  dup
-    IL_002e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'words@8-6'
+    IL_002e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::words@8
     IL_0033:  stloc.0
     IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_0039:  ldnull
@@ -1419,7 +1397,7 @@
     .line 17,17 : 1,32 ''
     IL_0057:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
     IL_005c:  dup
-    IL_005d:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'products@17-10'
+    IL_005d:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::products@17
     IL_0062:  stloc.2
     .line 19,25 : 1,21 ''
     IL_0063:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
@@ -1480,7 +1458,7 @@
     IL_00fb:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0100:  dup
-    IL_0101:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'numbers@28-7'
+    IL_0101:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::numbers@28
     IL_0106:  stloc.s    numbers
     IL_0108:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_010d:  ldnull


### PR DESCRIPTION
This PR attempts to fix #8295.

Apologies in advance, I'm not an F# programmer, so there's probably a much better way to implement what I'm trying to do.

It looks like a big diff, but most of it are changes to the indentation.
