### PR TITLE
Fixed find-all refs not looking at all files/projects

### DIFF
--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -103,7 +103,8 @@ type internal FSharpFindUsagesService
                                         |> Option.defaultValue externalDefinitionItem
 
                                 let referenceItem = FSharpSourceReferenceItem(definitionItem, FSharpDocumentSpan(doc, textSpan))
-                                do! context.OnReferenceFoundAsync(referenceItem) |> Async.AwaitTask }
+                                // REVIEW: OnReferenceFoundAsync is throwing inside Roslyn, putting a try/with so find-all refs doesn't fail.
+                                try do! context.OnReferenceFoundAsync(referenceItem) |> Async.AwaitTask with | _ -> () }
             
             match symbolUse.GetDeclarationLocation document with
             | Some SymbolDeclarationLocation.CurrentDocument ->


### PR DESCRIPTION
This fixes an issue when performing a find-all refs, it would not look through all files and/or projects.

This is a weird one, it's blowing up inside Roslyn because it's constructing a `TextSpan` with an invalid `start` value. To mitigate it, simply putting a try/with around the Roslyn call fixes the main issue mentioned above.