### PR TITLE
Redefine 'not' to not emit IL directly

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -3792,7 +3792,7 @@ namespace Microsoft.FSharp.Core
         let (|Failure|_|) (error: exn) = if error.GetType().Equals(typeof<System.Exception>) then Some error.Message else None
 
         [<CompiledName("Not")>]
-        let inline not (value: bool) = (# "ceq" value false : bool #)
+        let inline not (value: bool) = if value then false else true
            
 
         let inline (<) x y = GenericLessThan x y

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/InequalityComparison/InequalityComparison01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/InequalityComparison/InequalityComparison01.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly InequalityComparison01
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.InequalityComparison01
 {
-  // Offset: 0x00000000 Length: 0x0000020E
+  // Offset: 0x00000000 Length: 0x00000224
 }
 .mresource public FSharpOptimizationData.InequalityComparison01
 {
-  // Offset: 0x00000218 Length: 0x00000085
+  // Offset: 0x00000228 Length: 0x00000085
 }
 .module InequalityComparison01.exe
-// MVID: {59B19213-263A-E6D5-A745-03831392B159}
+// MVID: {5EE40368-263A-E6D5-A745-03836803E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x002E0000
+// Image base: 0x00E80000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -55,16 +55,34 @@
                                  int32 y) cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
-    // Code size       8 (0x8)
-    .maxstack  8
+    // Code size       24 (0x18)
+    .maxstack  4
+    .locals init ([0] int32 V_0,
+             [1] int32 V_1,
+             [2] int32 V_2,
+             [3] int32 V_3,
+             [4] int32 V_4,
+             [5] int32 V_5)
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 3,3 : 27,33 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\InequalityComparison\\InequalityComparison01.fs'
+    .line 3,3 : 27,33 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\InequalityComparison\\InequalityComparison01.fs'
     IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  cgt
-    IL_0004:  ldc.i4.0
-    IL_0005:  ceq
-    IL_0007:  ret
+    IL_0001:  stloc.0
+    IL_0002:  ldarg.1
+    IL_0003:  stloc.1
+    IL_0004:  ldloc.0
+    IL_0005:  stloc.2
+    IL_0006:  ldloc.1
+    IL_0007:  stloc.3
+    IL_0008:  ldloc.2
+    IL_0009:  stloc.s    V_4
+    IL_000b:  ldloc.3
+    IL_000c:  stloc.s    V_5
+    IL_000e:  ldloc.s    V_4
+    IL_0010:  ldloc.s    V_5
+    IL_0012:  cgt
+    IL_0014:  ldc.i4.0
+    IL_0015:  ceq
+    IL_0017:  ret
   } // end of method InequalityComparison01::f1
 
 } // end of class InequalityComparison01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/InequalityComparison/InequalityComparison02.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/InequalityComparison/InequalityComparison02.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly InequalityComparison02
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.InequalityComparison02
 {
-  // Offset: 0x00000000 Length: 0x0000020E
+  // Offset: 0x00000000 Length: 0x00000224
 }
 .mresource public FSharpOptimizationData.InequalityComparison02
 {
-  // Offset: 0x00000218 Length: 0x00000085
+  // Offset: 0x00000228 Length: 0x00000085
 }
 .module InequalityComparison02.exe
-// MVID: {59B19213-263A-E72C-A745-03831392B159}
+// MVID: {5EE40368-263A-E72C-A745-03836803E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02D40000
+// Image base: 0x00B80000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -55,16 +55,34 @@
                                  int32 y) cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
-    // Code size       8 (0x8)
-    .maxstack  8
+    // Code size       24 (0x18)
+    .maxstack  4
+    .locals init ([0] int32 V_0,
+             [1] int32 V_1,
+             [2] int32 V_2,
+             [3] int32 V_3,
+             [4] int32 V_4,
+             [5] int32 V_5)
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 3,3 : 27,33 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\InequalityComparison\\InequalityComparison02.fs'
+    .line 3,3 : 27,33 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\InequalityComparison\\InequalityComparison02.fs'
     IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  clt
-    IL_0004:  ldc.i4.0
-    IL_0005:  ceq
-    IL_0007:  ret
+    IL_0001:  stloc.0
+    IL_0002:  ldarg.1
+    IL_0003:  stloc.1
+    IL_0004:  ldloc.0
+    IL_0005:  stloc.2
+    IL_0006:  ldloc.1
+    IL_0007:  stloc.3
+    IL_0008:  ldloc.2
+    IL_0009:  stloc.s    V_4
+    IL_000b:  ldloc.3
+    IL_000c:  stloc.s    V_5
+    IL_000e:  ldloc.s    V_4
+    IL_0010:  ldloc.s    V_5
+    IL_0012:  clt
+    IL_0014:  ldc.i4.0
+    IL_0015:  ceq
+    IL_0017:  ret
   } // end of method InequalityComparison02::f2
 
 } // end of class InequalityComparison02

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Misc/Seq_for_all01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Misc/Seq_for_all01.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Seq_for_all01
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Seq_for_all01
 {
-  // Offset: 0x00000000 Length: 0x000001AB
+  // Offset: 0x00000000 Length: 0x000001C1
 }
 .mresource public FSharpOptimizationData.Seq_for_all01
 {
-  // Offset: 0x000001B0 Length: 0x00000072
+  // Offset: 0x000001C8 Length: 0x00000072
 }
 .module Seq_for_all01.exe
-// MVID: {59B19213-D30D-BA80-A745-03831392B159}
+// MVID: {5EE40368-D30D-BA80-A745-03836803E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02A60000
+// Image base: 0x07080000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -69,28 +69,33 @@
     .method public strict virtual instance bool 
             Invoke(int32 s) cil managed
     {
-      // Code size       14 (0xe)
+      // Code size       18 (0x12)
       .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 5,5 : 31,47 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\Misc\\Seq_for_all01.fs'
+      .line 5,5 : 31,47 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\Misc\\Seq_for_all01.fs'
       IL_0000:  ldc.i4.1
-      IL_0001:  brtrue.s   IL_0005
+      IL_0001:  ldc.i4.0
+      IL_0002:  ceq
+      .line 100001,100001 : 0,0 ''
+      IL_0004:  nop
+      .line 100001,100001 : 0,0 ''
+      IL_0005:  brfalse.s  IL_0009
 
-      IL_0003:  br.s       IL_0007
+      IL_0007:  br.s       IL_000b
 
-      IL_0005:  br.s       IL_000b
+      IL_0009:  br.s       IL_000f
 
       .line 5,5 : 48,50 ''
-      IL_0007:  nop
+      IL_000b:  nop
       .line 100001,100001 : 0,0 ''
-      IL_0008:  nop
-      IL_0009:  br.s       IL_000c
+      IL_000c:  nop
+      IL_000d:  br.s       IL_0010
 
       .line 100001,100001 : 0,0 ''
-      IL_000b:  nop
+      IL_000f:  nop
       .line 6,6 : 31,35 ''
-      IL_000c:  ldc.i4.1
-      IL_000d:  ret
+      IL_0010:  ldc.i4.1
+      IL_0011:  ret
     } // end of method q@4::Invoke
 
   } // end of class q@4

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Operators/comparison_decimal01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Operators/comparison_decimal01.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly comparison_decimal01
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.comparison_decimal01
 {
-  // Offset: 0x00000000 Length: 0x00000176
+  // Offset: 0x00000000 Length: 0x0000018C
 }
 .mresource public FSharpOptimizationData.comparison_decimal01
 {
-  // Offset: 0x00000180 Length: 0x0000005B
+  // Offset: 0x00000190 Length: 0x0000005B
 }
 .module comparison_decimal01.exe
-// MVID: {59B19240-76D8-7EE3-A745-03834092B159}
+// MVID: {5EE40368-76D8-7EE3-A745-03836803E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02980000
+// Image base: 0x06B30000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -63,10 +63,12 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       228 (0xe4)
+    // Code size       233 (0xe9)
     .maxstack  8
+    .locals init ([0] valuetype [mscorlib]System.Decimal V_0,
+             [1] valuetype [mscorlib]System.Decimal V_1)
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 4,4 : 9,20 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\Operators\\comparison_decimal01.fs'
+    .line 4,4 : 9,20 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\Operators\\comparison_decimal01.fs'
     IL_0000:  ldc.i4.s   10
     IL_0002:  ldc.i4.0
     IL_0003:  ldc.i4.0
@@ -197,70 +199,76 @@
                                                                        int32,
                                                                        bool,
                                                                        uint8)
-    IL_0097:  ldc.i4.s   20
-    IL_0099:  ldc.i4.0
+    IL_0097:  stloc.0
+    IL_0098:  ldc.i4.s   20
     IL_009a:  ldc.i4.0
     IL_009b:  ldc.i4.0
-    IL_009c:  ldc.i4.1
-    IL_009d:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
+    IL_009c:  ldc.i4.0
+    IL_009d:  ldc.i4.1
+    IL_009e:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
                                                                        int32,
                                                                        int32,
                                                                        bool,
                                                                        uint8)
-    IL_00a2:  call       bool [mscorlib]System.Decimal::op_Equality(valuetype [mscorlib]System.Decimal,
+    IL_00a3:  stloc.1
+    IL_00a4:  ldloc.0
+    IL_00a5:  ldloc.1
+    IL_00a6:  call       bool [mscorlib]System.Decimal::op_Equality(valuetype [mscorlib]System.Decimal,
                                                                     valuetype [mscorlib]System.Decimal)
-    IL_00a7:  ldc.i4.0
-    IL_00a8:  ceq
-    IL_00aa:  pop
+    IL_00ab:  ldc.i4.0
+    IL_00ac:  ceq
+    IL_00ae:  pop
+    .line 100001,100001 : 0,0 ''
+    IL_00af:  nop
     .line 10,10 : 9,20 ''
-    IL_00ab:  ldc.i4.s   10
-    IL_00ad:  ldc.i4.0
-    IL_00ae:  ldc.i4.0
-    IL_00af:  ldc.i4.0
-    IL_00b0:  ldc.i4.1
-    IL_00b1:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
+    IL_00b0:  ldc.i4.s   10
+    IL_00b2:  ldc.i4.0
+    IL_00b3:  ldc.i4.0
+    IL_00b4:  ldc.i4.0
+    IL_00b5:  ldc.i4.1
+    IL_00b6:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
                                                                        int32,
                                                                        int32,
                                                                        bool,
                                                                        uint8)
-    IL_00b6:  ldc.i4.s   20
-    IL_00b8:  ldc.i4.0
-    IL_00b9:  ldc.i4.0
-    IL_00ba:  ldc.i4.0
-    IL_00bb:  ldc.i4.1
-    IL_00bc:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
+    IL_00bb:  ldc.i4.s   20
+    IL_00bd:  ldc.i4.0
+    IL_00be:  ldc.i4.0
+    IL_00bf:  ldc.i4.0
+    IL_00c0:  ldc.i4.1
+    IL_00c1:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
                                                                        int32,
                                                                        int32,
                                                                        bool,
                                                                        uint8)
-    IL_00c1:  call       bool [mscorlib]System.Decimal::op_Equality(valuetype [mscorlib]System.Decimal,
+    IL_00c6:  call       bool [mscorlib]System.Decimal::op_Equality(valuetype [mscorlib]System.Decimal,
                                                                     valuetype [mscorlib]System.Decimal)
-    IL_00c6:  pop
+    IL_00cb:  pop
     .line 11,11 : 9,26 ''
-    IL_00c7:  ldc.i4.s   10
-    IL_00c9:  ldc.i4.0
-    IL_00ca:  ldc.i4.0
-    IL_00cb:  ldc.i4.0
-    IL_00cc:  ldc.i4.1
-    IL_00cd:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
+    IL_00cc:  ldc.i4.s   10
+    IL_00ce:  ldc.i4.0
+    IL_00cf:  ldc.i4.0
+    IL_00d0:  ldc.i4.0
+    IL_00d1:  ldc.i4.1
+    IL_00d2:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
                                                                        int32,
                                                                        int32,
                                                                        bool,
                                                                        uint8)
-    IL_00d2:  ldc.i4.s   20
-    IL_00d4:  ldc.i4.0
-    IL_00d5:  ldc.i4.0
-    IL_00d6:  ldc.i4.0
-    IL_00d7:  ldc.i4.1
-    IL_00d8:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
+    IL_00d7:  ldc.i4.s   20
+    IL_00d9:  ldc.i4.0
+    IL_00da:  ldc.i4.0
+    IL_00db:  ldc.i4.0
+    IL_00dc:  ldc.i4.1
+    IL_00dd:  newobj     instance void [mscorlib]System.Decimal::.ctor(int32,
                                                                        int32,
                                                                        int32,
                                                                        bool,
                                                                        uint8)
-    IL_00dd:  call       int32 [mscorlib]System.Decimal::Compare(valuetype [mscorlib]System.Decimal,
+    IL_00e2:  call       int32 [mscorlib]System.Decimal::Compare(valuetype [mscorlib]System.Decimal,
                                                                  valuetype [mscorlib]System.Decimal)
-    IL_00e2:  pop
-    IL_00e3:  ret
+    IL_00e7:  pop
+    IL_00e8:  ret
   } // end of method $Comparison_decimal01::main@
 
 } // end of class '<StartupCode$comparison_decimal01>'.$Comparison_decimal01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Partitioning01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Partitioning01.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:5:0:0
+  .ver 4:7:0:0
 }
 .assembly extern Utils
 {
@@ -33,20 +33,20 @@
 }
 .mresource public FSharpSignatureData.Linq101Partitioning01
 {
-  // Offset: 0x00000000 Length: 0x000003DE
+  // Offset: 0x00000000 Length: 0x000003EC
 }
 .mresource public FSharpOptimizationData.Linq101Partitioning01
 {
-  // Offset: 0x000003E8 Length: 0x00000138
+  // Offset: 0x000003F0 Length: 0x00000138
 }
 .module Linq101Partitioning01.exe
-// MVID: {5B9A632A-B280-A6A2-A745-03832A639A5B}
+// MVID: {5EE4036A-B280-A6A2-A745-03836A03E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00AF0000
+// Image base: 0x00C40000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -100,7 +100,7 @@
       .locals init ([0] int32 V_0,
                [1] int32 n)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Partitioning01.fs'
+      .line 100001,100001 : 0,0 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Partitioning01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Partitioning01/first3Numbers@12::pc
       IL_0006:  ldc.i4.1
@@ -1797,17 +1797,23 @@
     .method public strict virtual instance bool 
             Invoke(int32 n) cil managed
     {
-      // Code size       10 (0xa)
-      .maxstack  8
+      // Code size       14 (0xe)
+      .maxstack  6
+      .locals init ([0] int32 V_0,
+               [1] int32 V_1)
       .line 53,53 : 20,30 ''
       IL_0000:  ldarg.1
       IL_0001:  ldc.i4.3
       IL_0002:  rem
-      IL_0003:  ldc.i4.0
-      IL_0004:  ceq
-      IL_0006:  ldc.i4.0
-      IL_0007:  ceq
-      IL_0009:  ret
+      IL_0003:  stloc.0
+      IL_0004:  ldc.i4.0
+      IL_0005:  stloc.1
+      IL_0006:  ldloc.0
+      IL_0007:  ldloc.1
+      IL_0008:  ceq
+      IL_000a:  ldc.i4.0
+      IL_000b:  ceq
+      IL_000d:  ret
     } // end of method 'allButFirst3Numbers@53-1'::Invoke
 
   } // end of class 'allButFirst3Numbers@53-1'
@@ -1817,7 +1823,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'numbers@7-5'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::numbers@7
     IL_0005:  ret
   } // end of method Linq101Partitioning01::get_numbers
 
@@ -1835,7 +1841,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'customers@17-2'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::customers@17
     IL_0005:  ret
   } // end of method Linq101Partitioning01::get_customers
 
@@ -1937,11 +1943,11 @@
 .class private abstract auto ansi sealed '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01
        extends [mscorlib]System.Object
 {
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@7-5'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numbers@7
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> first3Numbers@10
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> 'customers@17-2'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> customers@17
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>[] WAOrders@18
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -2009,7 +2015,7 @@
     IL_003d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0042:  dup
-    IL_0043:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'numbers@7-5'
+    IL_0043:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::numbers@7
     IL_0048:  stloc.0
     .line 10,14 : 1,20 ''
     IL_0049:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
@@ -2033,7 +2039,7 @@
     .line 17,17 : 1,34 ''
     IL_0076:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
     IL_007b:  dup
-    IL_007c:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'customers@17-2'
+    IL_007c:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::customers@17
     IL_0081:  stloc.2
     .line 18,24 : 1,21 ''
     IL_0082:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Select01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Select01.il.bsl
@@ -33,20 +33,20 @@
 }
 .mresource public FSharpSignatureData.Linq101Select01
 {
-  // Offset: 0x00000000 Length: 0x00000655
+  // Offset: 0x00000000 Length: 0x00000671
 }
 .mresource public FSharpOptimizationData.Linq101Select01
 {
-  // Offset: 0x00000660 Length: 0x00000204
+  // Offset: 0x00000678 Length: 0x00000204
 }
 .module Linq101Select01.exe
-// MVID: {5ECD8279-6057-8F80-A745-03837982CD5E}
+// MVID: {5EE4036A-6057-8F80-A745-03836A03E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x058D0000
+// Image base: 0x055C0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -77,7 +77,7 @@
       .maxstack  5
       .locals init ([0] int32 n)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 12,12 : 9,28 'C:\\kevinransom\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Select01.fs'
+      .line 12,12 : 9,28 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Select01.fs'
       IL_0000:  ldarg.1
       IL_0001:  stloc.0
       .line 13,13 : 9,23 ''
@@ -2852,12 +2852,18 @@
     .method public strict virtual instance bool 
             Invoke(class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order> tupledArg) cil managed
     {
-      // Code size       48 (0x30)
+      // Code size       72 (0x48)
       .maxstack  7
       .locals init ([0] class [Utils]Utils/Customer c,
                [1] class [Utils]Utils/Order o,
                [2] valuetype [mscorlib]System.DateTime V_2,
-               [3] valuetype [mscorlib]System.DateTime V_3)
+               [3] valuetype [mscorlib]System.DateTime V_3,
+               [4] valuetype [mscorlib]System.DateTime V_4,
+               [5] valuetype [mscorlib]System.DateTime V_5,
+               [6] valuetype [mscorlib]System.DateTime V_6,
+               [7] valuetype [mscorlib]System.DateTime V_7,
+               [8] int32 V_8,
+               [9] int32 V_9)
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>::get_Item1()
@@ -2877,14 +2883,26 @@
                                                                           int32)
       IL_0021:  stloc.3
       IL_0022:  ldloc.2
-      IL_0023:  ldloc.3
-      IL_0024:  call       int32 [mscorlib]System.DateTime::Compare(valuetype [mscorlib]System.DateTime,
+      IL_0023:  stloc.s    V_4
+      IL_0025:  ldloc.3
+      IL_0026:  stloc.s    V_5
+      IL_0028:  ldloc.s    V_4
+      IL_002a:  stloc.s    V_6
+      IL_002c:  ldloc.s    V_5
+      IL_002e:  stloc.s    V_7
+      IL_0030:  ldloc.s    V_6
+      IL_0032:  ldloc.s    V_7
+      IL_0034:  call       int32 [mscorlib]System.DateTime::Compare(valuetype [mscorlib]System.DateTime,
                                                                     valuetype [mscorlib]System.DateTime)
-      IL_0029:  ldc.i4.0
-      IL_002a:  clt
-      IL_002c:  ldc.i4.0
-      IL_002d:  ceq
-      IL_002f:  ret
+      IL_0039:  stloc.s    V_8
+      IL_003b:  ldc.i4.0
+      IL_003c:  stloc.s    V_9
+      IL_003e:  ldloc.s    V_8
+      IL_0040:  ldloc.s    V_9
+      IL_0042:  clt
+      IL_0044:  ldc.i4.0
+      IL_0045:  ceq
+      IL_0047:  ret
     } // end of method 'orders2@93-2'::Invoke
 
   } // end of class 'orders2@93-2'
@@ -3322,12 +3340,18 @@
     .method public strict virtual instance bool 
             Invoke(class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order> tupledArg) cil managed
     {
-      // Code size       41 (0x29)
+      // Code size       65 (0x41)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Customer c,
                [1] class [Utils]Utils/Order o,
                [2] valuetype [mscorlib]System.DateTime V_2,
-               [3] valuetype [mscorlib]System.DateTime V_3)
+               [3] valuetype [mscorlib]System.DateTime V_3,
+               [4] valuetype [mscorlib]System.DateTime V_4,
+               [5] valuetype [mscorlib]System.DateTime V_5,
+               [6] valuetype [mscorlib]System.DateTime V_6,
+               [7] valuetype [mscorlib]System.DateTime V_7,
+               [8] int32 V_8,
+               [9] int32 V_9)
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>::get_Item1()
@@ -3342,14 +3366,26 @@
       IL_0015:  call       valuetype [mscorlib]System.DateTime Linq101Select01::get_cutOffDate()
       IL_001a:  stloc.3
       IL_001b:  ldloc.2
-      IL_001c:  ldloc.3
-      IL_001d:  call       int32 [mscorlib]System.DateTime::Compare(valuetype [mscorlib]System.DateTime,
+      IL_001c:  stloc.s    V_4
+      IL_001e:  ldloc.3
+      IL_001f:  stloc.s    V_5
+      IL_0021:  ldloc.s    V_4
+      IL_0023:  stloc.s    V_6
+      IL_0025:  ldloc.s    V_5
+      IL_0027:  stloc.s    V_7
+      IL_0029:  ldloc.s    V_6
+      IL_002b:  ldloc.s    V_7
+      IL_002d:  call       int32 [mscorlib]System.DateTime::Compare(valuetype [mscorlib]System.DateTime,
                                                                     valuetype [mscorlib]System.DateTime)
-      IL_0022:  ldc.i4.0
-      IL_0023:  clt
-      IL_0025:  ldc.i4.0
-      IL_0026:  ceq
-      IL_0028:  ret
+      IL_0032:  stloc.s    V_8
+      IL_0034:  ldc.i4.0
+      IL_0035:  stloc.s    V_9
+      IL_0037:  ldloc.s    V_8
+      IL_0039:  ldloc.s    V_9
+      IL_003b:  clt
+      IL_003d:  ldc.i4.0
+      IL_003e:  ceq
+      IL_0040:  ret
     } // end of method 'orders4@114-4'::Invoke
 
   } // end of class 'orders4@114-4'
@@ -3764,7 +3800,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       1128 (0x468)
+    // Code size       1145 (0x479)
     .maxstack  13
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numbers,
              [1] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numsPlusOne,
@@ -3796,11 +3832,15 @@
              [27] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_27,
              [28] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> V_28,
              [29] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> V_29,
-             [30] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_30,
-             [31] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_31,
-             [32] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_32,
-             [33] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_33,
-             [34] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_34)
+             [30] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> V_30,
+             [31] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> V_31,
+             [32] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> V_32,
+             [33] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> V_33,
+             [34] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_34,
+             [35] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_35,
+             [36] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_36,
+             [37] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_37,
+             [38] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_38)
     .line 7,7 : 1,47 ''
     IL_0000:  ldc.i4.5
     IL_0001:  ldc.i4.4
@@ -4016,220 +4056,231 @@
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0228:  stloc.s    V_29
     IL_022a:  ldloc.s    V_28
-    IL_022c:  ldloc.s    V_29
-    IL_022e:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-    IL_0233:  callvirt   instance bool class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Equals(object,
+    IL_022c:  stloc.s    V_30
+    IL_022e:  ldloc.s    V_29
+    IL_0230:  stloc.s    V_31
+    IL_0232:  ldloc.s    V_30
+    IL_0234:  stloc.s    V_32
+    IL_0236:  ldloc.s    V_31
+    IL_0238:  stloc.s    V_33
+    IL_023a:  ldloc.s    V_32
+    IL_023c:  ldloc.s    V_33
+    IL_023e:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+    IL_0243:  callvirt   instance bool class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Equals(object,
                                                                                                                     class [mscorlib]System.Collections.IEqualityComparer)
-    IL_0238:  ldc.i4.0
-    IL_0239:  ceq
-    IL_023b:  brfalse.s  IL_023f
+    IL_0248:  ldc.i4.0
+    IL_0249:  ceq
+    .line 100001,100001 : 0,0 ''
+    IL_024b:  nop
+    .line 100001,100001 : 0,0 ''
+    IL_024c:  brfalse.s  IL_0250
 
-    IL_023d:  br.s       IL_0241
+    IL_024e:  br.s       IL_0252
 
-    IL_023f:  br.s       IL_025b
+    IL_0250:  br.s       IL_026c
 
     .line 64,64 : 60,84 ''
-    IL_0241:  ldstr      "lowNums failed"
-    IL_0246:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-    IL_024b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-    IL_0250:  pop
+    IL_0252:  ldstr      "lowNums failed"
+    IL_0257:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+    IL_025c:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0261:  pop
     .line 64,64 : 86,92 ''
-    IL_0251:  ldc.i4.1
-    IL_0252:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Exit<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(int32)
-    IL_0257:  pop
+    IL_0262:  ldc.i4.1
+    IL_0263:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Exit<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(int32)
+    IL_0268:  pop
     .line 100001,100001 : 0,0 ''
-    IL_0258:  nop
-    IL_0259:  br.s       IL_025c
+    IL_0269:  nop
+    IL_026a:  br.s       IL_026d
 
     .line 100001,100001 : 0,0 ''
-    IL_025b:  nop
+    IL_026c:  nop
     .line 67,67 : 1,37 ''
-    IL_025c:  ldc.i4.0
-    IL_025d:  ldc.i4.2
-    IL_025e:  ldc.i4.4
-    IL_025f:  ldc.i4.5
-    IL_0260:  ldc.i4.6
-    IL_0261:  ldc.i4.8
-    IL_0262:  ldc.i4.s   9
-    IL_0264:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
-    IL_0269:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_026d:  ldc.i4.0
+    IL_026e:  ldc.i4.2
+    IL_026f:  ldc.i4.4
+    IL_0270:  ldc.i4.5
+    IL_0271:  ldc.i4.6
+    IL_0272:  ldc.i4.8
+    IL_0273:  ldc.i4.s   9
+    IL_0275:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_027a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_026e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_027f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0273:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_0284:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0278:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_0289:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_027d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_028e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0282:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_0293:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0287:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_0298:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_028c:  dup
-    IL_028d:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Select01>'.$Linq101Select01::numbersA@67
-    IL_0292:  stloc.s    numbersA
+    IL_029d:  dup
+    IL_029e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Select01>'.$Linq101Select01::numbersA@67
+    IL_02a3:  stloc.s    numbersA
     .line 68,68 : 1,31 ''
-    IL_0294:  ldc.i4.1
-    IL_0295:  ldc.i4.3
-    IL_0296:  ldc.i4.5
-    IL_0297:  ldc.i4.7
-    IL_0298:  ldc.i4.8
-    IL_0299:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
-    IL_029e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_02a5:  ldc.i4.1
+    IL_02a6:  ldc.i4.3
+    IL_02a7:  ldc.i4.5
+    IL_02a8:  ldc.i4.7
+    IL_02a9:  ldc.i4.8
+    IL_02aa:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_02af:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_02a3:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_02b4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_02a8:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_02b9:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_02ad:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_02be:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_02b2:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+    IL_02c3:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_02b7:  dup
-    IL_02b8:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Select01>'.$Linq101Select01::numbersB@68
-    IL_02bd:  stloc.s    numbersB
+    IL_02c8:  dup
+    IL_02c9:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Select01>'.$Linq101Select01::numbersB@68
+    IL_02ce:  stloc.s    numbersB
     .line 70,76 : 1,21 ''
-    IL_02bf:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_02c4:  stloc.s    V_30
-    IL_02c6:  ldloc.s    V_30
-    IL_02c8:  ldloc.s    V_30
-    IL_02ca:  ldloc.s    V_30
-    IL_02cc:  ldloc.s    V_30
-    IL_02ce:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbersA()
-    IL_02d3:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_02d8:  ldloc.s    V_30
-    IL_02da:  newobj     instance void Linq101Select01/pairs@72::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_02df:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02d0:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_02d5:  stloc.s    V_34
+    IL_02d7:  ldloc.s    V_34
+    IL_02d9:  ldloc.s    V_34
+    IL_02db:  ldloc.s    V_34
+    IL_02dd:  ldloc.s    V_34
+    IL_02df:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbersA()
+    IL_02e4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_02e9:  ldloc.s    V_34
+    IL_02eb:  newobj     instance void Linq101Select01/pairs@72::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_02f0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_02e4:  newobj     instance void Linq101Select01/'pairs@74-2'::.ctor()
-    IL_02e9:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02f5:  newobj     instance void Linq101Select01/'pairs@74-2'::.ctor()
+    IL_02fa:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_02ee:  newobj     instance void Linq101Select01/'pairs@75-3'::.ctor()
-    IL_02f3:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02ff:  newobj     instance void Linq101Select01/'pairs@75-3'::.ctor()
+    IL_0304:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_02f8:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_02fd:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<int32,int32>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0302:  dup
-    IL_0303:  stsfld     class [mscorlib]System.Tuple`2<int32,int32>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::pairs@70
-    IL_0308:  stloc.s    pairs
+    IL_0309:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_030e:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<int32,int32>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0313:  dup
+    IL_0314:  stsfld     class [mscorlib]System.Tuple`2<int32,int32>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::pairs@70
+    IL_0319:  stloc.s    pairs
     .line 79,79 : 1,34 ''
-    IL_030a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
-    IL_030f:  dup
-    IL_0310:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Select01>'.$Linq101Select01::customers@79
-    IL_0315:  stloc.s    customers
+    IL_031b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
+    IL_0320:  dup
+    IL_0321:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Select01>'.$Linq101Select01::customers@79
+    IL_0326:  stloc.s    customers
     .line 80,86 : 1,21 ''
-    IL_0317:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_031c:  stloc.s    V_31
-    IL_031e:  ldloc.s    V_31
-    IL_0320:  ldloc.s    V_31
-    IL_0322:  ldloc.s    V_31
-    IL_0324:  ldloc.s    V_31
-    IL_0326:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
-    IL_032b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0330:  ldloc.s    V_31
-    IL_0332:  newobj     instance void Linq101Select01/orders@82::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0337:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0328:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_032d:  stloc.s    V_35
+    IL_032f:  ldloc.s    V_35
+    IL_0331:  ldloc.s    V_35
+    IL_0333:  ldloc.s    V_35
+    IL_0335:  ldloc.s    V_35
+    IL_0337:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
+    IL_033c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0341:  ldloc.s    V_35
+    IL_0343:  newobj     instance void Linq101Select01/orders@82::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0348:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_033c:  newobj     instance void Linq101Select01/'orders@84-2'::.ctor()
-    IL_0341:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_034d:  newobj     instance void Linq101Select01/'orders@84-2'::.ctor()
+    IL_0352:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_0346:  newobj     instance void Linq101Select01/'orders@85-3'::.ctor()
-    IL_034b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0357:  newobj     instance void Linq101Select01/'orders@85-3'::.ctor()
+    IL_035c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0350:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0355:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_035a:  dup
-    IL_035b:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::orders@80
-    IL_0360:  stloc.s    orders
+    IL_0361:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0366:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_036b:  dup
+    IL_036c:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::orders@80
+    IL_0371:  stloc.s    orders
     .line 89,95 : 1,21 ''
-    IL_0362:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0367:  stloc.s    V_32
-    IL_0369:  ldloc.s    V_32
-    IL_036b:  ldloc.s    V_32
-    IL_036d:  ldloc.s    V_32
-    IL_036f:  ldloc.s    V_32
-    IL_0371:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
-    IL_0376:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_037b:  ldloc.s    V_32
-    IL_037d:  newobj     instance void Linq101Select01/orders2@91::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0382:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0373:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0378:  stloc.s    V_36
+    IL_037a:  ldloc.s    V_36
+    IL_037c:  ldloc.s    V_36
+    IL_037e:  ldloc.s    V_36
+    IL_0380:  ldloc.s    V_36
+    IL_0382:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
+    IL_0387:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_038c:  ldloc.s    V_36
+    IL_038e:  newobj     instance void Linq101Select01/orders2@91::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0393:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0387:  newobj     instance void Linq101Select01/'orders2@93-2'::.ctor()
-    IL_038c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0398:  newobj     instance void Linq101Select01/'orders2@93-2'::.ctor()
+    IL_039d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_0391:  newobj     instance void Linq101Select01/'orders2@94-3'::.ctor()
-    IL_0396:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03a2:  newobj     instance void Linq101Select01/'orders2@94-3'::.ctor()
+    IL_03a7:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_039b:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_03a0:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_03a5:  dup
-    IL_03a6:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::orders2@89
-    IL_03ab:  stloc.s    orders2
-    IL_03ad:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_03b2:  stloc.s    V_33
-    IL_03b4:  ldloc.s    V_33
-    IL_03b6:  ldloc.s    V_33
-    IL_03b8:  ldloc.s    V_33
-    IL_03ba:  ldloc.s    V_33
-    IL_03bc:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
-    IL_03c1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_03c6:  ldloc.s    V_33
-    IL_03c8:  newobj     instance void Linq101Select01/orders3@100::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_03cd:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03ac:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_03b1:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_03b6:  dup
+    IL_03b7:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::orders2@89
+    IL_03bc:  stloc.s    orders2
+    IL_03be:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_03c3:  stloc.s    V_37
+    IL_03c5:  ldloc.s    V_37
+    IL_03c7:  ldloc.s    V_37
+    IL_03c9:  ldloc.s    V_37
+    IL_03cb:  ldloc.s    V_37
+    IL_03cd:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
+    IL_03d2:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_03d7:  ldloc.s    V_37
+    IL_03d9:  newobj     instance void Linq101Select01/orders3@100::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_03de:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_03d2:  newobj     instance void Linq101Select01/'orders3@102-2'::.ctor()
-    IL_03d7:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03e3:  newobj     instance void Linq101Select01/'orders3@102-2'::.ctor()
+    IL_03e8:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_03dc:  newobj     instance void Linq101Select01/'orders3@103-3'::.ctor()
-    IL_03e1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03ed:  newobj     instance void Linq101Select01/'orders3@103-3'::.ctor()
+    IL_03f2:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_03e6:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_03eb:  dup
-    IL_03ec:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>> '<StartupCode$Linq101Select01>'.$Linq101Select01::orders3@98
-    IL_03f1:  stloc.s    orders3
+    IL_03f7:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_03fc:  dup
+    IL_03fd:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>> '<StartupCode$Linq101Select01>'.$Linq101Select01::orders3@98
+    IL_0402:  stloc.s    orders3
     .line 107,107 : 1,38 ''
-    IL_03f3:  ldc.i4     0x7cd
-    IL_03f8:  ldc.i4.1
-    IL_03f9:  ldc.i4.1
-    IL_03fa:  newobj     instance void [mscorlib]System.DateTime::.ctor(int32,
+    IL_0404:  ldc.i4     0x7cd
+    IL_0409:  ldc.i4.1
+    IL_040a:  ldc.i4.1
+    IL_040b:  newobj     instance void [mscorlib]System.DateTime::.ctor(int32,
                                                                         int32,
                                                                         int32)
-    IL_03ff:  dup
-    IL_0400:  stsfld     valuetype [mscorlib]System.DateTime '<StartupCode$Linq101Select01>'.$Linq101Select01::cutOffDate@107
-    IL_0405:  stloc.s    cutOffDate
-    IL_0407:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_040c:  stloc.s    V_34
-    IL_040e:  ldloc.s    V_34
-    IL_0410:  ldloc.s    V_34
-    IL_0412:  ldloc.s    V_34
-    IL_0414:  ldloc.s    V_34
-    IL_0416:  ldloc.s    V_34
-    IL_0418:  ldloc.s    V_34
-    IL_041a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
-    IL_041f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0424:  ldloc.s    V_34
-    IL_0426:  newobj     instance void Linq101Select01/orders4@111::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_042b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Customer,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0410:  dup
+    IL_0411:  stsfld     valuetype [mscorlib]System.DateTime '<StartupCode$Linq101Select01>'.$Linq101Select01::cutOffDate@107
+    IL_0416:  stloc.s    cutOffDate
+    IL_0418:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_041d:  stloc.s    V_38
+    IL_041f:  ldloc.s    V_38
+    IL_0421:  ldloc.s    V_38
+    IL_0423:  ldloc.s    V_38
+    IL_0425:  ldloc.s    V_38
+    IL_0427:  ldloc.s    V_38
+    IL_0429:  ldloc.s    V_38
+    IL_042b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
+    IL_0430:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0435:  ldloc.s    V_38
+    IL_0437:  newobj     instance void Linq101Select01/orders4@111::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_043c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Customer,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0430:  newobj     instance void Linq101Select01/'orders4@112-1'::.ctor()
-    IL_0435:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0441:  newobj     instance void Linq101Select01/'orders4@112-1'::.ctor()
+    IL_0446:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_043a:  ldloc.s    V_34
-    IL_043c:  newobj     instance void Linq101Select01/'orders4@111-2'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0441:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_044b:  ldloc.s    V_38
+    IL_044d:  newobj     instance void Linq101Select01/'orders4@111-2'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0452:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0446:  newobj     instance void Linq101Select01/'orders4@114-4'::.ctor()
-    IL_044b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0457:  newobj     instance void Linq101Select01/'orders4@114-4'::.ctor()
+    IL_045c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_0450:  newobj     instance void Linq101Select01/'orders4@115-5'::.ctor()
-    IL_0455:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0461:  newobj     instance void Linq101Select01/'orders4@115-5'::.ctor()
+    IL_0466:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_045a:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_045f:  dup
-    IL_0460:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,int32>> '<StartupCode$Linq101Select01>'.$Linq101Select01::orders4@109
-    IL_0465:  stloc.s    orders4
-    IL_0467:  ret
+    IL_046b:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0470:  dup
+    IL_0471:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,int32>> '<StartupCode$Linq101Select01>'.$Linq101Select01::orders4@109
+    IL_0476:  stloc.s    orders4
+    IL_0478:  ret
   } // end of method $Linq101Select01::main@
 
 } // end of class '<StartupCode$Linq101Select01>'.$Linq101Select01

--- a/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare01.il.bsl
+++ b/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare01.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Compare01
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Compare01
 {
-  // Offset: 0x00000000 Length: 0x00000225
+  // Offset: 0x00000000 Length: 0x0000023B
 }
 .mresource public FSharpOptimizationData.Compare01
 {
-  // Offset: 0x00000230 Length: 0x000000B2
+  // Offset: 0x00000240 Length: 0x000000B2
 }
 .module Compare01.dll
-// MVID: {59B18AEE-04A0-F88E-A745-0383EE8AB159}
+// MVID: {5EE40408-04A0-F88E-A745-03830804E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00FF0000
+// Image base: 0x06FC0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -63,7 +63,7 @@
                [1] int32 i,
                [2] int32 V_2)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 5,5 : 8,25 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\Optimizations\\GenericComparison\\Compare01.fsx'
+      .line 5,5 : 8,25 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\Optimizations\\GenericComparison\\Compare01.fsx'
       IL_0000:  ldc.i4.1
       IL_0001:  stloc.0
       .line 9,9 : 8,32 ''
@@ -77,16 +77,16 @@
       IL_0008:  cgt
       IL_000a:  stloc.2
       IL_000b:  ldloc.2
-      IL_000c:  brfalse.s  IL_0012
+      IL_000c:  brtrue.s   IL_0012
 
       .line 16707566,16707566 : 0,0 ''
-      IL_000e:  ldloc.2
+      IL_000e:  ldc.i4.m1
       .line 16707566,16707566 : 0,0 ''
       IL_000f:  nop
       IL_0010:  br.s       IL_0014
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0012:  ldc.i4.m1
+      IL_0012:  ldloc.2
       .line 16707566,16707566 : 0,0 ''
       IL_0013:  nop
       .line 16707566,16707566 : 0,0 ''

--- a/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare02.il.bsl
+++ b/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare02.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Compare02
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Compare02
 {
-  // Offset: 0x00000000 Length: 0x0000022C
+  // Offset: 0x00000000 Length: 0x00000242
 }
 .mresource public FSharpOptimizationData.Compare02
 {
-  // Offset: 0x00000230 Length: 0x000000B9
+  // Offset: 0x00000248 Length: 0x000000B9
 }
 .module Compare02.dll
-// MVID: {59B18AEE-0481-F88E-A745-0383EE8AB159}
+// MVID: {5EE40408-0481-F88E-A745-03830804E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00BA0000
+// Image base: 0x053D0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -64,7 +64,7 @@
                [2] int32 V_2,
                [3] int32 V_3)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 5,5 : 8,25 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\Optimizations\\GenericComparison\\Compare02.fsx'
+      .line 5,5 : 8,25 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\Optimizations\\GenericComparison\\Compare02.fsx'
       IL_0000:  ldc.i4.1
       IL_0001:  stloc.0
       .line 8,8 : 8,32 ''
@@ -78,21 +78,21 @@
       IL_0008:  cgt
       IL_000a:  stloc.2
       IL_000b:  ldloc.2
-      IL_000c:  brfalse.s  IL_0012
+      IL_000c:  brtrue.s   IL_001e
 
       .line 16707566,16707566 : 0,0 ''
-      IL_000e:  ldloc.2
-      .line 16707566,16707566 : 0,0 ''
-      IL_000f:  nop
-      IL_0010:  br.s       IL_0020
+      IL_000e:  ldc.i4.2
+      IL_000f:  ldc.i4.2
+      IL_0010:  cgt
+      IL_0012:  stloc.3
+      IL_0013:  ldloc.3
+      IL_0014:  brtrue.s   IL_001a
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0012:  ldc.i4.2
-      IL_0013:  ldc.i4.2
-      IL_0014:  cgt
-      IL_0016:  stloc.3
-      IL_0017:  ldloc.3
-      IL_0018:  brfalse.s  IL_001e
+      IL_0016:  ldc.i4.m1
+      .line 16707566,16707566 : 0,0 ''
+      IL_0017:  nop
+      IL_0018:  br.s       IL_0020
 
       .line 16707566,16707566 : 0,0 ''
       IL_001a:  ldloc.3
@@ -101,7 +101,7 @@
       IL_001c:  br.s       IL_0020
 
       .line 16707566,16707566 : 0,0 ''
-      IL_001e:  ldc.i4.m1
+      IL_001e:  ldloc.2
       .line 16707566,16707566 : 0,0 ''
       IL_001f:  nop
       .line 16707566,16707566 : 0,0 ''

--- a/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare03.il.bsl
+++ b/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare03.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Compare03
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Compare03
 {
-  // Offset: 0x00000000 Length: 0x00000237
+  // Offset: 0x00000000 Length: 0x0000024D
 }
 .mresource public FSharpOptimizationData.Compare03
 {
-  // Offset: 0x00000240 Length: 0x000000B9
+  // Offset: 0x00000258 Length: 0x000000B9
 }
 .module Compare03.dll
-// MVID: {59B18AEE-0562-F88E-A745-0383EE8AB159}
+// MVID: {5EE40408-0562-F88E-A745-03830804E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x002E0000
+// Image base: 0x06B20000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -65,7 +65,7 @@
                [3] int32 V_3,
                [4] int32 V_4)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 5,5 : 8,25 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\Optimizations\\GenericComparison\\Compare03.fsx'
+      .line 5,5 : 8,25 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\Optimizations\\GenericComparison\\Compare03.fsx'
       IL_0000:  ldc.i4.1
       IL_0001:  stloc.0
       .line 8,8 : 8,32 ''
@@ -79,47 +79,47 @@
       IL_0008:  cgt
       IL_000a:  stloc.2
       IL_000b:  ldloc.2
-      IL_000c:  brfalse.s  IL_0012
+      IL_000c:  brtrue.s   IL_003b
 
       .line 16707566,16707566 : 0,0 ''
-      IL_000e:  ldloc.2
-      .line 16707566,16707566 : 0,0 ''
-      IL_000f:  nop
-      IL_0010:  br.s       IL_003d
+      IL_000e:  ldc.i4.2
+      IL_000f:  ldc.i4.2
+      IL_0010:  cgt
+      IL_0012:  stloc.3
+      IL_0013:  ldloc.3
+      IL_0014:  brtrue.s   IL_0037
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0012:  ldc.i4.2
-      IL_0013:  ldc.i4.2
-      IL_0014:  cgt
-      IL_0016:  stloc.3
-      IL_0017:  ldloc.3
-      IL_0018:  brfalse.s  IL_001e
+      IL_0016:  ldc.i4.4
+      IL_0017:  ldc.i4.4
+      IL_0018:  cgt
+      IL_001a:  stloc.s    V_4
+      IL_001c:  ldloc.s    V_4
+      IL_001e:  brtrue.s   IL_0032
 
       .line 16707566,16707566 : 0,0 ''
-      IL_001a:  ldloc.3
-      .line 16707566,16707566 : 0,0 ''
-      IL_001b:  nop
-      IL_001c:  br.s       IL_003d
-
-      .line 16707566,16707566 : 0,0 ''
-      IL_001e:  ldc.i4.4
-      IL_001f:  ldc.i4.4
-      IL_0020:  cgt
-      IL_0022:  stloc.s    V_4
-      IL_0024:  ldloc.s    V_4
-      IL_0026:  brfalse.s  IL_002d
-
-      .line 16707566,16707566 : 0,0 ''
-      IL_0028:  ldloc.s    V_4
-      .line 16707566,16707566 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br.s       IL_003d
-
-      .line 16707566,16707566 : 0,0 ''
-      IL_002d:  ldstr      "five"
-      IL_0032:  ldstr      "5"
-      IL_0037:  call       int32 [mscorlib]System.String::CompareOrdinal(string,
+      IL_0020:  ldstr      "five"
+      IL_0025:  ldstr      "5"
+      IL_002a:  call       int32 [mscorlib]System.String::CompareOrdinal(string,
                                                                          string)
+      .line 16707566,16707566 : 0,0 ''
+      IL_002f:  nop
+      IL_0030:  br.s       IL_003d
+
+      .line 16707566,16707566 : 0,0 ''
+      IL_0032:  ldloc.s    V_4
+      .line 16707566,16707566 : 0,0 ''
+      IL_0034:  nop
+      IL_0035:  br.s       IL_003d
+
+      .line 16707566,16707566 : 0,0 ''
+      IL_0037:  ldloc.3
+      .line 16707566,16707566 : 0,0 ''
+      IL_0038:  nop
+      IL_0039:  br.s       IL_003d
+
+      .line 16707566,16707566 : 0,0 ''
+      IL_003b:  ldloc.2
       .line 16707566,16707566 : 0,0 ''
       IL_003c:  nop
       .line 16707566,16707566 : 0,0 ''

--- a/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare04.il.bsl
+++ b/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare04.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Compare04
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Compare04
 {
-  // Offset: 0x00000000 Length: 0x00000237
+  // Offset: 0x00000000 Length: 0x0000024D
 }
 .mresource public FSharpOptimizationData.Compare04
 {
-  // Offset: 0x00000240 Length: 0x000000B9
+  // Offset: 0x00000258 Length: 0x000000B9
 }
 .module Compare04.dll
-// MVID: {59B18AEE-053B-F88E-A745-0383EE8AB159}
+// MVID: {5EE40408-053B-F88E-A745-03830804E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x013E0000
+// Image base: 0x06AD0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -57,7 +57,7 @@
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
     .method public static int32  f4_tuple5() cil managed
     {
-      // Code size       208 (0xd0)
+      // Code size       211 (0xd3)
       .maxstack  5
       .locals init ([0] int32 x,
                [1] int32 i,
@@ -66,13 +66,13 @@
                [4] int32 V_4,
                [5] int32 V_5)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 5,5 : 8,25 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\Optimizations\\GenericComparison\\Compare04.fsx'
+      .line 5,5 : 8,25 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\Optimizations\\GenericComparison\\Compare04.fsx'
       IL_0000:  ldc.i4.1
       IL_0001:  stloc.0
       .line 8,8 : 8,32 ''
       IL_0002:  ldc.i4.0
       IL_0003:  stloc.1
-      IL_0004:  br         IL_00c3
+      IL_0004:  br         IL_00c6
 
       .line 9,9 : 12,30 ''
       IL_0009:  ldc.i4.1
@@ -80,116 +80,116 @@
       IL_000b:  cgt
       IL_000d:  stloc.2
       IL_000e:  ldloc.2
-      IL_000f:  brfalse.s  IL_0018
+      IL_000f:  brtrue     IL_00bf
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0011:  ldloc.2
-      .line 16707566,16707566 : 0,0 ''
-      IL_0012:  nop
-      IL_0013:  br         IL_00be
+      IL_0014:  ldc.i4.2
+      IL_0015:  ldc.i4.2
+      IL_0016:  cgt
+      IL_0018:  stloc.3
+      IL_0019:  ldloc.3
+      IL_001a:  brtrue     IL_00bb
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0018:  ldc.i4.2
-      IL_0019:  ldc.i4.2
-      IL_001a:  cgt
-      IL_001c:  stloc.3
-      IL_001d:  ldloc.3
-      IL_001e:  brfalse.s  IL_0027
+      IL_001f:  ldc.i4.4
+      IL_0020:  ldc.i4.4
+      IL_0021:  cgt
+      IL_0023:  stloc.s    V_4
+      IL_0025:  ldloc.s    V_4
+      IL_0027:  brtrue     IL_00b6
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0020:  ldloc.3
-      .line 16707566,16707566 : 0,0 ''
-      IL_0021:  nop
-      IL_0022:  br         IL_00be
-
-      .line 16707566,16707566 : 0,0 ''
-      IL_0027:  ldc.i4.4
-      IL_0028:  ldc.i4.4
-      IL_0029:  cgt
-      IL_002b:  stloc.s    V_4
-      IL_002d:  ldloc.s    V_4
-      IL_002f:  brfalse.s  IL_0039
-
-      .line 16707566,16707566 : 0,0 ''
-      IL_0031:  ldloc.s    V_4
-      .line 16707566,16707566 : 0,0 ''
-      IL_0033:  nop
-      IL_0034:  br         IL_00be
-
-      .line 16707566,16707566 : 0,0 ''
-      IL_0039:  ldstr      "5"
-      IL_003e:  ldstr      "5"
-      IL_0043:  call       int32 [mscorlib]System.String::CompareOrdinal(string,
+      IL_002c:  ldstr      "5"
+      IL_0031:  ldstr      "5"
+      IL_0036:  call       int32 [mscorlib]System.String::CompareOrdinal(string,
                                                                          string)
-      IL_0048:  stloc.s    V_5
-      IL_004a:  ldloc.s    V_5
-      IL_004c:  brfalse.s  IL_0053
+      IL_003b:  stloc.s    V_5
+      IL_003d:  ldloc.s    V_5
+      IL_003f:  brtrue     IL_00b1
 
       .line 16707566,16707566 : 0,0 ''
-      IL_004e:  ldloc.s    V_5
-      .line 16707566,16707566 : 0,0 ''
-      IL_0050:  nop
-      IL_0051:  br.s       IL_00be
+      IL_0044:  ldc.r8     6.
+      IL_004d:  ldc.r8     7.
+      IL_0056:  clt
+      IL_0058:  brfalse.s  IL_005e
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0053:  ldc.r8     6.
-      IL_005c:  ldc.r8     7.
-      IL_0065:  clt
-      IL_0067:  brfalse.s  IL_006d
+      IL_005a:  ldc.i4.m1
+      .line 16707566,16707566 : 0,0 ''
+      IL_005b:  nop
+      IL_005c:  br.s       IL_00c1
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0069:  ldc.i4.m1
-      .line 16707566,16707566 : 0,0 ''
-      IL_006a:  nop
-      IL_006b:  br.s       IL_00be
+      IL_005e:  ldc.r8     6.
+      IL_0067:  ldc.r8     7.
+      IL_0070:  cgt
+      IL_0072:  brfalse.s  IL_0078
 
       .line 16707566,16707566 : 0,0 ''
-      IL_006d:  ldc.r8     6.
-      IL_0076:  ldc.r8     7.
-      IL_007f:  cgt
-      IL_0081:  brfalse.s  IL_0087
+      IL_0074:  ldc.i4.1
+      .line 16707566,16707566 : 0,0 ''
+      IL_0075:  nop
+      IL_0076:  br.s       IL_00c1
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0083:  ldc.i4.1
-      .line 16707566,16707566 : 0,0 ''
-      IL_0084:  nop
-      IL_0085:  br.s       IL_00be
+      IL_0078:  ldc.r8     6.
+      IL_0081:  ldc.r8     7.
+      IL_008a:  ceq
+      IL_008c:  brfalse.s  IL_0092
 
       .line 16707566,16707566 : 0,0 ''
-      IL_0087:  ldc.r8     6.
-      IL_0090:  ldc.r8     7.
-      IL_0099:  ceq
-      IL_009b:  brfalse.s  IL_00a1
+      IL_008e:  ldc.i4.0
+      .line 16707566,16707566 : 0,0 ''
+      IL_008f:  nop
+      IL_0090:  br.s       IL_00c1
 
       .line 16707566,16707566 : 0,0 ''
-      IL_009d:  ldc.i4.0
-      .line 16707566,16707566 : 0,0 ''
-      IL_009e:  nop
-      IL_009f:  br.s       IL_00be
-
-      .line 16707566,16707566 : 0,0 ''
-      IL_00a1:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
-      IL_00a6:  ldc.r8     6.
-      IL_00af:  ldc.r8     7.
-      IL_00b8:  call       int32 [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/HashCompare::GenericComparisonWithComparerIntrinsic<float64>(class [mscorlib]System.Collections.IComparer,
+      IL_0092:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0097:  ldc.r8     6.
+      IL_00a0:  ldc.r8     7.
+      IL_00a9:  call       int32 [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/HashCompare::GenericComparisonWithComparerIntrinsic<float64>(class [mscorlib]System.Collections.IComparer,
                                                                                                                                                     !!0,
                                                                                                                                                     !!0)
       .line 16707566,16707566 : 0,0 ''
-      IL_00bd:  nop
+      IL_00ae:  nop
+      IL_00af:  br.s       IL_00c1
+
       .line 16707566,16707566 : 0,0 ''
-      IL_00be:  stloc.0
-      IL_00bf:  ldloc.1
-      IL_00c0:  ldc.i4.1
-      IL_00c1:  add
-      IL_00c2:  stloc.1
+      IL_00b1:  ldloc.s    V_5
+      .line 16707566,16707566 : 0,0 ''
+      IL_00b3:  nop
+      IL_00b4:  br.s       IL_00c1
+
+      .line 16707566,16707566 : 0,0 ''
+      IL_00b6:  ldloc.s    V_4
+      .line 16707566,16707566 : 0,0 ''
+      IL_00b8:  nop
+      IL_00b9:  br.s       IL_00c1
+
+      .line 16707566,16707566 : 0,0 ''
+      IL_00bb:  ldloc.3
+      .line 16707566,16707566 : 0,0 ''
+      IL_00bc:  nop
+      IL_00bd:  br.s       IL_00c1
+
+      .line 16707566,16707566 : 0,0 ''
+      IL_00bf:  ldloc.2
+      .line 16707566,16707566 : 0,0 ''
+      IL_00c0:  nop
+      .line 16707566,16707566 : 0,0 ''
+      IL_00c1:  stloc.0
+      IL_00c2:  ldloc.1
+      IL_00c3:  ldc.i4.1
+      IL_00c4:  add
+      IL_00c5:  stloc.1
       .line 8,8 : 8,32 ''
-      IL_00c3:  ldloc.1
-      IL_00c4:  ldc.i4     0x989681
-      IL_00c9:  blt        IL_0009
+      IL_00c6:  ldloc.1
+      IL_00c7:  ldc.i4     0x989681
+      IL_00cc:  blt        IL_0009
 
       .line 10,10 : 8,9 ''
-      IL_00ce:  ldloc.0
-      IL_00cf:  ret
+      IL_00d1:  ldloc.0
+      IL_00d2:  ret
     } // end of method CompareMicroPerfAndCodeGenerationTests::f4_tuple5
 
   } // end of class CompareMicroPerfAndCodeGenerationTests

--- a/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare10.il.bsl
+++ b/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare10.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Compare10
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Compare10
 {
-  // Offset: 0x00000000 Length: 0x00000AA4
+  // Offset: 0x00000000 Length: 0x00000AAE
 }
 .mresource public FSharpOptimizationData.Compare10
 {
-  // Offset: 0x00000AA8 Length: 0x0000058E
+  // Offset: 0x00000AB8 Length: 0x0000058E
 }
 .module Compare10.dll
-// MVID: {59B18AEE-04BF-1753-A745-0383EE8AB159}
+// MVID: {5EE40408-04BF-1753-A745-03830804E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x002E0000
+// Image base: 0x071F0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -187,7 +187,7 @@
                  [4] int32 V_4,
                  [5] int32 V_5)
         .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-        .line 16707566,16707566 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\Optimizations\\GenericComparison\\Compare10.fsx'
+        .line 16707566,16707566 : 0,0 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\Optimizations\\GenericComparison\\Compare10.fsx'
         IL_0000:  ldarg.0
         IL_0001:  ldnull
         IL_0002:  cgt.un
@@ -884,18 +884,18 @@
                                                                                                             class [mscorlib]System.Collections.IComparer)
         IL_0089:  stloc.s    V_10
         IL_008b:  ldloc.s    V_10
-        IL_008d:  brfalse.s  IL_0092
+        IL_008d:  brtrue.s   IL_009a
 
         .line 16707566,16707566 : 0,0 ''
-        IL_008f:  ldloc.s    V_10
-        IL_0091:  ret
-
-        .line 16707566,16707566 : 0,0 ''
-        IL_0092:  ldloc.s    V_5
-        IL_0094:  ldloc.s    V_9
-        IL_0096:  ldloc.3
-        IL_0097:  callvirt   instance int32 Compare10/CompareMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
+        IL_008f:  ldloc.s    V_5
+        IL_0091:  ldloc.s    V_9
+        IL_0093:  ldloc.3
+        IL_0094:  callvirt   instance int32 Compare10/CompareMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
                                                                                                             class [mscorlib]System.Collections.IComparer)
+        IL_0099:  ret
+
+        .line 16707566,16707566 : 0,0 ''
+        IL_009a:  ldloc.s    V_10
         IL_009c:  ret
 
         .line 16707566,16707566 : 0,0 ''
@@ -1028,18 +1028,18 @@
                                                                                                             class [mscorlib]System.Collections.IComparer)
         IL_0089:  stloc.s    V_10
         IL_008b:  ldloc.s    V_10
-        IL_008d:  brfalse.s  IL_0092
+        IL_008d:  brtrue.s   IL_009a
 
         .line 16707566,16707566 : 0,0 ''
-        IL_008f:  ldloc.s    V_10
-        IL_0091:  ret
-
-        .line 16707566,16707566 : 0,0 ''
-        IL_0092:  ldloc.s    V_5
-        IL_0094:  ldloc.s    V_9
-        IL_0096:  ldarg.2
-        IL_0097:  callvirt   instance int32 Compare10/CompareMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
+        IL_008f:  ldloc.s    V_5
+        IL_0091:  ldloc.s    V_9
+        IL_0093:  ldarg.2
+        IL_0094:  callvirt   instance int32 Compare10/CompareMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
                                                                                                             class [mscorlib]System.Collections.IComparer)
+        IL_0099:  ret
+
+        .line 16707566,16707566 : 0,0 ''
+        IL_009a:  ldloc.s    V_10
         IL_009c:  ret
 
         .line 16707566,16707566 : 0,0 ''

--- a/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare11.il.bsl
+++ b/tests/fsharpqa/Source/Optimizations/GenericComparison/Compare11.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Compare11
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Compare11
 {
-  // Offset: 0x00000000 Length: 0x00000230
+  // Offset: 0x00000000 Length: 0x00000246
 }
 .mresource public FSharpOptimizationData.Compare11
 {
-  // Offset: 0x00000238 Length: 0x000000B1
+  // Offset: 0x00000250 Length: 0x000000B1
 }
 .module Compare11.dll
-// MVID: {59B18AEE-04A0-1753-A745-0383EE8AB159}
+// MVID: {5EE40408-04A0-1753-A745-03830804E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x010A0000
+// Image base: 0x00E80000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -62,7 +62,7 @@
       .locals init ([0] bool x,
                [1] int32 i)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 5,5 : 8,29 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\Optimizations\\GenericComparison\\Compare11.fsx'
+      .line 5,5 : 8,29 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\Optimizations\\GenericComparison\\Compare11.fsx'
       IL_0000:  ldc.i4.0
       IL_0001:  stloc.0
       .line 9,9 : 8,32 ''

--- a/tests/fsharpqa/Source/Optimizations/GenericComparison/Equals09.il.bsl
+++ b/tests/fsharpqa/Source/Optimizations/GenericComparison/Equals09.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Equals09
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Equals09
 {
-  // Offset: 0x00000000 Length: 0x00000AA0
+  // Offset: 0x00000000 Length: 0x00000AAA
 }
 .mresource public FSharpOptimizationData.Equals09
 {
-  // Offset: 0x00000AA8 Length: 0x0000058B
+  // Offset: 0x00000AB0 Length: 0x0000058B
 }
 .module Equals09.dll
-// MVID: {59B18AEE-0759-46D9-A745-0383EE8AB159}
+// MVID: {5EE40408-0759-46D9-A745-03830804E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02720000
+// Image base: 0x07220000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -187,7 +187,7 @@
                  [4] int32 V_4,
                  [5] int32 V_5)
         .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-        .line 16707566,16707566 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\Optimizations\\GenericComparison\\Equals09.fsx'
+        .line 16707566,16707566 : 0,0 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\Optimizations\\GenericComparison\\Equals09.fsx'
         IL_0000:  ldarg.0
         IL_0001:  ldnull
         IL_0002:  cgt.un
@@ -884,18 +884,18 @@
                                                                                                           class [mscorlib]System.Collections.IComparer)
         IL_0089:  stloc.s    V_10
         IL_008b:  ldloc.s    V_10
-        IL_008d:  brfalse.s  IL_0092
+        IL_008d:  brtrue.s   IL_009a
 
         .line 16707566,16707566 : 0,0 ''
-        IL_008f:  ldloc.s    V_10
-        IL_0091:  ret
-
-        .line 16707566,16707566 : 0,0 ''
-        IL_0092:  ldloc.s    V_5
-        IL_0094:  ldloc.s    V_9
-        IL_0096:  ldloc.3
-        IL_0097:  callvirt   instance int32 Equals09/EqualsMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
+        IL_008f:  ldloc.s    V_5
+        IL_0091:  ldloc.s    V_9
+        IL_0093:  ldloc.3
+        IL_0094:  callvirt   instance int32 Equals09/EqualsMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
                                                                                                           class [mscorlib]System.Collections.IComparer)
+        IL_0099:  ret
+
+        .line 16707566,16707566 : 0,0 ''
+        IL_009a:  ldloc.s    V_10
         IL_009c:  ret
 
         .line 16707566,16707566 : 0,0 ''
@@ -1028,18 +1028,18 @@
                                                                                                           class [mscorlib]System.Collections.IComparer)
         IL_0089:  stloc.s    V_10
         IL_008b:  ldloc.s    V_10
-        IL_008d:  brfalse.s  IL_0092
+        IL_008d:  brtrue.s   IL_009a
 
         .line 16707566,16707566 : 0,0 ''
-        IL_008f:  ldloc.s    V_10
-        IL_0091:  ret
-
-        .line 16707566,16707566 : 0,0 ''
-        IL_0092:  ldloc.s    V_5
-        IL_0094:  ldloc.s    V_9
-        IL_0096:  ldarg.2
-        IL_0097:  callvirt   instance int32 Equals09/EqualsMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
+        IL_008f:  ldloc.s    V_5
+        IL_0091:  ldloc.s    V_9
+        IL_0093:  ldarg.2
+        IL_0094:  callvirt   instance int32 Equals09/EqualsMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
                                                                                                           class [mscorlib]System.Collections.IComparer)
+        IL_0099:  ret
+
+        .line 16707566,16707566 : 0,0 ''
+        IL_009a:  ldloc.s    V_10
         IL_009c:  ret
 
         .line 16707566,16707566 : 0,0 ''

--- a/tests/fsharpqa/Source/Optimizations/GenericComparison/Hash12.il.bsl
+++ b/tests/fsharpqa/Source/Optimizations/GenericComparison/Hash12.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.8.3928.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:0
+  .ver 4:7:0:0
 }
 .assembly Hash12
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.Hash12
 {
-  // Offset: 0x00000000 Length: 0x00000A98
+  // Offset: 0x00000000 Length: 0x00000AA2
 }
 .mresource public FSharpOptimizationData.Hash12
 {
-  // Offset: 0x00000AA0 Length: 0x00000585
+  // Offset: 0x00000AA8 Length: 0x00000585
 }
 .module Hash12.dll
-// MVID: {59B18AEE-9661-796E-A745-0383EE8AB159}
+// MVID: {5EE40408-9661-796E-A745-03830804E45E}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x01080000
+// Image base: 0x00E90000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -187,7 +187,7 @@
                  [4] int32 V_4,
                  [5] int32 V_5)
         .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-        .line 16707566,16707566 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\Optimizations\\GenericComparison\\Hash12.fsx'
+        .line 16707566,16707566 : 0,0 'C:\\Users\\phcart\\source\\repos\\fsharp\\tests\\fsharpqa\\source\\Optimizations\\GenericComparison\\Hash12.fsx'
         IL_0000:  ldarg.0
         IL_0001:  ldnull
         IL_0002:  cgt.un
@@ -884,18 +884,18 @@
                                                                                                       class [mscorlib]System.Collections.IComparer)
         IL_0089:  stloc.s    V_10
         IL_008b:  ldloc.s    V_10
-        IL_008d:  brfalse.s  IL_0092
+        IL_008d:  brtrue.s   IL_009a
 
         .line 16707566,16707566 : 0,0 ''
-        IL_008f:  ldloc.s    V_10
-        IL_0091:  ret
-
-        .line 16707566,16707566 : 0,0 ''
-        IL_0092:  ldloc.s    V_5
-        IL_0094:  ldloc.s    V_9
-        IL_0096:  ldloc.3
-        IL_0097:  callvirt   instance int32 Hash12/HashMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
+        IL_008f:  ldloc.s    V_5
+        IL_0091:  ldloc.s    V_9
+        IL_0093:  ldloc.3
+        IL_0094:  callvirt   instance int32 Hash12/HashMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
                                                                                                       class [mscorlib]System.Collections.IComparer)
+        IL_0099:  ret
+
+        .line 16707566,16707566 : 0,0 ''
+        IL_009a:  ldloc.s    V_10
         IL_009c:  ret
 
         .line 16707566,16707566 : 0,0 ''
@@ -1028,18 +1028,18 @@
                                                                                                       class [mscorlib]System.Collections.IComparer)
         IL_0089:  stloc.s    V_10
         IL_008b:  ldloc.s    V_10
-        IL_008d:  brfalse.s  IL_0092
+        IL_008d:  brtrue.s   IL_009a
 
         .line 16707566,16707566 : 0,0 ''
-        IL_008f:  ldloc.s    V_10
-        IL_0091:  ret
-
-        .line 16707566,16707566 : 0,0 ''
-        IL_0092:  ldloc.s    V_5
-        IL_0094:  ldloc.s    V_9
-        IL_0096:  ldarg.2
-        IL_0097:  callvirt   instance int32 Hash12/HashMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
+        IL_008f:  ldloc.s    V_5
+        IL_0091:  ldloc.s    V_9
+        IL_0093:  ldarg.2
+        IL_0094:  callvirt   instance int32 Hash12/HashMicroPerfAndCodeGenerationTests/Key::CompareTo(object,
                                                                                                       class [mscorlib]System.Collections.IComparer)
+        IL_0099:  ret
+
+        .line 16707566,16707566 : 0,0 ''
+        IL_009a:  ldloc.s    V_10
         IL_009c:  ret
 
         .line 16707566,16707566 : 0,0 ''


### PR DESCRIPTION
Fixes #9433

The current implementation of `not` gets funky when you pass in a call to `isNull` for a reference type. Probably other quirks too. The following benchmark shows the effect:

```fsharp
module Op =
    let inline not' x = if x then false else true
    let inline not'' x = match x with true -> false | false -> true


[<MemoryDiagnoser>]
type NotBench() =
    let s = "hello"

    [<Benchmark(Baseline=true)>]
    member _.Not() = 
        let mutable b = false
        for i=0 to 1 do b <- not (isNull s)
        b

    [<Benchmark>]
    member _.NotWithIf() = 
        let mutable b = false
        for i=0 to 1 do b <- Op.not' (isNull s)
        b

    [<Benchmark>]
    member _.NotWithMatch() = 
        let mutable b = false
        for i=0 to 1 do b <- Op.not'' (isNull s)
        b
```

I get these timings against .NET 5:

|       Method |     Mean |     Error |    StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |---------:|----------:|----------:|------:|------:|------:|------:|----------:|
|          Not | 1.859 ns | 0.0224 ns | 0.0187 ns |  1.00 |     - |     - |     - |         - |
|    NotWithIf | 1.277 ns | 0.0178 ns | 0.0139 ns |  0.69 |     - |     - |     - |         - |
| NotWithMatch | 1.277 ns | 0.0188 ns | 0.0157 ns |  0.69 |     - |     - |     - |         - |

And these for net48:

|       Method |     Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |---------:|----------:|----------:|------:|--------:|------:|------:|------:|----------:|
|          Not | 1.909 ns | 0.0448 ns | 0.0419 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    NotWithIf | 1.295 ns | 0.0357 ns | 0.0334 ns |  0.68 |    0.03 |     - |     - |     - |         - |
| NotWithMatch | 1.292 ns | 0.0126 ns | 0.0118 ns |  0.68 |    0.02 |     - |     - |     - |         - |