### PR TITLE
Include `end` to type repr ranges

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1592,8 +1592,7 @@ tyconClassDefn:
        needsCheck, (TyconUnspecified, decls), mopt }
 
   | classOrInterfaceOrStruct classDefnBlock END 
-     { let m = (rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range)
-       false, ($1, $2), Some(m) }
+     { false, ($1, $2), Some (rhs2 parseState 1 3) }
 
   | classOrInterfaceOrStruct classDefnBlock recover 
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedClassInterfaceOrStruct())
@@ -1602,7 +1601,7 @@ tyconClassDefn:
 
   | classOrInterfaceOrStruct error END
      { // silent recovery 
-       false, ($1, []), Some(rhs parseState 1) }
+       false, ($1, []), Some (rhs2 parseState 1 3) }
 
 
 /* The right-hand-side of a object type definition where the class/interface/struct kind has not been specified */


### PR DESCRIPTION
Fixes ranges for explicit representations of classes, structs, and interfaces, so they include `end` keywords.
```fsharp
type T1() =
    class end

type T2() =
    class
        let x = 1
    end
```