### PR TITLE
Eliminate tuple allocations in seekReadCustomAttributeRow via a custom reader for attribute rows

### DIFF
--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -12,6 +12,7 @@ module FSharp.Compiler.AbstractIL.ILBinaryReader
 open System
 open System.Collections.Concurrent
 open System.Collections.Generic
+open System.Collections.Immutable
 open System.Diagnostics
 open System.IO
 open System.IO.MemoryMappedFiles
@@ -80,7 +81,7 @@ let uncodedTokenToMethodDefOrRef (tab, tok) =
     TaggedIndex(tag, tok)
 
 let (|TaggedIndex|) (x: TaggedIndex<'T>) = x.tag, x.index    
-let tokToTaggedIdx f nbits tok = 
+let inline tokToTaggedIdx f nbits tok = 
     let tagmask = 
         if nbits = 1 then 1 
         elif nbits = 2 then 3 
@@ -814,7 +815,7 @@ let seekReadIndexedRows (numRows, rowReader, keyFunc, keyComparer, binaryChop, r
             let rowinfo = rowReader i
             if keyComparer (keyFunc rowinfo) = 0 then 
               res := rowConverter rowinfo :: !res
-        List.rev !res  
+        List.rev !res
 
 
 let seekReadOptionalIndexedRow info =
@@ -831,7 +832,7 @@ let seekReadIndexedRow info =
     | None -> failwith ("no row found for key when indexing table")
 
 //---------------------------------------------------------------------
-// The big fat reader.
+// IL Reading proper
 //---------------------------------------------------------------------
 
 type MethodData = MethodData of ILType * ILCallingConv * string * ILTypes * ILType * ILTypes
@@ -932,7 +933,83 @@ type ILMetadataReader =
     securityDeclsReader_MethodDef: ILSecurityDeclsStored
     securityDeclsReader_Assembly: ILSecurityDeclsStored
     typeDefReader: ILTypeDefStored }
-   
+
+type ISeekReadIndexedRowReader<'RowT, 'KeyT, 'T when 'RowT : struct> =
+    abstract GetRow: int * byref<'RowT> -> unit
+    abstract GetKey: byref<'RowT> -> 'KeyT
+    abstract CompareKey: 'KeyT -> int
+    abstract ConvertRow: byref<'RowT> -> 'T
+
+let seekReadIndexedRowsByInterface numRows binaryChop (reader: ISeekReadIndexedRowReader<'RowT, _, _>) =
+    let mutable row = Unchecked.defaultof<'RowT>
+    if binaryChop then
+        let mutable low = 0
+        let mutable high = numRows + 1
+
+        let mutable fin = false
+        while not fin do 
+            if high - low <= 1  then 
+                fin <- true 
+            else 
+                let mid = (low + high) / 2
+                reader.GetRow(mid, &row)
+                let c = reader.CompareKey(reader.GetKey(&row))
+                if c > 0 then 
+                    low <- mid
+                elif c < 0 then 
+                    high <- mid 
+                else 
+                    fin <- true
+
+        let res = ImmutableArray.CreateBuilder()
+        if high - low > 1 then 
+            // now read off rows, forward and backwards 
+            let mid = (low + high) / 2
+
+            // read backwards 
+            let mutable fin = false
+            let mutable curr = mid - 1
+            while not fin do 
+                if curr = 0 then 
+                    fin <- true
+                else  
+                    reader.GetRow(curr, &row)
+                    if reader.CompareKey(reader.GetKey(&row)) = 0 then
+                        res.Add(reader.ConvertRow(&row))
+                    else 
+                        fin <- true
+                curr <- curr - 1
+
+            res.Reverse()
+
+            // read forward 
+            let mutable fin = false
+            let mutable curr = mid
+            while not fin do 
+                if curr > numRows then 
+                    fin <- true
+                else 
+                    reader.GetRow(curr, &row)
+                    if reader.CompareKey(reader.GetKey(&row)) = 0 then
+                        res.Add(reader.ConvertRow(&row))
+                    else 
+                        fin <- true
+                    curr <- curr + 1
+
+        res.ToArray()
+    else 
+        let res = ImmutableArray.CreateBuilder()
+        for i = 1 to numRows do
+            reader.GetRow(i, &row)
+            if reader.CompareKey(reader.GetKey(&row)) = 0 then 
+              res.Add(reader.ConvertRow(&row))
+        res.ToArray()
+
+[<Struct>]
+type CustomAttributeRow =
+    val mutable parentIndex: TaggedIndex<HasCustomAttributeTag>
+    val mutable typeIndex: TaggedIndex<CustomAttributeTypeTag>
+    val mutable valueIndex: int
 
 let seekReadUInt16Adv mdv (addr: byref<int>) =  
     let res = seekReadUInt16 mdv addr
@@ -949,17 +1026,15 @@ let seekReadUInt16AsInt32Adv mdv (addr: byref<int>) =
     addr <- addr+2
     res
 
-let seekReadTaggedIdx f nbits big mdv (addr: byref<int>) =  
+let inline seekReadTaggedIdx f nbits big mdv (addr: byref<int>) =  
     let tok = if big then seekReadInt32Adv mdv &addr else seekReadUInt16AsInt32Adv mdv &addr 
     tokToTaggedIdx f nbits tok
-
 
 let seekReadIdx big mdv (addr: byref<int>) =  
     if big then seekReadInt32Adv mdv &addr else seekReadUInt16AsInt32Adv mdv &addr
 
 let seekReadUntaggedIdx (tab: TableName) (ctxt: ILMetadataReader) mdv (addr: byref<int>) =  
     seekReadIdx ctxt.tableBigness.[tab.Index] mdv &addr
-
 
 let seekReadResolutionScopeIdx (ctxt: ILMetadataReader) mdv (addr: byref<int>) = seekReadTaggedIdx mkResolutionScopeTag 2 ctxt.rsBigness mdv &addr
 let seekReadTypeDefOrRefOrSpecIdx (ctxt: ILMetadataReader) mdv (addr: byref<int>) = seekReadTaggedIdx mkTypeDefOrRefOrSpecTag 2 ctxt.tdorBigness mdv &addr   
@@ -1064,13 +1139,11 @@ let seekReadConstantRowUncached ctxtH idx =
     (kind, parentIdx, valIdx)
 
 /// Read Table CustomAttribute.
-let seekReadCustomAttributeRow (ctxt: ILMetadataReader) idx =
-    let mdv = ctxt.mdfile.GetView()
+let seekReadCustomAttributeRow (ctxt: ILMetadataReader) mdv idx (attrRow: byref<CustomAttributeRow>) =
     let mutable addr = ctxt.rowAddr TableNames.CustomAttribute idx
-    let parentIdx = seekReadHasCustomAttributeIdx ctxt mdv &addr
-    let typeIdx = seekReadCustomAttributeTypeIdx ctxt mdv &addr
-    let valIdx = seekReadBlobIdx ctxt mdv &addr
-    struct (parentIdx, typeIdx, valIdx)  
+    attrRow.parentIndex <- seekReadHasCustomAttributeIdx ctxt mdv &addr
+    attrRow.typeIndex <- seekReadCustomAttributeTypeIdx ctxt mdv &addr
+    attrRow.valueIndex <- seekReadBlobIdx ctxt mdv &addr
 
 /// Read Table FieldMarshal.
 let seekReadFieldMarshalRow (ctxt: ILMetadataReader) mdv idx = 
@@ -2351,14 +2424,17 @@ and seekReadProperties (ctxt: ILMetadataReader) numtypars tidx =
 
 and customAttrsReader ctxtH tag: ILAttributesStored = 
     mkILCustomAttrsReader
-      (fun idx -> 
-          let (ctxt: ILMetadataReader) = getHole ctxtH
-          seekReadIndexedRows (ctxt.getNumRows TableNames.CustomAttribute, 
-                                  seekReadCustomAttributeRow ctxt, (fun struct (a, _, _) -> a), 
-                                  hcaCompare (TaggedIndex(tag,idx)), 
-                                  isSorted ctxt TableNames.CustomAttribute, 
-                                  (fun struct (_, b, c) -> seekReadCustomAttr ctxt (b, c)))
-          |> List.toArray)
+        (fun idx -> 
+            let (ctxt: ILMetadataReader) = getHole ctxtH
+            let mdv = ctxt.mdfile.GetView()
+            let reader =
+                { new ISeekReadIndexedRowReader<CustomAttributeRow, TaggedIndex<HasCustomAttributeTag>, ILAttribute> with
+                    member _.GetRow(i, row) = seekReadCustomAttributeRow ctxt mdv i &row
+                    member _.GetKey(attrRow) = attrRow.parentIndex
+                    member _.CompareKey(key) = hcaCompare (TaggedIndex(tag, idx)) key
+                    member _.ConvertRow(attrRow) = seekReadCustomAttr ctxt (attrRow.typeIndex, attrRow.valueIndex)
+                }
+            seekReadIndexedRowsByInterface (ctxt.getNumRows TableNames.CustomAttribute) (isSorted ctxt TableNames.CustomAttribute) reader)
 
 and seekReadCustomAttr ctxt (TaggedIndex(cat, idx), b) = 
     ctxt.seekReadCustomAttr (CustomAttrIdx (cat, idx, b))

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -1070,7 +1070,7 @@ let seekReadCustomAttributeRow (ctxt: ILMetadataReader) idx =
     let parentIdx = seekReadHasCustomAttributeIdx ctxt mdv &addr
     let typeIdx = seekReadCustomAttributeTypeIdx ctxt mdv &addr
     let valIdx = seekReadBlobIdx ctxt mdv &addr
-    (parentIdx, typeIdx, valIdx)  
+    struct (parentIdx, typeIdx, valIdx)  
 
 /// Read Table FieldMarshal.
 let seekReadFieldMarshalRow (ctxt: ILMetadataReader) mdv idx = 
@@ -2354,10 +2354,10 @@ and customAttrsReader ctxtH tag: ILAttributesStored =
       (fun idx -> 
           let (ctxt: ILMetadataReader) = getHole ctxtH
           seekReadIndexedRows (ctxt.getNumRows TableNames.CustomAttribute, 
-                                  seekReadCustomAttributeRow ctxt, (fun (a, _, _) -> a), 
+                                  seekReadCustomAttributeRow ctxt, (fun struct (a, _, _) -> a), 
                                   hcaCompare (TaggedIndex(tag,idx)), 
                                   isSorted ctxt TableNames.CustomAttribute, 
-                                  (fun (_, b, c) -> seekReadCustomAttr ctxt (b, c)))
+                                  (fun struct (_, b, c) -> seekReadCustomAttr ctxt (b, c)))
           |> List.toArray)
 
 and seekReadCustomAttr ctxt (TaggedIndex(cat, idx), b) = 


### PR DESCRIPTION
This PR is more for folks like @dsyme and @TIHan to look at and see what they think.

From this issue: https://developercommunity.visualstudio.com/content/problem/1035124/trace-of-editing-experience-with-in-memory-cross-p-1.html

The submitted trace showed 120MB of allocations coming from this function, most of which are 3-tuples (~5.7% of all allocations in the sample):

![image](https://user-images.githubusercontent.com/6309070/82162392-ee40f580-9858-11ea-9073-31bff4687a06.png)

It's also 0.7% of total CPU time:

![image](https://user-images.githubusercontent.com/6309070/82162408-03b61f80-9859-11ea-817a-497da00e0f81.png)

Since the data being generated is all small value types, maybe a struct tuple would be better here.

Looking through what all calls this and the frequency, it looks like it's just a part of normal compiler routines so if we think this would speed things up a bit then that'd be nice.