### PR TITLE
Adjust FS-1075 : nullable interop - apply rule to all arguments, not just optional ones

### DIFF
--- a/tests/fsharp/core/fsfromfsviacs/compilation.errors.output.bsl
+++ b/tests/fsharp/core/fsfromfsviacs/compilation.errors.output.bsl
@@ -1,10 +1,10 @@
 
-test.fsx(186,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(217,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(187,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(218,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x:int
 
@@ -12,7 +12,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(188,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(219,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y:string
 
@@ -20,7 +20,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(189,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(220,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x:int option
 
@@ -28,7 +28,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(190,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(221,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y:string option
 
@@ -36,7 +36,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(191,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(222,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x:'a option
 
@@ -44,7 +44,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(192,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(223,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y:'a option
 
@@ -52,7 +52,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(193,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(224,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:'a option
 
@@ -60,7 +60,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(196,42): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(227,42): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a0
 
@@ -68,12 +68,12 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(198,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(229,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(199,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(230,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y:string
 
@@ -81,7 +81,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(200,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(231,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:Nullable<float>
 
@@ -89,7 +89,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(201,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(232,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:float
 
@@ -97,7 +97,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(202,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(233,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:float option
 
@@ -105,7 +105,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(203,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(234,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x:'a option
 
@@ -113,7 +113,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(204,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(235,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:'a option
 
@@ -121,7 +121,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(206,42): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(237,42): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a0
 
@@ -129,12 +129,12 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(207,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(239,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(208,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(240,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y:string
 
@@ -142,7 +142,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(209,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(241,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:float
 
@@ -150,7 +150,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(210,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(242,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:Nullable<float>
 
@@ -158,7 +158,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(211,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(243,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:float
 
@@ -166,7 +166,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(212,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(244,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:float option
 
@@ -174,7 +174,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(213,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(245,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x:'a option
 
@@ -182,7 +182,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(214,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(246,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:'a option
 
@@ -190,13 +190,23 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(215,42): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(247,42): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a0
 
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
+
+test.fsx(249,93): error FS0691: Named arguments must appear after all other arguments
+
+test.fsx(250,88): error FS0041: A unique overload for method 'OverloadedMethodTakingNullables' could not be determined based on type information prior to this program point. A type annotation may be needed.
+
+Known types of arguments: Nullable<'a> * string * Nullable<'b> when 'a : (new : unit -> 'a) and 'a : struct and 'a :> ValueType and 'b : (new : unit -> 'b) and 'b : struct and 'b :> ValueType
+
+Candidates:
+ - SomeClass.OverloadedMethodTakingNullables(x: Nullable<int64>, y: string, d: Nullable<float>) : int
+ - SomeClass.OverloadedMethodTakingNullables(x: Nullable<int>, y: string, d: Nullable<float>) : int
 
 test.fsx(267,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
 

--- a/tests/fsharp/core/fsfromfsviacs/compilation.errors.output.bsl
+++ b/tests/fsharp/core/fsfromfsviacs/compilation.errors.output.bsl
@@ -68,12 +68,12 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int,?y: string,?d: float32) : int
 
-test.fsx(229,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(229,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(230,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(230,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y:string
 
@@ -81,7 +81,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(231,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(231,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:Nullable<float>
 
@@ -89,7 +89,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(232,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(232,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:float
 
@@ -97,7 +97,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(233,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(233,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:float option
 
@@ -105,7 +105,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(234,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(234,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x:'a option
 
@@ -113,7 +113,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(235,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(235,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:'a option
 
@@ -121,7 +121,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(237,42): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(237,43): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a0
 
@@ -142,7 +142,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(241,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(241,33): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d:float
 

--- a/tests/fsharp/core/fsfromfsviacs/compilation.errors.output.bsl
+++ b/tests/fsharp/core/fsfromfsviacs/compilation.errors.output.bsl
@@ -198,6 +198,6 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>,?y: string,?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>,?y: string,?d: Nullable<float>) : int
 
-test.fsx(232,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+test.fsx(267,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
 
-test.fsx(249,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+test.fsx(284,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).

--- a/tests/fsharp/core/fsfromfsviacs/compilation.langversion.old.output.bsl
+++ b/tests/fsharp/core/fsfromfsviacs/compilation.langversion.old.output.bsl
@@ -118,11 +118,11 @@ is not compatible with type
     'Nullable<float>'    
 
 
-test.fsx(232,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+test.fsx(267,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
 
-test.fsx(249,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+test.fsx(284,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
 
-test.fsx(383,29): error FS0041: A unique overload for method 'SimpleOverload' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(418,29): error FS0041: A unique overload for method 'SimpleOverload' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.SimpleOverload(?x: Nullable<int>) : int
  - SomeClass.SimpleOverload(?x: int) : int

--- a/tests/fsharp/core/fsfromfsviacs/lib3.cs
+++ b/tests/fsharp/core/fsfromfsviacs/lib3.cs
@@ -81,7 +81,34 @@ namespace CSharpOptionalParameters
                 length = y.Length;
             return (x.HasValue ? (int) x.Value : -1) + length + (int) (d.HasValue ? d.Value : -1.0) + 7;
         }
+        public static int MethodTakingNullables(int? x, string y, double? d)
+        {
+            int length;
+            if (y == null)
+                length = -1;
+            else
+                length = y.Length;
+            return (x.HasValue ? x.Value : -1) + length + (int) (d.HasValue ? d.Value : -1.0);
+        }
 
+        public static int OverloadedMethodTakingNullables(int? x, string y, double? d)
+        {
+            int length;
+            if (y == null)
+                length = -1;
+            else
+                length = y.Length;
+            return (x.HasValue ? x.Value : -1) + length + (int) (d.HasValue ? d.Value : -1.0);
+        }
+        public static int OverloadedMethodTakingNullables(long? x, string y, double? d)
+        {
+            int length;
+            if (y == null)
+                length = -1;
+            else
+                length = y.Length;
+            return (x.HasValue ? (int) x.Value : -1) + length + (int) (d.HasValue ? d.Value : -1.0) + 7;
+        }
         public static int SimpleOverload(int? x = 3)
         {
             return (x.HasValue ? x.Value : 100);

--- a/tests/fsharp/core/fsfromfsviacs/test.fsx
+++ b/tests/fsharp/core/fsfromfsviacs/test.fsx
@@ -148,6 +148,35 @@ module TestConsumeCSharpOptionalParameter =
     // Check the type inferred for an un-annotated first-class use of the method
     check "csoptional23982f55" (let f = SomeClass.MethodTakingNullableOptionals in ((f : unit -> int) ())) -3
 
+#if LANGVERSION_PREVIEW
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", 8.0)) 20
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", Nullable 8.0)) 20
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", Nullable ())) 11
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(Nullable (), "aaaaaa", 8.0)) 13
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(Nullable 6, "aaaaaa", 8.0)) 20
+
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", d=8.0)) 20
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", d=Nullable 8.0)) 20
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", d=Nullable ())) 11
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(Nullable (), "aaaaaa", d=8.0)) 13
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(Nullable 6, "aaaaaa", d=8.0)) 20
+
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, y="aaaaaa", d=8.0)) 20
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, y="aaaaaa", d=Nullable 8.0)) 20
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, y="aaaaaa", d=Nullable ())) 11
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(Nullable (), y="aaaaaa", d=8.0)) 13
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(Nullable 6, y="aaaaaa", d=8.0)) 20
+
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, y="aaaaaa", d=8.0)) 20
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, y="aaaaaa", d=Nullable 8.0)) 20
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, y="aaaaaa", d=Nullable ())) 11
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(Nullable (), y="aaaaaa", d=8.0)) 13
+    check "acsoptional23982f51" (SomeClass.MethodTakingNullables(Nullable 6, y="aaaaaa", d=8.0)) 20
+
+    // Check the type inferred for an un-annotated first-class use of the method
+    check "acsoptional23982f55" (let f = SomeClass.MethodTakingNullables in ((f : Nullable<int> * string * Nullable<double> -> int) (Nullable 1,"aaaa",Nullable 3.0))) 8
+#endif
+
 // This tests overloaded variaitons of the methods, where the overloads vary by type but not nullability
 //
 // The CHECK_ERRORS cases are not execpted to compile
@@ -177,8 +206,10 @@ module TestConsumeCSharpOptionalParameterOverloads =
 
     check "csoptional23982f523o" (SomeClass.OverloadedMethodTakingNullableOptionals(x = 6)) 4
     
-    // When a C# argument has a default value and is nullable (without a default), using ?x to provide an argument takes type option
-    check "csoptional23982f527o" (SomeClass.OverloadedMethodTakingNullableOptionals(?x = Some 6)) 4
+    check "csoptional23982f52o1" (SomeClass.OverloadedMethodTakingNullables(6, "aaaaaa", 8.0)) 20 // can provide non-nullable
+    check "csoptional23982f52o2" (SomeClass.OverloadedMethodTakingNullables(Nullable(6), "aaaaaa", 8.0)) 20 // can provide nullable 
+    check "csoptional23982f52o3" (SomeClass.OverloadedMethodTakingNullables(Nullable(6), "aaaaaa", Nullable(8.0))) 20 // can provide nullable 
+
 #endif
 
 #if CHECK_ERRORS
@@ -195,24 +226,28 @@ module TestConsumeCSharpOptionalParameterOverloads =
     // Check the type inferred for an un-annotated first-class use of the method
     check "csoptional23982f35o" (let f = SomeClass.OverloadedMethodTakingOptionals in ((f : unit -> int) ())) 11
 
-    check "csoptional23982f41o" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults()) 11
-    check "csoptional23982f43o" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(y = "aaaaaa")) 14
-    check "csoptional23982f44o" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(d = Nullable 8.0)) 14 // can provide nullable for legacy
-    check "csoptional23982f442o" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(d = 8.0)) 14
-    check "csoptional23982f446o" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?d = Some 8.0)) 14
-    check "csoptional23982f43Eo" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x = None)) -92
-    check "csoptional23982f44Ro" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?d = None)) 6
+    check "csoptional23982f41ox" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults()) 11
+    check "csoptional23982f43ox" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(y = "aaaaaa")) 14
+    check "csoptional23982f44ox" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(d = Nullable 8.0)) 14 // can provide nullable for legacy
+    check "csoptional23982f442ox" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(d = 8.0)) 14
+    check "csoptional23982f446ox" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?d = Some 8.0)) 14
+    check "csoptional23982f43Eox" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x = None)) -92
+    check "csoptional23982f44Rox" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?d = None)) 6
     // Check the type inferred for an un-annotated first-class use of the method
-    check "csoptional23982f45o" (let f = SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults in ((f : unit -> int) ())) 11
+    check "csoptional23982f45ox" (let f = SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults in ((f : unit -> int) ())) 11
+
     check "csoptional23982f51o" (SomeClass.OverloadedMethodTakingNullableOptionals()) -3
     check "csoptional23982f53o" (SomeClass.OverloadedMethodTakingNullableOptionals(y = "aaaaaa")) 4
-    check "csoptional23982f54o" (SomeClass.OverloadedMethodTakingNullableOptionals(d = 8.0)) 6 
+    check "soptional23982f54o" (SomeClass.OverloadedMethodTakingNullableOptionals(d = 8.0)) 6 
     check "csoptional23982f54o" (SomeClass.OverloadedMethodTakingNullableOptionals(d = Nullable 8.0)) 6 // can provide nullable for legacy
     check "csoptional23982f544o" (SomeClass.OverloadedMethodTakingNullableOptionals(d = 8.0)) 6
     check "csoptional23982f548o" (SomeClass.OverloadedMethodTakingNullableOptionals(?d = Some 8.0)) 6
     check "csoptional23982f52To" (SomeClass.OverloadedMethodTakingNullableOptionals(?x = None)) -3
     check "csoptional23982f54Yo" (SomeClass.OverloadedMethodTakingNullableOptionals(?d = None)) -3
     check "csoptional23982f55o" (let f = SomeClass.OverloadedMethodTakingNullableOptionals in ((f : unit -> int) ())) -3
+
+    check "dcsoptional23982f544o" (SomeClass.OverloadedMethodTakingNullables(x= Nullable(), "aaaa" d = Nullable())) 6
+    check "dcsoptional23982f55o" (let (f: Nullable<_> * string * Nullable<_> -> int) = SomeClass.OverloadedMethodTakingNullables in f  (Nullable(), "aaa", Nullable())) -3
 #endif
 
 module NestedStructPatternMatchingAcrossAssemblyBoundaries = 


### PR DESCRIPTION
This is a potential adjustment to RFC FS-1075 which is currently in preview

The adjustment is based on [this usability feedback](https://github.com/fsharp/fslang-design/issues/428#issuecomment-634677857), which indicates that we should extend this to interoperating with non-optional nullable-typed arguments



