### PR TITLE
Added 'AddBoundValue' to `FsiEvaluationSession`

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -7827,7 +7827,7 @@ let SetGeneratedValue (ctxt: ExecutionContext) (g: TcGlobals) eenv isForced (v: 
 let ClearGeneratedValue (ctxt: ExecutionContext) (g: TcGlobals) eenv (v: Val) =
   try
     match StorageForVal g v.Range v eenv with
-      | StaticField (fspec, _, hasLiteralAttr, _, _, _, _ilGetterMethRef, ilSetterMethRef, _) ->
+      | StaticField (fspec, _, hasLiteralAttr, _, _, _, _ilGetterMethRef, _ilSetterMethRef, _) ->
           if not hasLiteralAttr && v.IsMutable then
               let ty = ctxt.LookupType fspec.ActualType
               SetGeneratedValue ctxt g eenv false v (defaultOf ty)

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -7799,17 +7799,38 @@ let LookupGeneratedValue (amap: ImportMap) (ctxt: ExecutionContext) eenv (v: Val
 #endif
       None
 
+// Invoke the set_Foo method for a declaration with a value. Used to create variables with values programatically in fsi.exe.
+let SetGeneratedValue (ctxt: ExecutionContext) (g: TcGlobals) eenv isForced (v: Val) (value: obj) =
+  try
+    match StorageForVal g v.Range v eenv with
+      | StaticField (fspec, _, hasLiteralAttr, _, _, _, _f, ilSetterMethRef, _) ->
+          if not hasLiteralAttr && (v.IsMutable || isForced) then
+              if isForced then
+                  let staticTy = ctxt.LookupTypeRef fspec.DeclaringTypeRef
+
+                  let fieldInfo = staticTy.GetField(fspec.Name, BindingFlags.Static ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+                  fieldInfo.SetValue(null, value)
+              else
+                  let staticTy = ctxt.LookupTypeRef ilSetterMethRef.DeclaringTypeRef
+
+                  let methInfo = staticTy.GetMethod(ilSetterMethRef.Name, BindingFlags.Static ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+                  methInfo.Invoke (null, [| value |]) |> ignore
+      | _ -> ()
+  with
+    e ->
+#if DEBUG  
+      printf "ilxGen.SetGeneratedValue for v=%s caught exception:\n%A\n\n" v.LogicalName e
+#endif
+      ()
+
 // Invoke the set_Foo method for a declaration with a default/null value. Used to release storage in fsi.exe
 let ClearGeneratedValue (ctxt: ExecutionContext) (g: TcGlobals) eenv (v: Val) =
   try
     match StorageForVal g v.Range v eenv with
       | StaticField (fspec, _, hasLiteralAttr, _, _, _, _ilGetterMethRef, ilSetterMethRef, _) ->
           if not hasLiteralAttr && v.IsMutable then
-              let staticTy = ctxt.LookupTypeRef ilSetterMethRef.DeclaringTypeRef
               let ty = ctxt.LookupType fspec.ActualType
-
-              let methInfo = staticTy.GetMethod(ilSetterMethRef.Name, BindingFlags.Static ||| BindingFlags.Public ||| BindingFlags.NonPublic)
-              methInfo.Invoke (null, [| defaultOf ty |]) |> ignore
+              SetGeneratedValue ctxt g eenv false v (defaultOf ty)
       | _ -> ()
   with
     e ->
@@ -7854,6 +7875,9 @@ type IlxAssemblyGenerator(amap: ImportMap, tcGlobals: TcGlobals, tcVal: Constrai
 
     /// Invert the compilation of the given value and clear the storage of the value
     member __.ClearGeneratedValue (ctxt, v) = ClearGeneratedValue ctxt tcGlobals ilxGenEnv v
+
+    /// Invert the compilation of the given value and set the storage of the value, even if it is immutable
+    member __.ForceSetGeneratedValue (ctxt, v, value: obj) = SetGeneratedValue ctxt tcGlobals ilxGenEnv true v value
 
     /// Invert the compilation of the given value and return its current dynamic value and its compiled System.Type
     member __.LookupGeneratedValue (ctxt, v) = LookupGeneratedValue amap ctxt ilxGenEnv v

--- a/src/fsharp/IlxGen.fsi
+++ b/src/fsharp/IlxGen.fsi
@@ -104,6 +104,9 @@ type public IlxAssemblyGenerator =
     /// Invert the compilation of the given value and clear the storage of the value
     member ClearGeneratedValue: ExecutionContext * Val -> unit
 
+    /// Invert the compilation of the given value and set the storage of the value, even if it is immutable
+    member ForceSetGeneratedValue: ExecutionContext * Val * obj -> unit
+
     /// Invert the compilation of the given value and return its current dynamic value and its compiled System.Type
     member LookupGeneratedValue: ExecutionContext * Val -> (obj * System.Type) option
 

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -1262,6 +1262,7 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
   member __.unchecked_unary_plus_info  = v_unchecked_unary_plus_info
   member __.unchecked_unary_minus_info = v_unchecked_unary_minus_info
   member __.unchecked_unary_not_info   = v_unchecked_unary_not_info
+  member __.unchecked_defaultof_info   = v_unchecked_defaultof_info
 
   member __.checked_addition_info      = v_checked_addition_info
   member __.checked_subtraction_info   = v_checked_subtraction_info

--- a/src/fsharp/TypeChecker.fsi
+++ b/src/fsharp/TypeChecker.fsi
@@ -24,6 +24,8 @@ type TcEnv =
 val CreateInitialTcEnv : TcGlobals * ImportMap * range * assemblyName: string * (CcuThunk * string list * string list) list -> TcEnv 
 val AddCcuToTcEnv      : TcGlobals * ImportMap * range * TcEnv * assemblyName: string * ccu: CcuThunk * autoOpens: string list * internalsVisibleToAttributes: string list -> TcEnv 
 val AddLocalRootModuleOrNamespace : NameResolution.TcResultsSink -> TcGlobals -> ImportMap -> range -> TcEnv -> ModuleOrNamespaceType -> TcEnv
+val AddLocalVal : NameResolution.TcResultsSink -> scopem: range -> v: Val -> TcEnv -> TcEnv
+val AddLocalSubModule : TcGlobals -> ImportMap -> range -> TcEnv -> ModuleOrNamespace -> TcEnv
 val TcOpenDecl         : NameResolution.TcResultsSink  -> TcGlobals -> ImportMap -> range -> range -> TcEnv -> LongIdent -> TcEnv 
 
 type TopAttribs =

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -6810,6 +6810,8 @@ let mkCallDivisionOperator (g: TcGlobals) m ty e1 e2 = mkApps g (typedExprForInt
 
 let mkCallModulusOperator (g: TcGlobals) m ty e1 e2 = mkApps g (typedExprForIntrinsic g m g.unchecked_modulus_info, [[ty; ty; ty]], [e1;e2], m)
 
+let mkCallDefaultOf (g: TcGlobals) m ty = mkApps g (typedExprForIntrinsic g m g.unchecked_defaultof_info, [[ty]], [], m)
+
 let mkCallBitwiseAndOperator (g: TcGlobals) m ty e1 e2 = mkApps g (typedExprForIntrinsic g m g.bitwise_and_info, [[ty]], [e1;e2], m)
 
 let mkCallBitwiseOrOperator (g: TcGlobals) m ty e1 e2 = mkApps g (typedExprForIntrinsic g m g.bitwise_or_info, [[ty]], [e1;e2], m)

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -1861,6 +1861,8 @@ val mkCallDivisionOperator                   : TcGlobals -> range -> TType -> Ex
 
 val mkCallModulusOperator                    : TcGlobals -> range -> TType -> Expr -> Expr -> Expr
 
+val mkCallDefaultOf                          : TcGlobals -> range -> TType -> Expr
+
 val mkCallBitwiseAndOperator                 : TcGlobals -> range -> TType -> Expr -> Expr -> Expr
 
 val mkCallBitwiseOrOperator                  : TcGlobals -> range -> TType -> Expr -> Expr -> Expr

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2398,8 +2398,8 @@ type internal FsiInteractionProcessor
     member __.AddBoundValue(ctok, errorLogger, name, value: obj) =
         currState 
         |> InteractiveCatch errorLogger (fun istate -> 
-            fsiDynamicCompiler.AddBoundValue(ctok, errorLogger, istate, name, value), Completed None)
-        |> commitResult
+            fsiDynamicCompiler.AddBoundValue(ctok, errorLogger, istate, name, value), Completed None) |> fst
+        |> setCurrState
 
     member __.PartialAssemblySignatureUpdated = event.Publish
 
@@ -2931,7 +2931,8 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         let errorOptions = TcConfig.Create(tcConfigB, validate = false).errorSeverityOptions
         let errorLogger = CompilationErrorLogger("AddBoundValue", errorOptions)
         fsiInteractionProcessor.AddBoundValue(ctok, errorLogger, name, reflectionValue)
-        |> commitResultNonThrowing errorOptions "input.fsx" errorLogger
+        let errs = errorLogger.GetErrors()
+        ErrorHelpers.CreateErrorInfos (errorOptions, true, "input.fsx", errs, true)
 
     /// Performs these steps:
     ///    - Load the dummy interaction, if any

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1516,7 +1516,6 @@ type internal FsiDynamicCompiler
         let prefixPath = pathOfLid prefix
         let qualifiedName = ComputeQualifiedNameOfFileFromUniquePath (rangeStdin,prefixPath)
 
-        let tcConfigB = { tcConfigB with implicitlyResolveAssemblies = false }
         let tcConfig = TcConfig.Create(tcConfigB,validate=false)
 
         // Build a simple module with a single 'let' decl with a default value.

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -59,6 +59,9 @@ open Internal.Utilities.StructuredFormat
 
 open Microsoft.DotNet.DependencyManager
 
+// Prevents warnings of experimental APIs - we are using FSharpLexer
+#nowarn "57"
+
 //----------------------------------------------------------------------------
 // For the FSI as a service methods...
 //----------------------------------------------------------------------------
@@ -942,7 +945,70 @@ let internal WithImplicitHome (tcConfigB, dir) f =
     try f() 
     finally tcConfigB.implicitIncludeDir <- old
 
+let internal importReflectionType amap (reflectionTy: Type) =
+    let reflectionTyToILTypeRef (reflectionTy: Type) =
+        let aref = ILAssemblyRef.FromAssemblyName(reflectionTy.Assembly.GetName())
+        let scoref = ILScopeRef.Assembly aref
 
+        let fullName = reflectionTy.FullName
+        let index = fullName.IndexOf("[")
+        let fullName =
+            if index = -1 then
+                fullName
+            else
+                fullName.Substring(0, index - 1)
+
+        let isTop = reflectionTy.DeclaringType = null
+        if isTop then
+            ILTypeRef.Create(scoref, [], fullName)
+        else
+            let names = String.split StringSplitOptions.None [|"+";"."|] fullName
+            let enc = names.[..names.Length - 2]
+            let nm = names.[names.Length - 1]
+            ILTypeRef.Create(scoref, List.ofArray enc, nm)
+
+    let rec reflectionTyToILType (reflectionTy: Type) =
+        let tref = reflectionTyToILTypeRef reflectionTy
+        let genericArgs =
+            reflectionTy.GenericTypeArguments
+            |> Seq.map reflectionTyToILType
+            |> List.ofSeq
+
+        let boxity =
+            if reflectionTy.IsValueType then
+                ILBoxity.AsValue
+            else
+                ILBoxity.AsObject
+
+        let tspec = ILTypeSpec.Create(tref, genericArgs)
+
+        mkILTy boxity tspec           
+
+    let ilTy = reflectionTyToILType reflectionTy
+
+    let rec import (ilTy: ILType) =              
+        Import.ImportILType amap range0 (ilTy.GenericArgs |> List.map import) ilTy
+
+    import ilTy
+
+let internal mkBoundValueTypedImpl tcGlobals m moduleName name ty =
+    let vis = Accessibility.TAccess([])
+    let compPath = (CompilationPath.CompPath(ILScopeRef.Local, []))
+    let mutable mty = Unchecked.defaultof<_>
+    let moduleOrNamespace = Construct.NewModuleOrNamespace (Some compPath) vis (Ident(moduleName, m)) XmlDoc.Empty [] (MaybeLazy.Lazy(lazy mty))
+    let v =
+        Construct.NewVal
+            (name, m, None, ty, ValMutability.Immutable,
+             false, Some(ValReprInfo([], [], { Attribs = []; Name = None })), vis, ValNotInRecScope, None, NormalVal, [], ValInline.Optional,
+             XmlDoc.Empty, true, false, false, false, 
+             false, false, None, Parent(TypedTreeBasics.ERefLocal moduleOrNamespace))
+    mty <- ModuleOrNamespaceType(ModuleOrNamespaceKind.ModuleOrType, QueueList.one v, QueueList.empty)
+
+    let bindExpr = TypedTreeOps.mkCallDefaultOf tcGlobals range0 ty
+    let binding = Binding.TBind(v, bindExpr, NoDebugPointAtLetBinding)
+    let mbinding = ModuleOrNamespaceBinding.Module(moduleOrNamespace, TMDefs([TMDefLet(binding, m)]))
+    let expr = ModuleOrNamespaceExprWithSig(mty, TMDefs([TMDefs[TMDefRec(false, [], [mbinding], m)]]), range0)
+    moduleOrNamespace, v, TypedImplFile.TImplFile(QualifiedNameOfFile.QualifiedNameOfFile(Ident(moduleName, m)), [], expr, false, false, StampMap.Empty)
 
 /// Encapsulates the coordination of the typechecking, optimization and code generation
 /// components of the F# compiler for interactively executed fragments of code.
@@ -995,37 +1061,8 @@ type internal FsiDynamicCompiler
                 (let man = mainModule.ManifestOfAssembly
                  Some { man with  CustomAttrsStored = storeILCustomAttrs (mkILCustomAttrs codegenResults.ilAssemAttrs) }) }
 
-    let ProcessInputs (ctok, errorLogger: ErrorLogger, istate: FsiDynamicCompilerState, inputs: ParsedInput list, showTypes: bool, isIncrementalFragment: bool, isInteractiveItExpr: bool, prefixPath: LongIdent) =
-        let optEnv    = istate.optEnv
-        let emEnv     = istate.emEnv
-        let tcState   = istate.tcState
-        let ilxGenerator = istate.ilxGenerator
-        let tcConfig = TcConfig.Create(tcConfigB,validate=false)
-
-        // Typecheck. The lock stops the type checker running at the same time as the 
-        // server intellisense implementation (which is currently incomplete and #if disabled)
-        let (tcState:TcState),topCustomAttrs,declaredImpls,tcEnvAtEndOfLastInput =
-            lock tcLockObject (fun _ -> TypeCheckClosedInputSet(ctok, errorLogger.CheckForErrors, tcConfig, tcImports, tcGlobals, Some prefixPath, tcState, inputs))
-
-#if DEBUG
-        // Logging/debugging
-        if tcConfig.printAst then
-            for input in declaredImpls do 
-                fprintfn fsiConsoleOutput.Out "AST:" 
-                fprintfn fsiConsoleOutput.Out "%+A" input
-#endif
-
-        errorLogger.AbortOnError(fsiConsoleOutput);
-         
-        let importMap = tcImports.GetImportMap()
-
-        // optimize: note we collect the incremental optimization environment 
-        let optimizedImpls, _optData, optEnv = ApplyAllOptimizations (tcConfig, tcGlobals, (LightweightTcValForUsingInBuildMethodCall tcGlobals), outfile, importMap, isIncrementalFragment, optEnv, tcState.Ccu, declaredImpls)
-        errorLogger.AbortOnError(fsiConsoleOutput);
-            
-        let fragName = textOfLid prefixPath 
-        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, ilxGenerator)
-        errorLogger.AbortOnError(fsiConsoleOutput);
+    let ProcessCodegenResults (ctok, errorLogger: ErrorLogger, istate, optEnv, tcState: TcState, tcConfig, prefixPath, showTypes: bool, isIncrementalFragment, fragName, declaredImpls, ilxGenerator: IlxAssemblyGenerator, codegenResults) =
+        let emEnv = istate.emEnv
 
         // Each input is like a small separately compiled extension to a single source file. 
         // The incremental extension to the environment is dictated by the "signature" of the values as they come out 
@@ -1117,7 +1154,44 @@ type internal FsiDynamicCompiler
                                    tcState   = tcState  }
         
         // Return the new state and the environment at the end of the last input, ready for further inputs.
-        (istate,tcEnvAtEndOfLastInput,declaredImpls)
+        (istate,declaredImpls)
+
+    let ProcessTypedImpl (errorLogger: ErrorLogger, optEnv, tcState: TcState, tcConfig: TcConfig, isInteractiveItExpr, topCustomAttrs, prefixPath, isIncrementalFragment, declaredImpls, ilxGenerator: IlxAssemblyGenerator) =
+        #if DEBUG
+        // Logging/debugging
+        if tcConfig.printAst then
+            for input in declaredImpls do 
+                fprintfn fsiConsoleOutput.Out "AST:" 
+                fprintfn fsiConsoleOutput.Out "%+A" input
+#endif
+
+        errorLogger.AbortOnError(fsiConsoleOutput);
+         
+        let importMap = tcImports.GetImportMap()
+
+        // optimize: note we collect the incremental optimization environment 
+        let optimizedImpls, _optData, optEnv = ApplyAllOptimizations (tcConfig, tcGlobals, (LightweightTcValForUsingInBuildMethodCall tcGlobals), outfile, importMap, isIncrementalFragment, optEnv, tcState.Ccu, declaredImpls)
+        errorLogger.AbortOnError(fsiConsoleOutput);
+            
+        let fragName = textOfLid prefixPath 
+        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, ilxGenerator)
+        errorLogger.AbortOnError(fsiConsoleOutput);
+        codegenResults, optEnv, fragName
+
+    let ProcessInputs (ctok, errorLogger: ErrorLogger, istate: FsiDynamicCompilerState, inputs: ParsedInput list, showTypes: bool, isIncrementalFragment: bool, isInteractiveItExpr: bool, prefixPath: LongIdent) =
+        let optEnv    = istate.optEnv
+        let tcState   = istate.tcState
+        let ilxGenerator = istate.ilxGenerator
+        let tcConfig = TcConfig.Create(tcConfigB,validate=false)
+
+        // Typecheck. The lock stops the type checker running at the same time as the 
+        // server intellisense implementation (which is currently incomplete and #if disabled)
+        let (tcState:TcState),topCustomAttrs,declaredImpls,tcEnvAtEndOfLastInput =
+            lock tcLockObject (fun _ -> TypeCheckClosedInputSet(ctok, errorLogger.CheckForErrors, tcConfig, tcImports, tcGlobals, Some prefixPath, tcState, inputs))
+
+        let codegenResults, optEnv, fragName = ProcessTypedImpl(errorLogger, optEnv, tcState, tcConfig, isInteractiveItExpr, topCustomAttrs, prefixPath, isIncrementalFragment, declaredImpls, ilxGenerator)
+        let newState, declaredImpls = ProcessCodegenResults(ctok, errorLogger, istate, optEnv, tcState, tcConfig, prefixPath, showTypes, isIncrementalFragment, fragName, declaredImpls, ilxGenerator, codegenResults)
+        (newState, tcEnvAtEndOfLastInput, declaredImpls)
 
     let tryGetGeneratedValue istate cenv v =
         match istate.ilxGenerator.LookupGeneratedValue(valuePrinter.GetEvaluationContext(istate.emEnv), v) with
@@ -1131,6 +1205,58 @@ type internal FsiDynamicCompiler
     let mkFragmentPath  i = 
         // NOTE: this text shows in exn traces and type names. Make it clear and fixed width 
         [mkSynId rangeStdin (FsiDynamicModulePrefix + sprintf "%04d" i)]
+
+    let processContents istate declaredImpls =
+        let tcState = istate.tcState
+
+        let mutable itValue = None
+        let mutable boundValues = istate.boundValues
+        try
+            let contents = FSharpAssemblyContents(tcGlobals, tcState.Ccu, Some tcState.CcuSig, tcImports, declaredImpls)
+            let contentFile = contents.ImplementationFiles.[0]
+
+            // Skip the "FSI_NNNN"
+            match contentFile.Declarations with
+            | [FSharpImplementationFileDeclaration.Entity (_eFakeModule,modDecls) ] ->
+                let cenv = SymbolEnv(istate.tcGlobals, istate.tcState.Ccu, Some istate.tcState.CcuSig, istate.tcImports)
+                for decl in modDecls do
+                    match decl with
+                    | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (v,_,_) ->
+                        // Report a top-level function or value definition
+                        if v.IsModuleValueOrMember && not v.IsMember then
+                            let fsiValueOpt =
+                                match v.Item with
+                                | Item.Value vref -> 
+                                    let fsiValueOpt = tryGetGeneratedValue istate cenv vref.Deref
+                                    if fsiValueOpt.IsSome then
+                                        boundValues <- boundValues |> NameMap.add v.CompiledName vref.Deref
+                                    fsiValueOpt
+                                | _ -> None
+
+                            if v.CompiledName = "it" then
+                                itValue <- fsiValueOpt
+
+                            match fsiValueOpt with
+                            | Some fsiValue -> valueBoundEvent.Trigger(fsiValue.ReflectionValue, fsiValue.ReflectionType, v.CompiledName)
+                            | None -> ()
+
+                            let symbol = FSharpSymbol.Create(cenv, v.Item)
+                            let symbolUse = FSharpSymbolUse(tcGlobals, istate.tcState.TcEnvFromImpls.DisplayEnv, symbol, ItemOccurence.Binding, v.DeclarationLocation)
+                            fsi.TriggerEvaluation (fsiValueOpt, symbolUse, decl)
+
+                    | FSharpImplementationFileDeclaration.Entity (e,_) ->
+                        // Report a top-level module or namespace definition
+                        let symbol = FSharpSymbol.Create(cenv, e.Item)
+                        let symbolUse = FSharpSymbolUse(tcGlobals, istate.tcState.TcEnvFromImpls.DisplayEnv, symbol, ItemOccurence.Binding, e.DeclarationLocation)
+                        fsi.TriggerEvaluation (None, symbolUse, decl)
+
+                    | FSharpImplementationFileDeclaration.InitAction _ ->
+                        // Top level 'do' bindings are not reported as incremental declarations
+                        ()
+            | _ -> ()
+        with _ -> ()
+
+        { istate with boundValues = boundValues }, Completed itValue
 
     member __.DynamicAssemblyName = assemblyName
 
@@ -1155,56 +1281,7 @@ type internal FsiDynamicCompiler
         let istate,tcEnvAtEndOfLastInput,declaredImpls = ProcessInputs (ctok, errorLogger, istate, [input], showTypes, true, isInteractiveItExpr, prefix)
         let tcState = istate.tcState 
         let newState = { istate with tcState = tcState.NextStateAfterIncrementalFragment(tcEnvAtEndOfLastInput) }
-
-        // Find all new declarations the EvaluationListener
-        let mutable itValue = None
-        let mutable boundValues = newState.boundValues
-        try
-            let contents = FSharpAssemblyContents(tcGlobals, tcState.Ccu, Some tcState.CcuSig, tcImports, declaredImpls)
-            let contentFile = contents.ImplementationFiles.[0]
-
-            // Skip the "FSI_NNNN"
-            match contentFile.Declarations with
-            | [FSharpImplementationFileDeclaration.Entity (_eFakeModule,modDecls) ] ->
-                let cenv = SymbolEnv(newState.tcGlobals, newState.tcState.Ccu, Some newState.tcState.CcuSig, newState.tcImports)
-                for decl in modDecls do
-                    match decl with
-                    | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (v,_,_) ->
-                        // Report a top-level function or value definition
-                        if v.IsModuleValueOrMember && not v.IsMember then
-                            let fsiValueOpt =
-                                match v.Item with
-                                | Item.Value vref -> 
-                                    let fsiValueOpt = tryGetGeneratedValue newState cenv vref.Deref
-                                    if fsiValueOpt.IsSome then
-                                        boundValues <- boundValues |> NameMap.add v.CompiledName vref.Deref
-                                    fsiValueOpt
-                                | _ -> None
-
-                            if v.CompiledName = "it" then
-                                itValue <- fsiValueOpt
-
-                            match fsiValueOpt with
-                            | Some fsiValue -> valueBoundEvent.Trigger(fsiValue.ReflectionValue, fsiValue.ReflectionType, v.CompiledName)
-                            | None -> ()
-
-                            let symbol = FSharpSymbol.Create(cenv, v.Item)
-                            let symbolUse = FSharpSymbolUse(tcGlobals, newState.tcState.TcEnvFromImpls.DisplayEnv, symbol, ItemOccurence.Binding, v.DeclarationLocation)
-                            fsi.TriggerEvaluation (fsiValueOpt, symbolUse, decl)
-
-                    | FSharpImplementationFileDeclaration.Entity (e,_) ->
-                        // Report a top-level module or namespace definition
-                        let symbol = FSharpSymbol.Create(cenv, e.Item)
-                        let symbolUse = FSharpSymbolUse(tcGlobals, newState.tcState.TcEnvFromImpls.DisplayEnv, symbol, ItemOccurence.Binding, e.DeclarationLocation)
-                        fsi.TriggerEvaluation (None, symbolUse, decl)
-
-                    | FSharpImplementationFileDeclaration.InitAction _ ->
-                        // Top level 'do' bindings are not reported as incremental declarations
-                        ()
-            | _ -> ()
-        with _ -> ()
-
-        { newState with boundValues = boundValues }, Completed itValue
+        processContents newState declaredImpls
 
     /// Evaluate the given expression and produce a new interactive state.
     member fsiDynamicCompiler.EvalParsedExpression (ctok, errorLogger: ErrorLogger, istate, expr: SynExpr) =
@@ -1417,6 +1494,44 @@ type internal FsiDynamicCompiler
                 None
         | _ ->
             None
+
+    member __.AddBoundValue (ctok, errorLogger: ErrorLogger, istate, name: string, value: obj) =
+        let name =
+            let mutable token = Unchecked.defaultof<_>
+            SourceCodeServices.Lexer.FSharpLexer.Lex(SourceText.ofString name, fun t -> token <- t)
+            if not token.IsIdentifier then
+                errorLogger.Error(Error(FSComp.SR.parsUnexpectedIdentifier name, range0))
+            name
+        let amap = istate.tcImports.GetImportMap()
+        let ty = importReflectionType amap (value.GetType())
+
+        let i = nextFragmentId()
+        let prefix = mkFragmentPath i
+        let prefixPath = pathOfLid prefix
+        let qualifiedName = ComputeQualifiedNameOfFileFromUniquePath (rangeStdin,prefixPath)
+
+        let tcConfig = TcConfig.Create(tcConfigB,validate=false)
+
+        // Build a simple module with a single 'let' decl with a default value.
+        let moduleOrNamespace, v, impl = mkBoundValueTypedImpl istate.tcGlobals range0 qualifiedName.Text name ty
+        let tcEnvAtEndOfLastInput = 
+            TypeChecker.AddLocalSubModule tcGlobals amap range0 istate.tcState.TcEnvFromImpls moduleOrNamespace
+            |> TypeChecker.AddLocalVal TcResultsSink.NoSink range0 v
+
+        // Generate IL for the given typled impl and create new interactive state.
+        let ilxGenerator = istate.ilxGenerator
+        let isIncrementalFragment = true
+        let showTypes = false
+        let declaredImpls = [impl]
+        let codegenResults, optEnv, fragName = ProcessTypedImpl(errorLogger, istate.optEnv, istate.tcState, tcConfig, false, EmptyTopAttrs, prefix, isIncrementalFragment, declaredImpls, ilxGenerator)
+        let istate, declaredImpls = ProcessCodegenResults(ctok, errorLogger, istate, optEnv, istate.tcState, tcConfig, prefix, showTypes, isIncrementalFragment, fragName, declaredImpls, ilxGenerator, codegenResults)
+        let newState = { istate with tcState = istate.tcState.NextStateAfterIncrementalFragment tcEnvAtEndOfLastInput }
+
+        // Force set the val with the given value obj.
+        let ctxt = valuePrinter.GetEvaluationContext(newState.emEnv)
+        ilxGenerator.ForceSetGeneratedValue(ctxt, v, value)
+
+        fst (processContents newState declaredImpls)
     
     member __.GetInitialInteractiveState () =
         let tcConfig = TcConfig.Create(tcConfigB,validate=false)
@@ -2274,6 +2389,12 @@ type internal FsiInteractionProcessor
             mainThreadProcessParsedExpression ctok errorLogger (exprWithSeq, istate))
         |> commitResult
 
+    member __.AddBoundValue(ctok, errorLogger, name, value: obj) =
+        currState 
+        |> InteractiveCatch errorLogger (fun istate -> 
+            fsiDynamicCompiler.AddBoundValue(ctok, errorLogger, istate, name, value), Completed None)
+        |> commitResult
+
     member __.PartialAssemblySignatureUpdated = event.Publish
 
     /// Start the background thread used to read the input reader and/or console
@@ -2794,6 +2915,18 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     member __.TryFindBoundValue(name: string) =
         fsiDynamicCompiler.TryFindBoundValue(fsiInteractionProcessor.CurrentState, name)
+
+    member __.AddBoundValue(name: string, reflectionValue: obj) =
+        // Explanation: When the user of the FsiInteractiveSession object calls this method, the 
+        // code is parsed, checked and evaluated on the calling thread. This means EvalExpression
+        // is not safe to call concurrently.
+        let ctok = AssumeCompilationThreadWithoutEvidence()
+
+        let errorOptions = TcConfig.Create(tcConfigB, validate = false).errorSeverityOptions
+        let errorLogger = CompilationErrorLogger("AddBoundValue", errorOptions)
+        fsiInteractionProcessor.AddBoundValue(ctok, errorLogger, name, reflectionValue)
+        |> commitResult
+        |> ignore
 
     /// Performs these steps:
     ///    - Load the dummy interaction, if any

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -267,9 +267,9 @@ type FsiEvaluationSession =
     member TryFindBoundValue : name: string -> FsiBoundValue option
 
     /// Creates a root-level value with the given name and .NET object.
-    /// This will throw if the .NET object contains types from assemblies that are not referenced in the interactive session.
+    /// If the .NET object contains types from assemblies that are not referenced in the interactive session, it will try to implicitly resolve them by default configuration.
     /// Name must be a valid identifier.
-    member AddBoundValue : name: string * reflectionValue: obj -> unit
+    member AddBoundValue : name: string * reflectionValue: obj -> Choice<FsiValue option, exn> * FSharpErrorInfo[]
 
     /// Load the dummy interaction, load the initial files, and,
     /// if interacting, start the background thread to read the standard input.

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -266,6 +266,11 @@ type FsiEvaluationSession =
     /// Tries to find a root-level value that is bound to the given identifier
     member TryFindBoundValue : name: string -> FsiBoundValue option
 
+    /// Creates a root-level value with the given name and .NET object.
+    /// This will throw if the .NET object contains types from assemblies that are not referenced in the interactive session.
+    /// Name must be a valid identifier.
+    member AddBoundValue : name: string * reflectionValue: obj -> unit
+
     /// Load the dummy interaction, load the initial files, and,
     /// if interacting, start the background thread to read the standard input.
     ///

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -269,7 +269,7 @@ type FsiEvaluationSession =
     /// Creates a root-level value with the given name and .NET object.
     /// If the .NET object contains types from assemblies that are not referenced in the interactive session, it will try to implicitly resolve them by default configuration.
     /// Name must be a valid identifier.
-    member AddBoundValue : name: string * reflectionValue: obj -> Choice<FsiValue option, exn> * FSharpErrorInfo[]
+    member AddBoundValue : name: string * reflectionValue: obj -> FSharpErrorInfo[]
 
     /// Load the dummy interaction, load the initial files, and,
     /// if interacting, start the background thread to read the standard input.

--- a/tests/FSharp.Compiler.UnitTests/FsiTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/FsiTests.fs
@@ -250,7 +250,7 @@ let ``Values are successfully shadowed even with intermediate interactions`` () 
 let ``Creation of a simple bound value succeeds`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("x", 1)
+    let errors = fsiSession.AddBoundValue("x", 1)
     Assert.IsEmpty errors
 
     let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
@@ -263,7 +263,7 @@ let ``Creation of a simple bound value succeeds`` () =
 let ``Creation of a bound value succeeds with underscores in the identifier`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("x_y_z", 1)
+    let errors = fsiSession.AddBoundValue("x_y_z", 1)
     Assert.IsEmpty errors
 
     let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
@@ -274,7 +274,7 @@ let ``Creation of a bound value succeeds with underscores in the identifier`` ()
 let ``Creation of a bound value succeeds with tildes in the identifier`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("``hello world``", 1)
+    let errors = fsiSession.AddBoundValue("``hello world``", 1)
     Assert.IsEmpty errors
 
     let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
@@ -282,10 +282,29 @@ let ``Creation of a bound value succeeds with tildes in the identifier`` () =
     Assert.AreEqual("``hello world``", boundValue.Name)
 
 [<Test>]
+let ``Creation of a bound value succeeds with 'it' as the indentifier`` () =
+    use fsiSession = createFsiSession ()
+
+    fsiSession.EvalInteraction("\"test\"")
+
+    let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
+
+    Assert.AreEqual("it", boundValue.Name)
+    Assert.AreEqual(typeof<string>, boundValue.Value.ReflectionType)
+
+    let errors = fsiSession.AddBoundValue("it", 1)
+    Assert.IsEmpty errors
+
+    let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
+
+    Assert.AreEqual("it", boundValue.Name)
+    Assert.AreEqual(typeof<int>, boundValue.Value.ReflectionType)
+
+[<Test>]
 let ``Creation of a bound value succeeds with tildes in the identifier and with 'at' but has warning`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("``hello @ world``", 1)
+    let errors = fsiSession.AddBoundValue("``hello @ world``", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Warning, error.Severity)
@@ -299,7 +318,7 @@ let ``Creation of a bound value succeeds with tildes in the identifier and with 
 let ``Creation of a bound value fails if the name is not a valid identifier with 'at' in front`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("@x", 1)
+    let errors = fsiSession.AddBoundValue("@x", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -309,7 +328,7 @@ let ``Creation of a bound value fails if the name is not a valid identifier with
 let ``Creation of a bound value fails if the name is not a valid identifier with 'at' in back`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("x@", 1)
+    let errors = fsiSession.AddBoundValue("x@", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -319,7 +338,7 @@ let ``Creation of a bound value fails if the name is not a valid identifier with
 let ``Creation of a bound value fails if the name is null`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue(null, 1)
+    let errors = fsiSession.AddBoundValue(null, 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -329,7 +348,7 @@ let ``Creation of a bound value fails if the name is null`` () =
 let ``Creation of a bound value fails if the name is empty`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("", 1)
+    let errors = fsiSession.AddBoundValue("", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -339,7 +358,7 @@ let ``Creation of a bound value fails if the name is empty`` () =
 let ``Creation of a bound value fails if the name is whitespace`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue(" ", 1)
+    let errors = fsiSession.AddBoundValue(" ", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -349,7 +368,7 @@ let ``Creation of a bound value fails if the name is whitespace`` () =
 let ``Creation of a bound value fails if the name contains spaces`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("x x", 1)
+    let errors = fsiSession.AddBoundValue("x x", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -359,7 +378,7 @@ let ``Creation of a bound value fails if the name contains spaces`` () =
 let ``Creation of a bound value fails if the name contains an operator at the end`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("x+", 1)
+    let errors = fsiSession.AddBoundValue("x+", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -369,7 +388,7 @@ let ``Creation of a bound value fails if the name contains an operator at the en
 let ``Creation of a bound value fails if the name contains an operator at the front`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("+x", 1)
+    let errors = fsiSession.AddBoundValue("+x", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -379,7 +398,7 @@ let ``Creation of a bound value fails if the name contains an operator at the fr
 let ``Creation of a bound value fails if the name contains dots`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("x.x", 1)
+    let errors = fsiSession.AddBoundValue("x.x", 1)
     let error = errors |> Array.exactlyOne
 
     Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
@@ -389,14 +408,14 @@ let ``Creation of a bound value fails if the name contains dots`` () =
 let ``Creation of a bound value succeeds if the value contains types from assemblies that are not referenced in the session, due to implicit resolution`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("x", { X = 1 })
+    let errors = fsiSession.AddBoundValue("x", { X = 1 })
     Assert.IsEmpty errors
 
 [<Test>]
 let ``Creation of a bound value succeeds if the value contains types from assemblies that are not referenced in the session, due to implicit resolution, and then doing some evaluation`` () =
     use fsiSession = createFsiSession ()
 
-    let _, errors = fsiSession.AddBoundValue("x", { X = 1 })
+    let errors = fsiSession.AddBoundValue("x", { X = 1 })
     Assert.IsEmpty errors
 
     fsiSession.EvalInteraction("let y = { x with X = 5 }")

--- a/tests/FSharp.Compiler.UnitTests/FsiTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/FsiTests.fs
@@ -376,6 +376,16 @@ let ``Creation of a bound value fails if the name contains an operator at the fr
     Assert.AreEqual("Identifier expected", error.Message)
 
 [<Test>]
+let ``Creation of a bound value fails if the name contains dots`` () =
+    use fsiSession = createFsiSession ()
+
+    let _, errors = fsiSession.AddBoundValue("x.x", 1)
+    let error = errors |> Array.exactlyOne
+
+    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
+    Assert.AreEqual("Identifier expected", error.Message)
+
+[<Test>]
 let ``Creation of a bound value succeeds if the value contains types from assemblies that are not referenced in the session, due to implicit resolution`` () =
     use fsiSession = createFsiSession ()
 


### PR DESCRIPTION
Allows the programmatic creation of named values with an actual instantiated object in a `FsiEvaluationSession` at the root-level via a method call: `fsiSession.AddBoundValue("x", 1)`. The value will be immutable(we could add an option later to make it mutable if we want).

A few notes:

- An object passed in that contains types that are not yet referenced by the interactive session can be implicitly resolved if FSI itself is configured to do so.

- The name of the value, or the identifier, must be valid like any other identifier in its context.
    - The rules for this was a little tricky to implement, there could be a better way to handle it; so far, it works as intended and the tests cover the cases AFAIK.