### PR TITLE
Copy XmlDocuments to output directory

### DIFF
--- a/src/fsharp/FSharp.Core/FSharp.Core.nuspec
+++ b/src/fsharp/FSharp.Core/FSharp.Core.nuspec
@@ -6,12 +6,16 @@
         <dependencies>
             <group targetFramework=".NETStandard2.0" />
         </dependencies>
+        <contentFiles> <!-- Deploy doc comments as Content -->
+            <files include="**/*" buildAction="None" copyToOutput="true" flatten="true" />
+        </contentFiles> 
     </metadata>
     <files>
         $CommonFileElements$
 
-        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.dll"              target="lib\netstandard2.0" />
-        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.xml"              target="lib\netstandard2.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.dll" target="lib\netstandard2.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.xml" target="lib\netstandard2.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.xml" target="contentFiles/any/netstandard2.0" />
 
         <!-- resources -->
         <file src="FSharp.Core\$Configuration$\netstandard2.0\**\FSharp.Core.resources.dll" target="lib\netstandard2.0" />

--- a/src/fsharp/FSharp.Core/FSharp.Core.nuspec
+++ b/src/fsharp/FSharp.Core/FSharp.Core.nuspec
@@ -7,7 +7,7 @@
             <group targetFramework=".NETStandard2.0" />
         </dependencies>
         <contentFiles> <!-- Deploy doc comments as Content -->
-            <files include="**/*" buildAction="None" copyToOutput="true" flatten="true" />
+            <files include="**/FSharp.Core.xml" buildAction="None" copyToOutput="true" flatten="true" />
         </contentFiles> 
     </metadata>
     <files>


### PR DESCRIPTION
This changes the xmldoc comments file for FSharp.Core into a nuget contentFile.  Following this change, build and publish will deploy the FSharp.Core.xml doc comment file to the output directory, without the build author having to do any extra work.

I wish I was smarter than I actually am, because this 2 minute job took over a day.  Good lord the contentFiles semantics are confusing.

Note: I have left the original FSharp.Core.xml in the lib directory, because when the package is referenced directly, which is a very common coreclr scenario it exists alongside the .dll.  Also, any existing builds that included targets to copy the file to the output directory will still work.  Although developers can ideally, remove those targets.

