### PR TITLE
Support packages that dont contribute to the build

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
@@ -26,8 +26,8 @@ type internal Resolution =
       FullPath : string
       AssetType: string
       IsNotImplementationReference: string
-      NativePath : string
       InitializeSourcePath : string
+      NativePath : string
     }
 
 
@@ -69,7 +69,6 @@ module internal ProjectFile =
                     String.IsNullOrEmpty(r.PackageRoot)) &&
                 Directory.Exists(r.PackageRoot))
             |> Array.map(fun r -> r.PackageRoot)
-            |> Array.distinct
 
         let nativeRoots =
             resolutions
@@ -78,9 +77,9 @@ module internal ProjectFile =
                     String.IsNullOrEmpty(r.NativePath)) &&
                 Directory.Exists(r.NativePath))
             |> Array.map(fun r -> r.NativePath)
-            |> Array.distinct
 
-        Array.concat [|managedRoots; nativeRoots|]
+        Array.concat [|managedRoots; nativeRoots|] |> Array.distinct
+
 
     let getResolutionsFromFile resolutionsFile =
 
@@ -194,11 +193,25 @@ $(PACKAGEREFERENCES)
             Condition="'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'">
             <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))'))</Path>
         </NativeIncludeRoots>
+
         <NativeIncludeRoots
             Include="@(NativeCopyLocalItems)"
             Condition="'%(NativeCopyLocalItems.AssetType)' == 'native'">
             <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))'))</Path>
         </NativeIncludeRoots>
+
+        <PropertyNames Include = "Pkg$([System.String]::Copy('%(PackageReference.FileName)').Replace('.','_'))" />
+        <PropertyNames Include = "Pkg$([System.String]::Copy('%(PackageReference.FileName)%(PackageReference.Extension)').Replace('.','_'))"/>
+
+        <ProvidedPackageRoots Include = "$(%(PropertyNames.FileName))" Condition="'$(%(PropertyNames.FileName))' != ''">
+          <ParentDirectory>$([System.IO.Path]::GetDirectoryName('$(%(PropertyNames.FileName))'))</ParentDirectory>
+          <NugetPackageId>$([System.IO.Path]::GetFileName('%(ProvidedPackageRoots.ParentDirectory)'))</NugetPackageId>
+          <NugetPackageVersion>$([System.IO.Path]::GetFileName('$(%(PropertyNames.FileName))'))</NugetPackageVersion>
+          <AssetType>package</AssetType>
+          <PackageRoot>$([MSBuild]::EnsureTrailingSlash('$(%(PropertyNames.FileName))'))</PackageRoot>
+          <PackageRoot>$([System.String]::Copy('%(ProvidedPackageRoots.PackageRoot)').Replace('\', '/'))</PackageRoot>
+          <Path>%(ProvidedPackageRoots.PackageRoot)</Path>
+        </ProvidedPackageRoots>
       </ItemGroup>
   </Target>
 
@@ -216,6 +229,10 @@ $(PACKAGEREFERENCES)
       <ResolvedReferenceLines
           Condition="(@(NativeIncludeRoots->Count()) &gt; 0) AND (('%(NativeIncludeRoots.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(NativeIncludeRoots.NugetPackageId)'=='FSharp.Core'))"
           Include='%(NativeIncludeRoots.NugetPackageId),%(NativeIncludeRoots.NugetPackageVersion),%(NativeIncludeRoots.PackageRoot),,%(NativeIncludeRoots.AssetType),,,%(NativeIncludeRoots.Path)'
+          KeepDuplicates="false" />
+      <ResolvedReferenceLines
+          Condition="(@(ProvidedPackageRoots->Count()) &gt; 0) AND (('%(ProvidedPackageRoots.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(ProvidedPackageRoots.NugetPackageId)'=='FSharp.Core'))"
+          Include='%(ProvidedPackageRoots.NugetPackageId),%(ProvidedPackageRoots.NugetPackageVersion),%(ProvidedPackageRoots.PackageRoot),,%(ProvidedPackageRoots.AssetType),,,%(ProvidedPackageRoots.Path)'
           KeepDuplicates="false" />
     </ItemGroup>
 

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -184,7 +184,7 @@ module internal Utilities =
             let stdOut = drainStreamToMemory p.StandardOutput
             let stdErr = drainStreamToMemory p.StandardError
 
-#if Debug
+#if DEBUG
             File.WriteAllLines(Path.Combine(workingDir, "StandardOutput.txt"), stdOut)
             File.WriteAllLines(Path.Combine(workingDir, "StandardError.txt"), stdErr)
 #endif

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -193,19 +193,7 @@ type FSharpDependencyManager (outputDir:string option) =
             sw.WriteLine(body)
         with | _ -> ()
 
-    do if deleteAtExit then AppDomain.CurrentDomain.ProcessExit |> Event.add(fun _ -> deleteScripts () )
-
-    member _.Name = name
-
-    member _.Key = key
-
-    member _.HelpMessages = [|
-        sprintf """    #r "nuget:FSharp.Data, 3.1.2";;               // %s 'FSharp.Data' %s '3.1.2'""" (SR.loadNugetPackage()) (SR.version())
-        sprintf """    #r "nuget:FSharp.Data";;                      // %s 'FSharp.Data' %s""" (SR.loadNugetPackage()) (SR.highestVersion())
-        |]
-
-    member _.PrepareDependencyResolutionFiles(scriptExt: string, packageManagerTextLines: (string * string) seq, targetFrameworkMoniker: string, runtimeIdentifier: string): PackageBuildResolutionResult =
-
+    let prepareDependencyResolutionFiles (scriptExt: string, packageManagerTextLines: (string * string) seq, targetFrameworkMoniker: string, runtimeIdentifier: string): PackageBuildResolutionResult =
         let scriptExt =
             match scriptExt with
             | ".csx" -> csxExt
@@ -242,6 +230,18 @@ type FSharpDependencyManager (outputDir:string option) =
 
         generateAndBuildProjectArtifacts
 
+
+    do if deleteAtExit then AppDomain.CurrentDomain.ProcessExit |> Event.add(fun _ -> deleteScripts () )
+
+    member _.Name = name
+
+    member _.Key = key
+
+    member _.HelpMessages = [|
+        sprintf """    #r "nuget:FSharp.Data, 3.1.2";;               // %s 'FSharp.Data' %s '3.1.2'""" (SR.loadNugetPackage()) (SR.version())
+        sprintf """    #r "nuget:FSharp.Data";;                      // %s 'FSharp.Data' %s""" (SR.loadNugetPackage()) (SR.highestVersion())
+        |]
+
     member this.ResolveDependencies(scriptExt: string, packageManagerTextLines: (string * string) seq, targetFramework: string, runtimeIdentifier: string) : obj =
         let poundRprefix  =
             match scriptExt with
@@ -249,8 +249,7 @@ type FSharpDependencyManager (outputDir:string option) =
             | _ -> "#r @\""
 
         let generateAndBuildProjectArtifacts =
-
-            let resolutionResult = this.PrepareDependencyResolutionFiles(scriptExt, packageManagerTextLines, targetFramework, runtimeIdentifier)
+            let resolutionResult = prepareDependencyResolutionFiles (scriptExt, packageManagerTextLines, targetFramework, runtimeIdentifier)
             match resolutionResult.resolutionsFile with
             | Some file ->
                 let resolutions = getResolutionsFromFile file

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
@@ -49,6 +49,4 @@ type FSharpDependencyManager =
 
     member HelpMessages:string[]
 
-    member PrepareDependencyResolutionFiles: scriptExt: string * packageManagerTextLines: (string * string) seq * targetFrameworkMoniker: string * runtimeIdentifier: string -> PackageBuildResolutionResult
-
     member ResolveDependencies: scriptExt: string * packageManagerTextLines: (string * string) seq * targetFrameworkMoniker: string * runtimeIdentifier: string -> obj

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
@@ -260,7 +260,7 @@ type ReflectionDependencyManagerProvider(theType: Type,
                     let success, sourceFiles, packageRoots =
                         let tupleFields = result |> FSharpValue.GetTupleFields
                         match tupleFields |> Array.length with
-                        | 3 -> tupleFields.[0] :?> bool, tupleFields.[1] :?> string list  |> List.toSeq, tupleFields.[2] :?> string list |> List.toSeq
+                        | 3 -> tupleFields.[0] :?> bool, tupleFields.[1] :?> string list  |> List.toSeq, tupleFields.[2] :?> string list |> List.distinct |> List.toSeq
                         | _ -> false, seqEmpty, seqEmpty
                     ReflectionDependencyManagerProvider.MakeResultFromFields(success, Array.empty, Array.empty, Seq.empty, sourceFiles, packageRoots)
                 else


### PR DESCRIPTION
Some nuget packages do not actually contribute to the build, although there dependencies provide files to the build.  The notebook supports extensions that may not contribute to the build. This PR, notifies FSI and the notebook that it has been successfully downloaded and what the package root is.
