### PR TITLE
Remove parseILGlobals

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -3708,6 +3708,7 @@ let getCustomAttrData (ilg: ILGlobals) cattr =
 let MscorlibScopeRef = ILScopeRef.Assembly (ILAssemblyRef.Create ("mscorlib", None, Some ecmaPublicKey, true, None, None))
 
 let EcmaMscorlibILGlobals = mkILGlobals (MscorlibScopeRef, [])
+let PrimaryAssemblyILGlobals = mkILGlobals (ILScopeRef.PrimaryAssembly, [])
 
 // ILSecurityDecl is a 'blob' having the following format:
 // - A byte containing a period (.).

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1614,6 +1614,7 @@ type ILGlobals =
 val mkILGlobals: primaryScopeRef: ILScopeRef * assembliesThatForwardToPrimaryAssembly: ILAssemblyRef list -> ILGlobals
 
 val EcmaMscorlibILGlobals: ILGlobals
+val PrimaryAssemblyILGlobals: ILGlobals
 
 /// When writing a binary the fake "toplevel" type definition (called <Module>)
 /// must come first. This function puts it first, and creates it in the returned 
@@ -2020,4 +2021,6 @@ type ILReferences =
 /// Find the full set of assemblies referenced by a module.
 val computeILRefs: ILGlobals -> ILModuleDef -> ILReferences
 val emptyILRefs: ILReferences
+
+val primaryAssemblyILGlobals: ILGlobals
 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -2022,5 +2022,3 @@ type ILReferences =
 val computeILRefs: ILGlobals -> ILModuleDef -> ILReferences
 val emptyILRefs: ILReferences
 
-val primaryAssemblyILGlobals: ILGlobals
-

--- a/src/absil/ilascii.fs
+++ b/src/absil/ilascii.fs
@@ -7,10 +7,6 @@ open Internal.Utilities.Collections
 open FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.AbstractIL.IL
 
-// set to the proper value at CompileOps.fs (BuildFrameworkTcImports)
-// Only relevant when compiling FSharp.Core.dll
-let mutable parseILGlobals = EcmaMscorlibILGlobals
-
 /// Table of parsing and pretty printing data for instructions.
 let noArgInstrs =
     lazy [

--- a/src/absil/ilascii.fsi
+++ b/src/absil/ilascii.fsi
@@ -11,12 +11,6 @@ open FSharp.Compiler.AbstractIL.Extensions.ILX.Types
 open FSharp.Compiler.AbstractIL.IL 
 
 // -------------------------------------------------------------------- 
-// IL Parser state - must be initialized before parsing a module
-// -------------------------------------------------------------------- 
-
-val mutable parseILGlobals: ILGlobals
-
-// -------------------------------------------------------------------- 
 // IL Lexer and pretty-printer tables
 // -------------------------------------------------------------------- 
 

--- a/src/absil/ilpars.fsy
+++ b/src/absil/ilpars.fsy
@@ -31,17 +31,6 @@ let resolveMethodSpecScopeThen (ResolvedAtMethodSpecScope f) g =
 let resolveCurrentMethodSpecScope obj = 
     resolveMethodSpecScope obj mkILEmptyGenericParams
 
-
-let findSystemRuntimeAssemblyRef() = 
-  match parseILGlobals.primaryAssemblyScopeRef with
-  | ILScopeRef.Assembly aref -> aref
-  | _ -> pfailwith "systemRuntimeScopeRef not set to valid assembly reference in parseILGlobals"
-
-let findAssemblyRef nm = 
-  if nm = "mscorlib" then findSystemRuntimeAssemblyRef() 
-  else
-  pfailwith ("Undefined assembly ref '" + nm + "'") 
-
 %} 
 
 /*-----------------------------------------------------------------------
@@ -178,8 +167,7 @@ name1:
 className:
      LBRACK name1 RBRACK slashedName
         { let (enc,nm) = $4 
-          let aref = findAssemblyRef $2 
-          ILScopeRef.Assembly aref, enc, nm }
+          ILScopeRef.PrimaryAssembly, enc, nm }
    | slashedName
         { let enc, nm = $1 in (ILScopeRef.Local, enc, nm) }
 
@@ -235,9 +223,9 @@ callKind:
  *---------------------------------------------*/
 
 typ: STRING
-       { noMethodSpecScope parseILGlobals.typ_String } 
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_String } 
    | OBJECT
-       { noMethodSpecScope parseILGlobals.typ_Object } 
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Object } 
    | CLASS typeNameInst
        { resolveMethodSpecScopeThen $2 (fun tspec -> 
           noMethodSpecScope (mkILBoxedType tspec)) } 
@@ -256,45 +244,45 @@ typ: STRING
    | typ STAR
        { resolveMethodSpecScopeThen $1 (fun ty -> noMethodSpecScope (ILType.Ptr ty)) }
    | CHAR
-       { noMethodSpecScope parseILGlobals.typ_Char }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Char }
    | VOID
        { noMethodSpecScope ILType.Void }
    | BOOL
-       { noMethodSpecScope parseILGlobals.typ_Bool }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Bool }
    | INT8
-       { noMethodSpecScope parseILGlobals.typ_SByte }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_SByte }
    | INT16              
-       { noMethodSpecScope parseILGlobals.typ_Int16 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Int16 }
    | INT32              
-       { noMethodSpecScope parseILGlobals.typ_Int32 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Int32 }
    | INT64              
-       { noMethodSpecScope parseILGlobals.typ_Int64 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Int64 }
    | FLOAT32            
-       { noMethodSpecScope parseILGlobals.typ_Single }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Single }
    | FLOAT64            
-       { noMethodSpecScope parseILGlobals.typ_Double }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Double }
    | UNSIGNED INT8      
-       { noMethodSpecScope parseILGlobals.typ_Byte }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Byte }
    | UNSIGNED INT16     
-       { noMethodSpecScope parseILGlobals.typ_UInt16 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_UInt16 }
    | UNSIGNED INT32     
-       { noMethodSpecScope parseILGlobals.typ_UInt32 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_UInt32 }
    | UNSIGNED INT64     
-       { noMethodSpecScope parseILGlobals.typ_UInt64 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_UInt64 }
    | UINT8      
-       { noMethodSpecScope parseILGlobals.typ_Byte }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_Byte }
    | UINT16     
-       { noMethodSpecScope parseILGlobals.typ_UInt16 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_UInt16 }
    | UINT32     
-       { noMethodSpecScope parseILGlobals.typ_UInt32 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_UInt32 }
    | UINT64     
-       { noMethodSpecScope parseILGlobals.typ_UInt64 }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_UInt64 }
    | NATIVE INT         
-       { noMethodSpecScope parseILGlobals.typ_IntPtr }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_IntPtr }
    | NATIVE UNSIGNED INT  
-       { noMethodSpecScope parseILGlobals.typ_UIntPtr }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_UIntPtr }
    | NATIVE UINT  
-       { noMethodSpecScope parseILGlobals.typ_UIntPtr }
+       { noMethodSpecScope PrimaryAssemblyILGlobals.typ_UIntPtr }
 
    | BANG int32
        { noMethodSpecScope (ILType.TypeVar (uint16 ( $2)))  }

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -1715,7 +1715,7 @@ and seekReadTypeDefOrRefAsTypeRef (ctxt: ILMetadataReader) (TaggedIndex(tag, idx
     | tag when tag = tdor_TypeRef -> seekReadTypeRef ctxt idx
     | tag when tag = tdor_TypeSpec -> 
         dprintn ("type spec used where a type ref or def is required")
-        primaryAssemblyILGlobals.typ_Object.TypeRef
+        PrimaryAssemblyILGlobals.typ_Object.TypeRef
     | _ -> failwith "seekReadTypeDefOrRefAsTypeRef_readTypeDefOrRefOrSpec"
 
 and seekReadMethodRefParent (ctxt: ILMetadataReader) mdv numtypars (TaggedIndex(tag, idx)) =
@@ -1833,22 +1833,22 @@ and sigptrGetTypeDefOrRefOrSpecIdx bytes sigptr =
 
 and sigptrGetTy (ctxt: ILMetadataReader) numtypars bytes sigptr = 
     let b0, sigptr = sigptrGetByte bytes sigptr
-    if b0 = et_OBJECT then primaryAssemblyILGlobals.typ_Object, sigptr
-    elif b0 = et_STRING then primaryAssemblyILGlobals.typ_String, sigptr
-    elif b0 = et_I1 then primaryAssemblyILGlobals.typ_SByte, sigptr
-    elif b0 = et_I2 then primaryAssemblyILGlobals.typ_Int16, sigptr
-    elif b0 = et_I4 then primaryAssemblyILGlobals.typ_Int32, sigptr
-    elif b0 = et_I8 then primaryAssemblyILGlobals.typ_Int64, sigptr
-    elif b0 = et_I then primaryAssemblyILGlobals.typ_IntPtr, sigptr
-    elif b0 = et_U1 then primaryAssemblyILGlobals.typ_Byte, sigptr
-    elif b0 = et_U2 then primaryAssemblyILGlobals.typ_UInt16, sigptr
-    elif b0 = et_U4 then primaryAssemblyILGlobals.typ_UInt32, sigptr
-    elif b0 = et_U8 then primaryAssemblyILGlobals.typ_UInt64, sigptr
-    elif b0 = et_U then primaryAssemblyILGlobals.typ_UIntPtr, sigptr
-    elif b0 = et_R4 then primaryAssemblyILGlobals.typ_Single, sigptr
-    elif b0 = et_R8 then primaryAssemblyILGlobals.typ_Double, sigptr
-    elif b0 = et_CHAR then primaryAssemblyILGlobals.typ_Char, sigptr
-    elif b0 = et_BOOLEAN then primaryAssemblyILGlobals.typ_Bool, sigptr
+    if b0 = et_OBJECT then PrimaryAssemblyILGlobals.typ_Object, sigptr
+    elif b0 = et_STRING then PrimaryAssemblyILGlobals.typ_String, sigptr
+    elif b0 = et_I1 then PrimaryAssemblyILGlobals.typ_SByte, sigptr
+    elif b0 = et_I2 then PrimaryAssemblyILGlobals.typ_Int16, sigptr
+    elif b0 = et_I4 then PrimaryAssemblyILGlobals.typ_Int32, sigptr
+    elif b0 = et_I8 then PrimaryAssemblyILGlobals.typ_Int64, sigptr
+    elif b0 = et_I then PrimaryAssemblyILGlobals.typ_IntPtr, sigptr
+    elif b0 = et_U1 then PrimaryAssemblyILGlobals.typ_Byte, sigptr
+    elif b0 = et_U2 then PrimaryAssemblyILGlobals.typ_UInt16, sigptr
+    elif b0 = et_U4 then PrimaryAssemblyILGlobals.typ_UInt32, sigptr
+    elif b0 = et_U8 then PrimaryAssemblyILGlobals.typ_UInt64, sigptr
+    elif b0 = et_U then PrimaryAssemblyILGlobals.typ_UIntPtr, sigptr
+    elif b0 = et_R4 then PrimaryAssemblyILGlobals.typ_Single, sigptr
+    elif b0 = et_R8 then PrimaryAssemblyILGlobals.typ_Double, sigptr
+    elif b0 = et_CHAR then PrimaryAssemblyILGlobals.typ_Char, sigptr
+    elif b0 = et_BOOLEAN then PrimaryAssemblyILGlobals.typ_Bool, sigptr
     elif b0 = et_WITH then 
         let b0, sigptr = sigptrGetByte bytes sigptr
         let tdorIdx, sigptr = sigptrGetTypeDefOrRefOrSpecIdx bytes sigptr
@@ -1894,7 +1894,7 @@ and sigptrGetTy (ctxt: ILMetadataReader) numtypars bytes sigptr =
         
     elif b0 = et_VOID then ILType.Void, sigptr
     elif b0 = et_TYPEDBYREF then 
-        primaryAssemblyILGlobals.typ_TypedReference, sigptr
+        PrimaryAssemblyILGlobals.typ_TypedReference, sigptr
     elif b0 = et_CMOD_REQD || b0 = et_CMOD_OPT then 
         let tdorIdx, sigptr = sigptrGetTypeDefOrRefOrSpecIdx bytes sigptr
         let ty, sigptr = sigptrGetTy ctxt numtypars bytes sigptr

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -33,8 +33,6 @@ open System.Reflection
 
 #nowarn "9"
 
-let primaryAssemblyILGlobals = mkILGlobals (ILScopeRef.PrimaryAssembly, [])
-
 let checking = false  
 let logging = false
 let _ = if checking then dprintn "warning: ILBinaryReader.checking is on"

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -4942,10 +4942,6 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
         // the global_g reference cell is used only for debug printing
         global_g <- Some tcGlobals
 #endif
-        // do this prior to parsing, since parsing IL assembly code may refer to mscorlib
-#if !NO_INLINE_IL_PARSER
-        FSharp.Compiler.AbstractIL.Internal.AsciiConstants.parseILGlobals <- tcGlobals.ilg 
-#endif
         frameworkTcImports.SetTcGlobals tcGlobals
         return tcGlobals, frameworkTcImports
       }


### PR DESCRIPTION
There is no need for this global anymore as we have `ILScopeRef.PrimaryAssembly` now.