### PR TITLE
Fix 9449

### DIFF
--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -5,7 +5,7 @@
 #load "../FSharp.TestHelpers/TestFramework.fs"
 #load "single-test.fs"
 #else
-module ``FSharp-Tests-Core``
+module FSharp.Tests.Core
 #endif
 
 open System
@@ -2203,6 +2203,15 @@ module TypecheckTests =
         let cfg = testConfig' "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos35.dll --warnaserror" cfg.fsc_flags ["pos35.fs"]
         peverify cfg "pos35.dll"
+
+    [<Test>]
+    let ``sigs pos36-srtp`` () =
+        let cfg = testConfig' "typecheck/sigs"
+        fsc cfg "%s --target:library -o:pos36-srtp-lib.dll --warnaserror" cfg.fsc_flags ["pos36-srtp-lib.fs"]
+        fsc cfg "%s --target:exe -r:pos36-srtp-lib.dll -o:pos36-srtp-app.exe --warnaserror" cfg.fsc_flags ["pos36-srtp-app.fs"]
+        peverify cfg "pos36-srtp-lib.dll"
+        peverify cfg "pos36-srtp-app.exe"
+        exec cfg ("." ++ "pos36-srtp-app.exe") ""
 
     [<Test>]
     let ``sigs pos23`` () =

--- a/tests/fsharp/typecheck/sigs/pos36-srtp-app.fs
+++ b/tests/fsharp/typecheck/sigs/pos36-srtp-app.fs
@@ -1,0 +1,11 @@
+module Pos36
+
+open Lib
+
+let check msg x y = if x = y then printfn "passed %s" msg else failwithf "failed '%s'" msg
+
+let tbind ()  =
+    check "vwknvewoiwvren1" (StaticMethods.M(C(3))) "M(C), x = 3"
+    check "vwknvewoiwvren2" (StaticMethods.M(3L)) "M(int64), x = 3"
+
+tbind()

--- a/tests/fsharp/typecheck/sigs/pos36-srtp-lib.fs
+++ b/tests/fsharp/typecheck/sigs/pos36-srtp-lib.fs
@@ -1,0 +1,22 @@
+
+
+module Lib
+
+let inline RequireM< ^Witnesses, ^T when (^Witnesses or ^T): (static member M : ^T -> string) > (x: ^T) : string = 
+    ((^Witnesses or ^T): (static member M : ^T -> string) x)
+
+type C(p:int) = 
+    member x.P = p
+
+type Witnesses() =
+
+    static member M (x: C) : string = sprintf "M(C), x = %d"  x.P
+
+    static member M (x: int64) : string = sprintf "M(int64), x = %d"  x
+
+type StaticMethods =
+
+    static member inline M< ^T when (Witnesses or  ^T): (static member M: ^T -> string)>  (x: ^T) : string =
+
+        RequireM< Witnesses, ^T> (x)
+


### PR DESCRIPTION
While integrating #6810 into #6811 a regression turned up.  

The problem lies in the fact that an extra constraint is being asserted during optimization.  The relevant lines of #6810 are things like [this](https://github.com/dotnet/fsharp/pull/6810/files#diff-641da7c52ffc888699888ebd03559cb5R1948) and [this].  The tril fix removes these lines which were not needed.  Extra constraints should *not* need to be asserted and [this](https://github.com/dotnet/fsharp/pull/6810/files#diff-641da7c52ffc888699888ebd03559cb5R3084) addition later in the development of #6810 meant these other two changes are not needed.

TODO:

* [x] add testing around the regression

Note the regression is active even if `langversion` is not set, which also indicates some inaccurate coding in #6810 


