### PR TITLE
Do not allow negative values to represent indentation scopes when pasting code

### DIFF
--- a/vsintegration/src/FSharp.Editor/Formatting/EditorFormattingService.fs
+++ b/vsintegration/src/FSharp.Editor/Formatting/EditorFormattingService.fs
@@ -138,8 +138,12 @@ type internal FSharpEditorFormattingService
                 let removeIndentation =
                     let nextLineIndent = fixedPasteText.Lines.[1].ToString() |> getIndentation
 
-                    if nextLineShouldBeIndented then nextLineIndent - tabSize
-                    else nextLineIndent
+                    let res =
+                        if nextLineShouldBeIndented then
+                            nextLineIndent - tabSize
+                        else nextLineIndent
+
+                    max 0 res
                 
                 return stripIndentation removeIndentation
         }


### PR DESCRIPTION
fixes https://github.com/dotnet/fsharp/issues/9752

I verified both repros and played around with a few other pasting scenarios and it appears to work well (Smart indent turned on, which activates things properly).