### PR TITLE
migrate version calculations from release/16.9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,6 +239,16 @@ stages:
             continueOnError: true
             condition: failed()
 
+        # Mock official build
+        - job: MockOfficial
+          pool:
+            vmImage: windows-2019
+          steps:
+          - checkout: self
+            clean: true
+          - pwsh: .\eng\MockBuild.ps1
+            displayName: Build with OfficialBuildId
+
         # Linux
         - job: Linux
           pool:
@@ -311,7 +321,7 @@ stages:
           - checkout: self
             clean: true
           - script: .\Build.cmd -c Release
-          - script: .\tests\EndToEndBuildTests\EndToEndBuildTests -c Release
+          - script: .\tests\EndToEndBuildTests\EndToEndBuildTests.cmd -c Release
             displayName: End to end build tests
 
         # Source Build Windows

--- a/eng/MockBuild.ps1
+++ b/eng/MockBuild.ps1
@@ -1,0 +1,15 @@
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    $fakeBuildId = (Get-Date -Format "yyyyMMdd") + ".0"
+    $visualStudioDropName = "Products/mock/dotnet-fsharp/branch/$fakeBuildId"
+    & "$PSScriptRoot\Build.ps1" -build -restore -ci -bootstrap -binaryLog -pack -configuration Release /p:OfficialBuildId=$fakeBuildId /p:VisualStudioDropName=$visualStudioDropName
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    Write-Host "##[error](NETCORE_ENGINEERING_TELEMETRY=Build) Error doing mock official build."
+    exit 1
+}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,17 +12,21 @@
   <!-- Version number computation -->
   <PropertyGroup>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <!-- F# Version components -->
     <FSMajorVersion>5</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>0</FSBuildVersion>
+    <FSBuildVersion>1</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
+    <!-- F# Language version -->
     <FSLanguageVersion>$(FSMajorVersion).$(FSMinorVersion)</FSLanguageVersion>
     <FSLanguageReleaseNotesVersion>$(FSMajorVersion)-$(FSMinorVersion)</FSLanguageReleaseNotesVersion>
+    <!-- FSharp.Core version -->
     <FSCoreProductVersion>$(FSMajorVersion).$(FSMinorVersion)</FSCoreProductVersion>
     <FSCorePackageVersion>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSCorePackageVersion>
     <FSCoreReleaseNotesVersion>$(FSMajorVersion)-$(FSMinorVersion)-$(FSBuildVersion)</FSCoreReleaseNotesVersion>
     <FSCoreVersionPrefix>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSCoreVersionPrefix>
-    <FSCoreVersion>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion).$(FSRevisionVersion)</FSCoreVersion>
+    <FSCoreVersion>$(FSMajorVersion).$(FSMinorVersion).0.0</FSCoreVersion>
+    <!-- FSharp.Compiler.Service version -->
     <FCSMajorVersion>38</FCSMajorVersion>
     <FCSMinorVersion>$(FSMinorVersion)</FCSMinorVersion>
     <FCSBuildVersion>$(FSBuildVersion)</FCSBuildVersion>
@@ -49,13 +53,16 @@
     <VSAssemblyVersion>$(VSAssemblyVersionPrefix).0</VSAssemblyVersion>
   </PropertyGroup>
   <!-- version number assignment -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(UseFSharpPackageVersion)' == 'true'">
     <VersionPrefix>$(FSCoreVersionPrefix)</VersionPrefix>
-    <VersionPrefix Condition="'$(UseFSharpPackageVersion)' == 'true'">$(FSCorePackageVersion)</VersionPrefix>
+    <AssemblyVersion>$(FSCoreVersion)</AssemblyVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseFSharpPackageVersion)' != 'true'">
+    <VersionPrefix>$(FSCoreVersionPrefix)</VersionPrefix>
     <VersionPrefix Condition="'$(UseFSharpProductVersion)' == 'true'">$(FSProductVersionPrefix)</VersionPrefix>
     <VersionPrefix Condition="'$(UseVsMicroBuildAssemblyVersion)' == 'true'">$(VSAssemblyVersionPrefix)</VersionPrefix>
     <VersionPrefix Condition="'$(UseFSharpCompilerServiceVersion)' == 'true'">$(FSharpCompilerServicePackageVersion)</VersionPrefix>
-    <AssemblyVersion Condition="'$(OfficialBuildId)' == ''">$(VersionPrefix).0</AssemblyVersion>
+    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <!-- PR builds should explicitly specify a version number -->
   </PropertyGroup>
   <PropertyGroup>

--- a/src/fsharp/FSharp.Core/Directory.Build.props
+++ b/src/fsharp/FSharp.Core/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseFSharpPackageVersion>true</UseFSharpPackageVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -15,6 +15,7 @@
 
     <PreRelease>true</PreRelease>
     <PackageId>FSharp.Core</PackageId>
+    <PackageVersionPrefix>$(FSCorePackageVersion)</PackageVersionPrefix>
     <NuspecFile>FSharp.Core.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>
     <PackageDescription>FSharp.Core redistributables from F# Tools version $(FSCorePackageVersion) For F# $(FSLanguageVersion).  Contains code from the F# Software Foundation.</PackageDescription>


### PR DESCRIPTION
This migrates the changes made in #10221 and #10249 to `main` and supersedes #10468.

The end result is that running `.\eng\MockBuild.ps1` resulted in the following:

- FSharp.Core.5.0.1.nupkg
  - FSharp.Core.dll:
    - AssemblyVersion = 5.0.0.0
    - AssemblyFileVersion = 5.0.120.56600 (calculated by Arcade)
    - AssemblyInformationalVersion = 5.0.1-beta.20566.0+###### (calculated by Arcade where ###### is the SHA)
- Microsoft.FSharp.Compiler.11.0.1.nupkg
  - fsc.exe:
    - AssemblyVersion = 11.0.1.0
    - AssemblyFileVersion = 11.0.120.56600 (calculated by Arcade)
    - AssemblyInformationalVersion = 11.0.1-beta.20566.0+###### (calculated by Arcade where ###### is the SHA)