### PR TITLE
Normalize Paths better in packagereferences and emit packageroot correctly for non-contributing packages

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
@@ -170,7 +170,7 @@ $(PACKAGEREFERENCES)
           Condition = "'$(Id)' != '' and '$(Version)' != ''">
         <NugetPackageId>$(Id)</NugetPackageId>
         <NugetPackageVersion>$(Version)</NugetPackageVersion>
-        <Path>$([MSBuild]::EnsureTrailingSlash("$([System.IO.Path]::GetDirectoryName('%(NuspecFiles.Identity)'))").Replace('\', '/'))</Path>
+        <PackageRoot>$([MSBuild]::EnsureTrailingSlash("$([System.IO.Path]::GetDirectoryName('%(NuspecFiles.Identity)'))").Replace('\', '/'))</PackageRoot>
         <AssetType>package</AssetType>
       </NugetPackageInfo>
     </ItemGroup>
@@ -225,13 +225,14 @@ $(PACKAGEREFERENCES)
         <NativeIncludeRoots
             Include="@(RuntimeTargetsCopyLocalItems)"
             Condition="'%(RuntimeTargetsCopyLocalItems.AssetType)' == 'native'">
-            <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))').Replace('\','/'))</Path>
+            <PackageRoot>$([MSBuild]::EnsureTrailingSlash("$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))").Replace('\','/'))</PackageRoot>
+            <Path>%(FullPath).Replace('\', '/'))</Path>
         </NativeIncludeRoots>
 
         <NativeIncludeRoots
             Include="@(NativeCopyLocalItems)"
             Condition="'%(NativeCopyLocalItems.AssetType)' == 'native'">
-            <Path>$([MSBuild]::EnsureTrailingSlash('$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))').Replace('\','/'))</Path>
+            <PackageRoot>$([MSBuild]::EnsureTrailingSlash("$([System.String]::Copy('%(FullPath)').Substring(0, $([System.String]::Copy('%(FullPath)').LastIndexOf('runtimes'))))").Replace('\','/'))</PackageRoot>
         </NativeIncludeRoots>
 
         <PropertyNames Include = "Pkg$([System.String]::Copy('%(PackageReference.FileName)').Replace('.','_'))" />
@@ -244,7 +245,6 @@ $(PACKAGEREFERENCES)
           <AssetType>package</AssetType>
           <PackageRoot>$([MSBuild]::EnsureTrailingSlash('$(%(PropertyNames.FileName))'))</PackageRoot>
           <PackageRoot>$([System.String]::Copy('%(ProvidedPackageRoots.PackageRoot)').Replace('\', '/'))</PackageRoot>
-          <Path>%(ProvidedPackageRoots.PackageRoot)</Path>
         </ProvidedPackageRoots>
       </ItemGroup>
   </Target>
@@ -258,15 +258,15 @@ $(PACKAGEREFERENCES)
       <ResolvedReferenceLines Remove='*' />
       <ResolvedReferenceLines
           Condition="(@(InteractiveResolvedFile->Count()) &gt; 0) AND (('%(InteractiveResolvedFile.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(InteractiveResolvedFile.NugetPackageId)'=='FSharp.Core'))"
-          Include="%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.PackageRoot),%(InteractiveResolvedFile.FullPath),%(InteractiveResolvedFile.AssetType),%(InteractiveResolvedFile.IsNotImplementationReference),%(InteractiveResolvedFile.InitializeSourcePath),"
+          Include="%(InteractiveResolvedFile.NugetPackageId),%(InteractiveResolvedFile.NugetPackageVersion),%(InteractiveResolvedFile.PackageRoot),$([System.String]::Copy('%(InteractiveResolvedFile.FullPath)').Replace('\','/')),%(InteractiveResolvedFile.AssetType),%(InteractiveResolvedFile.IsNotImplementationReference),%(InteractiveResolvedFile.InitializeSourcePath),"
           KeepDuplicates="false" />
       <ResolvedReferenceLines
           Condition="(@(NativeIncludeRoots->Count()) &gt; 0) AND (('%(NativeIncludeRoots.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(NativeIncludeRoots.NugetPackageId)'=='FSharp.Core'))"
-          Include="%(NativeIncludeRoots.NugetPackageId),%(NativeIncludeRoots.NugetPackageVersion),%(NativeIncludeRoots.PackageRoot),,%(NativeIncludeRoots.AssetType),,,%(NativeIncludeRoots.Path)"
+          Include="%(NativeIncludeRoots.NugetPackageId),%(NativeIncludeRoots.NugetPackageVersion),%(NativeIncludeRoots.PackageRoot),,%(NativeIncludeRoots.AssetType),,,$([System.String]::Copy('%(NativeIncludeRoots.FullPath)').Replace('\','/'))"
           KeepDuplicates="false" />
       <ResolvedReferenceLines
           Condition="(@(NugetPackageInfo->Count()) &gt; 0) AND (('%(NugetPackageInfo.NugetPackageId)'!='FSharp.Core') or ('$(SCRIPTEXTENSION)'!='.fsx' and '%(ProvidedPackageRoots.NugetPackageId)'=='FSharp.Core'))"
-          Include="%(NugetPackageInfo.NugetPackageId),%(NugetPackageInfo.NugetPackageVersion),%(NugetPackageInfo.PackageRoot),,%(NugetPackageInfo.AssetType),,,%(NugetPackageInfo.Path)"
+          Include="%(NugetPackageInfo.NugetPackageId),%(NugetPackageInfo.NugetPackageVersion),%(NugetPackageInfo.PackageRoot),,%(NugetPackageInfo.AssetType),,,"
           KeepDuplicates="false" />
     </ItemGroup>
 

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -168,7 +168,7 @@ type DependencyManagerInteractiveTests() =
             let result1 = dp1.Resolve(idm1, ".fsx", [|"r", "FSharp.Data"|], reportError, "net472")
             Assert.Equal(true, result1.Success)
             Assert.Equal(1, result1.Resolutions |> Seq.length)
-            Assert.True((result1.Resolutions |> Seq.head).Contains("\\net45\\"))
+            Assert.True((result1.Resolutions |> Seq.head).Contains("/net45/"))
             Assert.Equal(1, result1.SourceFiles |> Seq.length)
             Assert.Equal(2, result1.Roots |> Seq.length)
             Assert.True((result1.Roots |> Seq.head).EndsWith("/fsharp.data/3.3.3/"))
@@ -177,11 +177,7 @@ type DependencyManagerInteractiveTests() =
         let result2 = dp1.Resolve(idm1, ".fsx", [|"r", "FSharp.Data, 3.3.3"|], reportError, "netcoreapp3.1")
         Assert.Equal(true, result2.Success)
         Assert.Equal(1, result2.Resolutions |> Seq.length)
-        let expected2 =
-            if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-                "\\netstandard2.0\\"
-            else
-                "/netstandard2.0/"
+        let expected2 = "/netstandard2.0/"
         Assert.True((result2.Resolutions |> Seq.head).Contains(expected2))
         Assert.Equal(1, result2.SourceFiles |> Seq.length)
         Assert.Equal(1, result2.Roots |> Seq.length)
@@ -194,7 +190,7 @@ type DependencyManagerInteractiveTests() =
             let result3 = dp2.Resolve(idm2, ".fsx", [|"r", "System.Json, Version=4.6.0"|], reportError, "net472")
             Assert.Equal(true, result3.Success)
             Assert.Equal(1, result3.Resolutions |> Seq.length)
-            Assert.True((result3.Resolutions |> Seq.head).Contains("\\netstandard2.0\\"))
+            Assert.True((result3.Resolutions |> Seq.head).Contains("/netstandard2.0/"))
             Assert.Equal(1, result3.SourceFiles |> Seq.length)
             Assert.Equal(1, result3.SourceFiles |> Seq.length)
             Assert.True((result3.Roots |> Seq.head).EndsWith("/system.json/4.6.0/"))
@@ -202,11 +198,7 @@ type DependencyManagerInteractiveTests() =
         let result4 = dp2.Resolve(idm2, ".fsx", [|"r", "System.Json, Version=4.6.0"|], reportError, "netcoreapp3.1")
         Assert.Equal(true, result4.Success)
         Assert.Equal(1, result4.Resolutions |> Seq.length)
-        let expected4 =
-            if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-                "\\netstandard2.0\\"
-            else
-                "/netstandard2.0/"
+        let expected4 = "/netstandard2.0/"
         Assert.True((result4.Resolutions |> Seq.head).Contains(expected4))
         Assert.Equal(1, result4.SourceFiles |> Seq.length)
         Assert.Equal(1, result4.Roots |> Seq.length)
@@ -232,7 +224,7 @@ type DependencyManagerInteractiveTests() =
             let result1 = dp1.Resolve(idm1, ".fsx", [|"r", "Microsoft.Extensions.Configuration.Abstractions, 3.1.1"|], reportError, "net472")
             Assert.Equal(true, result1.Success)
             Assert.Equal(6, result1.Resolutions |> Seq.length)
-            Assert.True((result1.Resolutions |> Seq.head).Contains("\\netstandard2.0\\"))
+            Assert.True((result1.Resolutions |> Seq.head).Contains("/netstandard2.0/"))
             Assert.Equal(1, result1.SourceFiles |> Seq.length)
             Assert.Equal(7, result1.Roots |> Seq.length)
             Assert.True((result1.Roots |> Seq.head).EndsWith("/microsoft.extensions.configuration.abstractions/3.1.1/"))
@@ -242,11 +234,7 @@ type DependencyManagerInteractiveTests() =
         let result2 = dp1.Resolve(idm1, ".fsx", [|"r", "Microsoft.Extensions.Configuration.Abstractions, 3.1.1"|], reportError, "netcoreapp3.1")
         Assert.Equal(true, result2.Success)
         Assert.Equal(2, result2.Resolutions |> Seq.length)
-        let expected =
-            if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-                "\\netcoreapp3.1\\"
-            else
-                "/netcoreapp3.1/"
+        let expected = "/netcoreapp3.1/"
         Assert.True((result2.Resolutions |> Seq.head).Contains(expected))
         Assert.Equal(1, result2.SourceFiles |> Seq.length)
         Assert.Equal(2, result2.Roots |> Seq.length)


### PR DESCRIPTION
@brettfo the title says it all.

In the fix for non-contributing packages, I emitted the PackageRoot in the wrong column for the file.

I also took the opportunity to normalize the remaining paths emitted in the file.