### PR TITLE
Fix rebuild

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -69,24 +69,49 @@
   <Target Name="BeforeResGen"
           Inputs="@(EmbeddedResource->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
           Outputs="@(EmbeddedResource->'$(IntermediateOutputPath)resources\%(Filename)%(Extension)')"
-          DependsOnTargets="CopyVsixResources"
           Condition="'$(Configuration)' != 'Proto' and '$(Language)'=='F#' and '$(DisableCompilerRedirection)' != 'true' ">
+
+    <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
+    <MakeDir Directories="$(IntermediateOutputPath)resources\" Condition="!Exists('$(IntermediateOutputPath)resources\')" />
 
     <SubstituteText EmbeddedResources="@(EmbeddedResource)">
       <Output TaskParameter="CopiedFiles" ItemName="CopiedFiles" />
     </SubstituteText>
 
     <ItemGroup>
+      <IntermediateFiles Include="$(IntermediateOutputPath)\*.resx" />
+      <IntermediateResourcesFiles Include="$(IntermediateOutputPath)resources\*.resx" />
+    </ItemGroup>
+
+    <!-- IntermediateFiles Hashes -->
+    <GetFileHash Files="@(IntermediateFiles)">
+      <Output
+          TaskParameter="Items"
+          ItemName="IntermediateFilesHashes" />
+    </GetFileHash>
+
+    <Hash ItemsToHash="@(IntermediateFilesHashes->'%(FileHash)')">
+      <Output TaskParameter="HashResult" PropertyName="IntermediateFilesHash" />
+    </Hash>
+
+    <!-- CopiedFilesForHash Hashes -->
+    <GetFileHash Files="@(IntermediateResourceFilesForHash)">
+      <Output
+          TaskParameter="Items"
+          ItemName="IntermediateResourceFilesHashes" />
+    </GetFileHash>
+
+    <Hash ItemsToHash="@(IntermediateResourceFilesHashes->'%(FileHash)')">
+      <Output TaskParameter="HashResult" PropertyName="IntermediateResourceFilesHash" />
+    </Hash>
+
+    <!-- Update EmbeddedResources -->
+    <ItemGroup Condition="'$(IntermediateFilesHash)' != '$(IntermediateResourceFilesHash)'">
         <EmbeddedResource Remove="@(EmbeddedResource)"/>
         <EmbeddedResource Include="@(CopiedFiles)"/>
     </ItemGroup>
 
-    <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
-    <MakeDir Directories="$(IntermediateOutputPath)resources\" Condition="!Exists('$(IntermediateOutputPath)resources\')" />
-  </Target>
-
-  <Target Name="CopyVsixResources">
-    <Copy SourceFiles="@(CopyVsixResources)" DestinationFolder="$(IntermediateOutputPath)\resources\Resources" />
+    <Copy SourceFiles="@(CopyVsixResources)" DestinationFolder="$(IntermediateOutputPath)\resources\Resources" Condition="'$(IntermediateFilesHash)' != '$(IntermediateResourceFilesHash)'" />
   </Target>
 
 </Project>

--- a/eng/tests/UpToDate.ps1
+++ b/eng/tests/UpToDate.ps1
@@ -23,10 +23,19 @@ try {
     # gather assembly timestamps
     $ArtifactsBinDir = Join-Path $RepoRoot "artifacts" | Join-Path -ChildPath "bin" -Resolve
     $FSharpAssemblyDirs = Get-ChildItem -Path $ArtifactsBinDir -Filter "FSharp.*"
-    $FSharpAssemblyPaths = $FSharpAssemblyDirs | ForEach-Object { Get-ChildItem -Path (Join-Path $ArtifactsBinDir $_) -Recurse -Filter "$_.dll" } | ForEach-Object { $_.FullName }
+    $FscAssemblyDir = Get-ChildItem -Path $ArtifactsBinDir -Filter "fsc"
+    $FsiAssemblyDir = Get-ChildItem -Path $ArtifactsBinDir -Filter "fsi"
+    $FsiAnyCpuAssemblyDir = Get-ChildItem -Path $ArtifactsBinDir -Filter "fsiAnyCpu"
+    $DmAssemblyDir = Get-ChildItem -Path $ArtifactsBinDir -Filter "Microsoft.DotNet.DependencyManager"
+    $ProjectSystemAssemblyDirs = Get-ChildItem -Path $ArtifactsBinDir -Filter "ProjectSystem*"
+    $FSharpDirs = @($FSharpAssemblyDirs) + @($FscAssemblyDir) + @($FsiAssemblyDir) + @($FsiAnyCpuAssemblyDir) + @($DmAssemblyDir) + @($ProjectSystemAssemblyDirs)
+    $FSharpDllPaths = $FSharpDirs | ForEach-Object { Get-ChildItem -Path (Join-Path $ArtifactsBinDir $_) -Recurse -Filter "*.dll" } | ForEach-Object { $_.FullName }
+    $FSharpExePaths = $FSharpDirs | ForEach-Object { Get-ChildItem -Path (Join-Path $ArtifactsBinDir $_) -Recurse -Filter "*.exe" } | ForEach-Object { $_.FullName }
+    $FSharpAssemblyPaths = @($FSharpDllPaths) + @($FSharpExePaths)
 
     $InitialAssembliesAndTimes = @{}
     foreach ($asm in $FSharpAssemblyPaths) {
+        Write-Host "Assembly : $asm"
         $LastWriteTime = (Get-Item $asm).LastWriteTimeUtc
         $InitialAssembliesAndTimes.Add($asm, $LastWriteTime)
     }
@@ -53,6 +62,7 @@ try {
         $InitialTime = $InitialAssembliesAndTimes[$asm]
         $FinalTime = $FinalAssembliesAndTimes[$asm]
         if ($InitialTime -ne $FinalTime) {
+            Write-Host "Rebuilt assembly: $asm"
             $RecompiledFiles += $asm
         }
     }


### PR DESCRIPTION
1.   Parameterization of resources caused us to rebuild a few projects.
2.   The test that validated rebuild, didn't check all of the necessary files, and so missed the issue.

PR fixes the issue and the test.
