### PR TITLE
Fix 9150 --- #i nuget on desktop witout net48 ref assemblies fails.

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
@@ -144,6 +144,10 @@ $(POUND_R)
     <FSharpCoreImplicitPackageVersion Condition="'$(FSharpCoreImplicitPackageVersion)' == '{{FSharpCorePreviewPackageVersion}}'">4.7.1-*</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include='Microsoft.NETFramework.ReferenceAssemblies' Version='1.0.0' Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
+  </ItemGroup>
+
 $(PACKAGEREFERENCES)
 
   <Target Name="ComputePackageRootsForInteractivePackageManagement"

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -69,6 +69,7 @@ module FSharpDependencyManager =
                         validatePackageName v "FSharp.Core"
                     validatePackageName v "System.ValueTuple"
                     validatePackageName v "NETStandard.Library"
+                    validatePackageName v "Microsoft.NETFramework.ReferenceAssemblies"
                     Some { current with Include = v }
                 let setVersion v = Some { current with Version = v }
                 match opt with


### PR DESCRIPTION
This PR fixes #10114 

FSI uses reference assemblies for compilation purposes the same as the compiler, and relied on the built in msbuild resolver to find them.  This had the disadvantage of requiring the developer to install them when using the desktop version of fsi.

Visual Studio dwfault install for the Managed Code workflow, causes the net472 reference assemblies to be loaded.  So for any developer who goes for a clean install of VS, will have some trouble when using #r "nuget:blah"  from the desktop fsi.

The best fix is to use the : Microsoft.NETFramework.ReferenceAssemblies package, because that will cause the nuget package manager to find the best reference assemblies for the build.

Which is what this change does, when using #r "nuget:  we ensure that we go fetch the 
Microsoft.NETFramework.ReferenceAssemblies package only when the targetframeworkidentity is .NETFramework.

We also disallow Microsoft.NETFramework.ReferenceAssemblies as a valid user supplied package, to stop developers innovating and perhaps causing problems.


Kevin
