### PR TITLE
auto-complete vs insertions if not going to a release branch

### DIFF
--- a/eng/release/insert-into-vs.yml
+++ b/eng/release/insert-into-vs.yml
@@ -52,5 +52,7 @@ stages:
     - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@3
       displayName: 'Insert VS Payload'
       inputs:
+        # only auto-complete if the target branch is not `rel/*`
+        AutoCompletePR: ${{ not(contains(parameters.insertTargetBranch, 'rel/')) }}
         LinkWorkItemsToPR: false
       condition: and(succeeded(), eq(variables['Build.SourceBranch'], '${{ parameters.componentBranchName }}'))


### PR DESCRIPTION
The behavior of this is to set the auto-complete annotation if the build is _not_ getting inserted into a `rel/*` branch, with the result being that our normal insertions to VS `main` will be merged without any interaction from us, and the normal daily testing will catch any possible issues.

When we branch closer to release and insertions move to a `rel/*` branch, the auto-complete won't be enabled because at that point we want to manually verify what we're doing.

I added temporary commits and verified the resultant PR had the auto-complete annotation when inserting into VS `main`, but not when inserting into `rel/d16.8`.