### PR TITLE
don't auto-resolve types from System.Runtime.WindowsRuntime

### DIFF
--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -259,10 +259,23 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
             if not (assemblies.ContainsKey(referenceName)) then
                 try
                     if File.Exists(path) then
-                        // System.Private.CoreLib doesn't load with reflection
-                        if referenceName = "System.Private.CoreLib" then
+                        match referenceName with
+                        | "System.Runtime.WindowsRuntime"
+                        | "System.Runtime.WindowsRuntime.UI.Xaml" ->
+                            // The Windows compatibility pack included in the runtime contains a reference to
+                            // System.Runtime.WindowsRuntime, but to properly use that type the runtime also needs a
+                            // reference to the Windows.md meta-package, which isn't referenced by default.  To avoid
+                            // a bug where types from `Windows, Version=255.255.255.255` can't be found we're going to
+                            // not default include this assembly.  It can still be manually referenced if it's needed
+                            // via the System.Runtime.WindowsRuntime NuGet package.
+                            //
+                            // In the future this branch can be removed because WinRT support is being removed from the
+                            // .NET 5 SDK (https://github.com/dotnet/runtime/pull/36715)
+                            ()
+                        | "System.Private.CoreLib" ->
+                            // System.Private.CoreLib doesn't load with reflection
                             assemblies.Add(referenceName, path)
-                        else
+                        | _ ->
                             try
                                 let asm = System.Reflection.Assembly.LoadFrom(path)
                                 assemblies.Add(referenceName, path)

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/CompletionTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/CompletionTests.fs
@@ -32,6 +32,17 @@ type CompletionTests() =
         } |> Async.StartAsTask :> Task
 
     [<Test>]
+    member _.``Completions from types that try to pull in Windows runtime extensions``() =
+        async {
+            use script = new FSharpScript()
+            script.Eval("open System") |> ignoreValue
+            script.Eval("let t = TimeSpan.FromHours(1.0)") |> ignoreValue
+            let! completions = script.GetCompletionItems("t.", 1, 2)
+            let matchingCompletions = completions |> Array.filter (fun d -> d.Name = "TotalHours")
+            Assert.AreEqual(1, matchingCompletions.Length)
+        } |> Async.StartAsTask :> Task
+
+    [<Test>]
     member _.``Static member completions``() =
         async {
             use script = new FSharpScript()


### PR DESCRIPTION
When `fsi` is started it crawls the runtime directories and creates a map of short assembly names to file paths, e.g., `System.Drawing` => `C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.5\System.Drawing.dll`.  The assembly `System.Runtime.WindowsRuntime` includes some extension methods to make WinRT async operations behave like a regular C# `Task` (see [here](https://docs.microsoft.com/en-us/dotnet/api/system.windowsruntimesystemextensions.astask?view=dotnet-plat-ext-3.1#System_WindowsRuntimeSystemExtensions_AsTask__2_Windows_Foundation_IAsyncOperationWithProgress___0___1__System_Threading_CancellationToken_System_IProgress___1__)).

By delving into that assembly to find its types the `fsi` runtime inadvertently takes a dependency on the Windows SDK via `Windows.md`, but since that file isn't in the probed directories, and isn't necessarily even on the machine, any attempt to resolve types from the Windows SDK will fail.  Mix this behavior with the fact that the offending `Task`-like extension methods are brought into scope simply via `open System`, it's best to avoid loading that assembly all together.

Future versions of the .NET SDK will remove implicit WinRT support (dotnet/runtime#36715) so it makes sense to remove it from the main branch since this is only auto-flowing into branches that will ship with .NET 5 anyway.

Fixes #9206.