### PR TITLE
Detect type equiv for System.Tuple`8

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1029,6 +1029,10 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
     | TType_app (tc1, l1), TType_app (tc2, l2) when tyconRefEq g tc1 tc2  -> SolveTypeEqualsTypeEqns csenv ndeep m2 trace None l1 l2
 
     // Catch System.Tuple<'T1,'T2,'T3,'T4,'T5,'T6,'T7,'TRest> arising from SRTP constructions
+    | TType_app (tc1, [a1;b1;c1;d1;e1;f1;g1;rest1]), TType_tuple (tupInfo, [a2;b2;c2;d2;e2;f2;g2;h2]) when IsEncodedTuple tupInfo g tc1 ->
+        match stripTyEqnsA csenv.g canShortcut rest1 with
+        | TType_app (_, [h1]) -> SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;h1] [a2;b2;c2;d2;e2;f2;g2;h2]
+        | _ -> localAbortD
     | TType_app (tc1, [a1;b1;c1;d1;e1;f1;g1;rest1]), TType_tuple (tupInfo, a2::b2::c2::d2::e2::f2::g2::rest2) when IsEncodedTuple tupInfo g tc1 ->
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;rest1] [a2;b2;c2;d2;e2;f2;g2;TType_tuple (tupInfo, rest2)]
 

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1030,7 +1030,7 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
 
     // Catch System.Tuple<'T1,'T2,'T3,'T4,'T5,'T6,'T7,...> = 'T1*'T2*'T3*'T4*'T5*'T6*'T7*...
     | TType_app (tc1, [a1;b1;c1;d1;e1;f1;g1;rest1]), TType_tuple (tupInfo, [a2;b2;c2;d2;e2;f2;g2;h2]) when IsEncodedTuple tupInfo g tc1 ->
-        SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;rest1] [a2;b2;c2;d2;e2;f2;g2;TType_app (if evalTupInfoIsStruct tupInfo then g.struct_tuple1_tcr else g.ref_tuple1_tcr, [h2])]
+        SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;rest1] [a2;b2;c2;d2;e2;f2;g2;TType_app ((if evalTupInfoIsStruct tupInfo then g.struct_tuple1_tcr else g.ref_tuple1_tcr), [h2])]
     | TType_app (tc1, [a1;b1;c1;d1;e1;f1;g1;rest1]), TType_tuple (tupInfo, a2::b2::c2::d2::e2::f2::g2::rest2) when IsEncodedTuple tupInfo g tc1 ->
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;rest1] [a2;b2;c2;d2;e2;f2;g2;TType_tuple (tupInfo, rest2)]
 

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1033,6 +1033,10 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;rest1] [a2;b2;c2;d2;e2;f2;g2;TType_app ((if evalTupInfoIsStruct tupInfo then g.struct_tuple1_tcr else g.ref_tuple1_tcr), [h2])]
     | TType_app (tc1, [a1;b1;c1;d1;e1;f1;g1;rest1]), TType_tuple (tupInfo, a2::b2::c2::d2::e2::f2::g2::rest2) when IsEncodedTuple tupInfo g tc1 ->
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;rest1] [a2;b2;c2;d2;e2;f2;g2;TType_tuple (tupInfo, rest2)]
+    | TType_tuple (tupInfo, [a1;b1;c1;d1;e1;f1;g1;h1]), TType_app (tc2, [a2;b2;c2;d2;e2;f2;g2;rest2]) when IsEncodedTuple tupInfo g tc2 ->
+        SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;TType_app ((if evalTupInfoIsStruct tupInfo then g.struct_tuple2_tcr else g.ref_tuple2_tcr), [h1])] [a2;b2;c2;d2;e2;f2;g2;rest2]
+    | TType_tuple (tupInfo, a1::b1::c1::d1::e1::f1::g1::rest1), TType_app (tc2, [a2;b2;c2;d2;e2;f2;g2;rest2]) when IsEncodedTuple tupInfo g tc2 ->
+        SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;TType_tuple (tupInfo, rest1)] [a2;b2;c2;d2;e2;f2;g2;rest2]
 
     | TType_app (_, _), TType_app (_, _)   ->  localAbortD
     | TType_tuple (tupInfo1, l1), TType_tuple (tupInfo2, l2)      -> 

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1028,11 +1028,9 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
 
     | TType_app (tc1, l1), TType_app (tc2, l2) when tyconRefEq g tc1 tc2  -> SolveTypeEqualsTypeEqns csenv ndeep m2 trace None l1 l2
 
-    // Catch System.Tuple<'T1,'T2,'T3,'T4,'T5,'T6,'T7,'TRest> arising from SRTP constructions
+    // Catch System.Tuple<'T1,'T2,'T3,'T4,'T5,'T6,'T7,...> = 'T1*'T2*'T3*'T4*'T5*'T6*'T7*...
     | TType_app (tc1, [a1;b1;c1;d1;e1;f1;g1;rest1]), TType_tuple (tupInfo, [a2;b2;c2;d2;e2;f2;g2;h2]) when IsEncodedTuple tupInfo g tc1 ->
-        match stripTyEqnsA csenv.g canShortcut rest1 with
-        | TType_app (_, [h1]) -> SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;h1] [a2;b2;c2;d2;e2;f2;g2;h2]
-        | _ -> localAbortD
+        SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;rest1] [a2;b2;c2;d2;e2;f2;g2;TType_app (if evalTupInfoIsStruct tupInfo then g.struct_tuple1_tcr else g.ref_tuple1_tcr, [h2])]
     | TType_app (tc1, [a1;b1;c1;d1;e1;f1;g1;rest1]), TType_tuple (tupInfo, a2::b2::c2::d2::e2::f2::g2::rest2) when IsEncodedTuple tupInfo g tc1 ->
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace None [a1;b1;c1;d1;e1;f1;g1;rest1] [a2;b2;c2;d2;e2;f2;g2;TType_tuple (tupInfo, rest2)]
 

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1596,7 +1596,8 @@ let ExpandStructuralBindingRaw cenv expr =
     assert cenv.settings.ExpandStructuralValues()
     match expr with
     | Expr.Let (TBind(v, rhs, tgtSeqPtOpt), body, m, _) 
-        when (isRefTupleExpr rhs &&
+        when (isAnyTupleTy cenv.g v.Type &&
+              isRefTupleExpr rhs &&
               CanExpandStructuralBinding v) ->
           let args = tryDestRefTupleExpr rhs
           if List.forall ExprIsValue args then

--- a/tests/fsharp/core/csext/test.fsx
+++ b/tests/fsharp/core/csext/test.fsx
@@ -312,8 +312,8 @@ module TupleSRTP =
     let v2b =  (^T : (member get_Item2 : unit -> _ ) (System.Tuple<int,int>(1,3)))
     let v3b =  (^T : (member get_Item2 : unit -> _ ) ((1,3)))
     
-    let areEqualT8 = System.Tuple<_,_,_,_,_,_,_>  (1,2,3,4,5,6,7,System.Tuple<_,_>(8)  ) =  (1,2,3,4,5,6,7,8)
-    let areEqualT9 = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_,_>(8,9)) =  (1,2,3,4,5,6,7,8,9)
+    let areEqualT8 = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_>  (8)  ) = (1,2,3,4,5,6,7,8)
+    let areEqualT9 = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_,_>(8,9)) = (1,2,3,4,5,6,7,8,9)
 
 (*--------------------*)  
 

--- a/tests/fsharp/core/csext/test.fsx
+++ b/tests/fsharp/core/csext/test.fsx
@@ -312,7 +312,8 @@ module TupleSRTP =
     let v2b =  (^T : (member get_Item2 : unit -> _ ) (System.Tuple<int,int>(1,3)))
     let v3b =  (^T : (member get_Item2 : unit -> _ ) ((1,3)))
     
-    let areEqual = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_,_>(8,9)) =  (1,2,3,4,5,6,7,8,9)
+    let areEqualT8 = System.Tuple<_,_,_,_,_,_,_>  (1,2,3,4,5,6,7,System.Tuple<_,_>(8)  ) =  (1,2,3,4,5,6,7,8)
+    let areEqualT9 = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_,_>(8,9)) =  (1,2,3,4,5,6,7,8,9)
 
 (*--------------------*)  
 

--- a/tests/fsharp/core/csext/test.fsx
+++ b/tests/fsharp/core/csext/test.fsx
@@ -314,6 +314,11 @@ module TupleSRTP =
     
     let areEqualT8 = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_>  (8)  ) = (1,2,3,4,5,6,7,8)
     let areEqualT9 = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_,_>(8,9)) = (1,2,3,4,5,6,7,8,9)
+    
+    let c8 = System.Tuple<int,int,int,int,int,int,int,System.Tuple<int>>(1,2,3,4,5,6,7,System.Tuple<int>(8))
+    let c9 = System.Tuple<int,int,int,int,int,int,int,System.Tuple<int,int>>(1,2,3,4,5,6,7,System.Tuple<int,int>(8,9))
+    
+    
 
 (*--------------------*)  
 

--- a/tests/fsharp/core/csext/test.fsx
+++ b/tests/fsharp/core/csext/test.fsx
@@ -311,6 +311,8 @@ module TupleSRTP =
     let v1b =  (^T : (member get_Item2 : unit -> _ ) (new System.Tuple<int,int>(1,3)))
     let v2b =  (^T : (member get_Item2 : unit -> _ ) (System.Tuple<int,int>(1,3)))
     let v3b =  (^T : (member get_Item2 : unit -> _ ) ((1,3)))
+    
+    let areEqual = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_,_>(8,9)) =  (1,2,3,4,5,6,7,8,9)
 
 (*--------------------*)  
 

--- a/tests/fsharp/core/csext/test.fsx
+++ b/tests/fsharp/core/csext/test.fsx
@@ -315,6 +315,8 @@ module TupleSRTP =
     let areEqualT8 = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_>  (8)  ) = (1,2,3,4,5,6,7,8)
     let areEqualT9 = System.Tuple<_,_,_,_,_,_,_,_>(1,2,3,4,5,6,7,System.Tuple<_,_>(8,9)) = (1,2,3,4,5,6,7,8,9)
     
+    let areEqualT9' = System.Tuple<_,_,_,_,_,_,_,(int * int)>(1,2,3,4,5,6,7,(8,9)) = (1,2,3,4,5,6,7,8,9)
+    
     let c8 = System.Tuple<int,int,int,int,int,int,int,System.Tuple<int>>(1,2,3,4,5,6,7,System.Tuple<int>(8))
     let c9 = System.Tuple<int,int,int,int,int,int,int,System.Tuple<int,int>>(1,2,3,4,5,6,7,System.Tuple<int,int>(8,9))
     


### PR DESCRIPTION
This will allow the constraint solver to detect type equivalences between compiled and syntactic tuples over 8 elements.