### PR TITLE
Remove blocking members from FSharpDeclarationListItem

### DIFF
--- a/src/fsharp/service/ServiceDeclarationLists.fs
+++ b/src/fsharp/service/ServiceDeclarationLists.fs
@@ -23,13 +23,6 @@ open FSharp.Compiler.Range
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
 
-[<AutoOpen>]
-module EnvMisc3 =
-    /// dataTipSpinWaitTime limits how long we block the UI thread while a tooltip pops up next to a selected item in an IntelliSense completion list.
-    /// This time appears to be somewhat amortized by the time it takes the VS completion UI to actually bring up the tooltip after selecting an item in the first place.
-    let dataTipSpinWaitTime = GetEnvInteger "FCS_ToolTipSpinWaitTime" 5000
-
-
 [<Sealed>]
 /// Represents one parameter for one method (or other item) in a group. 
 type FSharpMethodGroupItemParameter(name: string, canonicalTypeTextForSorting: string, display: layout, isOptional: bool) = 
@@ -482,10 +475,6 @@ module internal DescriptionListsImpl =
 [<Sealed>]
 type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: string, glyph: FSharpGlyph, info, accessibility: FSharpAccessibility option,
                                kind: CompletionItemKind, isOwnMember: bool, priority: int, isResolved: bool, namespaceToOpen: string option) =
-
-    let mutable descriptionTextHolder: FSharpToolTipText<_> option = None
-    let mutable task = null
-
     member __.Name = name
     member __.NameInCode = nameInCode
 
@@ -505,34 +494,6 @@ type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: strin
         decl.StructuredDescriptionTextAsync
         |> Tooltips.Map Tooltips.ToFSharpToolTipText
 
-    member decl.StructuredDescriptionText = 
-      ErrorScope.Protect Range.range0 
-       (fun () -> 
-        match descriptionTextHolder with
-        | Some descriptionText -> descriptionText
-        | None ->
-            match info with
-            | Choice1Of2 _ -> 
-                // The dataTipSpinWaitTime limits how long we block the UI thread while a tooltip pops up next to a selected item in an IntelliSense completion list.
-                // This time appears to be somewhat amortized by the time it takes the VS completion UI to actually bring up the tooltip after selecting an item in the first place.
-                if isNull task then
-                    // kick off the actual (non-cooperative) work
-                    task <- System.Threading.Tasks.Task.Factory.StartNew(fun() -> 
-                        let text = decl.StructuredDescriptionTextAsync |> Async.RunSynchronously
-                        descriptionTextHolder <- Some text) 
-
-                // The dataTipSpinWaitTime limits how long we block the UI thread while a tooltip pops up next to a selected item in an IntelliSense completion list.
-                // This time appears to be somewhat amortized by the time it takes the VS completion UI to actually bring up the tooltip after selecting an item in the first place.
-                task.Wait EnvMisc3.dataTipSpinWaitTime  |> ignore
-                match descriptionTextHolder with 
-                | Some text -> text
-                | None -> FSharpToolTipText [ FSharpStructuredToolTipElement.Single(wordL (tagText (FSComp.SR.loadingDescription())), FSharpXmlDoc.None) ]
-
-            | Choice2Of2 result -> 
-                result
-       )
-       (fun err -> FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError err])
-    member decl.DescriptionText = decl.StructuredDescriptionText |> Tooltips.ToFSharpToolTipText
     member __.Glyph = glyph 
     member __.Accessibility = accessibility
     member __.Kind = kind

--- a/src/fsharp/service/ServiceDeclarationLists.fsi
+++ b/src/fsharp/service/ServiceDeclarationLists.fsi
@@ -20,14 +20,6 @@ type public FSharpDeclarationListItem =
     /// Get the name for the declaration as it's presented in source code.
     member NameInCode : string
 
-    /// Get the description text for the declaration. Computing this property may require using compiler
-    /// resources and may trigger execution of a type provider method to retrieve documentation.
-    ///
-    /// May return "Loading..." if timeout occurs
-    member StructuredDescriptionText : FSharpStructuredToolTipText
-
-    member DescriptionText : FSharpToolTipText
-
     /// Get the description text, asynchronously.  Never returns "Loading...".
     member StructuredDescriptionTextAsync : Async<FSharpStructuredToolTipText>
 

--- a/vsintegration/src/FSharp.LanguageService/Intellisense.fs
+++ b/vsintegration/src/FSharp.LanguageService/Intellisense.fs
@@ -183,7 +183,7 @@ type internal FSharpDeclarations_DEPRECATED(documentationBuilder, declarations: 
         let decls = trimmedDeclarations filterText
         if (index >= 0 && index < decls.Length) then
             let buf = Text.StringBuilder()
-            XmlDocumentation.BuildDataTipText_DEPRECATED(documentationBuilder, TaggedText.appendTo buf, TaggedText.appendTo buf, decls.[index].StructuredDescriptionText) 
+            XmlDocumentation.BuildDataTipText_DEPRECATED(documentationBuilder, TaggedText.appendTo buf, TaggedText.appendTo buf, decls.[index].StructuredDescriptionTextAsync |> Async.RunSynchronously) 
             buf.ToString()
         else ""
 


### PR DESCRIPTION
The asynchronous versions of these members are what are used in tools. These legacy members will just block on the caller for up to 5 seconds which is madness. Also removed all the comments about this, since those stem from _at least_ F# 3.0 days and refer to behavior in Visual Studio that has long since been outdated (at least since VS 2017 when we replaced the language service host, and certainly in VS 2019 when all completion was made asynchronous by default). No editor tooling should be calling these members.