### PR TITLE
Better classification: such colors, much wow

### DIFF
--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -52,6 +52,7 @@ type SemanticClassificationType =
     | NamedArgument
     | Value
     | LocalValue
+    | Parameter
     | Type
     | TypeDef
 
@@ -153,7 +154,7 @@ module TcResolutionsExtensions =
                             add m SemanticClassificationType.DisposableValue
                         elif Option.isSome vref.LiteralValue then
                             add m SemanticClassificationType.Literal
-                        elif vref.IsLocalRef && not vref.IsCompiledAsTopLevel then
+                        elif not vref.IsCompiledAsTopLevel then
                             add m SemanticClassificationType.LocalValue
                         else
                             add m SemanticClassificationType.Value

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -52,7 +52,6 @@ type SemanticClassificationType =
     | NamedArgument
     | Value
     | LocalValue
-    | Parameter
     | Type
     | TypeDef
 

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -51,6 +51,7 @@ type SemanticClassificationType =
     | Delegate
     | NamedArgument
     | Value
+    | LocalValue
     | Type
     | TypeDef
 
@@ -135,9 +136,6 @@ module TcResolutionsExtensions =
                     | Item.Value KeywordIntrinsicValue, ItemOccurence.Use, _, _, _, m ->
                         add m SemanticClassificationType.IntrinsicFunction
 
-                    | (Item.Value vref), _, _, _, _, m when Option.isSome vref.LiteralValue ->
-                        add m SemanticClassificationType.Literal
-
                     | (Item.Value vref), _, _, _, _, m when isFunction g vref.Type ->
                         if valRefEq g g.range_op_vref vref || valRefEq g g.range_step_op_vref vref then 
                             ()
@@ -150,10 +148,13 @@ module TcResolutionsExtensions =
                         else
                             add m SemanticClassificationType.Function
 
-                    | (Item.Value vref), _, _, _, _, m when isValRefDisposable vref ->
-
+                    | (Item.Value vref), _, _, _, _, m ->
                         if isValRefDisposable vref then
                             add m SemanticClassificationType.DisposableValue
+                        elif Option.isSome vref.LiteralValue then
+                            add m SemanticClassificationType.Literal
+                        elif vref.IsLocalRef && not vref.IsCompiledAsTopLevel then
+                            add m SemanticClassificationType.LocalValue
                         else
                             add m SemanticClassificationType.Value
 

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -36,6 +36,10 @@ type SemanticClassificationType =
     | TypeArgument
     | Operator
     | Disposable
+    | Method
+    | Constructor
+    | Literal
+    | RecordField
 
 [<AutoOpen>]
 module TcResolutionsExtensions =
@@ -89,6 +93,9 @@ module TcResolutionsExtensions =
                 let isDisposableTy (ty: TType) =
                     protectAssemblyExplorationNoReraise false false (fun () -> Infos.ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_IDisposable)
 
+                let isValRefDisposable (vref: ValRef) =
+                    not (vref.DisplayName = "_") && not (vref.DisplayName = "__") && isDisposableTy vref.Type
+
                 let isStructTyconRef (tyconRef: TyconRef) = 
                     let ty = generalizedTyconRef tyconRef
                     let underlyingTy = stripTyEqnsAndMeasureEqns g ty
@@ -116,61 +123,100 @@ module TcResolutionsExtensions =
                     // 'seq' in 'seq { ... }' gets colored as keywords
                     | (Item.Value vref), ItemOccurence.Use, _, _, _, m when valRefEq g g.seq_vref vref ->
                         add m SemanticClassificationType.ComputationExpression
+
                     | (Item.Value vref), _, _, _, _, m when isValRefMutable vref ->
                         add m SemanticClassificationType.MutableVar
+
                     | Item.Value KeywordIntrinsicValue, ItemOccurence.Use, _, _, _, m ->
                         add m SemanticClassificationType.IntrinsicFunction
+
+                    | (Item.Value vref), _, _, _, _, m when Option.isSome vref.LiteralValue ->
+                        add m SemanticClassificationType.Literal
+
                     | (Item.Value vref), _, _, _, _, m when isFunction g vref.Type ->
                         if valRefEq g g.range_op_vref vref || valRefEq g g.range_step_op_vref vref then 
                             ()
                         elif vref.IsPropertyGetterMethod || vref.IsPropertySetterMethod then
                             add m SemanticClassificationType.Property
+                        elif vref.IsMember then
+                            add m SemanticClassificationType.Method
                         elif IsOperatorName vref.DisplayName then
                             add m SemanticClassificationType.Operator
                         else
                             add m SemanticClassificationType.Function
-                    | Item.RecdField rfinfo, _, _, _, _, m when isRecdFieldMutable rfinfo ->
-                        add m SemanticClassificationType.MutableVar
-                    | Item.RecdField rfinfo, _, _, _, _, m when isFunction g rfinfo.FieldType ->
-                        add m SemanticClassificationType.Function
-                    | Item.RecdField EnumCaseFieldInfo, _, _, _, _, m ->
-                        add m SemanticClassificationType.Enumeration
+
+                    | (Item.Value vref), _, _, _, _, m when isValRefDisposable vref ->
+                        add m SemanticClassificationType.Disposable
+
+                    | Item.RecdField rfinfo, _, _, _, _, m ->
+                        match rfinfo with
+                        | EnumCaseFieldInfo ->
+                            add m SemanticClassificationType.Enumeration
+                        | _ ->
+                            if isRecdFieldMutable rfinfo then
+                                add m SemanticClassificationType.MutableVar
+                            else
+                                add m SemanticClassificationType.RecordField
+
+                    | Item.AnonRecdField(_, tys, idx, m), _, _, _, _, _ ->
+                        let ty = tys.[idx]
+                        if isRefCellTy g ty then
+                            add m SemanticClassificationType.MutableVar
+                        else
+                            add m SemanticClassificationType.RecordField
+
                     | Item.MethodGroup _, _, _, _, _, m ->
-                        add m SemanticClassificationType.Function
-                    // custom builders, custom operations get colored as keywords
+                        add m SemanticClassificationType.Method
+
+                    | Item.CtorGroup _, _, _, _, _, m ->
+                        add m SemanticClassificationType.Constructor
+                        
+                    | Item.CtorGroup(_, [MethInfo.FSMeth(_, OptionalArgumentAttribute, _, _)]), LegitTypeOccurence, _, _, _, _ ->
+                        ()
+
+                    // Custom builders, custom operations get colored as keywords
                     | (Item.CustomBuilder _ | Item.CustomOperation _), ItemOccurence.Use, _, _, _, m ->
                         add m SemanticClassificationType.ComputationExpression
-                    // types get colored as types when they occur in syntactic types or custom attributes
-                    // type variables get colored as types when they occur in syntactic types custom builders, custom operations get colored as keywords
-                    | Item.Types (_, [OptionalArgumentAttribute]), LegitTypeOccurence, _, _, _, _ -> ()
-                    | Item.CtorGroup(_, [MethInfo.FSMeth(_, OptionalArgumentAttribute, _, _)]), LegitTypeOccurence, _, _, _, _ -> ()
+
+                    // Types get colored as types when they occur in syntactic types or custom attributes
+                    // Type variables get colored as types when they occur in syntactic types custom builders, custom operations get colored as keywords
+                    | Item.Types (_, [OptionalArgumentAttribute]), LegitTypeOccurence, _, _, _, _ ->
+                        ()
+
                     | Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists (isInterfaceTy g) -> 
                         add m SemanticClassificationType.Interface
+
                     | Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists (isStructTy g) -> 
                         add m SemanticClassificationType.ValueType
+
                     | Item.Types(_, TType_app(tyconRef, TType_measure _ :: _) :: _), LegitTypeOccurence, _, _, _, m when isStructTyconRef tyconRef ->
                         add m SemanticClassificationType.ValueType
+
                     | Item.Types(_, types), LegitTypeOccurence, _, _, _, m when types |> List.exists isDisposableTy ->
                         add m SemanticClassificationType.Disposable
+
                     | Item.Types _, LegitTypeOccurence, _, _, _, m -> 
                         add m SemanticClassificationType.ReferenceType
+
                     | (Item.TypeVar _ ), LegitTypeOccurence, _, _, _, m ->
                         add m SemanticClassificationType.TypeArgument
+
                     | Item.UnqualifiedType tyconRefs, LegitTypeOccurence, _, _, _, m ->
                         if tyconRefs |> List.exists (fun tyconRef -> tyconRef.Deref.IsStructOrEnumTycon) then
                             add m SemanticClassificationType.ValueType
                         else add m SemanticClassificationType.ReferenceType
-                    | Item.CtorGroup(_, minfos), LegitTypeOccurence, _, _, _, m ->
-                        if minfos |> List.exists (fun minfo -> isStructTy g minfo.ApparentEnclosingType) then
-                            add m SemanticClassificationType.ValueType
-                        else add m SemanticClassificationType.ReferenceType
+
                     | Item.ExnCase _, LegitTypeOccurence, _, _, _, m ->
                         add m SemanticClassificationType.ReferenceType
+
                     | Item.ModuleOrNamespaces refs, LegitTypeOccurence, _, _, _, m when refs |> List.exists (fun x -> x.IsModule) ->
                         add m SemanticClassificationType.Module
+
                     | (Item.ActivePatternCase _ | Item.UnionCase _ | Item.ActivePatternResult _), _, _, _, _, m ->
                         add m SemanticClassificationType.UnionCase
-                    | _ -> ())
+
+                    | _ ->
+                        ())
                 results.AddRange(formatSpecifierLocations |> Array.map (fun (m, _) -> struct(m, SemanticClassificationType.Printf)))
                 results.ToArray()
                ) 

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -101,10 +101,10 @@ module TcResolutionsExtensions =
                     not (typeEquiv g ty g.system_IDisposable_ty) &&
                     protectAssemblyExplorationNoReraise false false (fun () -> Infos.ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_IDisposable)
                     
-                let isDiscardText (str: string) = str |> String.forall (fun c -> c = '_')
+                let isDiscard (str: string) = str.StartsWith("_")
 
                 let isValRefDisposable (vref: ValRef) =
-                    not (isDiscardText vref.DisplayName) && isDisposableTy vref.Type
+                    not (isDiscard vref.DisplayName) && isDisposableTy vref.Type
 
                 let isStructTyconRef (tyconRef: TyconRef) = 
                     let ty = generalizedTyconRef tyconRef
@@ -157,7 +157,7 @@ module TcResolutionsExtensions =
                             add m SemanticClassificationType.DisposableValue
                         elif Option.isSome vref.LiteralValue then
                             add m SemanticClassificationType.Literal
-                        elif not vref.IsCompiledAsTopLevel && not(isDiscardText vref.DisplayName) then
+                        elif not vref.IsCompiledAsTopLevel && not(isDiscard vref.DisplayName) then
                             add m SemanticClassificationType.LocalValue
                         else
                             add m SemanticClassificationType.Value

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -104,7 +104,9 @@ module TcResolutionsExtensions =
                 let isDiscard (str: string) = str.StartsWith("_")
 
                 let isValRefDisposable (vref: ValRef) =
-                    not (isDiscard vref.DisplayName) && isDisposableTy vref.Type
+                    not (isDiscard vref.DisplayName) &&
+                    // For values, we actually do want to color things if they literally are IDisposables 
+                    protectAssemblyExplorationNoReraise false false (fun () -> Infos.ExistsHeadTypeInEntireHierarchy g amap range0 vref.Type g.tcref_System_IDisposable)
 
                 let isStructTyconRef (tyconRef: TyconRef) = 
                     let ty = generalizedTyconRef tyconRef

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -151,10 +151,11 @@ module TcResolutionsExtensions =
                             add m SemanticClassificationType.Function
 
                     | (Item.Value vref), _, _, _, _, m when isValRefDisposable vref ->
-                        add m SemanticClassificationType.DisposableValue
 
-                    | Item.Value _, _, _, _, _, m ->
-                        add m SemanticClassificationType.Value
+                        if isValRefDisposable vref then
+                            add m SemanticClassificationType.DisposableValue
+                        else
+                            add m SemanticClassificationType.Value
 
                     | Item.RecdField rfinfo, _, _, _, _, m ->
                         match rfinfo with
@@ -179,8 +180,9 @@ module TcResolutionsExtensions =
                         else
                             add m SemanticClassificationType.RecordField
 
-                    | Item.Property _, _, _, _, _, m ->
-                        add m SemanticClassificationType.Property
+                    | Item.Property (_, pinfo :: _), _, _, _, _, m ->
+                        if not pinfo.IsIndexer then
+                            add m SemanticClassificationType.Property
                         
                     | (Item.CtorGroup _ | Item.DelegateCtor _ | Item.FakeInterfaceCtor _), _, _, _, _, m ->
                         add m SemanticClassificationType.Constructor
@@ -278,6 +280,9 @@ module TcResolutionsExtensions =
 
                     | (Item.ArgName _ | Item.SetterArg _), _, _, _, _, m ->
                         add m SemanticClassificationType.NamedArgument
+
+                    | Item.SetterArg _, _, _, _, _, m ->
+                        add m SemanticClassificationType.Property
 
                     | Item.UnqualifiedType (tcref :: _), LegitTypeOccurence, _, _, _, m ->
                         if tcref.IsEnumTycon || tcref.IsILEnumTycon then

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -45,7 +45,6 @@ type SemanticClassificationType =
     | Value
     | Type
     | TypeDef
-    | Measure
 
 /// Extension methods for the TcResolutions type.
 [<AutoOpen>]

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -28,6 +28,10 @@ type SemanticClassificationType =
     | TypeArgument
     | Operator
     | Disposable
+    | Method
+    | Constructor
+    | Literal
+    | RecordField
 
 /// Extension methods for the TcResolutions type.
 [<AutoOpen>]

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -2,7 +2,6 @@
 
 namespace FSharp.Compiler.SourceCodeServices
 
-open FSharp.Compiler
 open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.Import
 open FSharp.Compiler.NameResolution
@@ -16,10 +15,12 @@ type SemanticClassificationType =
     | ReferenceType
     | ValueType
     | UnionCase
+    | UnionCaseField
     | Function
     | Property
     | MutableVar
     | Module
+    | NameSpace
     | Printf
     | ComputationExpression
     | IntrinsicFunction
@@ -27,11 +28,19 @@ type SemanticClassificationType =
     | Interface
     | TypeArgument
     | Operator
-    | Disposable
+    | DisposableType
+    | DisposableValue
     | Method
+    | ExtensionMethod
     | Constructor
     | Literal
     | RecordField
+    | MutableRecordField
+    | RecordFieldAsFunction
+    | ExceptionCase
+    | Field
+    | Event
+    | Delegate
 
 /// Extension methods for the TcResolutions type.
 [<AutoOpen>]

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -44,7 +44,6 @@ type SemanticClassificationType =
     | NamedArgument
     | Value
     | LocalValue
-    | Parameter
     | Type
     | TypeDef
 

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -44,6 +44,7 @@ type SemanticClassificationType =
     | NamedArgument
     | Value
     | LocalValue
+    | Parameter
     | Type
     | TypeDef
 

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -43,6 +43,7 @@ type SemanticClassificationType =
     | Delegate
     | NamedArgument
     | Value
+    | LocalValue
     | Type
     | TypeDef
 

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -32,7 +32,8 @@ type SemanticClassificationType =
     | DisposableValue
     | Method
     | ExtensionMethod
-    | Constructor
+    | ConstructorForReferenceType
+    | ConstructorForValueType
     | Literal
     | RecordField
     | MutableRecordField

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -37,17 +37,20 @@ type SemanticClassificationType =
     | RecordField
     | MutableRecordField
     | RecordFieldAsFunction
-    | ExceptionCase
+    | Exception
     | Field
     | Event
     | Delegate
+    | NamedArgument
+    | Value
+    | Type
+    | TypeDef
+    | Measure
 
 /// Extension methods for the TcResolutions type.
 [<AutoOpen>]
 module internal TcResolutionsExtensions =
-
     val (|CNR|) : cnr: CapturedNameResolution -> (Item * ItemOccurence * DisplayEnv * NameResolutionEnv * AccessorDomain * range)
 
     type TcResolutions with
-
         member GetSemanticClassification: g: TcGlobals * amap: ImportMap * formatSpecifierLocations: (range * int) [] * range: range option -> struct(range * SemanticClassificationType) []

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -56,9 +56,9 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Property
         | SemanticClassificationType.RecordFieldAsFunction
         | SemanticClassificationType.RecordField -> ClassificationTypeNames.LocalName // Picking something with a distinct color instead of the white color that Property gives
+        | SemanticClassificationType.NamedArgument -> ClassificationTypeNames.LabelName
         | SemanticClassificationType.Event -> ClassificationTypeNames.EventName
         | SemanticClassificationType.Delegate -> ClassificationTypeNames.DelegateName
-        | SemanticClassificationType.NamedArgument -> ClassificationTypeNames.LabelName
         | SemanticClassificationType.Value -> ClassificationTypeNames.Identifier
 
 module internal ClassificationDefinitions =

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -21,9 +21,7 @@ open FSharp.Compiler.SourceCodeServices
 
 [<RequireQualifiedAccess>]
 module internal FSharpClassificationTypes =
-    let [<Literal>] Function = "FSharp.Function"
     let [<Literal>] MutableVar = "FSharp.MutableVar"
-    let [<Literal>] Printf = "FSharp.Printf"
     let [<Literal>] Disposable = "FSharp.Disposable"
 
     let getClassificationTypeName = function
@@ -126,28 +124,12 @@ module internal ClassificationDefinitions =
 
         interface ISetThemeColors with member this.SetColors() = setColors()
 
-
-    [<Export; Name(FSharpClassificationTypes.Function); BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)>]
-    let FSharpFunctionClassificationType : ClassificationTypeDefinition = null
-
     [<Export; Name(FSharpClassificationTypes.MutableVar); BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)>]
     let FSharpMutableVarClassificationType : ClassificationTypeDefinition = null
 
-    [<Export; Name(FSharpClassificationTypes.Printf); BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)>]
-    let FSharpPrintfClassificationType : ClassificationTypeDefinition = null
 
     [<Export; Name(FSharpClassificationTypes.Disposable); BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)>]
     let FSharpDisposableClassificationType : ClassificationTypeDefinition = null
-
-    [<Export(typeof<EditorFormatDefinition>)>]
-    [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.Function)>]
-    [<Name(FSharpClassificationTypes.Function)>]
-    [<UserVisible(true)>]
-    [<Order(After = PredefinedClassificationTypeNames.Keyword)>]
-    type internal FSharpFunctionTypeFormat() as self =
-        inherit ClassificationFormatDefinition()
-
-        do self.DisplayName <- SR.FSharpFunctionsOrMethodsClassificationType()
 
     [<Export(typeof<EditorFormatDefinition>)>]
     [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.MutableVar)>]
@@ -159,17 +141,6 @@ module internal ClassificationDefinitions =
 
         do self.DisplayName <- SR.FSharpMutableVarsClassificationType()
            self.ForegroundColor <- theme.GetColor FSharpClassificationTypes.MutableVar
-
-    [<Export(typeof<EditorFormatDefinition>)>]
-    [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.Printf)>]
-    [<Name(FSharpClassificationTypes.Printf)>]
-    [<UserVisible(true)>]
-    [<Order(After = PredefinedClassificationTypeNames.String)>]
-    type internal FSharpPrintfTypeFormat [<ImportingConstructor>](theme: ThemeColors) as self =
-        inherit ClassificationFormatDefinition()
-
-        do self.DisplayName <- SR.FSharpPrintfFormatClassificationType()
-           self.ForegroundColor <- theme.GetColor FSharpClassificationTypes.Printf
 
     [<Export(typeof<EditorFormatDefinition>)>]
     [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.Disposable)>]

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -29,7 +29,6 @@ module internal FSharpClassificationTypes =
     let getClassificationTypeName = function
         | SemanticClassificationType.MutableRecordField
         | SemanticClassificationType.MutableVar -> MutableVar
-        | SemanticClassificationType.Printf -> Printf
         | SemanticClassificationType.DisposableValue
         | SemanticClassificationType.DisposableType -> Disposable
         | SemanticClassificationType.NameSpace -> ClassificationTypeNames.NamespaceName
@@ -38,6 +37,7 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Type
         | SemanticClassificationType.TypeDef
         | SemanticClassificationType.ConstructorForReferenceType
+        | SemanticClassificationType.Printf
         | SemanticClassificationType.ReferenceType -> ClassificationTypeNames.ClassName
         | SemanticClassificationType.ConstructorForValueType
         | SemanticClassificationType.ValueType -> ClassificationTypeNames.StructName
@@ -84,11 +84,10 @@ module internal ClassificationDefinitions =
             let themeService = serviceProvider.GetService(typeof<SVsColorThemeService>) :?> IVsColorThemeService
             themeService.CurrentTheme.ThemeId
 
-        let colorData = // name,                      (light,                            dark)
+        let customColorData = // name,                (light,                            dark)
             [
                 FSharpClassificationTypes.MutableVar, (Color.FromRgb(160uy, 128uy, 0uy), Color.FromRgb(255uy, 210uy, 28uy))
-                FSharpClassificationTypes.Printf,     (Color.FromRgb(43uy, 145uy, 175uy), Color.FromRgb(78uy, 220uy, 176uy))
-                FSharpClassificationTypes.Disposable, (Colors.Tomato,                    Colors.Tomato)
+                FSharpClassificationTypes.Disposable, (Colors.Green,                     Color.FromRgb(51uy, 251uy, 96uy))
             ]
 
         let setColors _ =
@@ -100,7 +99,7 @@ module internal ClassificationDefinitions =
             let formatMap = classificationformatMapService.GetClassificationFormatMap(category = "text")
             try 
                 formatMap.BeginBatchUpdate()
-                for ctype, (light, dark) in colorData do
+                for ctype, (light, dark) in customColorData do
                     // we don't touch the changes made by the user
                     if fontAndColorStorage.GetItem(ctype, Array.zeroCreate 1) <> VSConstants.S_OK  then
                         let ict = classificationTypeRegistry.GetClassificationType(ctype)
@@ -119,7 +118,7 @@ module internal ClassificationDefinitions =
         interface IDisposable with member __.Dispose() = VSColorTheme.remove_ThemeChanged handler
 
         member __.GetColor(ctype) =
-            let light, dark = colorData |> Map.ofList |> Map.find ctype
+            let light, dark = customColorData |> Map.ofList |> Map.find ctype
             match getCurrentThemeId() with
             | LightTheme -> Nullable light
             | DarkTheme -> Nullable dark

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -25,28 +25,37 @@ module internal FSharpClassificationTypes =
     let [<Literal>] MutableVar = "FSharp.MutableVar"
     let [<Literal>] Printf = "FSharp.Printf"
     let [<Literal>] Disposable = "FSharp.Disposable"
-    let [<Literal>] RecordField = "FSharp.RecordField"
 
     let getClassificationTypeName = function
         | SemanticClassificationType.Function -> Function
+        | SemanticClassificationType.MutableRecordField
         | SemanticClassificationType.MutableVar -> MutableVar
         | SemanticClassificationType.Printf -> Printf
-        | SemanticClassificationType.Disposable -> Disposable
+        | SemanticClassificationType.DisposableValue
+        | SemanticClassificationType.DisposableType -> Disposable
+        | SemanticClassificationType.NameSpace -> ClassificationTypeNames.NamespaceName
+        | SemanticClassificationType.ExceptionCase
+        | SemanticClassificationType.Module
         | SemanticClassificationType.ReferenceType -> ClassificationTypeNames.ClassName
-        | SemanticClassificationType.Module -> ClassificationTypeNames.ModuleName
         | SemanticClassificationType.ValueType -> ClassificationTypeNames.StructName
         | SemanticClassificationType.ComputationExpression
         | SemanticClassificationType.IntrinsicFunction -> ClassificationTypeNames.Keyword
         | SemanticClassificationType.UnionCase
         | SemanticClassificationType.Enumeration -> ClassificationTypeNames.EnumName
+        | SemanticClassificationType.Field
+        | SemanticClassificationType.UnionCaseField -> ClassificationTypeNames.FieldName
         | SemanticClassificationType.Property -> ClassificationTypeNames.PropertyName
         | SemanticClassificationType.Interface -> ClassificationTypeNames.InterfaceName
         | SemanticClassificationType.TypeArgument -> ClassificationTypeNames.TypeParameterName
         | SemanticClassificationType.Operator -> ClassificationTypeNames.Operator
         | SemanticClassificationType.Constructor
         | SemanticClassificationType.Method -> ClassificationTypeNames.MethodName
+        | SemanticClassificationType.ExtensionMethod -> ClassificationTypeNames.ExtensionMethodName
         | SemanticClassificationType.Literal -> ClassificationTypeNames.ConstantName
+        | SemanticClassificationType.RecordFieldAsFunction
         | SemanticClassificationType.RecordField -> ClassificationTypeNames.LocalName
+        | SemanticClassificationType.Event -> ClassificationTypeNames.EventName
+        | SemanticClassificationType.Delegate -> ClassificationTypeNames.DelegateName
 
 module internal ClassificationDefinitions =
 
@@ -74,7 +83,7 @@ module internal ClassificationDefinitions =
                 FSharpClassificationTypes.Function,   (Colors.Black,                     Color.FromRgb(220uy, 220uy, 220uy))
                 FSharpClassificationTypes.MutableVar, (Color.FromRgb(160uy, 128uy, 0uy), Color.FromRgb(255uy, 210uy, 28uy))
                 FSharpClassificationTypes.Printf,     (Color.FromRgb(43uy, 145uy, 175uy), Color.FromRgb(78uy, 220uy, 176uy))
-                FSharpClassificationTypes.Disposable, (Colors.ForestGreen,                    Colors.ForestGreen)
+                FSharpClassificationTypes.Disposable, (Colors.Tomato,                    Colors.Tomato)
             ]
 
         let setColors _ =

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -27,16 +27,18 @@ module internal FSharpClassificationTypes =
     let [<Literal>] Disposable = "FSharp.Disposable"
 
     let getClassificationTypeName = function
-        | SemanticClassificationType.Function -> Function
         | SemanticClassificationType.MutableRecordField
         | SemanticClassificationType.MutableVar -> MutableVar
         | SemanticClassificationType.Printf -> Printf
         | SemanticClassificationType.DisposableValue
         | SemanticClassificationType.DisposableType -> Disposable
         | SemanticClassificationType.NameSpace -> ClassificationTypeNames.NamespaceName
-        | SemanticClassificationType.ExceptionCase
+        | SemanticClassificationType.Exception
         | SemanticClassificationType.Module
+        | SemanticClassificationType.Type
+        | SemanticClassificationType.TypeDef
         | SemanticClassificationType.ReferenceType -> ClassificationTypeNames.ClassName
+        | SemanticClassificationType.Measure
         | SemanticClassificationType.ValueType -> ClassificationTypeNames.StructName
         | SemanticClassificationType.ComputationExpression
         | SemanticClassificationType.IntrinsicFunction -> ClassificationTypeNames.Keyword
@@ -44,18 +46,21 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Enumeration -> ClassificationTypeNames.EnumName
         | SemanticClassificationType.Field
         | SemanticClassificationType.UnionCaseField -> ClassificationTypeNames.FieldName
-        | SemanticClassificationType.Property -> ClassificationTypeNames.PropertyName
         | SemanticClassificationType.Interface -> ClassificationTypeNames.InterfaceName
         | SemanticClassificationType.TypeArgument -> ClassificationTypeNames.TypeParameterName
         | SemanticClassificationType.Operator -> ClassificationTypeNames.Operator
         | SemanticClassificationType.Constructor
+        | SemanticClassificationType.Function
         | SemanticClassificationType.Method -> ClassificationTypeNames.MethodName
         | SemanticClassificationType.ExtensionMethod -> ClassificationTypeNames.ExtensionMethodName
         | SemanticClassificationType.Literal -> ClassificationTypeNames.ConstantName
+        | SemanticClassificationType.Property
         | SemanticClassificationType.RecordFieldAsFunction
         | SemanticClassificationType.RecordField -> ClassificationTypeNames.LocalName
         | SemanticClassificationType.Event -> ClassificationTypeNames.EventName
         | SemanticClassificationType.Delegate -> ClassificationTypeNames.DelegateName
+        | SemanticClassificationType.NamedArgument -> ClassificationTypeNames.LabelName
+        | SemanticClassificationType.Value -> ClassificationTypeNames.Identifier
 
 module internal ClassificationDefinitions =
 
@@ -80,7 +85,6 @@ module internal ClassificationDefinitions =
 
         let colorData = // name,                      (light,                            dark)
             [
-                FSharpClassificationTypes.Function,   (Colors.Black,                     Color.FromRgb(220uy, 220uy, 220uy))
                 FSharpClassificationTypes.MutableVar, (Color.FromRgb(160uy, 128uy, 0uy), Color.FromRgb(255uy, 210uy, 28uy))
                 FSharpClassificationTypes.Printf,     (Color.FromRgb(43uy, 145uy, 175uy), Color.FromRgb(78uy, 220uy, 176uy))
                 FSharpClassificationTypes.Disposable, (Colors.Tomato,                    Colors.Tomato)
@@ -101,17 +105,10 @@ module internal ClassificationDefinitions =
                         let ict = classificationTypeRegistry.GetClassificationType(ctype)
                         let oldProps = formatMap.GetTextProperties(ict)
                         let newProps =
-                            let props =
-                                match getCurrentThemeId() with
-                                | LightTheme -> oldProps.SetForeground light
-                                | DarkTheme -> oldProps.SetForeground dark
-                                | UnknownTheme -> oldProps
-
-                            // Distinguish F# functions from values with bold
-                            if ctype = FSharpClassificationTypes.Function then
-                                props.SetBold(true)
-                            else
-                                props
+                            match getCurrentThemeId() with
+                            | LightTheme -> oldProps.SetForeground light
+                            | DarkTheme -> oldProps.SetForeground dark
+                            | UnknownTheme -> oldProps
                         formatMap.SetTextProperties(ict, newProps)
                 fontAndColorStorage.CloseCategory() |> ignore
             finally formatMap.EndBatchUpdate()

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -37,7 +37,9 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Module
         | SemanticClassificationType.Type
         | SemanticClassificationType.TypeDef
+        | SemanticClassificationType.ConstructorForReferenceType
         | SemanticClassificationType.ReferenceType -> ClassificationTypeNames.ClassName
+        | SemanticClassificationType.ConstructorForValueType
         | SemanticClassificationType.ValueType -> ClassificationTypeNames.StructName
         | SemanticClassificationType.ComputationExpression
         | SemanticClassificationType.IntrinsicFunction -> ClassificationTypeNames.Keyword
@@ -48,7 +50,6 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Interface -> ClassificationTypeNames.InterfaceName
         | SemanticClassificationType.TypeArgument -> ClassificationTypeNames.TypeParameterName
         | SemanticClassificationType.Operator -> ClassificationTypeNames.Operator
-        | SemanticClassificationType.Constructor
         | SemanticClassificationType.Function
         | SemanticClassificationType.Method -> ClassificationTypeNames.MethodName
         | SemanticClassificationType.ExtensionMethod -> ClassificationTypeNames.ExtensionMethodName

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -38,7 +38,6 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Type
         | SemanticClassificationType.TypeDef
         | SemanticClassificationType.ReferenceType -> ClassificationTypeNames.ClassName
-        | SemanticClassificationType.Measure
         | SemanticClassificationType.ValueType -> ClassificationTypeNames.StructName
         | SemanticClassificationType.ComputationExpression
         | SemanticClassificationType.IntrinsicFunction -> ClassificationTypeNames.Keyword

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -55,7 +55,7 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Literal -> ClassificationTypeNames.ConstantName
         | SemanticClassificationType.Property
         | SemanticClassificationType.RecordFieldAsFunction
-        | SemanticClassificationType.RecordField -> ClassificationTypeNames.LocalName
+        | SemanticClassificationType.RecordField -> ClassificationTypeNames.LocalName // Picking something with a distinct color instead of the white color that Property gives
         | SemanticClassificationType.Event -> ClassificationTypeNames.EventName
         | SemanticClassificationType.Delegate -> ClassificationTypeNames.DelegateName
         | SemanticClassificationType.NamedArgument -> ClassificationTypeNames.LabelName

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -55,11 +55,12 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Literal -> ClassificationTypeNames.ConstantName
         | SemanticClassificationType.Property
         | SemanticClassificationType.RecordFieldAsFunction
-        | SemanticClassificationType.RecordField -> ClassificationTypeNames.LocalName // Picking something with a distinct color instead of the white color that Property gives
+        | SemanticClassificationType.RecordField -> ClassificationTypeNames.PropertyName // TODO - maybe pick something that isn't white by default like Property?
         | SemanticClassificationType.NamedArgument -> ClassificationTypeNames.LabelName
         | SemanticClassificationType.Event -> ClassificationTypeNames.EventName
         | SemanticClassificationType.Delegate -> ClassificationTypeNames.DelegateName
         | SemanticClassificationType.Value -> ClassificationTypeNames.Identifier
+        | SemanticClassificationType.LocalValue -> ClassificationTypeNames.LocalName
 
 module internal ClassificationDefinitions =
 

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -61,7 +61,6 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Delegate -> ClassificationTypeNames.DelegateName
         | SemanticClassificationType.Value -> ClassificationTypeNames.Identifier
         | SemanticClassificationType.LocalValue -> ClassificationTypeNames.LocalName
-        | SemanticClassificationType.Parameter -> ClassificationTypeNames.ParameterName
 
 module internal ClassificationDefinitions =
 

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -85,7 +85,7 @@ module internal ClassificationDefinitions =
         let customColorData = // name,                (light,                            dark)
             [
                 FSharpClassificationTypes.MutableVar, (Color.FromRgb(160uy, 128uy, 0uy), Color.FromRgb(255uy, 210uy, 28uy))
-                FSharpClassificationTypes.Disposable, (Colors.Green,                     Color.FromRgb(51uy, 251uy, 96uy))
+                FSharpClassificationTypes.Disposable, (Colors.Green,                     Color.FromRgb(2uy, 183uy, 43uy))
             ]
 
         let setColors _ =

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -61,6 +61,7 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Delegate -> ClassificationTypeNames.DelegateName
         | SemanticClassificationType.Value -> ClassificationTypeNames.Identifier
         | SemanticClassificationType.LocalValue -> ClassificationTypeNames.LocalName
+        | SemanticClassificationType.Parameter -> ClassificationTypeNames.ParameterName
 
 module internal ClassificationDefinitions =
 

--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -51,39 +51,39 @@ module internal RoslynHelpers =
 
     /// maps from `LayoutTag` of the F# Compiler to Roslyn `TextTags` for use in tooltips
     let roslynTag = function
-    | LayoutTag.ActivePatternCase
-    | LayoutTag.ActivePatternResult
-    | LayoutTag.UnionCase
-    | LayoutTag.Enum -> TextTags.Enum
-    | LayoutTag.Alias
-    | LayoutTag.Class
-    | LayoutTag.Union
-    | LayoutTag.Record
-    | LayoutTag.UnknownType -> TextTags.Class
-    | LayoutTag.Delegate -> TextTags.Delegate
-    | LayoutTag.Event -> TextTags.Event
-    | LayoutTag.Field -> TextTags.Field
-    | LayoutTag.Interface -> TextTags.Interface
-    | LayoutTag.Struct -> TextTags.Struct
-    | LayoutTag.Keyword -> TextTags.Keyword
-    | LayoutTag.Local -> TextTags.Local
-    | LayoutTag.Member
-    | LayoutTag.ModuleBinding
-    | LayoutTag.RecordField
-    | LayoutTag.Property -> TextTags.Property
-    | LayoutTag.Method -> TextTags.Method
-    | LayoutTag.Namespace -> TextTags.Namespace
-    | LayoutTag.Module -> TextTags.Module
-    | LayoutTag.LineBreak -> TextTags.LineBreak
-    | LayoutTag.Space -> TextTags.Space
-    | LayoutTag.NumericLiteral -> TextTags.NumericLiteral
-    | LayoutTag.Operator -> TextTags.Operator
-    | LayoutTag.Parameter -> TextTags.Parameter
-    | LayoutTag.TypeParameter -> TextTags.TypeParameter
-    | LayoutTag.Punctuation -> TextTags.Punctuation
-    | LayoutTag.StringLiteral -> TextTags.StringLiteral
-    | LayoutTag.Text
-    | LayoutTag.UnknownEntity -> TextTags.Text
+        | LayoutTag.ActivePatternCase
+        | LayoutTag.ActivePatternResult
+        | LayoutTag.UnionCase
+        | LayoutTag.Enum -> TextTags.Enum
+        | LayoutTag.Alias
+        | LayoutTag.Class
+        | LayoutTag.Union
+        | LayoutTag.Record
+        | LayoutTag.UnknownType -> TextTags.Class
+        | LayoutTag.Delegate -> TextTags.Delegate
+        | LayoutTag.Event -> TextTags.Event
+        | LayoutTag.Field -> TextTags.Field
+        | LayoutTag.Interface -> TextTags.Interface
+        | LayoutTag.Struct -> TextTags.Struct
+        | LayoutTag.Keyword -> TextTags.Keyword
+        | LayoutTag.Local -> TextTags.Local
+        | LayoutTag.Member
+        | LayoutTag.ModuleBinding
+        | LayoutTag.RecordField
+        | LayoutTag.Property -> TextTags.Property
+        | LayoutTag.Method -> TextTags.Method
+        | LayoutTag.Namespace -> TextTags.Namespace
+        | LayoutTag.Module -> TextTags.Module
+        | LayoutTag.LineBreak -> TextTags.LineBreak
+        | LayoutTag.Space -> TextTags.Space
+        | LayoutTag.NumericLiteral -> TextTags.NumericLiteral
+        | LayoutTag.Operator -> TextTags.Operator
+        | LayoutTag.Parameter -> TextTags.Parameter
+        | LayoutTag.TypeParameter -> TextTags.TypeParameter
+        | LayoutTag.Punctuation -> TextTags.Punctuation
+        | LayoutTag.StringLiteral -> TextTags.StringLiteral
+        | LayoutTag.Text
+        | LayoutTag.UnknownEntity -> TextTags.Text
 
     let CollectTaggedText (list: List<_>) (t:TaggedText) = list.Add(TaggedText(roslynTag t.Tag, t.Text))
 

--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -51,39 +51,39 @@ module internal RoslynHelpers =
 
     /// maps from `LayoutTag` of the F# Compiler to Roslyn `TextTags` for use in tooltips
     let roslynTag = function
-        | LayoutTag.ActivePatternCase
-        | LayoutTag.ActivePatternResult
-        | LayoutTag.UnionCase
-        | LayoutTag.Enum -> TextTags.Enum
-        | LayoutTag.Alias
-        | LayoutTag.Class
-        | LayoutTag.Union
-        | LayoutTag.Record
-        | LayoutTag.UnknownType -> TextTags.Class
-        | LayoutTag.Delegate -> TextTags.Delegate
-        | LayoutTag.Event -> TextTags.Event
-        | LayoutTag.Field -> TextTags.Field
-        | LayoutTag.Interface -> TextTags.Interface
-        | LayoutTag.Struct -> TextTags.Struct
-        | LayoutTag.Keyword -> TextTags.Keyword
-        | LayoutTag.Local -> TextTags.Local
-        | LayoutTag.Member
-        | LayoutTag.ModuleBinding
-        | LayoutTag.RecordField
-        | LayoutTag.Property -> TextTags.Property
-        | LayoutTag.Method -> TextTags.Method
-        | LayoutTag.Namespace -> TextTags.Namespace
-        | LayoutTag.Module -> TextTags.Module
-        | LayoutTag.LineBreak -> TextTags.LineBreak
-        | LayoutTag.Space -> TextTags.Space
-        | LayoutTag.NumericLiteral -> TextTags.NumericLiteral
-        | LayoutTag.Operator -> TextTags.Operator
-        | LayoutTag.Parameter -> TextTags.Parameter
-        | LayoutTag.TypeParameter -> TextTags.TypeParameter
-        | LayoutTag.Punctuation -> TextTags.Punctuation
-        | LayoutTag.StringLiteral -> TextTags.StringLiteral
-        | LayoutTag.Text
-        | LayoutTag.UnknownEntity -> TextTags.Text
+    | LayoutTag.ActivePatternCase
+    | LayoutTag.ActivePatternResult
+    | LayoutTag.UnionCase
+    | LayoutTag.Enum -> TextTags.Enum
+    | LayoutTag.Alias
+    | LayoutTag.Class
+    | LayoutTag.Union
+    | LayoutTag.Record
+    | LayoutTag.UnknownType -> TextTags.Class
+    | LayoutTag.Delegate -> TextTags.Delegate
+    | LayoutTag.Event -> TextTags.Event
+    | LayoutTag.Field -> TextTags.Field
+    | LayoutTag.Interface -> TextTags.Interface
+    | LayoutTag.Struct -> TextTags.Struct
+    | LayoutTag.Keyword -> TextTags.Keyword
+    | LayoutTag.Local -> TextTags.Local
+    | LayoutTag.Member
+    | LayoutTag.ModuleBinding
+    | LayoutTag.RecordField
+    | LayoutTag.Property -> TextTags.Property
+    | LayoutTag.Method -> TextTags.Method
+    | LayoutTag.Namespace -> TextTags.Namespace
+    | LayoutTag.Module -> TextTags.Module
+    | LayoutTag.LineBreak -> TextTags.LineBreak
+    | LayoutTag.Space -> TextTags.Space
+    | LayoutTag.NumericLiteral -> TextTags.NumericLiteral
+    | LayoutTag.Operator -> TextTags.Operator
+    | LayoutTag.Parameter -> TextTags.Parameter
+    | LayoutTag.TypeParameter -> TextTags.TypeParameter
+    | LayoutTag.Punctuation -> TextTags.Punctuation
+    | LayoutTag.StringLiteral -> TextTags.StringLiteral
+    | LayoutTag.Text
+    | LayoutTag.UnknownEntity -> TextTags.Text
 
     let CollectTaggedText (list: List<_>) (t:TaggedText) = list.Add(TaggedText(roslynTag t.Tag, t.Text))
 

--- a/vsintegration/tests/UnitTests/SemanticColorizationServiceTests.fs
+++ b/vsintegration/tests/UnitTests/SemanticColorizationServiceTests.fs
@@ -58,12 +58,12 @@ type SemanticClassificationServiceTests() =
         let anyData = ranges |> List.exists (fun struct (range, sct) -> Range.rangeContainsPos range markerPos && ((FSharpClassificationTypes.getClassificationTypeName sct) = classificationType))
         Assert.False(anyData, "Classification data was found when it wasn't expected.")
 
-    [<TestCase("(*1*)", ClassificationTypeNames.StructName)>] // Fails
+    [<TestCase("(*1*)", ClassificationTypeNames.StructName)>]
     [<TestCase("(*2*)", ClassificationTypeNames.ClassName)>]
-    [<TestCase("(*3*)", ClassificationTypeNames.StructName)>] // Fails
+    [<TestCase("(*3*)", ClassificationTypeNames.StructName)>]
     [<TestCase("(*4*)", ClassificationTypeNames.ClassName)>]
-    [<TestCase("(*5*)", ClassificationTypeNames.StructName)>] // Fails
-    [<TestCase("(*6*)", ClassificationTypeNames.StructName)>] // Fails
+    [<TestCase("(*5*)", ClassificationTypeNames.StructName)>]
+    [<TestCase("(*6*)", ClassificationTypeNames.StructName)>]
     [<TestCase("(*7*)", ClassificationTypeNames.ClassName)>]
     member __.Measured_Types(marker: string, classificationType: string) =
         verifyClassificationAtEndOfMarker(

--- a/vsintegration/tests/UnitTests/SemanticColorizationServiceTests.fs
+++ b/vsintegration/tests/UnitTests/SemanticColorizationServiceTests.fs
@@ -7,6 +7,7 @@ open Microsoft.VisualStudio.FSharp.Editor
 open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler
 open Microsoft.CodeAnalysis.Text
+open Microsoft.CodeAnalysis.Classification
 
 [<TestFixture; Category "Roslyn Services">]
 type SemanticClassificationServiceTests() =
@@ -57,13 +58,13 @@ type SemanticClassificationServiceTests() =
         let anyData = ranges |> List.exists (fun struct (range, sct) -> Range.rangeContainsPos range markerPos && ((FSharpClassificationTypes.getClassificationTypeName sct) = classificationType))
         Assert.False(anyData, "Classification data was found when it wasn't expected.")
 
-    [<TestCase("(*1*)", FSharpClassificationTypes.ValueType)>]
-    [<TestCase("(*2*)", FSharpClassificationTypes.ReferenceType)>]
-    [<TestCase("(*3*)", FSharpClassificationTypes.ValueType)>]
-    [<TestCase("(*4*)", FSharpClassificationTypes.ReferenceType)>]
-    [<TestCase("(*5*)", FSharpClassificationTypes.ValueType)>]
-    [<TestCase("(*6*)", FSharpClassificationTypes.ValueType)>]
-    [<TestCase("(*7*)", FSharpClassificationTypes.ReferenceType)>]
+    [<TestCase("(*1*)", ClassificationTypeNames.StructName)>] // Fails
+    [<TestCase("(*2*)", ClassificationTypeNames.ClassName)>]
+    [<TestCase("(*3*)", ClassificationTypeNames.StructName)>] // Fails
+    [<TestCase("(*4*)", ClassificationTypeNames.ClassName)>]
+    [<TestCase("(*5*)", ClassificationTypeNames.StructName)>] // Fails
+    [<TestCase("(*6*)", ClassificationTypeNames.StructName)>] // Fails
+    [<TestCase("(*7*)", ClassificationTypeNames.ClassName)>]
     member __.Measured_Types(marker: string, classificationType: string) =
         verifyClassificationAtEndOfMarker(
                 """#light (*Light*)


### PR DESCRIPTION
This all started because I wanted to fix https://github.com/dotnet/fsharp/issues/4618 and then fix https://github.com/dotnet/fsharp/issues/6117

Firstly, this PR produces a lot more distinct classification data than before. This can allow a much finer degree of control over what an editor chooses to do with it, such as coloring. It is done in a way that matches how we compute `FSharpGlyph` data.

For VS specifically, we do centralize a lot of these classification types to more common Roslyn classifications. That said, a lot have been updated so that we can have some Fancy Colors.

Currently, to get these Fancy Colors in VS, you'll need to toggle a setting int he _C# settings_. I will endeavor to submit a PR to Roslyn to move this to a more central location, or have a similar setting specifically for F#.

![image](https://user-images.githubusercontent.com/6309070/85180033-404db000-b237-11ea-9c2a-672c9c25ac3d.png)

Once this is turned on, you'll see the pretty colors.

Structs are distinct from classes. Methods and properties are colored distinctly:

![image](https://user-images.githubusercontent.com/6309070/85181312-704a8280-b23a-11ea-9e5b-2dbce96a13e7.png)

This applies to records and DUs too:

![image](https://user-images.githubusercontent.com/6309070/85181327-7f313500-b23a-11ea-838d-16b8a0d65246.png)

![image](https://user-images.githubusercontent.com/6309070/85181344-89533380-b23a-11ea-83f2-bdd1c0ad5806.png)

Anonymous record labels are now classified:

![image](https://user-images.githubusercontent.com/6309070/85181385-a4be3e80-b23a-11ea-8b48-7493229059db.png)

Functions, methods, constructors are colored similarly, unless they are record labels. Note the distinction between constructor invocation and qualifying something with the class name:

![image](https://user-images.githubusercontent.com/6309070/85181452-d1725600-b23a-11ea-9f96-9d56e6a03d94.png)

![image](https://user-images.githubusercontent.com/6309070/85181432-c5869400-b23a-11ea-9587-72b80fcd2432.png)

Disposable types and bindings are classified (color TBD, I picked `Colors.Tomato` because the name seemed funny to me):

![image](https://user-images.githubusercontent.com/6309070/85181538-0c748980-b23b-11ea-8e38-0390958f033d.png)

![image](https://user-images.githubusercontent.com/6309070/85181589-2910c180-b23b-11ea-8790-ecbdfe166cd6.png)

(note that the `this` was colored, but if you mark it as a discard then it won't be)

![image](https://user-images.githubusercontent.com/6309070/85181621-3d54be80-b23b-11ea-9ebd-81755046fcf2.png)

Here's what a lot of different things (generics, class, structs vs classes, UoM, functions, type abbreviations, exceptions) look like together:

![image](https://user-images.githubusercontent.com/6309070/85181045-dbe02000-b239-11ea-842b-47353a52fc79.png)
![image](https://user-images.githubusercontent.com/6309070/85181174-1f3a8e80-b23a-11ea-80ce-87d4a33e3b7e.png)

And here's what it looks like in some larger, more involved/complicated parts of the F# compiler codebase:

![image](https://user-images.githubusercontent.com/6309070/85181705-6e34f380-b23b-11ea-9a93-64c674df49fe.png)

![image](https://user-images.githubusercontent.com/6309070/85181726-7e4cd300-b23b-11ea-9f37-52d36856ef9c.png)

![image](https://user-images.githubusercontent.com/6309070/85181759-945a9380-b23b-11ea-8b5a-d4d24d675e22.png)

### THIS ALSO FIXED SOME STUFF

Indexers now don't color the `.` like it was a class

![image](https://user-images.githubusercontent.com/6309070/85182579-f4ead000-b23d-11ea-9b2e-bf41479b54d7.png)
![image](https://user-images.githubusercontent.com/6309070/85183783-dab2f100-b241-11ea-8149-ff8e56322efb.png)

Multiple active patterns can still be marked as "unused" and the ranges for that are still bonkers, but at least it doesn't show random white characters anymore:

Before:

![image](https://user-images.githubusercontent.com/6309070/85182984-1c8e6800-b23f-11ea-9a25-77f3f8021dc8.png)

After:

![image](https://user-images.githubusercontent.com/6309070/85183003-24e6a300-b23f-11ea-8a7f-93766375ff7e.png)

### BUT GENERIC PARAMETERS CAN STILL BE WEIRD

* Some cases with type arguments where they aren't resolved correctly in name resolution, leading to the whole thing being the classification of the kind of thing being parameterized (https://github.com/dotnet/fsharp/issues/4792, https://github.com/dotnet/fsharp/issues/6516, https://github.com/dotnet/fsharp/issues/2585)