### PR TITLE
Mutable fields --- Fixes #10021 --- fsi 10.9.1.0 for F# 4.7 reference dll ok but 10.10.0.0 for F# 4.7 not ok

### DIFF
--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -53,7 +53,8 @@ type PickledDataWithReferences<'rawData> =
             // Only fixup what needs fixing up
             if reqd.IsUnresolvedReference then
                 match loader reqd.AssemblyName with
-                | Some loaded -> reqd.Fixup loaded
+                | Some loaded ->
+                    if reqd.IsUnresolvedReference then reqd.Fixup loaded
                 | _ -> () )
         x.RawData
 


### PR DESCRIPTION
This is a bug caused by mutable state.

loader reqd.AssemblyName may cause the entry for reqd.AssemblyName to be fixed up, if the reference was provided using --reference.

So before we try to fix up the entry we re-check to see if the ccuthunk has already been fixed up.


Kevin