### PR TITLE
Add 'fsi' between 'dotnet' and '--help' for fsi.exe

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -579,8 +579,6 @@ let internal directoryName (s:string) =
         | res -> if res = "" then "." else res
 
 
-
-
 //----------------------------------------------------------------------------
 // cmd line - state for options
 //----------------------------------------------------------------------------
@@ -618,14 +616,20 @@ type internal FsiCommandLineOptions(fsi: FsiEvaluationSessionHostConfig, argv: s
             let getFsiCommandLine () =
                 let fileNameWithoutExtension path = Path.GetFileNameWithoutExtension(path)
 
-                let currentProcess = System.Diagnostics.Process.GetCurrentProcess()
+                let currentProcess = Process.GetCurrentProcess()
                 let processFileName = fileNameWithoutExtension currentProcess.MainModule.FileName
 
                 let commandLineExecutableFileName =
-                    try fileNameWithoutExtension (System.Environment.GetCommandLineArgs().[0])
+                    try fileNameWithoutExtension (Environment.GetCommandLineArgs().[0])
                     with _ -> ""
 
-                if processFileName = commandLineExecutableFileName
+                let stringComparison =
+                    match Environment.OSVersion.Platform with
+                    | PlatformID.MacOSX
+                    | PlatformID.Unix -> StringComparison.Ordinal
+                    | _ -> StringComparison.OrdinalIgnoreCase
+                
+                if String.Compare(processFileName, commandLineExecutableFileName, stringComparison) = 0
                 then processFileName
                 else sprintf "%s %s" processFileName commandLineExecutableFileName
 

--- a/tests/fsharpqa/Source/CompilerOptions/fsi/help/help40-nologo.437.1033.bsl
+++ b/tests/fsharpqa/Source/CompilerOptions/fsi/help/help40-nologo.437.1033.bsl
@@ -1,5 +1,5 @@
 
-Usage: fsi.exe <options> [script.fsx [<arguments>]]
+Usage: fsiAnyCpu <options> [script.fsx [<arguments>]]
 
 
 		- INPUT FILES -

--- a/tests/fsharpqa/Source/CompilerOptions/fsi/help/help40.437.1033.bsl
+++ b/tests/fsharpqa/Source/CompilerOptions/fsi/help/help40.437.1033.bsl
@@ -1,7 +1,7 @@
 Microsoft (R) F# Interactive version 10.2.3 for F# 4.5
 Copyright (c) Microsoft Corporation. All Rights Reserved.
 
-Usage: fsi.exe <options> [script.fsx [<arguments>]]
+Usage: fsiAnyCpu <options> [script.fsx [<arguments>]]
 
 
 		- INPUT FILES -


### PR DESCRIPTION
This PR fixes an issue where, if `fsi` was invoked from `dotnet fsi`, the `--help` printouts would show an incorrect way to execute `fsi` (see #8350).

Fixes #8350.