### PR TITLE
update vsix for marketplace

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,7 +154,7 @@ stages:
           - task: PublishBuildArtifacts@1
             displayName: Publish Artifact Nightly
             inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\VisualFSharpFull.vsix'
+              PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\Insertion\VisualFSharpFull.vsix'
               ArtifactName: 'Nightly'
             condition: succeeded()
           - task: PublishBuildArtifacts@1

--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="VisualFSharp" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft.VisualFSharpTools" />
+    <Identity Id="VisualFSharp" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Visual F# Tools</DisplayName>
     <Description xml:space="preserve">Deploy Visual F# Tools Binaries to Visual Studio</Description>
     <PackageId>Microsoft.FSharp.VSIX.Full.Core</PackageId>

--- a/vsintegration/Vsix/VisualFSharpTemplates/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpTemplates/Source.extension.vsixmanifest
@@ -3,7 +3,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
 
   <Metadata>
-    <Identity Id="VisualFSharpTemplates" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft.VisualFSharpTools" />
+    <Identity Id="VisualFSharpTemplates" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Visual F# Templates</DisplayName>
     <Description xml:space="preserve">Deploy Visual F# Tools Desktop Project Templates to Visual Studio</Description>
     <PackageId>Microsoft.FSharp.VSIX.Templates</PackageId>


### PR DESCRIPTION
This is an attempt to allow the nightly build of our VS component to be hosted entirely by the VS Extension Marketplace.

Marked as draft while I run internal builds and package upgrade scenarios.