### PR TITLE
Remove duplicate typeprovider target

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -95,13 +95,4 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     </ItemGroup>
   </Target>
-
-  <Target Name="CollectFSharpDesignTimeTools" BeforeTargets="BeforeCompile" DependsOnTargets="_GetFrameworkAssemblyReferences">
-    <ItemGroup>
-      <PropertyNames Include = "Pkg$([System.String]::Copy('%(PackageReference.FileName)').Replace('.','_'))" Condition = " '%(PackageReference.IsFSharpDesignTimeProvider)' == 'true' and '%(PackageReference.Extension)' == '' "/>
-      <PropertyNames Include = "Pkg$([System.String]::Copy('%(PackageReference.FileName)%(PackageReference.Extension)').Replace('.','_'))" Condition = " '%(PackageReference.IsFSharpDesignTimeProvider)' == 'true' and '%(PackageReference.Extension)' != '' "/>
-      <FscCompilerTools Include = "$(%(PropertyNames.Identity))" />
-    </ItemGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
The NetSdk.targets had a duplicate `CollectFSharpDesignTimeTools` target, and so now they don't.

The other, still-present target is at https://github.com/dotnet/fsharp/blob/4d1e14094ddee8aca9f017735363361b78d7dced/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets#L61-L67