### PR TITLE
Improved nice print to give literal values

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1301,7 +1301,7 @@ module private PrintTastMemberOrVals =
     let prettyLayoutOfMemberNoInstShort denv v = 
         prettyLayoutOfMemberShortOption denv emptyTyparInst v true |> snd
 
-    let prettyLayoutOfLiteralValue literalValue =
+    let layoutOfLiteralValue literalValue =
         let literalValue =
             match literalValue with
             | Const.Bool value -> if value then WordL.keywordTrue else WordL.keywordFalse
@@ -1320,9 +1320,9 @@ module private PrintTastMemberOrVals =
             | Const.Decimal _ -> literalValue.ToString() |> tagNumericLiteral |> wordL
             | Const.Char _
             | Const.String _ -> literalValue.ToString() |> tagStringLiteral |> wordL
-            | Const.Unit  -> literalValue.ToString() |> tagText |> wordL
+            | Const.Unit
             | Const.Zero -> literalValue.ToString() |> tagText |> wordL
-        LeftL.leftParen ++ literalValue ++ RightL.rightParen
+        WordL.equals ++ literalValue
 
     let private layoutNonMemberVal denv (tps, v: Val, tau, cxs) =
         let env = SimplifyTypes.CollectInfo true [tau] cxs
@@ -1356,7 +1356,7 @@ module private PrintTastMemberOrVals =
             | None -> valAndTypeL
             | Some rhsL -> (valAndTypeL ++ wordL (tagPunctuation"=")) --- rhsL
         match v.LiteralValue with
-        | Some literalValue -> valAndTypeL ++ prettyLayoutOfLiteralValue literalValue
+        | Some literalValue -> valAndTypeL ++ layoutOfLiteralValue literalValue
         | None -> valAndTypeL
 
     let prettyLayoutOfValOrMember denv typarInst (v: Val) =

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1301,6 +1301,29 @@ module private PrintTastMemberOrVals =
     let prettyLayoutOfMemberNoInstShort denv v = 
         prettyLayoutOfMemberShortOption denv emptyTyparInst v true |> snd
 
+    let prettyLayoutOfLiteralValue literalValue =
+        let literalValue =
+            match literalValue with
+            | Const.Bool value -> if value then WordL.keywordTrue else WordL.keywordFalse
+            | Const.SByte _
+            | Const.Byte _
+            | Const.Int16 _
+            | Const.UInt16 _
+            | Const.Int32 _
+            | Const.UInt32 _
+            | Const.Int64 _
+            | Const.UInt64 _
+            | Const.IntPtr _
+            | Const.UIntPtr _
+            | Const.Single _
+            | Const.Double _
+            | Const.Decimal _ -> literalValue.ToString() |> tagNumericLiteral |> wordL
+            | Const.Char _
+            | Const.String _ -> literalValue.ToString() |> tagStringLiteral |> wordL
+            | Const.Unit  -> literalValue.ToString() |> tagText |> wordL
+            | Const.Zero -> literalValue.ToString() |> tagText |> wordL
+        LeftL.leftParen ++ literalValue ++ RightL.rightParen
+
     let private layoutNonMemberVal denv (tps, v: Val, tau, cxs) =
         let env = SimplifyTypes.CollectInfo true [tau] cxs
         let cxs = env.postfixConstraints
@@ -1328,9 +1351,13 @@ module private PrintTastMemberOrVals =
                 layoutTyparDecls denv nameL true tps 
             else nameL
         let valAndTypeL = (WordL.keywordVal ^^ typarBindingsL --- wordL (tagPunctuation ":")) --- layoutTopType denv env argInfos rty cxs
-        match denv.generatedValueLayout v with
-          | None -> valAndTypeL
-          | Some rhsL -> (valAndTypeL ++ wordL (tagPunctuation"=")) --- rhsL
+        let valAndTypeL =
+            match denv.generatedValueLayout v with
+            | None -> valAndTypeL
+            | Some rhsL -> (valAndTypeL ++ wordL (tagPunctuation"=")) --- rhsL
+        match v.LiteralValue with
+        | Some literalValue -> valAndTypeL ++ prettyLayoutOfLiteralValue literalValue
+        | None -> valAndTypeL
 
     let prettyLayoutOfValOrMember denv typarInst (v: Val) =
         let prettyTyparInst, vL = 


### PR DESCRIPTION
This change enables pretty printing Const values. Need some help with deciding printing manner (currently I'm using parentheses to show literal value). Also, I'm not sure I used WordL api right but I hope I did.
Screenshots are from JetBrains Rider.
Seems like mapping from NumbericLiteral could be fixed in Rider as it reports wrong color for mkNumericLiteral, but okay with mkStringLiteral:
![image](https://user-images.githubusercontent.com/37334640/98347002-df791580-2027-11eb-98c7-a7ad28caf6af.png)
![image](https://user-images.githubusercontent.com/37334640/98347033-ebfd6e00-2027-11eb-8fff-f03ac3475fad.png)