### PR TITLE
fix #9279 - Range for UnionCase fields is missing field name

### DIFF
--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -102,7 +102,7 @@ let rec IsControlFlowExpression e =
 
 let mkAnonField (ty: SynType) = Field([], false, None, ty, false, PreXmlDoc.Empty, None, ty.Range)
 
-let mkNamedField (ident, ty: SynType) = Field([], false, Some ident, ty, false, PreXmlDoc.Empty, None, ty.Range)
+let mkNamedField (ident, ty: SynType, m) = Field([], false, Some ident, ty, false, PreXmlDoc.Empty, None, m)
 
 let mkSynPatVar vis (id: Ident) = SynPat.Named (SynPat.Wild id.idRange, id, false, vis, id.idRange)
 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -2453,7 +2453,8 @@ unionCaseReprElements:
 
 unionCaseReprElement:
   | ident COLON appType
-     { mkNamedField($1, $3) }
+     { let wholeRange = rhs2 parseState 1 3
+       mkNamedField($1, $3, wholeRange) }
 
   | appType
      { mkAnonField $1 }

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -41785,7 +41785,7 @@ FSharp.Compiler.SyntaxTreeOps: SynExpr mkSynTrifix(range, System.String, SynExpr
 FSharp.Compiler.SyntaxTreeOps: SynExpr mkSynUnit(range)
 FSharp.Compiler.SyntaxTreeOps: SynExpr |SynExprErrorSkip|(SynExpr)
 FSharp.Compiler.SyntaxTreeOps: SynField mkAnonField(SynType)
-FSharp.Compiler.SyntaxTreeOps: SynField mkNamedField(Ident, SynType)
+FSharp.Compiler.SyntaxTreeOps: SynField mkNamedField(Ident, SynType, range)
 FSharp.Compiler.SyntaxTreeOps: SynPat mkSynPatMaybeVar(LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTree+SynAccess], range)
 FSharp.Compiler.SyntaxTreeOps: SynPat mkSynPatVar(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTree+SynAccess], Ident)
 FSharp.Compiler.SyntaxTreeOps: SynPat mkSynThisPatVar(Ident)


### PR DESCRIPTION
This is my first change to the compiler inspired by the community compiler video sessions and fixes #9279 

Tested with the following script and my eyeballs:

```fsharp
#r "artifacts/bin/FSharp.Core/Debug/netstandard2.0/FSharp.Core.dll"
#r "artifacts/bin/FSharp.Compiler.Service/Debug/netstandard2.0/FSharp.Compiler.Service.dll"
open System
open FSharp.Compiler.SourceCodeServices
open FSharp.Compiler.Text

let checker = FSharpChecker.Create()

let getUntypedTree (file, input) =
  let projOptions, errors =
      checker.GetProjectOptionsFromScript(file, input)
      |> Async.RunSynchronously

  let parsingOptions, _errors = checker.GetParsingOptionsFromProjectOptions(projOptions)

  let parseFileResults =
      checker.ParseFile(file, input, parsingOptions)
      |> Async.RunSynchronously

  match parseFileResults.ParseTree with
  | Some tree -> tree
  | None -> failwith "Something went wrong during parsing!"

getUntypedTree("/home/tom/test.fsx", SourceText.ofString "type X = X of x : int") |> printfn "%A"
```

If someone could point me in the direction of a suitable place to add a test case and an example to follow then I'll add one.

