### PR TITLE
Include paren pattern range in tuple simple pat

### DIFF
--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -200,7 +200,7 @@ let rec SimplePatsOfPat synArgNameGenerator p =
 
     | SynPat.Tuple (false, ps, m)
 
-    | SynPat.Paren(SynPat.Tuple (false, ps, m), _) ->
+    | SynPat.Paren(SynPat.Tuple (false, ps, _), m) ->
         let ps2, laterF =
           List.foldBack
             (fun (p', rhsf) (ps', rhsf') ->


### PR DESCRIPTION
For tuple patterns like the following, include parens in lambda SimplePat range.
```fsharp
fun (a, b) -> ()
```