### PR TITLE
Eager Packages

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -209,10 +209,10 @@ module internal Utilities =
         let succeeded, stdOut, stdErr =
             if not (isRunningOnCoreClr) then
                 // The Desktop build uses "msbuild" to build
-                executeBuild msbuildExePath (arguments "") workingDir
+                executeBuild msbuildExePath (arguments "-v:quiet") workingDir
             else
                 // The coreclr uses "dotnet msbuild" to build
-                executeBuild dotnetHostPath (arguments "msbuild") workingDir
+                executeBuild dotnetHostPath (arguments "msbuild -v:quiet") workingDir
 
         let outputFile = projectPath + ".resolvedReferences.paths"
         let resultOutFile = if succeeded && File.Exists(outputFile) then Some outputFile else None

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2291,10 +2291,7 @@ type internal FsiInteractionProcessor
                 | CtrlC                        -> istate,CtrlC                                    (* drop nextAction on CtrlC *)
 
     /// Execute a single parsed interaction which may contain multiple items to be executed
-    /// independently, because some are #directives. Called on the GUI/execute/main thread.
-    /// 
-    /// #directive comes through with other definitions as a SynModuleDecl.HashDirective.
-    /// We split these out for individual processing.
+    /// independently
     let executeParsedInteractions (ctok, tcConfig, istate, action, errorLogger: ErrorLogger, lastResult:option<FsiInteractionStepStatus>, cancellationToken: CancellationToken)  =
         let istate, completed = execParsedInteractions (ctok, tcConfig, istate, action, errorLogger, lastResult, cancellationToken)
         match completed with

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -10,7 +10,7 @@
     <TargetExt>.exe</TargetExt>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
-    <OtherFlags>$(OtherFlags)  --warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
+    <OtherFlags>--warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <Win32Resource>fsi.res</Win32Resource>
     <NGenBinary>true</NGenBinary>
   </PropertyGroup>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -179,7 +179,12 @@ printfn ""%A"" result
         use output = new RedirectConsoleOutput()
         use script = new FSharpScript(additionalArgs=[|"/langversion:preview"|])
         let mutable found = 0
-        output.OutputProduced.Add (fun line -> if line.Contains("error NU1101:") && line.Contains("FSharp.Really.Not.A.Package") then found <- found + 1)
+        let outp = System.Collections.Generic.List<string>()
+        output.OutputProduced.Add(
+            fun line ->
+                if line.Contains("error NU1101:") && line.Contains("FSharp.Really.Not.A.Package") then
+                    found <- found + 1
+                outp.Add(line))
         let _result, _errors = script.Eval("""#r "nuget:FSharp.Really.Not.A.Package" """)
         Assert.True( (found = 1), "Expected to see output contains 'error NU1101:' and 'FSharp.Really.Not.A.Package'")
 
@@ -194,7 +199,7 @@ printfn ""%A"" result
 #r "nuget:FSharp.Really.Not.A.Package"
 #r "nuget:FSharp.Really.Not.Another.Package"
                 """)
-        Assert.True( (foundResolve = 1), (sprintf "Expected to see 'Microsoft (R) Build Engine version' resolve only onceactually resolve %d times" foundResolve))
+        Assert.True( (foundResolve = 1), (sprintf "Expected to see 'Microsoft (R) Build Engine version' only once actually resolved %d times" foundResolve))
 
     [<Test>]
     member __.``ML - use assembly with ref dependencies``() =


### PR DESCRIPTION
With the current implementation of the package manager resolution is delayed until code is generated and executed.  This has the side effect that errors are not displayed until later than expected.

It is commonly believed by developers that:
#r "nuget:FSharp.Data";;  should resolve and display errors immediately.

It is somewhat jarring to see:
````
Microsoft (R) F# Interactive version 10.10.0.0 for F# 4.7
Copyright (c) Microsoft Corporation. All Rights Reserved.

For help type #help;;

> #r "nuget:FSharp.DoTheWrongThing";;
>
-
- ;;
````
and then see the error happen when generating code:
````
> let _=();;
Microsoft (R) Build Engine version 16.7.0-preview-20310-07+ee1c9fd0c for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
C:\Users\codec\AppData\Local\Temp\nuget\10664--f16bc33b-68ac-44ec-9a70-21930c58e389\Project.fsproj : error NU1101: Unable to find package FSharp.DoTheWrongThing. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages, nuget.org
  Failed to restore C:\Users\codec\AppData\Local\Temp\nuget\10664--f16bc33b-68ac-44ec-9a70-21930c58e389\Project.fsproj (in 1.02 sec).
>
````

This PR, makes resolution and error reporting eager.
