### PR TITLE
Fix showing pars.fs, lex.fs output in solution view, fix auto-generating FsLex/FsYacc output on change, add fsl and fsy to solution view

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -351,10 +351,10 @@
       <Link>ParserAndUntypedAST\ParseHelpers.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pppars.fs">
-      <Link>$(FsYaccOutputFolder)ParserAndUntypedAST\pppars.fs</Link>
+      <Link>ParserAndUntypedAST\pppars.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pars.fs">
-      <Link>$(FsYaccOutputFolder)ParserAndUntypedAST\pars.fs</Link>
+      <Link>ParserAndUntypedAST\pars.fs</Link>
     </Compile>
     <Compile Include="..\lexhelp.fsi">
       <Link>ParserAndUntypedAST\lexhelp.fsi</Link>
@@ -363,10 +363,10 @@
       <Link>ParserAndUntypedAST\lexhelp.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pplex.fs">
-      <Link>$(FsYaccOutputFolder)ParserAndUntypedAST\pplex.fs</Link>
+      <Link>ParserAndUntypedAST\pplex.fs</Link>
     </Compile>
-    <Compile Include="$(FsYaccOutputFolder)lex.fs">
-      <Link>$(FsYaccOutputFolder)ParserAndUntypedAST\lex.fs</Link>
+    <Compile Include="$(FsYaccOutputFolder)\lex.fs">
+      <Link>ParserAndUntypedAST\lex.fs</Link>
     </Compile>
     <Compile Include="..\LexFilter.fs">
       <Link>ParserAndUntypedAST\LexFilter.fs</Link>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -242,10 +242,10 @@
       <Link>AbsIL\ilsupp.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)ilpars.fs">
-      <Link>$(FsYaccOutputFolder)AbsIL\ilpars.fs</Link>
+      <Link>AbsIL\ilpars.fs</Link>
     </Compile>
     <Compile Include="$(FsLexOutputFolder)illex.fs">
-      <Link>$(FsLexOutputFolder)AbsIL\illex.fs</Link>
+      <Link>AbsIL\illex.fs</Link>
     </Compile>
     <Compile Include="..\..\absil\ilbinary.fsi">
       <Link>AbsIL\ilbinary.fsi</Link>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -220,6 +220,12 @@
     <Compile Include="..\..\absil\ilascii.fs">
       <Link>AbsIL\ilascii.fs</Link>
     </Compile>
+    <Compile Include="$(FsYaccOutputFolder)ilpars.fs">
+      <Link>AbsIL\FsYaccOut\ilpars.fs</Link>
+    </Compile>
+    <Compile Include="$(FsLexOutputFolder)illex.fs">
+      <Link>AbsIL\FsLexOut\illex.fs</Link>
+    </Compile>
     <Compile Include="..\..\absil\ilprint.fsi">
       <Link>AbsIL\ilprint.fsi</Link>
     </Compile>
@@ -246,12 +252,6 @@
     </Compile>
     <Compile Include="..\..\absil\ilsupp.fs">
       <Link>AbsIL\ilsupp.fs</Link>
-    </Compile>
-    <Compile Include="$(FsYaccOutputFolder)ilpars.fs">
-      <Link>AbsIL\ilpars.fs</Link>
-    </Compile>
-    <Compile Include="$(FsLexOutputFolder)illex.fs">
-      <Link>AbsIL\illex.fs</Link>
     </Compile>
     <Compile Include="..\..\absil\ilbinary.fsi">
       <Link>AbsIL\ilbinary.fsi</Link>
@@ -369,10 +369,10 @@
       <Link>ParserAndUntypedAST\ParseHelpers.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pppars.fs">
-      <Link>ParserAndUntypedAST\FsYaccOut\pppars.fs</Link>
+      <Link>ParserAndUntypedAST\FsYaccOutput\pppars.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pars.fs">
-      <Link>ParserAndUntypedAST\FsYaccOut\pars.fs</Link>
+      <Link>ParserAndUntypedAST\FsYaccOutput\pars.fs</Link>
     </Compile>
     <Compile Include="..\lexhelp.fsi">
       <Link>ParserAndUntypedAST\lexhelp.fsi</Link>
@@ -381,10 +381,10 @@
       <Link>ParserAndUntypedAST\lexhelp.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pplex.fs">
-      <Link>ParserAndUntypedAST\FsLexOut\pplex.fs</Link>
+      <Link>ParserAndUntypedAST\FsLexOutput\pplex.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)\lex.fs">
-      <Link>ParserAndUntypedAST\FsLexOut\lex.fs</Link>
+      <Link>ParserAndUntypedAST\FsLexOutput\lex.fs</Link>
     </Compile>
     <Compile Include="..\LexFilter.fs">
       <Link>ParserAndUntypedAST\LexFilter.fs</Link>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -192,10 +192,16 @@
       <OtherFlags>--unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
       <Link>AbsIL\illex.fsl</Link>
     </FsLex>
+    <None Include="..\..\absil\illex.fsl">
+      <Link>AbsIL\FsLex\illex.fsl</Link>
+    </None>
     <FsYacc Include="..\..\absil\ilpars.fsy">
       <OtherFlags>--module FSharp.Compiler.AbstractIL.Internal.AsciiParser --open FSharp.Compiler.AbstractIL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
       <Link>AbsIL\ilpars.fsy</Link>
     </FsYacc>
+    <None Include="..\..\absil\ilpars.fsy">
+      <Link>AbsIL\FsYacc\ilpars.fsy</Link>
+    </None>
     <Compile Include="..\..\absil\il.fsi">
       <Link>AbsIL\il.fsi</Link>
     </Compile>
@@ -326,6 +332,18 @@
       <OtherFlags>--module FSharp.Compiler.Parser --open FSharp.Compiler --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
       <Link>ParserAndUntypedAST\pars.fsy</Link>
     </FsYacc>
+    <None Include="..\pplex.fsl">
+      <Link>ParserAndUntypedAST\FsLex\pplex.fsl</Link>
+    </None>
+    <None Include="..\lex.fsl">
+      <Link>ParserAndUntypedAST\FsLex\lex.fsl</Link>
+    </None>
+    <None Include="..\pppars.fsy">
+      <Link>ParserAndUntypedAST\FsYacc\pppars.fsy</Link>
+    </None>
+    <None Include="..\pars.fsy">
+      <Link>ParserAndUntypedAST\FsYacc\pars.fsy</Link>
+    </None>
     <Compile Include="..\UnicodeLexing.fsi">
       <Link>ParserAndUntypedAST\UnicodeLexing.fsi</Link>
     </Compile>
@@ -351,10 +369,10 @@
       <Link>ParserAndUntypedAST\ParseHelpers.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pppars.fs">
-      <Link>ParserAndUntypedAST\pppars.fs</Link>
+      <Link>ParserAndUntypedAST\FsYaccOut\pppars.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pars.fs">
-      <Link>ParserAndUntypedAST\pars.fs</Link>
+      <Link>ParserAndUntypedAST\FsYaccOut\pars.fs</Link>
     </Compile>
     <Compile Include="..\lexhelp.fsi">
       <Link>ParserAndUntypedAST\lexhelp.fsi</Link>
@@ -363,10 +381,10 @@
       <Link>ParserAndUntypedAST\lexhelp.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pplex.fs">
-      <Link>ParserAndUntypedAST\pplex.fs</Link>
+      <Link>ParserAndUntypedAST\FsLexOut\pplex.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)\lex.fs">
-      <Link>ParserAndUntypedAST\lex.fs</Link>
+      <Link>ParserAndUntypedAST\FsLexOut\lex.fs</Link>
     </Compile>
     <Compile Include="..\LexFilter.fs">
       <Link>ParserAndUntypedAST\LexFilter.fs</Link>


### PR DESCRIPTION
Fixes #9919
Also fixes #9920

This fixes an issue partially caused by #9877, partially already present prior to that, which hid certain linked files because the `<Link>` element in `fsproj` didn't point to the solution folder, but to the source folder where the linked file came from.

Also fixes the somewhat annoying situation that when you change an `fsl` or `fsy` file, it doesn't get compiled. I've taken the liberty of slightly changing the link-structure (physical structure remains the same). By adding `<None Include` for those files, Visual Studio tracks them and MSBuild builds them.

Before (and after #9877):
![image](https://user-images.githubusercontent.com/16015770/89889747-77569700-dbd2-11ea-9829-c177d7d6a412.png)

After this change:
![image](https://user-images.githubusercontent.com/16015770/89907552-1daf9600-dbed-11ea-806b-3702f630f07e.png)


_(note: I wanted to place the `*.fsl/fsy` input/output closer together, but the FsYacc and FsLex build tasks prevent this from happening. I.e., try moving `UnicodeLexing.fsi` up: you can't. I think this is the next best thing, let me know what you think ;) )._

Build now clearly shows that FsYacc (or FsLex) is run:
![image](https://user-images.githubusercontent.com/16015770/89896213-5e071800-dbdd-11ea-9dac-4796d3cb377d.png)
