### PR TITLE
Refactor async.fs.

### DIFF
--- a/src/fsharp/FSharp.Core/async.fs
+++ b/src/fsharp/FSharp.Core/async.fs
@@ -1223,7 +1223,8 @@ namespace Microsoft.FSharp.Control
                     let maxDegreeOfParallelism =
                         match maxDegreeOfParallelism with
                         | None -> None
-                        | Some maxDegreeOfParallelism -> if maxDegreeOfParallelism >= tasks.Length then None else Some maxDegreeOfParallelism
+                        | Some x when x >= tasks.Length -> None
+                        | Some _ as x -> x
 
                     // Simple case (no maxDegreeOfParallelism) just queue all the work, if we have maxDegreeOfParallelism set we start that many workers
                     // which will make progress on the actual computations


### PR DESCRIPTION
~~This PR makes cancelling `Async`s much easier by redirecting to their cancelling continuation if an appropriate `OperationCancelledException` is passed to their exception continuation.~~

~~This means that calling `ThrowIfRequested` on the `Async`'s `CancellationToken` will not propagate the exception but cancel the `Async`, as most probably intended.~~

Never mind, `ThrowingIfRequested` worked already before the PR. I added one new test case. And the PR refactored the `async.fs` file a bit, as explained in the commits.