### PR TITLE
don't emit empty assembly references to package resolution file

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -175,6 +175,9 @@
     <Compile Include="..\..\utils\PathMap.fs">
       <Link>Utilities\PathMap.fs</Link>
     </Compile>
+    <Compile Include="..\..\utils\RidHelpers.fs">
+      <Link>Utilities\RidHelpers.fs</Link>
+    </Compile>
     <Compile Include="..\range.fsi">
       <Link>ErrorLogging\range.fsi</Link>
     </Compile>

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
@@ -210,11 +210,11 @@ $(PACKAGEREFERENCES)
     <ItemGroup>
       <ResolvedReferenceLines Remove='*' />
       <ResolvedReferenceLines
-          Condition=" ('%(InteractiveResolvedFile.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(InteractiveResolvedFile.NugetPackageId)'=='FSharp.Core')"
+          Condition="(@(InteractiveResolvedFile->Count()) &gt; 0) AND (('%(InteractiveResolvedFile.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(InteractiveResolvedFile.NugetPackageId)'=='FSharp.Core'))"
           Include='%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.PackageRoot),%(InteractiveResolvedFile.FullPath),%(InteractiveResolvedFile.AssetType),%(InteractiveResolvedFile.IsNotImplementationReference),%(InteractiveResolvedFile.InitializeSourcePath),'
           KeepDuplicates="false" />
       <ResolvedReferenceLines
-          Condition="('%(NativeIncludeRoots.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(NativeIncludeRoots.NugetPackageId)'=='FSharp.Core')"
+          Condition="(@(NativeIncludeRoots->Count()) &gt; 0) AND (('%(NativeIncludeRoots.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(NativeIncludeRoots.NugetPackageId)'=='FSharp.Core'))"
           Include='%(NativeIncludeRoots.NugetPackageId),%(NativeIncludeRoots.NugetPackageVersion),%(NativeIncludeRoots.PackageRoot),,%(NativeIncludeRoots.AssetType),,,%(NativeIncludeRoots.Path)'
           KeepDuplicates="false" />
     </ItemGroup>

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -9,6 +9,14 @@ open System.Reflection
 [<AttributeUsage(AttributeTargets.Assembly ||| AttributeTargets.Class , AllowMultiple = false)>]
 type DependencyManagerAttribute() = inherit System.Attribute()
 
+/// The result of building the package resolution files.
+type PackageBuildResolutionResult =
+    { success: bool
+      projectPath: string
+      stdOut: string array
+      stdErr: string array
+      resolutionsFile: string option }
+
 module internal Utilities =
 
     /// Return a string array delimited by commas
@@ -202,7 +210,7 @@ module internal Utilities =
 
         let workingDir = Path.GetDirectoryName projectPath
 
-        let succeeded, stdOut, stdErr =
+        let success, stdOut, stdErr =
             if not (isRunningOnCoreClr) then
                 // The Desktop build uses "msbuild" to build
                 executeBuild msbuildExePath (arguments "-v:quiet") workingDir
@@ -211,5 +219,9 @@ module internal Utilities =
                 executeBuild dotnetHostPath (arguments "msbuild -v:quiet") workingDir
 
         let outputFile = projectPath + ".resolvedReferences.paths"
-        let resultOutFile = if succeeded && File.Exists(outputFile) then Some outputFile else None
-        succeeded, stdOut, stdErr, resultOutFile
+        let resolutionsFile = if success && File.Exists(outputFile) then Some outputFile else None
+        { success = success
+          projectPath = projectPath
+          stdOut = stdOut
+          stdErr = stdErr
+          resolutionsFile = resolutionsFile }

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
@@ -29,7 +29,7 @@ type ResolveDependenciesResult =
     /// The roots to package directories
     member Roots: seq<string>
 
-[<DependencyManagerAttribute>] 
+[<DependencyManagerAttribute>]
 type FSharpDependencyManager =
     new: outputDir:string option -> FSharpDependencyManager
 
@@ -39,4 +39,6 @@ type FSharpDependencyManager =
 
     member HelpMessages:string[]
 
-    member ResolveDependencies: scriptExt:string * packageManagerTextLines: (string * string) seq * tfm: string * rid: string -> obj
+    member PrepareDependencyResolutionFiles: scriptExt: string * packageManagerTextLines: (string * string) seq * targetFrameworkMoniker: string * runtimeIdentifier: string -> PackageBuildResolutionResult
+
+    member ResolveDependencies: scriptExt: string * packageManagerTextLines: (string * string) seq * targetFrameworkMoniker: string * runtimeIdentifier: string -> obj

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
@@ -6,6 +6,7 @@ open System
 open System.IO
 open System.Reflection
 open System.Runtime.InteropServices
+open Internal.Utilities
 open Internal.Utilities.FSharpEnvironment
 open Microsoft.FSharp.Reflection
 open System.Collections.Concurrent

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/Microsoft.DotNet.DependencyManager.fsproj
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/Microsoft.DotNet.DependencyManager.fsproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <EmbeddedText Include="DependencyManager.txt" />
     <EmbeddedText Include="..\..\utils\UtilsStrings.txt" />
+    <Compile Include="..\..\utils\RidHelpers.fs" />
     <Compile Include="..\..\utils\CompilerLocationUtils.fs" />
     <Compile Include="AssemblyResolveHandler.fsi" />
     <Compile Include="AssemblyResolveHandler.fs" />

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi
@@ -3,13 +3,6 @@
 namespace Microsoft.DotNet.DependencyManager
 
 open System
-open System.Collections.Generic
-
-module internal RidHelpers =
-    val probingRids:string []
-    val baseRid:string
-    val platformRid:string
-
 
 /// Signature for Native library resolution probe callback
 /// host implements this, it's job is to return a list of package roots to probe.

--- a/src/utils/RidHelpers.fs
+++ b/src/utils/RidHelpers.fs
@@ -1,0 +1,23 @@
+namespace Internal.Utilities
+
+open System.Runtime.InteropServices
+
+module internal RidHelpers =
+
+    // Computer valid dotnet-rids for this environment:
+    //      https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
+    //
+    // Where rid is: win, win-x64, win-x86, osx-x64, linux-x64 etc ...
+    let probingRids, baseRid, platformRid =
+        let processArchitecture = RuntimeInformation.ProcessArchitecture
+        let baseRid =
+            if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then "win"
+            elif RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then "osx"
+            else "linux"
+        let platformRid =
+            match processArchitecture with
+            | Architecture.X64 ->  baseRid + "-x64"
+            | Architecture.X86 -> baseRid + "-x86"
+            | Architecture.Arm64 -> baseRid + "-arm64"
+            | _ -> baseRid + "-arm"
+        [| "any"; baseRid; platformRid |], baseRid, platformRid

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="ConsoleHelpers.fs" />
+    <Compile Include="$(FSharpSourcesRoot)\utils\RidHelpers.fs" />
     <Compile Include="TestHelpers.fs" />
     <Compile Include="DependencyManagerInteractiveTests.fs" />
     <Compile Include="DependencyManagerLineParserTests.fs" />

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestHelpers.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/TestHelpers.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.Scripting.UnitTests
 
 open System
+open System.IO
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.SourceCodeServices
 
@@ -17,3 +18,15 @@ module TestHelpers =
         | Error ex -> raise ex
 
     let ignoreValue = getValue >> ignore
+
+    let getTempDir () =
+        let sysTempDir = Path.GetTempPath()
+        let customTempDirName = Guid.NewGuid().ToString("D")
+        let fullDirName = Path.Combine(sysTempDir, customTempDirName)
+        let dirInfo = Directory.CreateDirectory(fullDirName)
+        { new Object() with
+            member __.ToString() = dirInfo.FullName
+          interface IDisposable with
+            member __.Dispose() =
+                dirInfo.Delete(true)
+        }


### PR DESCRIPTION
If the `@(InteractiveResolvedFile)` or `@(NativeIncludeRoots)` collection is empty, then a blank entry will be emitted to the package assembly resolutions file as `,,,,,,,`.  While it's benign, it's a little sloppy, which leads me to my next point:

All of the sloppy refactorings in this PR were simply to make the one test case easy to write, and to accomplish this I simply split the `ResolveDependencies` function in half so I could easily access the resolutions file.  I'm certainly open to suggestions on how to make it less gross and/or how to test it better.  The entire fix is the addition of the `@(NativeIncludeRoots->Count()) &gt; 0` checks.