### PR TITLE
[Tooling] Prevent impl files with backing sig files from invalidating the build

### DIFF
--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -143,6 +143,9 @@ module IncrementalBuildSyntaxTree =
                 | _ -> parse sigNameOpt
             | _ -> parse sigNameOpt
 
+        member _.Invalidate() =
+            weakCache <- None
+
         member _.FileName = filename
 
 /// Accumulated results of type checking. The minimum amount of state in order to continue type-checking following files.
@@ -237,6 +240,23 @@ type SemanticModel private (tcConfig: TcConfig,
     member _.TcGlobals = tcGlobals
 
     member _.TcImports = tcImports
+
+    member _.BackingSignature =
+        match syntaxTreeOpt with
+        | Some syntaxTree ->
+            let sigFileName = Path.ChangeExtension(syntaxTree.FileName, ".fsi")
+            match prevTcInfo.sigNameOpt with
+            | Some (expectedSigFileName, sigName) when String.Equals(expectedSigFileName, sigFileName, StringComparison.OrdinalIgnoreCase) ->
+                Some sigName
+            | _ ->
+                None
+        | _ ->
+            None
+
+    member _.Invalidate() =
+        lazyTcInfoState := None
+        syntaxTreeOpt
+        |> Option.iter (fun x -> x.Invalidate())
 
     member this.GetState(partialCheck: bool) =
         let partialCheck =
@@ -344,7 +364,7 @@ type SemanticModel private (tcConfig: TcConfig,
                     }
         }
 
-    member private _.TypeCheck (partialCheck: bool) =  
+    member private this.TypeCheck (partialCheck: bool) =  
         match partialCheck, !lazyTcInfoState with
         | true, Some (PartialState _ as state)
         | true, Some (FullState _ as state) -> state |> Eventually.Done
@@ -357,12 +377,7 @@ type SemanticModel private (tcConfig: TcConfig,
             | Some syntaxTree ->
                 let sigNameOpt =
                     if partialCheck then
-                        let sigFileName = Path.ChangeExtension(syntaxTree.FileName, ".fsi")
-                        match prevTcInfo.sigNameOpt with
-                        | Some (expectedSigFileName, sigName) when String.Equals(expectedSigFileName, sigFileName, StringComparison.OrdinalIgnoreCase) ->
-                            Some sigName
-                        | _ ->
-                            None
+                        this.BackingSignature
                     else
                         None
                 match syntaxTree.Parse sigNameOpt with
@@ -910,7 +925,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     let stampedFileNames = Array.init fileNames.Length (fun _ -> DateTime.MinValue)
     let stampedReferencedAssemblies = Array.init referencedAssemblies.Length (fun _ -> DateTime.MinValue)
     let mutable initialSemanticModel = None
-    let semanticModels = Array.zeroCreate fileNames.Length
+    let semanticModels = Array.zeroCreate<SemanticModel option> fileNames.Length
     let mutable finalizedSemanticModel = None
 
     let computeStampedFileName (cache: TimeStampCache) (ctok: CompilationThreadToken) slot fileInfo cont =
@@ -918,15 +933,20 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         let stamp = StampFileNameTask cache ctok fileInfo
 
         if currentStamp <> stamp then
-            // Something changed, the finalized view of the project must be invalidated.
-            finalizedSemanticModel <- None
+            match semanticModels.[slot] with
+            // This prevents an implementation file that has a backing signature file from invalidating the rest of the build.
+            | Some(semanticModel) when enablePartialTypeChecking && semanticModel.BackingSignature.IsSome ->
+                semanticModel.Invalidate()
+            | _ ->
+                // Something changed, the finalized view of the project must be invalidated.
+                finalizedSemanticModel <- None
 
-            // Invalidate the file and all files below it.
-            stampedFileNames.[slot..]
-            |> Array.iteri (fun j _ -> 
-                stampedFileNames.[slot + j] <- StampFileNameTask cache ctok fileNames.[slot + j]
-                semanticModels.[slot + j] <- None
-            )
+                // Invalidate the file and all files below it.
+                stampedFileNames.[slot..]
+                |> Array.iteri (fun j _ -> 
+                    stampedFileNames.[slot + j] <- StampFileNameTask cache ctok fileNames.[slot + j]
+                    semanticModels.[slot + j] <- None
+                )
 
         if semanticModels.[slot].IsNone then
             cont slot fileInfo


### PR DESCRIPTION
Implements this: https://github.com/dotnet/fsharp/issues/10210

The refactor of incremental build has payed off. In the end, the solution to this required only a few changes.

The perf impact at the moment is completely night and day. Modifying then saving an impl file that has a backing sig file - is almost zero cost when VS/Roslyn tries to analyze other files that depend on it.