### PR TITLE
Add FSharp.DependencyManager.Nuget to FCS

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -764,6 +764,11 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.DependencyManager.Nuget\FSharp.DependencyManager.Nuget.fsproj" />
+  </ItemGroup>
+
+
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj" />
   </ItemGroup>

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.nuspec
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.nuspec
@@ -13,10 +13,14 @@
     <files>
         $CommonFileElements$
 
-        <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\FSharp.Compiler.Service.dll"                  target="lib\netstandard2.0" />
-        <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\FSharp.Compiler.Service.xml"                  target="lib\netstandard2.0" />
+        <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\FSharp.Compiler.Service.dll"                              target="lib\netstandard2.0" />
+        <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\FSharp.Compiler.Service.xml"                              target="lib\netstandard2.0" />
+
+        <file src="FSharp.DependencyManager.Nuget\$Configuration$\netstandard2.0\FSharp.DependencyManager.Nuget.dll"                target="lib\netstandard2.0" />
+        <file src="FSharp.DependencyManager.Nuget\$Configuration$\netstandard2.0\FSharp.DependencyManager.Nuget.xml"                target="lib\netstandard2.0" />
 
         <!-- resources -->
-        <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\**\FSharp.Compiler.Service.resources.dll"     target="lib\netstandard2.0" />
+        <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\**\FSharp.Compiler.Service.resources.dll"                 target="lib\netstandard2.0" />
+        <file src="FSharp.DependencyManager.Nuget\$Configuration$\netstandard2.0\**\FSharp.DependencyManager.Nuget.resources.dll"   target="lib\netstandard2.0" />
     </files>
 </package>


### PR DESCRIPTION
We haven't had a good story for how tools that depend on FCS acquire the nuget package management library.

This PR adds it into the FCS nuget package.  Developers who deploy fcs should ensure they deploy both dll's if they need package management.