### PR TITLE
Prep reorganize string module for String.xxx changes

### DIFF
--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -12,6 +12,9 @@ namespace Microsoft.FSharp.Core
     [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
     [<RequireQualifiedAccess>]
     module String =
+        [<CompiledName("Length")>]
+        let length (str:string) = if isNull str then 0 else str.Length
+
         [<CompiledName("Concat")>]
         let concat sep (strings : seq<string>) =  
             String.Join(sep, strings)
@@ -101,6 +104,3 @@ namespace Microsoft.FSharp.Core
             else
                 let rec check i = (i < str.Length) && (predicate str.[i] || check (i+1)) 
                 check 0  
-
-        [<CompiledName("Length")>]
-        let length (str:string) = if isNull str then 0 else str.Length


### PR DESCRIPTION
Several upcoming PR's related to String functions, need `String.length`, which was defined at the bottom. Putting it on top so that the function `length` gets in scope of the others.

No functional changes here.

Related to #9390.