### PR TITLE
Fixed error message for Seq.take when count exceeds sequence length

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -684,9 +684,9 @@ namespace Microsoft.FSharp.Collections
             (* Note: don't create or dispose any IEnumerable if n = 0 *)
             if count = 0 then empty else
             seq { use e = source.GetEnumerator()
-                  for x in 0 .. count - 1 do
+                  for x in count .. - 1 .. 1 do
                       if not (e.MoveNext()) then
-                          invalidOpFmt "tried to take {0} {1} past the end of the seq"
+                          invalidOpFmt "{0}: tried to take {1} {2} past the end of the seq"
                             [|SR.GetString SR.notEnoughElements; x; (if x = 1 then "element" else "elements")|]
                       yield e.Current }
 


### PR DESCRIPTION
#9490 
- Update error message placeholders to format error message correctly
- Converted count up to count down to show properly how many more elements were requested but not fulfilled