### PR TITLE
Include 'const' keyword range in static constant expr range

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -5044,7 +5044,7 @@ atomType:
 
   | CONST atomicExpr
      {  let e, _ = $2
-        SynType.StaticConstantExpr(e, e.Range) }
+        SynType.StaticConstantExpr(e, lhs parseState) }
 
   | FALSE  
       { SynType.StaticConstant(SynConst.Bool false, lhs parseState) } 

--- a/tests/fsharp/typeProviders/negTests/neg1.bsl
+++ b/tests/fsharp/typeProviders/negTests/neg1.bsl
@@ -1358,7 +1358,7 @@ neg1.fsx(341,110,341,114): typecheck error FS0001: This expression was expected 
 but here has type
     'bool'    
 
-neg1.fsx(342,110,342,114): typecheck error FS3045: Invalid static argument to provided type. Expected an argument of kind 'string'.
+neg1.fsx(342,104,342,114): typecheck error FS3045: Invalid static argument to provided type. Expected an argument of kind 'string'.
 
 neg1.fsx(345,104,345,106): typecheck error FS3045: Invalid static argument to provided type. Expected an argument of kind 'float'.
 


### PR DESCRIPTION
For static constant expressions like the following, add an extra range for the entire StaticConstantExpr including 'const'.
```f#
MyTypeProvider<const(...)>
```

This will make it easier to understand the boundaries of the entire static constant expression