### PR TITLE
Fix build break

### DIFF
--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/CeEdiThrow.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/CeEdiThrow.fs
@@ -3,6 +3,7 @@ namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Compiler.UnitTests
 open NUnit.Framework
+open FSharp.TestHelpers
 
 [<TestFixture>]
 module CeEdiThrow =


### PR DESCRIPTION
A recent PR merge overlapped some tst changes, this caused a build break.

````
  Compiler.Private.Scripting.UnitTests.dll
C:\kevinransom\fsharp\tests\fsharp\Compiler\CodeGen\EmittedIL\CeEdiThrow.fs(12,9): error FS0039: The value, namespace, type or module 'CompilerAssert' is not
defined. Maybe you want one of the following:↔   CompilerServices↔   CompilerMessageAttribute↔   ComparisonIdentity↔   compare↔   CompiledNameAttribute [C:\ke
vinransom\fsharp\tests\fsharp\FSharpSuite.Tests.fsproj]
  FSharp.VS.FSI -> C:\kevinransom\fsharp\artifacts\bin\FSharp.VS.FSI\Release\net472\FSharp.VS.FSI.dll
  VisualStudio.SetupPackage -> C:\kevinransom\fsharp\artifacts\VSSetup.obj\Release\Microsoft.FSharp.Compiler.MSBuild\net472\Microsoft.FSharp.Compiler.MSBuild.
  vsix
  FSharp.LanguageService.Base -> C:\kevinransom\fsharp\artifacts\bin\FSharp.LanguageService.Base\Release\net472\FSharp.LanguageService.Base.dll
C:\kevinransom\fsharp\tests\fsharp\Compiler\CodeGen\EmittedIL\CeEdiThrow.fs(12,9): error FS0039: The value, namespace, type or module 'CompilerAssert' is not
defined. Maybe you want one of the following:↔   CompilerServices↔   CompilerMessageAttribute↔   ComparisonIdentity↔   compare↔   CompiledNameAttribute [C:\ke
vinransom\fsharp\tests\fsharp\FSharpSuite.Tests.fsproj]
  FSharp.LanguageService -> C:\kevinransom\fsharp\artifacts\bin\FSharp.LanguageService\Release\net472\FSharp.LanguageService.dll
  FSharp.Editor -> C:\kevinransom\fsharp\artifacts\bin\FSharp.Editor\Release\net472\FSharp.Editor.dll
Attempting to cancel the build...
C:\Users\codec\.nuget\packages\microsoft.vssdk.buildtools\16.5.2044\tools\vssdk\Microsoft.VsSDK.targets(1111,5): error MSB5021: Terminating the task executabl
e "VsixUtil" and its child processes because the build was canceled. [C:\kevinransom\fsharp\vsintegration\src\FSharp.ProjectSystem.FSharp\ProjectSystem.fsproj
]

Build FAILED.

C:\kevinransom\fsharp\tests\fsharp\Compiler\CodeGen\EmittedIL\CeEdiThrow.fs(12,9): error FS0039: The value, namespace, type or module 'CompilerAssert' is not
defined. Maybe you want one of the following:↔   CompilerServices↔   CompilerMessageAttribute↔   ComparisonIdentity↔   compare↔   CompiledNameAttribute [C:\ke
vinransom\fsharp\tests\fsharp\FSharpSuite.Tests.fsproj]
C:\kevinransom\fsharp\tests\fsharp\Compiler\CodeGen\EmittedIL\CeEdiThrow.fs(12,9): error FS0039: The value, namespace, type or module 'CompilerAssert' is not
defined. Maybe you want one of the following:↔   CompilerServices↔   CompilerMessageAttribute↔   ComparisonIdentity↔   compare↔   CompiledNameAttribute [C:\ke
vinransom\fsharp\tests\fsharp\FSharpSuite.Tests.fsproj]
C:\Users\codec\.nuget\packages\microsoft.vssdk.buildtools\16.5.2044\tools\vssdk\Microsoft.VsSDK.targets(1111,5): error MSB5021: Terminating the task executabl
e "VsixUtil" and its child processes because the build was canceled. [C:\kevinransom\fsharp\vsintegration\src\FSharp.ProjectSystem.FSharp\ProjectSystem.fsproj
]
    0 Warning(s)
    3 Error(s)```
This PR fixes it.

