### PR TITLE
Provoke build

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
 namespace Microsoft.VisualStudio.FSharp.Editor
-
+ 
 open System
 open System.Collections.Generic
 open System.Collections.Concurrent

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -216,7 +216,7 @@ type private FSharpProjectOptionsReactor (workspace: Workspace, settings: Editor
 
                     if not (Seq.isEmpty projectsToClearCache) then
                         projectsToClearCache
-                        |> Seq.iter (fun pair -> cache.Remove pair.Key |> ignore)
+                        |> Seq.iter (fun pair -> cache.TryRemove pair.Key |> ignore)
                         let options =
                             projectsToClearCache
                             |> Seq.map (fun pair ->


### PR DESCRIPTION
Yep it fails in the CI too.

````
vsintegration\src\FSharp.Editor\LanguageService\FSharpProjectOptionsManager.fs(219,56): error FS0039: The type 'ConcurrentDictionary<TKey,TValue>' does not define the field, constructor or member 'Remove'. Maybe you want one of the following:   RemoveNode   RemoveNodes
````