### PR TITLE
[FCS] Added 'canInvalidateProject' parameter to find all refs related calls

### DIFF
--- a/src/fsharp/InternalCollections.fs
+++ b/src/fsharp/InternalCollections.fs
@@ -184,6 +184,18 @@ type internal MruCache<'Token, 'Key,'Value when 'Value : not struct>(keepStrongl
             if areSame(similarKey, key) && isStillValid(key,value) then Some value
             else None
         | None -> None
+
+    member bc.TryGetSimilarAny(tok, key) = 
+        match cache.TryGetKeyValue(tok, key) with
+        | Some(_, value) -> Some value
+        | None -> None
+
+    member bc.TryGetSimilar(tok, key) = 
+        match cache.TryGetKeyValue(tok, key) with
+        | Some(_, value) -> 
+            if isStillValid(key,value) then Some value
+            else None
+        | None -> None
            
     member bc.Set(tok, key:'Key,value:'Value) = 
         cache.Put(tok, key,value)

--- a/src/fsharp/InternalCollections.fsi
+++ b/src/fsharp/InternalCollections.fsi
@@ -66,6 +66,12 @@ namespace Internal.Utilities.Collections
     /// Get the value for the given key or None, but only if entry is still valid
     member TryGet : 'Token * key:'Key -> 'Value option
 
+    /// Get the value for the given key or <c>None</c> if not still valid. Skips `areSame` checking unless `areSimilar` is not provided.
+    member TryGetSimilarAny : 'Token * key:'Key -> 'Value option
+
+    /// Get the value for the given key or None, but only if entry is still valid. Skips `areSame` checking unless `areSimilar` is not provided.
+    member TryGetSimilar : 'Token * key:'Key -> 'Value option
+
     /// Remove the given value from the mru cache.
     member RemoveAnySimilar : 'Token * key:'Key -> unit
 

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1688,7 +1688,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         let t2 = MaxTimeStampInDependencies cache ctok stampedReferencedAssembliesNode 
         max t1 t2
         
-    member __.GetSlotOfFileName(filename: string) =
+    member __.TryGetSlotOfFileName(filename: string) =
         // Get the slot of the given file and force it to build.
         let CompareFileNames (_, f2, _) = 
             let result = 
@@ -1696,6 +1696,11 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                 || String.Compare(FileSystem.GetFullPathShim filename, FileSystem.GetFullPathShim f2, StringComparison.CurrentCultureIgnoreCase)=0
             result
         match TryGetSlotByInput(fileNamesNode, partialBuild, CompareFileNames) with
+        | Some slot -> Some slot
+        | None -> None
+        
+    member this.GetSlotOfFileName(filename: string) =
+        match this.TryGetSlotOfFileName(filename) with
         | Some slot -> slot
         | None -> failwith (sprintf "The file '%s' was not part of the project. Did you call InvalidateConfiguration when the list of files in the project changed?" filename)
         
@@ -1704,6 +1709,9 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         match partialBuild.Results.TryFind(expr.Id) with
         | Some (VectorResult vr) -> vr.Size
         | _ -> failwith "Failed to find sizes"
+
+    member this.ContainsFile(filename: string) =
+        (this.TryGetSlotOfFileName filename).IsSome
       
     member builder.GetParseResultsForFile (ctok: CompilationThreadToken, filename) =
       cancellable {

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -172,6 +172,9 @@ type internal IncrementalBuilder =
       /// Get the logical time stamp that is associated with the output of the project if it were gully built immediately
       member GetLogicalTimeStampForProject: TimeStampCache * CompilationThreadToken -> DateTime
 
+      /// Does the given file exist in the builder's pipeline?
+      member ContainsFile: filename: string -> bool
+
       /// Await the untyped parse results for a particular slot in the vector of parse results.
       ///
       /// This may be a marginally long-running operation (parses are relatively quick, only one file needs to be parsed)

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -289,8 +289,9 @@ type public FSharpChecker =
     /// <param name="filename">The filename for the file.</param>
     /// <param name="options">The options for the project or script, used to determine active --define conditionals and other options relevant to parsing.</param>
     /// <param name="symbol">The symbol to find all uses in the file.</param>
+    /// <param name="canInvalidateProject">Default: true. If true, this call can invalidate the current state of project if the options have changed. If false, the current state of the project will be used.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member FindBackgroundReferencesInFile : filename : string * options : FSharpProjectOptions * symbol: FSharpSymbol * ?userOpName: string -> Async<range seq>
+    member FindBackgroundReferencesInFile : filename : string * options : FSharpProjectOptions * symbol: FSharpSymbol * ?canInvalidateProject: bool * ?userOpName: string -> Async<range seq>
 
     /// <summary>
     /// <para>Get semantic classification for a file.</para>

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -42,7 +42,7 @@ module internal SymbolHelpers =
                 match! projectInfoManager.TryGetOptionsByProject(project, CancellationToken.None) with
                 | Some (_parsingOptions, projectOptions) ->
                     for filePath in projectOptions.SourceFiles do
-                        let! symbolUses = checker.FindBackgroundReferencesInFile(filePath, projectOptions, symbol, userOpName = userOpName)
+                        let! symbolUses = checker.FindBackgroundReferencesInFile(filePath, projectOptions, symbol, canInvalidateProject = false, userOpName = userOpName)
                         let documentOpt = project.Solution.TryGetDocumentFromPath(filePath, project.Id)
                         match documentOpt with
                         | Some document ->


### PR DESCRIPTION
Because we are making a single call to FCS per file when doing find all references, we should probably not invalidate entire projects and instead just use whatever the current state is. Invalidation of newer projects with old could cause cache thrashing.

While we can try to prevent that at the VS level, it could be possible for a newer project options to be passed followed by an old one. This change will just help make sure that if it does happen, it won't invalidate the world.

