### PR TITLE
[WIP] Look for string.GetPinnableReference when pinning a string first

### DIFF
--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/FixedExpressionCodeGen.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/FixedExpressionCodeGen.fs
@@ -1,0 +1,37 @@
+﻿namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
+
+open FSharp.Compiler.UnitTests
+open NUnit.Framework
+
+[<TestFixture>]
+module FixedExpressionCodeGen =
+
+#if NETCOREAPP
+    [<Test>]
+    let ``Pinning a string emits string.GetPinnableReference`` () =
+        let code = """
+module FixedOnAString
+#nowarn "9"
+let foo(s : string) =
+    use ptr = fixed s
+    ptr
+"""
+        let il = """
+char& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) [System.Runtime]System.String::GetPinnableReference()
+"""
+        CompilerAssert.CompileLibraryAndVerifyIL code (fun verifier -> verifier.VerifyIL([ il ]))
+#else
+    [<Test>]
+    let ``Pinning a string emits RuntimeHelpers.GetOffsetToStringData`` () =
+        let code = """
+module FixedOnAString
+#nowarn "9"
+let foo(s : string) =
+    use ptr = fixed s
+    ptr
+"""
+        let il = """
+int32 [runtime]System.Runtime.CompilerServices.RuntimeHelpers::get_OffsetToStringData()
+"""
+        CompilerAssert.CompileLibraryAndVerifyIL code (fun verifier -> verifier.VerifyIL([ il ]))
+#endif

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="Compiler\ILChecker.fs" />
     <Compile Include="Compiler\Utilities.fs" />
     <Compile Include="Compiler\CompilerAssert.fs" />
+    <Compile Include="Compiler\CodeGen\EmittedIL\FixedExpressionCodeGen.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\StaticLinkTests.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\LiteralValue.fs" />
     <Compile Include="Compiler\CodeGen\EmittedIL\Mutation.fs" />


### PR DESCRIPTION
This tries to address #9251 

I couldn't actually run these tests on my machine with VS for some weird reason, so I'll let CI tell me what I did wrong instead