### PR TITLE
Refactor the Fsc task's toolpath logic.

### DIFF
--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -64,7 +64,7 @@ type public Fsc () as this =
     let mutable targetProfile : string = null
     let mutable targetType : string = null
     let mutable toolExe : string = "fsc.exe"
-    let mutable toolPath : string =
+    let defaultToolPath =
         let locationOfThisDll =
             try Some(Path.GetDirectoryName(typeof<Fsc>.Assembly.Location))
             with _ -> None
@@ -471,11 +471,6 @@ type public Fsc () as this =
     member fsc.TreatWarningsAsErrors
         with get() = treatWarningsAsErrors
         and set(p) = treatWarningsAsErrors <- p
-        
-    // For targeting other folders for "fsc.exe" (or ToolExe if different)
-    member fsc.ToolPath
-        with get() = toolPath
-        and set(s) = toolPath <- s
 
     // When set to true, generate resource names in the same way as C# with root namespace and folder names
     member fsc.UseStandardResourceNames
@@ -536,8 +531,9 @@ type public Fsc () as this =
     override fsc.StandardErrorEncoding = if utf8output then System.Text.Encoding.UTF8 else base.StandardErrorEncoding
     override fsc.StandardOutputEncoding = if utf8output then System.Text.Encoding.UTF8 else base.StandardOutputEncoding
     override fsc.GenerateFullPathToTool() =
-        if toolPath = "" then raise (new System.InvalidOperationException(FSBuild.SR.toolpathUnknown()))
-        System.IO.Path.Combine(toolPath, fsc.ToolExe)
+        if defaultToolPath = "" then
+            raise (new System.InvalidOperationException(FSBuild.SR.toolpathUnknown()))
+        System.IO.Path.Combine(defaultToolPath, fsc.ToolExe)
     override fsc.LogToolCommand (message:string) =
         fsc.Log.LogMessageFromText(message, MessageImportance.Normal) |>ignore
 
@@ -579,8 +575,8 @@ type public Fsc () as this =
                     invokeCompiler baseCallDelegate
                 with
                 | e ->
-                        Debug.Assert(false, "HostObject received by Fsc task did not have a Compile method or the compile method threw an exception. "+(e.ToString()))
-                        reraise()
+                    Debug.Fail("HostObject received by Fsc task did not have a Compile method or the compile method threw an exception. " + (e.ToString()))
+                    reraise()
 
     override fsc.GenerateCommandLineCommands() =
         let builder = new FSharpCommandLineBuilder()

--- a/vsintegration/tests/UnitTests/Tests.Build.fs
+++ b/vsintegration/tests/UnitTests/Tests.Build.fs
@@ -70,16 +70,6 @@ type Build() =
         ()
 
     [<Test>]
-    member public this.MissingToolPathError() =
-        let tool = new FSharp.Build.Fsc()
-        tool.ToolPath <- ""
-        try
-            let p = tool.InternalGenerateFullPathToTool()
-            Assert.Fail("should not succeed")
-        with e -> 
-            e.Message.AssertMatchesPattern("ToolPath is unknown; specify the path to the tool.")
-        
-    [<Test>]
     member public this.TestCodePage() =
         let tool = new FSharp.Build.Fsc()
         printfn "By the way, the registry or app.config tool path is %s" tool.ToolPath


### PR DESCRIPTION
There is already a `ToolPath` property in the base `ToolTask` class.
This PR removes Fsc's duplicate definition.