### PR TITLE
Add stdout, stderr, exit code when running compiled test

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/MemberConstraints.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/MemberConstraints.fs
@@ -18,7 +18,7 @@ module MemberConstraints =
         |> withSingleDiagnostic (Error 697, Line 2, Col 43, Line 2, Col 76, "Invalid constraint")
 
     [<Fact>]
-    let ``we can overload operators on a type and not add all the extra jazz such as inlining and the ^ operator.``() =
+    let ``We can overload operators on a type and not add all the extra jazz such as inlining and the ^ operator.``() =
 
         FSharp """
 type Foo(x : int) =
@@ -40,8 +40,9 @@ elif y.Val <> 7 then  failwith "y.Val <> 7"
 elif x2.Val <> 7 then  failwith "x2.Val <> 7"
 elif y2.Val <> 7 then  failwith "x.Val <> 7"
 else ()
-        """
+"""
         |> asExe
         |> compile
         |> run
-        // OR |> compileAsExeAndRun
+        |> shouldSucceed
+        |> withExitCode 0

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -38,9 +38,10 @@
     <Compile Include="ErrorMessages\WrongSyntaxInForLoop.fs" />
     <Compile Include="ErrorMessages\ConfusingTypeName.fs" />
     <Compile Include="Language\CompilerDirectiveTests.fs" />
+    <Compile Include="Language\CodeQuotationTests.fs" />
     <Compile Include="ConstraintSolver\PrimitiveConstraints.fs" />
     <Compile Include="ConstraintSolver\MemberConstraints.fs" />
-    <Compile Include="Interop/SimpleInteropTests.fs" />
+    <Compile Include="Interop\SimpleInteropTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FSharp.Compiler.ComponentTests/Language/CodeQuotationTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CodeQuotationTests.fs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Compiler.UnitTests
+namespace FSharp.Compiler.Language.CodeQuatation
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test.Utilities.Compiler
 open FSharp.Quotations.Patterns
 
-[<TestFixture>]
 module CodeQuotationsTests =
 
-    [<Test>]
+    [<Fact>]
     let ``Quotation on op_UnaryPlus(~+) compiles and runs`` () =
         Fsx """
 open FSharp.Linq.RuntimeHelpers
@@ -39,5 +38,4 @@ let z : unit =
         |> asExe
         |> withOptions ["--langversion:preview"]
         |> compileAndRun
-        
-
+        |> shouldSucceed

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -42,7 +42,6 @@
     <Compile Include="Compiler\Warnings\PatternMatchingWarningTests.fs" />
     <Compile Include="Compiler\SourceTextTests.fs" />
     <Compile Include="Compiler\Language\WitnessTests.fs" />
-    <Compile Include="Compiler\Language\CodeQuotationTests.fs" />
     <Compile Include="Compiler\Language\CompilerDirectiveTests.fs" />
     <Compile Include="Compiler\Language\DefaultInterfaceMemberTests.fs" />
     <Compile Include="Compiler\Language\OptionalInteropTests.fs" />


### PR DESCRIPTION
Add standard output, standard error and error code, when running compiler tests via new test framework.

Related issues: https://github.com/dotnet/fsharp/issues/9798