### PR TITLE
Add parser recovery for unfinished interface implementation

### DIFF
--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -22,7 +22,7 @@ let outputPos os (p: Position) = Printf.fprintf os "(%d:%d)" p.OriginalLine p.Co
 /// Used for warning strings, which should display columns as 1-based and display 
 /// the lines after taking '# line' directives into account (i.e. do not use
 /// p.OriginalLine)
-let warningStringOfPos (p: Position) = sprintf "(%d:%d)" p.Line (p.Column + 1)
+let warningStringOfPosition (p: Position) = warningStringOfCoords p.Line p.Column
 
 type Context = 
     // Position is position of keyword.
@@ -651,7 +651,7 @@ type LexFilterImpl (lightStatus: LightSyntaxStatus, compilingFsLib, lexer, lexbu
         initialLookaheadTokenTup 
 
     let warn (s: TokenTup) msg = 
-        warning(Lexhelp.IndentationProblem(msg, mkSynRange (startPosOfTokenTup s) s.LexbufState.EndPos))
+        warning(IndentationProblem(msg, mkSynRange (startPosOfTokenTup s) s.LexbufState.EndPos))
 
     // 'query { join x in ys ... }'
     // 'query { ... 
@@ -865,9 +865,9 @@ type LexFilterImpl (lightStatus: LightSyntaxStatus, compilingFsLib, lexer, lexbu
                 warn tokenTup 
                     (if debug then 
                         sprintf "possible incorrect indentation: this token is offside of context at position %s, newCtxt = %A, stack = %A, newCtxtPos = %s, c1 = %d, c2 = %d" 
-                            (warningStringOfPos p1.Position) newCtxt offsideStack (stringOfPos (newCtxt.StartPos)) p1.Column c2 
+                            (warningStringOfPosition p1.Position) newCtxt offsideStack (stringOfPos (newCtxt.StartPos)) p1.Column c2 
                      else
-                        FSComp.SR.lexfltTokenIsOffsideOfContextStartedEarlier(warningStringOfPos p1.Position))
+                        FSComp.SR.lexfltTokenIsOffsideOfContextStartedEarlier(warningStringOfPosition p1.Position))
         let newOffsideStack = newCtxt :: offsideStack
         if debug then dprintf "--> pushing, stack = %A\n" newOffsideStack
         offsideStack <- newOffsideStack
@@ -1749,7 +1749,7 @@ type LexFilterImpl (lightStatus: LightSyntaxStatus, compilingFsLib, lexer, lexbu
                                 let cond1 = tokenStartCol + (if leadingBar then 0 else 2) < offsidePos.Column
                                 let cond2 = tokenStartCol + (if leadingBar then 1 else 2) < offsidePos.Column
                                 if (cond1 <> cond2) then 
-                                    errorR(Lexhelp.IndentationProblem(FSComp.SR.lexfltSeparatorTokensOfPatternMatchMisaligned(), mkSynRange (startPosOfTokenTup tokenTup) tokenTup.LexbufState.EndPos))
+                                    errorR(IndentationProblem(FSComp.SR.lexfltSeparatorTokensOfPatternMatchMisaligned(), mkSynRange (startPosOfTokenTup tokenTup) tokenTup.LexbufState.EndPos))
                                 cond1
                             | END -> tokenStartCol + (if leadingBar then -1 else 1) < offsidePos.Column
                             | _ -> tokenStartCol + (if leadingBar then -1 else 1) < offsidePos.Column)) -> 

--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -2066,6 +2066,11 @@ type LexFilterImpl (lightStatus: LightSyntaxStatus, compilingFsLib, lexer, lexbu
                     let offsidePos = tokenStartPos
                     pushCtxt tokenTup (CtxtWithAsLet offsidePos)
                     returnToken tokenLexbufState OWITH 
+
+                // Recovery for `interface ... with` member without further indented member implementations
+                elif lookaheadTokenStartPos.Column <= limCtxt.StartCol && (match limCtxt with CtxtInterfaceHead _ -> true | _ -> false) then
+                    returnToken tokenLexbufState token
+
                 else
                     // In these situations
                     //    interface I with 

--- a/src/fsharp/ParseHelpers.fs
+++ b/src/fsharp/ParseHelpers.fs
@@ -23,6 +23,14 @@ open Internal.Utilities.Text.Parsing
 [<NoEquality; NoComparison>]
 exception SyntaxError of obj (* ParseErrorContext<_> *) * range: range
 
+exception IndentationProblem of string * range
+
+let warningStringOfCoords line column =
+    sprintf "(%d:%d)" line (column + 1)
+
+let warningStringOfPos (p: pos) =
+    warningStringOfCoords p.Line p.Column
+
 //------------------------------------------------------------------------
 // Parsing: getting positions from the lexer
 //------------------------------------------------------------------------

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -230,7 +230,6 @@ let escape c =
 //-----------------------------------------------------------------------   
 
 exception ReservedKeyword of string * range
-exception IndentationProblem of string * range
 
 module Keywords = 
     type private compatibilityMode =

--- a/src/fsharp/lexhelp.fsi
+++ b/src/fsharp/lexhelp.fsi
@@ -93,8 +93,6 @@ val escape: char -> char
 
 exception ReservedKeyword of string * Range.range
 
-exception IndentationProblem of string * Range.range
-
 module Keywords = 
 
     val KeywordOrIdentifierToken: LexArgs -> UnicodeLexing.Lexbuf -> string -> token

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1649,9 +1649,13 @@ classDefnMembers:
   
 
 /* The members of an object type definition or type augmentation */
-classDefnMembersAtLeastOne:  
-  | classDefnMember opt_seps classDefnMembers 
-     { $1 @  $3 }
+classDefnMembersAtLeastOne:
+  | classDefnMember opt_seps classDefnMembers
+     { match $1, $3 with
+       | [ SynMemberDefn.Interface (_, Some [], m) ], nextMember :: _ ->
+           warning(IndentationProblem(FSComp.SR.lexfltTokenIsOffsideOfContextStartedEarlier(warningStringOfPos m.Start), nextMember.Range))
+       | _ -> ()
+       $1 @ $3 }
 
 
 /* The "with get, set" part of a member definition */

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1904,11 +1904,12 @@ classDefnMember:
   | opt_attributes opt_declVisibility interfaceMember appType opt_interfaceImplDefn  
      {  if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesAreNotPermittedOnInterfaceImplementations(), rhs parseState 1))
         if Option.isSome $2 then errorR(Error(FSComp.SR.parsInterfacesHaveSameVisibilityAsEnclosingType(), rhs parseState 3))
-        let mWhole = 
+        let members = Option.map fst $5
+        let mWhole =
             match $5 with
             | None -> rhs2 parseState 1 4
-            | Some(mems) -> (rhs2 parseState 1 4, mems) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
-        [ SynMemberDefn.Interface ($4, $5, mWhole) ] }
+            | Some (_, m) -> unionRanges (rhs2 parseState 1 4) m
+        [ SynMemberDefn.Interface ($4, members, mWhole) ] }
         
   | opt_attributes opt_declVisibility abstractMemberFlags opt_inline nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet  opt_ODECLEND
      { let ty, arity = $8
@@ -2042,9 +2043,14 @@ opt_declVisibility:
      { None }
   
 
-opt_interfaceImplDefn: 
+opt_interfaceImplDefn:
   | WITH objectImplementationBlock declEnd
-     { Some($2) } 
+     { let members = $2
+       let m = (rhs parseState 1, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
+       Some (members, m) }
+
+  | WITH
+     { Some ([], rhs parseState 1) }
 
   | /* EMPTY */
      { None }

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -67,6 +67,9 @@
     <Compile Include="..\service\ScriptOptionsTests.fs">
       <Link>ScriptOptionsTests.fs</Link>
     </Compile>
+    <Compile Include="..\service\ParserTests.fs" >
+      <Link>ParserTests.fs</Link>
+    </Compile>
     <Compile Include="..\service\Program.fs">
       <Link>Program.fs</Link>
     </Compile>

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -20020,6 +20020,20 @@ FSharp.Compiler.ParseHelpers: FSharp.Compiler.ParseHelpers+LexerStringStyle
 FSharp.Compiler.ParseHelpers: FSharp.Compiler.ParseHelpers+SyntaxError
 FSharp.Compiler.ParseHelpers: ILInstr[] ParseAssemblyCodeInstructions(System.String, range)
 FSharp.Compiler.ParseHelpers: ILType ParseAssemblyCodeType(System.String, range)
+FSharp.Compiler.ParseHelpers+IndentationProblem: Boolean Equals(System.Exception)
+FSharp.Compiler.ParseHelpers+IndentationProblem: Boolean Equals(System.Object)
+FSharp.Compiler.ParseHelpers+IndentationProblem: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
+FSharp.Compiler.ParseHelpers+IndentationProblem: Int32 GetHashCode()
+FSharp.Compiler.ParseHelpers+IndentationProblem: Int32 GetHashCode(System.Collections.IEqualityComparer)
+FSharp.Compiler.ParseHelpers+IndentationProblem: System.String Data0
+FSharp.Compiler.ParseHelpers+IndentationProblem: System.String get_Data0()
+FSharp.Compiler.ParseHelpers+IndentationProblem: Void .ctor()
+FSharp.Compiler.ParseHelpers+IndentationProblem: Void .ctor(System.String, range)
+FSharp.Compiler.ParseHelpers+IndentationProblem: range Data1
+FSharp.Compiler.ParseHelpers+IndentationProblem: range get_Data1()
+FSharp.Compiler.ParseHelpers: FSharp.Compiler.ParseHelpers+IndentationProblem
+FSharp.Compiler.ParseHelpers: System.String warningStringOfCoords(Int32, Int32)
+FSharp.Compiler.ParseHelpers: System.String warningStringOfPos(pos)
 FSharp.Compiler.PartialLongName: Boolean Equals(FSharp.Compiler.PartialLongName)
 FSharp.Compiler.PartialLongName: Boolean Equals(System.Object)
 FSharp.Compiler.PartialLongName: Boolean Equals(System.Object, System.Collections.IEqualityComparer)

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -337,8 +337,13 @@ let rec allSymbolsInEntities compGen (entities: IList<FSharpEntity>) =
                  yield (x :> FSharpSymbol)
           yield! allSymbolsInEntities compGen e.NestedEntities ]
 
+
+let getParseResults (source: string) =
+    parseSourceCode("/home/user/Test.fsx", source)
+
 let getParseAndCheckResults (source: string) =
     parseAndCheckScript("/home/user/Test.fsx", source)
+
 
 let inline dumpErrors results =
     (^TResults: (member Errors: FSharpErrorInfo[]) results)

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -1,0 +1,21 @@
+﻿module Tests.Parser
+
+open FSharp.Compiler.Service.Tests.Common
+open FSharp.Compiler.SyntaxTree
+open NUnit.Framework
+
+module Recovery =
+    [<Test>]
+    let ``Unfinished interface member`` () =
+        let parseResults = getParseResults """
+type T =
+    interface I with
+    member x.P2 = ()
+
+let x = ()
+"""
+        let (SynModuleOrNamespace (decls = decls)) = getSingleModuleLikeDecl parseResults
+        match decls with
+        | [ SynModuleDecl.Types ([ TypeDefn (typeRepr = SynTypeDefnRepr.ObjectModel (members = [ _; _ ])) ], _)
+            SynModuleDecl.Let _ ] -> ()
+        | _ -> failwith "Unexpected tree"


### PR DESCRIPTION
Adds recovery for unfinished `interface ... with` that contains no members but is already given `with` keyword.

Example 1: before (interface impl is not parsed at all, subsequent declarations are corrupted):
<img width="371" alt="Screenshot 2020-11-09 at 22 39 23" src="https://user-images.githubusercontent.com/3923587/98588476-cea4fa00-22dc-11eb-89a9-af240c7ddcd9.png">

Example 1: after (everything is parsed, type check results are available for the next declaration):
<img width="365" alt="Screenshot 2020-11-09 at 22 42 36" src="https://user-images.githubusercontent.com/3923587/98588531-e41a2400-22dc-11eb-8889-41767a3db70f.png">

The main problem with the example above is when `with` is present without any members, it simply fails to parse, skips other declarations, and no error about missing members is reported at all (for a user or tooling to fix it).

Example 2: before (subsequent member is considered to be interface part):
<img width="598" alt="Screenshot 2020-11-09 at 22 40 30" src="https://user-images.githubusercontent.com/3923587/98588562-ee3c2280-22dc-11eb-96af-e41fbe08ff01.png">

Example 2: after (subsequent member belongs to the type declaration):
<img width="433" alt="Screenshot 2020-11-09 at 22 40 45" src="https://user-images.githubusercontent.com/3923587/98588576-f4ca9a00-22dc-11eb-8d7e-61694b5426d9.png">

The current behaviour in the second example may actually be an intended behaviour. I've initially thought that from my experience it usually did more harm than good, since subsequence members do have the correct offset for the type declaration, but now I'm thinking it shouldn't have been changed. This part can easily be reverted by using `<` in the `LexFilter` change instead. @dsyme @cartermp  What do you think about this change?