### PR TITLE
Refactor the signature help file to be understandable

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -2,22 +2,40 @@
 
 namespace Microsoft.VisualStudio.FSharp.Editor
 
-open System
 open System.Composition
-open System.Collections.Generic
 
 open Microsoft.CodeAnalysis
-open Microsoft.CodeAnalysis.SignatureHelp
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.SignatureHelp
 
-open Microsoft.VisualStudio.Text
 open Microsoft.VisualStudio.Shell
-open Microsoft.VisualStudio.Shell.Interop
 
 open FSharp.Compiler.Layout
 open FSharp.Compiler.Range
 open FSharp.Compiler.SourceCodeServices
+
+type SignatureHelpParameterInfo =
+    { ParameterName: string
+      IsOptional: bool
+      CanonicalTypeTextForSorting: string
+      Documentation: ResizeArray<Microsoft.CodeAnalysis.TaggedText>
+      DisplayParts: ResizeArray<Microsoft.CodeAnalysis.TaggedText> }
+
+type SignatureHelpItem =
+    { HasParamArrayArg: bool
+      Documentation: ResizeArray<Microsoft.CodeAnalysis.TaggedText>
+      PrefixParts: Microsoft.CodeAnalysis.TaggedText[]
+      SeparatorParts: Microsoft.CodeAnalysis.TaggedText[]
+      SuffixParts: Microsoft.CodeAnalysis.TaggedText[]
+      Parameters: SignatureHelpParameterInfo[]
+      MainDescription: ResizeArray<Microsoft.CodeAnalysis.TaggedText> }
+
+type SignatureHelpData =
+    { SignatureHelpItems: SignatureHelpItem[]
+      ApplicableSpan: TextSpan
+      ArgumentIndex: int
+      ArgumentCount: int
+      ArgumentName: string option }
 
 [<Shared>]
 [<Export(typeof<IFSharpSignatureHelpProvider>)>]
@@ -36,190 +54,234 @@ type internal FSharpSignatureHelpProvider
     static let oneColBefore (lp: LinePosition) = LinePosition(lp.Line,max 0 (lp.Character-1))
 
     // Unit-testable core routine
-    static member internal ProvideMethodsAsyncAux(checker: FSharpChecker, documentationBuilder: IDocumentationBuilder, sourceText: SourceText, caretPosition: int, options: FSharpProjectOptions, triggerIsTypedChar: char option, filePath: string, textVersionHash: int) = async {
-        let! parseResults, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, textVersionHash, sourceText.ToFSharpSourceText(), options, userOpName = userOpName)
-        match checkFileAnswer with
-        | FSharpCheckFileAnswer.Aborted -> return None
-        | FSharpCheckFileAnswer.Succeeded(checkFileResults) -> 
+    static member internal ProvideMethodsAsyncAux(checker: FSharpChecker, documentationBuilder: IDocumentationBuilder, sourceText: SourceText, caretPosition: int, options: FSharpProjectOptions, triggerIsTypedChar: char option, filePath: string, textVersionHash: int) =
+        async {
+            let! parseResults, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, textVersionHash, sourceText.ToFSharpSourceText(), options, userOpName = userOpName)
+            match checkFileAnswer with
+            | FSharpCheckFileAnswer.Aborted ->
+                return None
+            | FSharpCheckFileAnswer.Succeeded(checkFileResults) -> 
+                let textLines = sourceText.Lines
+                let caretLinePos = textLines.GetLinePosition(caretPosition)
+                let caretLineColumn = caretLinePos.Character
 
-        let textLines = sourceText.Lines
-        let caretLinePos = textLines.GetLinePosition(caretPosition)
-        let caretLineColumn = caretLinePos.Character
+                // Get the parameter locations
+                let paramLocations = parseResults.FindNoteworthyParamInfoLocations(Pos.fromZ caretLinePos.Line caretLineColumn)
+                match paramLocations with
+                | None ->
+                    return None // no locations = no help
+                | Some nwpl -> 
+                    let names = nwpl.LongId
+                    let lidEnd = nwpl.LongIdEndLocation
 
-        // Get the parameter locations
-        let paramLocations = parseResults.FindNoteworthyParamInfoLocations(Pos.fromZ caretLinePos.Line caretLineColumn)
+                    // Get the methods
+                    let! methodGroup = checkFileResults.GetMethods(lidEnd.Line, lidEnd.Column, "", Some names)
 
-        match paramLocations with
-        | None -> return None // no locations = no help
-        | Some nwpl -> 
-        let names = nwpl.LongId
-        let lidEnd = nwpl.LongIdEndLocation
+                    let methods = methodGroup.Methods
 
-        // Get the methods
-        let! methodGroup = checkFileResults.GetMethods(lidEnd.Line, lidEnd.Column, "", Some names)
+                    if (methods.Length = 0 || methodGroup.MethodName.EndsWith("> )")) then return None else                    
 
-        let methods = methodGroup.Methods
+                    let isStaticArgTip =
+                        let parenLine, parenCol = Pos.toZ nwpl.OpenParenLocation 
+                        assert (parenLine < textLines.Count)
+                        let parenLineText = textLines.[parenLine].ToString()
+                        parenCol < parenLineText.Length && parenLineText.[parenCol] = '<'
 
-        if (methods.Length = 0 || methodGroup.MethodName.EndsWith("> )")) then return None else                    
+                    let filteredMethods =
+                        [| for m in methods do 
+                              if (isStaticArgTip && m.StaticParameters.Length > 0) ||
+                                  (not isStaticArgTip && m.HasParameters) then   // need to distinguish TP<...>(...)  angle brackets tip from parens tip
+                                  yield m |]
 
-        let isStaticArgTip =
-            let parenLine, parenCol = Pos.toZ nwpl.OpenParenLocation 
-            assert (parenLine < textLines.Count)
-            let parenLineText = textLines.[parenLine].ToString()
-            parenCol < parenLineText.Length && parenLineText.[parenCol] = '<'
+                    if filteredMethods.Length = 0 then return None else
 
-        let filteredMethods =
-            [| for m in methods do 
-                  if (isStaticArgTip && m.StaticParameters.Length > 0) ||
-                      (not isStaticArgTip && m.HasParameters) then   // need to distinguish TP<...>(...)  angle brackets tip from parens tip
-                      yield m |]
+                    let posToLinePosition pos = 
+                        let (l,c) = Pos.toZ  pos
+                        // FSROSLYNTODO: FCS gives back line counts that are too large. Really, this shouldn't happen
+                        let result =LinePosition(l,c)
+                        let lastPosInDocument = textLines.GetLinePosition(textLines.[textLines.Count-1].End)
+                        if lastPosInDocument.CompareTo(result) > 0 then result else lastPosInDocument
 
-        if filteredMethods.Length = 0 then return None else
+                    // Compute the start position
+                    let startPos = nwpl.LongIdStartLocation |> posToLinePosition
 
-        let posToLinePosition pos = 
-            let (l,c) = Pos.toZ  pos
-            // FSROSLYNTODO: FCS gives back line counts that are too large. Really, this shouldn't happen
-            let result =LinePosition(l,c)
-            let lastPosInDocument = textLines.GetLinePosition(textLines.[textLines.Count-1].End)
-            if lastPosInDocument.CompareTo(result) > 0 then result else lastPosInDocument
+                    // Compute the end position
+                    let endPos = 
+                        let last = nwpl.TupleEndLocations.[nwpl.TupleEndLocations.Length-1] |> posToLinePosition
+                        (if nwpl.IsThereACloseParen then oneColBefore last else last)  
 
-        // Compute the start position
-        let startPos = nwpl.LongIdStartLocation |> posToLinePosition
+                    assert (startPos.CompareTo(endPos) <= 0)
 
-        // Compute the end position
-        let endPos = 
-            let last = nwpl.TupleEndLocations.[nwpl.TupleEndLocations.Length-1] |> posToLinePosition
-            (if nwpl.IsThereACloseParen then oneColBefore last else last)  
+                    // Compute the applicable span between the parentheses
+                    let applicableSpan = 
+                        textLines.GetTextSpan(LinePositionSpan(startPos, endPos))
 
-        assert (startPos.CompareTo(endPos) <= 0)
+                    let startOfArgs = nwpl.OpenParenLocation |> posToLinePosition |> oneColAfter 
 
-        // Compute the applicable span between the parentheses
-        let applicableSpan = 
-            textLines.GetTextSpan(LinePositionSpan(startPos, endPos))
+                    let tupleEnds = 
+                        [| yield startOfArgs
+                           for i in 0..nwpl.TupleEndLocations.Length-2 do
+                               yield nwpl.TupleEndLocations.[i] |> posToLinePosition
+                           yield endPos  |]
 
-        let startOfArgs = nwpl.OpenParenLocation |> posToLinePosition |> oneColAfter 
+                    // If we are pressing "(" or "<" or ",", then only pop up the info if this is one of the actual, real detected positions in the detected promptable call
+                    //
+                    // For example the last "(" in 
+                    //    List.map (fun a -> (
+                    // should not result in a prompt.
+                    //
+                    // Likewise the last "," in 
+                    //    Console.WriteLine( [(1, 
+                    // should not result in a prompt, whereas this one will:
+                    //    Console.WriteLine( [(1,2)],
+                    match triggerIsTypedChar with 
+                    | Some ('<' | '(' | ',') when not (tupleEnds |> Array.exists (fun lp -> lp.Character = caretLineColumn))  -> 
+                        return None // comma or paren at wrong location = remove help display
+                    | _ -> 
 
-        let tupleEnds = 
-            [| yield startOfArgs
-               for i in 0..nwpl.TupleEndLocations.Length-2 do
-                   yield nwpl.TupleEndLocations.[i] |> posToLinePosition
-               yield endPos  |]
-
-        // If we are pressing "(" or "<" or ",", then only pop up the info if this is one of the actual, real detected positions in the detected promptable call
-        //
-        // For example the last "(" in 
-        //    List.map (fun a -> (
-        // should not result in a prompt.
-        //
-        // Likewise the last "," in 
-        //    Console.WriteLine( [(1, 
-        // should not result in a prompt, whereas this one will:
-        //    Console.WriteLine( [(1,2)],
-
-        match triggerIsTypedChar with 
-        | Some ('<' | '(' | ',') when not (tupleEnds |> Array.exists (fun lp -> lp.Character = caretLineColumn))  -> 
-            return None // comma or paren at wrong location = remove help display
-        | _ -> 
-
-        // Compute the argument index by working out where the caret is between the various commas.
-        let argumentIndex = 
-            let computedTextSpans =
-                tupleEnds 
-                |> Array.pairwise 
-                |> Array.map (fun (lp1, lp2) -> textLines.GetTextSpan(LinePositionSpan(lp1, lp2)))
+                        // Compute the argument index by working out where the caret is between the various commas.
+                        let argumentIndex = 
+                            let computedTextSpans =
+                                tupleEnds 
+                                |> Array.pairwise 
+                                |> Array.map (fun (lp1, lp2) -> textLines.GetTextSpan(LinePositionSpan(lp1, lp2)))
                 
-            match (computedTextSpans|> Array.tryFindIndex (fun t -> t.Contains(caretPosition))) with 
-            | None -> 
-                // Because 'TextSpan.Contains' only succeeds if 'TextSpan.Start <= caretPosition < TextSpan.End' is true,
-                // we need to check if the caret is at the very last position in the TextSpan.
-                //
-                // We default to 0, which is the first argument, if the caret position was nowhere to be found.
-                if computedTextSpans.[computedTextSpans.Length-1].End = caretPosition then
-                    computedTextSpans.Length-1 
-                else 0
-            | Some n -> n
+                            match (computedTextSpans|> Array.tryFindIndex (fun t -> t.Contains(caretPosition))) with 
+                            | None -> 
+                                // Because 'TextSpan.Contains' only succeeds if 'TextSpan.Start <= caretPosition < TextSpan.End' is true,
+                                // we need to check if the caret is at the very last position in the TextSpan.
+                                //
+                                // We default to 0, which is the first argument, if the caret position was nowhere to be found.
+                                if computedTextSpans.[computedTextSpans.Length-1].End = caretPosition then
+                                    computedTextSpans.Length-1 
+                                else 0
+                            | Some n -> n
          
-        // Compute the overall argument count
-        let argumentCount = 
-            match nwpl.TupleEndLocations.Length with 
-            | 1 when caretLinePos.Character = startOfArgs.Character -> 0  // count "WriteLine(" as zero arguments
-            | n -> n
+                        // Compute the overall argument count
+                        let argumentCount = 
+                            match nwpl.TupleEndLocations.Length with 
+                            | 1 when caretLinePos.Character = startOfArgs.Character -> 0  // count "WriteLine(" as zero arguments
+                            | n -> n
 
-        // Compute the current argument name, if any
-        let argumentName = 
-            if argumentIndex < nwpl.NamedParamNames.Length then 
-                nwpl.NamedParamNames.[argumentIndex] 
-            else 
-                None  // not a named argument
+                        // Compute the current argument name, if any
+                        let argumentName = 
+                            if argumentIndex < nwpl.NamedParamNames.Length then 
+                                nwpl.NamedParamNames.[argumentIndex] 
+                            else 
+                                None  // not a named argument
 
-        // Prepare the results
-        let results = ResizeArray()
+                        // Prepare the results
+                        let results =
+                            [|
+                                for method in methods do
+                                    // Create the documentation. Note, do this on the background thread, since doing it in the documentationBuild fails to build the XML index
+                                    let mainDescription = ResizeArray()
+                                    let documentation = ResizeArray()
+                                    XmlDocumentation.BuildMethodOverloadTipText(
+                                        documentationBuilder,
+                                        RoslynHelpers.CollectTaggedText mainDescription,
+                                        RoslynHelpers.CollectTaggedText documentation,
+                                        method.StructuredDescription, false)
 
-        for method in methods do
-            // Create the documentation. Note, do this on the background thread, since doing it in the documentationBuild fails to build the XML index
-            let mainDescription = ResizeArray()
-            let documentation = ResizeArray()
-            XmlDocumentation.BuildMethodOverloadTipText(documentationBuilder, RoslynHelpers.CollectTaggedText mainDescription, RoslynHelpers.CollectTaggedText documentation, method.StructuredDescription, false)
+                                    let parameters = 
+                                        let parameters = if isStaticArgTip then method.StaticParameters else method.Parameters
+                                        [|
+                                            for p in parameters do 
+                                                let doc = ResizeArray()
+                                                let parts = ResizeArray()
 
-            let parameters = 
-                let parameters = if isStaticArgTip then method.StaticParameters else method.Parameters
-                [| for p in parameters do 
-                      let doc = List()
-                      // FSROSLYNTODO: compute the proper help text for parameters, c.f. AppendParameter in XmlDocumentation.fs
-                      XmlDocumentation.BuildMethodParamText(documentationBuilder, RoslynHelpers.CollectTaggedText doc, method.XmlDoc, p.ParameterName) 
-                      let parts = List()
-                      renderL (taggedTextListR (RoslynHelpers.CollectTaggedText parts)) p.StructuredDisplay |> ignore
-                      yield (p.ParameterName, p.IsOptional, p.CanonicalTypeTextForSorting, doc, parts) 
-                |]
+                                                // FSROSLYNTODO: compute the proper help text for parameters, c.f. AppendParameter in XmlDocumentation.fs
+                                                XmlDocumentation.BuildMethodParamText(documentationBuilder, RoslynHelpers.CollectTaggedText doc, method.XmlDoc, p.ParameterName)
+                                                renderL (taggedTextListR (RoslynHelpers.CollectTaggedText parts)) p.StructuredDisplay |> ignore
+                                        
+                                                { ParameterName = p.ParameterName
+                                                  IsOptional = p.IsOptional
+                                                  CanonicalTypeTextForSorting = p.CanonicalTypeTextForSorting
+                                                  Documentation = doc
+                                                  DisplayParts = parts }
+                                        |]
 
-            let prefixParts = 
-                [| TaggedText(TextTags.Method, methodGroup.MethodName);  
-                   TaggedText(TextTags.Punctuation, (if isStaticArgTip then "<" else "(")) |]
+                                    let prefixParts = 
+                                        [| TaggedText(TextTags.Method, methodGroup.MethodName);  
+                                           TaggedText(TextTags.Punctuation, (if isStaticArgTip then "<" else "(")) |]
 
-            let separatorParts = [| TaggedText(TextTags.Punctuation, ","); TaggedText(TextTags.Space, " ") |]
-            let suffixParts = [| TaggedText(TextTags.Punctuation, (if isStaticArgTip then ">" else ")")) |]
+                                    let separatorParts = [| TaggedText(TextTags.Punctuation, ","); TaggedText(TextTags.Space, " ") |]
+                                    let suffixParts = [| TaggedText(TextTags.Punctuation, (if isStaticArgTip then ">" else ")")) |]
 
-            let completionItem = (method.HasParamArrayArg, documentation, prefixParts, separatorParts, suffixParts, parameters, mainDescription)
-            // FSROSLYNTODO: Do we need a cache like for completion?
-            //declarationItemsCache.Remove(completionItem.DisplayText) |> ignore // clear out stale entries if they exist
-            //declarationItemsCache.Add(completionItem.DisplayText, declarationItem)
-            results.Add(completionItem)
+                                    { HasParamArrayArg = method.HasParamArrayArg
+                                      Documentation = documentation
+                                      PrefixParts = prefixParts
+                                      SeparatorParts = separatorParts
+                                      SuffixParts = suffixParts
+                                      Parameters = parameters
+                                      MainDescription = mainDescription }
+                                |]
 
-
-        let items = (results.ToArray(),applicableSpan,argumentIndex,argumentCount,argumentName)
-        return Some items
-    }
+                        let data =
+                            { SignatureHelpItems = results
+                              ApplicableSpan = applicableSpan
+                              ArgumentIndex = argumentIndex
+                              ArgumentCount = argumentCount
+                              ArgumentName = argumentName }
+                        return Some data
+        }
 
     interface IFSharpSignatureHelpProvider with
-        member this.IsTriggerCharacter(c) = c ='(' || c = '<' || c = ',' 
-        member this.IsRetriggerCharacter(c) = c = ')' || c = '>' || c = '='
+        member _.IsTriggerCharacter(c) = c ='(' || c = '<' || c = ',' 
+        member _.IsRetriggerCharacter(c) = c = ')' || c = '>' || c = '='
 
-        member this.GetItemsAsync(document, position, triggerInfo, cancellationToken) = 
+        member _.GetItemsAsync(document, position, triggerInfo, cancellationToken) = 
             asyncMaybe {
-              try
-                let! _parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document, cancellationToken, userOpName)
-                let! sourceText = document.GetTextAsync(cancellationToken)
-                let! textVersion = document.GetTextVersionAsync(cancellationToken)
+                try
+                    let! _parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document, cancellationToken, userOpName)
+                    let! sourceText = document.GetTextAsync(cancellationToken)
+                    let! textVersion = document.GetTextVersionAsync(cancellationToken)
 
-                let triggerTypedChar = 
-                    if triggerInfo.TriggerCharacter.HasValue && triggerInfo.TriggerReason = FSharpSignatureHelpTriggerReason.TypeCharCommand then
-                        Some triggerInfo.TriggerCharacter.Value
-                    else None
+                    let triggerTypedChar = 
+                        if triggerInfo.TriggerCharacter.HasValue && triggerInfo.TriggerReason = FSharpSignatureHelpTriggerReason.TypeCharCommand then
+                            Some triggerInfo.TriggerCharacter.Value
+                        else None
 
-                let! (results,applicableSpan,argumentIndex,argumentCount,argumentName) = 
-                    FSharpSignatureHelpProvider.ProvideMethodsAsyncAux(checkerProvider.Checker, documentationBuilder, sourceText, position, projectOptions, triggerTypedChar, document.FilePath, textVersion.GetHashCode())
-                let items = 
-                    results 
-                    |> Array.map (fun (hasParamArrayArg, doc, prefixParts, separatorParts, suffixParts, parameters, descriptionParts) ->
-                            let parameters = parameters 
-                                                |> Array.map (fun (paramName, isOptional, _typeText, paramDoc, displayParts) -> 
-                                                FSharpSignatureHelpParameter(paramName,isOptional,documentationFactory=(fun _ -> paramDoc :> seq<_>),displayParts=displayParts))
-                            FSharpSignatureHelpItem(isVariadic=hasParamArrayArg, documentationFactory=(fun _ -> doc :> seq<_>),prefixParts=prefixParts,separatorParts=separatorParts,suffixParts=suffixParts,parameters=parameters,descriptionParts=descriptionParts))
+                    let! signatureHelpData =
+                        FSharpSignatureHelpProvider.ProvideMethodsAsyncAux(
+                            checkerProvider.Checker,
+                            documentationBuilder,
+                            sourceText,
+                            position,
+                            projectOptions,
+                            triggerTypedChar,
+                            document.FilePath,
+                            textVersion.GetHashCode())
+                    let items = 
+                        signatureHelpData.SignatureHelpItems 
+                        |> Array.map (fun item ->
+                                let parameters =
+                                    item.Parameters 
+                                    |> Array.map (fun paramInfo -> 
+                                        FSharpSignatureHelpParameter(
+                                            paramInfo.ParameterName,
+                                            paramInfo.IsOptional,
+                                            documentationFactory=(fun _ -> paramInfo.Documentation :> seq<_>),
+                                            displayParts=paramInfo.DisplayParts))
+                            
+                                FSharpSignatureHelpItem(
+                                    isVariadic=item.HasParamArrayArg,
+                                    documentationFactory=(fun _ -> item.Documentation :> seq<_>),
+                                    prefixParts=item.PrefixParts,
+                                    separatorParts=item.SeparatorParts,
+                                    suffixParts=item.SuffixParts,
+                                    parameters=parameters,
+                                    descriptionParts=item.MainDescription))
 
-                return FSharpSignatureHelpItems(items,applicableSpan,argumentIndex,argumentCount,Option.toObj argumentName)
-              with ex -> 
-                Assert.Exception(ex)
-                return! None
+                    return FSharpSignatureHelpItems(
+                        items,
+                        signatureHelpData.ApplicableSpan,
+                        signatureHelpData.ArgumentIndex,
+                        signatureHelpData.ArgumentCount,
+                        Option.toObj signatureHelpData.ArgumentName)
+                with ex -> 
+                    Assert.Exception(ex)
+                    return! None
             } 
             |> Async.map Option.toObj
             |> RoslynHelpers.StartAsyncAsTask cancellationToken

--- a/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
@@ -68,10 +68,10 @@ let GetCompletionTypeNames (project:FSharpProject) (fileName:string) (caretPosit
     let sigHelp = GetSignatureHelp project fileName caretPosition
     match sigHelp with
         | None -> [||]
-        | Some (items, _applicableSpan, _argumentIndex, _argumentCount, _argumentName) ->
+        | Some data ->
             let completionTypeNames =
-                items
-                |> Array.map (fun (_, _, _, _, _, x, _) -> x |> Array.map (fun (_, _, x, _, _) -> x))
+                data.SignatureHelpItems
+                |> Array.map (fun r -> r.Parameters |> Array.map (fun p -> p.CanonicalTypeTextForSorting))
             completionTypeNames
 
 let GetCompletionTypeNamesFromCursorPosition (project:FSharpProject) =
@@ -185,7 +185,7 @@ type foo5 = N1.T<Param1=1,ParamIgnored= >
             let actual = 
                 match triggered with 
                 | None -> None
-                | Some (_,applicableSpan,argumentIndex,argumentCount,argumentName) -> Some (applicableSpan.ToString(),argumentIndex,argumentCount,argumentName)
+                | Some data -> Some (data.ApplicableSpan.ToString(),data.ArgumentIndex,data.ArgumentCount,data.ArgumentName)
 
             if expected <> actual then 
                 sb.AppendLine(sprintf "FSharpCompletionProvider.ProvideMethodsAsyncAux() gave unexpected results, expected %A, got %A" expected actual) |> ignore


### PR DESCRIPTION
This was the type that you had to reason about before:

![image](https://user-images.githubusercontent.com/6309070/96167537-68db7300-0ed4-11eb-9793-633370301a20.png)

In other words, utterly impossible to understand. I moved this to named types. I also cleaned up formatting in the file and moved to a few other more idiomatic F#-y ways to do things.