### PR TITLE
Small improvement for String.length

### DIFF
--- a/FSharp.v3.ncrunchsolution.user
+++ b/FSharp.v3.ncrunchsolution.user
@@ -1,0 +1,5 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <CurrentEngineMode>Run all tests automatically [Global]</CurrentEngineMode>
+  </Settings>
+</SolutionConfiguration>

--- a/FSharp.v3.ncrunchsolution.user
+++ b/FSharp.v3.ncrunchsolution.user
@@ -1,5 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <CurrentEngineMode>Run all tests automatically [Global]</CurrentEngineMode>
-  </Settings>
-</SolutionConfiguration>

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -104,7 +104,5 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Length")>]
         let length (str:string) =
-            if String.IsNullOrEmpty str then
-                0
-            else
-                str.Length
+            if isNull str then 0
+            else str.Length

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -31,15 +31,12 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Map")>]
         let map (mapping: char -> char) (str:string) =
-            if String.IsNullOrEmpty str then String.Empty
+            if String.IsNullOrEmpty str then
+                String.Empty
             else
-                let result = str.ToCharArray()
-                let mutable i = 0
-                for c in result do
-                    result.[i] <- mapping c
-                    i <- i + 1
-
-                String result
+                let res = StringBuilder str.Length
+                str |> iter (fun c -> res.Append(mapping c) |> ignore)
+                res.ToString()
 
         [<CompiledName("MapIndexed")>]
         let mapi (mapping: int -> char -> char) (str:string) =

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -31,12 +31,15 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Map")>]
         let map (mapping: char -> char) (str:string) =
-            if String.IsNullOrEmpty str then
-                String.Empty
+            if String.IsNullOrEmpty str then String.Empty
             else
-                let res = StringBuilder str.Length
-                str |> iter (fun c -> res.Append(mapping c) |> ignore)
-                res.ToString()
+                let result = str.ToCharArray()
+                let mutable i = 0
+                for c in result do
+                    result.[i] <- mapping c
+                    i <- i + 1
+
+                String result
 
         [<CompiledName("MapIndexed")>]
         let mapi (mapping: int -> char -> char) (str:string) =

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -103,6 +103,4 @@ namespace Microsoft.FSharp.Core
                 check 0  
 
         [<CompiledName("Length")>]
-        let length (str:string) =
-            if isNull str then 0
-            else str.Length
+        let length (str:string) = if isNull str then 0 else str.Length


### PR DESCRIPTION
The PR removes some overhead for `String.length`, see https://github.com/dotnet/fsharp/issues/9390#issuecomment-643780818.

The disassembly will change from this:

```assembly
test      rax,rax              ; rax & rax, in other words: null-check, sets flags
je        short M00_L01        ; if zero (null) jump back to loop
cmp       dword ptr [rax+8],0  ; compare string-length to 0
jbe       short M00_L01        ; if equal, jump back to loop
mov       ecx,[rax+8]          ; if not, get string length fallthrough to loop
```

to this:

```assembly
test      rax,rax        ; rax & rax, for null-check, sets flags
je        short M00_L01  ; if zero (null) jump back to loop
mov       ecx,[rax+8]    ; get the string-length from the string and fallthrough to loop
```

Which, in timings, gives roughly a 33% improvement, but since this is hard to test in isolation, it may be more because more chances exist now for optimizing & inlining this by the JIT.

More info and timings in the connected issue comment above.