### PR TITLE
Seekreadcompresseduint32 to struct tuple

### DIFF
--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -1550,11 +1550,10 @@ and readBlobHeapAsTypeName ctxt (nameIdx, namespaceIdx) =
 
 and seekReadTypeDefRowExtents (ctxt: ILMetadataReader) _info (idx: int) =
     if idx >= ctxt.getNumRows TableNames.TypeDef then 
-        ctxt.getNumRows TableNames.Field + 1, 
-        ctxt.getNumRows TableNames.Method + 1
+        struct (ctxt.getNumRows TableNames.Field + 1, ctxt.getNumRows TableNames.Method + 1)
     else
         let (_, _, _, _, fieldsIdx, methodsIdx) = seekReadTypeDefRow ctxt (idx + 1)
-        fieldsIdx, methodsIdx 
+        struct (fieldsIdx, methodsIdx )
 
 and seekReadTypeDefRowWithExtents ctxt (idx: int) =
     let info= seekReadTypeDefRow ctxt idx
@@ -1578,7 +1577,7 @@ and typeDefReader ctxtH: ILTypeDefStored =
 
            let ((flags, nameIdx, namespaceIdx, extendsIdx, fieldsIdx, methodsIdx) as info) = seekReadTypeDefRow ctxt idx
            let nm = readBlobHeapAsTypeName ctxt (nameIdx, namespaceIdx)
-           let (endFieldsIdx, endMethodsIdx) = seekReadTypeDefRowExtents ctxt info idx
+           let struct (endFieldsIdx, endMethodsIdx) = seekReadTypeDefRowExtents ctxt info idx
            let typars = seekReadGenericParams ctxt 0 (tomd_TypeDef, idx)
            let numtypars = typars.Length
            let super = seekReadOptionalTypeDefOrRef ctxt numtypars AsObject extendsIdx

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -199,17 +199,17 @@ let seekReadUInt16AsInt32 mdv addr = int32 (seekReadUInt16 mdv addr)
     
 let seekReadCompressedUInt32 mdv addr = 
     let b0 = seekReadByte mdv addr
-    if b0 <= 0x7Fuy then int b0, addr+1
+    if b0 <= 0x7Fuy then struct (int b0, addr+1)
     elif b0 <= 0xBFuy then 
         let b0 = b0 &&& 0x7Fuy
         let b1 = seekReadByteAsInt32 mdv (addr+1) 
-        (int b0 <<< 8) ||| int b1, addr+2
+        struct ((int b0 <<< 8) ||| int b1, addr+2)
     else 
         let b0 = b0 &&& 0x3Fuy
         let b1 = seekReadByteAsInt32 mdv (addr+1) 
         let b2 = seekReadByteAsInt32 mdv (addr+2) 
         let b3 = seekReadByteAsInt32 mdv (addr+3) 
-        (int b0 <<< 24) ||| (int b1 <<< 16) ||| (int b2 <<< 8) ||| int b3, addr+4
+        struct ((int b0 <<< 24) ||| (int b1 <<< 16) ||| (int b2 <<< 8) ||| int b3, addr+4)
 
 let seekReadSByte mdv addr = sbyte (seekReadByte mdv addr)
 let seekReadSingle mdv addr = singleOfBits (seekReadInt32 mdv addr)
@@ -226,11 +226,11 @@ let seekReadUTF8String mdv addr =
     System.Text.Encoding.UTF8.GetString (bytes, 0, bytes.Length)
 
 let seekReadBlob mdv addr = 
-    let len, addr = seekReadCompressedUInt32 mdv addr
+    let struct (len, addr) = seekReadCompressedUInt32 mdv addr
     seekReadBytes mdv addr len
     
 let seekReadUserString mdv addr = 
-    let len, addr = seekReadCompressedUInt32 mdv addr
+    let struct (len, addr) = seekReadCompressedUInt32 mdv addr
     let bytes = seekReadBytes mdv addr (len - 1)
     Encoding.Unicode.GetString(bytes, 0, bytes.Length)
 


### PR DESCRIPTION
In a trace from here: https://developercommunity.visualstudio.com/content/problem/1035124/trace-of-editing-experience-with-in-memory-cross-p-1.html

I found what looked like needless allocations of a tuple of two integers:

![image](https://user-images.githubusercontent.com/6309070/82163572-f13fe400-9860-11ea-98a0-c848524fea25.png)

As with other PRs, this one should be a small win since it's tupling up two integers