### PR TITLE
Fix #9149: use proper syntax to call DebugDisplay property on FSharpOption

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -3435,7 +3435,7 @@ namespace Microsoft.FSharp.Core
     //-------------------------------------------------------------------------
 
     [<DefaultAugmentation(false)>]
-    [<DebuggerDisplay("{DebugDisplay,nq}")>]
+    [<DebuggerDisplay("{get_DebugDisplay(this),nq}")>]
     [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue)>]
     [<CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId="Option")>]
     [<StructuralEquality; StructuralComparison>]


### PR DESCRIPTION
See my explanation in https://github.com/dotnet/fsharp/issues/9149#issuecomment-688940244.

This fixes the debugger representation; I've verified in Rider and Visual Studio that debugger shows the right value after the fix.