### PR TITLE
Clean up CE classification

### DIFF
--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -89,13 +89,33 @@ module TcResolutionsExtensions =
                         | _ -> None
                     | _ -> None
 
+                // Custome builders like 'async { }' are both Item.Value and Item.CustomBuilder.
+                // We should prefer the latter, otherwise they would not get classified as CEs.
+                let takeCustomBuilder (cnrs: CapturedNameResolution[]) =
+                    assert (cnrs.Length > 0)
+                    if cnrs.Length = 1 then
+                        cnrs
+                    elif cnrs.Length = 2 then
+                        match cnrs.[0].Item, cnrs.[1].Item with
+                        | Item.Value _, Item.CustomBuilder _ ->
+                            [| cnrs.[1] |]
+                        | Item.CustomBuilder _, Item.Value _ ->
+                            [| cnrs.[0] |]
+                        | _ ->
+                            cnrs
+                    else
+                        cnrs
+
                 let resolutions =
                     match range with
                     | Some range ->
-                        sResolutions.CapturedNameResolutions
-                        |> Seq.filter (fun cnr -> rangeContainsPos range cnr.Range.Start || rangeContainsPos range cnr.Range.End)
+                        sResolutions.CapturedNameResolutions.ToArray()
+                        |> Array.filter (fun cnr -> rangeContainsPos range cnr.Range.Start || rangeContainsPos range cnr.Range.End)
+                        |> Array.groupBy (fun cnr -> cnr.Range)
+                        |> Array.map (fun (_, cnrs) -> takeCustomBuilder cnrs)
+                        |> Array.concat
                     | None -> 
-                        sResolutions.CapturedNameResolutions :> seq<_>
+                        sResolutions.CapturedNameResolutions.ToArray()
 
                 let isDisposableTy (ty: TType) =
                     not (typeEquiv g ty g.system_IDisposable_ty) &&
@@ -129,11 +149,11 @@ module TcResolutionsExtensions =
                 let inline add m typ =
                     if duplicates.Add m then
                         results.Add struct(m, typ)
+
                 resolutions
-                |> Seq.iter (fun cnr ->
-                    match cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.NameResolutionEnv, cnr.AccessorDomain, cnr.Range with
-                    // 'seq' in 'seq { ... }' gets colored as keywords
-                    | (Item.Value vref), ItemOccurence.Use, _, _, _, m when valRefEq g g.seq_vref vref ->
+                |> Array.iter (fun cnr ->
+                    match cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.NameResolutionEnv, cnr.AccessorDomain, cnr.Range with                        
+                    | (Item.CustomBuilder _ | Item.CustomOperation _), ItemOccurence.Use, _, _, _, m ->
                         add m SemanticClassificationType.ComputationExpression
 
                     | (Item.Value vref), _, _, _, _, m when isValRefMutable vref ->
@@ -207,9 +227,6 @@ module TcResolutionsExtensions =
                             add m SemanticClassificationType.ExtensionMethod
                         else
                             add m SemanticClassificationType.Method
-
-                    | (Item.CustomBuilder _ | Item.CustomOperation _), ItemOccurence.Use, _, _, _, m ->
-                        add m SemanticClassificationType.ComputationExpression
 
                     // Special case measures for struct types
                     | Item.Types(_, TType_app(tyconRef, TType_measure _ :: _) :: _), LegitTypeOccurence, _, _, _, m when isStructTyconRef tyconRef ->


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/9732

The problem is that for code like this:

```fsharp
let x = async { return 12 }
```

`async` has two captured name resolutions:

* An `Item.Value`
* A `Item.CustomBuilder`

Both are technically correct "views" of `async`, but the latter is the correct classification type when you consider colorization. Because the cache we use de-duplicates based on range, and `ItemValue` comes first in the array of captured name resolutions, `async` was classified as a `Value` and ultimately colored as plaintext.

This prefers `Item.CustomBuilder` for the purposes of classification.