### PR TITLE
Fix xmldoc comments

### DIFF
--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -235,11 +235,11 @@ type public FSharpCheckFileResults =
     /// Find the most precise display environment for the given line and column.
     member GetDisplayContextForPos : pos : pos -> Async<FSharpDisplayContext option>
 
-    /// Determines if a long ident is resolvable at a specific point.
+    /// <summary>Determines if a long ident is resolvable at a specific point.</summary>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member internal IsRelativeNameResolvable: cursorPos : pos * plid : string list * item: Item * ?userOpName: string -> Async<bool>
 
-    /// Determines if a long ident is resolvable at a specific point.
+    /// <summary>Determines if a long ident is resolvable at a specific point.</summary>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member IsRelativeNameResolvableFromSymbol: cursorPos : pos * plid : string list * symbol: FSharpSymbol * ?userOpName: string -> Async<bool>
 


### PR DESCRIPTION
The xmldoc comments are treated as plain-text if a `summary` tag is not present.

![image](https://user-images.githubusercontent.com/2375486/87775438-bac41c80-c843-11ea-9845-23a56ca5a61f.png)
