### PR TITLE
debump release/dev16.8

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,3 +1,2 @@
-rem bump
 @echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -build -restore %*"


### PR DESCRIPTION
When investigating the ci failure for : https://github.com/dotnet/fsharp/pull/10597 - VM updates broke the compilerasserts tests. This is a test fix. #10597

I inadvertently left in the bump.

This pr removes it.