### PR TITLE
String map performance improvement

### DIFF
--- a/FSharp.v3.ncrunchsolution.user
+++ b/FSharp.v3.ncrunchsolution.user
@@ -1,0 +1,5 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <CurrentEngineMode>Run all tests automatically [Global]</CurrentEngineMode>
+  </Settings>
+</SolutionConfiguration>

--- a/FSharp.v3.ncrunchsolution.user
+++ b/FSharp.v3.ncrunchsolution.user
@@ -1,5 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <CurrentEngineMode>Run all tests automatically [Global]</CurrentEngineMode>
-  </Settings>
-</SolutionConfiguration>

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -104,7 +104,5 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Length")>]
         let length (str:string) =
-            if String.IsNullOrEmpty str then
-                0
-            else
-                str.Length
+            if isNull str then 0
+            else str.Length

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -31,12 +31,15 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Map")>]
         let map (mapping: char -> char) (str:string) =
-            if String.IsNullOrEmpty str then
-                String.Empty
+            if String.IsNullOrEmpty str then String.Empty
             else
-                let res = StringBuilder str.Length
-                str |> iter (fun c -> res.Append(mapping c) |> ignore)
-                res.ToString()
+                let result = str.ToCharArray()
+                let mutable i = 0
+                for c in result do
+                    result.[i] <- mapping c
+                    i <- i + 1
+
+                String result
 
         [<CompiledName("MapIndexed")>]
         let mapi (mapping: int -> char -> char) (str:string) =

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -107,5 +107,7 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Length")>]
         let length (str:string) =
-            if isNull str then 0
-            else str.Length
+            if String.IsNullOrEmpty str then
+                0
+            else
+                str.Length

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -40,7 +40,7 @@ namespace Microsoft.FSharp.Core
                     result.[i] <- mapping c
                     i <- i + 1
 
-                String result
+                new String(result)
 
         [<CompiledName("MapIndexed")>]
         let mapi (mapping: int -> char -> char) (str:string) =

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -31,7 +31,7 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Map")>]
         let map (mapping: char -> char) (str:string) =
-            if String.IsNullOrEmpty str then 
+            if String.IsNullOrEmpty str then
                 String.Empty
             else
                 let result = str.ToCharArray()

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -31,7 +31,8 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Map")>]
         let map (mapping: char -> char) (str:string) =
-            if String.IsNullOrEmpty str then String.Empty
+            if String.IsNullOrEmpty str then 
+                String.Empty
             else
                 let result = str.ToCharArray()
                 let mutable i = 0

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -71,11 +71,26 @@ type StringModule() =
 
     [<Test>]
     member this.Map() =
-        let e1 = String.map (fun c -> c) "foo"
+        let e1 = String.map id "foo"
         Assert.AreEqual("foo", e1)
 
-        let e2 = String.map (fun c -> c) null 
-        Assert.AreEqual("", e2)
+        let e2 = String.map (fun c -> c + char 1) "abcde"
+        Assert.AreEqual("bcdef", e2)
+
+        let e3 = String.map (fun c -> c) null 
+        Assert.AreEqual("", e3)
+
+        let e4 = String.map (fun c -> c) String.Empty 
+        Assert.AreEqual("", e4)
+
+        let e5 = String.map (fun _ -> 'B') "A"
+        Assert.AreEqual("B", e5)
+
+        // side-effect and "order of operation" test
+        let mutable x = 0
+        let e6 = String.map (fun c -> x <- x + 1; c + char x) "abcde"
+        Assert.AreEqual(x, 5)
+        Assert.AreEqual(e6, "bdfhj")
 
     [<Test>]
     member this.MapI() =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -86,11 +86,20 @@ type StringModule() =
         let e5 = String.map (fun _ -> 'B') "A"
         Assert.AreEqual("B", e5)
 
+        let e6 = String.map (fun _ -> failwith "should not raise") null
+        Assert.AreEqual("", e6)
+
+        // this tests makes sure mapping function is not called too many times
+        let mutable x = 0
+        let e7 = String.map (fun _ -> if x > 2 then failwith "should not raise" else x <- x + 1; 'x') "abc"
+        Assert.AreEqual(e7, 3)
+        Assert.AreEqual(e7, "xxx")
+
         // side-effect and "order of operation" test
         let mutable x = 0
-        let e6 = String.map (fun c -> x <- x + 1; c + char x) "abcde"
+        let e8 = String.map (fun c -> x <- x + 1; c + char x) "abcde"
         Assert.AreEqual(x, 5)
-        Assert.AreEqual(e6, "bdfhj")
+        Assert.AreEqual(e8, "bdfhj")
 
     [<Test>]
     member this.MapI() =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -92,7 +92,7 @@ type StringModule() =
         // this tests makes sure mapping function is not called too many times
         let mutable x = 0
         let e7 = String.map (fun _ -> if x > 2 then failwith "should not raise" else x <- x + 1; 'x') "abc"
-        Assert.AreEqual(e7, 3)
+        Assert.AreEqual(x, 3)
         Assert.AreEqual(e7, "xxx")
 
         // side-effect and "order of operation" test

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -71,8 +71,8 @@ type StringModule() =
 
     [<Test>]
     member this.Map() =
-        let e1 = String.map id "foo"
-        Assert.AreEqual("foo", e1)
+        let e1 = String.map id "xyz"
+        Assert.AreEqual("xyz", e1)
 
         let e2 = String.map (fun c -> c + char 1) "abcde"
         Assert.AreEqual("bcdef", e2)


### PR DESCRIPTION
As in the title: Improve performance of String.map by 2 - 2.5x and reduce mem and GC pressure by 10%. For details of measurements, see https://github.com/dotnet/fsharp/issues/9390#issuecomment-640858818

I decided not to go for special-casing small values or loop-unrolling as for this specific case, the benefits don't outweigh the costs of the added complexity.

The chosen approach is the array-based approach.