### PR TITLE
Fix net sdk references discovery

### DIFF
--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -877,8 +877,6 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
 #endif
                 None, data.legacyReferenceResolver.HighestInstalledNetFrameworkVersion()
 
-    let systemAssemblies = systemAssemblies
-
     member x.primaryAssembly = data.primaryAssembly
     member x.noFeedback = data.noFeedback
     member x.stackReserveSize = data.stackReserveSize   

--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -29,7 +29,7 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
             location
 
     let inline ifEmptyUse alternative filename = if String.IsNullOrWhiteSpace filename then alternative else filename
-    
+
     let getFSharpCoreLibraryName = "FSharp.Core"
     let getFsiLibraryName = "FSharp.Compiler.Interactive.Settings"
     let getDefaultFSharpCoreLocation = Path.Combine(fSharpCompilerLocation, getFSharpCoreLibraryName + ".dll")
@@ -64,13 +64,19 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
     //     version of the runtime we are executing on
     //     Use the reference assemblies for the highest netcoreapp tfm that we find in that location that is 
     //     lower than or equal to the implementation version.
+    let zeroVersion = Version("0.0.0.0")
     let version, frameworkRefsPackDirectoryRoot =
         try
+            let computeVersion version =
+                match Version.TryParse(version) with
+                | true, v -> v
+                | false, _ -> zeroVersion
+
             let version = DirectoryInfo(implementationAssemblyDir).Name
             let microsoftNETCoreAppRef = Path.Combine(implementationAssemblyDir, "../../../packs/Microsoft.NETCore.App.Ref")
             if Directory.Exists(microsoftNETCoreAppRef) then
                 let directory = DirectoryInfo(microsoftNETCoreAppRef).GetDirectories()
-                                |> Array.sortBy (fun di -> di.Name)
+                                |> Array.sortBy (fun di -> (computeVersion di.Name))
                                 |> Array.filter(fun di -> di.Name <= version)
                                 |> Array.last
                 Some (directory.Name), Some microsoftNETCoreAppRef

--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -72,16 +72,17 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
                 | true, v -> v
                 | false, _ -> zeroVersion
 
-            let version = DirectoryInfo(implementationAssemblyDir).Name
+            let version = computeVersion (DirectoryInfo(implementationAssemblyDir).Name)
             let microsoftNETCoreAppRef = Path.Combine(implementationAssemblyDir, "../../../packs/Microsoft.NETCore.App.Ref")
             if Directory.Exists(microsoftNETCoreAppRef) then
                 let directory = DirectoryInfo(microsoftNETCoreAppRef).GetDirectories()
-                                |> Array.sortBy (fun di -> (computeVersion di.Name))
-                                |> Array.filter(fun di -> di.Name <= version)
+                                |> Array.map (fun di -> computeVersion di.Name)
+                                |> Array.sort
+                                |> Array.filter(fun v -> v <= version)
                                 |> Array.last
-                Some (directory.Name), Some microsoftNETCoreAppRef
+                Some (directory.ToString()), Some microsoftNETCoreAppRef
             else
-               Some version,  None
+               None,  None
         with | _ -> None, None
 
     // Tries to figure out the tfm for the compiler instance.


### PR DESCRIPTION
The original algorithm for mapping NETSdk  pack locations from the implementation directoy was incorrect.

We now compute the NETSdk reference assembly to be the highest version that is lower or equal to the implementation version. 
