### PR TITLE
Embed source generated by the build in portable pdbs

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -62,8 +62,9 @@
 
     <!-- Make sure it will get cleaned  -->
     <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)buildproperties.fs" />
       <CompileBefore Include="$(IntermediateOutputPath)buildproperties.fs" />
+      <FsGeneratedSource Include="$(IntermediateOutputPath)buildproperties.fs" />
+      <FileWrites Include="$(IntermediateOutputPath)buildproperties.fs" />
     </ItemGroup>
   </Target>
 

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -572,9 +572,7 @@ try {
             Write-Host "Already installed is not a problem"
         }
 
-        $nupkgs =  @(Get-ChildItem "$artifactsDir\packages\$configuration\PreRelease\*.nupkg" -recurse)
-        $nupkgs += @(Get-ChildItem "$artifactsDir\packages\$configuration\Release\*.nupkg" -recurse)
-        $nupkgs += @(Get-ChildItem "$artifactsDir\packages\$configuration\Shipping\*.nupkg" -recurse)
+        $nupkgs = @(Get-ChildItem "$artifactsDir\packages\$configuration\Shipping\*.nupkg" -recurse)
         $nupkgs | Foreach {
             Exec-Console "$dotnetPath\sourcelink.exe" "test ""$_"""
             if (-not $?) { $nupkgtestFailed = $true}

--- a/fcs/Directory.Build.targets
+++ b/fcs/Directory.Build.targets
@@ -50,6 +50,7 @@
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)$(ProjectName).BuildProperties.fs" />
       <CompileBefore Include="$(IntermediateOutputPath)$(ProjectName).BuildProperties.fs" />
+      <FsGeneratedSource Include="$(IntermediateOutputPath)$(ProjectName).BuildProperties.fs" />
     </ItemGroup>
   </Target>
 

--- a/src/buildtools/buildtools.targets
+++ b/src/buildtools/buildtools.targets
@@ -31,6 +31,7 @@
 
     <!-- Make sure it will get cleaned -->
     <CreateItem Include="$(FsLexOutputFolder)%(FsLex.Filename).fs">
+      <Output TaskParameter="Include" ItemName="FsGeneratedSource"/>
       <Output TaskParameter="Include" ItemName="FileWrites"/>
     </CreateItem>
   </Target>
@@ -54,6 +55,7 @@
 
     <!-- Make sure it will get cleaned -->
     <CreateItem Include="$(FsYaccOutputFolder)%(FsYacc.Filename).fs">
+      <Output TaskParameter="Include" ItemName="FsGeneratedSource"/>
       <Output TaskParameter="Include" ItemName="FileWrites"/>
     </CreateItem>
   </Target>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Overrides.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Overrides.NetSdk.targets
@@ -29,6 +29,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <WriteCodeFragment AssemblyAttributes="@(AssemblyAttribute)" Language="$(Language)" OutputFile="$(GeneratedAssemblyInfoFile)">
       <Output TaskParameter="OutputFile" ItemName="CompileBefore" />
+      <Output TaskParameter="OutputFile" ItemName="FsGeneratedSource" />
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
   </Target>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -187,6 +187,7 @@ this file.
 
         <ItemGroup>
             <CompileBefore Include="@(_FsGeneratedResXSource)" />
+            <FsGeneratedSource Include="@(_FsGeneratedResXSource)" />
             <FileWrites Include="@(_FsGeneratedResXSource)" />
         </ItemGroup>
 
@@ -198,11 +199,11 @@ this file.
 
         <ItemGroup>
             <CompileBefore Include="@(_FsGeneratedTxtSource)" />
+            <FsGeneratedSource Include="@(_FsGeneratedTxtSource)" />
             <EmbeddedResource Include="@(_FsGeneratedResx)" />
             <FileWrites Include="@(_FsGeneratedTxtSource)" />
             <FileWrites Include="@(_FsGeneratedResx)" />
         </ItemGroup>
-
     </Target>
 
     <Target
@@ -266,6 +267,7 @@ this file.
 
         <ItemGroup>
             <EmbeddedFiles Include="@(Embed)" KeepDuplicates="false" />
+            <EmbeddedFiles Include="@(FsGeneratedSource)"  KeepDuplicates="false" Condition="'$(SourceLink)'!='' or '$(EmbeddedFiles)'!='' or '$(EmbedAllSources)'!=''" />
         </ItemGroup>
 
         <!-- Dotnet SDK requires SimpleResolution to be true Legacy project system build not -->
@@ -412,10 +414,10 @@ this file.
             ContinueOnError="true"
             Overwrite="true"/>
 
-        <ItemGroup>
-            <CompileBefore Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" Condition="'$(AdditionalSourcesText)' != ''"/>
+        <ItemGroup Condition="'$(AdditionalSourcesText)' != ''">
+            <CompileBefore Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
+            <_FsGeneratedTfmAttributesSource Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
         </ItemGroup>
-
     </Target>
 
     <!--

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <FsYaccOutputFolder>$(IntermediateOutputPath)$(TargetFramework)/</FsYaccOutputFolder>
-    <FsLexOutputFolder>$(IntermediateOutputPath)$(TargetFramework)/</FsLexOutputFolder>
+    <FsYaccOutputFolder>$(IntermediateOutputPath)$(TargetFramework)\</FsYaccOutputFolder>
+    <FsLexOutputFolder>$(IntermediateOutputPath)$(TargetFramework)\</FsLexOutputFolder>
   </PropertyGroup>
 
   <Target Name="CopyToBuiltBin" BeforeTargets="BuiltProjectOutputGroup" AfterTargets="CoreCompile">

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -14,8 +14,8 @@
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
     <NGenBinary>true</NGenBinary>
 
-    <FsYaccOutputFolder>$(IntermediateOutputPath)$(TargetFramework)/</FsYaccOutputFolder>
-    <FsLexOutputFolder>$(IntermediateOutputPath)$(TargetFramework)/</FsLexOutputFolder>
+    <FsYaccOutputFolder>$(IntermediateOutputPath)$(TargetFramework)\</FsYaccOutputFolder>
+    <FsLexOutputFolder>$(IntermediateOutputPath)$(TargetFramework)\</FsLexOutputFolder>
 
     <PackageId>FSharp.Compiler.Service</PackageId>
     <NuspecFile>FSharp.Compiler.Service.nuspec</NuspecFile>


### PR DESCRIPTION
When we generate nuget packages we have added sourcelinks to source files stored on github, however the build generates some source files, and those files were not available for debugging.

This change updates the build to ensure that generated source files are added into the portable pdbs.

And runs sourcelink test to verify the nuget packages we generate.

Fixes: https://github.com/dotnet/fsharp/issues/9937
/cc @baronfel 