### PR TITLE
Improve perf for String.filter up to 3x

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -99,6 +99,13 @@ type StringModule() =
         let e4 = String.filter (fun c -> c <> 'o') ""
         Assert.AreEqual("", e4)
 
+        let e5 = String.filter (fun c -> c > 'B' ) "ABRACADABRA"
+        Assert.AreEqual("RCDR", e5)
+
+        // LOH test with 55k string, which is 110k bytes
+        let e5 = String.filter (fun c -> c > 'B' ) (String.replicate 5_000 "ABRACADABRA")
+        Assert.AreEqual(String.replicate 5_000 "RCDR", e5)
+
     [<Test>]
     member this.Collect() =
         let e1 = String.collect (fun c -> "a"+string c) "foo"

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -87,14 +87,14 @@ type StringModule() =
 
     [<Test>]
     member this.Filter() =
-        let e1 = String.filter (fun c -> true) "foo"
-        Assert.AreEqual("foo", e1)
+        let e1 = String.filter (fun c -> true) "Taradiddle"
+        Assert.AreEqual("Taradiddle", e1)
 
         let e2 = String.filter (fun c -> true) null 
         Assert.AreEqual("", e2)
 
-        let e3 = String.filter (fun c -> c <> 'o') "foo bar"
-        Assert.AreEqual("f bar", e3)
+        let e3 = String.filter (fun c -> c <> '\'') "Golliwog's cakewalk"
+        Assert.AreEqual("Golliwogs cakewalk", e3)
 
         let e4 = String.filter (fun c -> c <> 'o') ""
         Assert.AreEqual("", e4)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -93,8 +93,8 @@ type StringModule() =
         let e2 = String.filter (fun c -> true) null 
         Assert.AreEqual("", e2)
 
-        let e3 = String.filter (fun c -> c <> '\'') "Golliwog's cakewalk"
-        Assert.AreEqual("Golliwogs cakewalk", e3)
+        let e3 = String.filter Char.IsUpper "How Vexingly Quick Daft Zebras Jump!"
+        Assert.AreEqual("HVQDZJ", e3)
 
         let e4 = String.filter (fun c -> c <> 'o') ""
         Assert.AreEqual("", e4)


### PR DESCRIPTION
This PR is a follow-up on the findings in this comment in the main issue: https://github.com/dotnet/fsharp/issues/9390#issuecomment-642985879 (scroll to `String.filter`).

I've added the case for LOH scenarios to fallback to the old method, to prevent extra LOH allocations, however, this ultimately depends on the user-supplied filter, obviously. SB internally keeps an array and if that array exceeds the LOH threshold by repeated `Append`s there's little we can do. Also note that in general, SB will give more GC pressure, so there'll be a jump in the performance back to the old perf for strings > 40_000 chars (I didn't use the more exact threshold of 42_500 for having a safety margin, fcs uses this too with similar reasons).

For the average case, this gives a perf gain of 1.8x to ~3x depending on how much is filtered out. The rare case where input is large and filtering filters out everything, we still get a 35% gain. 

Reason for not using `Array.filter` is two-fold: it is not in scope yet (and the code is complex) and it is slower than the cut-off method shown here when the array contains value types (here `char`).

For ease of reference, here's the chart (where `None` means: filter out all characters, and `All` means keep all of the input after filter). The proposed method is `buildAndCut` from the chart, modified for LOH:

![image](https://user-images.githubusercontent.com/16015770/85168883-48bfde00-b26b-11ea-8f23-c9de7a2c0612.png)