### PR TITLE
Fix issue10550 Desktop FSI accessing System.Configuration

### DIFF
--- a/src/fsharp/DotNetFrameworkDependencies.fs
+++ b/src/fsharp/DotNetFrameworkDependencies.fs
@@ -302,6 +302,7 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
         yield "System.Data"
         yield "System.Drawing"
         yield "System.Core"
+        yield "System.Configuration"
 
         yield getFSharpCoreLibraryName
         if useFsiAuxLib then yield getFsiLibraryName
@@ -378,6 +379,7 @@ module internal FSharp.Compiler.DotNetFrameworkDependencies
             yield "System.Xml" 
             yield "System.Runtime.Remoting"
             yield "System.Runtime.Serialization.Formatters.Soap"
+            yield "System.Configuration"
             yield "System.Data"
             yield "System.Deployment"
             yield "System.Design"

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -117,6 +117,19 @@ stacktype.Name = "Stack"
         | Ok(_) -> Assert.False(true, "expected a failure")
         | Error(ex) -> Assert.IsAssignableFrom(typeof<FsiCompilationException>, ex)
 
+
+    [<Fact>]
+    member _.``Script using System.Configuration succeeds``() =
+        use script = new FSharpScript()
+        let result, errors = script.Eval("""
+#r "nuget:System.Configuration.ConfigurationManager,5.0.0"
+open System.Configuration
+System.Configuration.ConfigurationManager.AppSettings.Item "Environment" <- "LOCAL" """)
+        Assert.Empty(errors)
+        match result with
+        | Ok(_) -> ()
+        | Error(ex) -> Assert.True(true, "expected no failures")
+
     [<Theory>]
     [<InlineData("""#i""", "input.fsx (1,1)-(1,3) interactive warning Invalid directive '#i '")>]                                               // No argument
     [<InlineData("""#i "" """, "input.fsx (1,1)-(1,6) interactive error #i is not supported by the registered PackageManagers")>]               // empty argument


### PR DESCRIPTION
Fixes #10550   : Error accessing System.Configuration.ConfigurationManager in F# Script and F# Interactive on Visual Studio 16.8.0

On the desktop FSI did not pre-load : System.Configuration which meant that when using types from that assembly they couldn't be found.  On the coreclr build of fsi, all framework assemblies are pre-loaded, which allowed it to work.

This PR adds System.Configuration to the list of identified framework assemblies for pre-load and to identify core framework types.

And it adds a regression test.




