### PR TITLE
Fix docxml file distribution

### DIFF
--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -227,4 +227,13 @@
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(SystemThreadingTasksParallelVersion)" />
   </ItemGroup>
 
+  <Target Name="CopyToBuiltBin" BeforeTargets="BuiltProjectOutputGroup" AfterTargets="CoreCompile">
+    <PropertyGroup>
+      <BuildOutputGroupLocation>$(BaseOutputPath)\$(Configuration)\$(TargetFramework)</BuildOutputGroupLocation>
+    </PropertyGroup>
+    <ItemGroup>
+      <BuiltProjectOutputGroupKeyOutput Include="$(BuildOutputGroupLocation)\FSharp.Core.xml" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
fsi intellisense for Visual Studio was not displaying xml doc help messages for F# types.

![image](https://user-images.githubusercontent.com/5175830/101412133-ec8f5b80-3896-11eb-988a-b7453421df77.png)


This PR fixes that by ensuring that the FSharp.Core.xml doc file flows into the vsix file that is used to distribute to vs.

With this fix intellisense produces:
![image](https://user-images.githubusercontent.com/5175830/101412303-36784180-3897-11eb-91e2-c35171053f5a.png)


