### PR TITLE
Enable fsharp.core.5.0 apis

### DIFF
--- a/src/fsharp/FSharp.Core/async.fs
+++ b/src/fsharp/FSharp.Core/async.fs
@@ -1405,7 +1405,6 @@ namespace Microsoft.FSharp.Control
         static member Sleep (millisecondsDueTime: int32) : Async<unit> =
             Async.Sleep (millisecondsDueTime |> int64)
 
-        [<Experimental(ExperimentalAttributeMessages.RequiresPreview)>]
         static member Sleep (dueTime: TimeSpan) =
             if dueTime < TimeSpan.Zero then
                 raise (ArgumentOutOfRangeException("dueTime"))

--- a/src/fsharp/FSharp.Core/async.fsi
+++ b/src/fsharp/FSharp.Core/async.fsi
@@ -288,7 +288,6 @@ namespace Microsoft.FSharp.Control
         /// <param name="dueTime">The amount of time to sleep.</param>
         /// <returns>An asynchronous computation that will sleep for the given time.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the due time is negative.</exception>
-        [<Experimental(ExperimentalAttributeMessages.RequiresPreview)>]
         static member Sleep: dueTime:TimeSpan -> Async<unit>
 
         /// <summary>Creates an asynchronous computation in terms of a Begin/End pair of actions in 

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -549,7 +549,6 @@ type Map<[<EqualityConditionalOn>]'Key, [<EqualityConditionalOn; ComparisonCondi
 #endif
         new Map<'Key, 'Value>(comparer, MapTree.add comparer key value tree)
 
-    [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
     member m.Change(key, f) : Map<'Key, 'Value> =
         new Map<'Key, 'Value>(comparer, MapTree.change comparer key f tree)
 
@@ -770,7 +769,6 @@ module Map =
     let add key value (table: Map<_, _>) =
         table.Add (key, value)
 
-    [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
     [<CompiledName("Change")>]
     let change key f (table: Map<_, _>) =
         table.Change (key, f)

--- a/src/fsharp/FSharp.Core/map.fsi
+++ b/src/fsharp/FSharp.Core/map.fsi
@@ -26,7 +26,6 @@ namespace Microsoft.FSharp.Collections
         /// <param name="key">The input key.</param>
         /// <param name="f">The change function.</param>
         /// <returns>The resulting map.</returns>
-        [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
         member Change: key:'Key * f:('Value option -> 'Value option) -> Map<'Key,'Value>
 
         /// <summary>Returns true if there are no bindings in the map.</summary>
@@ -98,7 +97,6 @@ namespace Microsoft.FSharp.Collections
         /// <param name="f">The change function.</param>
         /// <param name="table">The input map.</param>
         /// <returns>The resulting map.</returns>
-        [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
         [<CompiledName("Change")>]
         val change: key:'Key -> f:('T option -> 'T option) -> table:Map<'Key,'T> -> Map<'Key,'T>
 


### PR DESCRIPTION
These F# core Api's are approved for use in FSharp.Core 5.0  when released.

It includes the api's that support witness passing.
It does not include reverse indexing APIs.
