### PR TITLE
Fix #9255 --- regression in `--staticlink`

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -579,8 +579,11 @@ type ILTypeRef =
       hashCode : int
       mutable asBoxedType: ILType }
 
+    static member ComputeHash(scope, enclosing, name) =
+        hash scope * 17 ^^^ (hash enclosing * 101 <<< 1) ^^^ (hash name * 47 <<< 2)
+
     static member Create (scope, enclosing, name) =
-        let hashCode = hash scope * 17 ^^^ (hash enclosing * 101 <<< 1) ^^^ (hash name * 47 <<< 2)
+        let hashCode = ILTypeRef.ComputeHash(scope, enclosing, name)
         { trefScope=scope
           trefEnclosing=enclosing
           trefName=name
@@ -610,11 +613,31 @@ type ILTypeRef =
     override x.GetHashCode() = x.hashCode
 
     override x.Equals yobj =
-         let y = (yobj :?> ILTypeRef)
-         (x.ApproxId = y.ApproxId) &&
-         (x.Scope = y.Scope) &&
-         (x.Name = y.Name) &&
-         (x.Enclosing = y.Enclosing)
+        let y = (yobj :?> ILTypeRef)
+        (x.ApproxId = y.ApproxId) &&
+        (x.Scope = y.Scope) &&
+        (x.Name = y.Name) &&
+        (x.Enclosing = y.Enclosing)
+
+    member x.EqualsWithPrimaryScopeRef (primaryScopeRef:ILScopeRef) (yobj:obj) =
+        let y = (yobj :?> ILTypeRef)
+        let isPrimary (v:ILTypeRef) =
+            match v.Scope with
+            | ILScopeRef.PrimaryAssembly -> true
+            | _ -> false
+
+        // Since we can remap the scope, we need to recompute hash ... this is not an expensive operation
+        let isPrimaryX = isPrimary x
+        let isPrimaryY = isPrimary y
+        let xApproxId = if isPrimaryX && not(isPrimaryY) then ILTypeRef.ComputeHash(primaryScopeRef, x.Enclosing, x.Name) else x.ApproxId
+        let yApproxId = if isPrimaryY && not(isPrimaryX) then ILTypeRef.ComputeHash(primaryScopeRef, y.Enclosing, y.Name) else y.ApproxId
+        let xScope = if isPrimaryX then primaryScopeRef else x.Scope
+        let yScope = if isPrimaryY then primaryScopeRef else y.Scope
+
+        (xApproxId = yApproxId) &&
+        (xScope = yScope) &&
+        (x.Name = y.Name) &&
+        (x.Enclosing = y.Enclosing)
 
     interface IComparable with
 
@@ -681,6 +704,10 @@ and [<StructuralEquality; StructuralComparison; StructuredFormatDisplay("{DebugT
     /// For debugging
     [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
     member x.DebugText = x.ToString()
+
+    member x.EqualsWithPrimaryScopeRef (primaryScopeRef:ILScopeRef) (yobj:obj) =
+        let y = (yobj :?> ILTypeSpec)
+        (x.tspecTypeRef.EqualsWithPrimaryScopeRef primaryScopeRef y.TypeRef) && (x.GenericArgs = y.GenericArgs)
 
     override x.ToString() = x.TypeRef.ToString() + if isNil x.GenericArgs then "" else "<...>"
 

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -619,7 +619,7 @@ type ILTypeRef =
         (x.Name = y.Name) &&
         (x.Enclosing = y.Enclosing)
 
-    member x.EqualsWithPrimaryScopeRef (primaryScopeRef:ILScopeRef) (yobj:obj) =
+    member x.EqualsWithPrimaryScopeRef(primaryScopeRef:ILScopeRef, yobj:obj) =
         let y = (yobj :?> ILTypeRef)
         let isPrimary (v:ILTypeRef) =
             match v.Scope with
@@ -705,9 +705,9 @@ and [<StructuralEquality; StructuralComparison; StructuredFormatDisplay("{DebugT
     [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
     member x.DebugText = x.ToString()
 
-    member x.EqualsWithPrimaryScopeRef (primaryScopeRef:ILScopeRef) (yobj:obj) =
+    member x.EqualsWithPrimaryScopeRef(primaryScopeRef:ILScopeRef, yobj:obj) =
         let y = (yobj :?> ILTypeSpec)
-        (x.tspecTypeRef.EqualsWithPrimaryScopeRef primaryScopeRef y.TypeRef) && (x.GenericArgs = y.GenericArgs)
+        x.tspecTypeRef.EqualsWithPrimaryScopeRef(primaryScopeRef, y.TypeRef) && (x.GenericArgs = y.GenericArgs)
 
     override x.ToString() = x.TypeRef.ToString() + if isNil x.GenericArgs then "" else "<...>"
 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -220,6 +220,9 @@ type ILTypeSpec =
     /// The name of the type in the assembly using the '.' notation for nested types.
     member FullName: string
     
+    /// The basic qualified name of the type in the assembly.
+    member BasicQualifiedName: string
+
     interface System.IComparable
 
 and 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -221,7 +221,7 @@ type ILTypeSpec =
     member FullName: string
     
     /// The basic qualified name of the type in the assembly.
-    member BasicQualifiedName: string
+    member internal BasicQualifiedName: string
 
     interface System.IComparable
 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -209,21 +209,18 @@ type ILTypeSpec =
 
     /// The type instantiation if the type is generic, otherwise empty
     member GenericArgs: ILGenericArgs
-    
-    /// Where is the type, i.e. is it in this module, in another module in this assembly or in another assembly? 
+
+    /// Where is the type, i.e. is it in this module, in another module in this assembly or in another assembly?
     member Scope: ILScopeRef
     
     /// The list of enclosing type names for a nested type. If non-nil then the first of these also contains the namespace.
     member Enclosing: string list
-    
+
     /// The name of the type. This also contains the namespace if Enclosing is empty.
     member Name: string
-    
+
     /// The name of the type in the assembly using the '.' notation for nested types.
     member FullName: string
-    
-    /// The basic qualified name of the type in the assembly.
-    member internal BasicQualifiedName: string
 
     member internal EqualsWithPrimaryScopeRef: ILScopeRef * obj -> bool
 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -194,7 +194,7 @@ type ILTypeRef =
 
     member QualifiedName: string
 
-    member internal EqualsWithPrimaryScopeRef: ILScopeRef -> obj -> bool
+    member internal EqualsWithPrimaryScopeRef: ILScopeRef * obj -> bool
 
     interface System.IComparable
     
@@ -225,7 +225,7 @@ type ILTypeSpec =
     /// The basic qualified name of the type in the assembly.
     member internal BasicQualifiedName: string
 
-    member internal EqualsWithPrimaryScopeRef: ILScopeRef -> obj -> bool
+    member internal EqualsWithPrimaryScopeRef: ILScopeRef * obj -> bool
 
     interface System.IComparable
 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -194,6 +194,8 @@ type ILTypeRef =
 
     member QualifiedName: string
 
+    member internal EqualsWithPrimaryScopeRef: ILScopeRef -> obj -> bool
+
     interface System.IComparable
     
 /// Type specs and types.  
@@ -222,6 +224,8 @@ type ILTypeSpec =
     
     /// The basic qualified name of the type in the assembly.
     member internal BasicQualifiedName: string
+
+    member internal EqualsWithPrimaryScopeRef: ILScopeRef -> obj -> bool
 
     interface System.IComparable
 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -443,16 +443,8 @@ type MethodDefKey(ilg:ILGlobals, tidx: int, garity: int, nm: string, rty: ILType
         match obj with
         | :? MethodDefKey as y ->
             let compareILTypes o1 o2 =
-                let getScope (v:ILTypeSpec) =
-                    match v.Scope with
-                    | ILScopeRef.PrimaryAssembly -> ilg.primaryAssemblyScopeRef
-                    | _ -> v.Scope
-
                 match o1, o2 with
-                | ILType.Value v1, ILType.Value v2 ->
-                    let s1 = getScope v1
-                    let s2 = getScope v2
-                    (s1 = s2) && (v1.BasicQualifiedName = v2.BasicQualifiedName)
+                | ILType.Value v1, ILType.Value v2 -> v1.EqualsWithPrimaryScopeRef ilg.primaryAssemblyScopeRef v2
                 | _ -> o1 = o2
 
             tidx = y.TypeIdx &&

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -451,8 +451,7 @@ type MethodDefKey(ilg:ILGlobals, tidx: int, garity: int, nm: string, rty: ILType
             garity = y.GenericArity &&
             nm = y.Name &&
             // note: these next two use structural equality on AbstractIL ILType values
-            rty = y.ReturnType &&
-            List.lengthsEqAndForall2 compareILTypes argtys y.ArgTypes &&
+            rty = y.ReturnType && List.lengthsEqAndForall2 compareILTypes argtys y.ArgTypes &&
             isStatic = y.IsStatic
         | _ -> false
 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -444,7 +444,7 @@ type MethodDefKey(ilg:ILGlobals, tidx: int, garity: int, nm: string, rty: ILType
         | :? MethodDefKey as y ->
             let compareILTypes o1 o2 =
                 match o1, o2 with
-                | ILType.Value v1, ILType.Value v2 -> v1.EqualsWithPrimaryScopeRef ilg.primaryAssemblyScopeRef v2
+                | ILType.Value v1, ILType.Value v2 -> v1.EqualsWithPrimaryScopeRef(ilg.primaryAssemblyScopeRef, v2 :> obj )
                 | _ -> o1 = o2
 
             tidx = y.TypeIdx &&

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -456,7 +456,6 @@ type MethodDefKey(ilg:ILGlobals, tidx: int, garity: int, nm: string, rty: ILType
                      let scope2 = getScopedTypeRef o2
                      match scope1, scope2 with
                      | Some s1, Some s2 -> s1 = s2
-                       
                      |_ -> o1 = o2
 
                 let compareMethodDefKeys =


### PR DESCRIPTION
Okay so ... firstly I'm sorry this was quite hard to pin down and so took a while.

The issue arises because when we import dependent assemblies such as the static link assemblies.  We don't have access to the same set of system references as can be found in ILGlobals are just not wired up to enable this.  Instead we use [PrimaryAssemblyILGlobals ](https://github.com/dotnet/fsharp/blob/main/src/absil/il.fs#L3711).

The issue occures because when we load types from IlGlobals instead of a PrimaryAssemblyReference they use ILAssemblyReferences.  This was of course necessary so type unification could occur.

However, types whose scope is from PrimaryAssemblyILGlobals, don't have this ... by definition.

So the fix was to:
1.   Make a PrimaryAssembly reference take an optional assembly scope ref.
2.   When we do a compare in MethodDefKey to ensure that two types are equal (this happens for method arguments and return types) We check to see if their assembly references match.


So this fixes the embedding thing, but has shown up different issue:
````
c:\Temp\repro>c:\kevinransom\fsharp\artifacts\bin\fsc\Debug\net472\fsc.exe @repro.rsp
Microsoft (R) F# Compiler version 11.0.0.0 for F# 5.0
Copyright (c) Microsoft Corporation. All Rights Reserved.
Duplicate in method table is:
 Type index: 30
 Method name: ToString
 Method arity (num generic params): 0

error FS2014: A problem occurred writing the binary 'c:\Temp\repro\obj\Debug\netcoreapp3.1\ConsoleApp1.dll': Error in pass2 for type Newtonsoft.Json.JsonConvert, error: duplicate entry 'ToString' in method table
````
This type has thousands of overloads for too string so perhaps overload our resolution is a bit iffy.  I will invetigate in a seperate PR.

Note:
This is a change in the way that we handle PrimaryAssemblyScopeRefs, there is existing code that uses an assemblyref held elsewhere.

I propose fixing it in this PR, but first I wanted Will and Don to run their eyes over this and see if they hate it, or whether I should move forward with it.

It probably needs a test case too, however, until the ToString() bug is addressed, that may be tricky.

Thanks

Kevin


