### PR TITLE
Check FSharp.Core xml doc comments for validity

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <FSCoreReleaseNotesVersion>$(FSMajorVersion)-$(FSMinorVersion)-$(FSBuildVersion)</FSCoreReleaseNotesVersion>
     <FSCoreVersionPrefix>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSCoreVersionPrefix>
     <FSCoreVersion>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion).$(FSRevisionVersion)</FSCoreVersion>
-    <FCSMajorVersion>38</FCSMajorVersion>
+    <FCSMajorVersion>39</FCSMajorVersion>
     <FCSMinorVersion>$(FSMinorVersion)</FCSMinorVersion>
     <FCSBuildVersion>$(FSBuildVersion)</FCSBuildVersion>
     <FCSRevisionVersion>$(FSRevisionVersion)</FCSRevisionVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <FSCoreReleaseNotesVersion>$(FSMajorVersion)-$(FSMinorVersion)-$(FSBuildVersion)</FSCoreReleaseNotesVersion>
     <FSCoreVersionPrefix>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSCoreVersionPrefix>
     <FSCoreVersion>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion).$(FSRevisionVersion)</FSCoreVersion>
-    <FCSMajorVersion>39</FCSMajorVersion>
+    <FCSMajorVersion>38</FCSMajorVersion>
     <FCSMinorVersion>$(FSMinorVersion)</FCSMinorVersion>
     <FCSBuildVersion>$(FSBuildVersion)</FCSBuildVersion>
     <FCSRevisionVersion>$(FSRevisionVersion)</FCSRevisionVersion>

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -404,6 +404,7 @@ let warningOn err level specificWarnOn =
     | 1182 -> false // chkUnusedValue - off by default
     | 3218 -> false // ArgumentsInSigAndImplMismatch - off by default
     | 3180 -> false // abImplicitHeapAllocation - off by default
+    | 3390 -> false // xmlDocBadlyFormed - off by default
     | _ -> level >= GetWarningLevel err 
 
 let SplitRelatedDiagnostics(err: PhasedDiagnostic) : PhasedDiagnostic * PhasedDiagnostic list = 

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1540,3 +1540,4 @@ forFormatInvalidForInterpolated4,"Interpolated strings used as type IFormattable
 3382,parsEmptyFillInInterpolatedString,"Invalid interpolated string. This interpolated string expression fill is empty, an expression was expected."
 3383,lexRBraceInInterpolatedString,"A '}}' character must be escaped (by doubling) in an interpolated string."
 #3501   "This construct is not supported by your version of the F# compiler" CompilerMessage(ExperimentalAttributeMessages.NotSupportedYet, 3501, IsError=true)
+3390,xmlDocBadlyFormed,"This XML comment is invalid XML: '%s'"

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1540,4 +1540,6 @@ forFormatInvalidForInterpolated4,"Interpolated strings used as type IFormattable
 3382,parsEmptyFillInInterpolatedString,"Invalid interpolated string. This interpolated string expression fill is empty, an expression was expected."
 3383,lexRBraceInInterpolatedString,"A '}}' character must be escaped (by doubling) in an interpolated string."
 #3501   "This construct is not supported by your version of the F# compiler" CompilerMessage(ExperimentalAttributeMessages.NotSupportedYet, 3501, IsError=true)
-3390,xmlDocBadlyFormed,"This XML comment is invalid XML: '%s'"
+3390,xmlDocBadlyFormed,"This XML comment is invalid: '%s'"
+3390,xmlDocMissingParameterName,"This XML comment is invalid: missing parameter name"
+3390,xmlDocInvalidParameterName,"This XML comment is invalid: invalid parameter reference '%s'"

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -21,7 +21,7 @@
     <NuspecFile>FSharp.Compiler.Service.nuspec</NuspecFile>
     <IsPackable Condition="'$(OS)' != 'Unix'">true</IsPackable>
     <PackageDescription>The F# Compiler Services package For F# $(FSLanguageVersion) exposes additional functionality for implementing F# language bindings, additional tools based on the compiler or refactoring tools. The package also includes F# interactive service that can be used for embedding F# scripting into your applications.  Contains code from the F# Software Foundation.</PackageDescription>
-    <PackageReleaseNotes>/blob/main/release-notes.md#FSharp-Compilere-Service-$(FSharpCompilerServiceReleaseNotesVersion)</PackageReleaseNotes>
+    <PackageReleaseNotes>/blob/main/release-notes.md#FSharp-Compiler-Service-$(FSharpCompilerServiceReleaseNotesVersion)</PackageReleaseNotes>
     <PackageTags>F#, fsharp, interactive, compiler, editor</PackageTags>
   </PropertyGroup>
 

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -9,7 +9,7 @@
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);FSHARP_CORE</DefineConstants>
     <DefineConstants Condition="'$(Configuration)' == 'Proto'">BUILDING_WITH_LKG;$(DefineConstants)</DefineConstants>
-    <OtherFlags>$(OtherFlags) --warnon:1182 --compiling-fslib --compiling-fslib-40 --maxerrors:20 --extraoptimizationloops:1 --nowarn:57</OtherFlags>
+    <OtherFlags>$(OtherFlags) --warnon:1182 --warnon:3390 --compiling-fslib --compiling-fslib-40 --maxerrors:20 --extraoptimizationloops:1 --nowarn:57</OtherFlags>
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
     <NGenBinary>true</NGenBinary>
 

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -370,7 +370,7 @@ namespace Microsoft.FSharp.Core
     [<MeasureAnnotatedAbbreviation>] type int16<[<Measure>] 'Measure> = int16
     [<MeasureAnnotatedAbbreviation>] type int64<[<Measure>] 'Measure> = int64
 
-    /// <summary>Represents a managed pointer in F# code.</c></summary>
+    /// <summary>Represents a managed pointer in F# code.</summary>
     type byref<'T> = (# "!0&" #)
 
     /// <summary>Represents a managed pointer in F# code.</summary>

--- a/src/fsharp/ParseHelpers.fs
+++ b/src/fsharp/ParseHelpers.fs
@@ -85,7 +85,7 @@ module LexbufLocalXmlDocStore =
         lexbuf.BufferLocalStore.[xmlDocKey] <- box (XmlDocCollector())
 
     /// Called from the lexer to save a single line of XML doc comment.
-    let internal SaveXmlDocLine (lexbuf: Lexbuf, lineText, pos) =
+    let internal SaveXmlDocLine (lexbuf: Lexbuf, lineText, range: range) =
         let collector =
             match lexbuf.BufferLocalStore.TryGetValue xmlDocKey with
             | true, collector -> collector
@@ -94,7 +94,7 @@ module LexbufLocalXmlDocStore =
                 lexbuf.BufferLocalStore.[xmlDocKey] <- collector
                 collector
         let collector = unbox<XmlDocCollector>(collector)
-        collector.AddXmlDocLine(lineText, pos)
+        collector.AddXmlDocLine(lineText, range)
 
     /// Called from the parser each time we parse a construct that marks the end of an XML doc comment range,
     /// e.g. a 'type' declaration. The markerRange is the range of the keyword that delimits the construct.

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -745,7 +745,9 @@ type Entity =
     member x.XmlDoc = 
 #if !NO_EXTENSIONTYPING
         match x.TypeReprInfo with
-        | TProvidedTypeExtensionPoint info -> XmlDoc (info.ProvidedType.PUntaintNoFailure(fun st -> (st :> IProvidedCustomAttributeProvider).GetXmlDocAttributes(info.ProvidedType.TypeProvider.PUntaintNoFailure id)))
+        | TProvidedTypeExtensionPoint info ->
+            let lines = info.ProvidedType.PUntaintNoFailure(fun st -> (st :> IProvidedCustomAttributeProvider).GetXmlDocAttributes(info.ProvidedType.TypeProvider.PUntaintNoFailure id))
+            XmlDoc (lines |> Array.map (fun line -> line, x.DefinitionRange))
         | _ -> 
 #endif
         match x.entity_opt_data with

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -1345,7 +1345,7 @@ let p_range (x: range) st =
 
 let p_dummy_range : range pickler   = fun _x _st -> ()
 let p_ident (x: Ident) st = p_tup2 p_string p_range (x.idText, x.idRange) st
-let p_xmldoc (XmlDoc x) st = p_array p_string x st
+let p_xmldoc (XmlDoc lines) st = p_array p_string (Array.map fst lines) st
 
 let u_pos st = let a = u_int st in let b = u_int st in mkPos a b
 let u_range st = let a = u_string st in let b = u_pos st in let c = u_pos st in mkRange a b c
@@ -1353,7 +1353,7 @@ let u_range st = let a = u_string st in let b = u_pos st in let c = u_pos st in 
 // Most ranges (e.g. on optimization expressions) can be elided from stored data
 let u_dummy_range : range unpickler = fun _st -> range0
 let u_ident st = let a = u_string st in let b = u_range st in ident(a, b)
-let u_xmldoc st = XmlDoc (u_array u_string st)
+let u_xmldoc st = XmlDoc (u_array u_string st |> Array.map (fun line -> line, range0))
 
 let p_local_item_ref ctxt tab st = p_osgn_ref ctxt tab st
 

--- a/src/fsharp/XmlDoc.fs
+++ b/src/fsharp/XmlDoc.fs
@@ -129,7 +129,7 @@ type PreXmlDoc =
                 // Note, the parameter names are curently only checked for internal
                 // consistency, so parameter references must match an XML doc parameter name.
                 let paramNames =
-                    [ for p in xml.Elements(XName.op_Implicit "param") do
+                    [ for p in xml.Descendants(XName.op_Implicit "param") do
                         match p.Attribute(XName.op_Implicit "name") with 
                         | null -> 
                             warning (Error (FSComp.SR.xmlDocMissingParameterName(), doc.Range))

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -328,11 +328,6 @@ module InterfaceFileWriter =
 
 module XmlDocWriter =
 
-    let getDoc xmlDoc = 
-        match XmlDoc.Process xmlDoc with
-        | XmlDoc [| |] -> ""
-        | XmlDoc strs  -> strs |> Array.toList |> String.concat Environment.NewLine
-
     let hasDoc xmlDoc =
         // No need to process the xml doc - just need to know if there's anything there
         match xmlDoc with
@@ -389,7 +384,7 @@ module XmlDocWriter =
         let mutable members = []
         let addMember id xmlDoc = 
             if hasDoc xmlDoc then
-                let doc = getDoc xmlDoc
+                let doc = xmlDoc.GetXml()
                 members <- (id, doc) :: members
         let doVal (v: Val) = addMember v.XmlDocSig v.XmlDoc
         let doUnionCase (uc: UnionCase) = addMember uc.XmlDocSig uc.XmlDoc

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -384,7 +384,7 @@ module XmlDocWriter =
         let mutable members = []
         let addMember id xmlDoc = 
             if hasDoc xmlDoc then
-                let doc = xmlDoc.GetXml()
+                let doc = xmlDoc.GetXmlText()
                 members <- (id, doc) :: members
         let doVal (v: Val) = addMember v.XmlDocSig v.XmlDoc
         let doUnionCase (uc: UnionCase) = addMember uc.XmlDocSig uc.XmlDoc

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1064,7 +1064,9 @@ type MethInfo =
         | DefaultStructCtor _ -> XmlDoc.Empty
 #if !NO_EXTENSIONTYPING
         | ProvidedMeth(_, mi, _, m)->
-            XmlDoc (mi.PUntaint((fun mix -> (mix :> IProvidedCustomAttributeProvider).GetXmlDocAttributes(mi.TypeProvider.PUntaintNoFailure id)), m))
+            let lines = mi.PUntaint((fun mix -> (mix :> IProvidedCustomAttributeProvider).GetXmlDocAttributes(mi.TypeProvider.PUntaintNoFailure id)), m)
+            let lines = lines |> Array.map (fun line -> line, m)
+            XmlDoc lines
 #endif
 
     /// Try to get an arbitrary F# ValRef associated with the member. This is to determine if the member is virtual, amongst other things.
@@ -2162,7 +2164,9 @@ type PropInfo =
         | FSProp(_, _, None, None) -> failwith "unreachable"
 #if !NO_EXTENSIONTYPING
         | ProvidedProp(_, pi, m) ->
-            XmlDoc (pi.PUntaint((fun pix -> (pix :> IProvidedCustomAttributeProvider).GetXmlDocAttributes(pi.TypeProvider.PUntaintNoFailure id)), m))
+            let lines = pi.PUntaint((fun pix -> (pix :> IProvidedCustomAttributeProvider).GetXmlDocAttributes(pi.TypeProvider.PUntaintNoFailure id)), m)
+            let lines = lines |> Array.map (fun line -> line, m)
+            XmlDoc lines
 #endif
 
     /// Get the TcGlobals associated with the object
@@ -2416,7 +2420,9 @@ type EventInfo =
         | FSEvent (_, p, _, _) -> p.XmlDoc
 #if !NO_EXTENSIONTYPING
         | ProvidedEvent (_, ei, m) ->
-            XmlDoc (ei.PUntaint((fun eix -> (eix :> IProvidedCustomAttributeProvider).GetXmlDocAttributes(ei.TypeProvider.PUntaintNoFailure id)), m))
+            let lines = ei.PUntaint((fun eix -> (eix :> IProvidedCustomAttributeProvider).GetXmlDocAttributes(ei.TypeProvider.PUntaintNoFailure id)), m)
+            let lines = lines |> Array.map (fun line -> line, m)
+            XmlDoc lines
 #endif
 
     /// Get the logical name of the event.

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -166,11 +166,11 @@ let startString args (lexbuf: UnicodeLexing.Lexbuf) =
              
 // Utility functions for processing XML documentation 
 
-let trySaveXmlDoc lexbuf (buff: (range * StringBuilder) option) =
+let trySaveXmlDoc (lexbuf: LexBuffer<char>) (buff: (range * StringBuilder) option) =
     match buff with 
     | None -> () 
     | Some (start, sb) ->
-        let xmlCommentLineRange = mkFileIndexRange start.FileIndex start.StartPos (posOfLexPosition lexbuf.StartPos)
+        let xmlCommentLineRange = mkFileIndexRange start.FileIndex start.Start (posOfLexPosition lexbuf.StartPos)
         LexbufLocalXmlDocStore.SaveXmlDocLine (lexbuf, sb.ToString(), xmlCommentLineRange)
   
 let tryAppendXmlDoc (buff: (range * StringBuilder) option) (s:string) =
@@ -662,7 +662,7 @@ rule token args skip = parse
        let doc = lexemeTrimLeft lexbuf 3  
        let sb = (new StringBuilder(100)).Append(doc)
        if not skip then LINE_COMMENT (LexCont.SingleLineComment(args.ifdefStack, args.stringNest, 1, m)) 
-       else singleLineComment (Some (m.StartPos, sb),1,m,args) skip lexbuf }
+       else singleLineComment (Some (m, sb),1,m,args) skip lexbuf }
 
  | "//" op_char*
      { // Need to read all operator symbols too, otherwise it might be parsed by a rule below 

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -166,15 +166,17 @@ let startString args (lexbuf: UnicodeLexing.Lexbuf) =
              
 // Utility functions for processing XML documentation 
 
-let trySaveXmlDoc lexbuf (buff:option<System.Text.StringBuilder>) =
+let trySaveXmlDoc lexbuf (buff: (range * StringBuilder) option) =
     match buff with 
     | None -> () 
-    | Some sb -> LexbufLocalXmlDocStore.SaveXmlDocLine (lexbuf, sb.ToString(), posOfLexPosition lexbuf.StartPos)
+    | Some (start, sb) ->
+        let xmlCommentLineRange = mkFileIndexRange start.FileIndex start.StartPos (posOfLexPosition lexbuf.StartPos)
+        LexbufLocalXmlDocStore.SaveXmlDocLine (lexbuf, sb.ToString(), xmlCommentLineRange)
   
-let tryAppendXmlDoc (buff:option<System.Text.StringBuilder>) (s:string) =
+let tryAppendXmlDoc (buff: (range * StringBuilder) option) (s:string) =
     match buff with 
     | None -> ()
-    | Some sb -> ignore(sb.Append s)
+    | Some (_, sb) -> ignore(sb.Append s)
 
 // Utilities for parsing #if/#else/#endif 
 
@@ -660,7 +662,7 @@ rule token args skip = parse
        let doc = lexemeTrimLeft lexbuf 3  
        let sb = (new StringBuilder(100)).Append(doc)
        if not skip then LINE_COMMENT (LexCont.SingleLineComment(args.ifdefStack, args.stringNest, 1, m)) 
-       else singleLineComment (Some sb,1,m,args) skip lexbuf }
+       else singleLineComment (Some (m.StartPos, sb),1,m,args) skip lexbuf }
 
  | "//" op_char*
      { // Need to read all operator symbols too, otherwise it might be parsed by a rule below 

--- a/src/fsharp/service/ServiceXmlDocParser.fs
+++ b/src/fsharp/service/ServiceXmlDocParser.fs
@@ -49,12 +49,10 @@ module XmlDocParsing =
             i
 
         let isEmptyXmlDoc (preXmlDoc: PreXmlDoc) =
-            match preXmlDoc.ToXmlDoc() with 
-            | XmlDoc [||] -> true
-            | XmlDoc [|x|] when x.Trim() = "" -> true
-            | _ -> false
+            preXmlDoc.ToXmlDoc().IsEmpty
 
-        let rec getXmlDocablesSynModuleDecl = function
+        let rec getXmlDocablesSynModuleDecl decl =
+            match decl with 
             | SynModuleDecl.NestedModule(_,  _, synModuleDecls, _, _) -> 
                 (synModuleDecls |> List.collect getXmlDocablesSynModuleDecl)
             | SynModuleDecl.Let(_, synBindingList, range) -> 

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -662,13 +662,14 @@ module internal SymbolHelpers =
     let GetXmlCommentForItemAux (xmlDoc: XmlDoc option) (infoReader: InfoReader) m d = 
         let result = 
             match xmlDoc with 
-            | None | Some (XmlDoc [| |]) -> ""
-            | Some (XmlDoc l) -> 
+            | None -> ""
+            | Some xmlDoc when xmlDoc.IsEmpty -> ""
+            | Some (XmlDoc lines) -> 
                 bufs (fun os -> 
                     bprintf os "\n"
-                    l |> Array.iter (fun (s: string) -> 
+                    lines |> Array.iter (fun (line, _) -> 
                         // Note: this code runs for local/within-project xmldoc tooltips, but not for cross-project or .XML
-                        bprintf os "\n%s" s))
+                        bprintf os "\n%s" line))
 
         if String.IsNullOrEmpty result then 
             GetXmlDocHelpSigOfItemForLookup infoReader m d

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -78,7 +78,8 @@ module Impl =
     let makeReadOnlyCollection (arr: seq<'T>) = 
         System.Collections.ObjectModel.ReadOnlyCollection<_>(Seq.toArray arr) :> IList<_>
         
-    let makeXmlDoc (XmlDoc x) = makeReadOnlyCollection x
+    let makeXmlDoc (XmlDoc lines) =
+        makeReadOnlyCollection (Array.map fst lines)
     
     let rescopeEntity optViewedCcu (entity: Entity) = 
         match optViewedCcu with 

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Pro odkazy na rozhraní .NET používejte referenční sestavení, pokud jsou k dispozici (ve výchozím nastavení povolené).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Zvažte použití parametru yield! namísto yield.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Verweisassemblys für .NET Framework-Verweise verwenden, wenn verfügbar (standardmäßig aktiviert).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Verwenden Sie ggf. "yield!" anstelle von "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Use ensamblados de referencia para las referencias de .NET Framework cuando estén disponibles (habilitado de forma predeterminada).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Considere la posibilidad de usar "yield!" en lugar de "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Utilisez des assemblys de référence pour les références .NET Framework quand ils sont disponibles (activé par défaut).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Utilisez 'yield!' à la place de 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Usa gli assembly di riferimento per i riferimenti a .NET Framework quando disponibili (abilitato per impostazione predefinita).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Provare a usare 'yield!' invece di 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -522,6 +522,21 @@
         <target state="translated">使用可能な場合は、.NET Framework リファレンスの参照アセンブリを使用します (既定で有効)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield' の代わりに 'yield!' を使うことを検討してください。</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -522,6 +522,21 @@
         <target state="translated">기본적으로 활성화되는 참조 어셈블리를 .NET Framework 참조에 사용합니다(사용 가능한 경우).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield'가 아닌 'yield!'를 사용하세요.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Użyj zestawów odwołań dla odwołań do programu .NET Framework, gdy są dostępne (domyślnie włączone).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Rozważ użycie polecenia „yield!” zamiast „yield”.</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Use assemblies de referência para referências do .NET Framework quando disponível (habilitado por padrão).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Considere usar 'yield!' em vez de 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Использовать базовые сборки для ссылок на платформу .NET, если базовые сборки доступны (включено по умолчанию).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Рекомендуется использовать "yield!" вместо "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -522,6 +522,21 @@
         <target state="translated">Kullanılabilir olduğunda, .NET Framework başvuruları için başvuru bütünleştirilmiş kodlarını kullanın (Varsayılan olarak etkindir).</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield' yerine 'yield!' kullanmayı deneyin.</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -522,6 +522,21 @@
         <target state="translated">如果可用，请对 .NET Framework 引用使用引用程序集(默认启用)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">考虑使用 "yield!"，而非 "yield"。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -522,6 +522,21 @@
         <target state="translated">請在可行的情況下使用適用於 .NET 架構參考的參考組件 (預設會啟用)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="xmlDocBadlyFormed">
+        <source>This XML comment is invalid: '{0}'</source>
+        <target state="new">This XML comment is invalid: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocInvalidParameterName">
+        <source>This XML comment is invalid: invalid parameter reference '{0}'</source>
+        <target state="new">This XML comment is invalid: invalid parameter reference '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="xmlDocMissingParameterName">
+        <source>This XML comment is invalid: missing parameter name</source>
+        <target state="new">This XML comment is invalid: missing parameter name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">請考慮使用 'yield!' 而不使用 'yield'。</target>

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -40,6 +40,7 @@
     <Compile Include="ErrorMessages\WarnExpressionTests.fs" />
     <Compile Include="ErrorMessages\WrongSyntaxInForLoop.fs" />
     <Compile Include="ErrorMessages\ConfusingTypeName.fs" />
+    <Compile Include="Language\XmlComments.fs" />
     <Compile Include="Language\CompilerDirectiveTests.fs" />
     <Compile Include="Language\CodeQuotationTests.fs" />
     <Compile Include="ConstraintSolver\PrimitiveConstraints.fs" />
@@ -53,5 +54,9 @@
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpTestsRoot)\FSharp.Test.Utilities\FSharp.Test.Utilities.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="NewFolder\" />
   </ItemGroup>
 </Project>

--- a/tests/FSharp.Compiler.ComponentTests/Language/XmlComments.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/XmlComments.fs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.XmlComments
+
+open Xunit
+open FSharp.Test.Utilities.Compiler
+
+module XmlCommentChecking =
+
+    [<Fact>]
+    let ``invalid XML is reported`` () =
+        Fsx"""
+/// <summary>
+let x = 1
+
+/// 
+/// <summary>Yo</summary>
+/// <remark>Yo</rem>
+module M =
+    /// <summary> <
+    let y = 1
+
+        """ 
+         |> withXmlCommentChecking
+         |> ignoreWarnings // means "don't treat warnings as errors"
+         |> compile
+         |> shouldSucceed
+         |> withDiagnostics
+                [ (Warning 3390, Line 2, Col 1, Line 2, Col 14,
+                   "This XML comment is invalid: 'The 'summary' start tag on line 2 position 3 does not match the end tag of 'doc'. Line 3, position 3.'");
+                  (Warning 3390, Line 5, Col 1, Line 7, Col 21,
+                   """This XML comment is invalid: 'The 'remark' start tag on line 3 position 3 does not match the end tag of 'rem'. Line 3, position 14.'""");
+                  (Warning 3390, Line 9, Col 5, Line 9, Col 20,
+                   "This XML comment is invalid: 'Name cannot begin with the '\n' character, hexadecimal value 0x0A. Line 2, position 13.'")
+                ]
+    [<Fact>]
+    let ``invalid parameter reference is reported`` () =
+        Fsx"""
+    /// <summary> Return <paramref name="b" /> </summary>
+    /// <param name="a"> the parameter </param>
+    let f a = a
+        """ 
+         |> withXmlCommentChecking
+         |> ignoreWarnings // means "don't treat warnings as errors"
+         |> compile
+         |> shouldSucceed
+         |> withDiagnostics
+                [ (Warning 3390, Line 2, Col 5, Line 3, Col 48,
+                   "This XML comment is invalid: invalid parameter reference 'b'");
+                ]

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.net472.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.net472.fs
@@ -41930,25 +41930,27 @@ FSharp.Compiler.XmlDoc+XmlDoc: Boolean Equals(System.Object, System.Collections.
 FSharp.Compiler.XmlDoc+XmlDoc: Boolean Equals(XmlDoc)
 FSharp.Compiler.XmlDoc+XmlDoc: Boolean NonEmpty
 FSharp.Compiler.XmlDoc+XmlDoc: Boolean get_NonEmpty()
-FSharp.Compiler.XmlDoc+XmlDoc: Int32 CompareTo(System.Object)
-FSharp.Compiler.XmlDoc+XmlDoc: Int32 CompareTo(System.Object, System.Collections.IComparer)
-FSharp.Compiler.XmlDoc+XmlDoc: Int32 CompareTo(XmlDoc)
 FSharp.Compiler.XmlDoc+XmlDoc: Int32 GetHashCode()
 FSharp.Compiler.XmlDoc+XmlDoc: Int32 GetHashCode(System.Collections.IEqualityComparer)
 FSharp.Compiler.XmlDoc+XmlDoc: Int32 Tag
 FSharp.Compiler.XmlDoc+XmlDoc: Int32 get_Tag()
 FSharp.Compiler.XmlDoc+XmlDoc: System.String ToString()
-FSharp.Compiler.XmlDoc+XmlDoc: System.String[] Item
-FSharp.Compiler.XmlDoc+XmlDoc: System.String[] get_Item()
 FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc Empty
 FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc Merge(XmlDoc, XmlDoc)
-FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc NewXmlDoc(System.String[])
 FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc Process(XmlDoc)
 FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc get_Empty()
-FSharp.Compiler.XmlDoc+XmlDocCollector: System.String[] LinesBefore(pos)
+FSharp.Compiler.XmlDoc+XmlDoc: Boolean IsEmpty
+FSharp.Compiler.XmlDoc+XmlDoc: Boolean get_IsEmpty()
+FSharp.Compiler.XmlDoc+XmlDoc: System.String GetXmlText()
+FSharp.Compiler.XmlDoc+XmlDoc: System.Tuple`2[System.String,FSharp.Compiler.Range+range][] Item
+FSharp.Compiler.XmlDoc+XmlDoc: System.Tuple`2[System.String,FSharp.Compiler.Range+range][] get_Item()
+FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc NewXmlDoc(System.Tuple`2[System.String,FSharp.Compiler.Range+range][])
+FSharp.Compiler.XmlDoc+XmlDoc: range Range
+FSharp.Compiler.XmlDoc+XmlDoc: range get_Range()
+FSharp.Compiler.XmlDoc+XmlDocCollector: System.Tuple`2[System.String,FSharp.Compiler.Range+range][] LinesBefore(pos)
+FSharp.Compiler.XmlDoc+XmlDocCollector: Void AddXmlDocLine(System.String, range)
 FSharp.Compiler.XmlDoc+XmlDocCollector: Void .ctor()
 FSharp.Compiler.XmlDoc+XmlDocCollector: Void AddGrabPoint(pos)
-FSharp.Compiler.XmlDoc+XmlDocCollector: Void AddXmlDocLine(System.String, pos)
 FSharp.Compiler.XmlDoc+XmlDocStatics: Void .ctor()
 FSharp.Compiler.XmlDoc+XmlDocStatics: XmlDoc Empty
 FSharp.Compiler.XmlDoc+XmlDocStatics: XmlDoc get_Empty()

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -41875,21 +41875,23 @@ FSharp.Compiler.XmlDoc+XmlDoc: Boolean Equals(System.Object, System.Collections.
 FSharp.Compiler.XmlDoc+XmlDoc: Boolean Equals(XmlDoc)
 FSharp.Compiler.XmlDoc+XmlDoc: Boolean NonEmpty
 FSharp.Compiler.XmlDoc+XmlDoc: Boolean get_NonEmpty()
-FSharp.Compiler.XmlDoc+XmlDoc: Int32 CompareTo(System.Object)
-FSharp.Compiler.XmlDoc+XmlDoc: Int32 CompareTo(System.Object, System.Collections.IComparer)
-FSharp.Compiler.XmlDoc+XmlDoc: Int32 CompareTo(XmlDoc)
 FSharp.Compiler.XmlDoc+XmlDoc: Int32 GetHashCode()
 FSharp.Compiler.XmlDoc+XmlDoc: Int32 GetHashCode(System.Collections.IEqualityComparer)
 FSharp.Compiler.XmlDoc+XmlDoc: Int32 Tag
 FSharp.Compiler.XmlDoc+XmlDoc: Int32 get_Tag()
 FSharp.Compiler.XmlDoc+XmlDoc: System.String ToString()
-FSharp.Compiler.XmlDoc+XmlDoc: System.String[] Item
-FSharp.Compiler.XmlDoc+XmlDoc: System.String[] get_Item()
 FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc Empty
 FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc Merge(XmlDoc, XmlDoc)
-FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc NewXmlDoc(System.String[])
 FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc Process(XmlDoc)
 FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc get_Empty()
+FSharp.Compiler.XmlDoc+XmlDoc: Boolean IsEmpty
+FSharp.Compiler.XmlDoc+XmlDoc: Boolean get_IsEmpty()
+FSharp.Compiler.XmlDoc+XmlDoc: System.String GetXmlText()
+FSharp.Compiler.XmlDoc+XmlDoc: System.Tuple`2[System.String,FSharp.Compiler.Range+range][] Item
+FSharp.Compiler.XmlDoc+XmlDoc: System.Tuple`2[System.String,FSharp.Compiler.Range+range][] get_Item()
+FSharp.Compiler.XmlDoc+XmlDoc: XmlDoc NewXmlDoc(System.Tuple`2[System.String,FSharp.Compiler.Range+range][])
+FSharp.Compiler.XmlDoc+XmlDoc: range Range
+FSharp.Compiler.XmlDoc+XmlDoc: range get_Range()
 FSharp.Compiler.XmlDoc+XmlDocCollector: System.String[] LinesBefore(pos)
 FSharp.Compiler.XmlDoc+XmlDocCollector: Void .ctor()
 FSharp.Compiler.XmlDoc+XmlDocCollector: Void AddGrabPoint(pos)

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -178,7 +178,7 @@ module rec Compiler =
         | _ -> failwith message
 
     let withOptions (options: string list) (cUnit: CompilationUnit) : CompilationUnit =
-        withOptionsHelper options "withOptions is only supported n F#" cUnit
+        withOptionsHelper options "withOptions is only supported for F#" cUnit
 
     let withErrorRanges (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ "--test:ErrorRanges" ] "withErrorRanges is only supported on F#" cUnit
@@ -194,6 +194,9 @@ module rec Compiler =
 
     let withLangVersionPreview (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ "--langversion:preview" ] "withLangVersionPreview is only supported on F#" cUnit
+
+    let withXmlCommentChecking (cUnit: CompilationUnit) : CompilationUnit =
+        withOptionsHelper [ "--warnon:3390" ] "withXmlCommentChecking is only supported for F#" cUnit
 
     let asLibrary (cUnit: CompilationUnit) : CompilationUnit =
         match cUnit with
@@ -573,7 +576,7 @@ module rec Compiler =
 
             let inline checkEqual k a b =
              if a <> b then
-                 Assert.AreEqual(a, b, sprintf "%s: Mismatch in %s, expected '%A', got '%A'.\nAll errors:\n%A" what k a b errors)
+                 Assert.AreEqual(a, b, sprintf "%s: Mismatch in %s, expected '%A', got '%A'.\nAll errors:\n%A\nExpected errors:\n%A" what k a b errors expected)
 
             // TODO: Check all "categories", collect all results and print alltogether.
             checkEqual "Errors count"  expected.Length errors.Length


### PR DESCRIPTION
This adds optional basic checking of XML validity of XML doc comments using a new off-by-default warning 3390 and turns it on for FSharp.Core via `/warnon:3390` 

The main reason to add this is to guarantee our doc quality - we currently don't have _any_ checking of the validity of the FSharp.Core.xml file,  This means a **single** mistake in any of the XML docs for FSharp.Core can kill **all** documentation tooling that consumes it including our intellisense hints - because the **whole file** is invalid XML.  By doing basic checking on individual comments we basically ensure overall validity of the file.

Separately I've been working on documentation for DiffSharp, and the lack of checking of XML docs in the F# compiler is really very driving me crazy - simple typos only reveal themselves much later.  Optionally giving warnings about invalid XML is really necessary if we expect anyone to write good documentation - though this only does one small part of doc checking.

This warning is off by default - we can turn it on by default for the standard templates in vNext.

