### PR TITLE
MakeCalledArgs allocates a struct tuple

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -821,7 +821,7 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
                       let nameOrOneBasedIndexMessage =
                           x.calledArg.NameOpt
                           |> Option.map (fun n -> FSComp.SR.csOverloadCandidateNamedArgumentTypeMismatch n.idText)
-                          |> Option.defaultValue (FSComp.SR.csOverloadCandidateIndexedArgumentTypeMismatch ((snd x.calledArg.Position) + 1))
+                          |> Option.defaultValue (FSComp.SR.csOverloadCandidateIndexedArgumentTypeMismatch ((Lib.vsnd x.calledArg.Position) + 1)) //snd
                       sprintf " // %s" nameOrOneBasedIndexMessage
                   | _ -> ""
                   

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -61,7 +61,7 @@ type CallerArg<'T> =
     
 /// Represents the information about an argument in the method being called
 type CalledArg = 
-    { Position: (int * int)
+    { Position: struct (int * int)
       IsParamArray : bool
       OptArgInfo : OptionalArgInfo
       CallerInfo : CallerInfo
@@ -303,7 +303,7 @@ let MakeCalledArgs amap m (minfo: MethInfo) minst =
     // Mark up the arguments with their position, so we can sort them back into order later 
     let paramDatas = minfo.GetParamDatas(amap, m, minst)
     paramDatas |> List.mapiSquared (fun i j (ParamData(isParamArrayArg, isInArg, isOutArg, optArgInfo, callerInfoFlags, nmOpt, reflArgInfo, typeOfCalledArg))  -> 
-      { Position=(i,j)
+      { Position=struct(i,j)
         IsParamArray=isParamArrayArg
         OptArgInfo=optArgInfo
         CallerInfo = callerInfoFlags

--- a/src/fsharp/lib.fs
+++ b/src/fsharp/lib.fs
@@ -564,3 +564,4 @@ type MaybeLazy<'T> =
         | Strict x -> x
         | Lazy x -> x.Force()
 
+let inline vsnd ((_, y): struct('T * 'T)) = y


### PR DESCRIPTION
In a trace from here: https://developercommunity.visualstudio.com/content/problem/1035124/trace-of-editing-experience-with-in-memory-cross-p-1.html

I found what looked like needless allocations of a tuple of two integers:

![image](https://user-images.githubusercontent.com/6309070/82163815-28fb5b80-9862-11ea-932a-2bcc81b9fefc.png)

This seemed like a needless tupling of two ints, though the values are contained within a larger record that's going on the heap anyways. But in my own testing struct tuples, when it's just things like two ints, is almost always faster for the CPU anyways