### PR TITLE
Perf: String.replicate from O(n) to O(log(n)), up to 12x speed improvement

### DIFF
--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -79,11 +79,22 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Replicate")>]
         let replicate (count:int) (str:string) =
-            if count < 0 then invalidArgInputMustBeNonNegative "count" count
+            //if count < 0 then invalidArgInputMustBeNonNegative "count" count
 
             let len = length str
             if len = 0 || count = 0 then 
                 String.Empty
+
+            elif len = 1 then
+                new String(str.[0], count)
+
+            elif count <= 4 then
+                match count with
+                | 1 -> str
+                | 2 -> String.Concat(str, str)
+                | 3 -> String.Concat(str, str, str)
+                | _ -> String.Concat(str, str, str, str)
+
             else
                 // Using the primitive, because array.fs is not yet in scope. It's safe: both len and count are positive.
                 let target = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked (len * count)

--- a/src/fsharp/FSharp.Core/string.fs
+++ b/src/fsharp/FSharp.Core/string.fs
@@ -79,7 +79,7 @@ namespace Microsoft.FSharp.Core
 
         [<CompiledName("Replicate")>]
         let replicate (count:int) (str:string) =
-            //if count < 0 then invalidArgInputMustBeNonNegative "count" count
+            if count < 0 then invalidArgInputMustBeNonNegative "count" count
 
             let len = length str
             if len = 0 || count = 0 then 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -141,13 +141,25 @@ type StringModule() =
         Assert.AreEqual(230 , e5.Length)
         Assert.AreEqual("天地玄黃，宇宙洪荒。天地玄黃，宇宙洪荒。", e5.Substring(0, 20))
 
-        // this tests the cut-off point for the O(log(n)) algorithm by using a prime number
+        // This tests the cut-off point for the O(log(n)) algorithm with a prime number
         let e6 = String.replicate 84673 "!!!"
         Assert.AreEqual(84673 * 3, e6.Length)
 
-        // this tests the cut-off point for the O(log(n)) algorithm by using a 2^x number
-        let e6 = String.replicate 1024 "!!!"
-        Assert.AreEqual(1024 * 3, e6.Length)
+        // This tests the cut-off point for the O(log(n)) algorithm with a 2^x number
+        let e7 = String.replicate 1024 "!!!"
+        Assert.AreEqual(1024 * 3, e7.Length)
+
+        let e8 = String.replicate 1 "What a wonderful world"
+        Assert.AreEqual("What a wonderful world", e8)
+
+        let e9 = String.replicate 3 "أضعت طريقي! أضعت طريقي"  // means: I'm lost
+        Assert.AreEqual("أضعت طريقي! أضعت طريقيأضعت طريقي! أضعت طريقيأضعت طريقي! أضعت طريقي", e9)
+
+        let e10 = String.replicate 4 "㏖ ㏗ ℵ "
+        Assert.AreEqual("㏖ ㏗ ℵ ㏖ ㏗ ℵ ㏖ ㏗ ℵ ㏖ ㏗ ℵ ", e10)
+
+        let e11 = String.replicate 5 "5"
+        Assert.AreEqual("55555", e11)
 
         CheckThrowsArgumentException(fun () -> String.replicate -1 "foo" |> ignore)
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -125,11 +125,11 @@ type StringModule() =
 
     [<Test>]
     member this.Replicate() = 
-        let e1 = String.replicate 0 "foo"
+        let e1 = String.replicate 0 "Snickersnee"
         Assert.AreEqual("", e1)
 
-        let e2 = String.replicate 2 "foo"
-        Assert.AreEqual("foofoo", e2)
+        let e2 = String.replicate 2 "Collywobbles, "
+        Assert.AreEqual("Collywobbles, Collywobbles, ", e2)
 
         let e3 = String.replicate 2 null
         Assert.AreEqual("", e3)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
 namespace FSharp.Core.UnitTests.Collections
 
@@ -133,6 +133,21 @@ type StringModule() =
 
         let e3 = String.replicate 2 null
         Assert.AreEqual("", e3)
+
+        let e4 = String.replicate 300_000 ""
+        Assert.AreEqual("", e4)
+
+        let e5 = String.replicate 23 "天地玄黃，宇宙洪荒。"
+        Assert.AreEqual(230 , e5.Length)
+        Assert.AreEqual("天地玄黃，宇宙洪荒。天地玄黃，宇宙洪荒。", e5.Substring(0, 20))
+
+        // this tests the cut-off point for the O(log(n)) algorithm by using a prime number
+        let e6 = String.replicate 84673 "!!!"
+        Assert.AreEqual(84673 * 3, e6.Length)
+
+        // this tests the cut-off point for the O(log(n)) algorithm by using a 2^x number
+        let e6 = String.replicate 1024 "!!!"
+        Assert.AreEqual(1024 * 3, e6.Length)
 
         CheckThrowsArgumentException(fun () -> String.replicate -1 "foo" |> ignore)
 


### PR DESCRIPTION
As in the title, plus it now doesn't create an unnecessary object anymore if the `count` is 0.

This is a follow-up on this comment, detailing the perf gains: https://github.com/dotnet/fsharp/issues/9390#issuecomment-644128788

EDIT: I've changed the code a bit more, so that there are no unnecessary copies of strings anymore, it now gives even better perf than before:

![image](https://user-images.githubusercontent.com/16015770/85187665-64de7200-b2a1-11ea-9fca-861dfb4ad7c5.png)
