### PR TITLE
[16.9] use proper assembly and package versions for FSharp.Core

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,6 +239,16 @@ stages:
             continueOnError: true
             condition: failed()
 
+        # Mock official build
+        - job: MockOfficial
+          pool:
+            vmImage: windows-2019
+          steps:
+          - checkout: self
+            clean: true
+          - pwsh: .\eng\MockBuild.ps1
+            displayName: Build with OfficialBuildId
+
         # Linux
         - job: Linux
           pool:
@@ -311,7 +321,7 @@ stages:
           - checkout: self
             clean: true
           - script: .\Build.cmd -c Release
-          - script: .\tests\EndToEndBuildTests\EndToEndBuildTests -c Release
+          - script: .\tests\EndToEndBuildTests\EndToEndBuildTests.cmd -c Release
             displayName: End to end build tests
 
         # Source Build Windows

--- a/eng/MockBuild.ps1
+++ b/eng/MockBuild.ps1
@@ -1,0 +1,15 @@
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    $fakeBuildId = (Get-Date -Format "yyyyMMdd") + ".0"
+    $visualStudioDropName = "Products/mock/dotnet-fsharp/branch/$fakeBuildId"
+    & "$PSScriptRoot\Build.ps1" -build -restore -ci -bootstrap -binaryLog -pack -configuration Release /p:OfficialBuildId=$fakeBuildId /p:VisualStudioDropName=$visualStudioDropName
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    Write-PipelineTelemetryError -Category "Build" -Message "Error doing mock official build"
+    ExitWithExitCode 1
+}

--- a/eng/MockBuild.ps1
+++ b/eng/MockBuild.ps1
@@ -10,6 +10,6 @@ catch {
     Write-Host $_
     Write-Host $_.Exception
     Write-Host $_.ScriptStackTrace
-    Write-PipelineTelemetryError -Category "Build" -Message "Error doing mock official build"
-    ExitWithExitCode 1
+    Write-Host "##[error](NETCORE_ENGINEERING_TELEMETRY=Build) Error doing mock official build."
+    exit 1
 }

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,14 +56,14 @@
   <!-- version number assignment -->
   <PropertyGroup Condition="'$(UseFSharpPackageVersion)' == 'true'">
     <VersionPrefix>$(FSCoreVersionPrefix)</VersionPrefix>
-    <AssemblyVersion Condition="'$(OfficialBuildId)' == ''">$(FSCoreVersion)</AssemblyVersion >
+    <AssemblyVersion>$(FSCoreVersion)</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseFSharpPackageVersion)' != 'true'">
     <VersionPrefix>$(FSCoreVersionPrefix)</VersionPrefix>
     <VersionPrefix Condition="'$(UseFSharpProductVersion)' == 'true'">$(FSProductVersionPrefix)</VersionPrefix>
     <VersionPrefix Condition="'$(UseVsMicroBuildAssemblyVersion)' == 'true'">$(VSAssemblyVersionPrefix)</VersionPrefix>
     <VersionPrefix Condition="'$(UseFSharpCompilerServiceVersion)' == 'true'">$(FSharpCompilerServicePackageVersion)</VersionPrefix>
-    <AssemblyVersion Condition="'$(OfficialBuildId)' == ''">$(VersionPrefix).0</AssemblyVersion>
+    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- PR builds should explicitly specify a version number -->
   </PropertyGroup>
   <PropertyGroup>

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -15,6 +15,7 @@
 
     <PreRelease>true</PreRelease>
     <PackageId>FSharp.Core</PackageId>
+    <PackageVersionPrefix>$(FSCorePackageVersion)</PackageVersionPrefix>
     <NuspecFile>FSharp.Core.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>
     <PackageDescription>FSharp.Core redistributables from F# Tools version $(FSCorePackageVersion) For F# $(FSLanguageVersion).  Contains code from the F# Software Foundation.</PackageDescription>


### PR DESCRIPTION
A recent version number refactor is failing internal builds due to how we calculate those.  The bug manifests itself when creating binding redirects and was rather tricky to track down, but the real issue is that we want to maintain assembly version `5.0.0.0` on `FSharp.Core` but update the NuGet package version to `5.0.1`.

I've also added another CI step to fake an internal build with a build ID to mimic the way this failed in the signed build.

~~PR is draft until a [full internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=853131&view=results) passes.~~ Internal build is good.