### PR TITLE
Update legacymsbuildreferenceresolver to support net48

### DIFF
--- a/src/fsharp/LegacyMSBuildReferenceResolver.fs
+++ b/src/fsharp/LegacyMSBuildReferenceResolver.fs
@@ -73,7 +73,10 @@ module LegacyMSBuildReferenceResolver
     [<Literal>]    
     let private Net472 = "v4.7.2"
 
-    let SupportedDesktopFrameworkVersions = [ Net472; Net471; Net47; Net462; Net461; Net46; Net452; Net451; Net45 ]
+    [<Literal>]    
+    let private Net48 = "v4.8"
+
+    let SupportedDesktopFrameworkVersions = [ Net48; Net472; Net471; Net47; Net462; Net461; Net46; Net452; Net451; Net45 ]
 
     /// Get the path to the .NET Framework implementation assemblies by using ToolLocationHelper.GetPathToDotNetFramework
     /// This is only used to specify the "last resort" path for assembly resolution.
@@ -90,6 +93,7 @@ module LegacyMSBuildReferenceResolver
             | Net47 -> Some TargetDotNetFrameworkVersion.Version47
             | Net471 -> Some TargetDotNetFrameworkVersion.Version471
             | Net472 -> Some TargetDotNetFrameworkVersion.Version472
+            | Net48 -> Some TargetDotNetFrameworkVersion.Version48
 #endif
             | _ -> assert false; None
         match v with
@@ -116,7 +120,8 @@ module LegacyMSBuildReferenceResolver
             try
 // The Mono build still uses an ancient version of msbuild from around Dev 14
 #if MSBUILD_AT_LEAST_15
-                if box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version472)) <> null then Net472
+                if box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version48)) <> null then Net48
+                elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version472)) <> null then Net472
                 elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version471)) <> null then Net471
                 elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version47)) <> null then Net47
                 elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version462)) <> null then Net462

--- a/src/utils/reshapedmsbuild.fs
+++ b/src/utils/reshapedmsbuild.fs
@@ -127,6 +127,7 @@ module internal ToolLocationHelper =
     let dotNetFrameworkVersion47  = Version(4, 7)
     let dotNetFrameworkVersion471 = Version(4, 7, 1)
     let dotNetFrameworkVersion472 = Version(4, 7, 2)
+    let dotNetFrameworkVersion48  = Version(4, 8)
 
     // visual studio versions.
     let visualStudioVersion100 = new Version(10, 0);
@@ -222,6 +223,7 @@ module internal ToolLocationHelper =
         | TargetDotNetFrameworkVersion.Version47 -> dotNetFrameworkVersion47
         | TargetDotNetFrameworkVersion.Version471 -> dotNetFrameworkVersion471
         | TargetDotNetFrameworkVersion.Version472 -> dotNetFrameworkVersion472
+        | TargetDotNetFrameworkVersion.Version48 -> dotNetFrameworkVersion48
         | _ -> raise (getArgumentException version)
 
     let complusInstallRoot = Environment.GetEnvironmentVariable("COMPLUS_INSTALLROOT")
@@ -765,6 +767,7 @@ module internal ToolLocationHelper =
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion47  visualStudioVersion150     // v4.7
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion471 visualStudioVersion150     // v4.7.1
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion472 visualStudioVersion150     // v4.7.2
+            CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion48  visualStudioVersion150     // v4.8
         |]
         array.ToDictionary<DotNetFrameworkSpec, Version>(fun spec -> spec.Version)
 

--- a/src/utils/reshapedmsbuild.fs
+++ b/src/utils/reshapedmsbuild.fs
@@ -93,7 +93,8 @@ module internal MsBuildAdapters =
     | Version47 = 11
     | Version471 = 12
     | Version472 = 13
-    | VersionLatest = 13  //TargetDotNetFrameworkVersion.Version472
+    | Version48 = 14
+    | VersionLatest = 14  //TargetDotNetFrameworkVersion.Version48
 
     /// <summary>
     /// Used to specify the targeted bitness of the .NET Framework for some methods of ToolLocationHelper


### PR DESCRIPTION
The LegacyMSBuildReferenceResolver, only went up to net472, this adds support for net46.

