### PR TITLE
don't test sourcelink in ci

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -143,10 +143,6 @@ function Process-Arguments() {
         $script:testpack = $False
     }
 
-    if ($pack -and $ci) {
-        $script:testpack = $true
-    }
-
     if ($noRestore) {
         $script:restore = $False;
     }


### PR DESCRIPTION
The sourcelink test has been causing CI builds to fail at least 25% of the time due to network timeouts.  It'll still be enabled for manual testing, but not during CI any more.