### PR TITLE
Emitting IsReadOnlyAttribute on return arguments of type inref<_>

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -1054,7 +1054,7 @@ let GetMethodSpecForMemberVal amap g (memberInfo: ValMemberInfo) (vref: ValRef) 
                 let nmW = ExtraWitnessMethodName nm
                 mkILInstanceMethSpecInTy (ilTy, nmW, ilWitnessArgTys @ ilMethodArgTys, ilActualRetTy, ilMethodInst)
     
-        mspec, mspecW, ctps, mtps, curriedArgInfos, paramInfos, retInfo, witnessInfos, methodArgTys
+        mspec, mspecW, ctps, mtps, curriedArgInfos, paramInfos, retInfo, witnessInfos, methodArgTys, returnTy
     else
         let methodArgTys, paramInfos = List.unzip flatArgInfos
         let ilMethodArgTys = GenParamTypes amap m tyenvUnderTypars false methodArgTys
@@ -1068,7 +1068,7 @@ let GetMethodSpecForMemberVal amap g (memberInfo: ValMemberInfo) (vref: ValRef) 
                 let nmW = ExtraWitnessMethodName nm
                 mkILStaticMethSpecInTy (ilTy, nmW, ilWitnessArgTys @ ilMethodArgTys, ilActualRetTy, ilMethodInst)
     
-        mspec, mspecW, ctps, mtps, curriedArgInfos, paramInfos, retInfo, witnessInfos, methodArgTys
+        mspec, mspecW, ctps, mtps, curriedArgInfos, paramInfos, retInfo, witnessInfos, methodArgTys, returnTy
 
 /// Determine how a top-level value is represented, when representing as a field, by computing an ILFieldSpec
 let ComputeFieldSpecForVal(optIntraAssemblyInfo: IlxGenIntraAssemblyInfo option, isInteractive, g, ilTyForProperty, vspec: Val, nm, m, cloc, ilTy, ilGetterMethRef) =
@@ -1105,7 +1105,7 @@ let ComputeStorageForFSharpValue amap (g:TcGlobals) cloc optIntraAssemblyInfo op
 
 /// Compute the representation information for an F#-declared member
 let ComputeStorageForFSharpMember amap g topValInfo memberInfo (vref: ValRef) m =
-    let mspec, mspecW, ctps, mtps, curriedArgInfos, paramInfos, retInfo, witnessInfos, methodArgTys = GetMethodSpecForMemberVal amap g memberInfo vref
+    let mspec, mspecW, ctps, mtps, curriedArgInfos, paramInfos, retInfo, witnessInfos, methodArgTys, _ = GetMethodSpecForMemberVal amap g memberInfo vref
     Method (topValInfo, vref, mspec, mspecW, m, ctps, mtps, curriedArgInfos, paramInfos, witnessInfos, methodArgTys, retInfo)
 
 /// Compute the representation information for an F#-declared function in a module or an F#-declared extension member.
@@ -5943,14 +5943,18 @@ and GenParams (cenv: cenv) eenv m (mspec: ILMethodSpec) witnessInfos (argInfos: 
     ilWitnessParams @ ilParams
 
 /// Generate IL method return information
-and GenReturnInfo cenv eenv retTy ilRetTy (retInfo: ArgReprInfo) : ILReturn =
+and GenReturnInfo cenv eenv returnTy ilRetTy (retInfo: ArgReprInfo) : ILReturn =
     let marshal, attribs = GenMarshal cenv retInfo.Attribs
     let ilAttribs = GenAttrs cenv eenv attribs
 
     let ilAttribs =
-        match GenReadOnlyAttributeIfNecessary cenv.g retTy with
-        | Some attr -> ilAttribs @ [attr]
-        | None -> ilAttribs
+        match returnTy with
+        | Some retTy ->
+            match GenReadOnlyAttributeIfNecessary cenv.g retTy with
+            | Some attr -> ilAttribs @ [attr]
+            | None -> ilAttribs
+        | _ ->
+            ilAttribs
 
     let ilAttrs = mkILCustomAttrs ilAttribs
     { Type=ilRetTy
@@ -6188,12 +6192,19 @@ and GenMethodForBinding
 
     let ilAttrsThatGoOnPrimaryItem =
         [ yield! GenAttrs cenv eenv attrs
-          yield! GenCompilationArgumentCountsAttr cenv v ] @ 
-        (match GenReadOnlyAttributeIfNecessary g returnTy with Some ilAttr -> [ilAttr] | _ -> [])
+          yield! GenCompilationArgumentCountsAttr cenv v
+
+          match v.MemberInfo with
+          | Some memberInfo when 
+            memberInfo.MemberFlags.MemberKind = MemberKind.PropertyGet ||
+            memberInfo.MemberFlags.MemberKind = MemberKind.PropertySet ||
+            memberInfo.MemberFlags.MemberKind = MemberKind.PropertyGetSet ->
+                match GenReadOnlyAttributeIfNecessary g returnTy with Some ilAttr -> ilAttr | _ -> ()
+          | _ -> () ]
 
     let ilTypars = GenGenericParams cenv eenvUnderMethLambdaTypars methLambdaTypars
     let ilParams = GenParams cenv eenvUnderMethTypeTypars m mspec witnessInfos paramInfos argTys (Some nonUnitNonSelfMethodVars)
-    let ilReturn = GenReturnInfo cenv eenvUnderMethTypeTypars returnTy mspec.FormalReturnType retInfo
+    let ilReturn = GenReturnInfo cenv eenvUnderMethTypeTypars (Some returnTy) mspec.FormalReturnType retInfo
     let methName = mspec.Name
     let tref = mspec.MethodRef.DeclaringTypeRef
 
@@ -6765,7 +6776,7 @@ and GenAttr amap g eenv (Attrib(_, k, args, props, _, _, _)) =
         | ILAttrib mref -> mkILMethSpec(mref, AsObject, [], [])
         | FSAttrib vref ->
              assert(vref.IsMember)
-             let mspec, _, _, _, _, _, _, _, _ = GetMethodSpecForMemberVal amap g (Option.get vref.MemberInfo) vref
+             let mspec, _, _, _, _, _, _, _, _, _ = GetMethodSpecForMemberVal amap g (Option.get vref.MemberInfo) vref
              mspec
     let ilArgs = List.map2 (fun (AttribExpr(_, vexpr)) ty -> GenAttribArg amap g eenv vexpr ty) args mspec.FormalArgTypes
     mkILCustomAttribMethRef g.ilg (mspec, ilArgs, props)
@@ -7113,16 +7124,14 @@ and GenAbstractBinding cenv eenv tref (vref: ValRef) =
             [ yield! GenAttrs cenv eenv attribs
               yield! GenCompilationArgumentCountsAttr cenv vref.Deref ]
     
-        let mspec, _mspecW, ctps, mtps, _curriedArgInfos, argInfos, retInfo, witnessInfos, methArgTys =
+        let mspec, _mspecW, ctps, mtps, _curriedArgInfos, argInfos, retInfo, witnessInfos, methArgTys, returnTy =
             GetMethodSpecForMemberVal cenv.amap cenv.g memberInfo vref
 
         assert witnessInfos.IsEmpty
 
-        let _, retTy = stripFunTy g vref.Type
-
         let eenvForMeth = EnvForTypars (ctps@mtps) eenv
         let ilMethTypars = GenGenericParams cenv eenvForMeth mtps
-        let ilReturn = GenReturnInfo cenv eenvForMeth retTy mspec.FormalReturnType retInfo
+        let ilReturn = GenReturnInfo cenv eenvForMeth returnTy mspec.FormalReturnType retInfo
         let ilParams = GenParams cenv eenvForMeth m mspec [] argInfos methArgTys None
     
         let compileAsInstance = ValRefIsCompiledAsInstanceMember g vref

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6188,7 +6188,8 @@ and GenMethodForBinding
 
     let ilAttrsThatGoOnPrimaryItem =
         [ yield! GenAttrs cenv eenv attrs
-          yield! GenCompilationArgumentCountsAttr cenv v ]
+          yield! GenCompilationArgumentCountsAttr cenv v ] @ 
+        (match GenReadOnlyAttributeIfNecessary g returnTy with Some ilAttr -> [ilAttr] | _ -> [])
 
     let ilTypars = GenGenericParams cenv eenvUnderMethLambdaTypars methLambdaTypars
     let ilParams = GenParams cenv eenvUnderMethTypeTypars m mspec witnessInfos paramInfos argTys (Some nonUnitNonSelfMethodVars)
@@ -6295,6 +6296,7 @@ and GenMethodForBinding
                    if mdef.Access <> ILMemberAccess.Private then
                        let vtyp = ReturnTypeOfPropertyVal g v
                        let ilPropTy = GenType cenv.amap m eenvUnderMethTypeTypars.tyenv vtyp
+                       let ilPropTy = GenReadOnlyModReqIfNecessary g vtyp ilPropTy
                        let ilArgTys = v |> ArgInfosOfPropertyVal g |> List.map fst |> GenTypes cenv.amap m eenvUnderMethTypeTypars.tyenv
                        let ilPropDef = GenPropertyForMethodDef compileAsInstance tref mdef v memberInfo ilArgTys ilPropTy (mkILCustomAttrs ilAttrsThatGoOnPrimaryItem) compiledName
                        mgbuf.AddOrMergePropertyDef(tref, ilPropDef, m)

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -279,7 +279,21 @@ type C() =
     member _.X: inref<_> = &x
             """
 
+        let verifyProperty = """.property instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
+                X()
+        {
+          .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 ) 
+          .get instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
+        }"""
+
+        let verifyMethod = """.method public hidebysig specialname 
+                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) 
+                get_X() cil managed
+        {
+          .param [0]
+          .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
+
         FSharp src
         |> compile
-        |> verifyIL [ """.custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""]
+        |> verifyIL [verifyProperty;verifyMethod]
         |> ignore

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -6,6 +6,9 @@ open NUnit.Framework
 open FSharp.Test.Utilities
 open FSharp.Test.Utilities.Utilities
 open FSharp.Compiler.SourceCodeServices
+open FSharp.Test.Utilities
+open FSharp.Test.Utilities.Compiler
+open FSharp.Tests
 
 [<TestFixture>]
 module ByrefTests =
@@ -233,7 +236,7 @@ type MyClass() =
             |> CompilationReference.Create
 
         let fsCmpl =
-            Compilation.Create(fs, Fsx, Library, cmplRefs = [csCmpl])
+            Compilation.Create(fs, SourceKind.Fsx, Library, cmplRefs = [csCmpl])
 
         CompilerAssert.Compile fsCmpl
 
@@ -264,3 +267,19 @@ let test () =
             """ [|
                     (FSharpErrorSeverity.Error, 256, (6, 13, 6, 16), "A value must be mutable in order to mutate the contents or take the address of a value type, e.g. 'let mutable x = ...'")
                 |]
+
+    [<Test>]
+    let ``Returning an 'inref<_>' from a function should emit System.Runtime.CompilerServices.IsReadOnlyAttribute on the return type of the signature`` () =
+        let src =
+            """
+module Test
+
+type C() =
+    let x = 59
+    member _.X: inref<_> = &x
+            """
+
+        FSharp src
+        |> compile
+        |> verifyIL [ """.custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""]
+        |> ignore


### PR DESCRIPTION
Resolves this: https://github.com/dotnet/fsharp/issues/9997#issuecomment-680028038

Pretty straight forward, though a little awkward due to passing an `ILType` and a `TType`.