### PR TITLE
Improve comments slightly

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -137,7 +137,7 @@ type ResolveDependenciesResult (success: bool, stdOut: string array, stdError: s
     /// The resolution error log (* process stderror *)
     member _.StdError = stdError
 
-    /// The resolution paths - the full paths to selcted resolved dll's.
+    /// The resolution paths - the full paths to selected resolved dll's.
     /// In scripts this is equivalent to #r @"c:\somepath\to\packages\ResolvedPackage\1.1.1\lib\netstandard2.0\ResolvedAssembly.dll"
     member _.Resolutions = resolutions
 
@@ -150,9 +150,9 @@ type ResolveDependenciesResult (success: bool, stdOut: string array, stdError: s
     ///     however, the dependency manager dll understands the nuget package layout
     ///     and so if the package contains folders similar to the nuget layout then
     ///     the dependency manager will be able to probe and resolve any native dependencies
-    ///     required by the buget package.
+    ///     required by the nuget package.
     ///
-    /// This path is also equivant to
+    /// This path is also equivalent to
     ///     #I @"c:\somepath\to\packages\ResolvedPackage\1.1.1\"
     member _.Roots = roots
 

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -137,13 +137,23 @@ type ResolveDependenciesResult (success: bool, stdOut: string array, stdError: s
     /// The resolution error log (* process stderror *)
     member _.StdError = stdError
 
-    /// The resolution paths
+    /// The resolution paths - the full paths to selcted resolved dll's.
+    /// In scripts this is equivalent to #r @"c:\somepath\to\packages\ResolvedPackage\1.1.1\lib\netstandard2.0\ResolvedAssembly.dll"
     member _.Resolutions = resolutions
 
     /// The source code file paths
     member _.SourceFiles = sourceFiles
 
     /// The roots to package directories
+    ///     This points to the root of each located package.
+    ///     The layout of the package manager will be package manager specific.
+    ///     however, the dependency manager dll understands the nuget package layout
+    ///     and so if the package contains folders similar to the nuget layout then
+    ///     the dependency manager will be able to probe and resolve any native dependencies
+    ///     required by the buget package.
+    ///
+    /// This path is also equivant to
+    ///     #I @"c:\somepath\to\packages\ResolvedPackage\1.1.1\"
     member _.Roots = roots
 
 [<DependencyManagerAttribute>] 

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
@@ -20,13 +20,23 @@ type ResolveDependenciesResult =
     /// The resolution error log (process stderr)
     member StdError: string[]
 
-    /// The resolution paths
+    /// The resolution paths - the full paths to selcted resolved dll's.
+    /// In scripts this is equivalent to #r @"c:\somepath\to\packages\ResolvedPackage\1.1.1\lib\netstandard2.0\ResolvedAssembly.dll"
     member Resolutions: seq<string>
 
     /// The source code file paths
     member SourceFiles: seq<string>
 
     /// The roots to package directories
+    ///     This points to the root of each located package.
+    ///     The layout of the package manager will be package manager specific.
+    ///     however, the dependency manager dll understands the nuget package layout
+    ///     and so if the package contains folders similar to the nuget layout then
+    ///     the dependency manager will be able to probe and resolve any native dependencies
+    ///     required by the buget package.
+    ///
+    /// This path is also equivant to
+    ///     #I @"c:\somepath\to\packages\ResolvedPackage\1.1.1\"
     member Roots: seq<string>
 
 [<DependencyManagerAttribute>]

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
@@ -20,7 +20,7 @@ type ResolveDependenciesResult =
     /// The resolution error log (process stderr)
     member StdError: string[]
 
-    /// The resolution paths - the full paths to selcted resolved dll's.
+    /// The resolution paths - the full paths to selected resolved dll's.
     /// In scripts this is equivalent to #r @"c:\somepath\to\packages\ResolvedPackage\1.1.1\lib\netstandard2.0\ResolvedAssembly.dll"
     member Resolutions: seq<string>
 
@@ -33,7 +33,7 @@ type ResolveDependenciesResult =
     ///     however, the dependency manager dll understands the nuget package layout
     ///     and so if the package contains folders similar to the nuget layout then
     ///     the dependency manager will be able to probe and resolve any native dependencies
-    ///     required by the buget package.
+    ///     required by the nuget package.
     ///
     /// This path is also equivant to
     ///     #I @"c:\somepath\to\packages\ResolvedPackage\1.1.1\"

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
@@ -90,13 +90,23 @@ type IResolveDependenciesResult =
     /// The resolution error log (* process stderror *)
     abstract StdError: string[]
 
-    /// The resolution paths
+    /// The resolution paths - the full paths to selcted resolved dll's.
+    /// In scripts this is equivalent to #r @"c:\somepath\to\packages\ResolvedPackage\1.1.1\lib\netstandard2.0\ResolvedAssembly.dll"
     abstract Resolutions: seq<string>
 
     /// The source code file paths
     abstract SourceFiles: seq<string>
 
     /// The roots to package directories
+    ///     This points to the root of each located package.
+    ///     The layout of the package manager will be package manager specific.
+    ///     however, the dependency manager dll understands the nuget package layout
+    ///     and so if the package contains folders similar to the nuget layout then
+    ///     the dependency manager will be able to probe and resolve any native dependencies
+    ///     required by the buget package.
+    ///
+    /// This path is also equivant to
+    ///     #I @"c:\somepath\to\packages\1.1.1\ResolvedPackage"
     abstract Roots: seq<string>
 
 

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
@@ -103,9 +103,9 @@ type IResolveDependenciesResult =
     ///     however, the dependency manager dll understands the nuget package layout
     ///     and so if the package contains folders similar to the nuget layout then
     ///     the dependency manager will be able to probe and resolve any native dependencies
-    ///     required by the buget package.
+    ///     required by the nuget package.
     ///
-    /// This path is also equivant to
+    /// This path is also equivalent to
     ///     #I @"c:\somepath\to\packages\1.1.1\ResolvedPackage"
     abstract Roots: seq<string>
 

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fsi
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fsi
@@ -19,13 +19,23 @@ type IResolveDependenciesResult =
     /// The resolution error log (process stderr)
     abstract StdError: string array
 
-    /// The resolution paths
+    /// The resolution paths - the full paths to selcted resolved dll's.
+    /// In scripts this is equivalent to #r @"c:\somepath\to\packages\ResolvedPackage\1.1.1\lib\netstandard2.0\ResolvedAssembly.dll"
     abstract Resolutions: seq<string>
 
     /// The source code file paths
     abstract SourceFiles: seq<string>
 
     /// The roots to package directories
+    ///     This points to the root of each located package.
+    ///     The layout of the package manager will be package manager specific.
+    ///     however, the dependency manager dll understands the nuget package layout
+    ///     and so if the package contains folders similar to the nuget layout then
+    ///     the dependency manager will be able to probe and resolve any native dependencies
+    ///     required by the buget package.
+    ///
+    /// This path is also equivant to
+    ///     #I @"c:\somepath\to\packages\1.1.1\ResolvedPackage"
     abstract Roots: seq<string>
 
 /// Wraps access to a DependencyManager implementation

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fsi
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fsi
@@ -19,7 +19,7 @@ type IResolveDependenciesResult =
     /// The resolution error log (process stderr)
     abstract StdError: string array
 
-    /// The resolution paths - the full paths to selcted resolved dll's.
+    /// The resolution paths - the full paths to selected resolved dll's.
     /// In scripts this is equivalent to #r @"c:\somepath\to\packages\ResolvedPackage\1.1.1\lib\netstandard2.0\ResolvedAssembly.dll"
     abstract Resolutions: seq<string>
 
@@ -32,9 +32,9 @@ type IResolveDependenciesResult =
     ///     however, the dependency manager dll understands the nuget package layout
     ///     and so if the package contains folders similar to the nuget layout then
     ///     the dependency manager will be able to probe and resolve any native dependencies
-    ///     required by the buget package.
+    ///     required by the nuget package.
     ///
-    /// This path is also equivant to
+    /// This path is also equivalent to
     ///     #I @"c:\somepath\to\packages\1.1.1\ResolvedPackage"
     abstract Roots: seq<string>
 


### PR DESCRIPTION
@smoothdeveloper , I have updated the comments.

Resolutions is equivalent to the
    #r "pathto.dll"

And Roots is equivalent to
    #I "path to root folder of package\"

The Resolutions, will duplicate lines in the generated .fsx file.  FSI ignores the Resolutions, and uses the generated .fsx file.  We do this because originally the plan was to have the package manager generate a script, I believe that paket still does this, but for notebooks we just wanted a list of the references, and didn't want to parse a .fsx to get it, so we return the list.

So return the resolutions in this collection, and paket will work fine with the notebook.  Well, we will have to wire some stuff up ... other than that it should work.



