### PR TITLE
Fix 9565 - The nullable interop feature caused an issue with byrefs when enabled.

### DIFF
--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -1169,8 +1169,9 @@ let AdjustCallerArgForOptional tcFieldInit eCallerMemberName (infoReader: InfoRe
     let calledArg = assignedArg.CalledArg
     let calledArgTy = calledArg.CalledArgumentType
     match calledArg.OptArgInfo with
-    | NotOptional when not (g.langVersion.SupportsFeature LanguageFeature.NullableOptionalInterop) ->
-        if isOptCallerArg then errorR(Error(FSComp.SR.tcFormalArgumentIsNotOptional(), m))
+    | NotOptional ->
+        if not (g.langVersion.SupportsFeature LanguageFeature.NullableOptionalInterop) &&
+           isOptCallerArg then errorR(Error(FSComp.SR.tcFormalArgumentIsNotOptional(), m))
         assignedArg
 
     | _ ->

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -1233,7 +1233,7 @@ let AdjustCallerArgForOptional tcFieldInit eCallerMemberName (infoReader: InfoRe
     | None -> assignedArg
     | Some callerArgExpr2 ->
         let callerArg2 = CallerArg(tyOfExpr g callerArgExpr2, m, isOptCallerArg, callerArgExpr2)
-        { assignedArg with CallerArg = callerArg2 }
+        { assignedArg with CallerArg=callerArg2 }
 
 // Handle CallerSide optional arguments. 
 //

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -254,7 +254,7 @@ module CoreTests =
         begin
             use testOkFile = fileguard cfg "test.ok"
 
-            fsc cfg "%s -o:test.exe -g" cfg.fsc_flags ["test.fsx"]
+            fsc cfg "%s -o:test.exe -g --langversion:5.0" cfg.fsc_flags ["test.fsx"]
 
             singleNegTest cfg "test"
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -254,9 +254,20 @@ module CoreTests =
         begin
             use testOkFile = fileguard cfg "test.ok"
 
+            fsc cfg "%s -o:test.exe -g --langversion:4.7" cfg.fsc_flags ["test.fsx"]
+
+            singleVersionedNegTest cfg "4.7" "test"
+            exec cfg ("." ++ "test.exe") ""
+
+            testOkFile.CheckExists()
+        end
+
+        begin
+            use testOkFile = fileguard cfg "test.ok"
+
             fsc cfg "%s -o:test.exe -g --langversion:5.0" cfg.fsc_flags ["test.fsx"]
 
-            singleNegTest cfg "test"
+            singleVersionedNegTest cfg "5.0" "test"
 
             exec cfg ("." ++ "test.exe") ""
 
@@ -482,7 +493,6 @@ module CoreTests =
     let ``enum-FSI_BASIC`` () = singleTestBuildAndRun' "core/enum" FSI_BASIC
 
 #if !NETCOREAPP
-
     // Requires winforms will not run on coreclr
     [<Test>]
     let controlWpf () = singleTestBuildAndRun' "core/controlwpf" FSC_BASIC


### PR DESCRIPTION
Fixes #9565 .     The nullable interop feature caused an issue with byrefs when enabled.

1. Eliminate [redundent pattern match](https://github.com/dotnet/fsharp/pull/9566/files#diff-456bef6dcdc9277074038269046cab70L1171)

2. [The function is called with an assignedArg](https://github.com/dotnet/fsharp/pull/9566/files#diff-456bef6dcdc9277074038269046cab70L1167) from this value is retrieved the callerArg and then the callerArgExpr.  If the assigned arg is a byref'2<T, U> later on when we [recreate the assigned arg](https://github.com/dotnet/fsharp/pull/9566/files#diff-456bef6dcdc9277074038269046cab70L1229) due to a bug in the compiler due to having multiple representations of byref: byref'1<T> and byref'2<T, U>.  The callerArgExpr is recreated with the wrong byref type, which messes with postinference checking.  Will is going to look at how best to address that issue.

3. However, this bug addresses the issue by not recreating the assignedArg, when a NullableExpression is not needed.

4. callerArgExprOpt now returns an option of expression, if it is None then the original assignedArg is sufficient.

5. Updated tests to run on 5.0 and 4.7.

6. An indent change, when reviewing tell github to ignore whitespace changes.

repro:
do a release build of master branch
pushd C:\kevinransom\fsharp\tests\fsharp\core\byrefs
C:\kevinransom\fsharp\tests\FSharp.Test.Utilities....\artifacts\bin\fsc\Release\net472\fsc.exe -r:System.Core.dll --nowarn:20 --define:COMPILED -o:test.exe -g test.fsx --langversion:5.0
Observe the error messages:

````
test.fsx(222,19): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(222,19): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(222,19): error FS0421: The address of the variable 'res' cannot be used at this point

test.fsx(240,28): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(240,28): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(240,28): error FS0421: The address of the variable 'res' cannot be used at this point

test.fsx(311,10): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(311,10): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(311,10): error FS0421: The address of the variable 'res' cannot be used at this point

test.fsx(890,31): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(890,31): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(890,31): error FS0421: The address of the variable 'r1' cannot be used at this point

test.fsx(1428,44): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1428,44): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1428,44): error FS0418: The byref typed value 'x' cannot be used at this point

test.fsx(1448,43): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1448,43): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1448,43): error FS0418: The byref typed value 'x' cannot be used at this point

test.fsx(1458,44): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1458,44): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1458,44): error FS0418: The byref typed value 'x' cannot be used at this point

test.fsx(1464,44): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1464,44): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1464,44): error FS0418: The byref typed value 'x' cannot be used at this point

test.fsx(1484,43): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1484,43): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1484,43): error FS0418: The byref typed value 'x' cannot be used at this point

test.fsx(1494,44): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1494,44): error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

test.fsx(1494,44): error FS0418: The byref typed value 'x' cannot be used at this point
````

/cc @dsyme, please take a look.