### PR TITLE
Fix issue 10505 --- `string` function returns null on `null` parameter of type `string`.

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -4509,7 +4509,10 @@ namespace Microsoft.FSharp.Core
         [<CompiledName("ToString")>]
         let inline string (value: 'T) = 
              anyToString "" value
-             when 'T : string     = (# "" value : string #)     // force no-op
+
+             when 'T : string =
+                if value = unsafeDefault<'T> then ""
+                else (# "" value : string #)     // force no-op
 
              // Using 'let x = (# ... #) in x.ToString()' leads to better IL, without it, an extra stloc and ldloca.s (get address-of)
              // gets emitted, which are unnecessary. With it, the extra address-of-variable is not created

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
@@ -740,6 +740,20 @@ type OperatorsModule2() =
         
     [<Fact>]
     member _.string() =
+
+        let result = Operators.string null
+        Assert.AreEqual("", result)
+
+        let nullStr:string = null
+        let result = Operators.string nullStr
+        Assert.AreEqual("", result)
+
+        let result = Operators.string null
+        Assert.AreEqual("", result)
+
+        let result = Operators.string (null:string)
+        Assert.AreEqual("", result)
+
         // value type
         let result = Operators.string 100
         Assert.AreEqual("100", result)

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -2792,7 +2792,7 @@ let ``Test Operator Declarations for String`` () =
         [], "let testStringToDoubleOperator(e1) = Double.Parse ((if Operators.op_Equality<Microsoft.FSharp.Core.string> (e1,dflt) then dflt else e1.Replace(\"_\",\"\")),167,CultureInfo.get_InvariantCulture () :> System.IFormatProvider) @ (53,47--53,55)"
         [], "let testStringToDecimalOperator(e1) = Decimal.Parse (e1,167,CultureInfo.get_InvariantCulture () :> System.IFormatProvider) @ (54,47--54,57)"
         [], "let testStringToCharOperator(e1) = Char.Parse (e1) @ (55,47--55,54)"
-        [FC47; FC50], "let testStringToStringOperator(e1) = e1 @ (56,54--56,56)"
+        [FC47; FC50], "let testStringToStringOperator(e1) = (if String.Equals (e1,dflt) then "" else e1) @ (56,47--56,56)"
       ]
 
     testOperators "String" "string" excludedTests expectedUnoptimized expectedOptimized

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -2792,7 +2792,7 @@ let ``Test Operator Declarations for String`` () =
         [], "let testStringToDoubleOperator(e1) = Double.Parse ((if Operators.op_Equality<Microsoft.FSharp.Core.string> (e1,dflt) then dflt else e1.Replace(\"_\",\"\")),167,CultureInfo.get_InvariantCulture () :> System.IFormatProvider) @ (53,47--53,55)"
         [], "let testStringToDecimalOperator(e1) = Decimal.Parse (e1,167,CultureInfo.get_InvariantCulture () :> System.IFormatProvider) @ (54,47--54,57)"
         [], "let testStringToCharOperator(e1) = Char.Parse (e1) @ (55,47--55,54)"
-        [FC47; FC50], "let testStringToStringOperator(e1) = (if String.Equals (e1,dflt) then "" else e1) @ (56,47--56,56)"
+        [FC47; FC50], """let testStringToStringOperator(e1) = (if String.Equals (e1,dflt) then "" else e1) @ (56,47--56,56)"""
       ]
 
     testOperators "String" "string" excludedTests expectedUnoptimized expectedOptimized


### PR DESCRIPTION
Fixes the issue: #10505 - `string` function returns null on `null` parameter of type `string`.

The error was introduced by an optimization in a recent PR.  That for any type that was discoverable at compile time as a string, it just nop'd.

The fix evaluated the value for values typed as string, and if they are null, it returns a "".  This restores the original behaviour that for string nulls it returns a "", although it goes through a ton less code now :-).

