### PR TITLE
[VS] Use current solution's project state to prevent any cache thrashing

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -243,7 +243,7 @@ type private FSharpProjectOptionsReactor (_workspace: VisualStudioWorkspace, set
                                 // We only care about the latest project in the workspace's solution.
                                 // We do this to prevent any possible cache thrashing in FCS.
                                 let project = document.Project.Solution.Workspace.CurrentSolution.GetProject(document.Project.Id)
-                                if project <> null then
+                                if not (isNull project) then
                                     let! options = tryComputeOptions project
                                     reply.Reply options
                                 else
@@ -263,7 +263,7 @@ type private FSharpProjectOptionsReactor (_workspace: VisualStudioWorkspace, set
                                 // We only care about the latest project in the workspace's solution.
                                 // We do this to prevent any possible cache thrashing in FCS.
                                 let project = project.Solution.Workspace.CurrentSolution.GetProject(project.Id)
-                                if project <> null then
+                                if not (isNull project) then
                                     let! options = tryComputeOptions project
                                     reply.Reply options
                                 else

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -243,8 +243,11 @@ type private FSharpProjectOptionsReactor (_workspace: VisualStudioWorkspace, set
                                 // We only care about the latest project in the workspace's solution.
                                 // We do this to prevent any possible cache thrashing in FCS.
                                 let project = document.Project.Solution.Workspace.CurrentSolution.GetProject(document.Project.Id)
-                                let! options = tryComputeOptions project
-                                reply.Reply options
+                                if project <> null then
+                                    let! options = tryComputeOptions project
+                                    reply.Reply options
+                                else
+                                    reply.Reply None
                         with
                         | _ ->
                             reply.Reply None
@@ -260,8 +263,11 @@ type private FSharpProjectOptionsReactor (_workspace: VisualStudioWorkspace, set
                                 // We only care about the latest project in the workspace's solution.
                                 // We do this to prevent any possible cache thrashing in FCS.
                                 let project = project.Solution.Workspace.CurrentSolution.GetProject(project.Id)
-                                let! options = tryComputeOptions project
-                                reply.Reply options
+                                if project <> null then
+                                    let! options = tryComputeOptions project
+                                    reply.Reply options
+                                else
+                                    reply.Reply None
                         with
                         | _ ->
                             reply.Reply None

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -240,7 +240,10 @@ type private FSharpProjectOptionsReactor (_workspace: VisualStudioWorkspace, set
                                 let! options = tryComputeOptionsByFile document ct
                                 reply.Reply options
                             else
-                                let! options = tryComputeOptions document.Project
+                                // We only care about the latest project in the workspace's solution.
+                                // We do this to prevent any possible cache thrashing in FCS.
+                                let project = document.Project.Solution.Workspace.CurrentSolution.GetProject(document.Project.Id)
+                                let! options = tryComputeOptions project
                                 reply.Reply options
                         with
                         | _ ->
@@ -254,6 +257,9 @@ type private FSharpProjectOptionsReactor (_workspace: VisualStudioWorkspace, set
                             if project.Solution.Workspace.Kind = WorkspaceKind.MiscellaneousFiles || project.Name = FSharpConstants.FSharpMiscellaneousFilesName then
                                 reply.Reply None
                             else
+                                // We only care about the latest project in the workspace's solution.
+                                // We do this to prevent any possible cache thrashing in FCS.
+                                let project = project.Solution.Workspace.CurrentSolution.GetProject(project.Id)
                                 let! options = tryComputeOptions project
                                 reply.Reply options
                         with


### PR DESCRIPTION
It can be possible to have cache thrashing inside of FCS when its sent old project options and new project options in an alternating manner. Instead, for VS we will always get the project's current state inside of the workspace rather than what was passed. This should prevent any thrashing that could occur.