### PR TITLE
Function tooltip shows documentation for its parameter

### DIFF
--- a/src/fsharp/XmlDoc.fs
+++ b/src/fsharp/XmlDoc.fs
@@ -78,16 +78,8 @@ type XmlDocCollector() =
                 Array.findFirstIndexWhereTrue lines (fun (_, pos) -> posGeq pos prevGrabPointPos)
 
         let lines = lines.[firstLineIndexAfterPrevGrabPoint..firstLineIndexAfterGrabPoint-1]
-        if lines.Length = 0 then
-            [| |]
-        else
-            let firstLineNumber = (snd lines.[0]).Line
-            lines
-            |> Array.mapi (fun i x -> firstLineNumber - i, x)
-            |> Array.takeWhile (fun (sequencedLineNumber, (_, pos)) -> sequencedLineNumber = pos.Line)
-            |> Array.map (fun (_, (lineStr, _)) -> lineStr)
+        lines |> Array.map fst
       with e ->
-        //printfn "unexpected error in LinesBefore:\n%s" (e.ToString())
         [| |]
 
 /// Represents the XmlDoc fragments as collected from the lexer during parsing

--- a/src/fsharp/XmlDoc.fs
+++ b/src/fsharp/XmlDoc.fs
@@ -77,7 +77,7 @@ type XmlDocCollector() =
                 let prevGrabPointPos = grabPoints.[grabPointIndex-1]
                 Array.findFirstIndexWhereTrue lines (fun (_, pos) -> posGeq pos prevGrabPointPos)
 
-        let lines = lines.[firstLineIndexAfterPrevGrabPoint..firstLineIndexAfterGrabPoint-1] |> Array.rev
+        let lines = lines.[firstLineIndexAfterPrevGrabPoint..firstLineIndexAfterGrabPoint-1]
         if lines.Length = 0 then
             [| |]
         else

--- a/src/fsharp/XmlDoc.fs
+++ b/src/fsharp/XmlDoc.fs
@@ -86,7 +86,6 @@ type XmlDocCollector() =
             |> Array.mapi (fun i x -> firstLineNumber - i, x)
             |> Array.takeWhile (fun (sequencedLineNumber, (_, pos)) -> sequencedLineNumber = pos.Line)
             |> Array.map (fun (_, (lineStr, _)) -> lineStr)
-            |> Array.rev
       with e ->
         //printfn "unexpected error in LinesBefore:\n%s" (e.ToString())
         [| |]

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -2876,9 +2876,14 @@ constant:
     { SynConst.Measure($1, $3) }
 
 bindingPattern:
-  | headBindingPattern   
-      {  let xmlDoc = grabXmlDoc(parseState, 1)
-         mkSynBinding (xmlDoc, $1), rhs parseState 1 }
+  | headBindingPattern
+     
+      { // Adds a grab point at the start of the binding, so as not to include XML doc comments on the arguments
+        let xmlDoc = LexbufLocalXmlDocStore.GrabXmlDocBeforeMarker(parseState.LexBuffer, (lhs parseState).StartRange)
+        // Adds grab point at the end of the binding head, so subsequent types don't erroneously include argument doc comemnts
+        grabXmlDoc(parseState, 1) |> ignore
+     
+        mkSynBinding (xmlDoc, $1), rhs parseState 1 }
 
 // Subset of patterns allowed to be used in implicit ctors.
 // For a better error recovery we could replace these rules with the actual SynPat parsing

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -17,7 +17,7 @@ open System.IO
 
 open FSharp.Compiler.Service.Tests.Common
 
-let toIList (x: _ array) = x :> System.Collections.Generic.IList<_>
+let toIList (x: _ array) = x :> System.Collections.Generic.IReadOnlyCollection<_>
 let numProjectsForStressTest = 100
 let internal checker = FSharpChecker.Create(projectCacheSize=numProjectsForStressTest + 10)
 
@@ -231,7 +231,7 @@ let ``Test multi project 1 xmldoc`` () =
     | _ -> failwith "odd symbol!"
     
     match x3FromProject1A with 
-    | :? FSharpMemberOrFunctionOrValue as v -> v.XmlDoc |> shouldEqual ([|"This is x3"|] |> toIList)
+    | :? FSharpMemberOrFunctionOrValue as v -> v.XmlDoc |> shouldEqual ([|" This is x3"|] |> toIList)
     | _ -> failwith "odd symbol!"
 
     match x1FromProjectMultiProject with 

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -14,10 +14,11 @@ open FSharp.Compiler.SourceCodeServices
 open NUnit.Framework
 open FsUnit
 open System.IO
+open System.Collections.Generic
 
 open FSharp.Compiler.Service.Tests.Common
 
-let toIList (x: _ array) = x :> System.Collections.Generic.IList<_>
+let toIList (x: _ array) = x :> IList<_>
 let numProjectsForStressTest = 100
 let internal checker = FSharpChecker.Create(projectCacheSize=numProjectsForStressTest + 10)
 
@@ -44,7 +45,8 @@ let x1 = C.M(arg1 = 3, arg2 = 4, arg3 = 5)
 /// This is x2
 let x2 = C.M(arg1 = 3, arg2 = 4, ?arg3 = Some 5)
 
-/// This is x3
+/// This is
+/// x3
 let x3 (
           /// This is not x3
           p: int
@@ -231,7 +233,7 @@ let ``Test multi project 1 xmldoc`` () =
     | _ -> failwith "odd symbol!"
     
     match x3FromProject1A with 
-    | :? FSharpMemberOrFunctionOrValue as v -> v.XmlDoc |> shouldEqual ([|" This is x3"|] |> toIList)
+    | :? FSharpMemberOrFunctionOrValue as v -> v.XmlDoc |> shouldEqual ([|" This is"; " x3"|] |> toIList)
     | _ -> failwith "odd symbol!"
 
     match x1FromProjectMultiProject with 

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -17,7 +17,7 @@ open System.IO
 
 open FSharp.Compiler.Service.Tests.Common
 
-let toIList (x: _ array) = x :> System.Collections.Generic.IReadOnlyCollection<_>
+let toIList (x: _ array) = x :> System.Collections.Generic.IList<_>
 let numProjectsForStressTest = 100
 let internal checker = FSharpChecker.Create(projectCacheSize=numProjectsForStressTest + 10)
 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -2942,7 +2942,8 @@ query."
                              type bar() =
                                  /// <summary> Test for members</summary>
                                  /// <param name="x1">x1 param!</param>
-                                 member this.foo (x1:int)=
+                                 member this.foo
+                                     (x1:int)=
                                      System.Console.WriteLine(x1.ToString())
                              
                              type Uni1 = 
@@ -2956,7 +2957,7 @@ query."
                              exception Ex1 of value: string
 
                              // Methods
-                             let f1 = (new bar()).foo(x1(*Marker1*) = 10)
+                             let f1 = (new bar()).foo(*Marker0*)(x1(*Marker1*) = 10)
                              let f2 = System.String.Concat(1, arg1(*Marker2*) = "") 
                              
                              //Unions
@@ -2976,6 +2977,7 @@ query."
                              type provType = N1.T<Param1(*Marker7*)="hello", ParamIgnored(*Marker8*)=10>
                              """
 
+        this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker0*)", "Test for members")
         this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker1*)", "x1 param!")
         this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker2*)", "[ParamName: arg1]")
         this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker3*)", "str of case1")


### PR DESCRIPTION
# Summary
I believe this change should fix this issue https://github.com/dotnet/fsharp/issues/7455, and have confirmed that it appears to do so when running an instance of ReSharper with this change built into it.
The method in question that's been changed `LinesBefore`, was behaving more like `LinesAfter`.

# Testing
 - Manual testing with Rider
 - Added a new testcase which should cover this case, though I've not been able to run it due to a "did not resolve mscorelib" error when trying to run the FCS tests (I'm running on Windows, nothing out of the ordinary) - if someone could point me to how to go about running them, that would be great.