### PR TITLE
Use arrays for storing source files in projects

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -240,7 +240,12 @@ module Array =
     /// Returns true if one array has trailing elements equal to another's.
     let endsWith (suffix: _ []) (whole: _ []) =
         isSubArray suffix whole (whole.Length-suffix.Length)
-        
+
+    let unzip4 (array: _ []) = 
+        let a, b, cd = Array.unzip3 (Array.map (fun (x, y, z, w) -> (x, y, (z, w))) array)
+        let c, d = Array.unzip cd
+        a, b, c, d
+
 module Option = 
 
     let mapFold f s opt = 

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -77,7 +77,7 @@ type ModuleNamesDict = Map<string,Map<string,QualifiedNameOfFile>>
 val DeduplicateParsedInputModuleName: ModuleNamesDict -> ParsedInput -> ParsedInput * ModuleNamesDict
 
 /// Parse a single input (A signature file or implementation file)
-val ParseInput: (UnicodeLexing.Lexbuf -> Parser.token) * ErrorLogger * UnicodeLexing.Lexbuf * string option * string * isLastCompiland:(bool * bool) -> ParsedInput
+val ParseInput: (UnicodeLexing.Lexbuf -> Parser.token) * ErrorLogger * UnicodeLexing.Lexbuf * string option * string * isLastCompiland: bool * isExe: bool -> ParsedInput
 
 //----------------------------------------------------------------------------
 // Error and warnings
@@ -722,7 +722,7 @@ val DefaultReferencesForScriptsAndOutOfProjectSources: bool -> string list
 //--------------------------------------------------------------------------
 
 /// Parse one input file
-val ParseOneInputFile: TcConfig * Lexhelp.LexResourceManager * string list * string * isLastCompiland: (bool * bool) * ErrorLogger * (*retryLocked*) bool -> ParsedInput option
+val ParseOneInputFile: TcConfig * Lexhelp.LexResourceManager * string list * string * isLastCompiland: bool * isExe: bool * ErrorLogger * (*retryLocked*) bool -> ParsedInput option
 
 //----------------------------------------------------------------------------
 // Type checking and querying the type checking state

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -274,7 +274,7 @@ type TcConfigBuilder =
       mutable light: bool option
       mutable conditionalCompilationDefines: string list
       /// Sources added into the build with #load
-      mutable loadedSources: (range * string * string) list
+      mutable loadedSources: (range * string * string)[]
       mutable compilerToolPaths: string  list
       mutable referencedDLLs: AssemblyReference  list
       mutable packageManagerLines: Map<string, (bool * string * range) list>
@@ -413,7 +413,7 @@ type TcConfigBuilder =
         tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot
           -> TcConfigBuilder
 
-    member DecideNames: string list -> outfile: string * pdbfile: string option * assemblyName: string 
+    member DecideNames: string[] -> outfile: string * pdbfile: string option * assemblyName: string 
     member TurnWarningOff: range * string -> unit
     member TurnWarningOn: range * string -> unit
     member AddIncludePath: range * string * string -> unit
@@ -547,9 +547,9 @@ type TcConfig =
     member GetTargetFrameworkDirectories: unit -> string list
     
     /// Get the loaded sources that exist and issue a warning for the ones that don't
-    member GetAvailableLoadedSources: unit -> (range*string) list
+    member GetAvailableLoadedSources: unit -> (range * string)[]
     
-    member ComputeCanContainEntryPoint: sourceFiles:string list -> bool list *bool 
+    member ComputeCanContainEntryPoint: sourceFiles: string[] -> bool[] * bool 
 
     /// File system query based on TcConfig settings
     member ResolveSourceFile: range * filename: string * pathLoadedFrom: string -> string
@@ -764,18 +764,18 @@ val TypeCheckOneInputEventually :
            -> Eventually<(TcEnv * TopAttribs * TypedImplFile option * ModuleOrNamespaceType) * TcState>
 
 /// Finish the checking of multiple inputs 
-val TypeCheckMultipleInputsFinish: (TcEnv * TopAttribs * 'T option * 'U) list * TcState -> (TcEnv * TopAttribs * 'T list * 'U list) * TcState
+val TypeCheckMultipleInputsFinish: (TcEnv * TopAttribs * 'T option * 'U)[] * TcState -> (TcEnv * TopAttribs * 'T[] * 'U[]) * TcState
     
 /// Finish the checking of a closed set of inputs 
-val TypeCheckClosedInputSetFinish: TypedImplFile list * TcState -> TcState * TypedImplFile list
+val TypeCheckClosedInputSetFinish: TypedImplFile[] * TcState -> TcState * TypedImplFile[]
 
 /// Check a closed set of inputs 
-val TypeCheckClosedInputSet: CompilationThreadToken * checkForErrors: (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * TcState * ParsedInput  list  -> TcState * TopAttribs * TypedImplFile list * TcEnv
+val TypeCheckClosedInputSet: CompilationThreadToken * checkForErrors: (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * TcState * ParsedInput[] -> TcState * TopAttribs * TypedImplFile[] * TcEnv
 
 /// Check a single input and finish the checking
 val TypeCheckOneInputAndFinishEventually :
     checkForErrors: (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * NameResolution.TcResultsSink * TcState * ParsedInput 
-        -> Eventually<(TcEnv * TopAttribs * TypedImplFile list * ModuleOrNamespaceType list) * TcState>
+        -> Eventually<(TcEnv * TopAttribs * TypedImplFile[] * ModuleOrNamespaceType[]) * TcState>
 
 /// Indicates if we should report a warning
 val ReportWarning: FSharpErrorSeverityOptions -> PhasedDiagnostic -> bool
@@ -812,10 +812,10 @@ type LoadClosure =
       UnresolvedReferences: UnresolvedAssemblyReference list
 
       /// The list of all sources in the closure with inputs when available, with associated parse errors and warnings
-      Inputs: LoadClosureInput list
+      Inputs: LoadClosureInput[]
 
       /// The original #load references, including those that didn't resolve
-      OriginalLoadReferences: (range * string * string) list
+      OriginalLoadReferences: (range * string * string)[]
 
       /// The #nowarns
       NoWarns: (string * range list) list

--- a/src/fsharp/CompileOptions.fsi
+++ b/src/fsharp/CompileOptions.fsi
@@ -66,7 +66,7 @@ val GetCoreFsiCompilerOptions     : TcConfigBuilder -> CompilerOptionBlock list
 val GetCoreServiceCompilerOptions : TcConfigBuilder -> CompilerOptionBlock list
 
 /// Apply args to TcConfigBuilder and return new list of source files
-val ApplyCommandLineArgs: tcConfigB: TcConfigBuilder * sourceFiles: string list * argv: string list -> string list
+val ApplyCommandLineArgs: tcConfigB: TcConfigBuilder * sourceFiles: string[] * argv: string list -> string[]
 
 // Expose the "setters" for some user switches, to enable setting of defaults
 val SetOptimizeSwitch : TcConfigBuilder -> OptionSwitch -> unit
@@ -79,7 +79,7 @@ val GetGeneratedILModuleName : CompilerTarget -> string -> string
 
 val GetInitialOptimizationEnv : TcImports * TcGlobals -> IncrementalOptimizationEnv
 val AddExternalCcuToOptimizationEnv : TcGlobals -> IncrementalOptimizationEnv -> ImportedAssembly -> IncrementalOptimizationEnv
-val ApplyAllOptimizations : TcConfig * TcGlobals * ConstraintSolver.TcValF * string * ImportMap * bool * IncrementalOptimizationEnv * CcuThunk * TypedImplFile list -> TypedAssemblyAfterOptimization * Optimizer.LazyModuleInfo * IncrementalOptimizationEnv 
+val ApplyAllOptimizations : TcConfig * TcGlobals * ConstraintSolver.TcValF * string * ImportMap * bool * IncrementalOptimizationEnv * CcuThunk * TypedImplFile[] -> TypedAssemblyAfterOptimization * Optimizer.LazyModuleInfo * IncrementalOptimizationEnv 
 
 val CreateIlxAssemblyGenerator : TcConfig * TcImports * TcGlobals * ConstraintSolver.TcValF * CcuThunk -> IlxGen.IlxAssemblyGenerator
 

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -1237,7 +1237,7 @@ and AddBindingsForModuleTopVals _g allocVal _cloc eenv vs =
 let AddIncrementalLocalAssemblyFragmentToIlxGenEnv (amap: ImportMap, isIncrementalFragment, g, ccu, fragName, intraAssemblyInfo, eenv, typedImplFiles) =
     let cloc = CompLocForFragment fragName ccu
     let allocVal = ComputeAndAddStorageForLocalTopVal (amap, g, intraAssemblyInfo, true, NoShadowLocal)
-    (eenv, typedImplFiles) ||> List.fold (fun eenv (TImplFile (qname, _, mexpr, _, _, _)) ->
+    (eenv, typedImplFiles) ||> Array.fold (fun eenv (TImplFile (qname, _, mexpr, _, _, _)) ->
         let cloc = { cloc with TopImplQualifiedName = qname.Text }
         if isIncrementalFragment then
             match mexpr with
@@ -7610,9 +7610,9 @@ and GenExnDef cenv mgbuf eenv m (exnc: Tycon) =
 
 
 let CodegenAssembly cenv eenv mgbuf fileImpls =
-    if not (isNil fileImpls) then
-        let a, b = List.frontAndBack fileImpls
-        let eenv = List.fold (GenTopImpl cenv mgbuf None) eenv a
+    if not (Array.isEmpty fileImpls) then
+        let a, b = Array.take (fileImpls.Length - 1) fileImpls, Array.last fileImpls
+        let eenv = Array.fold (GenTopImpl cenv mgbuf None) eenv a
         let eenv = GenTopImpl cenv mgbuf cenv.opts.mainMethodInfo eenv b
 
         // Some constructs generate residue types and bindings. Generate these now. They don't result in any

--- a/src/fsharp/IlxGen.fsi
+++ b/src/fsharp/IlxGen.fsi
@@ -96,7 +96,7 @@ type public IlxAssemblyGenerator =
 
     /// Register a fragment of the current assembly with the ILX code generator. If 'isIncrementalFragment' is true then the input
     /// is assumed to be a fragment 'typed' into FSI.EXE, otherwise the input is assumed to be the result of a '#load'
-    member AddIncrementalLocalAssemblyFragment: isIncrementalFragment: bool * fragName:string * typedImplFiles: TypedImplFile list -> unit
+    member AddIncrementalLocalAssemblyFragment: isIncrementalFragment: bool * fragName:string * typedImplFiles: TypedImplFile[] -> unit
 
     /// Generate ILX code for an assembly fragment
     member GenerateCode: IlxGenOptions * TypedAssemblyAfterOptimization * Attribs * Attribs -> IlxGenResults

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -209,7 +209,7 @@ type cenv =
 
       reportErrors: bool
 
-      isLastCompiland : bool*bool
+      isLastCompiland: bool
 
       isInternalTestSpanStackReferring: bool
 
@@ -1790,8 +1790,7 @@ let CheckModuleBinding cenv env (TBind(v, e, _) as bind) =
     let isExplicitEntryPoint = HasFSharpAttribute g g.attrib_EntryPointAttribute v.Attribs
     if isExplicitEntryPoint then 
         cenv.entryPointGiven <- true
-        let isLastCompiland = fst cenv.isLastCompiland
-        if not isLastCompiland && cenv.reportErrors  then 
+        if not cenv.isLastCompiland && cenv.reportErrors  then 
             errorR(Error(FSComp.SR.chkEntryPointUsage(), v.Range)) 
 
     // Analyze the r.h.s. for the "IsCompiledAsStaticPropertyWithoutField" condition
@@ -2293,7 +2292,7 @@ and CheckModuleSpec cenv env x =
         let env = { env with reflect = env.reflect || HasFSharpAttribute cenv.g cenv.g.attrib_ReflectedDefinitionAttribute mspec.Attribs }
         CheckDefnInModule cenv env rhs 
 
-let CheckTopImpl (g, amap, reportErrors, infoReader, internalsVisibleToPaths, viewCcu, denv, mexpr, extraAttribs, (isLastCompiland: bool*bool), isInternalTestSpanStackReferring) =
+let CheckTopImpl (g, amap, reportErrors, infoReader, internalsVisibleToPaths, viewCcu, denv, mexpr, extraAttribs, (isLastCompiland: bool), isInternalTestSpanStackReferring) =
     let cenv = 
         { g =g  
           reportErrors=reportErrors 

--- a/src/fsharp/PostInferenceChecks.fsi
+++ b/src/fsharp/PostInferenceChecks.fsi
@@ -20,6 +20,7 @@ val CheckTopImpl:
     viewCcu: CcuThunk *
     denv: DisplayEnv *
     mexpr: ModuleOrNamespaceExprWithSig *
-    extraAttribs: Attribs * (bool * bool) *
+    extraAttribs: Attribs *
+    isLastCompiland: bool *
     isInternalTestSpanStackReferring: bool 
        -> bool * StampMap<AnonRecdTypeInfo>

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -2241,7 +2241,7 @@ type ParsedImplFileInput =
         scopedPragmas: ScopedPragma list *
         hashDirectives: ParsedHashDirective list *
         modules: SynModuleOrNamespace list *
-        isLastCompiland: (bool * bool)
+        isLastCompiland: bool
 
 /// Represents the full syntax tree, file name and other parsing information for a signature file
 [<NoEquality; NoComparison>]

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -4933,7 +4933,7 @@ type TypedImplFile =
 /// Represents a complete typechecked assembly, made up of multiple implementation files.
 [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
 type TypedAssemblyAfterOptimization = 
-    | TypedAssemblyAfterOptimization of (TypedImplFile * (* optimizeDuringCodeGen: *) (Expr -> Expr)) list
+    | TypedAssemblyAfterOptimization of (TypedImplFile * (* optimizeDuringCodeGen: *) (Expr -> Expr))[]
 
     [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
     member x.DebugText = x.ToString()

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1844,7 +1844,7 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
             // PERF: consider making this parallel, once uses of global state relevant to parsing are cleaned up 
             |> List.choose (fun (filename: string, isLastCompiland) -> 
                 let pathOfMetaCommandSource = Path.GetDirectoryName filename
-                match ParseOneInputFile(tcConfig, lexResourceManager, ["COMPILED"], filename, (isLastCompiland, isExe), errorLogger, (*retryLocked*)false) with
+                match ParseOneInputFile(tcConfig, lexResourceManager, ["COMPILED"], filename, isLastCompiland, isExe, errorLogger, (*retryLocked*)false) with
                 | Some input -> Some (input, pathOfMetaCommandSource)
                 | None -> None
                 ) 

--- a/src/fsharp/fsc.fsi
+++ b/src/fsharp/fsc.fsi
@@ -71,7 +71,7 @@ val compileOfAst :
     noframework:bool *
     exiter:Exiter * 
     loggerProvider: ErrorLoggerProvider * 
-    inputs:ParsedInput list *
+    inputs:ParsedInput[] *
     tcImportsCapture : (TcImports -> unit) option *
     dynamicAssemblyCreator: (TcGlobals * string * ILModuleDef -> unit) option
       -> unit

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1304,7 +1304,7 @@ type internal FsiDynamicCompiler
         let prefix = mkFragmentPath i
         let prefixPath = pathOfLid prefix
         let impl = SynModuleOrNamespace(prefix,(*isRec*)false, NamedModule,defs,PreXmlDoc.Empty,[],None,rangeStdin)
-        let input = ParsedInput.ImplFile (ParsedImplFileInput (filename,true, ComputeQualifiedNameOfFileFromUniquePath (rangeStdin,prefixPath),[],[],[impl],(true (* isLastCompiland *), false (* isExe *)) ))
+        let input = ParsedInput.ImplFile (ParsedImplFileInput (filename,true, ComputeQualifiedNameOfFileFromUniquePath (rangeStdin,prefixPath),[],[],[impl], true))
         let istate,tcEnvAtEndOfLastInput,declaredImpls = ProcessInputs (ctok, errorLogger, istate, [input], showTypes, true, isInteractiveItExpr, prefix)
         let tcState = istate.tcState 
         let newState = { istate with tcState = tcState.NextStateAfterIncrementalFragment(tcEnvAtEndOfLastInput) }

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1488,7 +1488,7 @@ type internal FsiDynamicCompiler
                     input.MetaCommandDiagnostics |> List.iter diagnosticSink
                     let parsedInput = 
                         match input.SyntaxTree with 
-                        | None -> ParseOneInputFile(tcConfig,lexResourceManager,["INTERACTIVE"],input.FileName,(true,false),errorLogger,(*retryLocked*)false)
+                        | None -> ParseOneInputFile(tcConfig,lexResourceManager,["INTERACTIVE"],input.FileName,true,false,errorLogger,(*retryLocked*)false)
                         | _-> input.SyntaxTree
                     input.FileName, parsedInput)
               |> List.unzip

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -1669,7 +1669,7 @@ module internal ParseAndCheckFile =
                 with e ->
                     errorR e
                     let mty = Construct.NewEmptyModuleOrNamespaceType Namespace
-                    return Some((tcState.TcEnvFromSignatures, EmptyTopAttrs, [], [ mty ]), tcState)
+                    return Some((tcState.TcEnvFromSignatures, EmptyTopAttrs, Array.Empty(), [| mty |]), tcState)
             }
                 
         let errors = errHandler.CollectedDiagnostics
@@ -1678,7 +1678,7 @@ module internal ParseAndCheckFile =
             match resOpt with
             | Some ((tcEnvAtEnd, _, implFiles, ccuSigsForFiles), tcState) ->
                 TypeCheckInfo(tcConfig, tcGlobals, 
-                              List.head ccuSigsForFiles, 
+                              Array.head ccuSigsForFiles, 
                               tcState.Ccu,
                               tcImports,
                               tcEnvAtEnd.AccessRights,
@@ -1690,7 +1690,7 @@ module internal ParseAndCheckFile =
                               loadClosure,
                               reactorOps,
                               textSnapshotInfo,
-                              List.tryHead implFiles,
+                              Array.tryHead implFiles,
                               sink.GetOpenDeclarations())     
                      |> Result.Ok
             | None -> 
@@ -2011,7 +2011,7 @@ type FSharpCheckProjectResults
           errors: FSharpErrorInfo[], 
           details:(TcGlobals * TcImports * CcuThunk * ModuleOrNamespaceType * TcSymbolUses list *
                    TopAttribs option * CompileOps.IRawFSharpAssemblyData option * ILAssemblyRef *
-                   AccessorDomain * TypedImplFile list option * string[]) option) =
+                   AccessorDomain * TypedImplFile[] option * string[]) option) =
 
     let getDetails() = 
         match details with 
@@ -2036,7 +2036,7 @@ type FSharpCheckProjectResults
         let (tcGlobals, tcImports, thisCcu, _ccuSig, _tcSymbolUses, _topAttribs, _tcAssemblyData, _ilAssemRef, _ad, tcAssemblyExpr, _dependencyFiles) = getDetails()
         let mimpls = 
             match tcAssemblyExpr with 
-            | None -> []
+            | None -> Array.Empty()
             | Some mimpls -> mimpls
         tcGlobals, thisCcu, tcImports, mimpls
 
@@ -2045,7 +2045,7 @@ type FSharpCheckProjectResults
         let (tcGlobals, tcImports, thisCcu, ccuSig, _tcSymbolUses, _topAttribs, _tcAssemblyData, _ilAssemRef, _ad, tcAssemblyExpr, _dependencyFiles) = getDetails()
         let mimpls = 
             match tcAssemblyExpr with 
-            | None -> []
+            | None -> Array.Empty()
             | Some mimpls -> mimpls
         FSharpAssemblyContents(tcGlobals, thisCcu, Some ccuSig, tcImports, mimpls)
 
@@ -2054,7 +2054,7 @@ type FSharpCheckProjectResults
         let (tcGlobals, tcImports, thisCcu, ccuSig, _tcSymbolUses, _topAttribs, _tcAssemblyData, _ilAssemRef, _ad, tcAssemblyExpr, _dependencyFiles) = getDetails()
         let mimpls = 
             match tcAssemblyExpr with 
-            | None -> []
+            | None -> Array.Empty()
             | Some mimpls -> mimpls
         let outfile = "" // only used if tcConfig.writeTermsToFiles is true
         let importMap = tcImports.GetImportMap()
@@ -2063,8 +2063,7 @@ type FSharpCheckProjectResults
         let optimizedImpls, _optimizationData, _ = ApplyAllOptimizations (tcConfig, tcGlobals, (LightweightTcValForUsingInBuildMethodCall tcGlobals), outfile, importMap, false, optEnv0, thisCcu, mimpls)                
         let mimpls =
             match optimizedImpls with
-            | TypedAssemblyAfterOptimization files ->
-                files |> List.map fst
+            | TypedAssemblyAfterOptimization files -> Array.map fst files
 
         FSharpAssemblyContents(tcGlobals, thisCcu, Some ccuSig, tcImports, mimpls)
 

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -1514,7 +1514,7 @@ module internal ParseAndCheckFile =
                     fileName.Equals(options.LastFileName, StringComparison.CurrentCultureIgnoreCase) ||
                     CompileOps.IsScript(fileName)
                 let isExe = options.IsExe
-                try Some (ParseInput(lexfun, errHandler.ErrorLogger, lexbuf, None, fileName, (isLastCompiland, isExe)))
+                try Some (ParseInput(lexfun, errHandler.ErrorLogger, lexbuf, None, fileName, isLastCompiland, isExe))
                 with e ->
                     errHandler.ErrorLogger.StopProcessingRecovery e Range.range0 // don't re-raise any exceptions, we must return None.
                     None)

--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -357,7 +357,7 @@ type public FSharpCheckProjectResults =
         tcConfigOption: TcConfig option *
         keepAssemblyContents: bool *
         errors: FSharpErrorInfo[] * 
-        details:(TcGlobals * TcImports * CcuThunk * ModuleOrNamespaceType * TcSymbolUses list * TopAttribs option * IRawFSharpAssemblyData option * ILAssemblyRef * AccessorDomain * TypedImplFile list option * string[]) option 
+        details:(TcGlobals * TcImports * CcuThunk * ModuleOrNamespaceType * TcSymbolUses list * TopAttribs option * IRawFSharpAssemblyData option * ILAssemblyRef * AccessorDomain * TypedImplFile[] option * string[]) option 
            -> FSharpCheckProjectResults
 
 module internal ParseAndCheckFile = 

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -100,7 +100,7 @@ type internal IncrementalBuilder =
       member TcConfig : TcConfig
 
       /// The full set of source files including those from options
-      member SourceFiles : string list
+      member SourceFiles : string[]
 
       /// Raised just before a file is type-checked, to invalidate the state of the file in VS and force VS to request a new direct typecheck of the file.
       /// The incremental builder also typechecks the file (error and intellisense results from the background builder are not
@@ -167,7 +167,7 @@ type internal IncrementalBuilder =
       /// This may be a long-running operation.
       ///
       // TODO: make this an Eventually (which can be scheduled) or an Async (which can be cancelled)
-      member GetCheckResultsAndImplementationsForProject : CompilationThreadToken -> Cancellable<PartialCheckResults * IL.ILAssemblyRef * IRawFSharpAssemblyData option * TypedImplFile list option>
+      member GetCheckResultsAndImplementationsForProject : CompilationThreadToken -> Cancellable<PartialCheckResults * IL.ILAssemblyRef * IRawFSharpAssemblyData option * TypedImplFile[] option>
 
       /// Get the logical time stamp that is associated with the output of the project if it were gully built immediately
       member GetLogicalTimeStampForProject: TimeStampCache * CompilationThreadToken -> DateTime
@@ -178,9 +178,9 @@ type internal IncrementalBuilder =
       /// Await the untyped parse results for a particular slot in the vector of parse results.
       ///
       /// This may be a marginally long-running operation (parses are relatively quick, only one file needs to be parsed)
-      member GetParseResultsForFile : CompilationThreadToken * filename:string -> Cancellable<ParsedInput option * Range.range * string * (PhasedDiagnostic * FSharpErrorSeverity)[]>
+      member GetParseResultsForFile : CompilationThreadToken * filename:string -> Cancellable<ParsedInput option * string * (PhasedDiagnostic * FSharpErrorSeverity)[]>
 
-      static member TryCreateBackgroundBuilderForProjectOptions : CompilationThreadToken * ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * FrameworkImportsCache * scriptClosureOptions:LoadClosure option * sourceFiles:string list * commandLineArgs:string list * projectReferences: IProjectReference list * projectDirectory:string * useScriptResolutionRules:bool * keepAssemblyContents: bool * keepAllBackgroundResolutions: bool * maxTimeShareMilliseconds: int64 * tryGetMetadataSnapshot: ILBinaryReader.ILReaderTryGetMetadataSnapshot * suggestNamesForErrors: bool * keepAllBackgroundSymbolUses: bool * enableBackgroundItemKeyStoreAndSemanticClassification: bool -> Cancellable<IncrementalBuilder option * FSharpErrorInfo[]>
+      static member TryCreateBackgroundBuilderForProjectOptions : CompilationThreadToken * ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * FrameworkImportsCache * scriptClosureOptions:LoadClosure option * sourceFiles:string[] * commandLineArgs:string list * projectReferences: IProjectReference list * projectDirectory:string * useScriptResolutionRules:bool * keepAssemblyContents: bool * keepAllBackgroundResolutions: bool * maxTimeShareMilliseconds: int64 * tryGetMetadataSnapshot: ILBinaryReader.ILReaderTryGetMetadataSnapshot * suggestNamesForErrors: bool * keepAllBackgroundSymbolUses: bool * enableBackgroundItemKeyStoreAndSemanticClassification: bool -> Cancellable<IncrementalBuilder option * FSharpErrorInfo[]>
 
 /// Generalized Incremental Builder. This is exposed only for unit testing purposes.
 module internal IncrementalBuild =
@@ -258,7 +258,7 @@ module internal IncrementalBuild =
     type BuildInput =
         /// Declare a named scalar output.
         static member ScalarInput: node:Scalar<'T> * value: 'T -> BuildInput
-        static member VectorInput: node:Vector<'T> * value: 'T list -> BuildInput
+        static member VectorInput: node:Vector<'T> * value: 'T[] -> BuildInput
 
     /// Declare build outputs and bind them to real values.
     /// Only required for unit testing.

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -51,8 +51,8 @@ type public FSharpProjectOptions =
       /// Unused in this API and should be 'None' when used as user-specified input
       UnresolvedReferences : UnresolvedReferencesSet option
 
-      /// Unused in this API and should be '[]' when used as user-specified input
-      OriginalLoadReferences: (range * string * string) list
+      /// Unused in this API and should be empty when used as user-specified input
+      OriginalLoadReferences: (range * string * string)[]
 
       /// Extra information passed back on event trigger
       ExtraProjectInfo : obj option
@@ -245,7 +245,7 @@ type public FSharpChecker =
     ///
     /// <param name="sourceFiles">Initial source files list. Additional files may be added during argv evaluation.</param>
     /// <param name="argv">The command line arguments for the project build.</param>
-    member GetParsingOptionsFromCommandLineArgs: sourceFiles: string list * argv: string list * ?isInteractive: bool -> FSharpParsingOptions * FSharpErrorInfo list
+    member GetParsingOptionsFromCommandLineArgs: sourceFiles: string[] * argv: string list * ?isInteractive: bool -> FSharpParsingOptions * FSharpErrorInfo list
 
     /// <summary>
     /// <para>Get the FSharpParsingOptions implied by a set of command line arguments.</para>
@@ -315,7 +315,7 @@ type public FSharpChecker =
     /// TypeCheck and compile provided AST
     /// </summary>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member Compile: ast:ParsedInput list * assemblyName:string * outFile:string * dependencies:string list * ?pdbFile:string * ?executable:bool * ?noframework:bool * ?userOpName: string -> Async<FSharpErrorInfo [] * int>
+    member Compile: ast:ParsedInput[] * assemblyName:string * outFile:string * dependencies:string list * ?pdbFile:string * ?executable:bool * ?noframework:bool * ?userOpName: string -> Async<FSharpErrorInfo [] * int>
 
     /// <summary>
     /// Compiles to a dynamic assembly using the given flags.
@@ -336,7 +336,7 @@ type public FSharpChecker =
     /// TypeCheck and compile provided AST
     /// </summary>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member CompileToDynamicAssembly: ast:ParsedInput list * assemblyName:string * dependencies:string list * execute:(TextWriter * TextWriter) option * ?debug:bool * ?noframework:bool  * ?userOpName: string -> Async<FSharpErrorInfo [] * int * System.Reflection.Assembly option>
+    member CompileToDynamicAssembly: ast:ParsedInput[] * assemblyName:string * dependencies:string list * execute:(TextWriter * TextWriter) option * ?debug:bool * ?noframework:bool  * ?userOpName: string -> Async<FSharpErrorInfo [] * int * System.Reflection.Assembly option>
 
     /// <summary>
     /// Try to get type check results for a file. This looks up the results of recent type checks of the

--- a/src/fsharp/symbols/Exprs.fs
+++ b/src/fsharp/symbols/Exprs.fs
@@ -1232,7 +1232,7 @@ module FSharpExprConvert =
 
 
 /// The contents of the F# assembly as provided through the compiler API
-type FSharpAssemblyContents(cenv: SymbolEnv, mimpls: TypedImplFile list) = 
+type FSharpAssemblyContents(cenv: SymbolEnv, mimpls: TypedImplFile[]) = 
 
     new (g, thisCcu, thisCcuType, tcImports, mimpls) = FSharpAssemblyContents(SymbolEnv(g, thisCcu, thisCcuType, tcImports), mimpls)
 

--- a/src/fsharp/symbols/Exprs.fsi
+++ b/src/fsharp/symbols/Exprs.fsi
@@ -11,7 +11,7 @@ open FSharp.Compiler.TypedTree
 /// Represents the definitional contents of an assembly, as seen by the F# language
 type public FSharpAssemblyContents = 
 
-    internal new : tcGlobals: TcGlobals * thisCcu: CcuThunk * thisCcuType: ModuleOrNamespaceType option * tcImports: TcImports * mimpls: TypedImplFile list -> FSharpAssemblyContents
+    internal new : tcGlobals: TcGlobals * thisCcu: CcuThunk * thisCcuType: ModuleOrNamespaceType option * tcImports: TcImports * mimpls: TypedImplFile[] -> FSharpAssemblyContents
 
     /// The contents of the implementation files in the assembly
     member ImplementationFiles:  FSharpImplementationFileContents list

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -106,7 +106,7 @@ let ``FileSystem compilation test``() =
           UseScriptResolutionRules = true 
           LoadTime = System.DateTime.Now // Not 'now', we don't want to force reloading
           UnresolvedReferences = None 
-          OriginalLoadReferences = []
+          OriginalLoadReferences = [||]
           ExtraProjectInfo = None 
           Stamp = None }
 

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -895,13 +895,13 @@ let ``Type provider project references should not throw exceptions`` () =
                 UseScriptResolutionRules = false;
                 LoadTime = System.DateTime.Now
                 UnresolvedReferences = None;
-                OriginalLoadReferences = [];
+                OriginalLoadReferences = [||];
                 ExtraProjectInfo = None;})|];
            IsIncompleteTypeCheckEnvironment = false;
            UseScriptResolutionRules = false;
            LoadTime = System.DateTime.Now
            UnresolvedReferences = None;
-           OriginalLoadReferences = [];
+           OriginalLoadReferences = [||];
            ExtraProjectInfo = None;}
 
     //printfn "options: %A" options
@@ -990,7 +990,7 @@ let ``Projects creating generated types should not utilize cross-project-referen
                 UseScriptResolutionRules = false;
                 LoadTime = System.DateTime.Now
                 UnresolvedReferences = None;
-                OriginalLoadReferences = [];
+                OriginalLoadReferences = [||];
                 Stamp = None;
                 ExtraProjectInfo = None;})|];
            IsIncompleteTypeCheckEnvironment = false;
@@ -998,7 +998,7 @@ let ``Projects creating generated types should not utilize cross-project-referen
            LoadTime = System.DateTime.Now
            UnresolvedReferences = None;
            Stamp = None;
-           OriginalLoadReferences = [];
+           OriginalLoadReferences = [||];
            ExtraProjectInfo = None;}
     //printfn "options: %A" options
     let fileName = __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/Program.fs"    


### PR DESCRIPTION
I've started with trying to avoid converting between source files lists and arrays when creating parsing options for a project. Changing it to always use arrays required updating some other places and changing them added even more places needing fixes. I've managed to build FCS solution and removed some extra list conversions and mapping along the way.

I'm not sure if we want such changes but some of the previous discussions lead to idea that using arrays where possible would probably be good in some places in the compiler. I'd like to get some feedback on this PR, in particular if this approach should be used. :)

PR also changes how `isLastCompiland` and `isExe` are passed around. Would be good to simplify it even more if using arrays for source files paths is approved.