### PR TITLE
typeKindOfFlags allocates a struct 4-tuple inside of itself

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -1957,14 +1957,15 @@ type ILTypeDefKind =
 let typeKindOfFlags nm _mdefs _fdefs (super: ILType option) flags =
     if (flags &&& 0x00000020) <> 0x0 then ILTypeDefKind.Interface
     else
-         let isEnum, isDelegate, isMulticastDelegate, isValueType =
+         let struct (isEnum, isDelegate, isMulticastDelegate, isValueType) =
             match super with
-            | None -> false, false, false, false
+            | None -> struct (false, false, false, false)
             | Some ty ->
-                ty.TypeSpec.Name = "System.Enum",
-                ty.TypeSpec.Name = "System.Delegate",
-                ty.TypeSpec.Name = "System.MulticastDelegate",
-                ty.TypeSpec.Name = "System.ValueType" && nm <> "System.Enum"
+                struct (
+                    ty.TypeSpec.Name = "System.Enum",
+                    ty.TypeSpec.Name = "System.Delegate",
+                    ty.TypeSpec.Name = "System.MulticastDelegate",
+                    ty.TypeSpec.Name = "System.ValueType" && nm <> "System.Enum")
          let selfIsMulticastDelegate = nm = "System.MulticastDelegate"
          if isEnum then ILTypeDefKind.Enum
          elif (isDelegate && not selfIsMulticastDelegate) || isMulticastDelegate then ILTypeDefKind.Delegate


### PR DESCRIPTION
I noticed devenv.exe got up to ~2.2GB after working in a few files (`ilread` in particular) and using some IDE features and completing some code. I opened up perfview and recorded myself editing some code and using Go to Definition. I noticed that a 4-tuple of bools had 22MB of allocations which seemed excessive:

![image](https://user-images.githubusercontent.com/6309070/82176281-29f4b300-988b-11ea-9326-ff17bb15a0ae.png)

This can safely be made a struct tuple since it's small, structy data.