### PR TITLE
Fix problems with implementation of F# RFC 1056

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -426,6 +426,11 @@ module List =
         |> List.filter (fun (_, elems) -> Seq.length elems > 1) 
         |> List.map fst 
 
+    let allEqual (xs: 'T list) =
+        match xs with 
+        | [] -> true
+        | h::t -> t |> List.forall (fun h2 -> h = h2)
+
 module ResizeArray =
 
     /// Split a ResizeArray into an array of smaller chunks.

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -426,7 +426,7 @@ module List =
         |> List.filter (fun (_, elems) -> Seq.length elems > 1) 
         |> List.map fst 
 
-    let allEqual (xs: 'T list) =
+    let internal allEqual (xs: 'T list) =
         match xs with 
         | [] -> true
         | h::t -> t |> List.forall (fun h2 -> h = h2)

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -7956,7 +7956,7 @@ and TcComputationExpression cenv env overallTy mWhole (interpExpr: Expr) builder
                 let (opName, maintainsVarSpaceUsingBind, maintainsVarSpace, _allowInto, isLikeZip, isLikeJoin, isLikeGroupJoin, _joinConditionWord, methInfo) = opData
                 if (maintainsVarSpaceUsingBind && maintainsVarSpace) || (isLikeZip && isLikeJoin) || (isLikeZip && isLikeGroupJoin) || (isLikeJoin && isLikeGroupJoin) then 
                      errorR(Error(FSComp.SR.tcCustomOperationInvalid opName, nm.idRange))
-                if not cenv.g.langVersion.SupportsFeature LanguageFeature.OverloadsForCustomOperations then
+                if not (cenv.g.langVersion.SupportsFeature LanguageFeature.OverloadsForCustomOperations) then
                     match customOperationMethodsIndexedByMethodName.TryGetValue methInfo.LogicalName with 
                     | true, [_] -> ()
                     | _ -> errorR(Error(FSComp.SR.tcCustomOperationMayNotBeOverloaded nm.idText, nm.idRange))

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -7956,9 +7956,10 @@ and TcComputationExpression cenv env overallTy mWhole (interpExpr: Expr) builder
                 let (opName, maintainsVarSpaceUsingBind, maintainsVarSpace, _allowInto, isLikeZip, isLikeJoin, isLikeGroupJoin, _joinConditionWord, methInfo) = opData
                 if (maintainsVarSpaceUsingBind && maintainsVarSpace) || (isLikeZip && isLikeJoin) || (isLikeZip && isLikeGroupJoin) || (isLikeJoin && isLikeGroupJoin) then 
                      errorR(Error(FSComp.SR.tcCustomOperationInvalid opName, nm.idRange))
-                match customOperationMethodsIndexedByMethodName.TryGetValue methInfo.LogicalName with 
-                | true, [_] -> ()
-                | _ -> errorR(Error(FSComp.SR.tcCustomOperationMayNotBeOverloaded nm.idText, nm.idRange))
+                if not cenv.g.langVersion.SupportsFeature LanguageFeature.OverloadsForCustomOperations then
+                    match customOperationMethodsIndexedByMethodName.TryGetValue methInfo.LogicalName with 
+                    | true, [_] -> ()
+                    | _ -> errorR(Error(FSComp.SR.tcCustomOperationMayNotBeOverloaded nm.idText, nm.idRange))
             Some opDatas
         | true, (opData :: _) -> errorR(Error(FSComp.SR.tcCustomOperationMayNotBeOverloaded nm.idText, nm.idRange)); Some [opData]
         | _ -> None

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -7972,7 +7972,7 @@ and TcComputationExpression cenv env overallTy mWhole (interpExpr: Expr) builder
         let vs = opDatas |> List.map f
         let v0 = vs.[0]
         let (opName, _maintainsVarSpaceUsingBind, _maintainsVarSpace, _allowInto, _isLikeZip, _isLikeJoin, _isLikeGroupJoin, _joinConditionWord, _methInfo) = opDatas.[0]
-        if not (vs |> List.forall (fun v -> v = v0)) then 
+        if not (List.allEqual vs) then 
             errorR(Error(FSComp.SR.tcCustomOperationInvalid opName, m))
         v0
 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -8947,7 +8947,7 @@ and TcComputationExpression cenv env overallTy mWhole (interpExpr: Expr) builder
 
                     let (opName, _, _, _, _, _, _, _, methInfo) = opDatas.[0]
                     let isLikeZip = customOperationIsLikeZip nm
-                    let isLikeJoin = customOperationIsLikeZip nm
+                    let isLikeJoin = customOperationIsLikeJoin nm
                     let isLikeGroupJoin = customOperationIsLikeZip nm
 
                     // Record the resolution of the custom operation for posterity

--- a/tests/fsharp/typecheck/sigs/neg60.bsl
+++ b/tests/fsharp/typecheck/sigs/neg60.bsl
@@ -57,6 +57,12 @@ neg60.fs(65,19,65,24): typecheck error FS3087: The custom operation 'where' refe
 
 neg60.fs(65,19,65,24): typecheck error FS3087: The custom operation 'where' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
+neg60.fs(65,19,65,24): typecheck error FS3087: The custom operation 'where' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(65,19,65,24): typecheck error FS3087: The custom operation 'where' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(65,19,65,24): typecheck error FS3087: The custom operation 'where' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
 neg60.fs(65,19,65,38): typecheck error FS0001: This expression was expected to have type
     'bool'    
 but here has type
@@ -118,7 +124,11 @@ neg60.fs(128,9,128,13): typecheck error FS3087: The custom operation 'body' refe
 
 neg60.fs(128,9,128,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
-neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+neg60.fs(128,9,128,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(128,9,128,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(128,9,128,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
 neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
@@ -129,6 +139,20 @@ neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refe
 neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
 neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(129,9,129,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(130,9,130,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(130,9,130,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(130,9,130,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
 neg60.fs(130,9,130,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
@@ -141,6 +165,12 @@ neg60.fs(130,9,130,13): typecheck error FS3087: The custom operation 'body' refe
 neg60.fs(130,9,130,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
 neg60.fs(130,9,130,13): typecheck error FS3099: 'body' is used with an incorrect number of arguments. This is a custom operation in this query or computation expression. Expected 1 argument(s), but given 3.
+
+neg60.fs(131,9,131,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(131,9,131,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg60.fs(131,9,131,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
 neg60.fs(131,9,131,13): typecheck error FS3087: The custom operation 'body' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 

--- a/tests/fsharp/typecheck/sigs/neg87.bsl
+++ b/tests/fsharp/typecheck/sigs/neg87.bsl
@@ -38,3 +38,9 @@ neg87.fsx(14,5,14,10): typecheck error FS3087: The custom operation 'test2' refe
 neg87.fsx(14,5,14,10): typecheck error FS3087: The custom operation 'test2' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
 
 neg87.fsx(14,5,14,10): typecheck error FS3087: The custom operation 'test2' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg87.fsx(14,5,14,10): typecheck error FS3087: The custom operation 'test2' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg87.fsx(14,5,14,10): typecheck error FS3087: The custom operation 'test2' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.
+
+neg87.fsx(14,5,14,10): typecheck error FS3087: The custom operation 'test2' refers to a method which is overloaded. The implementations of custom operations may not be overloaded.


### PR DESCRIPTION
The process of activating [F# RFC 1056](https://github.com/fsharp/fslang-design/blob/master/preview/FS-1056-allow-custom-operation-overloads.md) [brought up some problems in changing of error messages](https://github.com/dotnet/fsharp/pull/10157/), and that led me to go back and [look more closely at the RFC and the implementation](https://github.com/fsharp/fslang-design/pull/504).

This makes changes (without yet adding testing) for the logic of looking up attributes on custom operators.

@cartermp @KevinRansom This was noticed because we were only now running this new feature over all test cases.  I think in the future we should ask people submitting preview features to also submit a PR that activates that feature, proving that the RFC implementation doesn't regress anything - and if it has fix things or add new test cases.


