### PR TITLE
Fix TFM Selector

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/TargetFrameworkMoniker.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/TargetFrameworkMoniker.vb
@@ -13,12 +13,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' Represents a target framework moniker and can be placed into a control
     ''' </summary>
     Class TargetFrameworkMoniker
+        Implements IComparable(Of TargetFrameworkMoniker)
 
-        ''' <summary>
-        ''' Stores the target framework moniker
-        ''' </summary>
+        Public Function CompareTo(other As TargetFrameworkMoniker) As Integer Implements IComparable(Of TargetFrameworkMoniker).CompareTo
+            Return String.Compare(other.DisplayOrder, Me.DisplayOrder)
+        End Function
+
         Private m_Moniker As String
-
         ''' <summary>
         ''' Stores the display name of the target framework moniker
         ''' </summary>
@@ -28,10 +29,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Constructor that uses the target framework moniker and display name provided by DTAR
         ''' </summary>
         Public Sub New(ByVal moniker As String, ByVal displayName As String)
-
             m_Moniker = moniker
             m_DisplayName = displayName
-
         End Sub
 
         ''' <summary>
@@ -43,11 +42,45 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Get
         End Property
 
+        Public ReadOnly Property NormalizedTFM() As String
+            Get
+                Dim p = GetFrameworkProfileFromMoniker(Me.Moniker)
+                If String.IsNullOrWhiteSpace(p) Then
+                    Return String.Format("{0},Version=v{1}", GetFrameworkIdFromMoniker(Me.Moniker), GetFrameworkVersionFromMoniker(Me.Moniker))
+                Else
+                    Return String.Format("{0},Version=v{1}-{2}", GetFrameworkIdFromMoniker(Me.Moniker), GetFrameworkVersionFromMoniker(Me.Moniker), p)
+                End If
+            End Get
+        End Property
+
+        Public ReadOnly Property DisplayName() As String
+            Get
+                Return m_DisplayName
+            End Get
+        End Property
+
+        Public ReadOnly Property DisplayOrder() As String
+            Get
+                Dim tfm As String = DisplayName
+                If tfm.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase) Then
+                    Return "80" + m_DisplayName
+                ElseIf tfm.StartsWith(".NET Standard", StringComparison.OrdinalIgnoreCase) Then
+                    Return "70" + m_DisplayName
+                ElseIf tfm.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase) Then
+                    Return "60" + m_DisplayName
+                ElseIf tfm.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase) Then
+                    Return "90" + m_DisplayName
+                Else
+                    Return "00" + m_DisplayName
+                End If
+            End Get
+        End Property
+
         ''' <summary>
         ''' Use the display name provided by DTAR for the string display
         ''' </summary>
         Public Overrides Function ToString() As String
-            Return m_DisplayName
+            Return DisplayName
         End Function
 
         Private Shared Function AddDotNetCoreFramework(prgSupportedFrameworks As Array, supportedTargetFrameworksDescriptor As PropertyDescriptor) As Array
@@ -64,13 +97,77 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         supportedFrameworksList.Add(framework)
                     End If
                 Next
-
                 Return supportedFrameworksList.ToArray
             End If
-
             Return prgSupportedFrameworks
         End Function
 
+        Public Shared Function GetDisplayIdFromMoniker(moniker As String) As String
+            If moniker.StartsWith(".NETStandard", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase) Then
+                Return ".NET Standard"
+            ElseIf moniker.StartsWith(".NETCoreApp", StringComparison.OrdinalIgnoreCase) Or
+                   moniker.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) Or
+                   moniker.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase) Then
+                Return ".NET Core"
+            ElseIf moniker.StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase) Then
+                Return ".NET Framework"
+            ElseIf moniker.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase) Or
+                   moniker.StartsWith("net", StringComparison.OrdinalIgnoreCase) Then
+                Return ".NET"
+            End If
+        End Function
+
+        Public Shared Function GetFrameworkIdFromMoniker(moniker As String) As String
+            If moniker.StartsWith(".NETStandard", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase) Then
+                Return ".NETStandard"
+            ElseIf moniker.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) Then
+                Return ".NETCore"
+            ElseIf moniker.StartsWith(".NETCoreApp", StringComparison.OrdinalIgnoreCase) Or
+                   moniker.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase) Or
+                   (moniker.StartsWith("net", StringComparison.OrdinalIgnoreCase) And moniker.Contains(".")) Then
+                Return ".NETCoreApp"
+            ElseIf moniker.StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase) Then
+                Return ".NETFramework"
+            ElseIf moniker.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase) Or
+                   (moniker.StartsWith("net", StringComparison.OrdinalIgnoreCase) And Not moniker.Contains(".")) Then
+                Return ".NET"
+            End If
+        End Function
+
+        Public Shared Function GetFrameworkVersionFromMoniker(moniker As String) As String
+            If moniker.StartsWith(".NETStandard", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith(".NETCoreApp", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase) Then
+                Dim fw As FrameworkName = New FrameworkName(moniker)
+                Return fw.Version.ToString()
+            ElseIf moniker.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase) Then
+                Dim v As String = moniker.Substring(10)
+                Return New Version(v).ToString()
+            ElseIf moniker.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase) Then
+                Dim v As String = moniker.Substring(11)
+                Return New Version(v).ToString()
+            ElseIf moniker.StartsWith("net", StringComparison.OrdinalIgnoreCase) Then
+                Dim v As String = moniker.Substring(3)
+                Return New Version(v).ToString()
+            End If
+        End Function
+
+        Public Shared Function GetFrameworkProfileFromMoniker(moniker As String) As String
+            If moniker.StartsWith(".NETStandard", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith(".NETCoreApp", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase) Or
+               moniker.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase) Then
+                Dim fw As FrameworkName = New FrameworkName(moniker)
+                Return fw.Profile.ToString()
+            Else
+                Return ""
+            End If
+        End Function
 
         ''' <summary>
         ''' Gets the supported target framework monikers from DTAR
@@ -89,7 +186,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             Dim targetFrameworkMonikerProperty As [Property] = currentProject.Properties.Item(ApplicationPropPage.Const_TargetFrameworkMoniker)
             Dim currentTargetFrameworkMoniker As String = CStr(targetFrameworkMonikerProperty.Value)
-            Dim currentFrameworkName As New FrameworkName(currentTargetFrameworkMoniker)
+            Dim currentFrameworkId = GetDisplayIdFromMoniker(currentTargetFrameworkMoniker)
 
             Dim supportedTargetFrameworkMonikers As New List(Of TargetFrameworkMoniker)
             Dim hashSupportedTargetFrameworkMonikers As New HashSet(Of String)
@@ -97,28 +194,34 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ' UNDONE: DTAR may currently send back duplicate monikers, so explicitly filter them out for now
             For Each moniker As String In supportedFrameworksArray
                 If hashSupportedTargetFrameworkMonikers.Add(moniker) Then
-
                     ' Filter out frameworks with a different identifier since they are not applicable to the current project type
-                    Dim newFrameworkName As FrameworkName = New FrameworkName(moniker)
-                    Dim displayName As String = ""
-
                     If isSdkProject Then
-                        If String.Compare(newFrameworkName.Identifier, ".NETStandard", StringComparison.Ordinal) = 0 OrElse
-                           String.Compare(newFrameworkName.Identifier, ".NETCoreApp", StringComparison.Ordinal) = 0 Then
-                            displayName = CStr(supportedTargetFrameworksDescriptor.Converter?.ConvertTo(moniker, GetType(String)))
-                            supportedTargetFrameworkMonikers.Add(New TargetFrameworkMoniker(moniker, displayName))
-                        Else
-                            If String.Compare(newFrameworkName.Identifier, ".NETFramework", StringComparison.OrdinalIgnoreCase) = 0 And newFrameworkName.Version >= New Version(4, 5, 0, 0) Then
-                                ' Use DTAR to get the display name corresponding to the moniker
-                                VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetDisplayNameForTargetFx(moniker, displayName))
+                        Dim displayName As String = CStr(supportedTargetFrameworksDescriptor.Converter?.ConvertTo(moniker, GetType(String)))
+                        If moniker.StartsWith(".NETStandard", StringComparison.OrdinalIgnoreCase) OrElse
+                           moniker.StartsWith(".NETCoreApp", StringComparison.OrdinalIgnoreCase) OrElse
+                           moniker.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) OrElse
+                           moniker.StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase) OrElse
+                           moniker.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase) Then
+                            Dim fw As FrameworkName = New FrameworkName(moniker)
+                            If Not (moniker.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) And fw.Version <= New Version("4.5")) Then
+                                displayName = String.Format("{0} {1} {2}", GetDisplayIdFromMoniker(moniker), GetFrameworkVersionFromMoniker(moniker), GetFrameworkProfileFromMoniker(moniker))
                                 supportedTargetFrameworkMonikers.Add(New TargetFrameworkMoniker(moniker, displayName))
                             End If
-                        End If
-                    Else
-                        If String.Compare(newFrameworkName.Identifier, currentFrameworkName.Identifier, StringComparison.OrdinalIgnoreCase) = 0 Then
-                            ' Use DTAR to get the display name corresponding to the moniker
-                            VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetDisplayNameForTargetFx(moniker, displayName))
+                        ElseIf moniker.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase) Then
+                            displayName = String.Format("{0} {1} {2}", GetDisplayIdFromMoniker(moniker), GetFrameworkVersionFromMoniker(moniker), GetFrameworkProfileFromMoniker(moniker))
                             supportedTargetFrameworkMonikers.Add(New TargetFrameworkMoniker(moniker, displayName))
+                        ElseIf moniker.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase) Then
+                            displayName = String.Format("{0} {1} {2}", GetDisplayIdFromMoniker(moniker), GetFrameworkVersionFromMoniker(moniker), GetFrameworkProfileFromMoniker(moniker))
+                            supportedTargetFrameworkMonikers.Add(New TargetFrameworkMoniker(moniker, displayName))
+                        ElseIf moniker.StartsWith("net", StringComparison.OrdinalIgnoreCase) Then
+                            displayName = String.Format("{0} {1} {2}", GetDisplayIdFromMoniker(moniker), GetFrameworkVersionFromMoniker(moniker), GetFrameworkProfileFromMoniker(moniker))
+                            supportedTargetFrameworkMonikers.Add(New TargetFrameworkMoniker(moniker, displayName))
+                        Else
+                            If currentFrameworkId = GetDisplayIdFromMoniker(moniker) Then
+                                ' Use DTAR to get the display name corresponding to the moniker
+                                displayName = String.Format("{0} {1} {2}", GetDisplayIdFromMoniker(moniker), GetFrameworkVersionFromMoniker(moniker), GetFrameworkProfileFromMoniker(moniker))
+                                supportedTargetFrameworkMonikers.Add(New TargetFrameworkMoniker(moniker, displayName))
+                            End If
                         End If
                     End If
                 End If


### PR DESCRIPTION
This was insanely hard to figure out, I think we need to rewrite this code.

Partially fixes: #10456   The complete fix depends on an external bug: https://github.com/dotnet/project-system/issues/6762


So this PR fixes some of the problem there is a project system bug, that still impacts TargetFramework selection:  https://github.com/dotnet/project-system/issues/6762

What works:
- Project load with net core tfms will load correctly and the target framework selector, will display and allow the selection of all tfms.
- Project load with legacy tfms net472, net48 etc. and the target framework selector, will be empty, to change the value at all edit the project file directly and unload and reload the project.

I cannot figure out a work-around for this issue, because I don't really know how the cps data gets plugged in.  I will try to dig around and see if I can figure it out.