### PR TITLE
Remove msbuildsdkspath from environment when executing dotnet build

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -166,6 +166,7 @@ module internal Utilities =
             psi.RedirectStandardError <- true
             psi.Arguments <- arguments
             psi.CreateNoWindow <- true
+            psi.EnvironmentVariables.Remove("MSBuildSDKsPath")          // Host can sometimes add this, and it can break things
             psi.UseShellExecute <- false
 
             use p = new Process()


### PR DESCRIPTION
So miserably I have sent the last week trying to figure out why a bunch of tests failed on one of my machines, but they passed on another and under the CI.

It turns out that the dotnet cli sets the MSBuildSdkPath environment variable, and under certain circumstances this can cause dotnet build to grab target and props files from different sdks, and if you are unlucky then this will result in targets missing.

Anyway, I finally have a fix, which is to remove the setting from the environment when using the #r nuget mechanism.  This stops the package management feature from mixing and matching sdk targets files.