### PR TITLE
String mapi ~2.5x perf improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ msbuild.binlog
 /tests/fsharp/regression/5531/compilation.output.test.txt
 /tests/fsharp/core/fsfromfsviacs/compilation.langversion.old.output.txt
 /tests/fsharp/core/fsfromfsviacs/compilation.errors.output.txt
+*.user

--- a/FSharp.v3.ncrunchsolution.user
+++ b/FSharp.v3.ncrunchsolution.user
@@ -1,0 +1,5 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <CurrentEngineMode>Run all tests automatically [Global]</CurrentEngineMode>
+  </Settings>
+</SolutionConfiguration>

--- a/FSharp.v3.ncrunchsolution.user
+++ b/FSharp.v3.ncrunchsolution.user
@@ -1,5 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <CurrentEngineMode>Run all tests automatically [Global]</CurrentEngineMode>
-  </Settings>
-</SolutionConfiguration>

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -104,7 +104,5 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Length")>]
         let length (str:string) =
-            if String.IsNullOrEmpty str then
-                0
-            else
-                str.Length
+            if isNull str then 0
+            else str.Length

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -31,15 +31,12 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Map")>]
         let map (mapping: char -> char) (str:string) =
-            if String.IsNullOrEmpty str then String.Empty
+            if String.IsNullOrEmpty str then
+                String.Empty
             else
-                let result = str.ToCharArray()
-                let mutable i = 0
-                for c in result do
-                    result.[i] <- mapping c
-                    i <- i + 1
-
-                String result
+                let res = StringBuilder str.Length
+                str |> iter (fun c -> res.Append(mapping c) |> ignore)
+                res.ToString()
 
         [<CompiledName("MapIndexed")>]
         let mapi (mapping: int -> char -> char) (str:string) =

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -31,12 +31,15 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Map")>]
         let map (mapping: char -> char) (str:string) =
-            if String.IsNullOrEmpty str then
-                String.Empty
+            if String.IsNullOrEmpty str then String.Empty
             else
-                let res = StringBuilder str.Length
-                str |> iter (fun c -> res.Append(mapping c) |> ignore)
-                res.ToString()
+                let result = str.ToCharArray()
+                let mutable i = 0
+                for c in result do
+                    result.[i] <- mapping c
+                    i <- i + 1
+
+                String result
 
         [<CompiledName("MapIndexed")>]
         let mapi (mapping: int -> char -> char) (str:string) =

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -103,6 +103,4 @@ namespace Microsoft.FSharp.Core
                 check 0  
 
         [<CompiledName("Length")>]
-        let length (str:string) =
-            if isNull str then 0
-            else str.Length
+        let length (str:string) = if isNull str then 0 else str.Length


### PR DESCRIPTION
**EDIT: closing in favor of  https://github.com/dotnet/fsharp/pull/9481 and https://github.com/dotnet/fsharp/pull/9482.**

See for details on this improvement: https://github.com/dotnet/fsharp/issues/9390#issuecomment-642985879. 

TLDR: using a `char []` on the fixed expected output improves ~2.1x, then 2x unrolling brings this to ~2.5x. In other words, if it took 1 second before, it now takes 0.4 seconds.
