### PR TITLE
back off sdk version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "3.1.401"
+    "version": "3.1.302"
   },
   "tools": {
-    "dotnet": "3.1.401",
+    "dotnet": "3.1.302",
     "vs": {
       "version": "16.4",
       "components": [


### PR DESCRIPTION
Internal builds are failing because the sdk specified is too new for what's installed on the VM build machines.

Backing off to what we had previously.

Also running this change on an [internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=797123&view=results).