### PR TITLE
make component branch name specification more flexible

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -415,7 +415,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/release/insert-into-vs.yml
     parameters:
-      componentBranchName: refs/heads/release/dev16.8
+      componentBranchName: release/dev16.8
       insertTargetBranch: master
       insertTeamEmail: fsharpteam@microsoft.com
       insertTeamName: 'F#'

--- a/eng/release/insert-into-vs.yml
+++ b/eng/release/insert-into-vs.yml
@@ -55,4 +55,4 @@ stages:
         # only auto-complete if the target branch is not `rel/*`
         AutoCompletePR: ${{ not(contains(parameters.insertTargetBranch, 'rel/')) }}
         LinkWorkItemsToPR: false
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], '${{ parameters.componentBranchName }}'))
+      condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], '${{ parameters.componentBranchName }}'), eq(variables['Build.SourceBranch'], 'refs/heads/${{ parameters.componentBranchName }}')))


### PR DESCRIPTION
This just makes our auto-insertion stuff easier to specify by making the `refs/heads/` prefix optional.