### PR TITLE
Fix arcade

### DIFF
--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -325,9 +325,12 @@ type cenv =
 
 let convResolveAssemblyRef (cenv: cenv) (asmref: ILAssemblyRef) qualifiedName =
     let assembly = 
-        match cenv.resolveAssemblyRef asmref with                     
+        match cenv.resolveAssemblyRef asmref with
         | Some (Choice1Of2 path) ->
-            FileSystem.AssemblyLoadFrom path              
+            // asmRef is a path but the runtime is smarter with assembly names so make one
+            let asmName = AssemblyName.GetAssemblyName(path)
+            asmName.CodeBase <- path
+            FileSystem.AssemblyLoad asmName
         | Some (Choice2Of2 assembly) ->
             assembly
         | None ->
@@ -358,9 +361,6 @@ let convTypeRefAux (cenv: cenv) (tref: ILTypeRef) =
         | res -> res
     | ILScopeRef.PrimaryAssembly ->
         convResolveAssemblyRef cenv cenv.ilg.primaryAssemblyRef qualifiedName
-
-
-
 /// The (local) emitter env (state). Some of these fields are effectively global accumulators
 /// and could be placed as hash tables in the global environment.
 [<AutoSerializable(false)>]

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -361,6 +361,7 @@ let convTypeRefAux (cenv: cenv) (tref: ILTypeRef) =
         | res -> res
     | ILScopeRef.PrimaryAssembly ->
         convResolveAssemblyRef cenv cenv.ilg.primaryAssemblyRef qualifiedName
+
 /// The (local) emitter env (state). Some of these fields are effectively global accumulators
 /// and could be placed as hash tables in the global environment.
 [<AutoSerializable(false)>]

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2809,7 +2809,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let fsiInteractionProcessor = FsiInteractionProcessor(fsi, tcConfigB, fsiOptions, fsiDynamicCompiler, fsiConsolePrompt, fsiConsoleOutput, fsiInterruptController, fsiStdinLexerProvider, lexResourceManager, initialInteractiveState) 
 
-    // Raising an exception throws away the exception stack mking diagnosis hard
+    // Raising an exception throws away the exception stack making diagnosis hard
     // this wraps the existing exception as the inner exception
     let makeNestedException (userExn: #Exception) =
         // clone userExn -- make userExn the inner exception, to retain the stacktrace on raise

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2809,11 +2809,18 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let fsiInteractionProcessor = FsiInteractionProcessor(fsi, tcConfigB, fsiOptions, fsiDynamicCompiler, fsiConsolePrompt, fsiConsoleOutput, fsiInterruptController, fsiStdinLexerProvider, lexResourceManager, initialInteractiveState) 
 
+    // Raising an exception throws away the exception stack mking diagnosis hard
+    // this wraps the existing exception as the inner exception
+    let makeNestedException (userExn: #Exception) =
+        // clone userExn -- make userExn the inner exception, to retain the stacktrace on raise
+        let arguments = [| userExn.Message :> obj; userExn :> obj |]
+        Activator.CreateInstance(userExn.GetType(), arguments) :?> Exception
+
     let commitResult res =
         match res with
         | Choice1Of2 r -> r
         | Choice2Of2 None -> raise (FsiCompilationException(FSIstrings.SR.fsiOperationFailed(), None))
-        | Choice2Of2 (Some userExn) -> raise userExn
+        | Choice2Of2 (Some userExn) -> raise (makeNestedException userExn)
 
     let commitResultNonThrowing errorOptions scriptFile (errorLogger: CompilationErrorLogger) res =
         let errs = errorLogger.GetErrors()


### PR DESCRIPTION
The recently added  creation of a bound value tests have been failing on internal builds.  It has been very tricky to repro elsewhere.  However, the failure was due to coreclr not being comfortable loadfroming System.Private.Corelib, since it was already loaded.  Yeah I know LoadFroming isn't a real word but hey!!! inventing new words is fun.

To fix things, I improved convResolveAssemblyRef when the assembly to load is a path.  Now it gets an assemblyname object from the file at the path and sets the codebase to the path, and then using Assembly.Load to do a proper job of loading it.

The fix includes an improvement to the exception thaat is thrown, essentially the original one is set to the new exceptions InternalException value.  This way we get a decent stacktrace, it makes diagnosis a lot easier.
