### PR TITLE
Properly fix find dotnet.exe

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -131,8 +131,8 @@ module internal Utilities =
                     let dotnetApp =
                         let platform = Environment.OSVersion.Platform
                         if platform = PlatformID.Unix then "dotnet" else "dotnet.exe"
-                    let assemblyLocation = typeof<Int32>.GetTypeInfo().Assembly.Location
-                    Path.Combine(assemblyLocation, "../../..", dotnetApp)
+                    let assemblyLocation = Path.GetDirectoryName(typeof<Int32>.GetTypeInfo().Assembly.Location)
+                    Path.GetFullPath(Path.Combine(assemblyLocation, "../../..", dotnetApp))
 
                 if File.Exists(dotnetLocation) then
                     Some dotnetLocation


### PR DESCRIPTION
Programming is hard and I am crap at it.  To compensate When I fixed the search for dotnet.exe I stupidly left in the assembly name.

This correctly removes it, and also normalizes the path.

/cc @cartermp , @brettfo 