### PR TITLE
Fix Equality comparison for `StringText` 

### DIFF
--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -53,6 +53,7 @@ type StringText(str: string) =
 
     override __.GetHashCode() = str.GetHashCode()
     override __.Equals(obj: obj) = str.Equals(obj)
+    override __.ToString() = str
 
     interface ISourceText with
 

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -52,7 +52,11 @@ type StringText(str: string) =
     member __.String = str
 
     override __.GetHashCode() = str.GetHashCode()
-    override __.Equals(obj: obj) = str.Equals(obj)
+    override __.Equals(obj: obj) = 
+        match obj with
+        | :? StringText as other -> other.String.Equals(str)
+        | :? string as other -> other.Equals(str)
+        | _ -> false        
     override __.ToString() = str
 
     interface ISourceText with


### PR DESCRIPTION
Fixes #9799 - equality comparison for `StringText` 

This being a container for a source string, while identical StringTexts will have the same `GetHashCode()`, it fails for equality testing because a StringText object is compared to the other's source text, which is always false.

The comparison to string behavior is retained.