### PR TITLE
[WIP] fsc.exe - Parallel Parsing

### DIFF
--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1844,11 +1844,7 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
             let isLastCompiland, isExe = sourceFiles |> tcConfig.ComputeCanContainEntryPoint 
             let sourceFiles = isLastCompiland |> List.zip sourceFiles |> Array.ofSeq
             
-            let parallelOptions = ParallelOptions()
-            parallelOptions.MaxDegreeOfParallelism <- Environment.ProcessorCount
-
-            if parallelOptions.MaxDegreeOfParallelism > sourceFiles.Length then
-                parallelOptions.MaxDegreeOfParallelism <- sourceFiles.Length
+            let parallelOptions = ParallelOptions(MaxDegreeOfParallelism=min Environment.ProcessorCount sourceFiles.Length)
 
             let results = Array.zeroCreate sourceFiles.Length
             Parallel.For(0, sourceFiles.Length, parallelOptions, fun i ->
@@ -2262,4 +2258,3 @@ let mainCompile
     typecheckAndCompile
        (ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, reduceMemoryUsage, 
         defaultCopyFSharpCore, exiter, errorLoggerProvider, tcImportsCapture, dynamicAssemblyCreator)
-

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -19,6 +19,7 @@ open System.IO
 open System.Reflection
 open System.Text
 open System.Threading
+open System.Threading.Tasks
 
 open Internal.Utilities
 open Internal.Utilities.Collections
@@ -1841,14 +1842,25 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
     let inputs =
         try
             let isLastCompiland, isExe = sourceFiles |> tcConfig.ComputeCanContainEntryPoint 
-            isLastCompiland |> List.zip sourceFiles
-            // PERF: consider making this parallel, once uses of global state relevant to parsing are cleaned up 
-            |> List.choose (fun (filename: string, isLastCompiland) -> 
-                let pathOfMetaCommandSource = Path.GetDirectoryName filename
-                match ParseOneInputFile(tcConfig, lexResourceManager, ["COMPILED"], filename, (isLastCompiland, isExe), errorLogger, (*retryLocked*)false) with
-                | Some input -> Some (input, pathOfMetaCommandSource)
-                | None -> None
-                ) 
+            let sourceFiles = isLastCompiland |> List.zip sourceFiles |> Array.ofSeq
+            
+            let parallelOptions = ParallelOptions()
+            parallelOptions.MaxDegreeOfParallelism <- Environment.ProcessorCount
+
+            if parallelOptions.MaxDegreeOfParallelism > sourceFiles.Length then
+                parallelOptions.MaxDegreeOfParallelism <- sourceFiles.Length
+
+            let results = Array.zeroCreate sourceFiles.Length
+            Parallel.For(0, sourceFiles.Length, parallelOptions, fun i ->
+                results.[i] <-
+                    let (filename: string, isLastCompiland) = sourceFiles.[i]
+                    let pathOfMetaCommandSource = Path.GetDirectoryName filename
+                    match ParseOneInputFile(tcConfig, lexResourceManager, ["COMPILED"], filename, (isLastCompiland, isExe), errorLogger, (*retryLocked*)false) with
+                    | Some input -> Some (input, pathOfMetaCommandSource)
+                    | None -> None) |> ignore
+            results
+            |> Array.choose id
+            |> List.ofArray
         with e -> 
             errorRecoveryNoRange e
             exiter.Exit 1

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -39,7 +39,7 @@ type LightSyntaxStatus(initial:bool,warn:bool) =
 /// Manage lexer resources (string interning)
 [<Sealed>]
 type LexResourceManager(?capacity: int) =
-    let strings = new System.Collections.Generic.Dictionary<string, Parser.token>(defaultArg capacity 1024)
+    let strings = new System.Collections.Concurrent.ConcurrentDictionary<string, Parser.token>(Environment.ProcessorCount, defaultArg capacity 1024)
     member x.InternIdentifierToken(s) = 
         match strings.TryGetValue s with
         | true, res -> res


### PR DESCRIPTION
This enables parallel parsing when running `fsc.exe`. I think this should be fairly straight forward to make safe.