### PR TITLE
Resolve issue with implicit yields requiring Zero

### DIFF
--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -949,6 +949,11 @@ let TcComputationExpression cenv env overallTy tpenv (mWhole, interpExpr: Expr, 
         | SynExpr.Paren (_, _, _, m) -> 
             error(Error(FSComp.SR.tcConstructIsAmbiguousInComputationExpression(), m))
 
+        // In some cases the node produced by `mkSynCall "Zero" m []` may be discarded in the case
+        // of implicit yields - for example "list { 1; 2 }" when each expression checks as an implicit yield.
+        // If it is not discarded, the syntax node will later be checked and the existence/non-existence of the Zero method
+        // will be checked/reported appropriately (though the error message won't mention computation expressions
+        // like our other error messages for missing methods).
         | SynExpr.ImplicitZero m -> 
             if (not enableImplicitYield) && 
                isNil (TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env m ad "Zero" builderTy) then error(Error(FSComp.SR.tcRequireBuilderMethod("Zero"), m))

--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -950,7 +950,8 @@ let TcComputationExpression cenv env overallTy tpenv (mWhole, interpExpr: Expr, 
             error(Error(FSComp.SR.tcConstructIsAmbiguousInComputationExpression(), m))
 
         | SynExpr.ImplicitZero m -> 
-            if isNil (TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env m ad "Zero" builderTy) then error(Error(FSComp.SR.tcRequireBuilderMethod("Zero"), m))
+            if (not enableImplicitYield) && 
+               isNil (TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env m ad "Zero" builderTy) then error(Error(FSComp.SR.tcRequireBuilderMethod("Zero"), m))
             Some (translatedCtxt (mkSynCall "Zero" m []))
             
         | OptionalSequential (JoinOrGroupJoinOrZipClause (_, _, _, _, _, mClause), _) 

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="Language\XmlComments.fs" />
     <Compile Include="Language\CompilerDirectiveTests.fs" />
     <Compile Include="Language\CodeQuotationTests.fs" />
+    <Compile Include="Language\ComputationExpressionTests.fs" />
     <Compile Include="ConstraintSolver\PrimitiveConstraints.fs" />
     <Compile Include="ConstraintSolver\MemberConstraints.fs" />
     <Compile Include="Interop\SimpleInteropTests.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -57,8 +57,4 @@
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpTestsRoot)\FSharp.Test.Utilities\FSharp.Test.Utilities.fsproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="NewFolder\" />
-  </ItemGroup>
 </Project>

--- a/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.Language
+
+open Xunit
+open FSharp.Test.Utilities.Compiler
+
+module ComputationExpressionTests =
+    [<Fact>]
+    let ``A CE not using Zero does not require Zero``() =
+        FSharp """
+module ComputationExpressionTests
+type ListBuilder () =
+    member __.Combine (a: List<'T>, b) = a @ b
+    member __.Yield  x = List.singleton x
+    member __.Delay expr = expr () :  List<'T>
+
+let lb = ListBuilder ()
+
+let x = lb {1; 2;}
+        """
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``A CE explicitly using Zero fails without a defined Zero``() =
+        FSharp """
+module ComputationExpressionTests
+type ListBuilder () =
+    member __.Combine (a: List<'T>, b) = a @ b
+    member __.Yield  x = List.singleton x
+    member __.Delay expr = expr () :  List<'T>
+
+let lb = ListBuilder ()
+
+let x = lb {1; 2;()}
+        """
+        |> compile
+        |> shouldFail
+        |> withSingleDiagnostic (Error 39, Line 10, Col 18, Line 10, Col 20, "The type 'ListBuilder' does not define the field, constructor or member 'Zero'.")
+        |> ignore
+
+    [<Fact>]
+    let ``A CE explicitly using Zero succeeds with a defined Zero``() =
+        FSharp """
+module ComputationExpressionTests
+type ListBuilder () =
+    member __.Zero () = []
+    member __.Combine (a: List<'T>, b) = a @ b
+    member __.Yield  x = List.singleton x
+    member __.Delay expr = expr () :  List<'T>
+
+let lb = ListBuilder ()
+
+let x = lb {1; 2;()}
+        """
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``A CE with a complete if-then expression does not require Zero``() =
+        FSharp """
+module ComputationExpressionTests
+type ListBuilder () =
+    member __.Combine (a: List<'T>, b) = a @ b
+    member __.Yield  x = List.singleton x
+    member __.Delay expr = expr () :  List<'T>
+
+let lb = ListBuilder ()
+
+let x = lb {1; 2; if true then 3 else 4;}
+        """
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``A CE with a missing/empty else branch implicitly requires Zero``() =
+        FSharp """
+module ComputationExpressionTests
+type ListBuilder () =
+    member __.Combine (a: List<'T>, b) = a @ b
+    member __.Yield  x = List.singleton x
+    member __.Delay expr = expr () :  List<'T>
+
+let lb = ListBuilder ()
+
+let x = lb {1; 2; if true then 3;}
+        """
+        |> compile
+        |> shouldFail
+        |> withSingleDiagnostic (Error 708, Line 10, Col 19, Line 10, Col 31, "This control construct may only be used if the computation expression builder defines a 'Zero' method")
+        |> ignore


### PR DESCRIPTION
Related to #8587 

I've been wrapping my head around this in the idle hours for a couple of days now and this seems like it should resolve the bug in question.  But I would appreciate eyes on it, and will with great joy take guidance on more elegant means of solving this.

Here's the low-down on the bug:
Based on [the RFC](https://github.com/fsharp/fslang-design/blob/13509be8a445d0b75d63ed9f44f9f127c21bcc51/FSharp-4.7/FS-1069-implicit-yields.md) - it's expected that a yielding CE require Zero (see Detailed Design - point 2)

In the code itself, we can see that the behavior makes sense:
CheckComputationExpressions.fs : 1440 states
> // "expr;" in final position is treated as { expr; zero }

And thus, relative to the samples in the ticket - the final 3, a raw expression, would be followed by a zero which would somewhat necessitate the need for that Zero method to exist.

The resolution for this that I have found is to do a safety-check with regards to how we handle ImplicitZero - if we're in a context where Implicit Yielding is enabled, then rather than erroring out if the builder lacks Zero, we can first check to see whether or not we're in an Implicit Yielding situation and therefore, if we are, rely on the translation context provided to handle the zero intelligently.

I've considered the placement of this logic - but cannot identify a better place to shim it in (without affecting more of the surrounding code than I feel comfortable with) than in `tryTrans` - while this results in a duplicate check around the `enableImplicitYield` value (now in `tryTrans` and then nearly immediately afterwards in in `translatedCtxt` callback defined at :1452) - this seems minor.  

My intuition is that there's a cleaner way to handle this, but it may require more significant modifications to the surrounding behaviors here than what I have made here and, as such, I hesitate to do so without further insights.