### PR TITLE
WIP - Add quick fixes to ignore values or add let bindings

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/AddIgnoreToExpression.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddIgnoreToExpression.fs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System.Composition
+open System.Collections.Immutable
+open System.Threading
+open System.Threading.Tasks
+
+open Microsoft.CodeAnalysis.Text
+open Microsoft.CodeAnalysis.CodeFixes
+open Microsoft.CodeAnalysis.CodeActions
+
+[<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = "AddIgnoreToExpression"); Shared>]
+type internal FSharpAddIgnoreKeywordCodeFixProvider() =
+    inherit CodeFixProvider()
+
+    static let fixableDiagnosticIds = set ["FS0020"; "FS0001" ]
+
+    override __.FixableDiagnosticIds = fixableDiagnosticIds.ToImmutableArray()
+
+    override this.RegisterCodeFixesAsync context : Task =
+        async {
+            let title = SR.IgnoreExpression()
+
+            let diagnostics =
+                context.Diagnostics
+                |> Seq.filter (fun x -> fixableDiagnosticIds |> Set.contains x.Id)
+                |> Seq.toImmutableArray
+
+            let codeFix =
+                CodeFixHelpers.createTextChangeCodeFix(
+                    title,
+                    context,
+                    (fun () -> asyncMaybe.Return [| TextChange(TextSpan(context.Span.End, 0), " |> ignore") |]))
+            
+            context.RegisterCodeFix(codeFix, diagnostics)
+        } |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+ 

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddLetBindingToExpression.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddLetBindingToExpression.fs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System.Composition
+open System.Collections.Immutable
+open System.Threading
+open System.Threading.Tasks
+
+open Microsoft.CodeAnalysis.Text
+open Microsoft.CodeAnalysis.CodeFixes
+open Microsoft.CodeAnalysis.CodeActions
+
+[<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = "AddLetBindingToExpression"); Shared>]
+type internal FSharpAddLetBindingCodeFixProvider() =
+    inherit CodeFixProvider()
+
+    static let fixableDiagnosticIds = set ["FS0020" ]
+
+    override __.FixableDiagnosticIds = fixableDiagnosticIds.ToImmutableArray()
+
+    override this.RegisterCodeFixesAsync context : Task =
+        async {
+            let title = SR.AddLetBindingToExpression()
+
+            let diagnostics =
+                context.Diagnostics
+                |> Seq.filter (fun x -> fixableDiagnosticIds |> Set.contains x.Id)
+                |> Seq.toImmutableArray
+
+            let codeFix =
+                CodeFixHelpers.createTextChangeCodeFix(
+                    title,
+                    context,
+                    (fun () -> asyncMaybe.Return [| TextChange(TextSpan(context.Span.Start, 0), "let x = ") |]))
+            
+            context.RegisterCodeFix(codeFix, diagnostics)
+        } |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+ 

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -89,6 +89,8 @@
     <Compile Include="Commands\FsiCommandService.fs" />
     <Compile Include="Commands\XmlDocCommandService.fs" />
     <Compile Include="CodeFix\CodeFixHelpers.fs" />
+    <Compile Include="CodeFix\AddLetBindingToExpression.fs" />
+    <Compile Include="CodeFix\AddIgnoreToExpression.fs" />
     <Compile Include="CodeFix\AddNewKeywordToDisposableConstructorInvocation.fs" />
     <Compile Include="CodeFix\AddOpenCodeFixProvider.fs" />
     <Compile Include="CodeFix\ProposeUppercaseLabel.fs" />

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
@@ -219,4 +219,10 @@
   <data name="FSharpDisposableTopLevelValuesClassificationType" xml:space="preserve">
     <value>F# Dispostable Values (top-level)</value>
   </data>
+  <data name="AddLetBindingToExpression" xml:space="preserve">
+    <value>Add 'let' binding</value>
+  </data>
+  <data name="IgnoreExpression" xml:space="preserve">
+    <value>Add 'ignore'</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Přidejte klíčové slovo new.</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Schlüsselwort "new" hinzufügen</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Agregar "nueva" palabra clave</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Ajouter le mot clé 'new'</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Aggiungi la parola chiave 'new'</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">'new' キーワードを追加する</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">'new' 키워드 추가</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Dodaj słowo kluczowe „new”</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Adicionar a palavra-chave 'new'</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">Добавить ключевое слово "new"</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">'new' anahtar sözcüğünü ekleme</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">添加“新”关键字</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../FSharp.Editor.resx">
     <body>
+      <trans-unit id="AddLetBindingToExpression">
+        <source>Add 'let' binding</source>
+        <target state="new">Add 'let' binding</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddNewKeyword">
         <source>Add 'new' keyword</source>
         <target state="translated">新增 'new' 關鍵字</target>
@@ -25,6 +30,11 @@
       <trans-unit id="FSharpFunctionsClassificationType">
         <source>F# Functions</source>
         <target state="new">F# Functions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreExpression">
+        <source>Add 'ignore'</source>
+        <target state="new">Add 'ignore'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementInterface">


### PR DESCRIPTION
This is only basic support for now:

![image](https://user-images.githubusercontent.com/6309070/99137545-5c842c00-25e0-11eb-8d2a-b86e8d4889d9.png)

### Some notes:

The following will let you `ignore` the inner expression, but not add a `let` binding:

```fsharp
if true then
    1 // right here
```

The following is fine as-is to `ignore`, but the `let` binding is bad, even though it compiles:

```fsharp
async {
    return 1
}
```

There are several places where we need to either:

* Indent the block after introducing the `let` binding
* Add parentheses around an expression before `ignore`ing it
* Add an `ignore` on a new line to avoid a different warning or error

I believe that these could all be detected by the syntax tree API, so I'll give that a shot.

However, this already addresses likely the bulk of usage.
