### PR TITLE
FSharp.Core: Set: optimize tree layout

### DIFF
--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -126,7 +126,7 @@ module internal SetTree =
             if height t2'.Left > t1h + 1 then  // balance left: combination 
                 let t2l = asNode(t2'.Left)
                 mk (mk t1 v t2l.Left) t2l.Key (mk t2l.Right t2'.Key t2'.Right) 
-            else // rotate left 
+            else // rotate left
                 mk (mk t1 v t2'.Left) t2.Key t2'.Right
         else
             if  t1h > t2h + tolerance then // left is heavier than right
@@ -144,7 +144,7 @@ module internal SetTree =
         if isEmpty t then SetTree k
         else
             let c = comparer.Compare(k, t.Key)
-            match t with 
+            match t with
             | :? SetTreeNode<'T> as tn ->
                 if   c < 0 then rebalance (add comparer k tn.Left) tn.Key tn.Right
                 elif c = 0 then t
@@ -224,11 +224,11 @@ module internal SetTree =
             | :? SetTreeNode<'T> as tn ->
                 if   c < 0 then rebalance (remove comparer k tn.Left) tn.Key tn.Right
                 elif c = 0 then
-                  if isEmpty tn.Left then tn.Right
-                  elif isEmpty tn.Right then tn.Left
-                  else
-                      let sk, r' = spliceOutSuccessor tn.Right 
-                      mk tn.Left sk r'
+                    if isEmpty tn.Left then tn.Right
+                    elif isEmpty tn.Right then tn.Left
+                    else
+                        let sk, r' = spliceOutSuccessor tn.Right 
+                        mk tn.Left sk r'
                 else rebalance tn.Left tn.Key (remove comparer k tn.Right)
             | _ ->  
                 if   c = 0 then empty
@@ -329,11 +329,11 @@ module internal SetTree =
                     //   Split t2 using pivot k1 into lo and hi.
                     //   Union disjoint subproblems and then combine. 
                     if t1n.Height > t2n.Height then
-                      let lo, _, hi = split comparer t1n.Key t2 in
-                      balance comparer (union comparer t1n.Left lo) t1n.Key (union comparer t1n.Right hi)
+                        let lo, _, hi = split comparer t1n.Key t2 in
+                        balance comparer (union comparer t1n.Left lo) t1n.Key (union comparer t1n.Right hi)
                     else
-                      let lo, _, hi = split comparer t2n.Key t1 in
-                      balance comparer (union comparer t2n.Left lo) t2n.Key (union comparer t2n.Right hi)
+                        let lo, _, hi = split comparer t2n.Key t1 in
+                        balance comparer (union comparer t2n.Left lo) t2n.Key (union comparer t2n.Right hi)
                 | _ -> add comparer t2.Key t1
             | _ -> add comparer t1.Key t2
 
@@ -431,8 +431,8 @@ module internal SetTree =
     let current i =
         if i.started then
             match i.stack with
-              | k :: _ -> k.Key
-              | []     -> alreadyFinished()
+            | k :: _ -> k.Key
+            | []     -> alreadyFinished()
         else
             notStarted()
 


### PR DESCRIPTION
Same changes as in #10188

Also fix tracing in Map: #if-protected tracing was not updated properly in the previous PR.

|      Method |    Job | BuildConfiguration |  Size |          Mean |        Error |        StdDev | Rank |   Gen 0 |  Gen 1 | Gen 2 | Allocated | Code Size |
|------------ |------- |------------------- |------ |--------------:|-------------:|--------------:|-----:|--------:|-------:|------:|----------:|----------:|
| containsKey |  After |         LocalBuild |   100 |      30.48 ns |     0.319 ns |      0.367 ns |    1 |       - |      - |     - |         - |     177 B |
| containsKey | Before |            Default |   100 |      46.77 ns |     0.172 ns |      0.199 ns |    2 |       - |      - |     - |         - |     261 B |
| containsKey |  After |         LocalBuild | 10000 |      56.06 ns |     0.358 ns |      0.412 ns |    3 |       - |      - |     - |         - |     177 B |
| containsKey | Before |            Default | 10000 |      92.14 ns |     0.314 ns |      0.362 ns |    4 |       - |      - |     - |         - |     261 B |
|             |        |                    |       |               |              |               |      |         |        |       |           |           |
|  isSubsetOf |  After |         LocalBuild |   100 |   1,003.26 ns |     7.438 ns |      8.565 ns |    1 |  0.0040 |      - |     - |      32 B |      80 B |
|  isSubsetOf | Before |            Default |   100 |   1,464.29 ns |    10.892 ns |     12.106 ns |    2 |       - |      - |     - |      32 B |      80 B |
|  isSubsetOf |  After |         LocalBuild | 10000 | 301,895.28 ns | 3,344.640 ns |  3,851.692 ns |    3 |       - |      - |     - |      34 B |      80 B |
|  isSubsetOf | Before |            Default | 10000 | 418,711.41 ns | 9,323.778 ns | 10,737.277 ns |    4 |       - |      - |     - |      34 B |      80 B |
|             |        |                    |       |               |              |               |      |         |        |       |           |           |
|     maxItem |  After |         LocalBuild |   100 |      14.99 ns |     0.050 ns |      0.058 ns |    1 |  0.0038 |      - |     - |      24 B |     218 B |
|     maxItem | Before |            Default |   100 |      31.11 ns |     0.067 ns |      0.072 ns |    3 |  0.0037 |      - |     - |      24 B |     218 B |
|     maxItem |  After |         LocalBuild | 10000 |      23.80 ns |     0.159 ns |      0.183 ns |    2 |  0.0037 |      - |     - |      24 B |     218 B |
|     maxItem | Before |            Default | 10000 |      52.40 ns |     0.135 ns |      0.156 ns |    4 |  0.0037 |      - |     - |      24 B |     218 B |
|             |        |                    |       |               |              |               |      |         |        |       |           |           |
|   itemCount |  After |         LocalBuild |   100 |     200.70 ns |     0.847 ns |      0.870 ns |    1 |       - |      - |     - |         - |      96 B |
|   itemCount | Before |            Default |   100 |     419.93 ns |     0.937 ns |      1.079 ns |    2 |       - |      - |     - |         - |     138 B |
|   itemCount |  After |         LocalBuild | 10000 |  25,581.85 ns |   188.342 ns |    216.895 ns |    3 |       - |      - |     - |         - |      96 B |
|   itemCount | Before |            Default | 10000 |  46,754.89 ns |   202.769 ns |    225.377 ns |    4 |       - |      - |     - |         - |     138 B |
|             |        |                    |       |               |              |               |      |         |        |       |           |           |
| iterForeach |  After |         LocalBuild |   100 |   2,881.03 ns |     7.049 ns |      7.835 ns |    1 |  0.9660 |      - |     - |    6120 B |     280 B |
| iterForeach | Before |            Default |   100 |   3,608.70 ns |    12.932 ns |     14.892 ns |    2 |  0.9644 |      - |     - |    6120 B |     280 B |
| iterForeach |  After |         LocalBuild | 10000 | 314,901.59 ns | 1,778.653 ns |  1,976.968 ns |    3 | 95.0000 |      - |     - |  600128 B |     280 B |
| iterForeach | Before |            Default | 10000 | 381,488.32 ns |   914.308 ns |  1,016.251 ns |    4 | 94.5122 |      - |     - |  600127 B |     280 B |
|             |        |                    |       |               |              |               |      |         |        |       |           |           |
|     addItem |  After |         LocalBuild |   100 |     193.98 ns |     0.587 ns |      0.652 ns |    1 |  0.0500 |      - |     - |     317 B |     499 B |
|     addItem | Before |            Default |   100 |     291.34 ns |     1.804 ns |      1.931 ns |    2 |  0.0501 |      - |     - |     317 B |     542 B |
|     addItem |  After |         LocalBuild | 10000 |  43,575.99 ns |   216.915 ns |    249.800 ns |    3 |  9.2188 | 2.8125 |     - |   58637 B |     499 B |
|     addItem | Before |            Default | 10000 |  62,096.44 ns |   205.697 ns |    228.632 ns |    4 |  9.1667 | 2.7083 |     - |   58637 B |     542 B |
|             |        |                    |       |               |              |               |      |         |        |       |           |           |
|  removeItem |  After |         LocalBuild |   100 |      12.05 ns |     0.055 ns |      0.061 ns |    1 |  0.0064 |      - |     - |      40 B |     447 B |
|  removeItem | Before |            Default |   100 |      14.71 ns |     0.248 ns |      0.285 ns |    2 |  0.0064 |      - |     - |      40 B |     500 B |
|  removeItem |  After |         LocalBuild | 10000 |   1,183.65 ns |     9.752 ns |     11.231 ns |    3 |  0.6343 |      - |     - |    4000 B |     447 B |
|  removeItem | Before |            Default | 10000 |   1,484.44 ns |    13.358 ns |     14.848 ns |    4 |  0.6368 |      - |     - |    4000 B |     500 B |