### PR TITLE
Fix 'open type' on generic unions and records

### DIFF
--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -137,7 +137,7 @@ val (|ItemWithInst|) : ItemWithInst -> Item * TyparInst
 val ItemWithNoInst : Item -> ItemWithInst
 
 /// Represents a record field resolution and the information if the usage is deprecated.
-type FieldResolution = FieldResolution of RecdFieldRef * bool
+type FieldResolution = FieldResolution of RecdFieldInfo * bool
 
 /// Information about an extension member held in the name resolution environment
 type ExtensionMember =
@@ -180,6 +180,9 @@ type NameResolutionEnv =
       /// by label rather than by known type annotation. 
       /// Bools indicate if from a record, where no warning is given on indeterminate lookup 
       eFieldLabels: NameMultiMap<RecdFieldRef>
+
+      /// RecdField labels that may have type instantiations associated with it.
+      eFieldLabelTypeInsts: TyconRefMap<TypeInst>
 
       /// Tycons indexed by the various names that may be used to access them, e.g. 
       ///     "List" --> multiple TyconRef's for the various tycons accessible by this name. 
@@ -510,7 +513,7 @@ exception internal IndeterminateType of range
 exception internal UpperCaseIdentifierInPattern of range
 
 /// Generate a new reference to a record field with a fresh type instantiation
-val FreshenRecdFieldRef :NameResolver -> Range.range -> RecdFieldRef -> Item
+val FreshenRecdFieldRef :NameResolver -> Range.range -> RecdFieldRef -> RecdFieldInfo
 
 /// Indicates the kind of lookup being performed. Note, this type should be made private to nameres.fs.
 [<RequireQualifiedAccess>]

--- a/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
+++ b/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
@@ -994,7 +994,7 @@ module Test2 =
         |> shouldSucceed
         |> ignore
 
-    [<Test;Ignore("https://github.com/dotnet/fsharp/issues/9914")>]
+    [<Test>]
     let ``Open generic union should have access to union cases with the enclosing type instantiations`` () =
         FSharp """
 namespace FSharpTest
@@ -1017,7 +1017,7 @@ module Test2 =
         """
         |> withOptions ["--langversion:preview"]
         |> compile
-        |> shouldFail
+        |> withErrorCode 1
         |> ignore
 
     [<Test>]

--- a/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
+++ b/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
@@ -1021,6 +1021,29 @@ module Test2 =
         |> ignore
 
     [<Test>]
+    let ``Open generic union should have access to pattern union cases with the enclosing type instantiations`` () =
+        FSharp """
+namespace FSharpTest
+
+module Test =
+
+    type TestUnion<'T> =
+        | UCase1 of 'T
+
+open type Test.TestUnion<int>
+
+module Test2 =
+
+    let f x : string =
+        match x with
+        | UCase1 x -> x
+        """
+        |> withOptions ["--langversion:preview"]
+        |> compile
+        |> withErrorCode 1
+        |> ignore
+
+    [<Test>]
     let ``Open record should have access to construct record via labels`` () =
         FSharp """
 namespace FSharpTest
@@ -1044,7 +1067,7 @@ module Test2 =
         |> shouldSucceed
         |> ignore
 
-    [<Test;Ignore("https://github.com/dotnet/fsharp/issues/9914")>]
+    [<Test>]
     let ``Open generic record should have access to construct record via labels with enclosing type instantiations`` () =
         FSharp """
 namespace FSharpTest
@@ -1055,9 +1078,15 @@ module Test =
 
         static member M() = ()
 
-open type Test.TestRecord<int>
+open Test
 
 module Test2 =
+
+    let x = { X = "" }
+
+open type Test.TestRecord<int>
+
+module Test3 =
 
     let x = { X = "" }
 
@@ -1065,7 +1094,37 @@ module Test2 =
         """
         |> withOptions ["--langversion:preview"]
         |> compile
-        |> shouldFail
+        |> withErrorCode 1
+        |> ignore
+
+    [<Test>]
+    let ``Open generic record should have access to pattern record via labels with enclosing type instantiations`` () =
+        FSharp """
+namespace FSharpTest
+
+module Test =
+
+    type TestRecord<'T> = { X: 'T }
+
+open Test
+
+module Test2 =
+
+    let f x : string =
+        match x with
+        | { X = x } -> x
+
+open type Test.TestRecord<int>
+
+module Test3 =
+
+    let f x : string =
+        match x with
+        | { X = x } -> x
+        """
+        |> withOptions ["--langversion:preview"]
+        |> compile
+        |> withErrorCode 1
         |> ignore
 
     [<Test>]


### PR DESCRIPTION
Resolves https://github.com/dotnet/fsharp/issues/9914

The fix for unions and records are different from each other. Union cases are stored in the unqualified items table, while record labels have their own table. 

The best way to handle record labels was adding a new field to name resolution to lookup the type instantiations based on `TyconRef`.