### PR TITLE
Increase package version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <FSMajorVersion>5</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>0</FSBuildVersion>
+    <FSBuildVersion>1</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <FSLanguageVersion>$(FSMajorVersion).$(FSMinorVersion)</FSLanguageVersion>
     <FSLanguageReleaseNotesVersion>$(FSMajorVersion)-$(FSMinorVersion)</FSLanguageReleaseNotesVersion>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -290,7 +290,7 @@ tInput.Length
     [<Fact>]
     member __.``System.Device.Gpio - Ensure we reference the runtime version of the assembly``() =
         let code = """
-#r "nuget:System.Device.Gpio"
+#r "nuget:System.Device.Gpio, 1.0.0"
 typeof<System.Device.Gpio.GpioController>.Assembly.Location
 """
         use script = new FSharpScript(additionalArgs=[|"/langversion:preview"|])


### PR DESCRIPTION
Now that we have shipped FSharp.Core and FCS nuget packages.  Well almost ....

Update fcs build version to:
![image](https://user-images.githubusercontent.com/5175830/98749351-4b34e880-2370-11eb-8782-1572133270da.png)
