### PR TITLE
General AddBoundValue fixes, test coverage, and slight API change

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -990,7 +990,15 @@ let rec internal convertReflectionTypeToILType (reflectionTy: Type) =
     let reflectionTy =
         // Special case functions.
         if FSharp.Reflection.FSharpType.IsFunction reflectionTy then
-            reflectionTy.BaseType
+            let ctors = reflectionTy.GetConstructors(BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance)
+            if ctors.Length = 1 && 
+               ctors.[0].GetCustomAttribute<CompilerGeneratedAttribute>() <> null && 
+               not ctors.[0].IsPublic && 
+               PrettyNaming.IsCompilerGeneratedName reflectionTy.Name then
+                let rec get (typ: Type) = if FSharp.Reflection.FSharpType.IsFunction typ.BaseType then get typ.BaseType else typ
+                get reflectionTy
+            else
+                reflectionTy
         else
             reflectionTy
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -970,7 +970,7 @@ let internal importReflectionType amap (reflectionTy: Type) =
             if index = -1 then
                 fullName
             else
-                fullName.Substring(0, index - 1)
+                fullName.Substring(0, index)
 
         let isTop = reflectionTy.DeclaringType = null
         if isTop then

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -269,7 +269,7 @@ type FsiEvaluationSession =
     /// Creates a root-level value with the given name and .NET object.
     /// If the .NET object contains types from assemblies that are not referenced in the interactive session, it will try to implicitly resolve them by default configuration.
     /// Name must be a valid identifier.
-    member AddBoundValue : name: string * value: obj -> FSharpErrorInfo[]
+    member AddBoundValue : name: string * value: obj -> unit
 
     /// Load the dummy interaction, load the initial files, and,
     /// if interacting, start the background thread to read the standard input.

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -1390,10 +1390,9 @@ module Lexer =
         use _unwindBP = PushThreadBuildPhaseUntilUnwind BuildPhase.Parse
         use _unwindEL = PushErrorLoggerPhaseUntilUnwind (fun _ -> DiscardErrorsLogger)
 
-        usingLexbufForParsing (lexbuf, filePath) (fun lexbuf -> 
-            while not lexbuf.IsPastEndOfStream do
-                ct.ThrowIfCancellationRequested ()
-                onToken (getNextToken lexbuf) lexbuf.LexemeRange)
+        while not lexbuf.IsPastEndOfStream do
+            ct.ThrowIfCancellationRequested ()
+            onToken (getNextToken lexbuf) lexbuf.LexemeRange
 
     let lex text filePath conditionalCompilationDefines flags supportsFeature lexCallback pathMap ct =
         let errorLogger = CompilationErrorLogger("Lexer", ErrorLogger.FSharpErrorSeverityOptions.Default)

--- a/tests/FSharp.Compiler.UnitTests/FsiTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/FsiTests.fs
@@ -252,8 +252,7 @@ let ``Values are successfully shadowed even with intermediate interactions`` () 
 let ``Creation of a simple bound value succeeds`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("x", 1)
-    Assert.IsEmpty errors
+    fsiSession.AddBoundValue("x", 1)
 
     let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
 
@@ -265,8 +264,7 @@ let ``Creation of a simple bound value succeeds`` () =
 let ``Creation of a bound value succeeds with underscores in the identifier`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("x_y_z", 1)
-    Assert.IsEmpty errors
+    fsiSession.AddBoundValue("x_y_z", 1)
 
     let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
 
@@ -276,8 +274,7 @@ let ``Creation of a bound value succeeds with underscores in the identifier`` ()
 let ``Creation of a bound value succeeds with tildes in the identifier`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("``hello world``", 1)
-    Assert.IsEmpty errors
+    fsiSession.AddBoundValue("``hello world``", 1)
 
     let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
 
@@ -294,8 +291,7 @@ let ``Creation of a bound value succeeds with 'it' as the indentifier`` () =
     Assert.AreEqual("it", boundValue.Name)
     Assert.AreEqual(typeof<string>, boundValue.Value.ReflectionType)
 
-    let errors = fsiSession.AddBoundValue("it", 1)
-    Assert.IsEmpty errors
+    fsiSession.AddBoundValue("it", 1)
 
     let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
 
@@ -303,111 +299,67 @@ let ``Creation of a bound value succeeds with 'it' as the indentifier`` () =
     Assert.AreEqual(typeof<int>, boundValue.Value.ReflectionType)
 
 [<Test>]
-let ``Creation of a bound value succeeds with tildes in the identifier and with 'at' but has warning`` () =
+let ``Creation of a bound value fails with tildes in the identifier and with 'at' but has warning`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("``hello @ world``", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Warning, error.Severity)
-    Assert.AreEqual("Identifiers containing '@' are reserved for use in F# code generation", error.Message)
-
-    let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
-
-    Assert.AreEqual("``hello @ world``", boundValue.Name)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue("``hello @ world``", 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name is not a valid identifier with 'at' in front`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("@x", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue("@x", 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name is not a valid identifier with 'at' in back`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("x@", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue("x@", 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name is null`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue(null, 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue(null, 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name is empty`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue("", 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name is whitespace`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue(" ", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue(" ", 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name contains spaces`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("x x", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue("x x", 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name contains an operator at the end`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("x+", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue("x+", 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name contains an operator at the front`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("+x", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue("+x", 1)) |> ignore
 
 [<Test>]
 let ``Creation of a bound value fails if the name contains dots`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("x.x", 1)
-    let error = errors |> Array.exactlyOne
-
-    Assert.AreEqual(FSharpErrorSeverity.Error, error.Severity)
-    Assert.AreEqual("Identifier expected", error.Message)
+    Assert.Throws<ArgumentException>(fun () -> fsiSession.AddBoundValue("x.x", 1)) |> ignore
 
 [<Test>]
-let ``Creation of a bound value throws if the value passed is null`` () =
+let ``Creation of a bound value fails if the value passed is null`` () =
     use fsiSession = createFsiSession ()
 
     Assert.Throws<ArgumentNullException>(fun () -> fsiSession.AddBoundValue("x", null) |> ignore) |> ignore
@@ -416,16 +368,13 @@ let ``Creation of a bound value throws if the value passed is null`` () =
 let ``Creation of a bound value succeeds if the value contains types from assemblies that are not referenced in the session, due to implicit resolution`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("x", { X = 1 })
-    Assert.IsEmpty errors
+    fsiSession.AddBoundValue("x", { X = 1 })
 
 [<Test>]
 let ``Creation of a bound value succeeds if the value contains types from assemblies that are not referenced in the session, due to implicit resolution, and then doing some evaluation`` () =
     use fsiSession = createFsiSession ()
 
-    let errors = fsiSession.AddBoundValue("x", { X = 1 })
-    Assert.IsEmpty errors
-
+    fsiSession.AddBoundValue("x", { X = 1 })
     fsiSession.EvalInteraction("let y = { x with X = 5 }")
 
     let boundValues = fsiSession.GetBoundValues()
@@ -441,3 +390,22 @@ let ``Creation of a bound value succeeds if the value contains types from assemb
     Assert.AreEqual("y", v2.Name)
     Assert.AreEqual({ X = 5 }, v2.Value.ReflectionValue)
     Assert.AreEqual(typeof<CustomType>, v2.Value.ReflectionType)
+
+[<Test>]
+let ``Creation of a bound value, of type ResizeArray<string>, succeeds`` () =
+    use fsiSession = createFsiSession ()
+
+    let xs = ResizeArray()
+    xs.Add("banana")
+    xs.Add("apple")
+
+    fsiSession.AddBoundValue("xs", xs)
+
+    let boundValues = fsiSession.GetBoundValues()
+    Assert.AreEqual(1, boundValues.Length)
+
+    let v1 = boundValues.[0]
+
+    Assert.AreEqual("xs", v1.Name)
+    Assert.AreEqual(xs, v1.Value.ReflectionValue)
+    Assert.AreEqual(typeof<ResizeArray<string>>, v1.Value.ReflectionType)

--- a/tests/FSharp.Compiler.UnitTests/FsiTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/FsiTests.fs
@@ -491,3 +491,37 @@ let ``Creation of a bound value fails if the value's type is not public`` () =
     use fsiSession = createFsiSession ()
 
     Assert.Throws<InvalidOperationException>(fun () -> fsiSession.AddBoundValue("x", NonPublicCustomType())) |> ignore
+
+[<Test>]
+let ``Creation of a bound value succeeds if the value is a partial application function type`` () =
+    use fsiSession = createFsiSession ()
+
+    fsiSession.AddBoundValue("createFsiSession", createFsiSession)
+
+    let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
+
+    Assert.AreEqual(typeof<unit -> FsiEvaluationSession>, boundValue.Value.ReflectionType)
+
+[<Test>]
+let ``Creation of a bound value succeeds if the value is a partial application function type with four arguments`` () =
+    use fsiSession = createFsiSession ()
+
+    let addXYZW x y z w = x + y + z + w
+    let addYZW = addXYZW 1
+    let addZW = addYZW 2
+
+    fsiSession.AddBoundValue("addZW", addZW)
+
+    let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
+
+    Assert.AreEqual(typeof<int -> int -> int>, boundValue.Value.ReflectionType.BaseType)
+
+[<Test>]
+let ``Creation of a bound value succeeds if the value is a lambda`` () =
+    use fsiSession = createFsiSession ()
+
+    fsiSession.AddBoundValue("addXYZW", fun x y z -> x + y + z)
+
+    let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
+
+    Assert.AreEqual(typeof<int -> int -> int -> int>, boundValue.Value.ReflectionType.BaseType)

--- a/tests/FSharp.Compiler.UnitTests/FsiTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/FsiTests.fs
@@ -522,7 +522,7 @@ let ``Creation of a bound value succeeds if the value is a partial application f
 let ``Creation of a bound value succeeds if the value is a lambda`` () =
     use fsiSession = createFsiSession ()
 
-    fsiSession.AddBoundValue("addXYZW", fun x y z -> x + y + z)
+    fsiSession.AddBoundValue("addXYZ", fun x y z -> x + y + z)
 
     let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
 


### PR DESCRIPTION
- Fixes an issue with importing reflection types.
- `AddBoundValue` does not return errors and instead will only throw exceptions.
- More test coverage, such as types from dynamic assemblies and non-public types.

@jonsequitur @colombod 