### PR TITLE
Add implementation for -excludeCIBinaryLog

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -37,6 +37,7 @@ param (
     [string]$bootstrapConfiguration = "Proto",
     [string]$bootstrapTfm = "net472",
     [switch][Alias('bl')]$binaryLog,
+    [switch][Alias('nobl')]$excludeCIBinaryLog,
     [switch]$ci,
     [switch]$official,
     [switch]$procdump,
@@ -69,6 +70,7 @@ function Print-Usage() {
     Write-Host "  -verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
     Write-Host "  -deployExtensions         Deploy built vsixes"
     Write-Host "  -binaryLog                Create MSBuild binary log (short: -bl)"
+    Write-Host "  -excludeCIBinaryLog       When running on CI, allow no binary log (short: -nobl)"
     Write-Host ""
     Write-Host "Actions:"
     Write-Host "  -restore                  Restore packages (short: -r)"
@@ -173,7 +175,12 @@ function BuildSolution() {
 
     Write-Host "$($solution):"
 
+    if ($binaryLog -and $excludeCIBinaryLog) { 
+        Write-Host "Invalid argument -binarylog(-bl) and -excludeCIBinaryLog(-nobl) cannot be set at the same time"
+        ExitWithExitCode 1
+        }
     $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
+
     $projects = Join-Path $RepoRoot $solution
     $officialBuildId = if ($official) { $env:BUILD_BUILDNUMBER } else { "" }
     $toolsetBuildProj = InitializeToolset


### PR DESCRIPTION
Fixes #9814 -- Running tests with -ci requires -excludeCIBinarylog switch, which doesn't exist

In the build we verify that when we are running under the CI we specify production of a  binary log.  The -excludeCIBinarylog was intended to allow a developer who knew they didn't need a binary log when specifying -CI could specify that, which would allow us to skip production of the binaryLog.  However, the implementation for it disappeared or never materialized because "busyness".

This PR adds it in.
- switch
- help text
- error if combined with -binarylog






