### PR TITLE
Don't lift the result of getting a symbol use in the add open code fix 

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -107,7 +107,7 @@ type internal FSharpAddOpenCodeFixProvider
                 asyncMaybe {
                     let! lexerSymbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, context.Span.End, document.FilePath, defines, SymbolLookupKind.Greedy, false, false)
                     return checkResults.GetSymbolUseAtLocation(Line.fromZ linePos.Line, lexerSymbol.Ident.idRange.EndColumn, line.ToString(), lexerSymbol.FullIsland)
-                } |> liftAsync
+                }
 
             do! Option.guard symbol.IsNone
 

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -104,7 +104,7 @@ type internal FSharpAddOpenCodeFixProvider
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
             
             let! symbol = 
-                asyncMaybe {
+                maybe {
                     let! lexerSymbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, context.Span.End, document.FilePath, defines, SymbolLookupKind.Greedy, false, false)
                     return checkResults.GetSymbolUseAtLocation(Line.fromZ linePos.Line, lexerSymbol.Ident.idRange.EndColumn, line.ToString(), lexerSymbol.FullIsland)
                 }


### PR DESCRIPTION
fixes #10533 

This commit broke the code fixer: https://github.com/dotnet/fsharp/commit/3b294c479cc9f8f5299a89db309a835678c259db

Before, the call was asynchronous and so we lifted that into an option. It's no longer asynchronous, but the code compiled because `asymcMaybe` can also work with options. So the code was now lifting the result into an option, creating a `Some(None)` as the result. Because we assert that there is _no_ symbol use, the code fixer would fail because `Some(None)` matches false for `IsNone`.

This removes the call to `liftAsync`, and also changes the CE to `maybe` because nothing is asynchronous.