### PR TITLE
Allow notebook to discover location of shared framework

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -126,12 +126,12 @@ module internal Utilities =
             | value when not (String.IsNullOrEmpty(value)) ->
                 Some value                           // Value set externally
             | _ ->
-                // Probe for netsdk install
+                // Probe for netsdk install, dotnet. and dotnet.exe is a constant offset from the location of System.Int32
                 let dotnetLocation =
                     let dotnetApp =
                         let platform = Environment.OSVersion.Platform
                         if platform = PlatformID.Unix then "dotnet" else "dotnet.exe"
-                    let assemblyLocation = typeof<DependencyManagerAttribute>.GetTypeInfo().Assembly.Location
+                    let assemblyLocation = typeof<Int32>.GetTypeInfo().Assembly.Location
                     Path.Combine(assemblyLocation, "../../..", dotnetApp)
 
                 if File.Exists(dotnetLocation) then


### PR DESCRIPTION
When fsi is running as part of the notebook, if the developer did not specify the path to the dotnet sdk, #r nuget won't work"

This fix, allows the FSharp.PackageManger.Nuget to find the location of dotnet sdk, by using the location of the shared framework assembly that holds System.Int32.

Previously we used the location of the DependencyManagerAttribute, which is shipped with the f# compiler.


