### PR TITLE
Confirms that dobang is not, in fact, simple

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -8884,6 +8884,7 @@ and TcComputationExpression cenv env overallTy mWhole (interpExpr: Expr) builder
             clauses |> List.forall (fun (Clause(_, _, clauseComp, _, _)) -> isSimpleExpr clauseComp)
         | SynExpr.YieldOrReturnFrom _ -> false
         | SynExpr.YieldOrReturn _ -> false
+        | SynExpr.DoBang _ -> false
         | _ -> true
 
     let basicSynExpr = 


### PR DESCRIPTION
Fixes #9412 by telling the compiler what we all knew all along: it is not simple to just `do!` the thing.

This fixes typechecker behavior where it would rewrite a `Sequential(DoBang, Return)` (and many other forms) into a `Sequential(lambda, lambda)` instead of allowing the CE typechecking process to continue processing the DoBang and Return exprs.

I could use pointers as to where to add tests.