### PR TITLE
Disabling string constant folding

### DIFF
--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -2015,9 +2015,12 @@ and MakeOptimizedSystemStringConcatCall cenv env m args =
           when IsILMethodRefSystemStringConcat mref ->
             optimizeArgs args accArgs
 
+// String constant folding requires a bit more work as we cannot quadratically concat strings at compile time.
+#if STRING_CONSTANT_FOLDING
         // Optimize string constants, e.g. "1" + "2" will turn into "12"
         | Expr.Const (Const.String str1, _, _), Expr.Const (Const.String str2, _, _) :: accArgs ->
             mkString cenv.g m (str1 + str2) :: accArgs
+#endif
 
         | arg, _ -> arg :: accArgs
 

--- a/tests/fsharp/Compiler/Language/StringConcatOptimizationTests.fs
+++ b/tests/fsharp/Compiler/Language/StringConcatOptimizationTests.fs
@@ -250,195 +250,203 @@ let test4 () =
   {
     
     .maxstack  8
-    .locals init (int32 V_0)
-    IL_0000:  ldc.i4.s   13
-    IL_0002:  newarr     [mscorlib]System.String
-    IL_0007:  dup
-    IL_0008:  ldc.i4.0
-    IL_0009:  ldc.i4.5
-    IL_000a:  stloc.0
-    IL_000b:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0010:  ldc.i4.5
-    IL_0011:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0016:  ldstr      "_"
-    IL_001b:  ldloca.s   V_0
-    IL_001d:  constrained. [mscorlib]System.Int32
-    IL_0023:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_0028:  ldstr      "_"
-    IL_002d:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0032:  stelem     [mscorlib]System.String
-    IL_0037:  dup
-    IL_0038:  ldc.i4.1
-    IL_0039:  ldc.i4.6
-    IL_003a:  stloc.0
-    IL_003b:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0040:  ldc.i4.6
-    IL_0041:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0046:  ldstr      "_"
-    IL_004b:  ldloca.s   V_0
-    IL_004d:  constrained. [mscorlib]System.Int32
-    IL_0053:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_0058:  ldstr      "_"
-    IL_005d:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0062:  stelem     [mscorlib]System.String
-    IL_0067:  dup
-    IL_0068:  ldc.i4.2
-    IL_0069:  ldc.i4.7
-    IL_006a:  stloc.0
-    IL_006b:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0070:  ldc.i4.7
-    IL_0071:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0076:  ldstr      "_"
-    IL_007b:  ldloca.s   V_0
-    IL_007d:  constrained. [mscorlib]System.Int32
-    IL_0083:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_0088:  ldstr      "_"
-    IL_008d:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0092:  stelem     [mscorlib]System.String
-    IL_0097:  dup
-    IL_0098:  ldc.i4.3
-    IL_0099:  ldc.i4.8
-    IL_009a:  stloc.0
-    IL_009b:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_00a0:  ldc.i4.8
-    IL_00a1:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_00a6:  ldstr      "_"
-    IL_00ab:  ldloca.s   V_0
-    IL_00ad:  constrained. [mscorlib]System.Int32
-    IL_00b3:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_00b8:  ldstr      "_"
-    IL_00bd:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_00c2:  stelem     [mscorlib]System.String
-    IL_00c7:  dup
-    IL_00c8:  ldc.i4.4
-    IL_00c9:  ldc.i4.s   9
-    IL_00cb:  stloc.0
-    IL_00cc:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_00d1:  ldc.i4.s   9
-    IL_00d3:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_00d8:  ldstr      "_"
-    IL_00dd:  ldloca.s   V_0
-    IL_00df:  constrained. [mscorlib]System.Int32
-    IL_00e5:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_00ea:  ldstr      "_"
-    IL_00ef:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_00f4:  stelem     [mscorlib]System.String
-    IL_00f9:  dup
-    IL_00fa:  ldc.i4.5
-    IL_00fb:  ldc.i4.s   10
-    IL_00fd:  stloc.0
-    IL_00fe:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0103:  ldc.i4.s   10
-    IL_0105:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_010a:  ldstr      "_"
-    IL_010f:  ldloca.s   V_0
-    IL_0111:  constrained. [mscorlib]System.Int32
-    IL_0117:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_011c:  ldstr      "_"
-    IL_0121:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0126:  stelem     [mscorlib]System.String
-    IL_012b:  dup
-    IL_012c:  ldc.i4.6
-    IL_012d:  ldstr      "_50__60_"
-    IL_0132:  stelem     [mscorlib]System.String
-    IL_0137:  dup
-    IL_0138:  ldc.i4.7
-    IL_0139:  ldc.i4.s   100
-    IL_013b:  stloc.0
-    IL_013c:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0141:  ldc.i4.s   100
-    IL_0143:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0148:  ldstr      "_"
-    IL_014d:  ldloca.s   V_0
-    IL_014f:  constrained. [mscorlib]System.Int32
-    IL_0155:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_015a:  ldstr      "_"
-    IL_015f:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0164:  stelem     [mscorlib]System.String
-    IL_0169:  dup
-    IL_016a:  ldc.i4.8
-    IL_016b:  ldc.i4.s   101
-    IL_016d:  stloc.0
-    IL_016e:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0173:  ldc.i4.s   101
-    IL_0175:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_017a:  ldstr      "_"
-    IL_017f:  ldloca.s   V_0
-    IL_0181:  constrained. [mscorlib]System.Int32
-    IL_0187:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_018c:  ldstr      "_"
-    IL_0191:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0196:  stelem     [mscorlib]System.String
-    IL_019b:  dup
-    IL_019c:  ldc.i4.s   9
-    IL_019e:  ldc.i4.s   102
-    IL_01a0:  stloc.0
-    IL_01a1:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_01a6:  ldc.i4.s   102
-    IL_01a8:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_01ad:  ldstr      "_"
-    IL_01b2:  ldloca.s   V_0
-    IL_01b4:  constrained. [mscorlib]System.Int32
-    IL_01ba:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_01bf:  ldstr      "_"
-    IL_01c4:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_01c9:  stelem     [mscorlib]System.String
-    IL_01ce:  dup
-    IL_01cf:  ldc.i4.s   10
-    IL_01d1:  ldc.i4.s   103
-    IL_01d3:  stloc.0
-    IL_01d4:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_01d9:  ldc.i4.s   103
-    IL_01db:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_01e0:  ldstr      "_"
-    IL_01e5:  ldloca.s   V_0
-    IL_01e7:  constrained. [mscorlib]System.Int32
-    IL_01ed:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_01f2:  ldstr      "_"
-    IL_01f7:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_01fc:  stelem     [mscorlib]System.String
-    IL_0201:  dup
-    IL_0202:  ldc.i4.s   11
-    IL_0204:  ldstr      "_104__105_"
-    IL_0209:  stelem     [mscorlib]System.String
-    IL_020e:  dup
-    IL_020f:  ldc.i4.s   12
-    IL_0211:  ldc.i4.s   106
-    IL_0213:  stloc.0
-    IL_0214:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0219:  ldc.i4.s   106
-    IL_021b:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0220:  ldstr      "_"
-    IL_0225:  ldloca.s   V_0
-    IL_0227:  constrained. [mscorlib]System.Int32
-    IL_022d:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_0232:  ldstr      "_"
-    IL_0237:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_023c:  stelem     [mscorlib]System.String
-    IL_0241:  call       string [mscorlib]System.String::Concat(string[])
-    IL_0246:  ret
+        .locals init (int32 V_0)
+        IL_0000:  ldc.i4.s   15
+        IL_0002:  newarr     [runtime]System.String
+        IL_0007:  dup
+        IL_0008:  ldc.i4.0
+        IL_0009:  ldc.i4.5
+        IL_000a:  stloc.0
+        IL_000b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0010:  ldc.i4.5
+        IL_0011:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0016:  ldstr      "_"
+        IL_001b:  ldloca.s   V_0
+        IL_001d:  constrained. [runtime]System.Int32
+        IL_0023:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0028:  ldstr      "_"
+        IL_002d:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0032:  stelem     [runtime]System.String
+        IL_0037:  dup
+        IL_0038:  ldc.i4.1
+        IL_0039:  ldc.i4.6
+        IL_003a:  stloc.0
+        IL_003b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0040:  ldc.i4.6
+        IL_0041:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0046:  ldstr      "_"
+        IL_004b:  ldloca.s   V_0
+        IL_004d:  constrained. [runtime]System.Int32
+        IL_0053:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0058:  ldstr      "_"
+        IL_005d:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0062:  stelem     [runtime]System.String
+        IL_0067:  dup
+        IL_0068:  ldc.i4.2
+        IL_0069:  ldc.i4.7
+        IL_006a:  stloc.0
+        IL_006b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0070:  ldc.i4.7
+        IL_0071:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0076:  ldstr      "_"
+        IL_007b:  ldloca.s   V_0
+        IL_007d:  constrained. [runtime]System.Int32
+        IL_0083:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0088:  ldstr      "_"
+        IL_008d:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0092:  stelem     [runtime]System.String
+        IL_0097:  dup
+        IL_0098:  ldc.i4.3
+        IL_0099:  ldc.i4.8
+        IL_009a:  stloc.0
+        IL_009b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_00a0:  ldc.i4.8
+        IL_00a1:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_00a6:  ldstr      "_"
+        IL_00ab:  ldloca.s   V_0
+        IL_00ad:  constrained. [runtime]System.Int32
+        IL_00b3:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_00b8:  ldstr      "_"
+        IL_00bd:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_00c2:  stelem     [runtime]System.String
+        IL_00c7:  dup
+        IL_00c8:  ldc.i4.4
+        IL_00c9:  ldc.i4.s   9
+        IL_00cb:  stloc.0
+        IL_00cc:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_00d1:  ldc.i4.s   9
+        IL_00d3:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_00d8:  ldstr      "_"
+        IL_00dd:  ldloca.s   V_0
+        IL_00df:  constrained. [runtime]System.Int32
+        IL_00e5:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_00ea:  ldstr      "_"
+        IL_00ef:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_00f4:  stelem     [runtime]System.String
+        IL_00f9:  dup
+        IL_00fa:  ldc.i4.5
+        IL_00fb:  ldc.i4.s   10
+        IL_00fd:  stloc.0
+        IL_00fe:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0103:  ldc.i4.s   10
+        IL_0105:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_010a:  ldstr      "_"
+        IL_010f:  ldloca.s   V_0
+        IL_0111:  constrained. [runtime]System.Int32
+        IL_0117:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_011c:  ldstr      "_"
+        IL_0121:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0126:  stelem     [runtime]System.String
+        IL_012b:  dup
+        IL_012c:  ldc.i4.6
+        IL_012d:  ldstr      "_50_"
+        IL_0132:  stelem     [runtime]System.String
+        IL_0137:  dup
+        IL_0138:  ldc.i4.7
+        IL_0139:  ldstr      "_60_"
+        IL_013e:  stelem     [runtime]System.String
+        IL_0143:  dup
+        IL_0144:  ldc.i4.8
+        IL_0145:  ldc.i4.s   100
+        IL_0147:  stloc.0
+        IL_0148:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_014d:  ldc.i4.s   100
+        IL_014f:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0154:  ldstr      "_"
+        IL_0159:  ldloca.s   V_0
+        IL_015b:  constrained. [runtime]System.Int32
+        IL_0161:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0166:  ldstr      "_"
+        IL_016b:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0170:  stelem     [runtime]System.String
+        IL_0175:  dup
+        IL_0176:  ldc.i4.s   9
+        IL_0178:  ldc.i4.s   101
+        IL_017a:  stloc.0
+        IL_017b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0180:  ldc.i4.s   101
+        IL_0182:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0187:  ldstr      "_"
+        IL_018c:  ldloca.s   V_0
+        IL_018e:  constrained. [runtime]System.Int32
+        IL_0194:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0199:  ldstr      "_"
+        IL_019e:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_01a3:  stelem     [runtime]System.String
+        IL_01a8:  dup
+        IL_01a9:  ldc.i4.s   10
+        IL_01ab:  ldc.i4.s   102
+        IL_01ad:  stloc.0
+        IL_01ae:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_01b3:  ldc.i4.s   102
+        IL_01b5:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_01ba:  ldstr      "_"
+        IL_01bf:  ldloca.s   V_0
+        IL_01c1:  constrained. [runtime]System.Int32
+        IL_01c7:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_01cc:  ldstr      "_"
+        IL_01d1:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_01d6:  stelem     [runtime]System.String
+        IL_01db:  dup
+        IL_01dc:  ldc.i4.s   11
+        IL_01de:  ldc.i4.s   103
+        IL_01e0:  stloc.0
+        IL_01e1:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_01e6:  ldc.i4.s   103
+        IL_01e8:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_01ed:  ldstr      "_"
+        IL_01f2:  ldloca.s   V_0
+        IL_01f4:  constrained. [runtime]System.Int32
+        IL_01fa:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_01ff:  ldstr      "_"
+        IL_0204:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0209:  stelem     [runtime]System.String
+        IL_020e:  dup
+        IL_020f:  ldc.i4.s   12
+        IL_0211:  ldstr      "_104_"
+        IL_0216:  stelem     [runtime]System.String
+        IL_021b:  dup
+        IL_021c:  ldc.i4.s   13
+        IL_021e:  ldstr      "_105_"
+        IL_0223:  stelem     [runtime]System.String
+        IL_0228:  dup
+        IL_0229:  ldc.i4.s   14
+        IL_022b:  ldc.i4.s   106
+        IL_022d:  stloc.0
+        IL_022e:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0233:  ldc.i4.s   106
+        IL_0235:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_023a:  ldstr      "_"
+        IL_023f:  ldloca.s   V_0
+        IL_0241:  constrained. [runtime]System.Int32
+        IL_0247:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_024c:  ldstr      "_"
+        IL_0251:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0256:  stelem     [runtime]System.String
+        IL_025b:  call       string [runtime]System.String::Concat(string[])
+        IL_0260:  ret
   }"""
   
         let test5Source = """
@@ -448,200 +456,208 @@ let test5 () =
         let test5IL = """.method public static string  test5() cil managed
   {
     
-    .maxstack  9
-    .locals init (int32 V_0,
-             string V_1)
-    IL_0000:  ldc.i4.s   12
-    IL_0002:  newarr     [mscorlib]System.String
-    IL_0007:  dup
-    IL_0008:  ldc.i4.0
-    IL_0009:  ldc.i4.5
-    IL_000a:  stloc.0
-    IL_000b:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0010:  ldc.i4.5
-    IL_0011:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0016:  ldstr      "_"
-    IL_001b:  ldloca.s   V_0
-    IL_001d:  constrained. [mscorlib]System.Int32
-    IL_0023:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_0028:  ldstr      "_"
-    IL_002d:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0032:  stelem     [mscorlib]System.String
-    IL_0037:  dup
-    IL_0038:  ldc.i4.1
-    IL_0039:  ldc.i4.6
-    IL_003a:  stloc.0
-    IL_003b:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0040:  ldc.i4.6
-    IL_0041:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0046:  ldstr      "_"
-    IL_004b:  ldloca.s   V_0
-    IL_004d:  constrained. [mscorlib]System.Int32
-    IL_0053:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_0058:  ldstr      "_"
-    IL_005d:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0062:  stelem     [mscorlib]System.String
-    IL_0067:  dup
-    IL_0068:  ldc.i4.2
-    IL_0069:  ldc.i4.7
-    IL_006a:  stloc.0
-    IL_006b:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0070:  ldc.i4.7
-    IL_0071:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0076:  ldstr      "_"
-    IL_007b:  ldloca.s   V_0
-    IL_007d:  constrained. [mscorlib]System.Int32
-    IL_0083:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_0088:  ldstr      "_"
-    IL_008d:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0092:  stelem     [mscorlib]System.String
-    IL_0097:  dup
-    IL_0098:  ldc.i4.3
-    IL_0099:  ldc.i4.8
-    IL_009a:  stloc.0
-    IL_009b:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_00a0:  ldc.i4.8
-    IL_00a1:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_00a6:  ldstr      "_"
-    IL_00ab:  ldloca.s   V_0
-    IL_00ad:  constrained. [mscorlib]System.Int32
-    IL_00b3:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_00b8:  ldstr      "_"
-    IL_00bd:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_00c2:  stelem     [mscorlib]System.String
-    IL_00c7:  dup
-    IL_00c8:  ldc.i4.4
-    IL_00c9:  ldc.i4.s   9
-    IL_00cb:  stloc.0
-    IL_00cc:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_00d1:  ldc.i4.s   9
-    IL_00d3:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_00d8:  ldstr      "_"
-    IL_00dd:  ldloca.s   V_0
-    IL_00df:  constrained. [mscorlib]System.Int32
-    IL_00e5:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_00ea:  ldstr      "_"
-    IL_00ef:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_00f4:  stelem     [mscorlib]System.String
-    IL_00f9:  dup
-    IL_00fa:  ldc.i4.5
-    IL_00fb:  ldc.i4.s   10
-    IL_00fd:  stloc.0
-    IL_00fe:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0103:  ldc.i4.s   10
-    IL_0105:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_010a:  ldstr      "_"
-    IL_010f:  ldloca.s   V_0
-    IL_0111:  constrained. [mscorlib]System.Int32
-    IL_0117:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_011c:  ldstr      "_"
-    IL_0121:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0126:  stelem     [mscorlib]System.String
-    IL_012b:  dup
-    IL_012c:  ldc.i4.6
-    IL_012d:  ldstr      "_50__60_"
-    IL_0132:  stelem     [mscorlib]System.String
-    IL_0137:  dup
-    IL_0138:  ldc.i4.7
-    IL_0139:  ldc.i4.s   100
-    IL_013b:  stloc.0
-    IL_013c:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0141:  ldc.i4.s   100
-    IL_0143:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0148:  ldstr      "_"
-    IL_014d:  ldloca.s   V_0
-    IL_014f:  constrained. [mscorlib]System.Int32
-    IL_0155:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_015a:  ldstr      "_"
-    IL_015f:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0164:  stelem     [mscorlib]System.String
-    IL_0169:  dup
-    IL_016a:  ldc.i4.8
-    IL_016b:  ldc.i4.s   101
-    IL_016d:  stloc.0
-    IL_016e:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_0173:  ldc.i4.s   101
-    IL_0175:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_017a:  ldstr      "_"
-    IL_017f:  ldloca.s   V_0
-    IL_0181:  constrained. [mscorlib]System.Int32
-    IL_0187:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_018c:  ldstr      "_"
-    IL_0191:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0196:  ldc.i4.s   102
-    IL_0198:  stloc.0
-    IL_0199:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_019e:  ldc.i4.s   102
-    IL_01a0:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_01a5:  ldstr      "_"
-    IL_01aa:  ldloca.s   V_0
-    IL_01ac:  constrained. [mscorlib]System.Int32
-    IL_01b2:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_01b7:  ldstr      "_"
-    IL_01bc:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_01c1:  call       string [mscorlib]System.String::Concat(string,
-                                                                string)
-    IL_01c6:  stloc.1
-    IL_01c7:  ldloc.1
-    IL_01c8:  call       void [mscorlib]System.Console::WriteLine(string)
-    IL_01cd:  ldloc.1
-    IL_01ce:  stelem     [mscorlib]System.String
-    IL_01d3:  dup
-    IL_01d4:  ldc.i4.s   9
-    IL_01d6:  ldc.i4.s   103
-    IL_01d8:  stloc.0
-    IL_01d9:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_01de:  ldc.i4.s   103
-    IL_01e0:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_01e5:  ldstr      "_"
-    IL_01ea:  ldloca.s   V_0
-    IL_01ec:  constrained. [mscorlib]System.Int32
-    IL_01f2:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_01f7:  ldstr      "_"
-    IL_01fc:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0201:  stelem     [mscorlib]System.String
-    IL_0206:  dup
-    IL_0207:  ldc.i4.s   10
-    IL_0209:  ldstr      "_104__105_"
-    IL_020e:  stelem     [mscorlib]System.String
-    IL_0213:  dup
-    IL_0214:  ldc.i4.s   11
-    IL_0216:  ldc.i4.s   106
-    IL_0218:  stloc.0
-    IL_0219:  call       class [mscorlib]System.Collections.Generic.List`1<int32> Test::get_arr()
-    IL_021e:  ldc.i4.s   106
-    IL_0220:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
-    IL_0225:  ldstr      "_"
-    IL_022a:  ldloca.s   V_0
-    IL_022c:  constrained. [mscorlib]System.Int32
-    IL_0232:  callvirt   instance string [mscorlib]System.Object::ToString()
-    IL_0237:  ldstr      "_"
-    IL_023c:  call       string [mscorlib]System.String::Concat(string,
-                                                                string,
-                                                                string)
-    IL_0241:  stelem     [mscorlib]System.String
-    IL_0246:  call       string [mscorlib]System.String::Concat(string[])
-    IL_024b:  ret
+.maxstack  9
+        .locals init (int32 V_0,
+                 string V_1)
+        IL_0000:  ldc.i4.s   14
+        IL_0002:  newarr     [runtime]System.String
+        IL_0007:  dup
+        IL_0008:  ldc.i4.0
+        IL_0009:  ldc.i4.5
+        IL_000a:  stloc.0
+        IL_000b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0010:  ldc.i4.5
+        IL_0011:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0016:  ldstr      "_"
+        IL_001b:  ldloca.s   V_0
+        IL_001d:  constrained. [runtime]System.Int32
+        IL_0023:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0028:  ldstr      "_"
+        IL_002d:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0032:  stelem     [runtime]System.String
+        IL_0037:  dup
+        IL_0038:  ldc.i4.1
+        IL_0039:  ldc.i4.6
+        IL_003a:  stloc.0
+        IL_003b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0040:  ldc.i4.6
+        IL_0041:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0046:  ldstr      "_"
+        IL_004b:  ldloca.s   V_0
+        IL_004d:  constrained. [runtime]System.Int32
+        IL_0053:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0058:  ldstr      "_"
+        IL_005d:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0062:  stelem     [runtime]System.String
+        IL_0067:  dup
+        IL_0068:  ldc.i4.2
+        IL_0069:  ldc.i4.7
+        IL_006a:  stloc.0
+        IL_006b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0070:  ldc.i4.7
+        IL_0071:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0076:  ldstr      "_"
+        IL_007b:  ldloca.s   V_0
+        IL_007d:  constrained. [runtime]System.Int32
+        IL_0083:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0088:  ldstr      "_"
+        IL_008d:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0092:  stelem     [runtime]System.String
+        IL_0097:  dup
+        IL_0098:  ldc.i4.3
+        IL_0099:  ldc.i4.8
+        IL_009a:  stloc.0
+        IL_009b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_00a0:  ldc.i4.8
+        IL_00a1:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_00a6:  ldstr      "_"
+        IL_00ab:  ldloca.s   V_0
+        IL_00ad:  constrained. [runtime]System.Int32
+        IL_00b3:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_00b8:  ldstr      "_"
+        IL_00bd:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_00c2:  stelem     [runtime]System.String
+        IL_00c7:  dup
+        IL_00c8:  ldc.i4.4
+        IL_00c9:  ldc.i4.s   9
+        IL_00cb:  stloc.0
+        IL_00cc:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_00d1:  ldc.i4.s   9
+        IL_00d3:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_00d8:  ldstr      "_"
+        IL_00dd:  ldloca.s   V_0
+        IL_00df:  constrained. [runtime]System.Int32
+        IL_00e5:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_00ea:  ldstr      "_"
+        IL_00ef:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_00f4:  stelem     [runtime]System.String
+        IL_00f9:  dup
+        IL_00fa:  ldc.i4.5
+        IL_00fb:  ldc.i4.s   10
+        IL_00fd:  stloc.0
+        IL_00fe:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0103:  ldc.i4.s   10
+        IL_0105:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_010a:  ldstr      "_"
+        IL_010f:  ldloca.s   V_0
+        IL_0111:  constrained. [runtime]System.Int32
+        IL_0117:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_011c:  ldstr      "_"
+        IL_0121:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0126:  stelem     [runtime]System.String
+        IL_012b:  dup
+        IL_012c:  ldc.i4.6
+        IL_012d:  ldstr      "_50_"
+        IL_0132:  stelem     [runtime]System.String
+        IL_0137:  dup
+        IL_0138:  ldc.i4.7
+        IL_0139:  ldstr      "_60_"
+        IL_013e:  stelem     [runtime]System.String
+        IL_0143:  dup
+        IL_0144:  ldc.i4.8
+        IL_0145:  ldc.i4.s   100
+        IL_0147:  stloc.0
+        IL_0148:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_014d:  ldc.i4.s   100
+        IL_014f:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0154:  ldstr      "_"
+        IL_0159:  ldloca.s   V_0
+        IL_015b:  constrained. [runtime]System.Int32
+        IL_0161:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0166:  ldstr      "_"
+        IL_016b:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_0170:  stelem     [runtime]System.String
+        IL_0175:  dup
+        IL_0176:  ldc.i4.s   9
+        IL_0178:  ldc.i4.s   101
+        IL_017a:  stloc.0
+        IL_017b:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0180:  ldc.i4.s   101
+        IL_0182:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_0187:  ldstr      "_"
+        IL_018c:  ldloca.s   V_0
+        IL_018e:  constrained. [runtime]System.Int32
+        IL_0194:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0199:  ldstr      "_"
+        IL_019e:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_01a3:  ldc.i4.s   102
+        IL_01a5:  stloc.0
+        IL_01a6:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_01ab:  ldc.i4.s   102
+        IL_01ad:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_01b2:  ldstr      "_"
+        IL_01b7:  ldloca.s   V_0
+        IL_01b9:  constrained. [runtime]System.Int32
+        IL_01bf:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_01c4:  ldstr      "_"
+        IL_01c9:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_01ce:  call       string [runtime]System.String::Concat(string,
+                                                                    string)
+        IL_01d3:  stloc.1
+        IL_01d4:  ldloc.1
+        IL_01d5:  call       void [runtime]System.Console::WriteLine(string)
+        IL_01da:  ldloc.1
+        IL_01db:  stelem     [runtime]System.String
+        IL_01e0:  dup
+        IL_01e1:  ldc.i4.s   10
+        IL_01e3:  ldc.i4.s   103
+        IL_01e5:  stloc.0
+        IL_01e6:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_01eb:  ldc.i4.s   103
+        IL_01ed:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_01f2:  ldstr      "_"
+        IL_01f7:  ldloca.s   V_0
+        IL_01f9:  constrained. [runtime]System.Int32
+        IL_01ff:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0204:  ldstr      "_"
+        IL_0209:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_020e:  stelem     [runtime]System.String
+        IL_0213:  dup
+        IL_0214:  ldc.i4.s   11
+        IL_0216:  ldstr      "_104_"
+        IL_021b:  stelem     [runtime]System.String
+        IL_0220:  dup
+        IL_0221:  ldc.i4.s   12
+        IL_0223:  ldstr      "_105_"
+        IL_0228:  stelem     [runtime]System.String
+        IL_022d:  dup
+        IL_022e:  ldc.i4.s   13
+        IL_0230:  ldc.i4.s   106
+        IL_0232:  stloc.0
+        IL_0233:  call       class [runtime]System.Collections.Generic.List`1<int32> Test::get_arr()
+        IL_0238:  ldc.i4.s   106
+        IL_023a:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+        IL_023f:  ldstr      "_"
+        IL_0244:  ldloca.s   V_0
+        IL_0246:  constrained. [runtime]System.Int32
+        IL_024c:  callvirt   instance string [runtime]System.Object::ToString()
+        IL_0251:  ldstr      "_"
+        IL_0256:  call       string [runtime]System.String::Concat(string,
+                                                                    string,
+                                                                    string)
+        IL_025b:  stelem     [runtime]System.String
+        IL_0260:  call       string [runtime]System.String::Concat(string[])
+        IL_0265:  ret
   }"""
 
         let test6Source = """


### PR DESCRIPTION
We need to disable string constant folding due to potential issues when concatenating strings at compile time; they could become resource consuming depending on how big and how many there are.