### PR TITLE
Remove FSharp.Data.TypeProviders from Visual Studio

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -177,7 +177,6 @@
     <MicrosoftNETCoreILDAsmVersion>3.0.0-preview-27318-01</MicrosoftNETCoreILDAsmVersion>
     <MicrosoftNETCoreILAsmVersion>3.0.0-preview-27318-01</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETTestSdkVersion>15.8.0</MicrosoftNETTestSdkVersion>
-    <MicrosoftVisualFSharpTypeProvidersRedistVersion>1.0.0</MicrosoftVisualFSharpTypeProvidersRedistVersion>
     <MicrosoftWin32RegistryVersion>4.3.0</MicrosoftWin32RegistryVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <NUnitVersion>3.11.0</NUnitVersion>

--- a/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
+++ b/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
@@ -15,10 +15,6 @@
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\FSharp.Build.fsproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualFSharp.Type.Providers.Redist" Version="$(MicrosoftVisualFSharpTypeProvidersRedistVersion)" IncludeAssets="none" />
-  </ItemGroup>
-
   <!--
   Splits the $(XlfLanguages) property into an item group.  E.g., this:
 
@@ -106,7 +102,6 @@ folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp"
   file source="$(BinariesFolder)\FSharp.Core\$(Configuration)\net45\FSharp.Core.optdata"
   file source="$(BinariesFolder)\FSharp.Core\$(Configuration)\net45\FSharp.Core.sigdata"
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\$(TargetFramework)\FSharp.Build.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
-  file source="$(NuGetPackageRoot)\Microsoft.VisualFSharp.Type.Providers.Redist\$(MicrosoftVisualFSharpTypeProvidersRedistVersion)\content\$(FSharpDataTypeProvidersVersion)\FSharp.Data.TypeProviders.dll"
   file source="$(BinariesFolder)\Interactive.DependencyManager\$(Configuration)\net472\Interactive.DependencyManager.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.dll"
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.Framework.dll"

--- a/setup/Swix/Microsoft.FSharp.IDE/Microsoft.FSharp.IDE.csproj
+++ b/setup/Swix/Microsoft.FSharp.IDE/Microsoft.FSharp.IDE.csproj
@@ -19,7 +19,6 @@
     <_Dependency Include="FSharp.Compiler.Private" Version="$(FSProductVersion)" />
     <_Dependency Include="FSharp.Compiler.Server.Shared" Version="$(FSProductVersion)" />
     <_Dependency Include="FSharp.Core" Version="$(FSCoreVersion)" />
-    <_Dependency Include="FSharp.Data.TypeProviders" Version="$(FSharpDataTypeProvidersVersion)" />
     <_Dependency Include="FSharp.Editor" Version="$(VSAssemblyVersion)" />
     <_Dependency Include="FSharp.LanguageService.Base" Version="$(VSAssemblyVersion)" />
     <_Dependency Include="FSharp.LanguageService" Version="$(VSAssemblyVersion)" />

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -42,8 +42,7 @@ module AssemblyCheck =
     let verifyAssemblies (binariesPath:string) =
 
         let excludedAssemblies =
-            [ "FSharp.Data.TypeProviders.dll" ]
-            |> Set.ofList
+            [ ] |> Set.ofList
 
         let fsharpAssemblies =
             [ "FSharp*.dll"

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -44,10 +44,6 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="Microsoft.VisualFSharp.Type.Providers.Redist" Version="$(MicrosoftVisualFSharpTypeProvidersRedistVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -491,7 +491,7 @@ this file.
 
       </ItemGroup>
       <Error
-          Text="This Project references an obsolete TypeProvider: FSharp.Data.TypeProviders.dll, this was removed In VS2019 16.7.0 Preview 1.  Consider Switching to the Nuget package version: https://www.nuget.org/packages/FSharp.Data.TypeProviders."
+          Text="This Project references an obsolete TypeProvider: FSharp.Data.TypeProviders.dll, this was removed In Visual Studio 2019 16.7.0. Consider Switching to the NuGet package version: https://www.nuget.org/packages/FSharp.Data.TypeProviders."
           Condition=" '@(ReferenceToInboxTP->Count())' != '0' " />
     </Target>
 

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -474,44 +474,24 @@ this file.
 
     <Target Name="RedirectTPReferenceToNewRedistributableLocation" BeforeTargets="ResolveAssemblyReferences">
       <PropertyGroup>
-        <_OldRefAssemTPLocation>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers\FSharp.Data.TypeProviders.dll</_OldRefAssemTPLocation>
+        <_OldRefAssemTPLocation>Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers\FSharp.Data.TypeProviders.dll</_OldRefAssemTPLocation>
         <_OldSdkTPLocationPrefix>$(MSBuildProgramFiles32)\Microsoft SDKs\F#</_OldSdkTPLocationPrefix>
         <_OldSdkTPLocationSuffix>Framework\v4.0\FSharp.Data.TypeProviders.dll</_OldSdkTPLocationSuffix>
-
-        <NewFSharpCompilerLocation Condition=" '$(NewFSharpCompilerLocation)' == '' ">$(MSBuildThisFileDirectory)</NewFSharpCompilerLocation>
-        <NewFSharpCompilerLocation Condition=" !HasTrailingSlash('$(NewFSharpCompilerLocation)') ">$(NewFSharpCompilerLocation)\</NewFSharpCompilerLocation>
       </PropertyGroup>
 
       <ItemGroup>
-        <!-- Issue warning message if there is an inbox TypeProvider referenced.-->
+        <!-- Issue error message if there is an inbox TypeProvider referenced.-->
         <ReferenceToInboxTP Include="@(Reference)"
                             Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
-                                       '%(Reference.HintPath)' == '$(_OldRefAssemTPLocation)' and
-                                       Exists('$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll')" />
+                                       $([System.String]::new('%(Reference.HintPath)').EndsWith('$(_OldRefAssemTPLocation)', System.StringComparison.OrdinalIgnoreCase))" />
         <ReferenceToInboxTP Include="@(Reference)"
                             Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
                                        $([System.String]::new('%(Reference.HintPath)').StartsWith('$(_OldSdkTPLocationPrefix)', System.StringComparison.OrdinalIgnoreCase)) and
-                                       $([System.String]::new('%(Reference.HintPath)').EndsWith('$(_OldSdkTPLocationSuffix)', System.StringComparison.OrdinalIgnoreCase)) and
-                                       Exists('$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll')" />
+                                       $([System.String]::new('%(Reference.HintPath)').EndsWith('$(_OldSdkTPLocationSuffix)', System.StringComparison.OrdinalIgnoreCase))" />
 
-        <!-- Update references to FSharp.Data.TypeProviders.dll -->
-        <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
-                              '%(Reference.HintPath)' == '$(_OldRefAssemTPLocation)' and
-                              Exists('$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll')">
-          <HintPath>$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll</HintPath>
-        </Reference>
-
-        <!-- Update references to FSharp.Data.TypeProviders.dll -->
-        <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
-                               $([System.String]::new('%(Reference.HintPath)').StartsWith('$(_OldSdkTPLocationPrefix)', System.StringComparison.OrdinalIgnoreCase)) and
-                               $([System.String]::new('%(Reference.HintPath)').EndsWith('$(_OldSdkTPLocationSuffix)', System.StringComparison.OrdinalIgnoreCase)) and
-                               Exists('$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll')">
-
-          <HintPath>$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll</HintPath>
-        </Reference>
       </ItemGroup>
-      <Warning
-          Text="This Project references the obsolete TypeProvider: FSharp.Data.TypeProviders.dll.  Consider Switching to the Nuget package version: https://www.nuget.org/packages/FSharp.Data.TypeProviders."
+      <Error
+          Text="This Project references an obsolete TypeProvider: FSharp.Data.TypeProviders.dll, this was removed In VS2019 16.7.0 Preview 1.  Consider Switching to the Nuget package version: https://www.nuget.org/packages/FSharp.Data.TypeProviders."
           Condition=" '@(ReferenceToInboxTP->Count())' != '0' " />
     </Target>
 

--- a/tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
+++ b/tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
@@ -19,10 +19,6 @@
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="Microsoft.VisualFSharp.Type.Providers.Redist" Version="$(MicrosoftVisualFSharpTypeProvidersRedistVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -873,7 +873,6 @@ let ``Type provider project references should not throw exceptions`` () =
                    yield "--platform:anycpu";
                    for r in mkStandardProjectReferences () do
                        yield "-r:" + r
-                   yield "-r:" + __SOURCE_DIRECTORY__ + @"/data/TypeProviderLibrary/FSharp.Data.TypeProviders.dll"; 
                   |];
                 ReferencedProjects = [||];
                 IsIncompleteTypeCheckEnvironment = false;

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -30,12 +30,6 @@
       <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-
-    <Content Include="$(NuGetPackageRoot)\Microsoft.VisualFSharp.Type.Providers.Redist\$(MicrosoftVisualFSharpTypeProvidersRedistVersion)\content\$(FSharpDataTypeProvidersVersion)\FSharp.Data.TypeProviders.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>FSharp.Data.TypeProviders.dll</Link>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -288,7 +282,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualFSharp.Type.Providers.Redist" Version="$(MicrosoftVisualFSharpTypeProvidersRedistVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
At the start of VS2017 we obsoleted the in-box FSharp.Data.TypeProviders in favour of the equivalent nuget package : https://www.nuget.org/packages/FSharp.Data.TypeProviders

With builds of projects referencing it producing this warning message:  
This change is targeted at VS2019 v 16.7.0

````
"C:\Users\kevinr\source\repos\ConsoleApplication1\ConsoleApplication1\ConsoleApplication1.fsproj" (rebuild target) (1) ->
(RedirectTPReferenceToNewRedistributableLocation target) ->
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.targets(513,7): warning : This Project references the obsolete TypePr
ovider: FSharp.Data.TypeProviders.dll.  Consider Switching to the Nuget package version: https://www.nuget.org/packages/FSharp.Data.TypeProviders. [C:\Users\kevinr\source\repos\ConsoleApplication1
\ConsoleApplication1\ConsoleApplication1.fsproj]
````

We are now removing it from the build completely, builds will now yield this error message:
````
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.targets(493,7): error : This Project references an obsolete TypeProvide
r: FSharp.Data.TypeProviders.dll, this was removed In VS2019 16.7.0 Preview 1.  Consider Switching to the Nuget package version: https://www.nuget.org/packages/FSharp.Data.TypeProviders. [C:\Users
\kevinr\source\repos\ConsoleApplication1\ConsoleApplication1\ConsoleApplication1.fsproj]
````
Any projects still referencing the in-box type provider, must be updated to use the FSharp.Data.TypeProviders.dll from the nuget package.


This PR:
removes the packaging, and updates the build warning to a build error.
/CC @brettfo , @cartermp 
