### PR TITLE
ColumnsOfCurrentToken to struct tuple in ServiceLexing

### DIFF
--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -616,7 +616,7 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf,
                     | Some mx when rightp.Line > leftp.Line -> mx
                     | _ -> rightp.Column
                 let rightc = rightc - 1
-                leftc, rightc
+                struct (leftc, rightc)
 
             // Get the token & position - either from a stack or from the lexer
             try
@@ -624,7 +624,7 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf,
                 else
                   // Choose which lexer entry point to call and call it
                   let token = LexerStateEncoding.callLexCont lexcontInitial lexargs skip lexbuf
-                  let leftc, rightc = ColumnsOfCurrentToken()
+                  let struct (leftc, rightc) = ColumnsOfCurrentToken()
 
                   // Splits tokens like ">." into multiple tokens - this duplicates behavior from the 'lexfilter'
                   // which cannot be (easily) used from the language service. The rules here are not always valid,


### PR DESCRIPTION
In a trace from here: https://developercommunity.visualstudio.com/content/problem/1035124/trace-of-editing-experience-with-in-memory-cross-p-1.html

I found what looked like needless allocations of a tuple of two integers:

![image](https://user-images.githubusercontent.com/6309070/82162772-d9199600-985b-11ea-8304-f7d98a0ec5b8.png)

Seems like a perfect candidate to turn into a struct.