### PR TITLE
NGen fails with spaces in path

### DIFF
--- a/eng/targets/NGenBinaries.targets
+++ b/eng/targets/NGenBinaries.targets
@@ -31,7 +31,7 @@
       <PathToNGen64>$(windir)\Microsoft.NET\Framework64\v4.0.30319\ngen.exe</PathToNGen64>
     </PropertyGroup>
 
-    <Exec Command='"$(PathToNGen32)" install "$(TargetPath)" /nologo /silent /ExeConfig:$(TargetPath)' 
+    <Exec Command='"$(PathToNGen32)" install "$(TargetPath)" /nologo /silent /ExeConfig:"$(TargetPath)"' 
           Condition = "Exists('$(PathToNGen32)') AND '$(PlatformTarget)' != 'x64' AND Exists('$(TargetPath).config') AND '$(OutputType)' == 'Exe' AND '$(IsAdministrator)' == 'true'"
           ConsoleToMSBuild="true"
           IgnoreStandardErrorWarningFormat="true" />
@@ -41,7 +41,7 @@
           ConsoleToMSBuild="true"
           IgnoreStandardErrorWarningFormat="true"/>
 
-    <Exec Command='"$(PathToNGen64)" install "$(TargetPath)" /nologo /silent /ExeConfig:$(TargetPath)' 
+    <Exec Command='"$(PathToNGen64)" install "$(TargetPath)" /nologo /silent /ExeConfig:"$(TargetPath)"' 
           Condition = "Exists('$(PathToNGen64)') AND '$(PlatformTarget)' != 'x86' AND Exists('$(TargetPath).config') AND '$(OutputType)' == 'Exe' AND '$(IsAdministrator)' == 'true'"
           ConsoleToMSBuild="true"
           IgnoreStandardErrorWarningFormat="true" />


### PR DESCRIPTION

@ChrisNikkel provide this pr: https://github.com/dotnet/fsharp/pull/10219  Which fixes the build script issue with spaces in file names.

Whilst looking at it I realized that we still have an issue with the ngen command line we use.

````
C:\root with spaces\fsharp\eng\targets\NGenBinaries.targets(34,5): error MSB3073: The command ""C:\WINDOWS\Microsoft.NET\Framework\v4.0.30319\ngen.exe" install "C:\root with spaces\fsharp\artifacts\bin\fsc\Proto\net472\fsc.exe" /nologo /silent /ExeConfig:C:\root with spaces\fsharp\artifacts\bin\fsc\Proto\net472\fsc.exe" exited with code -1. [C:\root with spaces\fsharp\src\fsharp\fsc\fsc.fsproj]
````
This PR fixes that.


