### PR TITLE
Improve error reporting: Missing = on type declaration

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1498,7 +1498,7 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3351,chkFeatureNotRuntimeSupported,"Feature '%s' is not supported by target runtime."
 3352,typrelInterfaceMemberNoMostSpecificImplementation,"Interface member '%s' does not have a most specific implementation."
 3353,chkFeatureNotSupportedInLibrary,"Feature '%s' requires the F# library for language version %s or greater."
-3360,parsEqualsMissingInTypeDefinition,"Unexpected token in type definition. Expected '='."
+3360,parsEqualsMissingInTypeDefinition,"Unexpected token in type definition. Expected '=' after the type '%s'."
 useSdkRefs,"Use reference assemblies for .NET framework references when available (Enabled by default)."
 optsLangVersion,"Display the allowed values for language version, specify language version such as 'latest' or 'preview'"
 optsSupportedLangVersions,"Supported language versions:"

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1498,6 +1498,7 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3351,chkFeatureNotRuntimeSupported,"Feature '%s' is not supported by target runtime."
 3352,typrelInterfaceMemberNoMostSpecificImplementation,"Interface member '%s' does not have a most specific implementation."
 3353,chkFeatureNotSupportedInLibrary,"Feature '%s' requires the F# library for language version %s or greater."
+3360,parsEqualsMissingInTypeDefinition,"Unexpected symbol in type definition. Did you forget to use the = operator?"
 useSdkRefs,"Use reference assemblies for .NET framework references when available (Enabled by default)."
 optsLangVersion,"Display the allowed values for language version, specify language version such as 'latest' or 'preview'"
 optsSupportedLangVersions,"Supported language versions:"

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1498,7 +1498,7 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3351,chkFeatureNotRuntimeSupported,"Feature '%s' is not supported by target runtime."
 3352,typrelInterfaceMemberNoMostSpecificImplementation,"Interface member '%s' does not have a most specific implementation."
 3353,chkFeatureNotSupportedInLibrary,"Feature '%s' requires the F# library for language version %s or greater."
-3360,parsEqualsMissingInTypeDefinition,"Unexpected symbol in type definition. Did you forget to use the = operator?"
+3360,parsEqualsMissingInTypeDefinition,"Unexpected token in type definition. Expected '='."
 useSdkRefs,"Use reference assemblies for .NET framework references when available (Enabled by default)."
 optsLangVersion,"Display the allowed values for language version, specify language version such as 'latest' or 'preview'"
 optsSupportedLangVersions,"Supported language versions:"

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1496,7 +1496,7 @@ tyconDefn:
   | typeNameInfo 
      { TypeDefn($1, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range), $1.Range), [], $1.Range) }
 
-  | typeNameInfo type_opt_equals tyconDefnRhsBlock 
+  | typeNameInfo opt_equals tyconDefnRhsBlock 
      { if not $2 then raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsEqualsMissingInTypeDefinition())
        let nameRange = rhs parseState 1
        let (tcDefRepr:SynTypeDefnRepr), members = $3 nameRange
@@ -5446,7 +5446,7 @@ deprecated_opt_equals:
   | EQUALS      { deprecatedWithError (FSComp.SR.parsNoEqualShouldFollowNamespace()) (lhs parseState); () } 
   | /* EMPTY */ {  }
 
-type_opt_equals:
+opt_equals:
   | EQUALS      { true }
   | /* EMPTY */ { false } 
 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1496,8 +1496,9 @@ tyconDefn:
   | typeNameInfo 
      { TypeDefn($1, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range), $1.Range), [], $1.Range) }
 
-  | typeNameInfo EQUALS tyconDefnRhsBlock
-     { let nameRange = rhs parseState 1
+  | typeNameInfo type_opt_equals tyconDefnRhsBlock 
+     { if not $2 then raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsEqualsMissingInTypeDefinition())
+       let nameRange = rhs parseState 1
        let (tcDefRepr:SynTypeDefnRepr), members = $3 nameRange
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
        let mWhole = (declRange, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)    
@@ -5444,6 +5445,10 @@ opt_ODECLEND:
 deprecated_opt_equals: 
   | EQUALS      { deprecatedWithError (FSComp.SR.parsNoEqualShouldFollowNamespace()) (lhs parseState); () } 
   | /* EMPTY */ {  }
+
+type_opt_equals:
+  | EQUALS      { true }
+  | /* EMPTY */ { false } 
 
 opt_OBLOCKSEP: 
   | OBLOCKSEP   { }

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1497,7 +1497,12 @@ tyconDefn:
      { TypeDefn($1, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range), $1.Range), [], $1.Range) }
 
   | typeNameInfo opt_equals tyconDefnRhsBlock 
-     { if not $2 then raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsEqualsMissingInTypeDefinition())
+     { if not $2 then (
+            let (ComponentInfo(_, _, _, lid, _, _, _, _)) = $1 
+            // While the spec doesn't allow long idents here, the parser doesn't enforce this, so take one ident
+            let typeNameId = List.last lid
+            raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsEqualsMissingInTypeDefinition(typeNameId.ToString()))
+       )
        let nameRange = rhs parseState 1
        let (tcDefRepr:SynTypeDefnRepr), members = $3 nameRange
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Compiler.ErrorMessages.ComponentTests
+namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
 open FSharp.Test.Utilities

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ErrorMessages.ComponentTests
+
+open Xunit
+open FSharp.Test.Utilities
+open FSharp.Compiler.SourceCodeServices
+
+
+module ``Type definition missing equals`` =
+
+    [<Fact>]
+    let ``Missing equals in DU``() =
+        CompilerAssert.TypeCheckSingleError
+            """
+type X | A | B
+            """
+            FSharpErrorSeverity.Error
+            3360 
+            (2, 8, 2, 9)
+            "Unexpected symbol in type definition. Did you forget to use the = operator?"

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
@@ -18,4 +18,4 @@ type X | A | B
             FSharpErrorSeverity.Error
             3360 
             (2, 8, 2, 9)
-            "Unexpected token in type definition. Expected '='."
+            "Unexpected token in type definition. Expected '=' after the type 'X'."

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
@@ -18,4 +18,4 @@ type X | A | B
             FSharpErrorSeverity.Error
             3360 
             (2, 8, 2, 9)
-            "Unexpected symbol in type definition. Did you forget to use the = operator?"
+            "Unexpected token in type definition. Expected '='."

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="EmittedIL\Operators.fs" />
     <Compile Include="EmittedIL\Literals.fs" />
     <Compile Include="EmittedIL\TailCalls.fs" />
+    <Compile Include="ErrorMessages\TypeEqualsMissingTests.fs" />
     <Compile Include="ErrorMessages\AccessOfTypeAbbreviationTests.fs" />
     <Compile Include="ErrorMessages\AssignmentErrorTests.fs" />
     <Compile Include="ErrorMessages\ClassesTests.fs" />


### PR DESCRIPTION
This is my attempt to implement #1121, leaning on the start made in #6603.

This is my first contribution, so feedback appreciated!

I'm not quite sure what's happening with the xlf files. Is it possible a previous commit on master forgot to generate them?


