### PR TITLE
Allow more SDK versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.302"
+    "version": "3.1.300",
+    "rollForward": "minor"
   },
   "tools": {
     "dotnet": "3.1.302",


### PR DESCRIPTION
Allows all 3.x SDK versions, starting with 3.1.300. Not sure what the minimum allowed version should be here.