### PR TITLE
[WIP] trial fix for 9449

### DIFF
--- a/src/fsharp/ConstraintSolver.fsi
+++ b/src/fsharp/ConstraintSolver.fsi
@@ -192,13 +192,13 @@ val SolveTypeAsError: DisplayEnv -> ConstraintSolverState -> range -> TType -> u
 val ApplyTyparDefaultAtPriority: DisplayEnv -> ConstraintSolverState -> priority: int -> Typar -> unit
 
 /// Generate a witness expression if none is otherwise available, e.g. in legacy non-witness-passing code
-val CodegenWitnessForTraitConstraint : TcValF -> TcGlobals -> ImportMap -> range -> TraitConstraintInfo -> Expr list -> OperationResult<Expr option>
+val CodegenWitnessForTraitConstraint : TcValF -> TcGlobals -> ImportMap -> range -> TraitConstraintInfo -> Expr list -> bool -> OperationResult<Expr option>
 
 /// Generate the arguments passed when using a generic construct that accepts traits witnesses
-val CodegenWitnessesForTyparInst : TcValF -> TcGlobals -> ImportMap -> range -> Typars -> TType list -> OperationResult<Choice<TraitConstraintInfo, Expr> list>
+val CodegenWitnessesForTyparInst : TcValF -> TcGlobals -> ImportMap -> range -> Typars -> TType list -> bool -> OperationResult<Choice<TraitConstraintInfo, Expr> list>
 
 /// Generate the lambda argument passed for a use of a generic construct that accepts trait witnesses
-val CodegenWitnessesForTraitWitness : TcValF -> TcGlobals -> ImportMap -> range -> TraitConstraintInfo -> OperationResult<Choice<TraitConstraintInfo, Expr>>
+val CodegenWitnessesForTraitWitness : TcValF -> TcGlobals -> ImportMap -> range -> TraitConstraintInfo -> bool -> OperationResult<Choice<TraitConstraintInfo, Expr>>
 
 /// For some code like "let f() = ([] = [])", a free choice is made for a type parameter
 /// for an interior type variable.  This chooses a solution for a type parameter subject

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -3114,7 +3114,7 @@ and GenWitnessArgFromTraitInfo cenv cgbuf eenv m traitInfo =
     match storage with 
     | None ->
         let witnessExpr =
-           ConstraintSolver.CodegenWitnessesForTraitWitness cenv.tcVal g cenv.amap m traitInfo 
+           ConstraintSolver.CodegenWitnessesForTraitWitness cenv.tcVal g cenv.amap m traitInfo true
             |> CommitOperationResult
         match witnessExpr with
         | Choice1Of2 _traitInfo ->
@@ -3152,7 +3152,7 @@ and GenWitnessArgs cenv cgbuf eenv m tps tyargs =
     // Witness arguments are only generated in emitted 'inline' code where witness parameters are available.
     if generateWitnesses then 
         let mwitnesses = 
-            ConstraintSolver.CodegenWitnessesForTyparInst cenv.tcVal g cenv.amap m tps tyargs 
+            ConstraintSolver.CodegenWitnessesForTyparInst cenv.tcVal g cenv.amap m tps tyargs true
             |> CommitOperationResult
 
         for witnessArg in mwitnesses do
@@ -4084,7 +4084,7 @@ and GenTraitCall (cenv: cenv) cgbuf eenv (traitInfo: TraitConstraintInfo, argExp
     // If witnesses are available, we should now always find trait witnesses in scope
     assert not generateWitnesses
         
-    let minfoOpt = CommitOperationResult (ConstraintSolver.CodegenWitnessForTraitConstraint cenv.tcVal g cenv.amap m traitInfo argExprs)
+    let minfoOpt = CommitOperationResult (ConstraintSolver.CodegenWitnessForTraitConstraint cenv.tcVal g cenv.amap m traitInfo argExprs true)
     match minfoOpt with
     | None ->
         let exnArg = mkString g m (FSComp.SR.ilDynamicInvocationNotSupported(traitInfo.MemberName))

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -520,9 +520,9 @@ let BindInternalLocalVal cenv (v: Val) vval env =
         env
         
 let BindExternalLocalVal cenv (v: Val) vval env = 
-#if CHECKED
-    CheckInlineValueIsComplete v vval
-#endif
+//#if CHECKED
+    CheckInlineValueIsComplete v vval.ValExprInfo
+//#endif
 
     let vval = if v.IsMutable then {vval with ValExprInfo=UnknownValue } else vval
     let env = 
@@ -2451,7 +2451,7 @@ and OptimizeWhileLoop cenv env (spWhile, marker, e1, e2, m) =
 and OptimizeTraitCall cenv env (traitInfo, args, m) =
 
     // Resolve the static overloading early (during the compulsory rewrite phase) so we can inline. 
-    match ConstraintSolver.CodegenWitnessForTraitConstraint cenv.TcVal cenv.g cenv.amap m traitInfo args with
+    match ConstraintSolver.CodegenWitnessForTraitConstraint cenv.TcVal cenv.g cenv.amap m traitInfo args false with
 
     | OkResult (_, Some expr) -> OptimizeExpr cenv env expr
 

--- a/src/fsharp/QuotationTranslator.fs
+++ b/src/fsharp/QuotationTranslator.fs
@@ -249,7 +249,7 @@ and GetWitnessArgs cenv (env : QuotationTranslationEnv) m tps tyargs =
     let g = cenv.g
     if g.generateWitnesses && not env.suppressWitnesses then 
         let witnessExprs = 
-            ConstraintSolver.CodegenWitnessesForTyparInst cenv.tcVal g cenv.amap m tps tyargs 
+            ConstraintSolver.CodegenWitnessesForTyparInst cenv.tcVal g cenv.amap m tps tyargs false
             |> CommitOperationResult
         let env = { env with suppressWitnesses = true }
         witnessExprs |> List.map (fun arg -> 
@@ -737,7 +737,7 @@ and private ConvExprCore cenv (env : QuotationTranslationEnv) (expr: Expr) : QP.
         
                 let minfoOpt =
                     if g.generateWitnesses then 
-                        ConstraintSolver.CodegenWitnessForTraitConstraint cenv.tcVal g cenv.amap m traitInfo args |> CommitOperationResult 
+                        ConstraintSolver.CodegenWitnessForTraitConstraint cenv.tcVal g cenv.amap m traitInfo args false |> CommitOperationResult 
                     else
                         None
                 match minfoOpt with


### PR DESCRIPTION

While integrating #6810 into #6811 a regression turned up.  This trials the likely fix for it

The problem lies in the fact that an extra constraint is being asserted during optimization.  The relevant lines of #6810 are things like [this](https://github.com/dotnet/fsharp/pull/6810/files#diff-641da7c52ffc888699888ebd03559cb5R1948) and [this].  The tril fix disables one of these lines during optimization.  

However I need to do further analysis for why these lines were needed. Extra constraints should *not* need to be asserted and it is possile that [this](https://github.com/dotnet/fsharp/pull/6810/files#diff-641da7c52ffc888699888ebd03559cb5R3084) call to 'freshen' ultimately meant the other two changes where not needed.

* [ ] check if this fix is green 
* [ ] more analysis needed and trial possible alternative fixes
* [ ] add testing around the regression

Note the regression is active even if `langversion` is not set, which also indicates some inaccurate coding in #6810 

