### PR TITLE
Don't mark CE methods on builders as unused

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -14,7 +14,6 @@
     <DefineConstants>$(DefineConstants);LOCALIZATION_FCOMP</DefineConstants>
     <OtherFlags>$(OtherFlags) --warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <Target Name="CopyToBuiltBin" BeforeTargets="BuiltProjectOutputGroup" AfterTargets="CoreCompile">

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -14,6 +14,7 @@
     <DefineConstants>$(DefineConstants);LOCALIZATION_FCOMP</DefineConstants>
     <OtherFlags>$(OtherFlags) --warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <Target Name="CopyToBuiltBin" BeforeTargets="BuiltProjectOutputGroup" AfterTargets="CoreCompile">

--- a/src/fsharp/service/ServiceAnalysis.fs
+++ b/src/fsharp/service/ServiceAnalysis.fs
@@ -305,10 +305,11 @@ module UnusedDeclarations =
         | :? FSharpEntity as e when e.IsFSharpRecord || e.IsFSharpUnion || e.IsInterface || e.IsFSharpModule || e.IsClass || e.IsNamespace -> false
 
         // FCS returns inconsistent results for override members; we're skipping these symbols.
-        | :? FSharpMemberOrFunctionOrValue as f when 
-                f.IsOverrideOrExplicitInterfaceImplementation ||
-                f.IsBaseValue ||
-                f.IsConstructor -> false
+        | :? FSharpMemberOrFunctionOrValue as f when
+            f.IsComputationExpressionMethod ||
+            f.IsOverrideOrExplicitInterfaceImplementation ||
+            f.IsBaseValue ||
+            f.IsConstructor -> false
 
         // Usage of DU case parameters does not give any meaningful feedback; we never gray them out.
         | :? FSharpParameter -> false
@@ -317,7 +318,7 @@ module UnusedDeclarations =
     let getUnusedDeclarationRanges (symbolsUses: FSharpSymbolUse[]) (isScript: bool) =
         let definitions =
             symbolsUses
-            |> Array.filter (fun su -> 
+            |> Array.filter (fun su ->
                 su.IsFromDefinition && 
                 su.Symbol.DeclarationLocation.IsSome && 
                 (isScript || su.IsPrivateToFile) && 

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2028,7 +2028,7 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
                 false
         let isBindNReturn (methodName: string) =
             if methodName.StartsWith("Bind") && methodName.EndsWith("Return") then
-                let (didParse, _) = System.Int32.TryParse(methodName.[4..^6])
+                let (didParse, _) = System.Int32.TryParse(methodName.[4..methodName.Length-7]) // replace this disgusting mess with reverse indexing some time
                 didParse
             else
                 false

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2019,6 +2019,20 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         | V valRef -> not (SymbolHelpers.isFunction cenv.g valRef.Type)
         | _ -> false
 
+    member x.IsComputationExpressionMethod =
+        x.CompiledName = "Bind"
+        || x.CompiledName = "Return"
+        || x.CompiledName = "ReturnFrom"
+        || x.CompiledName = "Combine"
+        || x.CompiledName = "Delay"
+        || x.CompiledName = "Zero"
+        || x.CompiledName = "TryWith"
+        || x.CompiledName = "TryFinally"
+        || x.CompiledName = "For"
+        || x.CompiledName = "Using"
+        || x.CompiledName = "BindReturn"
+        || x.CompiledName = "MergeSources"
+
     override x.Equals(other: obj) =
         box x === other ||
         match other with

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2020,6 +2020,18 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         | _ -> false
 
     member x.IsComputationExpressionMethod =
+        let isNameN (methodName: string) (methodKind: string) =
+            if methodName.StartsWith(methodKind) then
+                let (didParse, _) = System.Int32.TryParse(methodName.[methodKind.Length..])
+                didParse
+            else
+                false
+        let isBindNReturn (methodName: string) =
+            if methodName.StartsWith("Bind") && methodName.EndsWith("Return") then
+                let (didParse, _) = System.Int32.TryParse(methodName.[4..^6])
+                didParse
+            else
+                false
         x.CompiledName = "Bind"
         || x.CompiledName = "Return"
         || x.CompiledName = "ReturnFrom"
@@ -2032,6 +2044,9 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         || x.CompiledName = "Using"
         || x.CompiledName = "BindReturn"
         || x.CompiledName = "MergeSources"
+        || isNameN x.CompiledName "Bind"
+        || isNameN x.CompiledName "MergeSources"
+        || isBindNReturn x.CompiledName
 
     override x.Equals(other: obj) =
         box x === other ||

--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -860,6 +860,9 @@ and [<Class>] public FSharpMemberOrFunctionOrValue =
 
     /// Indicates if this is a constructor.
     member IsConstructor : bool
+
+    /// Indicates if this is a special method used in Computation Expression builders.
+    member IsComputationExpressionMethod : bool
     
     /// Format the type using the rules of the given display context
     member FormatLayout : context: FSharpDisplayContext -> Layout


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/6309070/88120853-c2076500-cb78-11ea-8d6f-6b7e962a85c0.png)

After:

![image](https://user-images.githubusercontent.com/6309070/88120872-d4819e80-cb78-11ea-8926-5f737efd7ca7.png)

Probably need to figure out the `BindN` ones too but I figured I'd get this up into a PR first