### PR TITLE
Fix tool path

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -565,8 +565,11 @@ try {
         # Fetch soucelink test
         $dotnetPath = InitializeDotNetCli
         $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
+        $dotnettoolsPath = Join-Path $RepoRoot "\.tools\"
+        $sourcelink = Join-Path $dotnettoolsPath "sourcelink.exe"
         try {
-            Exec-Console $dotnetExe "tool install sourcelink --tool-path ""$dotnetPath"""
+            $out = New-Item -Path $dotnettoolsPath -ItemType Directory -Force
+            Exec-Console $dotnetExe "tool install sourcelink --tool-path $dotnettoolsPath"
         }
         catch {
             Write-Host "Already installed is not a problem"
@@ -574,7 +577,7 @@ try {
 
         $nupkgs = @(Get-ChildItem "$artifactsDir\packages\$configuration\Shipping\*.nupkg" -recurse)
         $nupkgs | Foreach {
-            Exec-Console "$dotnetPath\sourcelink.exe" "test ""$_"""
+            Exec-Console """$sourcelink"" test ""$_"""
             if (-not $?) { $nupkgtestFailed = $true}
         }
     }


### PR DESCRIPTION
The recent embed PR, found a way to add files into the program files directory.  Which requires admin rights.  
And was a silly thing to do anyway.

This pr fixes that by installing the sourcelink tool to the .tools subdirectory of the repo.

