### PR TITLE
remove version numbers from product details strings

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
@@ -464,10 +464,10 @@
     <value>Customizes the environment to maximize code editor screen space and improve the visibility of F# commands and tool windows.</value>
   </data>
   <data name="ProductDetails" xml:space="preserve">
-    <value>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</value>
+    <value>Microsoft Visual F# Tools</value>
   </data>
   <data name="9002" xml:space="preserve">
-    <value>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</value>
+    <value>Microsoft Visual F# Tools</value>
   </data>
   <data name="ProductID" xml:space="preserve">
     <value>1.0</value>
@@ -476,7 +476,7 @@
     <value>Microsoft Visual F# Tools</value>
   </data>
   <data name="9001" xml:space="preserve">
-    <value>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</value>
+    <value>Visual F# Tools</value>
   </data>
   <data name="9027" xml:space="preserve">
     <value>F# Interactive</value>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.cs.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.cs.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} pro F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Microsoft Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} pro F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Microsoft Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Visual F# Tools {{FSProductVersion}} pro F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="translated">Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.de.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.de.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} für F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Microsoft Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} für F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Microsoft Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Visual F# Tools {{FSProductVersion}} für F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="translated">Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.es.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.es.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Herramientas de Microsoft Visual F# {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Herramientas de Microsoft Visual F#</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Herramientas de Microsoft Visual F# {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Herramientas de Microsoft Visual F#</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Herramientas de Visual F# {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="translated">Herramientas de Visual F#</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.fr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.fr.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} pour F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Microsoft Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} pour F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Microsoft Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Visual F# Tools {{FSProductVersion}} pour F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="translated">Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.it.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.it.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} per F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Microsoft Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} per F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="translated">Microsoft Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Visual F# Tools {{FSProductVersion}} per F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="translated">Visual F# Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ja.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ja.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
+        <source>Microsoft Visual F# Tools</source>
         <target state="translated">F# {{FSLanguageVersion}} の Microsoft Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">F# {{FSLanguageVersion}} の Microsoft Visual F# Tools {{FSProductVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">F# {{FSLanguageVersion}} の Microsoft Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">F# {{FSLanguageVersion}} の Visual F# Tools {{FSProductVersion}} </target>
+        <source>Visual F# Tools</source>
+        <target state="needs-review-translation">F# {{FSLanguageVersion}} の Visual F# Tools {{FSProductVersion}} </target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ko.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ko.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">F# {{FSLanguageVersion}}용 Microsoft Visual F# Tools {{FSProductVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">F# {{FSLanguageVersion}}용 Microsoft Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">F# {{FSLanguageVersion}}용 Microsoft Visual F# Tools {{FSProductVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">F# {{FSLanguageVersion}}용 Microsoft Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">F# {{FSLanguageVersion}}용 Visual F# Tools {{FSProductVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="needs-review-translation">F# {{FSLanguageVersion}}용 Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pl.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pl.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} dla języka F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools {{FSProductVersion}} dla języka F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} dla języka F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools {{FSProductVersion}} dla języka F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Visual F# Tools {{FSProductVersion}} dla języka F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="needs-review-translation">Visual F# Tools {{FSProductVersion}} dla języka F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pt-BR.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pt-BR.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Visual F# Tools {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="needs-review-translation">Visual F# Tools {{FSProductVersion}} para F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ru.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ru.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} для F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools {{FSProductVersion}} для F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} для F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools {{FSProductVersion}} для F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Visual F# Tools {{FSProductVersion}} для F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="needs-review-translation">Visual F# Tools {{FSProductVersion}} для F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.tr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.tr.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">F# {{FSLanguageVersion}} için Microsoft Visual F# Tools {{FSProductVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">F# {{FSLanguageVersion}} için Microsoft Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">F# {{FSLanguageVersion}} için Microsoft Visual F# Tools {{FSProductVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">F# {{FSLanguageVersion}} için Microsoft Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">F# {{FSLanguageVersion}} için Visual F# Tools {{FSProductVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="needs-review-translation">F# {{FSLanguageVersion}} için Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hans.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="needs-review-translation">Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hant.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">適用於 F# {{FSLanguageVersion}} 的 Microsoft Visual F# Tools {{FSProductVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">適用於 F# {{FSLanguageVersion}} 的 Microsoft Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">適用於 F# {{FSLanguageVersion}} 的 Microsoft Visual F# Tools {{FSProductVersion}}</target>
+        <source>Microsoft Visual F# Tools</source>
+        <target state="needs-review-translation">適用於 F# {{FSLanguageVersion}} 的 Microsoft Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools {{FSProductVersion}} for F# {{FSLanguageVersion}}</source>
-        <target state="translated">適用於 F# {{FSLanguageVersion}} 的 Visual F# Tools {{FSProductVersion}}</target>
+        <source>Visual F# Tools</source>
+        <target state="needs-review-translation">適用於 F# {{FSLanguageVersion}} 的 Visual F# Tools {{FSProductVersion}}</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">


### PR DESCRIPTION
After #9770 the placeholder strings weren't getting replaced in Help -> About.  Given how important the no-rebuild scenario is and given that C#/VB doesn't include extra version numbers, the decision was made to remove them.  The result is this, where the `dev` portion of the version number will look similar to what's offered on the line above for VB:

![image](https://user-images.githubusercontent.com/926281/88599164-f74fff00-d01f-11ea-81b3-20723b1b20c3.png)
