### PR TITLE
don't trigger ci checks on doc updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,14 +1,49 @@
 # CI and PR triggers
 trigger:
-- main
-- dev16.1
-- feature/*
-- release/*
+  branches:
+    include:
+    - main
+    - dev16.1
+    - feature/*
+    - release/*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - .github/*
+    - docs/compiler-guide.md
+    - attributions.md
+    - CODE_OF_CONDUCT.md
+    - DEVGUIDE.md
+    - INTERNAL.md
+    - Language-Version-History.md
+    - License.txt
+    - README.md
+    - release-notes.md
+    - TESTGUIDE.md
+
 pr:
-- main
-- dev16.1
-- feature/*
-- release/*
+  branches:
+    include:
+    - main
+    - dev16.1
+    - feature/*
+    - release/*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - .github/*
+    - docs/compiler-guide.md
+    - attributions.md
+    - CODE_OF_CONDUCT.md
+    - DEVGUIDE.md
+    - INTERNAL.md
+    - Language-Version-History.md
+    - License.txt
+    - README.md
+    - release-notes.md
+    - TESTGUIDE.md
 
 variables:
   - name: _TeamName


### PR DESCRIPTION
With guidance from @abelbraaksma, don't unnecessarily build the repo on just doc changes.  Inspiration taken from [dotnet/runtime:eng/pipelines/runtime.yml](https://github.com/dotnet/runtime/blob/master/eng/pipelines/runtime.yml).