### PR TITLE
build net472 of Microsoft.DotNet.DependencyMangager since the netstandard2.0 can't be ngened

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
+++ b/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
@@ -101,7 +101,7 @@ folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp"
   file source="$(BinariesFolder)\FSharp.Core\$(Configuration)\netstandard2.0\FSharp.Core.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
   file source="$(BinariesFolder)\FSharp.Core\$(Configuration)\netstandard2.0\FSharp.Core.xml"
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\$(TargetFramework)\FSharp.Build.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
-  file source="$(BinariesFolder)\Microsoft.DotNet.DependencyManager\$(Configuration)\netstandard2.0\Microsoft.DotNet.DependencyManager.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
+  file source="$(BinariesFolder)\Microsoft.DotNet.DependencyManager\$(Configuration)\net472\Microsoft.DotNet.DependencyManager.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.Framework.dll"
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.Tasks.Core.dll"
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.Utilities.Core.dll"

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/Microsoft.DotNet.DependencyManager.fsproj
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/Microsoft.DotNet.DependencyManager.fsproj
@@ -4,8 +4,9 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.DotNet.DependencyManager</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs
@@ -14,6 +14,7 @@ open Internal.Utilities.FSharpEnvironment
 /// host implements this, it's job is to return a list of package roots to probe.
 type NativeResolutionProbe = delegate of Unit -> seq<string>
 
+#if NETSTANDARD
 open System.Runtime.Loader
 
 // Cut down AssemblyLoadContext, for loading native libraries
@@ -105,12 +106,15 @@ type NativeDllResolveHandlerCoreClr (nativeProbingRoots: NativeResolutionProbe) 
             if not (isNull eventInfo) then
                 eventInfo.RemoveEventHandler(AssemblyLoadContext.Default, handler)
             ()
+#endif
 
-type NativeDllResolveHandler (nativeProbingRoots: NativeResolutionProbe) =
-    let handler:IDisposable option =
+type NativeDllResolveHandler (_nativeProbingRoots: NativeResolutionProbe) =
+    let handler: IDisposable option =
+#if NETSTANDARD
         if isRunningOnCoreClr then
-            Some (new NativeDllResolveHandlerCoreClr(nativeProbingRoots) :> IDisposable)
+            Some (new NativeDllResolveHandlerCoreClr(_nativeProbingRoots) :> IDisposable)
         else
+#endif
             None
 
     let appendSemiColon (p:string) =

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi
@@ -12,7 +12,7 @@ type NativeResolutionProbe = delegate of Unit -> seq<string>
 type NativeDllResolveHandler =
 
     /// Construct a new NativeDllResolveHandler
-    new: nativeProbingRoots: NativeResolutionProbe -> NativeDllResolveHandler
+    new: _nativeProbingRoots: NativeResolutionProbe -> NativeDllResolveHandler
 
     member internal RefreshPathsInEnvironment: string seq -> unit
 

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -95,7 +95,7 @@
       <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=netstandard2.0</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>


### PR DESCRIPTION
Because Microsoft.DotNet.DependencyManager depends on System.Runtime.Loader in netstandard2.0, it can't be ngened and FSharp.Compiler.Private has a reference to MS.DN.DM which will always pull it into the ngen graph.

Eventually this will be corrected (@KevinRansom and I had a terrifying talk), but for now we still need net472.

Confirmed this passes ngen.