### PR TITLE
Fix unused open type declaration detection

### DIFF
--- a/src/fsharp/service/ServiceAnalysis.fs
+++ b/src/fsharp/service/ServiceAnalysis.fs
@@ -67,9 +67,9 @@ module UnusedOpens =
                             yield! getModuleAndItsAutoOpens true ent |]
             { OpenedModules = getModuleAndItsAutoOpens false modul }
 
-    /// Represents single open statement.
+    /// Represents a single open statement
     type OpenStatement =
-        { /// All namespaces and modules which this open declaration effectively opens, including the AutoOpen ones
+        { /// All namespaces, modules and types which this open declaration effectively opens, including the AutoOpen ones
           OpenedGroups: OpenedModuleGroup list
 
           /// The range of open statement itself
@@ -90,7 +90,8 @@ module UnusedOpens =
                     if firstId.idText = MangledGlobalName then 
                         None
                     else
-                        Some { OpenedGroups = openDecl.Modules |> List.map OpenedModuleGroup.Create
+                        let openedModulesAndTypes = List.concat [openDecl.Modules; openDecl.Types |> List.map(fun ty -> ty.TypeDefinition)]
+                        Some { OpenedGroups = openedModulesAndTypes |> List.map OpenedModuleGroup.Create
                                Range = range
                                AppliedScope = openDecl.AppliedScope }
                 | _ -> None)

--- a/vsintegration/tests/UnitTests/UnusedOpensTests.fs
+++ b/vsintegration/tests/UnitTests/UnusedOpensTests.fs
@@ -809,3 +809,48 @@ open Nested
 let _ = f 1
 """
     => []
+
+[<Test>]
+let ``used open C# type``() =
+    """
+open type System.Console
+
+WriteLine("Hello World")
+    """
+    => []
+    
+[<Test>]
+let ``unused open C# type``() =
+    """
+open type System.Console
+    
+printfn "%s" "Hello World"
+    """
+    => [2, (10, 24)]
+    
+[<Test>]
+let ``used open type from module``() =
+    """
+module MyModule =
+    type Thingy =
+        static member Thing = ()
+    
+open type MyModule.Thingy
+
+printfn "%A" Thing
+    """
+    => []
+        
+[<Test>]
+let ``unused open type from module``() =
+    """
+module MyModule =
+    type Thingy =
+        static member Thing = ()
+    
+open type MyModule.Thingy
+
+printfn "%A" MyModule.Thingy.Thing
+    """
+    => [6, (10, 25)]
+


### PR DESCRIPTION
Unused open declaration seemed broken on `open type`:

```
module MyModule =
    type Thingy = 
        static member Thing = ()

// These will be marked as unused even though they have usages below
open type System.Console
open type MyModule.Thingy

[<EntryPoint>]
let main argv =
    WriteLine("Hello World!")
    printfn "%A" Thing
    0
```

The original code only considered modules and namespaces opened via regular "open"; the fix is to add the types opened via "open type" to the list when determining what open statements are used.

I am trying to add unit tests in vsintegration\tests\UnitTests\UnusedOpensTests.fs, but I'm running into an error trying to run them:

```
build.cmd -testvs
(...)

test C:\git\fsharp\vsintegration\tests\GetTypesVS.UnitTests\GetTypesVS.UnitTests.fsproj -c Debug -f net472 -v n --test-adapter-path C:\git\fsharp\artifacts\bin\GetTypesVS.UnitTests --logger "nunit;LogFilePath=C:\git\fsharp\artifacts\TestResults\Debug\GetTypesVS.UnitTests_net472.xml" /bl:C:\git\fsharp\artifacts\log\Debug\GetTypesVS.UnitTests_net472.binlog --no-restore --no-build --filter TestCategory!=PullRequest
C:\Program Files\dotnet\sdk\3.1.302\MSBuild.dll -nologo -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Program Files\dotnet\sdk\3.1.302\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Program Files\dotnet\sdk\3.1.302\dotnet.dll -maxcpucount -nodereuse:false -property:Configuration=Debug -property:TargetFramework=net472 -property:VSTestTestAdapterPath=C:\git\fsharp\artifacts\bin\GetTypesVS.UnitTests -property:VSTestLogger=nunit%3bLogFilePath=C:\git\fsharp\artifacts\TestResults\Debug\GetTypesVS.UnitTests_net472.xml -property:VSTestNoBuild=true -property:VSTestTestCaseFilter=TestCategory!=PullRequest -property:VSTestVerbosity=n -target:VSTest -verbosity:m -verbosity:quiet -verbosity:n /bl:C:\git\fsharp\artifacts\log\Debug\GetTypesVS.UnitTests_net472.binlog C:\git\fsharp\vsintegration\tests\GetTypesVS.UnitTests\GetTypesVS.UnitTests.fsproj
Build started 2020-11-19 19:18:20.
Test run for C:\git\fsharp\artifacts\bin\GetTypesVS.UnitTests\Debug\net472\GetTypesVS.UnitTests.dll(.NETFramework,Version=v4.7.2)
Microsoft (R) Test Execution Command Line Tool Version 16.6.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

A total of 1 test files matched the specified pattern.
NUnit Adapter 3.11.2.0: Test execution started
Running all tests in C:\git\fsharp\artifacts\bin\GetTypesVS.UnitTests\Debug\net472\GetTypesVS.UnitTests.dll
   NUnit3TestExecutor converted 1 of 1 NUnit test cases
NUnit Adapter 3.11.2.0: Test execution complete
  X GetTypesForVSUnitTests [334ms]
  Error Message:
   TypeLoad failure: Could not load file or assembly 'VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.

  Stack Trace:
     at GetTypesVSUnitTests.VerifyUnitTests.GetTypesForVSUnitTests() in C:\git\fsharp\vsintegration\tests\GetTypesVS.UnitTests\GetTypesVS.UnitTests.fs:line 17

Results File: C:\git\fsharp\artifacts\TestResults\Debug\GetTypesVS.UnitTests_net472.xml

Test Run Failed.
Total tests: 1
     Failed: 1
 Total time: 1,4182 Seconds
```