### PR TITLE
VM updates broke the compilerasserts tests.  This is a test fix.

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,2 +1,3 @@
+rem bump
 @echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -build -restore %*"

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -137,7 +137,9 @@ let main argv = 0"""
         let mutable output = ""
         let mutable errors = ""
         let mutable cleanUp = true
-        let pathToTemp = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../Temp"))
+        let pathToArtifacts = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../.."))
+        if Path.GetFileName(pathToArtifacts) <> "artifacts" then failwith "CompilerAssert did not find artifacts directory --- has the location changed????"
+        let pathToTemp = Path.Combine(pathToArtifacts, "Temp")
         let projectDirectory = Path.Combine(pathToTemp, "CompilerAssert", Path.GetRandomFileName())
         let pathToFSharpCore = typeof<RequireQualifiedAccessAttribute>.Assembly.Location
         try

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -159,15 +159,15 @@ let main argv = 0"""
 
                 if not (String.IsNullOrWhiteSpace errors) then
                     printfn "Output:\n=======\n%s\n" output
-                    printfn "Errors:\n=======\n%s\n" error
+                    printfn "Errors:\n=======\n%s\n" errors
                     Assert.Fail errors
                 if p.ExitCode <> 0 then
                     printfn "Output:\n=======\n%s\n" output
-                    printfn "Errors:\n=======\n%s\n" error
+                    printfn "Errors:\n=======\n%s\n" errors
                     Assert.Fail(sprintf "Program exited with exit code %d" p.ExitCode)
                 if not succeeded then
                     printfn "Output:\n=======\n%s\n" output
-                    printfn "Errors:\n=======\n%s\n" error
+                    printfn "Errors:\n=======\n%s\n" errors
                     Assert.Fail(sprintf "Program timed out after %d ms" timeout)
 
                 File.ReadLines(frameworkReferencesFileName) |> Seq.toArray

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -117,6 +117,16 @@ type CompilerAssert private () =
 
 </Project>"""
 
+    static let directoryBuildProps = """
+<Project>
+  <PropertyGroup>
+    <DisableCompilerRedirection>true</DisableCompilerRedirection>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+</Project>
+"""
+
     static let programFs = """
 open System
 
@@ -127,13 +137,15 @@ let main argv = 0"""
         let mutable output = ""
         let mutable errors = ""
         let mutable cleanUp = true
-        let projectDirectory = Path.Combine(Path.GetTempPath(), "CompilerAssert", Path.GetRandomFileName())
+        let pathToTemp = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../Temp"))
+        let projectDirectory = Path.Combine(pathToTemp, "CompilerAssert", Path.GetRandomFileName())
         let pathToFSharpCore = typeof<RequireQualifiedAccessAttribute>.Assembly.Location
         try
             try
                 Directory.CreateDirectory(projectDirectory) |> ignore
                 let projectFileName = Path.Combine(projectDirectory, "ProjectFile.fsproj")
                 let programFsFileName = Path.Combine(projectDirectory, "Program.fs")
+                let directoryBuildPropsFileName = Path.Combine(projectDirectory, "Directory.Build.props")
                 let frameworkReferencesFileName = Path.Combine(projectDirectory, "FrameworkReferences.txt")
 #if NETCOREAPP
                 File.WriteAllText(projectFileName, projectFile.Replace("$TARGETFRAMEWORK", "netcoreapp3.1").Replace("$FSHARPCORELOCATION", pathToFSharpCore))
@@ -141,6 +153,7 @@ let main argv = 0"""
                 File.WriteAllText(projectFileName, projectFile.Replace("$TARGETFRAMEWORK", "net472").Replace("$FSHARPCORELOCATION", pathToFSharpCore))
 #endif
                 File.WriteAllText(programFsFileName, programFs)
+                File.WriteAllText(directoryBuildPropsFileName, directoryBuildProps)
 
                 let pInfo = ProcessStartInfo ()
                 pInfo.FileName <- config.DotNetExe
@@ -175,7 +188,9 @@ let main argv = 0"""
                 cleanUp <- false
                 printfn "Project directory: %s" projectDirectory
                 printfn "STDOUT: %s" output
+                File.WriteAllText(Path.Combine(projectDirectory, "project.stdout"), output)
                 printfn "STDERR: %s" errors
+                File.WriteAllText(Path.Combine(projectDirectory, "project.stderror"), errors)
                 raise (new Exception (sprintf "An error occurred getting netcoreapp references: %A" e))
         finally
             if cleanUp then

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -157,9 +157,18 @@ let main argv = 0"""
                 output <- p.StandardOutput.ReadToEnd ()
                 errors <- p.StandardError.ReadToEnd ()
 
-                if not (String.IsNullOrWhiteSpace errors) then Assert.Fail errors
-                if p.ExitCode <> 0 then Assert.Fail(sprintf "Program exited with exit code %d" p.ExitCode)
-                if not succeeded then Assert.Fail(sprintf "Program timed out after %d ms" timeout)
+                if not (String.IsNullOrWhiteSpace errors) then
+                    printfn "Output:\n=======\n%s\n" output
+                    printfn "Errors:\n=======\n%s\n" error
+                    Assert.Fail errors
+                if p.ExitCode <> 0 then
+                    printfn "Output:\n=======\n%s\n" output
+                    printfn "Errors:\n=======\n%s\n" error
+                    Assert.Fail(sprintf "Program exited with exit code %d" p.ExitCode)
+                if not succeeded then
+                    printfn "Output:\n=======\n%s\n" output
+                    printfn "Errors:\n=======\n%s\n" error
+                    Assert.Fail(sprintf "Program timed out after %d ms" timeout)
 
                 File.ReadLines(frameworkReferencesFileName) |> Seq.toArray
             with | e ->

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -3,6 +3,7 @@
 open System
 open System.IO
 open System.Diagnostics
+open System.Reflection
 open NUnit.Framework
 open TestFramework
 open HandleExpects
@@ -222,12 +223,15 @@ let singleTestBuildAndRunCore cfg copyFiles p languageVersion =
             let mutable result = ""
             lock lockObj <| (fun () ->
                 let rec loop () =
-                    let dir = Path.Combine(Path.GetTempPath(), "FSharp.Cambridge", Path.GetRandomFileName())
-                    if Directory.Exists(dir) then
+                    let pathToArtifacts = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../.."))
+                    if Path.GetFileName(pathToArtifacts) <> "artifacts" then failwith "FSharp.Cambridge did not find artifacts directory --- has the location changed????"
+                    let pathToTemp = Path.Combine(pathToArtifacts, "Temp")
+                    let projectDirectory = Path.Combine(pathToTemp, "FSharp.Cambridge", Path.GetRandomFileName())
+                    if Directory.Exists(projectDirectory) then
                         loop ()
                     else
-                        Directory.CreateDirectory(dir) |>ignore
-                        dir
+                        Directory.CreateDirectory(projectDirectory) |>ignore
+                        projectDirectory
                 result <- loop())
             result
 


### PR DESCRIPTION
Recently the Virtual Machines used for CI have been updated this has caused the CompilerAssert tests to file.

This PR, adds some logging to the tests and has a cherry pick of the fix from master branch