### PR TITLE
enable v3 package publishing via arcade

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -403,6 +403,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/common/templates/post-build/post-build.yml
     parameters:
+      publishingInfraVersion: 3
       # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
       enableSymbolValidation: false
       # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
~~Leaving as draft until the [internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=853286&view=results) has passed.~~  Internal build is good.