### PR TITLE
always re-compute PackageReleaseNotes

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -125,9 +125,9 @@
           DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager"
           Condition="'$(IsPackable)'=='true'">
 
-    <PropertyGroup Condition="$(ScmRepositoryUrl.EndsWith('.git'))">
-        <_GitUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), ".git$", ""))</_GitUrl>
-        <PackageReleaseNotes>$(_GitUrl)$(PackageReleaseNotes)</PackageReleaseNotes>
+    <PropertyGroup>
+      <_GitUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), ".git$", ""))</_GitUrl>
+      <PackageReleaseNotes>$(_GitUrl)$(PackageReleaseNotes)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #10278.

The issue is that `$(PackageReleaseNotes)` was only getting re-computed if the repo URL ended with ".git", which doesn't appear to be the case any more.  The fix is to always set the temporary `$(_GitUrl)` variable and always do the regex replace.  If the expected ".git" suffix isn't present, then no harm done.

Draft until I can verify the generated artifacts.