### PR TITLE
fix VS insertion step

### DIFF
--- a/eng/release/scripts/GetPublishUrls.ps1
+++ b/eng/release/scripts/GetPublishUrls.ps1
@@ -8,6 +8,8 @@ param (
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
+$dropUrlRegex = "(https://vsdrop\.corp\.microsoft\.com/[^\r\n;]+);([^\r\n]+)\r?\n"
+
 function Invoke-WebRequestWithAccessToken([string] $uri, [string] $accessToken, [int] $retryCount = 5) {
     Write-Host "Fetching content from $uri"
     $base64 = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$accessToken"))
@@ -28,24 +30,15 @@ function Invoke-WebRequestWithAccessToken([string] $uri, [string] $accessToken, 
     throw "Unable to fetch $uri after $retryCount tries."
 }
 
-try {
-    # build map of all *.vsman files to their `info.buildVersion` values
-    $manifestVersionMap = @{}
-    Get-ChildItem -Path "$insertionDir\*" -Filter "*.vsman" | ForEach-Object {
-        $manifestName = Split-Path $_ -Leaf
-        $vsmanContents = Get-Content $_ | ConvertFrom-Json
-        $buildVersion = $vsmanContents.info.buildVersion
-        $manifestVersionMap.Add($manifestName, $buildVersion)
-    }
-
-    # find all publish URLs
+# this function has to download ~500 individual logs and check each one; prone to timeouts
+function Get-ManifestsViaIndividualLogs([PSObject] $manifestVersionMap, [string] $buildId, [string] $accessToken) {
     $manifests = @()
     $seenManifests = @{}
     $json = Invoke-WebRequestWithAccessToken -uri "https://dev.azure.com/dnceng/internal/_apis/build/builds/$buildId/logs?api-version=5.1" -accessToken $accessToken | ConvertFrom-Json
     foreach ($l in $json.value) {
         $logUrl = $l.url
         $log = (Invoke-WebRequestWithAccessToken -uri $logUrl -accessToken $accessToken).Content
-        If ($log -Match "(https://vsdrop\.corp\.microsoft\.com/[^\r\n;]+);([^\r\n]+)\r?\n") {
+        If ($log -Match $dropUrlRegex) {
             $manifestShortUrl = $Matches[1]
             $manifestName = $Matches[2]
             $manifestUrl = "$manifestShortUrl;$manifestName"
@@ -57,6 +50,66 @@ try {
             }
         }
     }
+
+    return $manifests
+}
+
+# this function only has to download 1 file and look at a very specific file
+function Get-ManifestsViaZipLog([PSObject] $manifestVersionMap, [string] $buildId, [string] $accessToken) {
+    # create temporary location
+    $guid = [System.Guid]::NewGuid().ToString()
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) $guid
+    New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+    # download the logs
+    $base64 = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$accessToken"))
+    $headers = @{
+        Authorization = "Basic $base64"
+    }
+    $uri = "https://dev.azure.com/dnceng/internal/_apis/build/builds/$buildId/logs?`$format=zip"
+    Invoke-WebRequest -Uri $uri -Method Get -Headers $headers -UseBasicParsing -OutFile "$tempDir/logs.zip"
+
+    # expand the logs
+    New-Item -ItemType Directory -Path "$tempDir/logs" | Out-Null
+    Expand-Archive -Path "$tempDir/logs.zip" -DestinationPath "$tempDir/logs"
+
+    # parse specific logs
+    $logDir = "$tempDir/logs"
+    $manifests = @()
+    $seenManifests = @{}
+    Get-ChildItem $logDir -r -inc "*Upload VSTS Drop*" | ForEach-Object {
+        $result = Select-String -Path $_ -Pattern "(https://vsdrop\.corp\.microsoft\.com[^;]+);(.*)" -AllMatches
+        $result.Matches | ForEach-Object {
+            $manifestShortUrl = $_.Groups[1].Value
+            $manifestName = $_.Groups[2].Value
+            $manifestUrl = "$manifestShortUrl;$manifestName"
+            If (-Not $seenManifests.Contains($manifestUrl)) {
+                $seenManifests.Add($manifestUrl, $true)
+                $buildVersion = $manifestVersionMap[$manifestName]
+                $manifestEntry = "$manifestName{$buildVersion}=$manifestUrl"
+                $manifests += $manifestEntry
+            }
+        }
+    }
+
+    Remove-Item -Path $tempDir -Recurse
+
+    return $manifests
+}
+
+try {
+    # build map of all *.vsman files to their `info.buildVersion` values
+    $manifestVersionMap = @{}
+    Get-ChildItem -Path "$insertionDir\*" -Filter "*.vsman" | ForEach-Object {
+        $manifestName = Split-Path $_ -Leaf
+        $vsmanContents = Get-Content $_ | ConvertFrom-Json
+        $buildVersion = $vsmanContents.info.buildVersion
+        $manifestVersionMap.Add($manifestName, $buildVersion)
+    }
+
+    # find all publish URLs
+    #$manifests = Get-ManifestsViaIndividualLogs -manifestVersionMap $manifestVersionMap -buildId $buildId -accessToken $accessToken
+    $manifests = Get-ManifestsViaZipLog -manifestVersionMap $manifestVersionMap -buildId $buildId -accessToken $accessToken
 
     $final = $manifests -Join ","
     Write-Host "Setting InsertJsonValues to $final"


### PR DESCRIPTION
To find values needed to perform a VS insertion, we have to download around 500 individual log files and parse them all with a regex.  This is slow and error-prone, and recently has been timing out.  The first part of this PR would retry each log up to 5 times.  That's slightly more stable, but not necessarily.  The second part of this PR abuses an undocumented API shape to download all logs as a single zip file and then only the interesting ones (e.g., one of them) is checked with the regex.  This should be much faster and more stable, assuming the undocumented API doesn't disappear.  If it does disappear, there's a one-line change that will switch back to the 500 item download.

Tested via internal build.