### PR TITLE
Add withPreview to compiler testing API

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Language/CodeQuotationTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CodeQuotationTests.fs
@@ -36,6 +36,6 @@ let z : unit =
         failwithf "did not expect expression for 'z': %A" e
         """
         |> asExe
-        |> withOptions ["--langversion:preview"]
+        |> withPreview
         |> compileAndRun
         |> shouldSucceed

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -176,6 +176,11 @@ module rec Compiler =
         | FS fs -> FS { fs with Options = options }
         | _ -> failwith "withOptions is only supported n F#"
 
+    let withPreview (cUnit: CompilationUnit) : CompilationUnit =
+        match cUnit with
+        | FS fs -> FS { fs with Options = [ "--langversion:preview" ] }
+        | _ -> failwith "withPreview is only supported in F#"
+
     let asLibrary (cUnit: CompilationUnit) : CompilationUnit =
         match cUnit with
         | FS fs -> FS { fs with OutputType = CompileOutput.Library }

--- a/tests/fsharp/Compiler/Language/WitnessTests.fs
+++ b/tests/fsharp/Compiler/Language/WitnessTests.fs
@@ -19,7 +19,7 @@ module WitnessTests =
         """ (dir ++ "provider.fsx"))
         |> asExe
         |> ignoreWarnings
-        |> withOptions ["--langversion:preview"]
+        |> withPreview
         |> compile
         |> shouldSucceed
         |> ignore


### PR DESCRIPTION
Added `withPreview` and replaced usages where `withOptions` was only used with the preview option.