### PR TITLE
Use roslyn API to display extended completion and fix quirks with scripts/top of file

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -139,10 +139,10 @@ type internal FSharpCompletionProvider
 
             declarationItems |> Array.iteri (fun number declarationItem ->
                 let glyph = Tokenizer.FSharpGlyphToRoslynGlyph (declarationItem.Glyph, declarationItem.Accessibility)
-                let name =
+                let namespaceName =
                     match declarationItem.NamespaceToOpen with
-                    | Some namespaceToOpen -> sprintf "%s (open %s)" declarationItem.Name namespaceToOpen
-                    | _ -> declarationItem.Name
+                    | Some namespaceToOpen -> namespaceToOpen
+                    | _ -> null // Icky, but this is how roslyn handles it
                     
                 let filterText =
                     match declarationItem.NamespaceToOpen, declarationItem.Name.Split '.' with
@@ -153,8 +153,14 @@ type internal FSharpCompletionProvider
                     | _, idents -> Array.last idents
 
                 let completionItem = 
-                    FSharpCommonCompletionItem.Create(name, null, rules = getRules intellisenseOptions.ShowAfterCharIsTyped, glyph = Nullable glyph, filterText = filterText)
-                                        .AddProperty(FullNamePropName, declarationItem.FullName)
+                    FSharpCommonCompletionItem.Create(
+                        declarationItem.Name,
+                        null,
+                        rules = getRules intellisenseOptions.ShowAfterCharIsTyped,
+                        glyph = Nullable glyph,
+                        filterText = filterText,
+                        inlineDescription = namespaceName)
+                        .AddProperty(FullNamePropName, declarationItem.FullName)
                         
                 let completionItem =
                     match declarationItem.Kind with
@@ -163,7 +169,7 @@ type internal FSharpCompletionProvider
                     | _ -> completionItem
                 
                 let completionItem =
-                    if name <> declarationItem.NameInCode then
+                    if declarationItem.Name <> declarationItem.NameInCode then
                         completionItem.AddProperty(NameInCodePropName, declarationItem.NameInCode)
                     else completionItem
 


### PR DESCRIPTION
Looks like this with the change

![image](https://user-images.githubusercontent.com/6309070/81525430-7bd88e80-9309-11ea-9802-8fc224be19ab.png)

What's neat about this is that the completion window will resize dynamically as the items to the right get larger. This also happens as you scroll, so if you have some items with a giant namespace but they aren't visible in the window, the window won't get large until they are visible. This is all just the Roslyn tooling infrastructure under the hood powering this. We only need to pass in a string 🙂 

Also fixes #9167, #9166 