### PR TITLE
Updated DEVGUIDE.md test flags to match the build help

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -80,15 +80,19 @@ You can then open `FSharp.sln` in your editor of choice.
 
 ## Testing from the command line
 
-You can find all test options as separate flags. For example:
+You can find all test options as separate flags. For example `build -testAll`:
 
 ```
-build -testDesktop                          -- test all net472 target frameworks
-build -testCoreClr                          -- test all netstandard and netcoreapp target frameworks
-build -testFSharpQA                         -- test all F# Cambridge tests
-build -testVs                               -- test all VS integration points
-build -testFcs                              -- test F# compiler service components
-build -testAll                              -- all of the above
+  -testAll                  Run all tests
+  -testCambridge            Run Cambridge tests
+  -testCompiler             Run FSharpCompiler unit tests
+  -testCompilerService      Run FSharpCompilerService unit tests
+  -testDesktop              Run tests against full .NET Framework
+  -testCoreClr              Run tests against CoreCLR
+  -testFSharpCore           Run FSharpCore unit tests
+  -testFSharpQA             Run F# Cambridge tests
+  -testScripting            Run Scripting tests
+  -testVs                   Run F# editor unit tests
 ```
 
 Running any of the above will build the latest changes and run tests against them.


### PR DESCRIPTION
For instance, the `-testFcs` flag is no longer valid.