### PR TITLE
Improve perf or String.iter and String.iteri by 25%

### DIFF
--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -54,13 +54,13 @@ namespace Microsoft.FSharp.Core
                 let mutable i = 0
                 while i < len - len % 8 do
                     f.Invoke(i, str.[i])
-                    f.Invoke(i, str.[i + 1])
-                    f.Invoke(i, str.[i + 2])
-                    f.Invoke(i, str.[i + 3])
-                    f.Invoke(i, str.[i + 4])
-                    f.Invoke(i, str.[i + 5])
-                    f.Invoke(i, str.[i + 6])
-                    f.Invoke(i, str.[i + 7])
+                    f.Invoke(i + 1, str.[i + 1])
+                    f.Invoke(i + 2, str.[i + 2])
+                    f.Invoke(i + 3, str.[i + 3])
+                    f.Invoke(i + 4, str.[i + 4])
+                    f.Invoke(i + 5, str.[i + 5])
+                    f.Invoke(i + 6, str.[i + 6])
+                    f.Invoke(i + 7, str.[i + 7])
                     i <- i + 8
 
                 // The remainder

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -50,7 +50,7 @@ namespace Microsoft.FSharp.Core
             else
                 let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(action)
 
-                // unrolling gives a ~25% boost on older proc, more on modern proc
+                // Unrolling gives a ~25% boost over a regular for loop on an older processor, more on a modern processor
                 let mutable i = 0
                 while i < len - len % 8 do
                     f.Invoke(i, str.[i])

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -25,7 +25,7 @@ namespace Microsoft.FSharp.Core
 
             if len = 0 then ()
             else
-                // unrolling gives a ~25% boost on older proc, more on modern proc
+                // Unrolling gives a ~25% boost over a regular for loop on an older processor, more on a modern processor
                 let mutable i = 0
                 while i < len - len % 8 do
                     action str.[i]
@@ -63,7 +63,7 @@ namespace Microsoft.FSharp.Core
                     f.Invoke(i, str.[i + 7])
                     i <- i + 8
 
-                // the remainder
+                // The remainder
                 while i < len do
                     f.Invoke(i, str.[i])
                     i <- i + 1

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -38,7 +38,7 @@ namespace Microsoft.FSharp.Core
                     action str.[i + 7]
                     i <- i + 8
 
-                // the remainder
+                // The remainder
                 while i < len do
                     action str.[i]
                     i <- i + 1

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Core.UnitTests.Collections
 
 open System
+open System.Text
 open NUnit.Framework
 
 open FSharp.Core.UnitTests.LibraryTestFx
@@ -59,6 +60,28 @@ type StringModule() =
         do String.iter (fun c -> result := !result + (int c)) null
         Assert.AreEqual(0, !result)
 
+        // These tests test the unrolling cut-off points
+        let mutable x = 0
+        do String.iter (fun _ -> x <- x + 1) "1"
+        Assert.AreEqual(x, 1)
+
+        let mutable x = 0
+        do String.iter (fun _ -> x <- x + 1) "1234567"
+        Assert.AreEqual(x, 7)
+
+        let mutable x = 0
+        do String.iter (fun _ -> x <- x + 1) "12345678"
+        Assert.AreEqual(x, 8)
+
+        let mutable x = 0
+        do String.iter (fun _ -> x <- x + 1) "123456789"
+        Assert.AreEqual(x, 9)
+
+        // Test order of execution
+        let sb = StringBuilder()
+        do String.iter (fun c -> sb.Append c |> ignore) "abcdefghijklmnopqrstuvwxyz"
+        Assert.AreEqual(sb.ToString(), "abcdefghijklmnopqrstuvwxyz")
+
     [<Test>]
     member this.IterI() =
         let result = ref 0
@@ -68,6 +91,28 @@ type StringModule() =
         result := 0
         do String.iteri(fun i c -> result := !result + (i*(int c))) null
         Assert.AreEqual(0, !result)
+
+        // These tests test the unrolling cut-off points
+        let mutable x = 42
+        do String.iteri (fun i _ -> x <- x + i) "1"
+        Assert.AreEqual(x, 42)
+
+        let mutable x = 0
+        do String.iteri (fun i _ -> x <- x + i) "1234567"
+        Assert.AreEqual(x, 21)
+
+        let mutable x = 0
+        do String.iteri (fun i _ -> x <- x + i) "12345678"
+        Assert.AreEqual(x, 28)
+
+        let mutable x = 0
+        do String.iteri (fun i _ -> x <- x + i) "123456789"
+        Assert.AreEqual(x, 36)
+
+        // Test order of execution
+        let sb = StringBuilder()
+        do String.iteri (fun i c -> sb.Append [|char i; c|] |> ignore) "abcdefghijklmnopqrstuvwxyz"
+        Assert.AreEqual(sb.ToString(), "\u0000a\u0001b\u0002c\u0003d\u0004e\u0005f\u0006g\u0007h\u0008i\u0009j\u000Ak\u000Bl\u000Cm\u000Dn\u000Eo\u000Fp\u0010q\u0011r\u0012s\u0013t\u0014u\u0015v\u0016w\u0017x\u0018y\u0019z")
 
     [<Test>]
     member this.Map() =


### PR DESCRIPTION
Following up on the findings and timings presented at https://github.com/dotnet/fsharp/issues/9390#issuecomment-642985879, this PR improves performance to about 25%, sometimes more on modern processors.