### PR TITLE
use 5.0 sdk

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -44,6 +44,8 @@ Install the latest released [Visual Studio](https://www.visualstudio.com/downloa
 * .NET desktop development (also check F# desktop support, as this will install some legacy templates)
 * Visual Studio extension development
 
+You will also need the latest .NET 5 SDK installed from [here](https://dotnet.microsoft.com/download/dotnet/5.0).
+
 Building is simple:
 
     build.cmd

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 You're invited to contribute to future releases of the F# compiler, core library, and tools. Development of this repository can be done on any OS supported by [.NET Core](https://dotnet.microsoft.com/).
 
+You will also need the latest .NET 5 SDK installed from [here](https://dotnet.microsoft.com/download/dotnet/5.0).
+
 ## Contributing
 
 ### Quickstart on Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,8 @@ variables:
     value: .NETCore
   - name: VisualStudioDropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+  - name: DotNetSdkVersion
+    value: '5.0.100'
   - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - name: RunningAsPullRequest
       value: true
@@ -407,6 +409,12 @@ stages:
         #     displayName: Initial build
         #   - script: dotnet --list-sdks
         #     displayName: Report dotnet SDK versions
+        #   - task: UseDotNet@2
+        #       displayName: install SDK
+        #       inputs:
+        #         packageType: sdk
+        #         version: $(DotNetSdkVersion)
+        #         installationPath: $(Agent.ToolsDirectory)/dotnet
         #   - script: dotnet build .\FSharp.sln /bl:\"artifacts/log/$(_BuildConfig)/RegularBuild.binlog\"
         #     displayName: Regular rebuild
 
@@ -424,6 +432,12 @@ stages:
             displayName: Initial build
           - script: dotnet --list-sdks
             displayName: Report dotnet SDK versions
+          - task: UseDotNet@2
+            displayName: install SDK
+            inputs:
+              packageType: sdk
+              version: $(DotNetSdkVersion)
+              installationPath: $(Agent.ToolsDirectory)/dotnet
           - script: dotnet build ./FSharp.sln /bl:\"artifacts/log/$(_BuildConfig)/RegularBuild.binlog\"
             displayName: Regular rebuild
 
@@ -441,6 +455,12 @@ stages:
             displayName: Initial build
           - script: dotnet --list-sdks
             displayName: Report dotnet SDK versions
+          - task: UseDotNet@2
+            displayName: install SDK
+            inputs:
+              packageType: sdk
+              version: $(DotNetSdkVersion)
+              installationPath: $(Agent.ToolsDirectory)/dotnet
           - script: dotnet build ./FSharp.sln /bl:\"artifacts/log/$(_BuildConfig)/RegularBuild.binlog\"
             displayName: Regular rebuild
 

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
-    "version": "3.1.302",
+    "version": "5.0.100",
     "rollForward": "minor"
   },
   "tools": {
-    "dotnet": "3.1.302",
+    "dotnet": "5.0.100",
     "vs": {
-      "version": "16.4",
+      "version": "16.8",
       "components": [
         "Microsoft.VisualStudio.Component.FSharp"
       ]

--- a/src/fsharp/fsc/fsc.fsproj
+++ b/src/fsharp/fsc/fsc.fsproj
@@ -12,6 +12,7 @@
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <OtherFlags>$(OtherFlags) --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <NGenBinary>true</NGenBinary>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -13,6 +13,7 @@
     <OtherFlags>--warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <Win32Resource>fsi.res</Win32Resource>
     <NGenBinary>true</NGenBinary>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -453,7 +453,7 @@ let main argv = 0"""
         "tfm": "netcoreapp3.1",
         "framework": {
             "name": "Microsoft.NETCore.App",
-            "version": "3.1.0"
+            "version": "5.0.0"
         }
     }
 }"""

--- a/vsintegration/tests/GetTypesVS.UnitTests/GetTypesVS.UnitTests.fsproj
+++ b/vsintegration/tests/GetTypesVS.UnitTests/GetTypesVS.UnitTests.fsproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="VSSDK.VSLangProj.8" Version="$(VSSDKVSLangProj8Version)" PrivateAssets="all" ExcludeAssets="contentFiles;build;analyzers;native" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now that dotnet/runtime#40864 is fixed, we can directly consume the 5.0 SDK.

tl;dr
-----
VS 16.8 is now required to build.

Long version
------------

The 5.0 SDK requires MSBuild 16.8 which requires VS 16.8.  The internal VMs have been updated.

Local run of `.\build.cmd -testVs` passes.

[Internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=906098&view=results) has passed.