### PR TITLE
bump fcs major versions to have a split between public FCS and nightly

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <FSCoreReleaseNotesVersion>$(FSMajorVersion)-$(FSMinorVersion)-$(FSBuildVersion)</FSCoreReleaseNotesVersion>
     <FSCoreVersionPrefix>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSCoreVersionPrefix>
     <FSCoreVersion>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion).$(FSRevisionVersion)</FSCoreVersion>
-    <FCSMajorVersion>37</FCSMajorVersion>
+    <FCSMajorVersion>38</FCSMajorVersion>
     <FCSMinorVersion>$(FSMinorVersion)</FCSMinorVersion>
     <FCSBuildVersion>$(FSBuildVersion)</FCSBuildVersion>
     <FCSRevisionVersion>$(FSRevisionVersion)</FCSRevisionVersion>


### PR DESCRIPTION
The current version of FCS on nuget.org is 37 stable, and the version published nightly from this repo (which IIRC will contain breaking changes to go with F# 5.0) should therefore be 38.x.

This does that! Once this is done and a version published from here I plan to start tinkering with using this nightly feed in FSAC and other downstream repos.