### PR TITLE
Go back to an SDK that is actually installed on machines

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "3.1.302"
+    "version": "3.1.401"
   },
   "tools": {
-    "dotnet": "3.1.302",
+    "dotnet": "3.1.401",
     "vs": {
       "version": "16.4",
       "components": [

--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
   "tools": {
     "dotnet": "3.1.401",
     "vs": {
-      "version": "16.4",
+      "version": "16.7",
       "components": [
         "Microsoft.VisualStudio.Component.FSharp"
       ]


### PR DESCRIPTION
fixes https://github.com/dotnet/fsharp/issues/10073 and reverts #10051

Note that the internal build in #10051 also failed, so we've simply regressed this repo's contribution story with no benefit.