### PR TITLE
Un-inline 'string' to fix throwing FS0670, and remove null-check

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -781,8 +781,8 @@ namespace Microsoft.FSharp.Core
 
         let inline anyToString nullStr x = 
             match box x with 
-            | null -> nullStr
             | :? System.IFormattable as f -> f.ToString(null,System.Globalization.CultureInfo.InvariantCulture)
+            | null -> nullStr
             | obj ->  obj.ToString()
 
         let anyToStringShowingNull x = anyToString "null" x
@@ -4457,23 +4457,11 @@ namespace Microsoft.FSharp.Core
              when ^T : ^T = (^T : (static member op_Explicit: ^T -> nativeint) (value))
 
         [<CompiledName("ToString")>]
-        let inline string (value: ^T) = 
-             anyToString "" value
-             // since we have static optimization conditionals for ints below, we need to special-case Enums.
-             // This way we'll print their symbolic value, as opposed to their integral one (Eg., "A", rather than "1")
-             when ^T struct = anyToString "" value
-             when ^T : float      = (# "" value : float      #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : float32    = (# "" value : float32    #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : int64      = (# "" value : int64      #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : int32      = (# "" value : int32      #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : int16      = (# "" value : int16      #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : nativeint  = (# "" value : nativeint  #).ToString()
-             when ^T : sbyte      = (# "" value : sbyte      #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : uint64     = (# "" value : uint64     #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : uint32     = (# "" value : uint32     #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : int16      = (# "" value : int16      #).ToString("g",CultureInfo.InvariantCulture)
-             when ^T : unativeint = (# "" value : unativeint #).ToString()
-             when ^T : byte       = (# "" value : byte       #).ToString("g",CultureInfo.InvariantCulture)
+        let string (value: 'T) = 
+            match box value with 
+            | :? System.IFormattable as f -> f.ToString(null,System.Globalization.CultureInfo.InvariantCulture)
+            | null -> ""
+            | obj ->  obj.ToString()
 
         [<NoDynamicInvocation(isLegacy=true)>]
         [<CompiledName("ToChar")>]

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -2824,12 +2824,12 @@ namespace Microsoft.FSharp.Core
         
         /// <summary>Converts the argument to a string using <c>ToString</c>.</summary>
         ///
-        /// <remarks>For standard integer and floating point values the <c>ToString</c> conversion 
-        /// uses <c>CultureInfo.InvariantCulture</c>. </remarks>
+        /// <remarks>For standard integer and floating point values the and any type that implements <c>IFormattable</c>
+        /// <c>ToString</c> conversion uses <c>CultureInfo.InvariantCulture</c>. </remarks>
         /// <param name="value">The input value.</param>
         /// <returns>The converted string.</returns>
         [<CompiledName("ToString")>]
-        val inline string  : value:^T -> string
+        val string  : value:'T -> string
 
         /// <summary>Converts the argument to System.Decimal using a direct conversion for all 
         /// primitive numeric types. For strings, the input is converted using <c>UInt64.Parse()</c>  

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
@@ -33,6 +33,13 @@
   <ItemGroup>
     <Compile Include="NUnitFrameworkShims.fs" />
     <Compile Include="LibraryTestFx.fs" />
+    <Compile Include="FSharp.Core\PrimTypes.fs" />
+    <Compile Include="FSharp.Core\ComparersRegression.fs" />
+    <Compile Include="FSharp.Core\DiscrimantedUnionType.fs" />
+    <Compile Include="FSharp.Core\RecordTypes.fs" />
+    <Compile Include="FSharp.Core\OperatorsModule1.fs" />
+    <Compile Include="FSharp.Core\OperatorsModule2.fs" />
+    <Compile Include="FSharp.Core\OperatorsModuleChecked.fs" />
 
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\Utils.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\ArrayModule.fs" />
@@ -59,10 +66,6 @@
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\CollectionModulesConsistency.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\StringModule.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\SeqMultipleIteration.fs" />
-    <Compile Include="FSharp.Core\PrimTypes.fs" />
-    <Compile Include="FSharp.Core\ComparersRegression.fs" />
-    <Compile Include="FSharp.Core\DiscrimantedUnionType.fs" />
-    <Compile Include="FSharp.Core\RecordTypes.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Core\BigIntType.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Core\IntConversions.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Core\IntConversionsGenerated.fs" />
@@ -87,9 +90,7 @@
     <Compile Include="SurfaceArea.net40.fs" Condition="$(TargetFramework.StartsWith('net4'))" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="**/*" Exclude="**/*.bak;Directory.Build.Props;Directory.Build.targets;FSharp.Core.UnitTests.fsproj" CopyToOutputDirectory="never" />
-  </ItemGroup>
+  <ItemGroup />
 
   <ItemGroup Condition="'$(BUILD_IN_FSHARP_REPOSITORY)' == 'true'">
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
@@ -104,6 +105,10 @@
   <ItemGroup Condition="'$(UnitTestType)' == 'xunit'">
     <PackageReference Include="xunit" Version="2.4.1" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Remove="FSharp.Core\OperatorsModule2.fs" />
   </ItemGroup>
 
 </Project>

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule1.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule1.fs
@@ -3,360 +3,57 @@
 // Various tests for the:
 // Microsoft.FSharp.Core.Operators module
 
-namespace SystematicUnitTests.FSharp_Core.Microsoft_FSharp_Core
+namespace FSharp.Core.UnitTests.Operators
 
 open System
-open SystematicUnitTests.LibraryTestFx
+open FSharp.Core.UnitTests.LibraryTestFx
 open NUnit.Framework
-open Microsoft.FSharp.Core.Operators.Checked
 
 [<TestFixture>]
 type OperatorsModule1() =
 
     [<Test>]
-    member this.Checkedbyte() =
-        // int type   
-        let intByte = Operators.Checked.byte 100
-        Assert.AreEqual(intByte,(byte)100)
-        
-        // char type  
-        let charByte = Operators.Checked.byte '0'
-        Assert.AreEqual(charByte,(byte)48)
-        
-        // boundary value
-        let boundByte = Operators.Checked.byte 255.0
-        Assert.AreEqual(boundByte, (byte)255)
-        
-        // overflow exception
-        try 
-            let overflowByte = Operators.Checked.byte 256.0
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        
-        
-       
+    member _.KeyValue() =
 
-    [<Test>]
-    member this.Checkedchar() =
-
-        // number
-        let numberChar = Operators.Checked.char 48 
-        Assert.AreEqual(numberChar,'0')
-        
-        // letter
-        let letterChar = Operators.Checked.char 65 
-        Assert.AreEqual(letterChar,'A')
-        
-        // boundary value
-        let boundchar = Operators.Checked.char 126
-        Assert.AreEqual(boundchar, '~')
-        
-        // overflow exception
-        try 
-            let overflowchar = Operators.Checked.char (System.Int64.MaxValue+(int64)2)
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        
-    [<Test>]
-    member this.CheckedInt() =
-
-        // char
-        let charInt = Operators.Checked.int '0' 
-        Assert.AreEqual(charInt,48)
-        
-        // float
-        let floatInt = Operators.Checked.int 10.0 
-        Assert.AreEqual(floatInt,10)
-        
-        
-        // boundary value
-        let boundInt = Operators.Checked.int 32767.0
-        Assert.AreEqual(boundInt, (int)32767)
-        
-        // overflow exception
-        try 
-            let overflowint = Operators.Checked.int 2147483648.0
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-                  
-        ()   
-        
-    [<Test>]
-    member this.CheckedInt16() =
-
-        // char
-        let charInt16 = Operators.Checked.int16 '0' 
-        Assert.AreEqual(charInt16,(int16)48)
-        
-        // float
-        let floatInt16 = Operators.Checked.int16 10.0 
-        Assert.AreEqual(floatInt16,(int16)10)
-        
-        // boundary value
-        let boundInt16 = Operators.Checked.int16 32767.0
-        Assert.AreEqual(boundInt16, (int16)32767)
-        
-        // overflow exception
-        try 
-            let overflowint16 = Operators.Checked.int16 32768.0
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        ()   
-        
-    [<Test>]
-    member this.CheckedInt32() =
-
-        // char
-        let charInt32 = Operators.Checked.int32 '0' 
-        Assert.AreEqual(charInt32,(int32)48)
-        
-        // float
-        let floatInt32 = Operators.Checked.int32 10.0
-        Assert.AreEqual(floatInt32,(int32)10)
-        
-        // boundary value
-        let boundInt32 = Operators.Checked.int32 2147483647.0
-        Assert.AreEqual(boundInt32, (int32)2147483647)
-        
-        // overflow exception
-        try 
-            let overflowint32 = Operators.Checked.int32 2147483648.0
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-          
-        ()   
-        
-    [<Test>]
-    member this.CheckedInt64() =
-
-        // char
-        let charInt64 = Operators.Checked.int64 '0' 
-        Assert.AreEqual(charInt64,(int64)48)
-        
-        // float
-        let floatInt64 = Operators.Checked.int64 10.0
-        Assert.AreEqual(floatInt64,(int64)10)
-        
-        // boundary value
-        let boundInt64 = Operators.Checked.int64 9223372036854775807I
-        let a  = 9223372036854775807L
-        Assert.AreEqual(boundInt64, 9223372036854775807L)
-        
-        // overflow exception
-        try 
-            let overflowint64 = Operators.Checked.int64 (System.Double.MaxValue+2.0)
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        ()
-        
-    [<Test>]
-    member this.CheckedNativeint() =
-
-        // char
-        let charnativeint = Operators.Checked.nativeint '0' 
-        Assert.AreEqual(charnativeint,(nativeint)48)
-        
-        // float
-        let floatnativeint = Operators.Checked.nativeint 10.0
-        Assert.AreEqual(floatnativeint,(nativeint)10)
-        
-        // boundary value
-        let boundnativeint = Operators.Checked.nativeint 32767.0
-        Assert.AreEqual(boundnativeint, (nativeint)32767)
-        
-        // overflow exception
-        try 
-            let overflownativeint = Operators.Checked.nativeint 2147483648.0
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        ()
-        
-    [<Test>]
-    member this.Checkedsbyte() =
-
-        // char
-        let charsbyte = Operators.Checked.sbyte '0' 
-        Assert.AreEqual(charsbyte,(sbyte)48)
-        
-        // float
-        let floatsbyte = Operators.Checked.sbyte -10.0
-        Assert.AreEqual(floatsbyte,(sbyte)(-10))
-        
-        // boundary value
-        let boundsbyte = Operators.Checked.sbyte -127.0
-        Assert.AreEqual(boundsbyte, (sbyte)(-127))
-        
-        // overflow exception
-        try 
-            let overflowsbyte = Operators.Checked.sbyte -256.0
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        
-        ()
-        
-    [<Test>]
-    member this.Checkeduint16() =
-
-        // char
-        let charuint16 = Operators.Checked.uint16 '0'
-        Assert.AreEqual(charuint16,(uint16)48)
-        
-        // float
-        let floatuint16 = Operators.Checked.uint16 10.0
-        Assert.AreEqual(floatuint16,(uint16)(10))
-        
-        // boundary value
-        let bounduint16 = Operators.Checked.uint16 65535.0
-        Assert.AreEqual(bounduint16, (uint16)(65535))
-        
-        // overflow exception
-        try 
-            let overflowuint16 = Operators.Checked.uint16 65536.0
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        ()
-        
-    [<Test>]
-    member this.Checkeduint32() =
-
-        // char
-        let charuint32 = Operators.Checked.uint32 '0'
-        Assert.AreEqual(charuint32,(uint32)48)
-        
-        // float
-        let floatuint32 = Operators.Checked.uint32 10.0
-        Assert.AreEqual(floatuint32,(uint32)(10))
-        
-        // boundary value
-        let bounduint32 = Operators.Checked.uint32 429496729.0
-        Assert.AreEqual(bounduint32, (uint32)(429496729))
-        
-        
-        // overflow exception
-        try 
-            let overflowuint32 = Operators.Checked.uint32 uint32.MaxValue+1u
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        ()
-        
-    [<Test>]
-    member this.Checkeduint64() =
-
-        // char
-        let charuint64 = Operators.Checked.uint64 '0'
-        Assert.AreEqual(charuint64,(uint64)48)
-        
-        // float
-        let floatuint64 = Operators.Checked.uint64 10.0
-        Assert.AreEqual(floatuint64,(uint64)(10))
-        
-        // boundary value
-        let bounduint64 = Operators.Checked.uint64 429496729.0
-        Assert.AreEqual(bounduint64, (uint64)(429496729))
-        
-        // overflow exception
-        try 
-            let overflowuint64 = Operators.Checked.uint64 System.UInt64.MaxValue+1UL
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        ()
-        
-    [<Test>]
-    member this.Checkedunativeint() =
-
-        // char
-        let charunativeint = Operators.Checked.unativeint '0' 
-        Assert.AreEqual(charunativeint,(unativeint)48)
-        
-        // float
-        let floatunativeint = Operators.Checked.unativeint 10.0
-        Assert.AreEqual(floatunativeint,(unativeint)10)
-        
-        // boundary value
-        let boundunativeint = Operators.Checked.unativeint 65353.0
-        Assert.AreEqual(boundunativeint, (unativeint)65353)
-        
-        // overflow exception
-        try 
-            let overflowuint64 = Operators.Checked.uint64 System.UInt64.MaxValue+1UL
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
-        ()
-        
-    [<Test>]
-    member this.KeyValue() =
-        
-        
         let funcKeyValue x =
             match x with
             | Operators.KeyValue(a) -> a
         
         // string int
         let stringint = funcKeyValue ( new System.Collections.Generic.KeyValuePair<string,int>("string",1))
-        Assert.AreEqual(stringint,("string",1))
+        Assert.AreEqual(("string",1), stringint)
         
         // float char
         let floatchar = funcKeyValue ( new System.Collections.Generic.KeyValuePair<float,char>(1.0,'a'))
-        Assert.AreEqual(floatchar,(1.0,'a'))
+        Assert.AreEqual((1.0,'a'), floatchar)
         
         // null
         let nullresult = funcKeyValue ( new System.Collections.Generic.KeyValuePair<string,char>(null,' '))
         let (nullstring:string,blankchar:char) = nullresult
         
         CheckThrowsNullRefException(fun () -> nullstring.ToString() |> ignore)
-        
-        
-        ()
-        
-    [<Test>]
-    member this.OptimizedRangesGetArraySlice() =
 
-        
+    [<Test>]
+    member _.OptimizedRangesGetArraySlice() =
+
         let param1 = Some(1)
         let param2 = Some(2)
             
         // int
         let intslice = Operators.OperatorIntrinsics.GetArraySlice [|1;2;3;4;5;6|] param1 param2
-        Assert.AreEqual(intslice,[|2;3|])
+        Assert.AreEqual([|2;3|], intslice)
         
         // string
         let stringslice = Operators.OperatorIntrinsics.GetArraySlice [|"1";"2";"3"|] param1 param2
-        Assert.AreEqual(stringslice,[|"2";"3"|])
+        Assert.AreEqual([|"2";"3"|], stringslice)
         
         // null
         let stringslice = Operators.OperatorIntrinsics.GetArraySlice [|null;null;null|] param1 param2
-        Assert.AreEqual(stringslice,[|null;null|])
-        
-        ()
-    
-    [<Test>]
-    member this.OptimizedRangesGetArraySlice2D() =
+        Assert.AreEqual([|null;null|], stringslice)
 
-        
+    [<Test>]
+    member _.OptimizedRangesGetArraySlice2D() =
+
         let param1D1 = Some(0)
         let param1D2 = Some(1)
         let param2D1 = Some(0)
@@ -366,36 +63,32 @@ type OperatorsModule1() =
         let intArray2D = Array2D.init 2 3 (fun i j -> i*100+j)
         let intslice = Operators.OperatorIntrinsics.GetArraySlice2D intArray2D param1D1 param1D2 param2D1 param2D2
         
-        Assert.AreEqual(intslice.[1,1],101)
+        Assert.AreEqual(101, intslice.[1,1])
          
         // string
         let stringArray2D = Array2D.init 2 3 (fun i j -> (i*100+j).ToString())
         let stringslice = Operators.OperatorIntrinsics.GetArraySlice2D stringArray2D param1D1 param1D2 param2D1 param2D2
-        Assert.AreEqual(stringslice.[1,1],(101).ToString())
+        Assert.AreEqual((101).ToString(), stringslice.[1,1])
         
         // null
         let nullArray2D = Array2D.init 2 3 (fun i j -> null)
         let nullslice = Operators.OperatorIntrinsics.GetArraySlice2D nullArray2D param1D1 param1D2 param2D1 param2D2
-        Assert.AreEqual(nullslice.[1,1],null)
-        
-        ()
-    
+        Assert.AreEqual(null, nullslice.[1,1])
+
     [<Test>]
-    member this.OptimizedRangesGetStringSlice() =
+    member _.OptimizedRangesGetStringSlice() =
         let param1 = Some(4)
         let param2 = Some(6)
             
         // string
         let stringslice = Operators.OperatorIntrinsics.GetStringSlice "abcdefg" param1 param2
-        Assert.AreEqual(stringslice,"efg")
+        Assert.AreEqual("efg", stringslice)
         
         // null
         CheckThrowsNullRefException(fun () -> Operators.OperatorIntrinsics.GetStringSlice null param1 param2 |> ignore)
-        ()
-    
-        
+
     [<Test>]
-    member this.OptimizedRangesSetArraySlice() =
+    member _.OptimizedRangesSetArraySlice() =
         let param1 = Some(1)
         let param2 = Some(2)
             
@@ -403,23 +96,22 @@ type OperatorsModule1() =
         let intArray1 = [|1;2;3|]
         let intArray2 = [|4;5;6|]
         Operators.OperatorIntrinsics.SetArraySlice intArray1 param1 param2 intArray2
-        Assert.AreEqual(intArray1,[|1;4;5|])
+        Assert.AreEqual([|1;4;5|], intArray1)
         
         // string
         let stringArray1 = [|"1";"2";"3"|]
         let stringArray2 = [|"4";"5";"6"|]
         Operators.OperatorIntrinsics.SetArraySlice stringArray1 param1 param2 stringArray2
-        Assert.AreEqual(stringArray1,[|"1";"4";"5"|])
+        Assert.AreEqual([|"1";"4";"5"|], stringArray1)
         
         // null
         let nullArray1 = [|null;null;null|]
         let nullArray2 = [|null;null;null|]
         Operators.OperatorIntrinsics.SetArraySlice nullArray1  param1 param2 nullArray2
         CheckThrowsNullRefException(fun () -> nullArray1.[0].ToString() |> ignore)
-        ()
-        
+
     [<Test>]
-    member this.OptimizedRangesSetArraySlice2D() =
+    member _.OptimizedRangesSetArraySlice2D() =
         let param1D1 = Some(0)
         let param1D2 = Some(1)
         let param2D1 = Some(0)
@@ -429,43 +121,40 @@ type OperatorsModule1() =
         let intArray1 = Array2D.init 2 3 (fun i j -> i*10+j)
         let intArray2 = Array2D.init 2 3 (fun i j -> i*100+j)
         Operators.OperatorIntrinsics.SetArraySlice2D intArray1 param1D1 param1D2 param2D1 param2D2 intArray2
-        Assert.AreEqual(intArray1.[1,1],101)
+        Assert.AreEqual(101, intArray1.[1,1])
         
         // string
         let stringArray2D1 = Array2D.init 2 3 (fun i j -> (i*10+j).ToString())
         let stringArray2D2 = Array2D.init 2 3 (fun i j -> (i*100+j).ToString())
         Operators.OperatorIntrinsics.SetArraySlice2D stringArray2D1 param1D1 param1D2 param2D1 param2D2 stringArray2D2
-        Assert.AreEqual(stringArray2D1.[1,1],(101).ToString())
+        Assert.AreEqual((101).ToString(), stringArray2D1.[1,1])
         
         // null
         let nullArray2D1 = Array2D.init 2 3 (fun i j -> null)
         let nullArray2D2 = Array2D.init 2 3 (fun i j -> null)
         Operators.OperatorIntrinsics.SetArraySlice2D nullArray2D1 param1D1 param1D2 param2D1 param2D2 nullArray2D2
         CheckThrowsNullRefException(fun () -> nullArray2D1.[0,0].ToString()  |> ignore)
-        ()
-        
+
     [<Test>]
-    member this.OptimizedRangesSetArraySlice3D() =
+    member _.OptimizedRangesSetArraySlice3D() =
         let intArray1 = Array3D.init 2 3 4 (fun i j k -> i*10+j)
         let intArray2 = Array3D.init 2 3 4 (fun i j k -> i*100+j)
         Operators.OperatorIntrinsics.SetArraySlice3D intArray1 (Some 0) (Some 1) (Some 0) (Some 1) (Some 0) (Some 1) intArray2
-        Assert.AreEqual(intArray1.[1,1,1],101)
-        ()
+        Assert.AreEqual(101, intArray1.[1,1,1])
 
     [<Test>]
-    member this.OptimizedRangesSetArraySlice4D() =
+    member _.OptimizedRangesSetArraySlice4D() =
         let intArray1 = Array4D.init 2 3 4 5 (fun i j k l -> i*10+j)
         let intArray2 = Array4D.init 2 3 4 5 (fun i j k l -> i*100+j)
-        Operators.OperatorIntrinsics.SetArraySlice4D intArray1 (Some 0) (Some 1) (Some 0) (Some 1) (Some 0) (Some 1) intArray2
-        Assert.AreEqual(intArray1.[1,1,1,1],101)
-        ()
-        
+        Operators.OperatorIntrinsics.SetArraySlice4D intArray1 (Some 0) (Some 1) (Some 0) (Some 1) (Some 0) (Some 1) (Some 0) (Some 1) intArray2
+        Assert.AreEqual(101, intArray1.[1,1,1,1])
+
     [<Test>]
-    member this.Uncheckeddefaultof () =
+    member _.Uncheckeddefaultof () =
         
         // int
         let intdefault = Operators.Unchecked.defaultof<int>
-        Assert.AreEqual(intdefault, 0)
+        Assert.AreEqual(0, intdefault)
       
         // string
         let stringdefault = Operators.Unchecked.defaultof<string>
@@ -473,433 +162,419 @@ type OperatorsModule1() =
         
         // null
         let structdefault = Operators.Unchecked.defaultof<DateTime>
-        Assert.AreEqual( structdefault.Day,1)
-        
-        ()
-        
+        Assert.AreEqual(1,  structdefault.Day)
+
     [<Test>]
-    member this.abs () =
+    member _.abs () =
         
         // int
         let intabs = Operators.abs (-7)
-        Assert.AreEqual(intabs, 7)
+        Assert.AreEqual(7, intabs)
       
-        // float 
+        // float
         let floatabs = Operators.abs (-100.0)
-        Assert.AreEqual(floatabs, 100.0)
+        Assert.AreEqual(100.0, floatabs)
         
         // decimal
         let decimalabs = Operators.abs (-1000M)
-        Assert.AreEqual(decimalabs, 1000M)
-        
-        ()
-        
+        Assert.AreEqual(1000M, decimalabs)
+
     [<Test>]
-    member this.acos () =
+    member _.acos () =
         
         // min value
         let minacos = Operators.acos (0.0)
-        Assert.AreEqual(minacos, 1.5707963267948966)
+        Assert.AreNearEqual(1.5707963267948966, minacos)
       
         // normal value
         let normalacos = Operators.acos (0.3)
-        Assert.AreEqual(normalacos, 1.2661036727794992)
+        Assert.AreNearEqual(1.2661036727794992, normalacos)
       
         // max value
         let maxacos = Operators.acos (1.0)
-        Assert.AreEqual(maxacos, 0.0)
-        ()
-        
+        Assert.AreEqual(0.0, maxacos)
+
     [<Test>]
-    member this.asin () =
+    member _.asin () =
         
         // min value
         let minasin = Operators.asin (0.0)
-        Assert.AreEqual(minasin, 0)
+        Assert.AreEqual(0.0, minasin)
       
         // normal value
         let normalasin = Operators.asin (0.5)
-        Assert.AreEqual(normalasin, 0.52359877559829893)
+        Assert.AreNearEqual(0.52359877559829893, normalasin)
       
         // max value
         let maxasin = Operators.asin (1.0)
-        Assert.AreEqual(maxasin, 1.5707963267948966)
-        ()
-        
-   
-        
+        Assert.AreNearEqual(1.5707963267948966, maxasin)
+
     [<Test>]
-    member this.atan () =
+    member _.atan () =
         
         // min value
         let minatan = Operators.atan (0.0)
-        Assert.AreEqual(minatan, 0)
+        Assert.AreNearEqual(0.0, minatan)
       
         // normal value
         let normalatan = Operators.atan (1.0)
-        Assert.AreEqual(normalatan, 0.78539816339744828)
+        Assert.AreNearEqual(0.78539816339744828, normalatan)
       
         // biggish  value
         let maxatan = Operators.atan (infinity)
-        Assert.AreEqual(maxatan, 1.5707963267948966)
-        ()
-       
+        Assert.AreNearEqual(1.5707963267948966, maxatan)
+
     [<Test>]
-    member this.atan2 () =
+    member _.atan2 () =
         
         // min value
         let minatan2 = Operators.atan2 (0.0) (1.0)
-        Assert.AreEqual(minatan2, 0)
+        Assert.AreNearEqual(0.0, minatan2)
       
         // normal value
         let normalatan2 = Operators.atan2 (1.0) (1.0)
-        Assert.AreEqual(normalatan2, 0.78539816339744828)
+        Assert.AreNearEqual(0.78539816339744828, normalatan2)
       
         // biggish  value
         let maxatan2 = Operators.atan2 (1.0) (0.0)
-        Assert.AreEqual(maxatan2, 1.5707963267948966)
-        ()
-        
+        Assert.AreNearEqual(1.5707963267948966, maxatan2)
+
     [<Test>]
-    member this.box () =
+    member _.box () =
         
         // int value
         let intbox = Operators.box 1
-        Assert.AreEqual(intbox, 1)
+        Assert.AreEqual(1, intbox)
       
         // string value
         let stringlbox = Operators.box "string"
-        Assert.AreEqual(stringlbox, "string")
+        Assert.AreEqual("string", stringlbox)
       
         // null  value
         let nullbox = Operators.box null
         CheckThrowsNullRefException(fun () -> nullbox.ToString()  |> ignore)
-        ()
-        
+
     [<Test>]
-    member this.byte() =
-        // int type   
+    member _.byte() =
+        // int type
         let intByte = Operators.byte 100
-        Assert.AreEqual(intByte,(byte)100)
+        Assert.AreEqual(100uy, intByte)
         
-        // char type  
+        // char type
         let charByte = Operators.byte '0'
-        Assert.AreEqual(charByte,(byte)48)
+        Assert.AreEqual(48uy, charByte)
         
         // boundary value
         let boundByte = Operators.byte 255.0
-        Assert.AreEqual(boundByte, (byte)255)
+        Assert.AreEqual(255uy, boundByte)
         
-        // overflow exception
-        try 
-            let overflowbyte = Operators.byte (System.Int64.MaxValue*(int64)2)
-            Assert.Fail("Expectt overflow exception but not.")
-        with
-            | :? System.OverflowException -> ()
-            | _ -> Assert.Fail("Expectt overflow exception but not.")
+        // Overflow
+        let result = Operators.byte Int64.MaxValue
+        Assert.AreEqual(Byte.MaxValue, result)
+        
+        // Overflow
+        let result = Operators.byte Int64.MinValue
+        Assert.AreEqual(0uy, result)
+        
+        // Overflow
+        let result = Operators.byte Double.MinValue
+        Assert.AreEqual(0uy, result)
+        
+        // Overflow
+        let result = Operators.byte Double.MaxValue
+        Assert.AreEqual(0uy, result)
+        
+        // Overflow
+        let result = Operators.byte (Int64.MaxValue * 8L)
+        Assert.AreEqual(248uy, result)      // bit-complement
+
+        // Overflow
+        let result = 255uy + 5uy
+        Assert.AreEqual(4uy, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.byte Decimal.MinValue |> ignore)
         
     [<Test>]
-    member this.ceil() =
-        // min value   
+    member _.ceil() =
+        // min value
         let minceil = Operators.ceil 0.1
-        Assert.AreEqual(minceil,1.0)
+        Assert.AreEqual(1.0, minceil)
         
-        // normal value  
+        // normal value
         let normalceil = Operators.ceil 100.0
-        Assert.AreEqual(normalceil,100.0)
+        Assert.AreEqual(100.0, normalceil)
         
         // max value
         let maxceil = Operators.ceil 1.7E+308
-        Assert.AreEqual(maxceil, 1.7E+308)
+        Assert.AreEqual(1.7E+308, maxceil)
         
     [<Test>]
-    member this.char() =
-        // int type   
+    member _.char() =
+        // int type
         let intchar = Operators.char 48
-        Assert.AreEqual(intchar,'0')
+        Assert.AreEqual('0', intchar)
         
-        // string type  
+        // string type
         let stringchar = Operators.char " "
-        Assert.AreEqual(stringchar, ' ')
+        Assert.AreEqual(' ', stringchar)
        
     [<Test>]
-    member this.compare() =
-        // int type   
+    member _.compare() =
+        // int type
         let intcompare = Operators.compare 100 101
-        Assert.AreEqual(intcompare,-1)
+        Assert.AreEqual(-1, intcompare)
         
-        // char type  
+        // char type
         let charcompare = Operators.compare '0' '1'
-        Assert.AreEqual(charcompare,-1)
+        Assert.AreEqual(-1, charcompare)
         
         // null value
         let boundcompare = Operators.compare null null
-        Assert.AreEqual(boundcompare, 0)
-   
-        
+        Assert.AreEqual(0, boundcompare)
+
     [<Test>]
-    member this.cos () =
+    member _.cos () =
         
         // min value
         let mincos = Operators.cos (0.0)
-        Assert.AreEqual(mincos, 1)
+        Assert.AreEqual(1.0, mincos)
       
         // normal value
         let normalcos = Operators.cos (1.0)
-        Assert.AreEqual(normalcos, 0.54030230586813977)
+        Assert.AreNearEqual(0.54030230586813977, normalcos)
         
         // biggish  value
         let maxcos = Operators.cos (1.57)
-        Assert.AreEqual(maxcos, 0.00079632671073326335)
-        ()
-        
+        Assert.AreNearEqual(0.00079632671073326335, maxcos)
+
     [<Test>]
-    member this.cosh () =
-        
+    member _.cosh () =
+
         // min value
         let mincosh = Operators.cosh (0.0)
-        Assert.AreEqual(mincosh, 1.0)
+        Assert.AreEqual(1.0, mincosh)
       
         // normal value
         let normalcosh = Operators.cosh (1.0)
-        Assert.AreEqual(normalcosh, 1.5430806348152437)
+        Assert.AreNearEqual(1.5430806348152437, normalcosh)
         
         // biggish  value
         let maxcosh = Operators.cosh (1.57)
-        Assert.AreEqual(maxcosh, 2.5073466880660993)
-        
-        
-        ()
-        
-    
-        
+        Assert.AreNearEqual(2.5073466880660993, maxcosh)
+
     [<Test>]
-    member this.decimal () =
+    member _.decimal () =
         
         // int value
         let mindecimal = Operators.decimal (1)
-        Assert.AreEqual(mindecimal, 1)
+        Assert.AreEqual(1M, mindecimal)
        
         // float  value
         let maxdecimal = Operators.decimal (1.0)
-        Assert.AreEqual(maxdecimal, 1)
-        ()
-        
+        Assert.AreEqual(1M, maxdecimal)
+
     [<Test>]
-    member this.decr() =
-        // zero   
+    member _.decr() =
+        // zero
         let zeroref = ref 0
         Operators.decr zeroref
-        Assert.AreEqual(zeroref,(ref -1))
+        Assert.AreEqual((ref -1), zeroref)
         
         //  big number
         let bigref = ref 32767
         Operators.decr bigref
-        Assert.AreEqual(bigref,(ref 32766))
+        Assert.AreEqual((ref 32766), bigref)
         
         // normal value
         let normalref = ref 100
         Operators.decr (normalref)
-        Assert.AreEqual(normalref,(ref 99))
+        Assert.AreEqual((ref 99), normalref)
         
     [<Test>]
-    member this.defaultArg() =
-        // zero   
+    member _.defaultArg() =
+        // zero
         let zeroOption = Some(0)
         let intdefaultArg = Operators.defaultArg zeroOption 2
-        Assert.AreEqual(intdefaultArg,0)
+        Assert.AreEqual(0, intdefaultArg)
         
         //  big number
         let bigOption = Some(32767)
         let bigdefaultArg = Operators.defaultArg bigOption 32766
-        Assert.AreEqual(bigdefaultArg,32767)
+        Assert.AreEqual(32767, bigdefaultArg)
         
         // normal value
         let normalOption = Some(100)
         let normalfaultArg = Operators.defaultArg normalOption 100
-        Assert.AreEqual(normalfaultArg, 100)
+        Assert.AreEqual(100, normalfaultArg)
         
     [<Test>]
-    member this.double() =
-        // int type   
-        let intdouble = Operators.double 100
-        Assert.AreEqual(intdouble,100.0)
+    member _.double() =
+        // int type
+        let intdouble = Operators.float 100
+        Assert.AreEqual(100.0, intdouble)
         
-        // char type  
-        let chardouble = Operators.double '0'
-        Assert.AreEqual(chardouble,48)
-        ()
-       
+        // char type
+        let chardouble = Operators.float '0'
+        Assert.AreEqual(48.0, chardouble)
+
     [<Test>]
-    member this.enum() =
-        // zero   
+    member _.enum() =
+        // zero
         let intarg : int32 = 0
         let intenum = Operators.enum<System.ConsoleColor> intarg
-        Assert.AreEqual(intenum,System.ConsoleColor.Black)
+        Assert.AreEqual(System.ConsoleColor.Black, intenum)
         
         //  big number
         let bigarg : int32 = 15
         let charenum = Operators.enum<System.ConsoleColor> bigarg
-        Assert.AreEqual(charenum,System.ConsoleColor.White)
+        Assert.AreEqual(System.ConsoleColor.White, charenum)
         
         // normal value
         let normalarg : int32 = 9
         let boundenum = Operators.enum<System.ConsoleColor> normalarg
-        Assert.AreEqual(boundenum, System.ConsoleColor.Blue)
+        Assert.AreEqual(System.ConsoleColor.Blue, boundenum)
         
 #if IGNORED
     [<Test;Ignore("See FSB #3826 ? Need way to validate Operators.exit function.")>]
-    member this.exit() =
-        // zero  
-        try 
+    member _.exit() =
+        // zero
+        try
             let intexit = Operators.exit 1
-            ()
+
         with
             | _ -> ()
-        //Assert.AreEqual(intexit,-1)
+        //Assert.AreEqual(-1, intexit)
         
         //  big number
         let charexit = Operators.exit 32767
-        //Assert.AreEqual(charexit,-1)
+        //Assert.AreEqual(-1, charexit)
         
         // normal value
         let boundexit = Operators.exit 100
-        Assert.AreEqual(boundexit, 0)
+        Assert.AreEqual(0, boundexit)
 #endif
 
     [<Test>]
-    member this.exp() =
-        // zero   
+    member _.exp() =
+        // zero
         let zeroexp = Operators.exp 0.0
-        Assert.AreEqual(zeroexp,1.0)
+        Assert.AreEqual(1.0, zeroexp)
         
         //  big number
         let bigexp = Operators.exp 32767.0
-        Assert.AreEqual(bigexp,infinity)
+        Assert.AreEqual(infinity, bigexp)
         
         // normal value
         let normalexp = Operators.exp 100.0
-        Assert.AreEqual(normalexp, 2.6881171418161356E+43)
+        Assert.AreEqual(2.6881171418161356E+43, normalexp)
         
     [<Test>]
-    member this.failwith() =
-        try 
+    member _.failwith() =
+        try
             let _ = Operators.failwith "failwith"
             Assert.Fail("Expect fail but not.")
-            ()
+
         with
             | Failure("failwith") -> ()
             |_ -> Assert.Fail("Throw unexpected exception")
-        
-        
+
     [<Test>]
-    member this.float() =
-        // int type   
+    member _.float() =
+        // int type
         let intfloat = Operators.float 100
-        Assert.AreEqual(intfloat,(float)100)
+        Assert.AreEqual((float)100, intfloat)
         
-        // char type  
+        // char type
         let charfloat = Operators.float '0'
-        Assert.AreEqual(charfloat,(float)48)
-      
-        ()
-       
-        
+        Assert.AreEqual((float)48, charfloat)
+
     [<Test>]
-    member this.float32() =
-        // int type   
+    member _.float32() =
+        // int type
         let intfloat32 = Operators.float32 100
-        Assert.AreEqual(intfloat32,(float32)100)
+        Assert.AreEqual((float32)100, intfloat32)
         
-        // char type  
+        // char type
         let charfloat32 = Operators.float32 '0'
-        Assert.AreEqual(charfloat32,(float32)48)
-     
-        ()
-       
-        
+        Assert.AreEqual((float32)48, charfloat32)
+
     [<Test>]
-    member this.floor() =
-        // float type   
-        let intfloor = Operators.floor 100.0
-        Assert.AreEqual(intfloor,100)
+    member _.floor() =
+        // float type
+        let intfloor = Operators.floor 100.9
+        Assert.AreEqual(100.0, intfloor)
         
-        // float32 type  
-        let charfloor = Operators.floor ((float32)100.0)
-        Assert.AreEqual(charfloor,100)
+        // float32 type
+        let charfloor = Operators.floor ((float32)100.9)
+        Assert.AreEqual(100.0f, charfloor)
     
     [<Test>]
-    member this.fst() =
-        // int type   
+    member _.fst() =
+        // int type
         let intfst = Operators.fst (100,101)
-        Assert.AreEqual(intfst,100)
+        Assert.AreEqual(100, intfst)
         
-        // char type  
+        // char type
         let charfst = Operators.fst ('0','1')
-        Assert.AreEqual(charfst,'0')
+        Assert.AreEqual('0', charfst)
         
         // null value
         let boundfst = Operators.fst (null,null)
-        Assert.AreEqual(boundfst, null)
+        Assert.AreEqual(null, boundfst)
         
     [<Test>]
-    member this.hash() =
-        // int type   
+    member _.hash() =
+        // int type (stable between JIT versions)
         let inthash = Operators.hash 100
-        Assert.AreEqual(inthash,100)
+        Assert.AreEqual(100, inthash)
         
-        // char type  
+        // char type (stable between JIT versions)
         let charhash = Operators.hash '0'
-        Assert.AreEqual(charhash,3145776)
+        Assert.AreEqual(3145776, charhash)
         
-        // string value
-        let boundhash = Operators.hash "A"
-        Assert.AreEqual(boundhash, -842352673)
+        // string value (test disabled, each JIT and each x86 vs x64 creates a different hash here)
+        //let boundhash = Operators.hash "A"
+        //Assert.AreEqual(-842352673, boundhash)
         
     [<Test>]
-    member this.id() =
-        // int type   
+    member _.id() =
+        // int type
         let intid = Operators.id 100
-        Assert.AreEqual(intid,100)
+        Assert.AreEqual(100, intid)
         
-        // char type  
+        // char type
         let charid = Operators.id '0'
-        Assert.AreEqual(charid,'0')
+        Assert.AreEqual('0', charid)
         
         // string value
         let boundid = Operators.id "A"
-        Assert.AreEqual(boundid, "A")
-        
-        
+        Assert.AreEqual("A", boundid)
+
     [<Test>]
-    member this.ignore() =         
-        // value type 
+    member _.ignore() =
+        // value type
         let result = Operators.ignore 10
-        Assert.AreEqual(result,null)
+        Assert.AreEqual(null, result)
         
         // reference type
         let result = Operators.ignore "A"
-        Assert.AreEqual(result,null) 
-        
-        ()
-
-#if IGNORED
-    [<Test; Ignore( "[FSharp Bugs 1.0] #3842 - OverflowException does not pop up on Operators.int int16 int 32 int64 ")>]
-    member this.incr() =         
-        // legit value 
-        let result = ref 10
-        Operators.incr result
-        Assert.AreEqual(!result,11)
-        
-        // overflow
-        let result = ref (Operators.Checked.int System.Int32.MaxValue)
-        CheckThrowsOverflowException(fun() -> Operators.incr result |> ignore)
-        
-        ()
-#endif
+        Assert.AreEqual(null, result)
 
     [<Test>]
-    member this.infinity() =         
+    member _.incr() =
+        // legit value
+        let result = ref 10
+        Operators.incr result
+        Assert.AreEqual(11, !result)
+        
+        // Overflow.
+        let result = ref (Operators.Checked.int System.Int32.MaxValue)
+        Operators.incr result
+        Assert.AreEqual(System.Int32.MinValue, !result)
+
+    [<Test>]
+    member _.infinity() =
         
         let inf = Operators.infinity
         let result = inf > System.Double.MaxValue
@@ -907,21 +582,18 @@ type OperatorsModule1() =
         
         // arithmetic operation
         let result = infinity + 3.0
-        Assert.AreEqual(result,infinity)
+        Assert.AreEqual(Double.PositiveInfinity, result)
         let result = infinity - 3.0
-        Assert.AreEqual(result,infinity)
+        Assert.AreEqual(Double.PositiveInfinity, result)
         let result = infinity * 3.0
-        Assert.AreEqual(result,infinity)
+        Assert.AreEqual(Double.PositiveInfinity, result)
         let result = infinity / 3.0
-        Assert.AreEqual(result,infinity)
+        Assert.AreEqual(Double.PositiveInfinity, result)
         let result = infinity / 3.0
-        Assert.AreEqual(result,infinity)
-        
-        
-        ()
-        
+        Assert.AreEqual(Double.PositiveInfinity, result)
+
     [<Test>]
-    member this.infinityf() =         
+    member _.infinityf() =
         
         let inf = Operators.infinityf
         let result = inf > System.Single.MaxValue
@@ -929,16 +601,12 @@ type OperatorsModule1() =
         
         // arithmetic operation
         let result = infinityf + 3.0f
-        Assert.AreEqual(result,infinity)
+        Assert.AreEqual(Single.PositiveInfinity, result)
         let result = infinityf - 3.0f
-        Assert.AreEqual(result,infinity)
+        Assert.AreEqual(Single.PositiveInfinity, result)
         let result = infinityf * 3.0f
-        Assert.AreEqual(result,infinity)
+        Assert.AreEqual(Single.PositiveInfinity, result)
         let result = infinityf / 3.0f
-        Assert.AreEqual(result,infinity)
+        Assert.AreEqual(Single.PositiveInfinity, result)
         let result = infinityf / 3.0f
-        Assert.AreEqual(result,infinityf)
-        
-        ()
-        
-    
+        Assert.AreEqual(Single.PositiveInfinity, result)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
@@ -3,138 +3,194 @@
 // Various tests for the:
 // Microsoft.FSharp.Core.Operators module
 
-namespace SystematicUnitTests.FSharp_Core.Microsoft_FSharp_Core
+namespace FSharp.Core.UnitTests.Operators
 
 open System
-open SystematicUnitTests.LibraryTestFx
+open FSharp.Core.UnitTests.LibraryTestFx
 open NUnit.Framework
-open Microsoft.FSharp.Core.Operators.Checked
 
 [<TestFixture>]
 type OperatorsModule2() =
 
-#if IGNORED
-    [<Test; Ignore( "[FSharp Bugs 1.0] #3842 - OverflowException does not pop up on Operators.int int16 int 32 int64 ")>]
-    member this.int() =         
-        // int 
+    [<Test>]
+    member _.int() =
+        // int
         let result = Operators.int 10
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10, result)
         
         // string
         let result = Operators.int "10"
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10, result)
         
         // double
         let result = Operators.int 10.0
-        Assert.AreEqual(result,10) 
+        Assert.AreEqual(10, result)
         
         // negative
         let result = Operators.int -10
-        Assert.AreEqual(result,-10) 
+        Assert.AreEqual(-10, result)
         
         // zero
         let result = Operators.int 0
-        Assert.AreEqual(result,0) 
+        Assert.AreEqual(0, result)
         
-        // overflow
-        CheckThrowsOverflowException(fun() -> Operators.int System.Double.MaxValue |>ignore)
+        // Overflow
+        let result = Operators.int Double.MaxValue
+        Assert.AreEqual(Int32.MinValue, result)
         
-        ()
-#endif
+        // Overflow
+        let result = Operators.int Double.MinValue
+        Assert.AreEqual(Int32.MinValue, result)
+        
+        // Overflow
+        let result = Operators.int Int64.MaxValue
+        Assert.AreEqual(-1, result)
+        
+        // Overflow
+        let result = Operators.int Int64.MinValue
+        Assert.AreEqual(0, result)
 
-#if IGNORED
-    [<Test; Ignore( "[FSharp Bugs 1.0] #3842 - OverflowException does not pop up on Operators.int int16 int 32 int64 ")>]
-    member this.int16() =         
-        // int 
+        // Overflow
+        let result = Int32.MaxValue + 1
+        Assert.AreEqual(Int32.MinValue, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.int Decimal.MinValue |> ignore)
+        
+    [<Test>]
+    member _.int16() =
+        // int
         let result = Operators.int16 10
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10s, result)
         
         // double
         let result = Operators.int16 10.0
-        Assert.AreEqual(result,10) 
+        Assert.AreEqual(10s, result)
         
         // negative
         let result = Operators.int16 -10
-        Assert.AreEqual(result,-10) 
+        Assert.AreEqual(-10s, result)
         
         // zero
         let result = Operators.int16 0
-        Assert.AreEqual(result,0) 
+        Assert.AreEqual(0s, result)
         
         // string
         let result = Operators.int16 "10"
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10s, result)
         
-        // overflow
-        CheckThrowsOverflowException(fun() -> Operators.int16 System.Double.MaxValue |>ignore)
-        ()
-#endif
+        // Overflow
+        let result = Operators.int16 Double.MaxValue
+        Assert.AreEqual(0s, result)
 
-#if IGNORED
-    [<Test; Ignore( "[FSharp Bugs 1.0] #3842 - OverflowException does not pop up on Operators.int int16 int 32 int64 ")>]
-    member this.int32() =         
-        // int 
+        // Overflow
+        let result = Operators.int16 Double.MinValue
+        Assert.AreEqual(0s, result)
+
+        let result = Operators.int16 Int64.MaxValue
+        Assert.AreEqual(-1s, result)
+
+        // Overflow
+        let result = Operators.int16 Int64.MinValue
+        Assert.AreEqual(0s, result)
+
+        // Overflow
+        let result = Int16.MaxValue + 1s
+        Assert.AreEqual(Int16.MinValue, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.int16 Decimal.MinValue |> ignore)
+
+    [<Test>]
+    member _.int32() =
+        // int
         let result = Operators.int32 10
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10, result)
         
         // double
         let result = Operators.int32 10.0
-        Assert.AreEqual(result,10) 
+        Assert.AreEqual(10, result)
         
         // negative
         let result = Operators.int32 -10
-        Assert.AreEqual(result,-10) 
+        Assert.AreEqual(-10, result)
         
         // zero
         let result = Operators.int32 0
-        Assert.AreEqual(result,0) 
+        Assert.AreEqual(0, result)
         
         // string
         let result = Operators.int32 "10"
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10, result)
         
-        // overflow
-        CheckThrowsOverflowException(fun() -> Operators.int32 System.Double.MaxValue |>ignore)
-        ()
-#endif
+        // Overflow
+        let result = Operators.int32 Double.MaxValue
+        Assert.AreEqual(Int32.MinValue, result)
+        
+        // Overflow
+        let result = Operators.int32 Double.MinValue
+        Assert.AreEqual(Int32.MinValue, result)
+        
+        // Overflow
+        let result = Operators.int32 Int64.MaxValue
+        Assert.AreEqual(-1, result)
+        
+        // Overflow
+        let result = Operators.int32 Int64.MinValue
+        Assert.AreEqual(0, result)
 
-#if IGNORED
-    [<Test; Ignore( "[FSharp Bugs 1.0] #3842 - OverflowException does not pop up on Operators.int int16 int 32 int64 ")>]
-    member this.int64() =         
-        // int 
+        // Overflow
+        let result = Int32.MaxValue + 5
+        Assert.AreEqual(Int32.MinValue + 4, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.int32 Decimal.MinValue |> ignore)
+
+    [<Test>]
+    member _.int64() =
+        // int
         let result = Operators.int64 10
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10L, result)
         
         // double
         let result = Operators.int64 10.0
-        Assert.AreEqual(result,10) 
+        Assert.AreEqual(10L, result)
         
         // negative
         let result = Operators.int64 -10
-        Assert.AreEqual(result,-10) 
+        Assert.AreEqual(-10L, result)
         
         // zero
         let result = Operators.int64 0
-        Assert.AreEqual(result,0) 
+        Assert.AreEqual(0L, result)
         
         // string
         let result = Operators.int64 "10"
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10L, result)
         
-        // overflow
-        CheckThrowsOverflowException(fun() -> Operators.int64 System.Double.MaxValue |>ignore)
-        ()
-#endif
+        // Overflow.
+        let result = Operators.int64 Double.MaxValue
+        Assert.AreEqual(Int64.MinValue, result)
 
-//    [<Test>]
-//    member this.invalidArg() =         
-//        CheckThrowsArgumentException(fun() -> Operators.invalidArg  "A" "B" |>ignore )
-//        
-//        ()
+        // Overflow
+        let result = Operators.int64 Double.MinValue
+        Assert.AreEqual(Int64.MinValue, result)
+
+        // Overflow
+        let result = Operators.int64 UInt64.MaxValue
+        Assert.AreEqual(-1L, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.int64 Decimal.MinValue |> ignore)
+
+    [<Test>]
+    member _.invalidArg() =
+        CheckThrowsArgumentException(fun() -> Operators.invalidArg  "A" "B" |>ignore )
+
         
     [<Test>]
-    member this.lock() = 
-        // lock         
+    member _.lock() =
+        // lock
         printfn "test8 started"
         let syncRoot = System.Object()
         let k = ref 0
@@ -142,542 +198,753 @@ type OperatorsModule2() =
                                                              System.Threading.Thread.Sleep(1)
                                                              !k ) }
         let arr = Async.RunSynchronously (Async.Parallel(Seq.map comp [1..50]))
-        Assert.AreEqual((Array.sort compare arr; arr), [|1..50|])
+        Assert.AreEqual([|1..50|], Array.sort arr)
         
         // without lock
         let syncRoot = System.Object()
         let k = ref 0
         let comp _ = async { do incr k
-                             do! System.Threading.Thread.AsyncSleep(10)
+                             do! Async.Sleep (10)
                              return !k }
         let arr = Async.RunSynchronously (Async.Parallel(Seq.map comp [1..100]))
-        Assert.AreNotEqual ((Array.sort compare arr; arr) , [|1..100|])
-        
-        ()
+        Assert.AreNotEqual ([|1..100|], Array.sort arr)
         
     [<Test>]
-    member this.log() =  
+    member _.log() =
         // double
         let result = Operators.log 10.0
-        Assert.AreEqual(result.ToString(),"2.30258509299405") 
+        Assert.AreEqual(2.3025850929940459, result)
         
         // negative
         let result = Operators.log -10.0
-        Assert.AreEqual(result.ToString(),System.Double.NaN.ToString()) 
+        Assert.AreEqual(Double.NaN, result)
         
         // zero
         let result = Operators.log 0.0
-        Assert.AreEqual(result,-infinity) 
-        
-        ()
+        Assert.AreEqual(Double.NegativeInfinity , result)
         
     [<Test>]
-    member this.log10() =  
+    member _.log10() =
         // double
         let result = Operators.log10 10.0
-        Assert.AreEqual(result,1) 
+        Assert.AreEqual(1.0, result)
         
         // negative
         let result = Operators.log10 -10.0
-        Assert.AreEqual(result.ToString(),System.Double.NaN.ToString())
+        Assert.AreEqual(System.Double.NaN, result)
         
         // zero
         let result = Operators.log10 0.0
-        Assert.AreEqual(result,-infinity) 
-        
-        ()
+        Assert.AreEqual(Double.NegativeInfinity, result)
         
     [<Test>]
-    member this.max() =  
+    member _.max() =
         // value type
         let result = Operators.max 10 8
-        Assert.AreEqual(result,10) 
+        Assert.AreEqual(10, result)
         
         // negative
         let result = Operators.max -10.0 -8.0
-        Assert.AreEqual(result,-8.0) 
+        Assert.AreEqual(-8.0, result)
         
         // zero
         let result = Operators.max 0 0
-        Assert.AreEqual(result,0) 
+        Assert.AreEqual(0, result)
         
         // reference type
         let result = Operators.max "A" "ABC"
-        Assert.AreEqual(result,"ABC") 
-        
-        // overflow
-        CheckThrowsOverflowException(fun() -> Operators.max 10 System.Int32.MaxValue+1 |>ignore)
-        
-        ()
+        Assert.AreEqual("ABC", result)
         
     [<Test>]
-    member this.min() =  
+    member _.min() =
         // value type
         let result = Operators.min 10 8
-        Assert.AreEqual(result,8) 
+        Assert.AreEqual(8, result)
         
         // negative
         let result = Operators.min -10.0 -8.0
-        Assert.AreEqual(result,-10.0) 
+        Assert.AreEqual(-10.0, result)
         
         // zero
         let result = Operators.min 0 0
-        Assert.AreEqual(result,0) 
+        Assert.AreEqual(0, result)
         
         // reference type
         let result = Operators.min "A" "ABC"
-        Assert.AreEqual(result,"A") 
-        
-        // overflow
-        CheckThrowsOverflowException(fun() -> Operators.min 10 System.Int32.MinValue - 1 |>ignore)
-        
-        ()
+        Assert.AreEqual("A", result)
         
     [<Test>]
-    member this.nan() =  
+    member _.nan() =
         // value type
-        let result = Operators.nan 
-        Assert.AreEqual(result.ToString(),System.Double.NaN.ToString()) 
-        
-        ()
+        let result = Operators.nan
+        Assert.AreEqual(System.Double.NaN, nan)
         
     [<Test>]
-    member this.nanf() =  
+    member _.nanf() =
         // value type
-        let result = Operators.nanf 
-        Assert.AreEqual(result,System.Single.NaN) 
+        let result = Operators.nanf
+        Assert.AreEqual(System.Single.NaN, result)
         
-        ()
-
-#if IGNORED
-    [<Test; Ignore( "[FSharp Bugs 1.0] #3842 - OverflowException does not pop up on Operators.int int16 int 32 int64 ")>]
-    member this.nativeint() =  
-        // int 
+    [<Test>]
+    member _.nativeint() =
+        // int
         let result = Operators.nativeint 10
-        Assert.AreEqual(result,10n)
+        Assert.AreEqual(10n, result)
         
         // double
         let result = Operators.nativeint 10.0
-        Assert.AreEqual(result,10n) 
+        Assert.AreEqual(10n, result)
         
         // int64
         let result = Operators.nativeint 10L
-        Assert.AreEqual(result,10n)         
+        Assert.AreEqual(10n, result)
        
         // negative
         let result = Operators.nativeint -10
-        Assert.AreEqual(result,-10n) 
+        Assert.AreEqual(-10n, result)
         
         // zero
         let result = Operators.nativeint 0
-        Assert.AreEqual(result,0n) 
+        Assert.AreEqual(0n, result)
         
-        // overflow
-        CheckThrowsOverflowException(fun() -> Operators.nativeint System.Double.MaxValue |>ignore)
+        // Overflow Double.MaxValue is equal on 32 bits and 64 bits runtimes
+        let result = Operators.nativeint Double.MaxValue
+        if Info.isX86Runtime then
+            Assert.AreEqual(-2147483648n, result)
+        else
+            // Cannot use -9223372036854775808, compiler doesn't allow it, see https://github.com/dotnet/fsharp/issues/9524
+            Assert.AreEqual(-9223372036854775807n - 1n, result)
         
-        ()
-#endif
+        // Overflow (depends on pointer size)
+        let result = Operators.nativeint Double.MinValue
+        if Info.isX86Runtime then
+            Assert.AreEqual(-2147483648n, result)
+        else
+            // Cannot use -9223372036854775808, compiler doesn't allow it, see https://github.com/dotnet/fsharp/issues/9524
+            Assert.AreEqual(-9223372036854775807n - 1n, result)
+        
+        // Overflow (depends on pointer size)
+        let result = Operators.nativeint Int64.MinValue
+        if Info.isX86Runtime then
+            Assert.AreEqual(0n, result)
+        else
+            // Cannot use -9223372036854775808, compiler doesn't allow it, see https://github.com/dotnet/fsharp/issues/9524
+            Assert.AreEqual(-9223372036854775807n - 1n, result)
+
+        // Overflow (depends on pointer size)
+        if Info.isX86Runtime then
+            let result = nativeint Int32.MaxValue + 5n
+            Assert.AreEqual(-2147483644n, result)
+        else
+            let result = nativeint Int64.MaxValue + 5n
+            Assert.AreEqual(-9223372036854775804n, result)
+
+
+        // Overflow (depends on pointer size)
+        let result = Operators.nativeint System.Double.MaxValue
+        if Info.isX86Runtime then
+            Assert.AreEqual(-2147483648n, result)
+        else
+            // Cannot express this as a literal, see https://github.com/dotnet/fsharp/issues/9524
+            Assert.AreEqual("-9223372036854775808", string result)
+
+        let result = Operators.nativeint System.Double.MinValue
+        if Info.isX86Runtime then
+            Assert.AreEqual(-2147483648n, result)
+        else
+            // Cannot express this as a literal, see https://github.com/dotnet/fsharp/issues/9524
+            Assert.AreEqual("-9223372036854775808", string result)
 
     [<Test>]
-    member this.not() =  
+    member _.not() =
         let result = Operators.not true
         Assert.IsFalse(result)
         
         let result = Operators.not false
-        Assert.IsTrue(result) 
-        
-        ()
-        
-//    [<Test>]
-//    member this.nullArg() =  
-//        CheckThrowsArgumentNullException(fun() -> Operators.nullArg "A" |> ignore)
-//          
-//        ()
+        Assert.IsTrue(result)
         
     [<Test>]
-    member this.pown() =  
-        // int 
+    member _.nullArg() =
+        CheckThrowsArgumentNullException(fun() -> Operators.nullArg "A" |> ignore)
+
+        
+    [<Test>]
+    member _.pown() =
+        // int
         let result = Operators.pown 10 2
-        Assert.AreEqual(result,100)
+        Assert.AreEqual(100, result)
         
         // double
         let result = Operators.pown 10.0 2
-        Assert.AreEqual(result,100) 
+        Assert.AreEqual(100.0, result)
         
         // int64
         let result = Operators.pown 10L 2
-        Assert.AreEqual(result,100) 
+        Assert.AreEqual(100L, result)
         
         // decimal
         let result = Operators.pown 10M 2
-        Assert.AreEqual(result,100) 
+        Assert.AreEqual(100M, result)
         
         // negative
         let result = Operators.pown -10 2
-        Assert.AreEqual(result,100) 
+        Assert.AreEqual(100, result)
         
         // zero
         let result = Operators.pown 0 2
-        Assert.AreEqual(result,0) 
+        Assert.AreEqual(0, result)
         
         // overflow
         let result = Operators.pown System.Double.MaxValue System.Int32.MaxValue
-        Assert.AreEqual(result,infinity) 
+        Assert.AreEqual(Double.PositiveInfinity, result)
         
         CheckThrowsOverflowException(fun() -> Operators.pown System.Int32.MaxValue System.Int32.MaxValue |>ignore)
         
-        ()
-        
     [<Test>]
-    member this.raise() =  
+    member _.raise() =
         CheckThrowsArgumentException(fun()-> Operators.raise <| new ArgumentException("Invalid Argument ")  |> ignore)
-          
-        ()
         
     
     [<Test>]
-    member this.ref() =
+    member _.ref() =
         // value type
-        let result = Operators.ref 0    
-        let funInt (x:int) =   
-            result := !result + x              
-            () 
-        Array.iter funInt [|1..10|]  
+        let result = Operators.ref 0
+        let funInt (x:int) =
+            result := !result + x
+            ()
+        Array.iter funInt [|1..10|]
         Assert.AreEqual(!result,55)
         
         // reference type
         let result = Operators.ref ""
         let funStr (x : string) =
-            result := (!result) + x   
+            result := (!result) + x
             ()
         Array.iter funStr [|"A";"B";"C";"D"|]
         Assert.AreEqual(!result,"ABCD")
         
-        ()    
-    
     [<Test>]
-    member this.reraise() =
-        // double
+    member _.reraise() =
+        // nothing to reraise should not trigger exception
         try
             ()
         with
         | _ ->    Operators.reraise()
         
-        ()
-    
     [<Test>]
-    member this.round() =
+    member _.round() =
         // double
         let result = Operators.round 10.0
-        Assert.AreEqual(result,10) 
+        Assert.AreEqual(10.0, result)
+        
+        // double
+        let result = Operators.round 0.6640367702678489
+        Assert.AreEqual(1.0, result)
+        
+        // double
+        let result = Operators.round 0.6640367702678489e4
+        Assert.AreEqual(6640.0, result)
+        
+        // double, show half-to-even
+        let result = Operators.round 0.6640500000e4
+        Assert.AreEqual(6640.0, result)
+        
+        // double, show half-to-even
+        let result = Operators.round 0.6639500000e4
+        Assert.AreEqual(6640.0, result)
+        
+        // double, show half-to-even
+        let result = Operators.round 0.6641500000e4
+        Assert.AreEqual(6642.0, result)
+        
+        // double, show rounding up if anything follows '5'
+        let result = Operators.round 0.66405000001e4
+        Assert.AreEqual(6641.0, result)
         
         // decimal
         let result = Operators.round 10M
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10M, result)
         
-        ()
-    
+        // decimal, show half-to-even
+        let result = Operators.round 1233.5M
+        Assert.AreEqual(1234M, result)
+        
+        // decimal, show half-to-even
+        let result = Operators.round 1234.5M
+        Assert.AreEqual(1234M, result)
+        
+        // decimal, show half-to-even
+        let result = Operators.round 1235.5M
+        Assert.AreEqual(1236M, result)
+        
+        // decimal, show rounding up if anything follows '5'
+        let result = Operators.round 1234.500000000001M
+        Assert.AreEqual(1235M, result)
+        
+        // decimal, round up
+        let result = Operators.round 1234.6M
+        Assert.AreEqual(1235M, result)
+        
     [<Test>]
-    member this.sbyte() =         
-        // int 
+    member _.sbyte() =
+        // int
         let result = Operators.sbyte 10
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10y, result)
         
         // double
         let result = Operators.sbyte 10.0
-        Assert.AreEqual(result,10) 
+        Assert.AreEqual(10y, result)
         
         // negative
         let result = Operators.sbyte -10
-        Assert.AreEqual(result,-10) 
+        Assert.AreEqual(-10y, result)
         
         // zero
         let result = Operators.sbyte 0
-        Assert.AreEqual(result,0) 
+        Assert.AreEqual(0y, result)
+
+        // Overflow
+        let result = Operators.sbyte Int64.MaxValue
+        Assert.AreEqual(-1y, result)
         
-        ()
-    
+        // Overflow
+        let result = Operators.sbyte Int64.MinValue
+        Assert.AreEqual(0y, result)
+        
+        // Overflow
+        let result = Operators.sbyte Double.MinValue
+        Assert.AreEqual(0y, result)
+        
+        // Overflow
+        let result = Operators.sbyte Double.MaxValue
+        Assert.AreEqual(0y, result)
+        
+        // Overflow
+        let result = Operators.sbyte (Int64.MaxValue * 8L)
+        Assert.AreEqual(-8y, result)      // bit-complement
+        
+        // Overflow
+        let result = 127y + 1y
+        Assert.AreEqual(-128y, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.sbyte Decimal.MinValue |> ignore)
+        
     [<Test>]
-    member this.sign() =         
-        // int 
+    member _.sign() =
+        // int
         let result = Operators.sign 10
-        Assert.AreEqual(result,1)
+        Assert.AreEqual(1, result)
         
+        // negative int
+        let result = Operators.sign -10
+        Assert.AreEqual(-1, result)
+        
+        // zero int
+        let result = Operators.sign 0
+        Assert.AreEqual(0, result)
+
         // double
         let result = Operators.sign 10.0
-        Assert.AreEqual(result,1) 
+        Assert.AreEqual(1, result)
         
-        // negative
-        let result = Operators.sign -10
-        Assert.AreEqual(result,-1) 
+        // double max
+        let result = Operators.sign Double.MaxValue
+        Assert.AreEqual(1, result)
         
-        // zero
-        let result = Operators.sign 0
-        Assert.AreEqual(result,0) 
+        // double min
+        let result = Operators.sign Double.MinValue
+        Assert.AreEqual(-1, result)
         
-        ()
-    
+        // double epsilon positive
+        let result = Operators.sign Double.Epsilon
+        Assert.AreEqual(1, result)
+        
+        // double epsilon negative
+        let result = Operators.sign (-Double.Epsilon)
+        Assert.AreEqual(-1, result)
+        
+        // double inf
+        let result = Operators.sign Double.PositiveInfinity
+        Assert.AreEqual(1, result)
+                
+        // double -inf
+        let result = Operators.sign Double.NegativeInfinity
+        Assert.AreEqual(-1, result)
+
+        // float32
+        let result = Operators.sign 10.0f
+        Assert.AreEqual(1, result)
+        
+        // float32 max
+        let result = Operators.sign Single.MaxValue
+        Assert.AreEqual(1, result)
+        
+        // float32 min
+        let result = Operators.sign Single.MinValue
+        Assert.AreEqual(-1, result)
+        
+        // float32 epsilon positive
+        let result = Operators.sign Single.Epsilon
+        Assert.AreEqual(1, result)
+        
+        // float32 epsilon negative
+        let result = Operators.sign (-Single.Epsilon)
+        Assert.AreEqual(-1, result)
+        
+        // float32 inf
+        let result = Operators.sign Single.PositiveInfinity
+        Assert.AreEqual(1, result)
+                
+        // float32 -inf
+        let result = Operators.sign Single.NegativeInfinity
+        Assert.AreEqual(-1, result)
+
+        // double nan
+        CheckThrowsArithmeticException(fun () -> Operators.sign Double.NaN |> ignore)
+
+        // float32 nan
+        CheckThrowsArithmeticException(fun () -> Operators.sign Single.NaN |> ignore)
+        
     [<Test>]
-    member this.sin() = 
+    member _.sin() =
         
         let result = Operators.sin 0.5
-        Assert.AreEqual(result.ToString(),"0.479425538604203")      
+        Assert.AreNearEqual(0.479425538604203, result)
+
+        let result = Operators.sin Double.NaN
+        Assert.AreEqual(Double.NaN, result)
         
-        ()
-    
+        let result = Operators.sin Double.PositiveInfinity
+        Assert.AreEqual(Double.NaN, result)
+        
+        let result = Operators.sin Double.NegativeInfinity
+        Assert.AreEqual(Double.NaN, result)
+        
     [<Test>]
-    member this.single() = 
-        // int 
-        let result = Operators.single 10
-        Assert.AreEqual(result,10)
+    member _.single() =
+        // int
+        let result = Operators.float32 10
+        Assert.AreEqual(10f, result)
         
         // double
-        let result = Operators.single 10.0
-        Assert.AreEqual(result,10) 
+        let result = Operators.float32 10.0
+        Assert.AreEqual(10f, result)
         
         // string
-        let result = Operators.single "10"
-        Assert.AreEqual(result,10) 
-                
-        ()
-    
+        let result = Operators.float32 "10"
+        Assert.AreEqual(10f, result)
+        
     [<Test>]
-    member this.sinh() = 
+    member _.sinh() =
      
         let result = Operators.sinh 1.0
-        Assert.AreEqual(result.ToString(),"1.1752011936438") 
+        Assert.AreNearEqual(1.1752011936438014, result)
         
-        ()
-    
+        let result = Operators.sinh 0.0
+        Assert.AreNearEqual(0.0, result)
+
+        let result = Operators.sinh Double.PositiveInfinity
+        Assert.AreNearEqual(Double.PositiveInfinity, result)
+
+        let result = Operators.sinh Double.NegativeInfinity
+        Assert.AreNearEqual(Double.NegativeInfinity, result)
+
+        let result = Operators.sinh Double.NaN
+        Assert.AreNearEqual(Double.NaN, result)
+
     [<Test>]
-    member this.sizeof() = 
-        // value type        
+    member _.sizeof() =
+        // value type
         let result = Operators.sizeof<int>
-        Assert.AreEqual(result,4) 
+        Assert.AreEqual(4, result)
         
-        // System.Int64        
+        // System.Int64
         let result = Operators.sizeof<System.Int64>
-        Assert.AreEqual(result,8) 
+        Assert.AreEqual(8, result)
         
-        // reference type        
+        // reference type should have the same size as the IntPtr
         let result = Operators.sizeof<string>
-        Assert.AreEqual(result,4) 
+        Assert.AreEqual(IntPtr.Size, result)
         
-        // null        
+        // null should have the same size as the IntPtr
         let result = Operators.sizeof<unit>
-        Assert.AreEqual(result,4) 
+        Assert.AreEqual(IntPtr.Size, result)
         
-        ()
-    
     [<Test>]
-    member this.snd() = 
-        // value type        
+    member _.snd() =
+        // value type
         let result = Operators.snd ("ABC",100)
-        Assert.AreEqual(result,100) 
+        Assert.AreEqual(100, result)
         
-        // reference type        
+        // reference type
         let result = Operators.snd (100,"ABC")
-        Assert.AreEqual(result,"ABC") 
+        Assert.AreEqual("ABC", result)
         
-        // null        
+        // null
         let result = Operators.snd (100,null)
-        Assert.AreEqual(result,null) 
+        Assert.AreEqual(null, result)
         
-        ()
-    
     [<Test>]
-    member this.sqrt() = 
-        // double        
+    member _.sqrt() =
+        // double
         let result = Operators.sqrt 100.0
-        Assert.AreEqual(result,10) 
+        Assert.AreEqual(10.0, result)
         
-        ()
-    
-    [<Test>]
-    member this.stderr() =         
-        let result = Operators.stderr 
-        Assert.AreEqual(result.WriteLine("go"),null) 
+        let result = Operators.sqrt -2.0
+        Assert.AreEqual(Double.NaN, result)
         
-        ()
-    
     [<Test>]
-    member this.stdin() =         
-        let result = Operators.stdin 
-        Assert.AreEqual(result.Dispose(),null)
+    member _.stderr() =
+        let result = Operators.stderr
+        Assert.AreEqual(null, result.WriteLine("go"))
         
-        ()   
-    
     [<Test>]
-    member this.stdout() =         
-        let result = Operators.stdout 
-        Assert.AreEqual(result.WriteLine("go"),null)
+    member _.stdin() =
+        let result = Operators.stdin
+        Assert.AreEqual(null, result.Dispose())
         
-        ()   
-    
     [<Test>]
-    member this.string() =  
+    member _.stdout() =
+        let result = Operators.stdout
+        Assert.AreEqual(null, result.WriteLine("go"))
+        
+    [<Test>]
+    member _.string() =
         // value type
         let result = Operators.string 100
-        Assert.AreEqual(result,"100")
+        Assert.AreEqual("100", result)
         
         // reference type
         let result = Operators.string "ABC"
-        Assert.AreEqual(result,"ABC")
+        Assert.AreEqual("ABC", result)
         
-        // unit
-        CheckThrowsNullRefException(fun () -> Operators.string null |>ignore)
-        
-        ()      
-    
     [<Test>]
-    member this.tan() =  
+    member _.tan() =
         // double
         let result = Operators.tan 1.0
-        Assert.AreEqual(result.ToString(),"1.5574077246549")
+        Assert.AreNearEqual(1.5574077246549023, result)
         
-        ()    
-    
     [<Test>]
-    member this.tanh() =  
-        // double
+    member _.tanh() =
+        // The x86 runtime uses 64 bit precision, whereas the x64 runtime uses SSE instructions with 80 bit precision
+        // details can be found here: https://github.com/dotnet/fsharp/issues/9522
         let result = Operators.tanh 0.8
-        Assert.AreEqual(result,0.664036770267849)
+        Assert.AreNearEqual(0.66403677026784902, result)
+
+        let result = Operators.tanh 19.06154
+        Assert.AreNearEqual(1.0, result)        // can be 0.99999999999999989
+
+        let result = tanh 0.0
+        Assert.AreEqual(0.0, result)
+
+        let result = tanh infinity
+        Assert.AreEqual(1.0, result)
+
+        let result = tanh -infinity
+        Assert.AreEqual(-1.0, result)
         
-        ()    
-    
     [<Test>]
-    member this.truncate() =        
+    member _.truncate() =
         // double
         let result = Operators.truncate 10.101
-        Assert.AreEqual(result,10)
+        Assert.AreEqual(10.0, result)
         
         // decimal
         let result = Operators.truncate 10.101M
-        Assert.AreEqual(result,10M)
+        Assert.AreEqual(10M, result)
         
         // zero
         let result = Operators.truncate 0.101
-        Assert.AreEqual(result,0)
+        Assert.AreEqual(0.0, result)
         
-        ()    
-    
     [<Test>]
-    member this.typedefof() =        
+    member _.typedefof() =
         // value type
         let result = Operators.typedefof<int>
-        Assert.AreEqual(result.FullName,"System.Int32")
+        Assert.AreEqual("System.Int32", result.FullName)
         
         // reference type
         let result = Operators.typedefof<string>
-        Assert.AreEqual(result.FullName,"System.String")
+        Assert.AreEqual("System.String", result.FullName)
         
         // unit
         let result = Operators.typedefof<unit>
-        Assert.AreEqual(result.FullName,"Microsoft.FSharp.Core.Unit")
+        Assert.AreEqual("Microsoft.FSharp.Core.Unit", result.FullName)
         
-        ()
-    
     [<Test>]
-    member this.typeof() =        
+    member _.typeof() =
         // value type
         let result = Operators.typeof<int>
-        Assert.AreEqual(result.FullName,"System.Int32")
+        Assert.AreEqual("System.Int32", result.FullName)
         
         // reference type
         let result = Operators.typeof<string>
-        Assert.AreEqual(result.FullName,"System.String")
+        Assert.AreEqual("System.String", result.FullName)
         
         // unit
         let result = Operators.typeof<unit>
-        Assert.AreEqual(result.FullName,"Microsoft.FSharp.Core.Unit")
+        Assert.AreEqual("Microsoft.FSharp.Core.Unit", result.FullName)
         
-        ()
-    
     [<Test>]
-    member this.uint16() =        
-        // int        
+    member _.uint16() =
+        // int
         let result = Operators.uint16 100
-        Assert.AreEqual(result,100us)
+        Assert.AreEqual(100us, result)
         
         // double
         let result = Operators.uint16 (100.0:double)
-        Assert.AreEqual(result,100us)
+        Assert.AreEqual(100us, result)
         
         // decimal
         let result = Operators.uint16 100M
-        Assert.AreEqual(result,100us)
+        Assert.AreEqual(100us, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.uint16 Decimal.MinValue |> ignore)
         
-        ()
-    
     [<Test>]
-    member this.uint32() =        
+    member _.uint32() =
         // int
         let result = Operators.uint32 100
-        Assert.AreEqual(result,100ul)
+        Assert.AreEqual(100u, result)
         
         // double
         let result = Operators.uint32 (100.0:double)
-        Assert.AreEqual(result,100ul)
+        Assert.AreEqual(100u, result)
         
         // decimal
         let result = Operators.uint32 100M
-        Assert.AreEqual(result,100ul)
+        Assert.AreEqual(100u, result)
         
-        ()
-    
+        // Overflow
+        let result = Operators.uint32 Double.MaxValue
+        Assert.AreEqual(0u, result)
+        
+        // Overflow
+        let result = Operators.uint32 Double.MinValue
+        Assert.AreEqual(0u, result)
+        
+        // Overflow
+        let result = Operators.uint32 Int64.MaxValue
+        Assert.AreEqual(UInt32.MaxValue, result)
+        
+        // Overflow
+        let result = Operators.uint32 Int64.MinValue
+        Assert.AreEqual(0u, result)
+
+        // Overflow
+        let result = UInt32.MaxValue + 5u
+        Assert.AreEqual(4u, result)
+
+        // both 'u' and 'ul' are valid numeric suffixes for UInt32
+        let result = 42u + 42ul
+        Assert.AreEqual(84u, result)
+        Assert.AreEqual(84ul, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.uint32 Decimal.MinValue |> ignore)
+
     [<Test>]
-    member this.uint64() =        
+    member _.uint64() =
         // int
         let result = Operators.uint64 100
-        Assert.AreEqual(result,100UL)
+        Assert.AreEqual(100UL, result)
         
         // double
-        let result = Operators.uint64 (100.0:double)
-        Assert.AreEqual(result,100UL)
+        let result = Operators.uint64 100.0
+        Assert.AreEqual(100UL, result)
         
         // decimal
         let result = Operators.uint64 100M
-        Assert.AreEqual(result,100UL)
-            
-        ()   
-    
+        Assert.AreEqual(100UL, result)
+
+        // Overflow
+        let result = Operators.uint64 Double.MaxValue
+        Assert.AreEqual(0UL, result)
+        
+        // Overflow
+        let result = Operators.uint64 Double.MinValue
+        Assert.AreEqual(9223372036854775808UL, result)      // surprising, but true, 2^63 + 1
+        
+        // Overflow
+        let result = Operators.uint64 Int64.MinValue
+        Assert.AreEqual(9223372036854775808UL, result)
+
+        // Overflow
+        let result = Operators.uint64 SByte.MinValue
+        Assert.AreEqual(UInt64.MaxValue - 127UL, result)
+
+        // Overflow
+        let result = UInt64.MaxValue + 5UL
+        Assert.AreEqual(4UL, result)
+
+        // OverflowException, from decimal is always checked
+        CheckThrowsOverflowException(fun() -> Operators.uint64 Decimal.MinValue |> ignore)
+        
     [<Test>]
-    member this.unativeint() =        
+    member _.unativeint() =
         // int
         let result = Operators.unativeint 100
-        Assert.AreEqual(result,100un)
+        let x: unativeint = 12un
+        Assert.AreEqual(100un, result)
         
         // double
-        let result = Operators.unativeint (100.0:double)
-        Assert.AreEqual(result,100un)
-            
-        ()     
-    
+        let result = Operators.unativeint 100.0
+        Assert.AreEqual(100un, result)
+        
+        // Overflow Double.MaxValue is equal on 32 bits and 64 bits runtimes
+        let result = Operators.unativeint Double.MaxValue
+        Assert.AreEqual(0un, result)
+        
+        // Overflow (depends on pointer size)
+        let result = Operators.unativeint Double.MinValue
+        if Info.isX86Runtime then
+            Assert.AreEqual(0un, result)
+        else
+            Assert.AreEqual(9223372036854775808un, result)      // surprising, but true, 2^63 + 1
+        
+        // Overflow (depends on pointer size)
+        let result = Operators.unativeint Int64.MinValue
+        if Info.isX86Runtime then
+            Assert.AreEqual(0un, result)
+        else
+            Assert.AreEqual(9223372036854775808un, result)
+
+        // Overflow (depends on pointer size)
+        let result = 0un - 1un
+        if Info.isX86Runtime then
+            Assert.AreEqual(4294967295un, result)
+        else
+            Assert.AreEqual(18446744073709551615un, result)
+
     [<Test>]
-    member this.unbox() =        
+    member _.unbox() =
         // value type
         let oint = box 100
         let result = Operators.unbox oint
-        Assert.AreEqual(result,100)
+        Assert.AreEqual(100, result)
         
         // reference type
         let ostr = box "ABC"
         let result = Operators.unbox ostr
-        Assert.AreEqual(result,"ABC")
+        Assert.AreEqual("ABC", result)
         
-        // null 
+        // null
         let onull = box null
         let result = Operators.unbox onull
-        Assert.AreEqual(result,null)
-            
-        ()     
-    
+        Assert.AreEqual(null, result)
+
+        // None == null
+        let onone = box None
+        let result = Operators.unbox<int option> onone
+        Assert.AreEqual(None, result)
+        Assert.AreEqual(null, result)
+        
     [<Test>]
-    member this.using() =
+    member _.using() =
         let sr = new System.IO.StringReader("ABCD")
         Assert.AreEqual(sr.ReadToEnd(),"ABCD")
-        let result = Operators.using sr (fun x -> x.ToString())        
+        let _ = Operators.using sr (fun x -> x.ToString())
         CheckThrowsObjectDisposedException(fun () -> sr.ReadToEnd() |> ignore)
-        
-        ()    
     

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModuleChecked.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModuleChecked.fs
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+// Various tests for the Checked module
+
+namespace FSharp.Core.UnitTests.Operators
+
+open System
+open FSharp.Core.UnitTests.LibraryTestFx
+open NUnit.Framework
+open Microsoft.FSharp.Core.Operators.Checked
+
+[<TestFixture>]
+type OperatorsModuleChecked() =
+
+    [<Test>]
+    member _.Checkedbyte() =
+        // int type
+        let intByte = Operators.Checked.byte 100
+        Assert.AreEqual(100uy, intByte)
+        
+        // char type
+        let charByte = Operators.Checked.byte '0'
+        Assert.AreEqual(48uy, charByte)
+        
+        // boundary value
+        let boundByte = Operators.Checked.byte 255.0
+        Assert.AreEqual(255uy, boundByte)
+        
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Operators.Checked.byte 256 |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> 255uy + 1uy |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> 0uy - 1uy |> ignore)
+
+    [<Test>]
+    member _.Checkedchar() =
+
+        // number
+        let numberChar = Operators.Checked.char 48
+        Assert.AreEqual('0', numberChar)
+        
+        // letter
+        let letterChar = Operators.Checked.char 65
+        Assert.AreEqual('A', letterChar)
+        
+        // boundary value
+        let boundchar = Operators.Checked.char 126
+        Assert.AreEqual('~', boundchar)
+        
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Operators.Checked.char (int64 Char.MaxValue + 1L) |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> '\uFFFF' + '\u0001' |> ignore)
+
+        
+    [<Test>]
+    member _.CheckedInt() =
+
+        // char
+        let charInt = Operators.Checked.int '0'
+        Assert.AreEqual(48, charInt)
+        
+        // float
+        let floatInt = Operators.Checked.int 10.0
+        Assert.AreEqual(10, floatInt)
+
+        // boundary value
+        let boundInt = Operators.Checked.int 32767.0
+        Assert.AreEqual(32767, boundInt)
+        
+        // overflow exception
+        CheckThrowsOverflowException(fun() -> Operators.Checked.int 2147483648.0 |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Int32.MaxValue + 1 |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Int32.MinValue - 1 |> ignore)
+
+    [<Test>]
+    member _.CheckedInt16() =
+
+        // char
+        let charInt16 = Operators.Checked.int16 '0'
+        Assert.AreEqual(48s, charInt16)
+        
+        // float
+        let floatInt16 = Operators.Checked.int16 10.0
+        Assert.AreEqual(10s, floatInt16)
+        
+        // boundary value
+        let boundInt16 = Operators.Checked.int16 32767.0
+        Assert.AreEqual(32767s, boundInt16)
+        
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Operators.Checked.int16 32768.0 |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Int16.MaxValue + 1s |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Int16.MinValue - 1s |> ignore)
+
+    [<Test>]
+    member _.CheckedInt32() =
+
+        // char
+        let charInt32 = Operators.Checked.int32 '0'
+        Assert.AreEqual(48, charInt32)
+        
+        // float
+        let floatInt32 = Operators.Checked.int32 10.0
+        Assert.AreEqual(10, floatInt32)
+        
+        // boundary value
+        let boundInt32 = Operators.Checked.int32 2147483647.0
+        Assert.AreEqual(2147483647, boundInt32)
+        
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Operators.Checked.int32 2147483648.0 |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Int32.MaxValue + 1 |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Int32.MinValue - 1 |> ignore)
+
+    [<Test>]
+    member _.CheckedInt64() =
+
+        // char
+        let charInt64 = Operators.Checked.int64 '0'
+        Assert.AreEqual(48L, charInt64)
+        
+        // float
+        let floatInt64 = Operators.Checked.int64 10.0
+        Assert.AreEqual(10L, floatInt64)
+        
+        // boundary value
+        let boundInt64 = Operators.Checked.int64 9223372036854775807I
+        let _  = 9223372036854775807L
+        Assert.AreEqual(9223372036854775807L, boundInt64)
+        
+        // boundary value
+        let boundInt64 = Operators.Checked.int64 -9223372036854775808I
+        let _  = -9223372036854775808L
+        Assert.AreEqual(-9223372036854775808L, boundInt64)
+        
+        // overflow exception
+        CheckThrowsOverflowException(fun() -> Operators.Checked.int64 (float Int64.MaxValue + 1.0) |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Int64.MaxValue + 1L |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Int64.MinValue - 1L |> ignore)
+
+    [<Test>]
+    member _.CheckedNativeint() =
+
+        // char
+        let charnativeint = Operators.Checked.nativeint '0'
+        Assert.AreEqual(48n, charnativeint)
+        
+        // float
+        let floatnativeint = Operators.Checked.nativeint 10.0
+        Assert.AreEqual(10n, floatnativeint)
+        
+        // boundary value
+        let boundnativeint = Operators.Checked.nativeint 32767.0
+        Assert.AreEqual(32767n, boundnativeint)
+        
+        // overflow exception (depends on pointer size)
+        CheckThrowsOverflowException(fun() ->
+            if Info.isX86Runtime then
+                Operators.Checked.nativeint 2147483648.0 |> ignore
+            else
+                Operators.Checked.nativeint 9223372036854775808.0 |> ignore)
+
+         
+    [<Test>]
+    member _.Checkedsbyte() =
+
+        // char
+        let charsbyte = Operators.Checked.sbyte '0'
+        Assert.AreEqual(48y, charsbyte)
+        
+        // float
+        let floatsbyte = Operators.Checked.sbyte -10.0
+        Assert.AreEqual(-10y, floatsbyte)
+        
+        // boundary value
+        let boundsbyte = Operators.Checked.sbyte -127.0
+        Assert.AreEqual(-127y, boundsbyte)
+        
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Operators.Checked.sbyte -256 |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> SByte.MaxValue + 1y |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> SByte.MinValue - 1y |> ignore)
+
+    [<Test>]
+    member _.Checkeduint16() =
+
+        // char
+        let charuint16 = Operators.Checked.uint16 '0'
+        Assert.AreEqual(48us, charuint16)
+        
+        // float
+        let floatuint16 = Operators.Checked.uint16 10.0
+        Assert.AreEqual(10us, floatuint16)
+        
+        // boundary value
+        let bounduint16 = Operators.Checked.uint16 65535.0
+        Assert.AreEqual(65535us, bounduint16)
+        
+        CheckThrowsOverflowException(fun() -> Operators.Checked.uint16 65536.0 |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> UInt16.MaxValue + 1us |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> UInt16.MinValue - 1us |> ignore)
+
+    [<Test>]
+    member _.Checkeduint32() =
+
+        // char
+        let charuint32 = Operators.Checked.uint32 '0'
+        Assert.AreEqual(48u, charuint32)
+        
+        // float
+        let floatuint32 = Operators.Checked.uint32 10.0
+        Assert.AreEqual(10u, floatuint32)
+        
+        // boundary value
+        let bounduint32 = Operators.Checked.uint32 429496729.0
+        Assert.AreEqual(429496729u, bounduint32)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () ->  Operators.Checked.uint32(float UInt32.MaxValue + 1.0) |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> UInt32.MaxValue + 1u |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> UInt32.MinValue - 1u |> ignore)
+
+    [<Test>]
+    member _.Checkeduint64() =
+
+        // char
+        let charuint64 = Operators.Checked.uint64 '0'
+        Assert.AreEqual(48UL, charuint64)
+        
+        // float
+        let floatuint64 = Operators.Checked.uint64 10.0
+        Assert.AreEqual(10UL, floatuint64)
+        
+        // boundary value
+        let bounduint64 = Operators.Checked.uint64 429496729.0
+        Assert.AreEqual(429496729UL, bounduint64)
+        
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> Operators.Checked.uint64 (float System.UInt64.MaxValue + 1.0) |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> UInt64.MaxValue + 1UL |> ignore)
+
+        // overflow exception
+        CheckThrowsOverflowException(fun () -> UInt64.MinValue - 1UL |> ignore)
+
+    [<Test>]
+    member _.Checkedunativeint() =
+
+        // char
+        let charunativeint = Operators.Checked.unativeint '0'
+        Assert.AreEqual(48un, charunativeint)
+        
+        // float
+        let floatunativeint = Operators.Checked.unativeint 10.0
+        Assert.AreEqual(10un, floatunativeint)
+        
+        // boundary value (dependent on pointer size)
+        if Info.isX86Runtime then
+            let boundunativeint = Operators.Checked.unativeint 4294967295.0
+            Assert.AreEqual(4294967295un, boundunativeint)
+        else
+            let boundnativeint = Operators.Checked.unativeint 1.84467440737095505E+19  // 64 bit max value cannot be expressed exactly as double
+            Assert.AreEqual(18446744073709549568un, boundnativeint)
+        
+        // overflow exception (depends on pointer size)
+        CheckThrowsOverflowException(fun () -> 
+            if Info.isX86Runtime then
+                Operators.Checked.unativeint (float UInt32.MaxValue + 1.0) |> ignore
+            else 
+                Operators.Checked.unativeint (float UInt64.MaxValue + 1.0) |> ignore
+        )
+
+

--- a/tests/FSharp.Core.UnitTests/LibraryTestFx.fs
+++ b/tests/FSharp.Core.UnitTests/LibraryTestFx.fs
@@ -37,6 +37,7 @@ let private CheckThrowsExn2<'a when 'a :> exn> s (f : unit -> unit) =
 // attribute to flag these exception's usage as a bug.
 let CheckThrowsNullRefException      f = CheckThrowsExn<NullReferenceException>   f
 let CheckThrowsIndexOutRangException f = CheckThrowsExn<IndexOutOfRangeException> f
+let CheckThrowsObjectDisposedException f = CheckThrowsExn<ObjectDisposedException> f
 
 // Legit exceptions
 let CheckThrowsNotSupportedException f = CheckThrowsExn<NotSupportedException>    f
@@ -49,6 +50,7 @@ let CheckThrowsDivideByZeroException f = CheckThrowsExn<DivideByZeroException>  
 let CheckThrowsOverflowException     f = CheckThrowsExn<OverflowException>        f
 let CheckThrowsInvalidOperationExn   f = CheckThrowsExn<InvalidOperationException> f
 let CheckThrowsFormatException       f = CheckThrowsExn<FormatException>           f
+let CheckThrowsArithmeticException   f = CheckThrowsExn<ArithmeticException>  f
 
 // Verifies two sequences are equal (same length, equiv elements)
 let VerifySeqsEqual (seq1 : seq<'T>) (seq2 : seq<'T>) =

--- a/tests/FSharp.Core.UnitTests/NUnitFrameworkShims.fs
+++ b/tests/FSharp.Core.UnitTests/NUnitFrameworkShims.fs
@@ -5,6 +5,8 @@ namespace NUnit.Framework
 open System
 open System.Collections.Generic
 open System.Linq
+open System.Runtime.InteropServices
+
 #if XUNIT
 open Xunit
 
@@ -39,7 +41,27 @@ type IgnoreAttribute (_comment:string) =
 // Alias NUnit and XUnit Assert  as LocalAssert
 type TestFrameworkAssert = Assert
 
-exception AssertionException of string
+module Info =
+    /// Use this to distinguish cases where output is deterministically different between x86 runtime or x64 runtime,
+    /// for instance w.r.t. floating point arithmetic. For more info, see https://github.com/dotnet/roslyn/issues/7333
+    let isX86Runtime = sizeof<IntPtr> = 4
+
+    /// Use this to distinguish cases where output is deterministically different between x86 runtime or x64 runtime,
+    /// for instance w.r.t. floating point arithmetic. For more info, see https://github.com/dotnet/roslyn/issues/7333
+    let isX64Runtime = sizeof<IntPtr> = 8
+
+    let framework = RuntimeInformation.FrameworkDescription
+
+    /// Whether a test is run inside a .NET Core Runtime
+    let isNetCore = framework.StartsWith(".NET Core")
+
+    /// Whether a test is run using a .NET Framework Runtime
+    let isNetFramework = framework.StartsWith(".NET Framework")
+
+    /// Whether a test is run after being compiled to .NET Native
+    let isNetNative = framework.StartsWith(".NET Native")
+
+
 
 module private Impl =
     open FsCheck.Arb
@@ -86,10 +108,28 @@ module private Impl =
         |   _ ->
                 Object.Equals(expected, actual)
 
+    /// Special treatment of float and float32 to get a somewhat meaningful error message 
+    /// (otherwise, the missing precision leads to different values that are close together looking the same)
+    let floatStr (flt1: obj) (flt2: obj)  = 
+        match flt1, flt2 with
+        | :? float as flt1, (:? float as flt2) ->
+            flt1.ToString("R"), flt2.ToString("R")
+
+        | :? float32 as flt1, (:? float32 as flt2) ->
+            flt1.ToString("R"), flt2.ToString("R")
+
+        | _ -> flt1.ToString(), flt2.ToString()
+
+
 type Assert =
+    
     static member AreEqual(expected : obj, actual : obj, message : string) =
+            
         if not (Impl.equals expected actual) then
-            let message = sprintf "%s: Expected %A but got %A" message expected actual
+            let message = 
+                let (exp, act) = Impl.floatStr expected actual
+                sprintf "%s: Expected %s but got %s" message exp act
+
             AssertionException message |> raise
 
     static member AreNotEqual(expected : obj, actual : obj, message : string) =
@@ -98,6 +138,17 @@ type Assert =
             AssertionException message |> raise
 
     static member AreEqual(expected : obj, actual : obj) = Assert.AreEqual(expected, actual, "Assertion")
+
+    /// Use this to compare floats within a delta of 1e-15, useful for discrepancies
+    /// between 80-bit (dotnet, RyuJIT) and 64-bit (x86, Legacy JIT) floating point calculations
+    static member AreNearEqual(expected: float, actual: float) =
+        let delta = 1.0e-15
+        let message = 
+            let ((e, a)) = Impl.floatStr expected actual
+            sprintf "Are near equal: expected %s, but got %s (with delta: %f)" e a delta
+
+        global.NUnit.Framework.Assert.AreEqual(expected, actual, 1.0, message)
+        Assert.AreEqual(Math.Round(expected, 15), Math.Round(actual, 15), message)
 
     static member AreNotEqual(expected : obj, actual : obj) = Assert.AreNotEqual(expected, actual, "Assertion")
 


### PR DESCRIPTION
Fixes #7958, #9153

In summary, this fixes the following things:

* When `string` was used on a variable inside a generic type, where that variable has that generic type, it failed with FS0670. This disallowed its use in many situations, like in `override this.ToString()` (see #7958)
* The original code had a redundant (although invisible) null-check (see #9153), it is now removed
* The original code used compiler-syntax that was unreachable, leading to the code always falling-through to use `anyToString "" value`. The dead code is removed.
* Added tests, specifically also to ensure that `InvariantCulture` is definitely used (I added tests that switch the culture to check if it influences the result)

After this change:

* The `string` function can be used anywhere where a normal generic function can be used (exception: ref types, see #9402)
* The original special-casing in the `string` function was never called or compiled, though even if it had been, it would've lead to the same result
* No effect on performance for as far as I can tell. Measurements are within error range. There's one extra `call`, but also one less null-check.