### PR TITLE
Enable rollforward to enable building on sdk version missmatch 

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.302"
+    "version": "3.1.302",
+    "rollForward" : "minor"
   },
   "tools": {
     "dotnet": "3.1.302",

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "3.1.302",
-    "rollForward" : "minor"
+    "rollForward" : "latestFeature"
   },
   "tools": {
     "dotnet": "3.1.302",

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "3.1.302",
-    "rollForward" : "latestFeature"
+    "rollForward" : "minor"
   },
   "tools": {
     "dotnet": "3.1.302",


### PR DESCRIPTION
Currently it is not possible to load the solution and build with latest Visual Studio 2019 installed since the dotnet sdk version 3.1.402 is not an exact match of the version in specified in global.json (3.1.302)

This pr sets the [rollforward option](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#rollforward)  to enable roll forward of sdk version so never versions can be used so that you can open the solution in VS 2019 16.7.5.