### PR TITLE
Fix extern declaration accessibility

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -2643,7 +2643,7 @@ cPrototype:
                                   SynExpr.Ident (ident("failwith", rhs parseState 6)),
                                   SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", rhs parseState 8), rhs parseState 8),
                                   mRhs)
-        (fun attrs vis -> 
+        (fun attrs _ -> 
             let bindingId = SynPat.LongIdent (LongIdentWithDots([nm], []), None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
             let binding = mkSynBinding 
                               (xmlDoc, bindingId) 

--- a/tests/fsharp/typeProviders/helloWorld/provided.fs
+++ b/tests/fsharp/typeProviders/helloWorld/provided.fs
@@ -196,5 +196,5 @@ module TheOuterType =
 
 module DllImportSmokeTest = 
     [<System.Runtime.InteropServices.DllImport("kernel32.dll")>]
-    extern System.UInt32 private GetLastError()
+    extern System.UInt32 GetLastError()
 

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -228,10 +228,15 @@ let matchBraces (name: string, code: string) =
     let braces = checker.MatchBraces(filePath, FSharp.Compiler.Text.SourceText.ofString code, options) |> Async.RunSynchronously
     braces
 
-let parseSourceCodeAndGetModule (source: string) =
-    match parseSourceCode ("test", source) with
-    | Some (ParsedInput.ImplFile (ParsedImplFileInput (_, _, _, _, _, [ moduleOrNamespace ], _))) -> moduleOrNamespace
+
+let getSingleModuleLikeDecl (input: ParsedInput option) =
+    match input with
+    | Some (ParsedInput.ImplFile (ParsedImplFileInput (modules = [ decl ]))) -> decl
     | _ -> failwith "Could not get module decls"
+    
+let parseSourceCodeAndGetModule (source: string) =
+    parseSourceCode ("test", source) |> getSingleModuleLikeDecl
+
 
 /// Extract range info 
 let tups (m:Range.range) = (m.StartLine, m.StartColumn), (m.EndLine, m.EndColumn)

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -63,13 +63,10 @@ module ExternDeclarations =
     let ``Access modifier`` () =
         let parseResults, checkResults = getParseAndCheckResults "extern int private f()"
 
-        match parseResults.ParseTree with
-        | Some (ParsedInput.ImplFile (ParsedImplFileInput (modules = [SynModuleOrNamespace (decls = [decl])]))) ->
-            match decl with
-            | SynModuleDecl.Let (_, [Binding (accessibility = accessibility)], _) ->
-                accessibility |> should equal (Some SynAccess.Private)
-            | _ -> failwith "Couldn't get f"
-        | _ -> failwith "Couldn't get bindings"
+        match getSingleModuleLikeDecl parseResults.ParseTree with
+        | SynModuleOrNamespace (decls = [SynModuleDecl.Let (_, [Binding (accessibility = accessibility)], _)]) ->
+            accessibility |> should equal (Some SynAccess.Private)
+        | _ -> failwith "Couldn't get f"
 
         match findSymbolByName "f" checkResults with
         | :? FSharpMemberOrFunctionOrValue as mfv -> mfv.Accessibility.IsPrivate |> should equal true

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -72,7 +72,7 @@ extern int private c()
           Some SynAccess.Public
           Some SynAccess.Private ]
         |> List.zip decls
-        |> List.iter (fun (actual, (expected)) ->
+        |> List.iter (fun (actual, expected) ->
             match actual with
             | SynModuleDecl.Let (_, [Binding (accessibility = access)], _) -> access |> should equal expected
             | decl -> failwithf "unexpected decl: %O" decl)
@@ -80,13 +80,13 @@ extern int private c()
         [ "a", (true, false, false, false)
           "b", (true, false, false, false)
           "c", (false, false, false, true) ]
-        |> List.iter (fun (name, expectedAccess) ->
+        |> List.iter (fun (name, expected) ->
             match findSymbolByName name checkResults with
             | :? FSharpMemberOrFunctionOrValue as mfv ->
                 let access = mfv.Accessibility
                 (access.IsPublic, access.IsProtected, access.IsInternal, access.IsPrivate)
-                |> should equal expectedAccess
-            | _ -> failwith "Couldn't get f")
+                |> should equal expected
+            | _ -> failwithf "Couldn't get mfv: %s" name)
 
 
 module XmlDocSig =


### PR DESCRIPTION
Is needed for https://github.com/fsprojects/fantomas/issues/1213. It seems access modifiers are always ignored for `extern` declarations.