### PR TITLE
Fix ParseAndCheckFileInProject

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -782,8 +782,5 @@
     <PackageReference Include="System.Threading.ThreadPool" Version="$(SystemThreadingThreadPoolVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
   </ItemGroup>
 </Project>

--- a/src/fsharp/SimulatedMSBuildReferenceResolver.fs
+++ b/src/fsharp/SimulatedMSBuildReferenceResolver.fs
@@ -10,9 +10,12 @@ open System
 open System.IO
 open System.Reflection
 open Microsoft.Win32
-open Microsoft.Build.Utilities
 open FSharp.Compiler.ReferenceResolver
 open FSharp.Compiler.AbstractIL.Internal.Library
+
+#if !NETSTANDARD
+open Microsoft.Build.Utilities
+#endif
 
 // ATTENTION!: the following code needs to be updated every time we are switching to the new MSBuild version because new .NET framework version was released
 // 1. List of frameworks
@@ -53,6 +56,7 @@ let SupportedDesktopFrameworkVersions = [ Net48; Net472; Net471; Net47; Net462; 
 
 let private SimulatedMSBuildResolver =
 
+#if !NETSTANDARD
     /// Get the path to the .NET Framework implementation assemblies by using ToolLocationHelper.GetPathToDotNetFramework
     /// This is only used to specify the "last resort" path for assembly resolution.
     let GetPathToDotNetFrameworkImlpementationAssemblies(v) =
@@ -75,6 +79,7 @@ let private SimulatedMSBuildResolver =
             | null -> []
             | x -> [x]
         | _ -> []
+#endif
 
     let GetPathToDotNetFrameworkReferenceAssemblies(version) = 
 #if NETSTANDARD
@@ -149,7 +154,9 @@ let private SimulatedMSBuildResolver =
                     yield! registrySearchPaths()
 #endif
                 yield! GetPathToDotNetFrameworkReferenceAssemblies targetFrameworkVersion
+#if !NETSTANDARD
                 yield! GetPathToDotNetFrameworkImlpementationAssemblies targetFrameworkVersion
+#endif
               ]
 
             for (r, baggage) in references do


### PR DESCRIPTION
Fixes #10303.

Moves code that is never used in FCS to `#if` block (the same way as it's already done for the callee code). Reverts adding extra package references.