### PR TITLE
Fix recovery #9420

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -5551,16 +5551,14 @@ and TcPat warnOnUpper cenv env topValInfo vFlags (tpenv, names, takenNames) ty p
                 let numArgs = args.Length
                 if numArgs = numArgTys then
                     args, extraPatterns
+                elif numArgs < numArgTys then
+                    errorR (UnionCaseWrongArguments (env.DisplayEnv, numArgTys, numArgs, m))
+                    args @ (List.init (numArgTys - numArgs) (fun _ -> SynPat.Wild (m.MakeSynthetic()))), extraPatterns
                 else
-                    if numArgs < numArgTys then
-                        if numArgs <> 0 && numArgTys <> 0 then
-                            errorR (UnionCaseWrongArguments (env.DisplayEnv, numArgTys, numArgs, m))
-                        args @ (List.init (numArgTys - numArgs) (fun _ -> SynPat.Wild (m.MakeSynthetic()))), extraPatterns
-                    else
-                        let args, remaining = args |> List.splitAt numArgTys
-                        for remainingArg in remaining do
-                            errorR (UnionCaseWrongArguments (env.DisplayEnv, numArgTys, numArgs, remainingArg.Range))
-                        args, extraPatterns @ remaining
+                    let args, remaining = args |> List.splitAt numArgTys
+                    for remainingArg in remaining do
+                        errorR (UnionCaseWrongArguments (env.DisplayEnv, numArgTys, numArgs, remainingArg.Range))
+                    args, extraPatterns @ remaining
 
             let extraPatterns = extraPatterns @ extraPatternsFromNames
             let args', acc = TcPatterns warnOnUpper cenv env vFlags (tpenv, names, takenNames) argTys args

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -5464,7 +5464,6 @@ and TcPat warnOnUpper cenv env topValInfo vFlags (tpenv, names, takenNames) ty p
                 TPat_query((activePatExpr, activePatResTys, activePatIdentity, idx, apinfo), arg' values, m)), acc
 
         | (Item.UnionCase _ | Item.ExnCase _) as item ->
-
             // Report information about the case occurrence to IDE
             CallNameResolutionSink cenv.tcSink (lidRange, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.eAccessRights)
 

--- a/tests/service/PatternMatchCompilationTests.fs
+++ b/tests/service/PatternMatchCompilationTests.fs
@@ -80,7 +80,7 @@ match A with
 """
     assertHasSymbolUsages ["x"; "y"] checkResults
     dumpErrors checkResults |> shouldEqual [
-        "(7,2--7,10): This constructor is applied to 2 argument(s) but expects 3"
+        "(7,2--7,10): This union case expects 3 arguments in tupled form"        
         "(6,6--6,7): Incomplete pattern matches on this expression. For example, the value 'A' may indicate a case not covered by the pattern(s)."
     ]
 
@@ -257,6 +257,23 @@ match TraceLevel.Off with
     ]
 
 
+[<Test>]
+let ``Caseless DU`` () =
+    let _, checkResults = getParseAndCheckResults """
+type DU = Case of int
+
+let f du =
+    match du with
+    | Case -> ()
+
+let dowork () =
+    f (Case 1)
+    0 // return an integer exit code"""
+    assertHasSymbolUsages ["DU"; "dowork"; "du"; "f"] checkResults
+    dumpErrors checkResults |> shouldEqual [
+        "(6,6--6,10): This constructor is applied to 0 argument(s) but expects 1"
+    ]
+    
 [<Test>]
 let ``Or 01 - No errors`` () =
     let _, checkResults = getParseAndCheckResults """


### PR DESCRIPTION
Fixes: https://github.com/dotnet/fsharp/issues/9420

Regression: DU case at pattern match site no longer requires parameter #9420

A recent PR [here ]( https://github.com/dotnet/fsharp/pull/7711) caused a regression in Pattern matching validation.  This PR is intended to fix it.
- Adds a regression test case.
- Also fixes the case that DUs with tuple args produced one error message if only a single arg was provided, but another if multiple args were provided.

//cc @auduchinok , @dsyme 