### PR TITLE
Improve FSharp.Compiler.Private.Scripting dependencies

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.fsproj
@@ -17,6 +17,11 @@
     <NuspecProperty Include="FsharpCorePackageVersion=$(FSCorePackageVersion)" Condition="'$(VersionSuffix)'==''" />
     <NuspecProperty Include="FsharpCorePackageVersion=$(FSCorePackageVersion)-$(VersionSuffix)" Condition="'$(VersionSuffix)'!=''" />
     <NuspecProperty Include="TargetFramework=$(TargetFramework)" />
+    <NuspecProperty Include="SystemCollectionsImmutablePackageVersion=$(SystemCollectionsImmutableVersion)" />
+    <NuspecProperty Include="SystemReflectionMetadataPackageVersion=$(SystemReflectionMetadataVersion)" />
+    <NuspecProperty Include="MicrosoftBuildFrameworkPackageVersion=$(MicrosoftBuildFrameworkVersion)" />
+    <NuspecProperty Include="MicrosoftBuildTasksCorePackageVersion=$(MicrosoftBuildTasksCoreVersion)" />
+    <NuspecProperty Include="MicrosoftBuildUtilitiesCorePackageVersion=$(MicrosoftBuildUtilitiesCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.nuspec
+++ b/src/fsharp/FSharp.Compiler.Private.Scripting/FSharp.Compiler.Private.Scripting.nuspec
@@ -6,6 +6,11 @@
         <dependencies>
             <group targetFramework=".NETStandard2.0">
                 <dependency id="FSharp.Core" version="$FSharpCorePackageVersion$" />
+                <dependency id="System.Collections.Immutable" version="$SystemCollectionsImmutablePackageVersion$" />
+                <dependency id="System.Reflection.Metadata" version="$SystemReflectionMetadataPackageVersion$" />
+                <dependency id="Microsoft.Build.Framework" version="$MicrosoftBuildFrameworkPackageVersion$" />
+                <dependency id="Microsoft.Build.Tasks.Core" version="$MicrosoftBuildTasksCorePackageVersion$" />
+                <dependency id="Microsoft.Build.Utilities.Core" version="$MicrosoftBuildUtilitiesCorePackageVersion$" />
             </group>
         </dependencies>
     </metadata>


### PR DESCRIPTION
FSharp.Compiler.Private.Scripting, does not accurately document it's dependencies ... this PR fixes that.

@brettfo , please take a look mate.