### PR TITLE
[Probably dangerous?] Fixes printing argument tuple name in a tooltip

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -1659,8 +1659,8 @@ let CombineSyntacticAndInferredArities g declKind rhsExpr prelimScheme =
                     | [], _ -> []
                     // Dont infer eliminated unit args from the expression if they don't occur syntactically.
                     | ai, [] -> ai
-                    // If we infer a tupled argument from the expression and/or type then use that
-                    | _ when ai1.Length < ai2.Length -> ai2
+                    // If we infer a tupled argument from the expression and/or type and at least one arg has a name then use that
+                    | _ when ai1.Length < ai2.Length && ai2 |> List.exists (fun (valInfo: ArgReprInfo) -> valInfo.Name.IsSome) -> ai2
                     | _ -> ai1
                 let rec loop ais1 ais2 =
                     match ais1, ais2 with 

--- a/src/fsharp/ConstraintSolver.fsi
+++ b/src/fsharp/ConstraintSolver.fsi
@@ -144,7 +144,7 @@ val SimplifyMeasuresInTypeScheme: TcGlobals -> bool -> Typars -> TType -> TyparC
 
 val ResolveOverloadingForCall: DisplayEnv -> ConstraintSolverState -> range -> methodName: string -> ndeep: int -> cx: TraitConstraintInfo option -> callerArgs: CallerArgs<Expr> -> AccessorDomain -> calledMethGroup: CalledMeth<Expr> list -> permitOptArgs: bool -> reqdRetTyOpt: TType option -> CalledMeth<Expr> option * OperationResult<unit>
 
-val UnifyUniqueOverloading: DisplayEnv -> ConstraintSolverState -> range -> int * int -> string -> AccessorDomain -> CalledMeth<SynExpr> list -> TType -> OperationResult<bool> 
+val UnifyUniqueOverloading: DisplayEnv -> ConstraintSolverState -> range -> callerArgCounts: (int * int) -> string -> AccessorDomain -> CalledMeth<SynExpr> list -> TType -> OperationResult<bool>
 
 /// Remove the global constraints where these type variables appear in the support of the constraint 
 val EliminateConstraintsForGeneralizedTypars: DisplayEnv -> ConstraintSolverState -> range -> OptionalTrace -> Typars -> unit 

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -930,9 +930,9 @@ module PrettyTypes =
 
     val PrettifyType : TcGlobals -> TType -> TType * TyparConstraintsWithTypars
 
-    val PrettifyInstAndTyparsAndType : TcGlobals -> TyparInst * Typars * TType -> (TyparInst * Typars * TType) * TyparConstraintsWithTypars
+    val PrettifyInstAndTyparsAndType : g: TcGlobals -> x: (TyparInst * Typars * TType) -> (TyparInst * Typars * TType) * TyparConstraintsWithTypars
 
-    val PrettifyTypePair : TcGlobals -> TType * TType -> (TType * TType) * TyparConstraintsWithTypars
+    val PrettifyTypePair : g: TcGlobals -> x: (TType * TType) -> (TType * TType) * TyparConstraintsWithTypars
 
     val PrettifyTypes : TcGlobals -> TTypes -> TTypes * TyparConstraintsWithTypars
     
@@ -943,19 +943,19 @@ module PrettyTypes =
 
     val PrettifyInst : TcGlobals -> TyparInst -> TyparInst * TyparConstraintsWithTypars
 
-    val PrettifyInstAndType : TcGlobals -> TyparInst * TType -> (TyparInst * TType) * TyparConstraintsWithTypars
+    val PrettifyInstAndType : g: TcGlobals -> x: (TyparInst * TType) -> (TyparInst * TType) * TyparConstraintsWithTypars
 
-    val PrettifyInstAndTypes : TcGlobals -> TyparInst * TTypes -> (TyparInst * TTypes) * TyparConstraintsWithTypars
+    val PrettifyInstAndTypes : g: TcGlobals -> x: (TyparInst * TTypes) -> (TyparInst * TTypes) * TyparConstraintsWithTypars
 
-    val PrettifyInstAndSig : TcGlobals -> TyparInst * TTypes * TType -> (TyparInst * TTypes * TType) * TyparConstraintsWithTypars
+    val PrettifyInstAndSig : g: TcGlobals -> x: (TyparInst * TTypes * TType) -> (TyparInst * TTypes * TType) * TyparConstraintsWithTypars
 
     val PrettifyCurriedTypes : TcGlobals -> TType list list -> TType list list * TyparConstraintsWithTypars
 
-    val PrettifyCurriedSigTypes : TcGlobals -> TType list list * TType -> (TType list list * TType) * TyparConstraintsWithTypars
+    val PrettifyCurriedSigTypes : g: TcGlobals -> x: (TType list list * TType) -> (TType list list * TType) * TyparConstraintsWithTypars
 
-    val PrettifyInstAndUncurriedSig : TcGlobals -> TyparInst * UncurriedArgInfos * TType -> (TyparInst * UncurriedArgInfos * TType) * TyparConstraintsWithTypars
+    val PrettifyInstAndUncurriedSig : g: TcGlobals -> x: (TyparInst * UncurriedArgInfos * TType) -> (TyparInst * UncurriedArgInfos * TType) * TyparConstraintsWithTypars
 
-    val PrettifyInstAndCurriedSig : TcGlobals -> TyparInst * TTypes * CurriedArgInfos * TType -> (TyparInst * TTypes * CurriedArgInfos * TType) * TyparConstraintsWithTypars
+    val PrettifyInstAndCurriedSig : g: TcGlobals -> x: (TyparInst * TTypes * CurriedArgInfos * TType) -> (TyparInst * TTypes * CurriedArgInfos * TType) * TyparConstraintsWithTypars
 
 [<NoEquality; NoComparison>]
 type DisplayEnv = 

--- a/src/fsharp/utils/sformat.fs
+++ b/src/fsharp/utils/sformat.fs
@@ -1303,7 +1303,7 @@ module Display =
 
     let output_any writer x = output_any_ex FormatOptions.Default writer x
 
-    let layout_as_string options x = x |> any_to_layout options |> layout_to_string options
+    let layout_as_string options (value, typValue) = (value, typValue) |> any_to_layout options |> layout_to_string options
 
     let any_to_string x = layout_as_string FormatOptions.Default x
 

--- a/tests/fsharp/core/hiding/lib2.mli
+++ b/tests/fsharp/core/hiding/lib2.mli
@@ -1,7 +1,7 @@
 
 
 val f1: Lib.abstractType -> unit  (* looks OK, but optimization data may refer to hidden type *)
-val f2: Lib.abstractType * Lib.abstractType -> unit  (* looks OK, but optimization data may refer to hidden type *)
+val f2: x: Lib.abstractType * Lib.abstractType -> unit  (* looks OK, but optimization data may refer to hidden type *)
 
 
 val e2: exn

--- a/tests/fsharp/core/printing/z.output.test.1000.stdout.47.bsl
+++ b/tests/fsharp/core/printing/z.output.test.1000.stdout.47.bsl
@@ -2661,7 +2661,7 @@ end
 > > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on match val"
 
-> val ( |A|B| ) : p:bool -> 'a * 'b -> Choice<'a,'b>
+> val ( |A|B| ) : p:bool -> x:('a * 'b) -> Choice<'a,'b>
 
 > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on parameters"

--- a/tests/fsharp/core/printing/z.output.test.1000.stdout.50.bsl
+++ b/tests/fsharp/core/printing/z.output.test.1000.stdout.50.bsl
@@ -2663,7 +2663,7 @@ end
 > > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on match val"
 
-> val ( |A|B| ) : p:bool -> 'a * 'b -> Choice<'a,'b>
+> val ( |A|B| ) : p:bool -> x:('a * 'b) -> Choice<'a,'b>
 
 > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on parameters"

--- a/tests/fsharp/core/printing/z.output.test.200.stdout.47.bsl
+++ b/tests/fsharp/core/printing/z.output.test.200.stdout.47.bsl
@@ -1906,7 +1906,7 @@ end
 > > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on match val"
 
-> val ( |A|B| ) : p:bool -> 'a * 'b -> Choice<'a,'b>
+> val ( |A|B| ) : p:bool -> x:('a * 'b) -> Choice<'a,'b>
 
 > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on parameters"

--- a/tests/fsharp/core/printing/z.output.test.200.stdout.50.bsl
+++ b/tests/fsharp/core/printing/z.output.test.200.stdout.50.bsl
@@ -1908,7 +1908,7 @@ end
 > > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on match val"
 
-> val ( |A|B| ) : p:bool -> 'a * 'b -> Choice<'a,'b>
+> val ( |A|B| ) : p:bool -> x:('a * 'b) -> Choice<'a,'b>
 
 > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on parameters"

--- a/tests/fsharp/core/printing/z.output.test.default.stdout.47.bsl
+++ b/tests/fsharp/core/printing/z.output.test.default.stdout.47.bsl
@@ -6208,7 +6208,7 @@ end
 > > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on match val"
 
-> val ( |A|B| ) : p:bool -> 'a * 'b -> Choice<'a,'b>
+> val ( |A|B| ) : p:bool -> x:('a * 'b) -> Choice<'a,'b>
 
 > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on parameters"

--- a/tests/fsharp/core/printing/z.output.test.default.stdout.50.bsl
+++ b/tests/fsharp/core/printing/z.output.test.default.stdout.50.bsl
@@ -6210,7 +6210,7 @@ end
 > > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on match val"
 
-> val ( |A|B| ) : p:bool -> 'a * 'b -> Choice<'a,'b>
+> val ( |A|B| ) : p:bool -> x:('a * 'b) -> Choice<'a,'b>
 
 > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on parameters"

--- a/tests/fsharp/core/printing/z.output.test.off.stdout.47.bsl
+++ b/tests/fsharp/core/printing/z.output.test.off.stdout.47.bsl
@@ -1676,7 +1676,7 @@ end
 > > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on match val"
 
-> val ( |A|B| ) : p:bool -> 'a * 'b -> Choice<'a,'b>
+> val ( |A|B| ) : p:bool -> x:('a * 'b) -> Choice<'a,'b>
 
 > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on parameters"

--- a/tests/fsharp/core/printing/z.output.test.off.stdout.50.bsl
+++ b/tests/fsharp/core/printing/z.output.test.off.stdout.50.bsl
@@ -1678,7 +1678,7 @@ end
 > > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on match val"
 
-> val ( |A|B| ) : p:bool -> 'a * 'b -> Choice<'a,'b>
+> val ( |A|B| ) : p:bool -> x:('a * 'b) -> Choice<'a,'b>
 
 > val it : string =
   "** Expect OK since active pattern result is not too generic, typars depend on parameters"


### PR DESCRIPTION
This tries to fix printing tuple name (#10441) like in this case:
before:
![image](https://user-images.githubusercontent.com/37334640/99154872-27e9a080-26c4-11eb-94d6-2700b25b8ace.png)
after:
![image](https://user-images.githubusercontent.com/37334640/99154903-739c4a00-26c4-11eb-9d31-ae55dd594a40.png)

or this:
before:
![image](https://user-images.githubusercontent.com/37334640/99154909-831b9300-26c4-11eb-85a6-902eda583a43.png)
after:
![image](https://user-images.githubusercontent.com/37334640/99154913-8f075500-26c4-11eb-97f4-985f543a6a10.png)

or this:
before:
![image](https://user-images.githubusercontent.com/37334640/99154932-ae05e700-26c4-11eb-9827-5b5f56e2f7c4.png)
after:
![image](https://user-images.githubusercontent.com/37334640/99154941-bc540300-26c4-11eb-8390-512e609e7faa.png)

Needs testing as it's goes way lower than Tooltip's creation