### PR TITLE
reenable tp tests

### DIFF
--- a/src/scripts/scriptlib.fsx
+++ b/src/scripts/scriptlib.fsx
@@ -172,7 +172,7 @@ module Scripting =
 
     let redirectToLog () = redirectTo System.Console.Out
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     let defaultPlatform = 
         match Environment.OSVersion.Platform, Environment.Is64BitOperatingSystem with 
         | PlatformID.MacOSX, true -> "osx.10.11-x64"

--- a/tests/fsharp/Compiler/CompilerAssert.fs
+++ b/tests/fsharp/Compiler/CompilerAssert.fs
@@ -85,8 +85,7 @@ type CompilerAssert private () =
     static let _ = config |> ignore
 
 // Do a one time dotnet sdk build to compute the proper set of reference assemblies to pass to the compiler
-#if !NETCOREAPP
-#else
+#if NETCOREAPP
     static let projectFile = """
 <Project Sdk="Microsoft.NET.Sdk">
 
@@ -189,12 +188,12 @@ let main argv = 0"""
             ProjectFileName = "Z:\\test.fsproj"
             ProjectId = None
             SourceFiles = [|"test.fs"|]
-#if !NETCOREAPP
-            OtherOptions = [|"--preferreduilang:en-US";"--warn:5"|]
-#else
+#if NETCOREAPP
             OtherOptions =
                 let assemblies = getNetCoreAppReferences |> Array.map (fun x -> sprintf "-r:%s" x)
                 Array.append [|"--preferreduilang:en-US"; "--targetprofile:netcore"; "--noframework";"--warn:5"|] assemblies
+#else
+            OtherOptions = [|"--preferreduilang:en-US";"--warn:5"|]
 #endif
             ReferencedProjects = [||]
             IsIncompleteTypeCheckEnvironment = false
@@ -554,10 +553,10 @@ let main argv = 0"""
 
             // Build command line arguments & start FSI session
             let argv = [| "C:\\fsi.exe" |]
-    #if !NETCOREAPP
-            let args = Array.append argv [|"--noninteractive"|]
-    #else
+    #if NETCOREAPP
             let args = Array.append argv [|"--noninteractive"; "--targetprofile:netcore"|]
+    #else
+            let args = Array.append argv [|"--noninteractive"|]
     #endif
             let allArgs = Array.append args options
 

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -15,10 +15,6 @@
     <UnitTestType>nunit</UnitTestType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">
-    <DefineConstants>$(DefineConstants);FSHARP_SUITE_DRIVES_CORECLR_TESTS</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\..\src\scripts\scriptlib.fsx">
       <Link>scriptlib.fsx</Link>

--- a/tests/fsharp/readme.md
+++ b/tests/fsharp/readme.md
@@ -16,7 +16,7 @@ test cases look similar to:
 This test case builds and runs the test case in the folder core/array
 
 this #define is used to exclude from the build tests that run will not run correctly on the coreclr
-__#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS__
+__#if !NETCOREAPP__
 
 There are some older tests in this section that looks similar to:
 ````

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -11,7 +11,7 @@ type Permutation =
     | FSC_CORECLR
     | FSC_CORECLR_BUILDONLY
     | FSI_CORECLR
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     | FSI_FILE
     | FSI_STDIN
     | GENERATED_SIGNATURE
@@ -309,7 +309,7 @@ let singleTestBuildAndRunCore cfg copyFiles p languageVersion =
     | FSC_CORECLR_BUILDONLY -> executeSingleTestBuildAndRun OutputType.Exe "coreclr" "netcoreapp3.0" true true
     | FSI_CORECLR -> executeSingleTestBuildAndRun OutputType.Script "coreclr" "netcoreapp3.0" true false
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     | FSC_BUILDONLY -> executeSingleTestBuildAndRun OutputType.Exe "net40" "net472" false true
     | FSC_OPT_PLUS_DEBUG -> executeSingleTestBuildAndRun OutputType.Exe "net40" "net472" true false
     | FSC_OPT_MINUS_DEBUG -> executeSingleTestBuildAndRun OutputType.Exe "net40" "net472" false false

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -82,13 +82,13 @@ module Commands =
             CmdResult.ErrorLevel (msg, err)
 #else
         ignore workDir 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if NETCOREAPP
+        exec dotNetExe (fscExe + " " + args)
+#else
         ignore dotNetExe
         printfn "fscExe: %A" fscExe
         printfn "args: %A" args
         exec fscExe args
-#else
-        exec dotNetExe (fscExe + " " + args)
 #endif
 #endif
 
@@ -127,7 +127,7 @@ type TestConfig =
       fsc_flags : string
       FSCOREDLLPATH : string
       FSI : string
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
       FSIANYCPU : string
 #endif
       FSI_FOR_SCRIPTS : string
@@ -204,7 +204,7 @@ let config configurationName envVars =
     File.Copy(coreclrdll, Path.GetDirectoryName(ILASM) ++ "coreclr.dll", overwrite=true)
 
     let FSI = requireFile (FSI_FOR_SCRIPTS)
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     let FSIANYCPU = requireFile (artifactsBinPath ++ "fsiAnyCpu" ++ configurationName ++ "net472" ++ "fsiAnyCpu.exe")
 #endif
     let FSC = requireFile (artifactsBinPath ++ "fsc" ++ configurationName ++ fscArchitecture ++ "fsc.exe")
@@ -226,7 +226,7 @@ let config configurationName envVars =
       BUILD_CONFIG = configurationName
       FSC = FSC
       FSI = FSI
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
       FSIANYCPU = FSIANYCPU
 #endif
       FSI_FOR_SCRIPTS = FSI_FOR_SCRIPTS
@@ -250,7 +250,7 @@ let logConfig (cfg: TestConfig) =
     log "fsc_flags           =%s" cfg.fsc_flags
     log "FSCOREDLLPATH       =%s" cfg.FSCOREDLLPATH
     log "FSI                 =%s" cfg.FSI
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     log "FSIANYCPU           =%s" cfg.FSIANYCPU
 #endif
     log "fsi_flags           =%s" cfg.fsi_flags
@@ -466,7 +466,7 @@ let ilasm cfg arg = Printf.ksprintf (Commands.ilasm (exec cfg) cfg.ILASM) arg
 let peverify cfg = Commands.peverify (exec cfg) cfg.PEVERIFY "/nologo"
 let peverifyWithArgs cfg args = Commands.peverify (exec cfg) cfg.PEVERIFY args
 let fsi cfg = Printf.ksprintf (Commands.fsi (exec cfg) cfg.FSI)
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
 let fsiAnyCpu cfg = Printf.ksprintf (Commands.fsi (exec cfg) cfg.FSIANYCPU)
 #endif
 let fsi_script cfg = Printf.ksprintf (Commands.fsi (exec cfg) cfg.FSI_FOR_SCRIPTS)

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -18,7 +18,7 @@ open Scripting
 open SingleTest
 open HandleExpects
 
-#if FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if NETCOREAPP
 // Use these lines if you want to test CoreCLR
 let FSC_BASIC = FSC_CORECLR
 let FSC_BUILDONLY = FSC_CORECLR_BUILDONLY
@@ -234,7 +234,7 @@ module CoreTests =
         let cfg = testConfig "SDKTests"
         exec cfg cfg.DotNetExe ("msbuild " + Path.Combine(cfg.Directory, "AllSdkTargetsTests.proj"))
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     [<Test>]
     let ``attributes-FSC_BASIC`` () = singleTestBuildAndRun "core/attributes" FSC_BASIC
 
@@ -476,7 +476,7 @@ module CoreTests =
     [<Test>]
     let ``enum-FSI_BASIC`` () = singleTestBuildAndRun "core/enum" FSI_BASIC
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
 
     // Requires winforms will not run on coreclr
     [<Test>]
@@ -956,7 +956,7 @@ module CoreTests =
     let ``signedtest-16`` () = signedtest("test-sha1024-full-attributes", "--define:SHA1024", SigningType.PublicSigned)
 #endif
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     [<Test>]
     let quotes () = 
         let cfg = testConfig "core/quotes"
@@ -1355,7 +1355,7 @@ module CoreTests =
     [<Test>]
     let ``fsi_load-FSI_BASIC`` () = singleTestBuildAndRun "core/fsi-load" FSI_BASIC
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     [<Test>]
     let ``measures-AS_DLL`` () = singleTestBuildAndRun "core/measures" AS_DLL
 
@@ -1586,7 +1586,7 @@ module CoreTests =
     [<Test>]
     let ``reflect-FSI_BASIC`` () = singleTestBuildAndRun "core/reflect" FSI_BASIC
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     [<Test>]
     let refnormalization () = 
         let cfg = testConfig "core/refnormalization"
@@ -1835,7 +1835,7 @@ module VersionTests =
     [<Test>]
     let ``nameof-fsi``() = singleTestBuildAndRunVersion "core/nameof/preview" FSI_BASIC "preview"
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
 module ToolsTests = 
 
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/Microsoft/visualfsharp/issues/2600
@@ -1885,7 +1885,7 @@ module RegressionTests =
     [<Test >]
     let ``tuple-bug-1-FSC_BASIC`` () = singleTestBuildAndRun "regression/tuple-bug-1" FSC_BASIC
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS 
+#if !NETCOREAPP 
     [<Test>]
     let ``SRTP doesn't handle calling member hiding hinherited members`` () =
         let cfg = testConfig "regression/5531" 
@@ -1920,7 +1920,7 @@ module RegressionTests =
     [<Test >]
     let ``321`` () = singleTestBuildAndRun "regression/321" FSC_BASIC
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/Microsoft/visualfsharp/issues/2600
     [<Test>]
     let ``655`` () = 
@@ -1950,7 +1950,7 @@ module RegressionTests =
         peverify cfg  "pack.exe"
 #endif
                 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     // Requires WinForms
     [<Test>]
     let ``83`` () = singleTestBuildAndRun "regression/83" FSC_BASIC
@@ -1973,7 +1973,7 @@ module RegressionTests =
     [<Test >]
     let ``struct-tuple-bug-1-FSI_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/Microsoft/visualfsharp/issues/2600
     [<Test>]
     let ``struct-measure-bug-1`` () = 
@@ -1982,8 +1982,7 @@ module RegressionTests =
         fsc cfg "%s --optimize- -o:test.exe -g" cfg.fsc_flags ["test.fs"]
 
         peverify cfg "test.exe"
-#endif
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+
 module OptimizationTests =
 
     [<Test>]
@@ -2126,7 +2125,7 @@ module TypecheckTests =
     [<Test>]
     let misc () = singleTestBuildAndRun "typecheck/misc" FSC_BASIC
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
 
     [<Test>]
     let ``sigs pos26`` () = 
@@ -2953,7 +2952,7 @@ module GeneratedSignatureTests =
     let ``measures-GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/measures" GENERATED_SIGNATURE
 #endif
 
-#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+#if !NETCOREAPP
 module OverloadResolution =
     module ``fsharpqa migrated tests`` = 
         let [<Test>] ``Conformance\Expressions\SyntacticSugar (E_Slices01.fs)`` () = singleNegTest (testConfig "conformance/expressions/syntacticsugar") "E_Slices01"

--- a/tests/fsharp/typeProviders/negTests/EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments.bsl
+++ b/tests/fsharp/typeProviders/negTests/EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments.bsl
@@ -5,4 +5,4 @@ EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments.fsx(6,39,6,14
 
 EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments.fsx(8,41,8,58): typecheck error FS0039: The type 'TheGeneratedTypeJ' is not defined.
 
-EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments.fsx(8,79,8,96): typecheck error FS0039: The field, constructor or member 'TheGeneratedTypeJ' is not defined.
+EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments.fsx(8,79,8,96): typecheck error FS0039: The type 'Object' does not define the field, constructor or member 'TheGeneratedTypeJ'.

--- a/tests/fsharp/typeProviders/negTests/ProviderAttributeErrorConsume.bslpp
+++ b/tests/fsharp/typeProviders/negTests/ProviderAttributeErrorConsume.bslpp
@@ -1,4 +1,4 @@
 
-providerAttributeErrorConsume.fsx(1,1,1,48): parse error FS3031: The type provider '<ASSEMBLY>' reported an error: Assembly attribute 'TypeProviderAssemblyAttribute' refers to a designer assembly 'Invalid.Assembly.Name' which cannot be loaded or doesn't exist. The exception reported was: Could not load file or assembly '<URIPATH>Invalid.Assembly.Name.dll' or one of its dependencies. The system cannot find the file specified.
+providerAttributeErrorConsume.fsx(1,1,1,48): parse error FS3031: The type provider '<ASSEMBLY>' reported an error: Assembly attribute 'TypeProviderAssemblyAttribute' refers to a designer assembly 'Invalid.Assembly.Name' which cannot be loaded from path '<FILEPATH>Invalid.Assembly.Name.dll'. The exception reported was: System.IO.FileNotFoundException - Could not load file or assembly '<URIPATH>Invalid.Assembly.Name.dll' or one of its dependencies. The system cannot find the file specified.
 
 providerAttributeErrorConsume.fsx(1,1,1,48): parse error FS3005: Referenced assembly '<ASSEMBLY>' has assembly level attribute 'Microsoft.FSharp.Core.CompilerServices.TypeProviderAssemblyAttribute' but no public type provider classes were found

--- a/tests/fsharp/typeProviders/negTests/neg1.bsl
+++ b/tests/fsharp/typeProviders/negTests/neg1.bsl
@@ -29,7 +29,6 @@ neg1.fsx(11,38,11,66): typecheck error FS3072: The type provider 'Provider.EvilP
 neg1.fsx(11,38,11,66): typecheck error FS3072: The type provider 'Provider.EvilProvider' reported an error: An exception occurred when accessing the 'Name' of a provided type: deliberate error for testing purposes
 
 neg1.fsx(11,38,11,66): typecheck error FS0039: The type 'TypeWhereNameRaisesException' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    IsArrayTypeRaisesException
 
 neg1.fsx(11,38,11,66): typecheck error FS3072: The type provider 'Provider.EvilProvider' reported an error: An exception occurred when accessing the 'Name' of a provided type: deliberate error for testing purposes
@@ -41,7 +40,6 @@ neg1.fsx(11,38,11,66): typecheck error FS3072: The type provider 'Provider.EvilP
 neg1.fsx(11,38,11,66): typecheck error FS3072: The type provider 'Provider.EvilProvider' reported an error: An exception occurred when accessing the 'Name' of a provided type: deliberate error for testing purposes
 
 neg1.fsx(11,38,11,66): typecheck error FS0039: The type 'TypeWhereNameRaisesException' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    IsArrayTypeRaisesException
 
 neg1.fsx(12,38,12,62): typecheck error FS3073: The type provider 'Provider.EvilProvider' reported an error: The 'Name' of a provided type was null or empty.
@@ -305,7 +303,6 @@ neg1.fsx(25,39,25,78): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(25,39,25,78): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetConstructorsRaisesException' member 'GetConstructors': The type provider 'Provider.EvilProvider' reported an error: deliberate error for testing purposes
 
 neg1.fsx(25,39,25,78): typecheck error FS0039: The type 'TypeWhereGetConstructorsRaisesException' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(25,39,25,78): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetConstructorsRaisesException' member 'GetConstructors': The type provider 'Provider.EvilProvider' reported an error: deliberate error for testing purposes
@@ -317,7 +314,6 @@ neg1.fsx(25,39,25,78): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(25,39,25,78): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetConstructorsRaisesException' member 'GetConstructors': The type provider 'Provider.EvilProvider' reported an error: deliberate error for testing purposes
 
 neg1.fsx(25,39,25,78): typecheck error FS0039: The type 'TypeWhereGetConstructorsRaisesException' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(27,39,27,69): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetMethodsReturnsNull' member 'GetMethods': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetMethods'
@@ -329,7 +325,6 @@ neg1.fsx(27,39,27,69): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(27,39,27,69): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetMethodsReturnsNull' member 'GetMethods': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetMethods'
 
 neg1.fsx(27,39,27,69): typecheck error FS0039: The type 'TypeWhereGetMethodsReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(27,39,27,69): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetMethodsReturnsNull' member 'GetMethods': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetMethods'
@@ -341,7 +336,6 @@ neg1.fsx(27,39,27,69): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(27,39,27,69): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetMethodsReturnsNull' member 'GetMethods': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetMethods'
 
 neg1.fsx(27,39,27,69): typecheck error FS0039: The type 'TypeWhereGetMethodsReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(28,39,28,68): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetEventsReturnsNull' member 'GetEvents': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetEvents'
@@ -353,7 +347,6 @@ neg1.fsx(28,39,28,68): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(28,39,28,68): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetEventsReturnsNull' member 'GetEvents': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetEvents'
 
 neg1.fsx(28,39,28,68): typecheck error FS0039: The type 'TypeWhereGetEventsReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(28,39,28,68): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetEventsReturnsNull' member 'GetEvents': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetEvents'
@@ -365,7 +358,6 @@ neg1.fsx(28,39,28,68): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(28,39,28,68): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetEventsReturnsNull' member 'GetEvents': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetEvents'
 
 neg1.fsx(28,39,28,68): typecheck error FS0039: The type 'TypeWhereGetEventsReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(29,39,29,68): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetFieldsReturnsNull' member 'GetFields': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetFields'
@@ -377,7 +369,6 @@ neg1.fsx(29,39,29,68): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(29,39,29,68): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetFieldsReturnsNull' member 'GetFields': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetFields'
 
 neg1.fsx(29,39,29,68): typecheck error FS0039: The type 'TypeWhereGetFieldsReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(29,39,29,68): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetFieldsReturnsNull' member 'GetFields': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetFields'
@@ -389,7 +380,6 @@ neg1.fsx(29,39,29,68): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(29,39,29,68): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetFieldsReturnsNull' member 'GetFields': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetFields'
 
 neg1.fsx(29,39,29,68): typecheck error FS0039: The type 'TypeWhereGetFieldsReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(30,39,30,72): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetPropertiesReturnsNull' member 'GetProperties': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetProperties'
@@ -401,7 +391,6 @@ neg1.fsx(30,39,30,72): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(30,39,30,72): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetPropertiesReturnsNull' member 'GetProperties': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetProperties'
 
 neg1.fsx(30,39,30,72): typecheck error FS0039: The type 'TypeWhereGetPropertiesReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(30,39,30,72): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetPropertiesReturnsNull' member 'GetProperties': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetProperties'
@@ -413,7 +402,6 @@ neg1.fsx(30,39,30,72): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(30,39,30,72): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetPropertiesReturnsNull' member 'GetProperties': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetProperties'
 
 neg1.fsx(30,39,30,72): typecheck error FS0039: The type 'TypeWhereGetPropertiesReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(31,39,31,73): typecheck error FS3004: The provided type 'FSharp.EvilProvider.TypeWhereGetNestedTypesReturnsNull' has member 'Boo' which has declaring type 'FSharp.EvilProvider.TheType'. Expected declaring type to be the same as provided type.
@@ -429,9 +417,7 @@ neg1.fsx(32,39,32,74): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(32,39,32,74): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetConstructorsReturnsNull' member 'GetConstructors': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetConstructors'
 
 neg1.fsx(32,39,32,74): typecheck error FS0039: The type 'TypeWhereGetConstructorsReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesReturnsNull
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(32,39,32,74): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetConstructorsReturnsNull' member 'GetConstructors': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetConstructors'
@@ -443,9 +429,7 @@ neg1.fsx(32,39,32,74): typecheck error FS3021: Unexpected exception from provide
 neg1.fsx(32,39,32,74): typecheck error FS3021: Unexpected exception from provided type 'FSharp.EvilProvider.TypeWhereGetConstructorsReturnsNull' member 'GetConstructors': The type provider 'Provider.EvilProvider' reported an error: The type provider returned 'null', which is not a valid return value from 'GetConstructors'
 
 neg1.fsx(32,39,32,74): typecheck error FS0039: The type 'TypeWhereGetConstructorsReturnsNull' is not defined in 'FSharp.EvilProvider'. Maybe you want one of the following:
-
    TypeWhereGetNestedTypesReturnsNull
-
    TypeWhereGetNestedTypesRaisesException
 
 neg1.fsx(33,39,33,72): typecheck error FS3042: Unexpected 'null' return value from provided type 'FSharp.EvilProvider.TypeWhereGetInterfacesReturnsNull' member 'GetInterfaces'
@@ -1654,21 +1638,15 @@ neg1.fsx(438,109,438,110): typecheck error FS0001: This expression was expected 
 but here has type
     'string'    
 
-neg1.fsx(438,9,438,111): typecheck error FS3033: The type provider 'Provider.GoodProviderForNegativeStaticParameterTypeTests' reported an error: Specified cast is not valid.
-
 neg1.fsx(440,119,440,120): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
     'string'    
 
-neg1.fsx(440,19,440,121): typecheck error FS3033: The type provider 'Provider.GoodProviderForNegativeStaticParameterTypeTests' reported an error: Specified cast is not valid.
-
 neg1.fsx(440,119,440,120): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
     'string'    
-
-neg1.fsx(440,19,440,121): typecheck error FS3033: The type provider 'Provider.GoodProviderForNegativeStaticParameterTypeTests' reported an error: Specified cast is not valid.
 
 neg1.fsx(448,9,448,107): typecheck error FS3148: Too many static parameters. Expected at most 1 parameters, but got 2 unnamed and 0 named parameters.
 

--- a/tests/fsharp/typeProviders/negTests/neg2.bsl
+++ b/tests/fsharp/typeProviders/negTests/neg2.bsl
@@ -4,5 +4,4 @@ neg2.fsx(3,59,3,66): typecheck error FS3033: The type provider 'Provider.GoodPro
 neg2.fsx(3,59,3,66): typecheck error FS3033: The type provider 'Provider.GoodProviderForNegativeTypeTests1' reported an error: Kaboom
 
 neg2.fsx(3,59,3,66): typecheck error FS0039: The value, constructor, namespace or type 'TheHype' is not defined. Maybe you want one of the following:
-
    TheType


### PR DESCRIPTION
A bunch of type provider tests [have been disabled for a fair while](https://github.com/dotnet/fsharp/pull/9009#issuecomment-617706530). This reenables them for .NET Framework

With regard to .NET Core - It looks like all tests under `tests\fsharp` that do a manual invoke of `fsc` in the test code are not yet enabled for .NET Core.  These tests are in that category


