### PR TITLE
Optimize reflection of F# types, part 2

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Reflection/FSharpReflection.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Reflection/FSharpReflection.fs
@@ -103,6 +103,14 @@ type FSharpValueTests() =
     let discStructUnionCaseB = DiscStructUnionType.B(1)
     let discStructUnionCaseC = DiscStructUnionType.C(1.0, "stringparam")
     
+    let optionSome = Some(3)
+    let optionNone: int option = None
+
+    let voptionSome = ValueSome("stringparam")
+    let voptionNone: string voption = ValueNone
+
+    let list1 = [ 1; 2 ]
+    let list2: int list = []
     
     let fsharpDelegate1 = new FSharpDelegate(fun (x:int) -> "delegate1")
     let fsharpDelegate2 = new FSharpDelegate(fun (x:int) -> "delegate2")
@@ -738,6 +746,24 @@ type FSharpValueTests() =
         let (discUnionInfo, discvaluearray) = FSharpValue.GetUnionFields(discUnionRecCaseB, typeof<DiscUnionType<int>>)
         let discUnionReader = FSharpValue.PreComputeUnionReader(discUnionInfo)    
         Assert.AreEqual(discUnionReader(box(discUnionRecCaseB)) , [| box 1; box(Some(discUnionCaseB)) |])
+
+        // Option
+        let (optionCaseInfo, _) = FSharpValue.GetUnionFields(optionSome, typeof<int option>)
+        let optionReader = FSharpValue.PreComputeUnionReader(optionCaseInfo)
+        Assert.AreEqual(optionReader(box(optionSome)), [| box 3 |])
+
+        let (optionCaseInfo, _) = FSharpValue.GetUnionFields(optionNone, typeof<int option>)
+        let optionReader = FSharpValue.PreComputeUnionReader(optionCaseInfo)
+        Assert.AreEqual(optionReader(box(optionNone)), [| |])
+
+        // List
+        let (listCaseInfo, _) = FSharpValue.GetUnionFields(list1, typeof<int list>)
+        let listReader = FSharpValue.PreComputeUnionReader(listCaseInfo)
+        Assert.AreEqual(listReader(box(list1)), [| box 1; box [ 2 ] |])
+
+        let (listCaseInfo, _) = FSharpValue.GetUnionFields(list2, typeof<int list>)
+        let listReader = FSharpValue.PreComputeUnionReader(listCaseInfo)
+        Assert.AreEqual(listReader(box(list2)), [| |])
         
     [<Test>]
     member __.PreComputeStructUnionReader() =
@@ -751,6 +777,15 @@ type FSharpValueTests() =
         let (discUnionInfo, discvaluearray) = FSharpValue.GetUnionFields(discStructUnionCaseB, typeof<DiscStructUnionType<int>>)
         let discUnionReader = FSharpValue.PreComputeUnionReader(discUnionInfo)    
         Assert.AreEqual(discUnionReader(box(discStructUnionCaseB)) , [| box 1|])
+
+        // Value Option
+        let (voptionCaseInfo, _) = FSharpValue.GetUnionFields(voptionSome, typeof<string voption>)
+        let voptionReader = FSharpValue.PreComputeUnionReader(voptionCaseInfo)
+        Assert.AreEqual(voptionReader(box(voptionSome)), [| box "stringparam" |])
+
+        let (voptionCaseInfo, _) = FSharpValue.GetUnionFields(voptionNone, typeof<string voption>)
+        let voptionReader = FSharpValue.PreComputeUnionReader(voptionCaseInfo)
+        Assert.AreEqual(voptionReader(box(voptionNone)), [| |])
         
     [<Test>]
     member __.PreComputeUnionTagMemberInfo() =
@@ -790,6 +825,16 @@ type FSharpValueTests() =
         // DiscUnion
         let discUnionTagReader = FSharpValue.PreComputeUnionTagReader(typeof<DiscUnionType<int>>) 
         Assert.AreEqual(discUnionTagReader(box(discUnionCaseB)), 1)
+
+        // Option
+        let optionTagReader = FSharpValue.PreComputeUnionTagReader(typeof<int option>)
+        Assert.AreEqual(optionTagReader(box(optionSome)), 1)
+        Assert.AreEqual(optionTagReader(box(optionNone)), 0)
+
+        // Value Option
+        let voptionTagReader = FSharpValue.PreComputeUnionTagReader(typeof<string voption>)
+        Assert.AreEqual(voptionTagReader(box(voptionSome)), 1)
+        Assert.AreEqual(voptionTagReader(box(voptionNone)), 0)
         
          // null value
         CheckThrowsArgumentException(fun () ->FSharpValue.PreComputeUnionTagReader(null)|> ignore)


### PR DESCRIPTION
Continuation of #9714.

- `PreComputeRecordConstructor`
- `PreComputeRecordFieldReader`
- `PreComputeRecordReader` - reworked from last time
- `PreComputeUnionConstructor`
- `PreComputeUnionReader`
- `PreComputeUnionTagReader`

`PreComputeTupleReader` and `PreComputeTupleConstructor` are a little more complicated, so perhaps another time.

The rest of the `PreCompute` family only return corresponding `System.Reflection.MethodBase` for further reflection use.

|                        Type |     Method |       Mean |      Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------- |----------- |-----------:|-----------:|----------:|-------:|------:|------:|----------:|
| PreComputeRecordConstructor | Reflection | 554.210 ns |  3.3056 ns | 3.0921 ns | 0.0134 |     - |     - |     112 B |
| PreComputeRecordConstructor |   Compiled |   9.999 ns |  0.0416 ns | 0.0389 ns | 0.0057 |     - |     - |      48 B |
|                             |            |            |            |           |        |       |       |           |
| PreComputeRecordFieldReader | Reflection | 112.941 ns |  1.9830 ns | 1.8549 ns | 0.0029 |     - |     - |      24 B |
| PreComputeRecordFieldReader |   Compiled |   3.431 ns |  0.1047 ns | 0.1120 ns | 0.0029 |     - |     - |      24 B |
|                             |            |            |            |           |        |       |       |           |
|      PreComputeRecordReader | Reflection | 562.094 ns | 10.2099 ns | 9.5503 ns | 0.0134 |     - |     - |     112 B |
|      PreComputeRecordReader |   Compiled |  22.212 ns |  0.2661 ns | 0.2489 ns | 0.0134 |     - |     - |     112 B |
|                             |            |            |            |           |        |       |       |           |
|  PreComputeUnionConstructor | Reflection | 473.935 ns |  5.1988 ns | 4.8629 ns | 0.0105 |     - |     - |      88 B |
|  PreComputeUnionConstructor |   Compiled |   7.737 ns |  0.0595 ns | 0.0497 ns | 0.0048 |     - |     - |      40 B |
|                             |            |            |            |           |        |       |       |           |
|       PreComputeUnionReader | Reflection | 318.424 ns |  4.2661 ns | 3.9905 ns | 0.0086 |     - |     - |      72 B |
|       PreComputeUnionReader |   Compiled |  13.706 ns |  0.3290 ns | 0.4822 ns | 0.0086 |     - |     - |      72 B |
|                             |            |            |            |           |        |       |       |           |
|    PreComputeUnionTagReader | Reflection | 373.670 ns |  2.4971 ns | 2.3358 ns | 0.0029 |     - |     - |      24 B |
|    PreComputeUnionTagReader |   Compiled |   6.567 ns |  0.1600 ns | 0.2136 ns |      - |     - |     - |         - |