### PR TITLE
Fix 'dotnet test' for xunit on netframework.

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -175,7 +175,7 @@ function BuildSolution() {
 
     Write-Host "$($solution):"
 
-    if ($binaryLog -and $excludeCIBinaryLog) { 
+    if ($binaryLog -and $excludeCIBinaryLog) {
         Write-Host "Invalid argument -binarylog(-bl) and -excludeCIBinaryLog(-nobl) cannot be set at the same time"
         ExitWithExitCode 1
         }
@@ -247,7 +247,7 @@ function VerifyAssemblyVersionsAndSymbols() {
     }
 }
 
-function TestUsingNUnit([string] $testProject, [string] $targetFramework) {
+function TestUsingNUnit([string] $testProject, [string] $targetFramework, [boolean] $noTestFilter = $false) {
     $dotnetPath = InitializeDotNetCli
     $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
     $projectName = [System.IO.Path]::GetFileNameWithoutExtension($testProject)
@@ -263,7 +263,7 @@ function TestUsingNUnit([string] $testProject, [string] $targetFramework) {
         $args += " --no-build"
     }
 
-    if ($env:RunningAsPullRequest -ne "true") {
+    if ($env:RunningAsPullRequest -ne "true" -and $noTestFilter -eq $false) {
         $args += " --filter TestCategory!=PullRequest"
     }
 
@@ -276,7 +276,7 @@ function BuildCompiler() {
         $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
         $fscProject = "$RepoRoot\src\fsharp\fsc\fsc.fsproj"
         $fsiProject = "$RepoRoot\src\fsharp\fsi\fsi.fsproj"
-        
+
         $argNoRestore = if ($norestore) { " --no-restore" } else { "" }
         $argNoIncremental = if ($rebuild) { " --no-incremental" } else { "" }
 
@@ -458,7 +458,7 @@ try {
     $coreclrTargetFramework = "netcoreapp3.1"
 
     if ($testDesktop -and -not $noVisualStudio) {
-        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.ComponentTests\FSharp.Compiler.ComponentTests.fsproj" -targetFramework $desktopTargetFramework
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.ComponentTests\FSharp.Compiler.ComponentTests.fsproj" -targetFramework $desktopTargetFramework -noTestFilter $true
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.Private.Scripting.UnitTests\FSharp.Compiler.Private.Scripting.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Build.UnitTests\FSharp.Build.UnitTests.fsproj" -targetFramework $desktopTargetFramework
@@ -467,7 +467,7 @@ try {
     }
 
     if ($testCoreClr) {
-        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.ComponentTests\FSharp.Compiler.ComponentTests.fsproj" -targetFramework $coreclrTargetFramework
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.ComponentTests\FSharp.Compiler.ComponentTests.fsproj" -targetFramework $coreclrTargetFramework -noTestFilter $true
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.Private.Scripting.UnitTests\FSharp.Compiler.Private.Scripting.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Build.UnitTests\FSharp.Build.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
@@ -505,10 +505,10 @@ try {
 
     if ($testCompiler) {
         if (-not $noVisualStudio) {
-            TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.ComponentTests\FSharp.Compiler.ComponentTests.fsproj" -targetFramework $desktopTargetFramework
+            TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.ComponentTests\FSharp.Compiler.ComponentTests.fsproj" -targetFramework $desktopTargetFramework -noTestFilter $true
             TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         }
-        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.ComponentTests\FSharp.Compiler.ComponentTests.fsproj" -targetFramework $coreclrTargetFramework
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.ComponentTests\FSharp.Compiler.ComponentTests.fsproj" -targetFramework $coreclrTargetFramework -noTestFilter $true
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
     }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -157,6 +157,7 @@ function TestUsingNUnit() {
   BuildMessage="Error running tests"
   testproject=""
   targetframework=""
+  notestfilter=0
   while [[ $# > 0 ]]; do
     opt="$(echo "$1" | awk '{print tolower($0)}')"
     case "$opt" in
@@ -166,6 +167,10 @@ function TestUsingNUnit() {
         ;;
       --targetframework)
         targetframework=$2
+        shift
+        ;;
+      --notestfilter)
+        notestfilter=$3
         shift
         ;;
       *)
@@ -182,7 +187,7 @@ function TestUsingNUnit() {
   fi
 
   filterArgs=""
-  if [[ "${RunningAsPullRequest:-}" != "true" ]]; then
+  if [[ "${RunningAsPullRequest:-}" != "true" && $notestfilter == 0 ]]; then
     filterArgs=" --filter TestCategory!=PullRequest"
   fi
 
@@ -294,7 +299,7 @@ BuildSolution
 
 if [[ "$test_core_clr" == true ]]; then
   coreclrtestframework=netcoreapp3.1
-  TestUsingNUnit --testproject "$repo_root/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj" --targetframework $coreclrtestframework
+  TestUsingNUnit --testproject "$repo_root/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj" --targetframework $coreclrtestframework --notestfilter 1
   TestUsingNUnit --testproject "$repo_root/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.UnitTests.fsproj" --targetframework $coreclrtestframework
   TestUsingNUnit --testproject "$repo_root/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj" --targetframework $coreclrtestframework
   TestUsingNUnit --testproject "$repo_root/tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj" --targetframework $coreclrtestframework

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -170,7 +170,7 @@ function TestUsingNUnit() {
         shift
         ;;
       --notestfilter)
-        notestfilter=$3
+        notestfilter=$2
         shift
         ;;
       *)

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="ErrorMessages\AccessOfTypeAbbreviationTests.fs" />
     <Compile Include="ErrorMessages\AssignmentErrorTests.fs" />
     <Compile Include="ErrorMessages\ClassesTests.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Interop/SimpleInteropTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Interop/SimpleInteropTests.fs
@@ -5,7 +5,7 @@ namespace FSharp.Compiler.ComponentTests.Interop
 open Xunit
 open FSharp.Test.Utilities.Compiler
 
-module ``C# <-> F# basic interop`` =
+module ``Simple interop verification`` =
 
     [<Fact>]
     let ``Instantiate C# type from F#`` () =
@@ -72,7 +72,6 @@ public class BicycleShop {
         |> compile
         |> shouldFail
 
-module ``C# <-> F# interop: fields`` =
     [<Fact>]
     let ``can't mutably set a C#-const field in F#`` () =
         let csLib =

--- a/tests/FSharp.Compiler.ComponentTests/xunit.runner.json
+++ b/tests/FSharp.Compiler.ComponentTests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "shadowCopy": false
+}

--- a/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.UnitTests.fsproj
@@ -12,7 +12,11 @@
     <NoWarn>$(NoWarn);3186;1104</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+	<ItemGroup>
+		<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
+
+	<ItemGroup>
     <Compile Include="CompilerTestHelpers.fs" />
     <Compile Include="ManglingNameOfProvidedTypes.fs" />
     <Compile Include="HashIfExpression.fs" />

--- a/tests/FSharp.Compiler.UnitTests/xunit.runner.json
+++ b/tests/FSharp.Compiler.UnitTests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "shadowCopy": false
+}

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -218,8 +218,8 @@ let config configurationName envVars =
     let artifactsPath = repoRoot ++ "artifacts"
     let artifactsBinPath = artifactsPath ++ "bin"
     let coreClrRuntimePackageVersion = "3.0.0-preview-27318-01"
-    let csc_flags = "/nologo" 
-    let vbc_flags = "/nologo" 
+    let csc_flags = "/nologo"
+    let vbc_flags = "/nologo"
     let fsc_flags = "-r:System.Core.dll --nowarn:20 --define:COMPILED"
     let fsi_flags = "-r:System.Core.dll --nowarn:20 --define:INTERACTIVE --maxerrors:1 --abortonerror"
     let operatingSystem = getOperatingSystem ()
@@ -236,7 +236,7 @@ let config configurationName envVars =
     let ILASM = requirePackage (("runtime." + operatingSystem + "-" + architectureMoniker + ".Microsoft.NETCore.ILAsm") ++ coreClrRuntimePackageVersion ++ "runtimes" ++ (operatingSystem + "-" + architectureMoniker) ++ "native" ++ ILASM_EXE)
     let CORECLR_DLL = if operatingSystem = "win" then "coreclr.dll" elif operatingSystem = "osx" then "libcoreclr.dylib" else "libcoreclr.so"
     let coreclrdll = requirePackage (("runtime." + operatingSystem + "-" + architectureMoniker + ".Microsoft.NETCore.Runtime.CoreCLR") ++ coreClrRuntimePackageVersion ++ "runtimes" ++ (operatingSystem + "-" + architectureMoniker) ++ "native" ++ CORECLR_DLL)
-    let PEVERIFY_EXE = if operatingSystem = "win" then "PEVerify.exe" else "PEVerify"
+    let PEVERIFY_EXE = if operatingSystem = "win" then "PEVerify.exe" elif operatingSystem = "osx" then "PEVerify.dll" else "PEVerify"
     let PEVERIFY = requireArtifact ("PEVerify" ++ configurationName ++ peverifyArchitecture ++ PEVERIFY_EXE)
 //    let FSI_FOR_SCRIPTS = artifactsBinPath ++ "fsi" ++ configurationName ++ fsiArchitecture ++ "fsi.exe"
     let FSharpBuild = requireArtifact ("FSharp.Build" ++ configurationName ++ fsharpBuildArchitecture ++ "FSharp.Build.dll")
@@ -275,7 +275,7 @@ let config configurationName envVars =
       ILASM = ILASM
       PEVERIFY = PEVERIFY
       VBC = VBC
-      CSC = CSC 
+      CSC = CSC
       BUILD_CONFIG = configurationName
       FSC = FSC
       FSI = FSI
@@ -286,10 +286,10 @@ let config configurationName envVars =
       FSharpBuild = FSharpBuild
       FSharpCompilerInteractiveSettings = FSharpCompilerInteractiveSettings
       csc_flags = csc_flags
-      fsc_flags = fsc_flags 
+      fsc_flags = fsc_flags
       fsi_flags = fsi_flags
       vbc_flags = vbc_flags
-      Directory="" 
+      Directory=""
       DotNetExe = dotNetExe
       DefaultPlatform = defaultPlatform }
 


### PR DESCRIPTION
* Fixed a xUnit problem when running tests on netfx with Strong Named assemblies: added a xunit.runner.json file to turn off Shadow Copying on those cases.
* Fixed netfx tests visibility in VS Test Explorer.
* Increased timeout when we generate references in CompilerAssert, since it was taking a bit longer on the netframework for some reason.
* Removed "TestCategory" filter from component tests, since xUnit does not understand it. It's more of a temp workaround, as a long-term solution, we need to move tests to xUnit and use its "Trait" attribute with the category.