### PR TITLE
Fix 7734: Strings with line continuations giving incorrect locations 

### DIFF
--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -560,9 +560,8 @@ and convTypeAux cenv emEnv preferCreated ty =
         let baseT = convTypeAux cenv emEnv preferCreated eltType
         baseT.MakeByRefType()
     | ILType.TypeVar tv -> envGetTyvar emEnv tv
-    // Consider completing the following cases:                                                      
     | ILType.Modified (_, _, modifiedTy) -> 
-        // Note, "modreq" are not being emitted. This is 
+        
         convTypeAux cenv emEnv preferCreated modifiedTy
 
     | ILType.FunctionPointer _callsig -> failwith "convType: fptr"

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -1069,6 +1069,9 @@ and singleQuoteString sargs skip = parse
  |  '\\' newline anywhite* 
     { let (_buf, _fin, m, kind, args) = sargs 
       newline lexbuf 
+      let text = lexeme lexbuf
+      let text2 = text |> String.filter (fun c -> c <> ' ' && c <> '\t')
+      advanceColumnBy lexbuf (text.Length - text2.Length)
       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.SingleQuote, kind, m))
       else singleQuoteString sargs skip lexbuf }
 

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -170,6 +170,9 @@ let stringBufferIsBytes (buf: ByteBuffer) =
 let newline (lexbuf:LexBuffer<_>) = 
     lexbuf.EndPos <- lexbuf.EndPos.NextLine
 
+let advanceColumnBy (lexbuf:LexBuffer<_>) n = 
+    lexbuf.EndPos <- lexbuf.EndPos.ShiftColumnBy(n)
+
 let trigraph c1 c2 c3 =
     let digit (c:char) = int c - int '0' 
     char (digit c1 * 100 + digit c2 * 10 + digit c3)

--- a/src/fsharp/lexhelp.fsi
+++ b/src/fsharp/lexhelp.fsi
@@ -75,6 +75,8 @@ val stringBufferIsBytes: ByteBuffer -> bool
 
 val newline: Lexing.LexBuffer<'a> -> unit
 
+val advanceColumnBy: Lexing.LexBuffer<'a> -> n: int -> unit
+
 val trigraph: char -> char -> char -> char
 
 val digit: char -> int32

--- a/tests/fsharp/Compiler/Language/StringInterpolation.fs
+++ b/tests/fsharp/Compiler/Language/StringInterpolation.fs
@@ -853,3 +853,11 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
             code
             [|(FSharpErrorSeverity.Error, 3383, (1, 14, 1, 17),
                "A '}' character must be escaped (by doubling) in an interpolated string.")|]
+
+    [<Test>]
+    let ``String continuation character gives right ranges`` () =
+        let code = "let x1 = \"hello \\\n     world\", foo"
+        CompilerAssert.TypeCheckWithErrorsAndOptions  [| |]
+            code
+            [|(FSharpErrorSeverity.Error, 39, (2, 14, 2, 17),
+               "The value or constructor 'foo' is not defined. Maybe you want one of the following:\n   floor")|]


### PR DESCRIPTION
This is a tenative fix for #7734 

Testing needs to be added.  I'll add that sometime soon if no one gets to it first (@abelbraaksma you might want to give it a shot?)

Command line example showing the corrected ranges:

```
let multiLineString = 
    "hello \
        world", foo
```

comparing:
```
>fsc.exe a.fs --vserrors
Microsoft (R) F# Compiler version 10.9.1.0 for F# 4.7
Copyright (c) Microsoft Corporation. All Rights Reserved.

a.fs(3,6,3,9): typecheck error FS0039: The value or constructor 'foo' is not defined. ...

>artifacts\bin\fsc\Debug\net472\fsc.exe a.fs --vserrors
Microsoft (R) F# Compiler version 11.0.0.0 for F# 5.0
Copyright (c) Microsoft Corporation. All Rights Reserved.

a.fs(3,14,3,17): typecheck error FS0039: The value or constructor 'foo' is not defined. ...

```
And editor tooling:

![image](https://user-images.githubusercontent.com/7204669/91202215-612ff700-e6f9-11ea-8867-9e26d0ec80db.png)

![image](https://user-images.githubusercontent.com/7204669/91202282-7c026b80-e6f9-11ea-89d9-9cc8c68dd14f.png)
