### PR TITLE
binary logging defaults for build

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -build -restore -binaryLog %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -build -restore %*"

--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/build.sh" --build --restore --binaryLog $@
+"$scriptroot/eng/build.sh" --build --restore $@

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -36,8 +36,9 @@ param (
     [switch][Alias('proto')]$bootstrap,
     [string]$bootstrapConfiguration = "Proto",
     [string]$bootstrapTfm = "net472",
-    [switch][Alias('bl')]$binaryLog,
-    [switch][Alias('nobl')]$excludeCIBinaryLog,
+    [switch][Alias('bl')]$binaryLog = $true,
+    [switch][Alias('nobl')]$excludeCIBinaryLog = $false,
+    [switch][Alias('nolog')]$noBinaryLog = $false,
     [switch]$ci,
     [switch]$official,
     [switch]$procdump,
@@ -73,6 +74,7 @@ function Print-Usage() {
     Write-Host "  -verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
     Write-Host "  -deployExtensions         Deploy built vsixes"
     Write-Host "  -binaryLog                Create MSBuild binary log (short: -bl)"
+    Write-Host "  -noLog                    Turn off logging (short: -nolog)"
     Write-Host "  -excludeCIBinaryLog       When running on CI, allow no binary log (short: -nobl)"
     Write-Host ""
     Write-Host "Actions:"
@@ -160,6 +162,10 @@ function Process-Arguments() {
         $script:testpack = $False;
     }
 
+    if ($noBinaryLog) {
+        $script:binaryLog = $False;
+    }
+
     foreach ($property in $properties) {
         if (!$property.StartsWith("/p:", "InvariantCultureIgnoreCase")) {
             Write-Host "Invalid argument: $property"
@@ -192,10 +198,6 @@ function BuildSolution() {
 
     Write-Host "$($solution):"
 
-    if ($binaryLog -and $excludeCIBinaryLog) {
-        Write-Host "Invalid argument -binarylog(-bl) and -excludeCIBinaryLog(-nobl) cannot be set at the same time"
-        ExitWithExitCode 1
-        }
     $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
 
     $projects = Join-Path $RepoRoot $solution


### PR DESCRIPTION
A recent PR added binarylogging by default to build.cmd and build.sh

I assume this was a deliberate choice.  This has messed me up, because I now type -binaryLog when I want logging, which command crashes the script.

````
c:\kevinransom\fsharp>build -binarylog
C:\kevinransom\fsharp\eng\build.ps1 : Cannot bind parameter because parameter 'binarylog' is specified more than once. To provide multiple values to parameters that can accept multiple values, use the array
syntax. For example, "-parameter value1,value2,value3".
At line:1 char:68
+ ... vinransom\fsharp\eng\build.ps1" -build -restore -binaryLog -binarylog
+                                                                ~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [build.ps1], ParameterBindingException
    + FullyQualifiedErrorId : ParameterAlreadyBound,build.ps1

````

So ... I have removed the -binaryLog from build.sh and build.cmd and made binarylogging the default for the build.ps1.  and add a switch to disable logging.

-noBinaryLog the good shortname has been used so the alias for this option is -log.
