### PR TITLE
Fix illegal XML doc in FSharp.Core

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -1126,7 +1126,7 @@ namespace Microsoft.FSharp.Core
         [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
         val RightShiftDynamic : value:'T1 -> shift:'T2 -> 'U
 
-        /// <summary>A compiler intrinsic that implements dynamic invocations to the '&&&' operator.</summary>
+        /// <summary>A compiler intrinsic that implements dynamic invocations to the '&amp;&amp;&amp;' operator.</summary>
         [<CompilerMessage("This function is for use by dynamic invocations of F# code and should not be used directly", 1204, IsHidden=true)>]
         [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
         val BitwiseAndDynamic : x:'T1 -> y:'T2 -> 'U


### PR DESCRIPTION
This fixes an illegal XML doc in FSharp.Core that can prevent FSharp.Core.xml loading into some tools

This may actually affect F# docs in Visual Studio, so is an important fix.

This is included in https://github.com/dotnet/fsharp/pull/9837, however we should accept this fix asap

We should also add a test that the FSHarp.Core.xml at least loads into a standard XML reader, I'll do that separately, I thought we had one but I can't find it.  The code was added in this https://github.com/dotnet/fsharp/commit/ed9b9b7df908bbc2b90e46de27dc05678a6d787a  about 2 months ago so I guess we don't have an active test for validity, and this hasn't yet been released into the wild

