### PR TITLE
Revert "Go back to an SDK that is actually installed on machines"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "3.1.401"
+    "version": "3.1.302"
   },
   "tools": {
-    "dotnet": "3.1.401",
+    "dotnet": "3.1.302",
     "vs": {
-      "version": "16.7",
+      "version": "16.4",
       "components": [
         "Microsoft.VisualStudio.Component.FSharp"
       ]


### PR DESCRIPTION
Reverts dotnet/fsharp#10076

Internal validation VMs still don't have 16.7 (and 3.1.401 requires 16.7).

https://dev.azure.com/dnceng/internal/_build/results?buildId=807628&view=logs&j=306272fe-0d8c-58af-8d13-1dae09fcca5c&t=5fb73c2f-2eea-59ef-8241-10ac18d76c2a