### PR TITLE
[VS] Fixed duplication of entries for find all refs. Minor perf improvements.

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/CodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CodeAnalysisExtensions.fs
@@ -47,6 +47,14 @@ type Solution with
         self.GetDocumentIdsWithFilePath (Path.GetFullPath filePath)
         |> Seq.tryHead |> Option.map (fun docId -> self.GetDocument docId)
 
+    /// Try to find the documentId corresponding to the provided filepath and ProjectId within this solution  
+    member self.TryGetDocumentFromPath(filePath, projId: ProjectId) =
+       // It's crucial to normalize file path here (specificaly, remove relative parts),
+       // otherwise Roslyn does not find documents.
+       self.GetDocumentIdsWithFilePath (Path.GetFullPath filePath)
+       |> Seq.filter (fun x -> x.ProjectId = projId)
+       |> Seq.tryHead |> Option.map (fun docId -> self.GetDocument docId)
+
 
     /// Try to get a project inside the solution using the project's id
     member self.TryGetProject (projId:ProjectId) =

--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -13,6 +13,7 @@ open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor.FindUsages
 
 open FSharp.Compiler.Range
 open FSharp.Compiler.SourceCodeServices
+open Microsoft.CodeAnalysis.Text
 
 [<Export(typeof<IFSharpFindUsagesService>)>]
 type internal FSharpFindUsagesService
@@ -79,37 +80,39 @@ type internal FSharpFindUsagesService
                             [ FSharpDefinitionItem.CreateNonNavigableItem(
                                 tags,
                                 ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Ident.idText)),
-                                ImmutableArray.Create(TaggedText(TextTags.Assembly, symbolUse.Symbol.Assembly.SimpleName))) ]
-                        | _ ->
-                            declarationSpans
-                            |> List.map (fun span ->
-                                FSharpDefinitionItem.Create(tags, ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Ident.idText)), span))
+                                ImmutableArray.Create(TaggedText(TextTags.Assembly, symbolUse.Symbol.Assembly.SimpleName))), None ]
+                        | spans ->
+                            spans |> List.map (fun span -> FSharpDefinitionItem.Create(tags, ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Ident.idText)), span), Some span.Document.Id)
                 } |> liftAsync
             
-            for definitionItem in definitionItems do
+            for definitionItem, _ in definitionItems do
                 do! context.OnDefinitionFoundAsync(definitionItem) |> Async.AwaitTask |> liftAsync
             
             let onFound =
-                fun (symbolUse: range) ->
+                fun (doc: Document) (textSpan: TextSpan) (symbolUse: range) ->
                     async {
                         match declarationRange with
                         | Some declRange when FSharp.Compiler.Range.equals declRange symbolUse -> ()
                         | _ ->
                             if allReferences then
-                                let! referenceDocSpans = rangeToDocumentSpans(document.Project.Solution, symbolUse)
-                                match referenceDocSpans with
-                                | [] -> ()
-                                | _ ->
-                                    for referenceDocSpan in referenceDocSpans do
-                                        for definitionItem in definitionItems do
-                                            let referenceItem = FSharpSourceReferenceItem(definitionItem, referenceDocSpan)
-                                            do! context.OnReferenceFoundAsync(referenceItem) |> Async.AwaitTask }
+                                for definitionItem, docId in definitionItems do
+                                    match docId with
+                                    | Some docId ->
+                                        if doc.Id.ProjectId = docId.ProjectId then
+                                            let referenceItem = FSharpSourceReferenceItem(definitionItem, FSharpDocumentSpan(doc, textSpan))
+                                            do! context.OnReferenceFoundAsync(referenceItem) |> Async.AwaitTask 
+                                    | _ ->
+                                        () }
             
             match symbolUse.GetDeclarationLocation document with
             | Some SymbolDeclarationLocation.CurrentDocument ->
                 let! symbolUses = checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol) |> liftAsync
                 for symbolUse in symbolUses do
-                    do! onFound symbolUse.RangeAlternate |> liftAsync
+                    match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, symbolUse.RangeAlternate) with
+                    | Some textSpan ->
+                        do! onFound document textSpan symbolUse.RangeAlternate |> liftAsync
+                    | _ ->
+                        ()
             | scope ->
                 let projectsToCheck =
                     match scope with


### PR DESCRIPTION
There was some duplication of entries for find all references which occurred in multi-targeted projects. This should help improve a little bit of performance for them.

Also, per found range, we were making constant calls to get its related documents and source text. Roslyn does have caching for getting a source text but we still made calls to get documents by file path. This will now be done per source file.