### PR TITLE
Lazily produce TokenTups for the pool when needed

### DIFF
--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -427,12 +427,18 @@ type TokenTupPool() =
     [<Literal>]
     let maxSize = 100
 
-    let stack = System.Collections.Generic.Stack(Array.init maxSize (fun _ -> TokenTup(Unchecked.defaultof<_>, Unchecked.defaultof<_>, Unchecked.defaultof<_>)))
+    let mutable currentPoolSize = 0
+    let stack = System.Collections.Generic.Stack(10)
 
-    member _.Rent() = 
+    member this.Rent() = 
         if stack.Count = 0 then
-            assert false
-            TokenTup(Unchecked.defaultof<_>, Unchecked.defaultof<_>, Unchecked.defaultof<_>)
+            if currentPoolSize < maxSize then
+                stack.Push(TokenTup(Unchecked.defaultof<_>, Unchecked.defaultof<_>, Unchecked.defaultof<_>))
+                currentPoolSize <- currentPoolSize + 1
+                this.Rent()
+            else
+                assert false
+                TokenTup(Unchecked.defaultof<_>, Unchecked.defaultof<_>, Unchecked.defaultof<_>)
         else
             stack.Pop()
 


### PR DESCRIPTION
This is a minor change to the `TokenTup` pool. It just lazily produces `TokenTup`s for the pool itself. We do this so we can avoid always allocating 100 `TokenTup`s for every file.