### PR TITLE
[VS,FCS] Added 'canInvalidateProject' parameter to find all refs related calls

### DIFF
--- a/src/fsharp/InternalCollections.fs
+++ b/src/fsharp/InternalCollections.fs
@@ -184,6 +184,18 @@ type internal MruCache<'Token, 'Key,'Value when 'Value : not struct>(keepStrongl
             if areSame(similarKey, key) && isStillValid(key,value) then Some value
             else None
         | None -> None
+
+    member bc.TryGetSimilarAny(tok, key) = 
+        match cache.TryGetKeyValue(tok, key) with
+        | Some(_, value) -> Some value
+        | None -> None
+
+    member bc.TryGetSimilar(tok, key) = 
+        match cache.TryGetKeyValue(tok, key) with
+        | Some(_, value) -> 
+            if isStillValid(key,value) then Some value
+            else None
+        | None -> None
            
     member bc.Set(tok, key:'Key,value:'Value) = 
         cache.Put(tok, key,value)

--- a/src/fsharp/InternalCollections.fsi
+++ b/src/fsharp/InternalCollections.fsi
@@ -66,6 +66,12 @@ namespace Internal.Utilities.Collections
     /// Get the value for the given key or None, but only if entry is still valid
     member TryGet : 'Token * key:'Key -> 'Value option
 
+    /// Get the value for the given key or <c>None</c> if not still valid. Skips `areSame` checking unless `areSimilar` is not provided.
+    member TryGetSimilarAny : 'Token * key:'Key -> 'Value option
+
+    /// Get the value for the given key or None, but only if entry is still valid. Skips `areSame` checking unless `areSimilar` is not provided.
+    member TryGetSimilar : 'Token * key:'Key -> 'Value option
+
     /// Remove the given value from the mru cache.
     member RemoveAnySimilar : 'Token * key:'Key -> unit
 

--- a/src/fsharp/Logger.fs
+++ b/src/fsharp/Logger.fs
@@ -11,6 +11,8 @@ type LogCompilerFunctionId =
     | Service_IncrementalBuildersCache_BuildingNewCache = 3
     | Service_IncrementalBuildersCache_GettingCache = 4
     | CompileOps_TypeCheckOneInputAndFinishEventually = 5
+    | IncrementalBuild_CreateItemKeyStoreAndSemanticClassification = 6
+    | IncrementalBuild_TypeCheck = 7
     
 /// This is for ETW tracing across FSharp.Compiler.
 [<Sealed;EventSource(Name = "FSharpCompiler")>]

--- a/src/fsharp/Logger.fsi
+++ b/src/fsharp/Logger.fsi
@@ -10,6 +10,8 @@ type internal LogCompilerFunctionId =
     | Service_IncrementalBuildersCache_BuildingNewCache = 3
     | Service_IncrementalBuildersCache_GettingCache = 4
     | CompileOps_TypeCheckOneInputAndFinishEventually = 5
+    | IncrementalBuild_CreateItemKeyStoreAndSemanticClassification = 6
+    | IncrementalBuild_TypeCheck = 7
 
 [<RequireQualifiedAccess>]
 module internal Logger =

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1224,7 +1224,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                         sourceFiles, loadClosureOpt: LoadClosure option, 
                         keepAssemblyContents, keepAllBackgroundResolutions, maxTimeShareMilliseconds, keepAllBackgroundSymbolUses, enableBackgroundItemKeyStoreAndSemanticClassification) =
 
-    let keyBuilder = ItemKeyStoreBuilder()
     let tcConfigP = TcConfigProvider.Constant tcConfig
     let fileParsed = new Event<string>()
     let beforeFileChecked = new Event<string>()
@@ -1411,6 +1410,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                     let itemKeyStore, semanticClassification =
                         if enableBackgroundItemKeyStoreAndSemanticClassification then
                             Logger.LogBlockMessageStart filename LogCompilerFunctionId.IncrementalBuild_CreateItemKeyStoreAndSemanticClassification
+                            let keyBuilder = ItemKeyStoreBuilder()
                             let sResolutions = sink.GetResolutions()
                             let preventDuplicates = HashSet({ new IEqualityComparer<struct(pos * pos)> with 
                                                                 member _.Equals((s1, e1): struct(pos * pos), (s2, e2): struct(pos * pos)) = Range.posEq s1 s2 && Range.posEq e1 e2

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -172,6 +172,9 @@ type internal IncrementalBuilder =
       /// Get the logical time stamp that is associated with the output of the project if it were gully built immediately
       member GetLogicalTimeStampForProject: TimeStampCache * CompilationThreadToken -> DateTime
 
+      /// Does the given file exist in the builder's pipeline?
+      member ContainsFile: filename: string -> bool
+
       /// Await the untyped parse results for a particular slot in the vector of parse results.
       ///
       /// This may be a marginally long-running operation (parses are relatively quick, only one file needs to be parsed)

--- a/src/fsharp/service/ItemKey.fs
+++ b/src/fsharp/service/ItemKey.fs
@@ -160,8 +160,9 @@ type ItemKeyStore(mmf: MemoryMappedFile, length) =
     interface IDisposable with
 
         member _.Dispose() =
-            isDisposed <- true
-            mmf.Dispose()
+            if not isDisposed then
+                isDisposed <- true
+                mmf.Dispose()
 
 and [<Sealed>] ItemKeyStoreBuilder() =
 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -357,6 +357,19 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
               return builderOpt, creationErrors
       }
 
+    let getSimilarOrCreateBuilder (ctok, options, userOpName) =
+        RequireCompilationThread ctok
+        match incrementalBuildersCache.TryGetSimilar (ctok, options) with
+        | Some res -> Cancellable.ret res
+        // The builder does not exist at all. Create it.
+        | None -> getOrCreateBuilder (ctok, options, userOpName)
+
+    let getOrCreateBuilderWithInvalidationFlag (ctok, options, canInvalidateProject, userOpName) =
+        if canInvalidateProject then
+            getOrCreateBuilder (ctok, options, userOpName)
+        else
+            getSimilarOrCreateBuilder (ctok, options, userOpName)
+
     let parseCacheLock = Lock<ParseCacheLockToken>()
     
 
@@ -699,28 +712,34 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                 return (parseResults, typedResults)
            })
 
-    member __.FindReferencesInFile(filename: string, options: FSharpProjectOptions, symbol: FSharpSymbol, userOpName: string) =
+    member __.FindReferencesInFile(filename: string, options: FSharpProjectOptions, symbol: FSharpSymbol, canInvalidateProject: bool, userOpName: string) =
         reactor.EnqueueAndAwaitOpAsync(userOpName, "FindReferencesInFile", filename, fun ctok -> 
           cancellable {
-            let! builderOpt, _ = getOrCreateBuilder (ctok, options, userOpName)
+            let! builderOpt, _ = getOrCreateBuilderWithInvalidationFlag (ctok, options, canInvalidateProject, userOpName)
             match builderOpt with
             | None -> return Seq.empty
             | Some builder -> 
-                let! checkResults = builder.GetCheckResultsAfterFileInProject (ctok, filename)
-                return 
-                    match checkResults.ItemKeyStore with
-                    | None -> Seq.empty
-                    | Some reader -> reader.FindAll symbol.Item })
+                if builder.ContainsFile filename then
+                    let! checkResults = builder.GetCheckResultsAfterFileInProject (ctok, filename)
+                    return 
+                        match checkResults.ItemKeyStore with
+                        | None -> Seq.empty
+                        | Some reader -> reader.FindAll symbol.Item 
+                else
+                    return Seq.empty })
 
-    member __.GetSemanticClassificationForFile(filename: string, options: FSharpProjectOptions, userOpName: string) =
+    member __.GetSemanticClassificationForFile(filename: string, options: FSharpProjectOptions, canInvalidateProject: bool, userOpName: string) =
         reactor.EnqueueAndAwaitOpAsync(userOpName, "GetSemanticClassificationForFile", filename, fun ctok -> 
             cancellable {
-            let! builderOpt, _ = getOrCreateBuilder (ctok, options, userOpName)
+            let! builderOpt, _ = getOrCreateBuilderWithInvalidationFlag (ctok, options, canInvalidateProject, userOpName)
             match builderOpt with
             | None -> return [||]
             | Some builder -> 
-                let! checkResults = builder.GetCheckResultsAfterFileInProject (ctok, filename)
-                return checkResults.SemanticClassification })
+                if builder.ContainsFile filename then
+                    let! checkResults = builder.GetCheckResultsAfterFileInProject (ctok, filename)
+                    return checkResults.SemanticClassification 
+                else
+                    return [||] })
 
 
     /// Try to get recent approximate type check results for a file. 
@@ -1172,15 +1191,17 @@ type FSharpChecker(legacyReferenceResolver,
         ic.CheckMaxMemoryReached()
         backgroundCompiler.ParseAndCheckProject(options, userOpName)
 
-    member ic.FindBackgroundReferencesInFile(filename:string, options: FSharpProjectOptions, symbol: FSharpSymbol, ?userOpName: string) =
+    member ic.FindBackgroundReferencesInFile(filename:string, options: FSharpProjectOptions, symbol: FSharpSymbol, ?canInvalidateProject: bool, ?userOpName: string) =
+        let canInvalidateProject = defaultArg canInvalidateProject true
         let userOpName = defaultArg userOpName "Unknown"
         ic.CheckMaxMemoryReached()
-        backgroundCompiler.FindReferencesInFile(filename, options, symbol, userOpName)
+        backgroundCompiler.FindReferencesInFile(filename, options, symbol, canInvalidateProject, userOpName)
 
-    member ic.GetBackgroundSemanticClassificationForFile(filename:string, options: FSharpProjectOptions, ?userOpName) =
+    member ic.GetBackgroundSemanticClassificationForFile(filename:string, options: FSharpProjectOptions, ?canInvalidateProject: bool, ?userOpName) =
+        let canInvalidateProject = defaultArg canInvalidateProject true
         let userOpName = defaultArg userOpName "Unknown"
         ic.CheckMaxMemoryReached()
-        backgroundCompiler.GetSemanticClassificationForFile(filename, options, userOpName)
+        backgroundCompiler.GetSemanticClassificationForFile(filename, options, canInvalidateProject, userOpName)
 
     /// For a given script file, get the ProjectOptions implied by the #load closure
     member __.GetProjectOptionsFromScript(filename, source, ?previewEnabled, ?loadedTimeStamp, ?otherFlags, ?useFsiAuxLib, ?useSdkRefs, ?assumeDotNetFramework, ?extraProjectInfo: obj, ?optionsStamp: int64, ?userOpName: string) = 

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -289,8 +289,9 @@ type public FSharpChecker =
     /// <param name="filename">The filename for the file.</param>
     /// <param name="options">The options for the project or script, used to determine active --define conditionals and other options relevant to parsing.</param>
     /// <param name="symbol">The symbol to find all uses in the file.</param>
+    /// <param name="canInvalidateProject">Default: true. If true, this call can invalidate the current state of project if the options have changed. If false, the current state of the project will be used.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member FindBackgroundReferencesInFile : filename : string * options : FSharpProjectOptions * symbol: FSharpSymbol * ?userOpName: string -> Async<range seq>
+    member FindBackgroundReferencesInFile : filename : string * options : FSharpProjectOptions * symbol: FSharpSymbol * ?canInvalidateProject: bool * ?userOpName: string -> Async<range seq>
 
     /// <summary>
     /// <para>Get semantic classification for a file.</para>
@@ -299,8 +300,9 @@ type public FSharpChecker =
     ///
     /// <param name="filename">The filename for the file.</param>
     /// <param name="options">The options for the project or script, used to determine active --define conditionals and other options relevant to parsing.</param>
+    /// <param name="canInvalidateProject">Default: true. If true, this call can invalidate the current state of project if the options have changed. If false, the current state of the project will be used.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetBackgroundSemanticClassificationForFile : filename : string * options : FSharpProjectOptions * ?userOpName: string -> Async<struct(range * SemanticClassificationType) []>
+    member GetBackgroundSemanticClassificationForFile : filename : string * options : FSharpProjectOptions * ?canInvalidateProject: bool * ?userOpName: string -> Async<struct(range * SemanticClassificationType) []>
 
     /// <summary>
     /// Compile using the given flags.  Source files names are resolved via the FileSystem API.

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationService.fs
@@ -168,7 +168,8 @@ type internal FSharpClassificationService
                     | ValueSome classificationDataLookup ->
                         addSemanticClassificationByLookup sourceText textSpan classificationDataLookup result
                     | _ ->
-                        let! classificationData = checkerProvider.Checker.GetBackgroundSemanticClassificationForFile(document.FilePath, projectOptions, userOpName=userOpName) |> liftAsync
+                        // Do not invalidate the project while this is running in case anything has changed.
+                        let! classificationData = checkerProvider.Checker.GetBackgroundSemanticClassificationForFile(document.FilePath, projectOptions, canInvalidateProject = false, userOpName=userOpName) |> liftAsync
                         let classificationDataLookup = toSemanticClassificationLookup classificationData
                         do! semanticClassificationCache.SetAsync(document, classificationDataLookup) |> liftAsync
                         addSemanticClassificationByLookup sourceText textSpan classificationDataLookup result


### PR DESCRIPTION
Because we are making a single call to FCS per file when doing find all references, we should probably not invalidate entire projects and instead just use whatever the current state is. Invalidation can cause cache thrashing if a user performs a find all references and for some reason a project(s) changes.

Also adds two ETW events to check performance of background type checking and building of the item key store.