### PR TITLE
Turn XML doc and Sig<->Impl mismatch warnings on by default

### DIFF
--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -374,9 +374,7 @@ let warningOn err level specificWarnOn =
     // Some specific warnings are never on by default, i.e. unused variable warnings
     match n with 
     | 1182 -> false // chkUnusedValue - off by default
-    | 3218 -> false // ArgumentsInSigAndImplMismatch - off by default
     | 3180 -> false // abImplicitHeapAllocation - off by default
-    | 3390 -> false // xmlDocBadlyFormed - off by default
     | _ -> level >= GetWarningLevel err 
 
 let SplitRelatedDiagnostics(err: PhasedDiagnostic) : PhasedDiagnostic * PhasedDiagnostic list = 

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -242,14 +242,14 @@ type FSharpDependencyManager (outputDir:string option) =
         sprintf """    #r "nuget:FSharp.Data";;                      // %s 'FSharp.Data' %s""" (SR.loadNugetPackage()) (SR.highestVersion())
         |]
 
-    member this.ResolveDependencies(scriptExt: string, packageManagerTextLines: (string * string) seq, targetFramework: string, runtimeIdentifier: string) : obj =
+    member this.ResolveDependencies(scriptExt: string, packageManagerTextLines: (string * string) seq, targetFrameworkMoniker: string, runtimeIdentifier: string) : obj =
         let poundRprefix  =
             match scriptExt with
             | ".csx" -> "#r \""
             | _ -> "#r @\""
 
         let generateAndBuildProjectArtifacts =
-            let resolutionResult = prepareDependencyResolutionFiles (scriptExt, packageManagerTextLines, targetFramework, runtimeIdentifier)
+            let resolutionResult = prepareDependencyResolutionFiles (scriptExt, packageManagerTextLines, targetFrameworkMoniker, runtimeIdentifier)
             match resolutionResult.resolutionsFile with
             | Some file ->
                 let resolutions = getResolutionsFromFile file

--- a/tests/service/data/TestTP/ProvidedTypes.fsi
+++ b/tests/service/data/TestTP/ProvidedTypes.fsi
@@ -412,7 +412,8 @@ type ProvidedAssembly =
     /// and adjust the 'Assembly' property of all provided type definitions to return that
     /// assembly.
     /// </summary>
-    /// <param name="enclosingTypeNames">A path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
+    /// <param name="types">A list of nested ProvidedTypeDefinitions to add to the ProvidedAssembly.</param>
+    /// <param name="enclosingGeneratedTypeNames">A path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
     member AddNestedTypes : types : ProvidedTypeDefinition list * enclosingGeneratedTypeNames: string list -> unit
 
 #if FX_NO_LOCAL_FILESYSTEM

--- a/tests/service/data/TestTP/TestTP.fsproj
+++ b/tests/service/data/TestTP/TestTP.fsproj
@@ -5,6 +5,7 @@
     <TargetFramework>net472</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <UnitTestType>nunit</UnitTestType>
+    <OtherFlags>--nowarn:3390 --nowarn:3218</OtherFlags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fsproj
+++ b/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fsproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <OtherFlags>--nowarn:3390</OtherFlags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fsproj
+++ b/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fsproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <OtherFlags>--nowarn:3390</OtherFlags>
+    <OtherFlags>--nowarn:3390 --nowarn:3218</OtherFlags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/ProvidedTypes.fsi
+++ b/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/ProvidedTypes.fsi
@@ -427,7 +427,8 @@ type ProvidedAssembly =
     /// and adjust the 'Assembly' property of all provided type definitions to return that
     /// assembly.
     /// </summary>
-    /// <param name="enclosingTypeNames">A path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
+    /// <param name="types">A list of nested ProvidedTypeDefinitions to add to the ProvidedAssembly.</param>
+    /// <param name="enclosingGeneratedTypeNames">A path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
     member AddNestedTypes : types : ProvidedTypeDefinition list * enclosingGeneratedTypeNames: string list -> unit
 
 #if FX_NO_LOCAL_FILESYSTEM


### PR DESCRIPTION
I think these should just be on by default.

1. Nobody actually _relies_ on malformed XML documentation, or documentation where things like parameter names are different in XML docs than their names in source.
2. Sig and Impl file parameter mismatches have less of a "nobody actually relies on this" factor, but like ... nobody actually _relies_ on parameter names differing between signature and implementation files.

This is technically a breaking change for anyone who has warnings set as errors, and should be treated like any circumstance where if we introduce a warning it will break people with that setting turned on.

That said, I think that these two checks move code towards being _more_ correct, and especially in the case of the XML doc thing can catch some bugs that they might otherwise not easily catch.