### PR TITLE
Further improve TESTGUIDE.md

### DIFF
--- a/TESTGUIDE.md
+++ b/TESTGUIDE.md
@@ -270,7 +270,7 @@ To get an idea of how long it may take, or how much coffee you'll need while wai
 |-------|-------|-----|
 | sln build time | 1 min* | n/a |
 | `-testDesktop` | 5 min | ? |
-| `-testCoreClr` | 6 min | ? |
+| `-testCoreClr` | 36 min | ? |
 | `-testCambridge` | 72 min | 35 min |
 | `-testFSharpQA`  | 13 min | ? |
 | `-testCompiler` | 30 seconds | n/a |


### PR DESCRIPTION
This is a follow-up of #10018  (Improve info on running tests for contributors), which wasn't finished when merged ;).

* Added TOC
* fixed the lingering stuff still open since https://github.com/dotnet/fsharp/pull/10018
* added info for Linux
* added a table giving brief info for each test option
* added test running times
* improved wording in several places

I can think of other stuff to improve (like: how to run a single test), but that's for another time. Unless I find another typo, this is finished for now :).