### PR TITLE
add ci step to do a plain `dotnet build`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -382,6 +382,24 @@ stages:
               continueOnError: true
               condition: not(succeeded())
 
+        # Plain build Windows
+        # Disabled until the Windows Proto compiler is coreclr
+        # - job: Plain_Build_Windows
+        #   pool:
+        #     vmImage: windows-latest
+        #   variables:
+        #   - name: _BuildConfig
+        #     value: Debug
+        #   steps:
+        #   - checkout: self
+        #     clean: true
+        #   - script: .\Build.cmd
+        #     displayName: Initial build
+        #   - script: dotnet --list-sdks
+        #     displayName: Report dotnet SDK versions
+        #   - script: dotnet build .\FSharp.sln /bl:\"artifacts/log/$(_BuildConfig)/RegularBuild.binlog\"
+        #     displayName: Regular rebuild
+
         # Plain build Linux
         - job: Plain_Build_Linux
           pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -386,6 +386,9 @@ stages:
         - job: Plain_Build_Linux
           pool:
             vmImage: ubuntu-latest
+          variables:
+          - name: _BuildConfig
+            value: Debug
           steps:
           - checkout: self
             clean: true
@@ -393,13 +396,16 @@ stages:
             displayName: Initial build
           - script: dotnet --list-sdks
             displayName: Report dotnet SDK versions
-          - script: dotnet build ./FSharp.sln
+          - script: dotnet build ./FSharp.sln /bl:\"artifacts/log/$(_BuildConfig)/RegularBuild.binlog\"
             displayName: Regular rebuild
 
         # Plain build Mac
         - job: Plain_Build_MacOS
           pool:
             vmImage: macos-latest
+          variables:
+          - name: _BuildConfig
+            value: Debug
           steps:
           - checkout: self
             clean: true
@@ -407,7 +413,7 @@ stages:
             displayName: Initial build
           - script: dotnet --list-sdks
             displayName: Report dotnet SDK versions
-          - script: dotnet build ./FSharp.sln
+          - script: dotnet build ./FSharp.sln /bl:\"artifacts/log/$(_BuildConfig)/RegularBuild.binlog\"
             displayName: Regular rebuild
 
     # Arcade-powered source build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -382,6 +382,30 @@ stages:
               continueOnError: true
               condition: not(succeeded())
 
+        # Plain build Linux
+        - job: Plain_Build_Linux
+          pool:
+            vmImage: ubuntu-latest
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./build.sh
+            displayName: Initial build
+          - script: dotnet build ./FSharp.sln
+            displayName: Regular rebuild
+
+        # Plain build Mac
+        - job: Plain_Build_MacOS
+          pool:
+            vmImage: macos-latest
+          steps:
+          - checkout: self
+            clean: true
+          - script: ./build.sh
+            displayName: Initial build
+          - script: dotnet build ./FSharp.sln
+            displayName: Regular rebuild
+
     # Arcade-powered source build
     # turned off until https://github.com/dotnet/source-build/issues/1795 is fixed
     # - template: /eng/common/templates/jobs/jobs.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -391,6 +391,8 @@ stages:
             clean: true
           - script: ./build.sh
             displayName: Initial build
+          - script: dotnet --list-sdks
+            displayName: Report dotnet SDK versions
           - script: dotnet build ./FSharp.sln
             displayName: Regular rebuild
 
@@ -403,6 +405,8 @@ stages:
             clean: true
           - script: ./build.sh
             displayName: Initial build
+          - script: dotnet --list-sdks
+            displayName: Report dotnet SDK versions
           - script: dotnet build ./FSharp.sln
             displayName: Regular rebuild
 


### PR DESCRIPTION
While investigating #10151 I decided it would be a good idea to ensure that `dotnet build ./FSharp.sln` always works following an initial `./build.sh`.