### PR TITLE
Fix Package Scripting nuget package

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.fsproj
@@ -13,7 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <NuspecProperty Include="FSharpCoreVersion=$(FSCorePackageVersion)-$(VersionSuffix)" />
+    <NuspecProperty Include="FsharpCorePackageVersion=$(FSCorePackageVersion)" Condition="'$(VersionSuffix)'==''" />
+    <NuspecProperty Include="FsharpCorePackageVersion=$(FSCorePackageVersion)-$(VersionSuffix)" Condition="'$(VersionSuffix)'!=''" />
     <NuspecProperty Include="TargetFramework=$(TargetFramework)" />
   </ItemGroup>
 

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.nuspec
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.nuspec
@@ -5,13 +5,12 @@
         <language>en-US</language>
         <dependencies>
             <group targetFramework=".NETStandard2.0">
+                <dependency id="FSharp.Core" version="$FSharpCorePackageVersion$" />
             </group>
         </dependencies>
     </metadata>
     <files>
         $CommonFileElements$
-        <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Core.dll" target="lib\netstandard2.0" />
-        <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Core.xml" target="lib\netstandard2.0" />
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.Scripting.dll" target="lib\netstandard2.0" />
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.Scripting.xml" target="lib\netstandard2.0" />
         <file src="FSharp.Compiler.Private.Scripting\$Configuration$\$TargetFramework$\FSharp.Compiler.Private.dll" target="lib\netstandard2.0" />


### PR DESCRIPTION
FSharp.Compiler.Private.Scripting nuget package does not specify an FSharp.Core dependency.

This fixes that.