### PR TITLE
Don't report "type is not an interface" twice

### DIFF
--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -2365,8 +2365,7 @@ let TcMutRecDefns_Phase2 (cenv: cenv) envInitial bindsm scopem mutRecNSInfo (env
                   let ity' = 
                       let envinner = AddDeclaredTypars CheckForDuplicateTypars declaredTyconTypars envForTycon
                       TcTypeAndRecover cenv NoNewTypars CheckCxs ItemOccurence.UseInType envinner emptyUnscopedTyparEnv ity |> fst
-                  if not (isInterfaceTy g ity') then errorR(Error(FSComp.SR.tcTypeIsNotInterfaceType0(), ity.Range))
-                  
+
                   if not (tcref.HasInterface g ity') then 
                       error(Error(FSComp.SR.tcAllImplementedInterfacesShouldBeDeclared(), ity.Range))
                    

--- a/tests/fsharp/typecheck/sigs/neg10.bsl
+++ b/tests/fsharp/typecheck/sigs/neg10.bsl
@@ -13,11 +13,7 @@ neg10.fs(16,32,16,34): typecheck error FS0887: The type 'C1' is not an interface
 
 neg10.fs(16,32,16,34): typecheck error FS1207: Interfaces inherited by other interfaces should be declared using 'inherit ...' instead of 'interface ...'
 
-neg10.fs(16,32,16,34): typecheck error FS0908: This type is not an interface type
-
 neg10.fs(17,28,17,30): typecheck error FS0887: The type 'C1' is not an interface type
-
-neg10.fs(17,28,17,30): typecheck error FS0908: This type is not an interface type
 
 neg10.fs(19,17,19,28): typecheck error FS0870: Structs cannot have an object constructor with no arguments. This is a restriction imposed on all CLI languages as structs automatically support a default constructor.
 


### PR DESCRIPTION
An experiment with removing an extra error. The same error is reported in `PublishInterface`, so it gets reported twice. Let's see if anything breaks.

<img width="427" alt="Screenshot 2020-11-10 at 20 24 51" src="https://user-images.githubusercontent.com/3923587/98708971-d1fabd00-2392-11eb-8b4b-e8ee722f8bc3.png">