### PR TITLE
Add test for ServiceAssemblyContent with property getter and setter

### DIFF
--- a/tests/service/AssemblyContentProviderTests.fs
+++ b/tests/service/AssemblyContentProviderTests.fs
@@ -73,7 +73,7 @@ module MyType =
         "Test.MyType.func123"]
         
 [<Test>]
-let ``Module suffix added by an xplicitly applied MuduleSuffix attribute is removed``() =
+let ``Module suffix added by an explicitly applied ModuleSuffix attribute is removed``() =
     """
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module MyType =

--- a/tests/service/AssemblyContentProviderTests.fs
+++ b/tests/service/AssemblyContentProviderTests.fs
@@ -83,4 +83,14 @@ module MyType =
          "Test.MyType"
          "Test.MyType.func123" ]
 
-
+[<Test>]
+let ``Property getters and setters are removed``() =
+    """
+    type MyType() =
+        static member val MyProperty = 0 with get,set
+"""
+    => [
+        "Test"
+        "Test.MyType"
+        "Test.MyType.MyProperty"
+    ]

--- a/tests/service/AssemblyContentProviderTests.fs
+++ b/tests/service/AssemblyContentProviderTests.fs
@@ -89,8 +89,6 @@ let ``Property getters and setters are removed``() =
     type MyType() =
         static member val MyProperty = 0 with get,set
 """
-    => [
-        "Test"
-        "Test.MyType"
-        "Test.MyType.MyProperty"
-    ]
+    => [ "Test"
+         "Test.MyType"
+         "Test.MyType.MyProperty" ]


### PR DESCRIPTION
Contributes to #4024.

Adds a test to check that no "get_" and "set_" prefixed entries show in assembly signature content.