### PR TITLE
Store background semantic classification in a memory-mapped file

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -141,6 +141,8 @@ Renamings in `FSharp.Compiler.SourceCodeServices`:
 ```
 
 * Extension methods in `ServiceAssemblyContent.fsi` are now now intrinsic methods on the symbol types themselves.
+* `SemanticClassificationType` is now an enum instead of a discriminated union.
+* `GetBackgroundSemanticClassificationForFile` now returns `Async<SemanticClassificationView option>` instead of `Async<struct(range * SemanticClassificationType) []>`. The `SemanticClassificationView` provides a read-only view over the semantic classification contents via the `ForEach (FSharpSemanticClassificationItem -> unit) -> unit` function.
 
 The following namespaces have been made internal
 

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -850,6 +850,12 @@
     <Compile Include="..\service\ItemKey.fs">
       <Link>Service/ItemKey.fs</Link>
     </Compile>
+	<Compile Include="..\service\SemanticClassificationKey.fsi">
+		<Link>Service/SemanticClassificationKey.fsi</Link>
+	</Compile>
+	<Compile Include="..\service\SemanticClassificationKey.fs">
+		<Link>Service/SemanticClassificationKey.fs</Link>
+	</Compile>
     <Compile Include="..\service\IncrementalBuild.fsi">
       <Link>Service/IncrementalBuild.fsi</Link>
     </Compile>

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -1317,7 +1317,7 @@ type internal TypeCheckInfo
     member _.GetFormatSpecifierLocationsAndArity() = 
          sSymbolUses.GetFormatSpecifierLocationsAndArity()
 
-    member _.GetSemanticClassification(range: range option) : struct (range * SemanticClassificationType) [] =
+    member _.GetSemanticClassification(range: range option) : FSharpSemanticClassificationItem [] =
         sResolutions.GetSemanticClassification(g, amap, sSymbolUses.GetFormatSpecifierLocationsAndArity(), range)
 
     /// The resolutions in the file

--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -200,7 +200,7 @@ type public FSharpCheckFileResults =
     member GetSymbolUseAtLocation  : line:int * colAtEndOfNames:int * lineText:string * names:string list -> FSharpSymbolUse option
 
     /// <summary>Get any extra colorization info that is available after the typecheck</summary>
-    member GetSemanticClassification : range option -> struct (range * SemanticClassificationType)[]
+    member GetSemanticClassification : range option -> FSharpSemanticClassificationItem[]
 
     /// <summary>Get the locations of format specifiers</summary>
     [<System.Obsolete("This member has been replaced by GetFormatSpecifierLocationsAndArity, which returns both range and arity of specifiers")>]

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -86,7 +86,7 @@ type internal TcInfoOptional =
       itemKeyStore: ItemKeyStore option
       
       /// If enabled, holds semantic classification information for Item(symbol)s in a file.
-      semanticClassification: struct (range * SemanticClassificationType) []
+      semanticClassificationKeyStore: SemanticClassificationKeyStore option
     }
 
     member TcSymbolUses: TcSymbolUses list
@@ -115,7 +115,7 @@ type internal PartialCheckResults =
 
     /// Can cause a second type-check if `enablePartialTypeChecking` is true in the checker.
     /// Only use when it's absolutely necessary to get rich information on a file.
-    member GetSemanticClassification: CompilationThreadToken -> struct(range * SemanticClassificationType) []
+    member GetSemanticClassification: CompilationThreadToken -> SemanticClassificationKeyStore option
 
     member TimeStamp: DateTime 
 

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -20,43 +20,50 @@ open FSharp.Compiler.TypedTreeOps
 
 [<RequireQualifiedAccess>]
 type SemanticClassificationType =
-    | ReferenceType
-    | ValueType
-    | UnionCase
-    | UnionCaseField
-    | Function
-    | Property
-    | MutableVar
-    | Module
-    | Namespace
-    | Printf
-    | ComputationExpression
-    | IntrinsicFunction
-    | Enumeration
-    | Interface
-    | TypeArgument
-    | Operator
-    | DisposableType
-    | DisposableTopLevelValue
-    | DisposableLocalValue
-    | Method
-    | ExtensionMethod
-    | ConstructorForReferenceType
-    | ConstructorForValueType
-    | Literal
-    | RecordField
-    | MutableRecordField
-    | RecordFieldAsFunction
-    | Exception
-    | Field
-    | Event
-    | Delegate
-    | NamedArgument
-    | Value
-    | LocalValue
-    | Type
-    | TypeDef
-    | Plaintext
+    | ReferenceType = 0
+    | ValueType = 1
+    | UnionCase = 2
+    | UnionCaseField = 3
+    | Function = 4
+    | Property = 5
+    | MutableVar = 6
+    | Module = 7
+    | Namespace = 8
+    | Printf = 9
+    | ComputationExpression = 10
+    | IntrinsicFunction = 11
+    | Enumeration = 12
+    | Interface = 13
+    | TypeArgument = 14
+    | Operator = 15
+    | DisposableType = 16
+    | DisposableTopLevelValue = 17
+    | DisposableLocalValue = 18
+    | Method = 19
+    | ExtensionMethod = 20
+    | ConstructorForReferenceType = 21
+    | ConstructorForValueType = 22
+    | Literal = 23
+    | RecordField = 24
+    | MutableRecordField = 25
+    | RecordFieldAsFunction = 26
+    | Exception = 27
+    | Field = 28
+    | Event = 29
+    | Delegate = 30
+    | NamedArgument = 31
+    | Value = 32
+    | LocalValue = 33
+    | Type = 34
+    | TypeDef = 35
+    | Plaintext = 36
+
+[<RequireQualifiedAccess>]
+[<Struct>]
+type FSharpSemanticClassificationItem =
+    val Range: range
+    val Type: SemanticClassificationType
+    new((range, ty)) = { Range = range; Type = ty }
 
 [<AutoOpen>]
 module TcResolutionsExtensions =
@@ -64,7 +71,7 @@ module TcResolutionsExtensions =
         (cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.NameResolutionEnv, cnr.AccessorDomain, cnr.Range)
 
     type TcResolutions with
-        member sResolutions.GetSemanticClassification(g: TcGlobals, amap: Import.ImportMap, formatSpecifierLocations: (range * int) [], range: range option) : struct(range * SemanticClassificationType) [] =
+        member sResolutions.GetSemanticClassification(g: TcGlobals, amap: Import.ImportMap, formatSpecifierLocations: (range * int) [], range: range option) : FSharpSemanticClassificationItem [] =
             ErrorScope.Protect Range.range0 (fun () ->
                 let (|LegitTypeOccurence|_|) = function
                     | ItemOccurence.UseInType
@@ -149,9 +156,9 @@ module TcResolutionsExtensions =
                 let duplicates = HashSet<range>(Range.comparer)
 
                 let results = ImmutableArray.CreateBuilder()
-                let inline add m typ =
+                let inline add m (typ: SemanticClassificationType) =
                     if duplicates.Add m then
-                        results.Add struct(m, typ)
+                        results.Add (new FSharpSemanticClassificationItem((m, typ)))
 
                 resolutions
                 |> Array.iter (fun cnr ->
@@ -368,7 +375,7 @@ module TcResolutionsExtensions =
 
                     | _, _, _, _, _, m ->
                         add m SemanticClassificationType.Plaintext)
-                results.AddRange(formatSpecifierLocations |> Array.map (fun (m, _) -> struct(m, SemanticClassificationType.Printf)))
+                results.AddRange(formatSpecifierLocations |> Array.map (fun (m, _) -> new FSharpSemanticClassificationItem((m, SemanticClassificationType.Printf))))
                 results.ToArray()
                ) 
                (fun msg -> 

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -13,43 +13,50 @@ open FSharp.Compiler.TcGlobals
 /// A kind that determines what range in a source's text is semantically classified as after type-checking.
 [<RequireQualifiedAccess>]
 type SemanticClassificationType =
-    | ReferenceType
-    | ValueType
-    | UnionCase
-    | UnionCaseField
-    | Function
-    | Property
-    | MutableVar
-    | Module
-    | Namespace
-    | Printf
-    | ComputationExpression
-    | IntrinsicFunction
-    | Enumeration
-    | Interface
-    | TypeArgument
-    | Operator
-    | DisposableType
-    | DisposableTopLevelValue
-    | DisposableLocalValue
-    | Method
-    | ExtensionMethod
-    | ConstructorForReferenceType
-    | ConstructorForValueType
-    | Literal
-    | RecordField
-    | MutableRecordField
-    | RecordFieldAsFunction
-    | Exception
-    | Field
-    | Event
-    | Delegate
-    | NamedArgument
-    | Value
-    | LocalValue
-    | Type
-    | TypeDef
-    | Plaintext
+    | ReferenceType = 0
+    | ValueType = 1
+    | UnionCase = 2
+    | UnionCaseField = 3
+    | Function = 4
+    | Property = 5
+    | MutableVar = 6
+    | Module = 7
+    | Namespace = 8
+    | Printf = 9
+    | ComputationExpression = 10
+    | IntrinsicFunction = 11
+    | Enumeration = 12
+    | Interface = 13
+    | TypeArgument = 14
+    | Operator = 15
+    | DisposableType = 16
+    | DisposableTopLevelValue = 17
+    | DisposableLocalValue = 18
+    | Method = 19
+    | ExtensionMethod = 20
+    | ConstructorForReferenceType = 21
+    | ConstructorForValueType = 22
+    | Literal = 23
+    | RecordField = 24
+    | MutableRecordField = 25
+    | RecordFieldAsFunction = 26
+    | Exception = 27
+    | Field = 28
+    | Event = 29
+    | Delegate = 30
+    | NamedArgument = 31
+    | Value = 32
+    | LocalValue = 33
+    | Type = 34
+    | TypeDef = 35
+    | Plaintext = 36
+
+[<RequireQualifiedAccess>]
+[<Struct>]
+type FSharpSemanticClassificationItem =
+    val Range: range
+    val Type: SemanticClassificationType
+    new: (range * SemanticClassificationType) -> FSharpSemanticClassificationItem
 
 /// Extension methods for the TcResolutions type.
 [<AutoOpen>]
@@ -57,4 +64,4 @@ module internal TcResolutionsExtensions =
     val (|CNR|) : cnr: CapturedNameResolution -> (Item * ItemOccurence * DisplayEnv * NameResolutionEnv * AccessorDomain * range)
 
     type TcResolutions with
-        member GetSemanticClassification: g: TcGlobals * amap: ImportMap * formatSpecifierLocations: (range * int) [] * range: range option -> struct(range * SemanticClassificationType) []
+        member GetSemanticClassification: g: TcGlobals * amap: ImportMap * formatSpecifierLocations: (range * int) [] * range: range option -> FSharpSemanticClassificationItem []

--- a/src/fsharp/service/SemanticClassificationKey.fs
+++ b/src/fsharp/service/SemanticClassificationKey.fs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.SourceCodeServices
+
+open System
+open System.IO
+open System.IO.MemoryMappedFiles
+open System.Reflection.Metadata
+open System.Runtime.Serialization.Formatters.Binary
+
+open FSharp.NativeInterop
+open FSharp.Compiler.Text
+open FSharp.Compiler.Text.Pos
+open FSharp.Compiler.Text.Range
+
+#nowarn "9"
+
+[<Sealed>]
+type FSharpSemanticClassificationView(mmf: MemoryMappedFile, length) =
+    member _.ReadRange(reader: byref<BlobReader>) =
+        let startLine = reader.ReadInt32()
+        let startColumn = reader.ReadInt32()
+        let endLine = reader.ReadInt32()
+        let endColumn = reader.ReadInt32()
+        let fileIndex = reader.ReadInt32()
+
+        let posStart = mkPos startLine startColumn
+        let posEnd = mkPos endLine endColumn
+        mkFileIndexRange fileIndex posStart posEnd
+
+    member this.ForEach(f: FSharpSemanticClassificationItem -> unit) =
+        use view = mmf.CreateViewAccessor(0L, length)
+        let mutable reader = BlobReader(view.SafeMemoryMappedViewHandle.DangerousGetHandle() |> NativePtr.ofNativeInt, int length)
+
+        reader.Offset <- 0
+        while reader.Offset < reader.Length do
+            let m = this.ReadRange &reader
+            let sct = reader.ReadInt32()
+            let item = FSharpSemanticClassificationItem((m, (enum<SemanticClassificationType>(sct))))
+            f item
+
+and [<Sealed>] SemanticClassificationKeyStore(mmf: MemoryMappedFile, length) =
+    let mutable isDisposed = false
+    let checkDispose() =
+        if isDisposed then
+            raise (ObjectDisposedException("SemanticClassificationKeyStore"))
+
+    member _.GetView() =
+        checkDispose()
+        FSharpSemanticClassificationView(mmf, length)
+
+    interface IDisposable with
+
+            member _.Dispose() =
+                isDisposed <- true
+                mmf.Dispose()
+
+and [<Sealed>] SemanticClassificationKeyStoreBuilder() =
+
+    let b = BlobBuilder()
+
+    member _.WriteAll (semanticClassification: FSharpSemanticClassificationItem[]) =
+        use ptr = fixed semanticClassification
+        b.WriteBytes(NativePtr.ofNativeInt (NativePtr.toNativeInt ptr), semanticClassification.Length * sizeof<FSharpSemanticClassificationItem>)
+
+    member _.TryBuildAndReset() =
+        if b.Count > 0 then
+            let length = int64 b.Count
+            let mmf = 
+                let mmf =
+                    MemoryMappedFile.CreateNew(
+                        null, 
+                        length, 
+                        MemoryMappedFileAccess.ReadWrite, 
+                        MemoryMappedFileOptions.None, 
+                        HandleInheritability.None)
+                use stream = mmf.CreateViewStream(0L, length, MemoryMappedFileAccess.ReadWrite)
+                b.WriteContentTo stream
+                mmf
+
+            b.Clear()
+
+            Some(new SemanticClassificationKeyStore(mmf, length))       
+        else
+            b.Clear()
+            None

--- a/src/fsharp/service/SemanticClassificationKey.fsi
+++ b/src/fsharp/service/SemanticClassificationKey.fsi
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.SourceCodeServices
+
+open System
+
+open FSharp.Compiler.Text
+
+/// Provides a read only view to iterate over the semantic classification contents.
+[<Sealed>]
+type FSharpSemanticClassificationView =
+
+    /// Iterate through the stored FSharpSemanticClassificationItem entries from the store and apply the passed function on each entry.
+    member ForEach: (FSharpSemanticClassificationItem -> unit) -> unit
+
+/// Stores a list of semantic classification key strings and their ranges in a memory mapped file.
+/// Provides a view to iterate over the contents of the file.
+[<Sealed>]
+type internal SemanticClassificationKeyStore =
+    interface IDisposable
+
+    /// Get a read only view on the semantic classification key store
+    member GetView: unit -> FSharpSemanticClassificationView
+
+
+/// A builder that will build an semantic classification key store based on the written Item and its associated range.
+[<Sealed>]
+type internal SemanticClassificationKeyStoreBuilder =
+
+    new: unit -> SemanticClassificationKeyStoreBuilder
+
+    member WriteAll: FSharpSemanticClassificationItem[] -> unit
+
+    member TryBuildAndReset: unit -> SemanticClassificationKeyStore option

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -785,10 +785,13 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
             cancellable {
                 let! builderOpt, _ = getOrCreateBuilder (ctok, options, userOpName)
                 match builderOpt with
-                | None -> return [||]
+                | None -> return None
                 | Some builder -> 
                     let! checkResults = builder.GetFullCheckResultsAfterFileInProject (ctok, filename)
-                    return checkResults.GetSemanticClassification ctok })
+                    let scopt = checkResults.GetSemanticClassification ctok 
+                    match scopt with
+                    | None -> return None
+                    | Some sc -> return Some (sc.GetView ()) })
 
     /// Try to get recent approximate type check results for a file. 
     member _.TryGetRecentCheckResultsForFile(filename: string, options:FSharpProjectOptions, sourceText: ISourceText option, _userOpName: string) =

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -312,7 +312,7 @@ type public FSharpChecker =
     /// <param name="filename">The filename for the file.</param>
     /// <param name="options">The options for the project or script, used to determine active --define conditionals and other options relevant to parsing.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetBackgroundSemanticClassificationForFile: filename: string * options: FSharpProjectOptions * ?userOpName: string -> Async<struct(range * SemanticClassificationType) []>
+    member GetBackgroundSemanticClassificationForFile : filename : string * options : FSharpProjectOptions * ?userOpName: string -> Async<FSharpSemanticClassificationView option>
 
     /// <summary>
     /// Compile using the given flags.  Source files names are resolved via the FileSystem API.

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -70,7 +70,7 @@
     <Compile Include="..\service\ParserTests.fs">
       <Link>ParserTests.fs</Link>
     </Compile>
-    <Compile Include="..\service\Program.fs">
+	<Compile Include="..\service\Program.fs">
       <Link>Program.fs</Link>
     </Compile>
   </ItemGroup>

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -2069,7 +2069,7 @@ FSharp.Compiler.SourceCodeServices.FSharpCheckFileResults: System.String ToStrin
 FSharp.Compiler.SourceCodeServices.FSharpCheckFileResults: System.String[] DependencyFiles
 FSharp.Compiler.SourceCodeServices.FSharpCheckFileResults: System.String[] get_DependencyFiles()
 FSharp.Compiler.SourceCodeServices.FSharpCheckFileResults: System.Tuple`2[FSharp.Compiler.Text.Range,System.Int32][] GetFormatSpecifierLocationsAndArity()
-FSharp.Compiler.SourceCodeServices.FSharpCheckFileResults: System.ValueTuple`2[FSharp.Compiler.Text.Range,FSharp.Compiler.SourceCodeServices.SemanticClassificationType][] GetSemanticClassification(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SourceCodeServices.FSharpCheckFileResults: FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem[] GetSemanticClassification(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
 FSharp.Compiler.SourceCodeServices.FSharpCheckProjectResults
 FSharp.Compiler.SourceCodeServices.FSharpCheckProjectResults: Boolean HasCriticalErrors
 FSharp.Compiler.SourceCodeServices.FSharpCheckProjectResults: Boolean get_HasCriticalErrors()
@@ -2112,6 +2112,7 @@ FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FShar
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[FSharp.Compiler.SourceCodeServices.FSharpParseFileResults] ParseFileInProject(System.String, System.String, FSharp.Compiler.SourceCodeServices.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[FSharp.Compiler.SourceCodeServices.FSharpParseFileResults] ParseFileNoCache(System.String, FSharp.Compiler.Text.ISourceText, FSharp.Compiler.SourceCodeServices.FSharpParsingOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SourceCodeServices.FSharpCheckFileAnswer]] CheckFileInProjectAllowingStaleCachedResults(FSharp.Compiler.SourceCodeServices.FSharpParseFileResults, System.String, Int32, System.String, FSharp.Compiler.SourceCodeServices.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
+FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationView]] GetBackgroundSemanticClassificationForFile(System.String, FSharp.Compiler.SourceCodeServices.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.Unit] NotifyProjectCleaned(FSharp.Compiler.SourceCodeServices.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[System.Collections.Generic.IEnumerable`1[FSharp.Compiler.Text.Range]] FindBackgroundReferencesInFile(System.String, FSharp.Compiler.SourceCodeServices.FSharpProjectOptions, FSharp.Compiler.SourceCodeServices.FSharpSymbol, Microsoft.FSharp.Core.FSharpOption`1[System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[System.Tuple`2[FSharp.Compiler.SourceCodeServices.FSharpDiagnostic[],System.Int32]] Compile(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTree+ParsedInput], System.String, System.String, Microsoft.FSharp.Collections.FSharpList`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[System.String])
@@ -2123,7 +2124,6 @@ FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FShar
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[System.Tuple`2[FSharp.Compiler.Text.Range,FSharp.Compiler.Text.Range][]] MatchBraces(System.String, System.String, FSharp.Compiler.SourceCodeServices.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[System.Tuple`3[FSharp.Compiler.SourceCodeServices.FSharpDiagnostic[],System.Int32,Microsoft.FSharp.Core.FSharpOption`1[System.Reflection.Assembly]]] CompileToDynamicAssembly(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTree+ParsedInput], System.String, Microsoft.FSharp.Collections.FSharpList`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[System.IO.TextWriter,System.IO.TextWriter]], Microsoft.FSharp.Core.FSharpOption`1[System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[System.Tuple`3[FSharp.Compiler.SourceCodeServices.FSharpDiagnostic[],System.Int32,Microsoft.FSharp.Core.FSharpOption`1[System.Reflection.Assembly]]] CompileToDynamicAssembly(System.String[], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[System.IO.TextWriter,System.IO.TextWriter]], Microsoft.FSharp.Core.FSharpOption`1[System.String])
-FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[System.ValueTuple`2[FSharp.Compiler.Text.Range,FSharp.Compiler.SourceCodeServices.SemanticClassificationType][]] GetBackgroundSemanticClassificationForFile(System.String, FSharp.Compiler.SourceCodeServices.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.IEvent`2[Microsoft.FSharp.Control.FSharpHandler`1[Microsoft.FSharp.Core.Unit],Microsoft.FSharp.Core.Unit] MaxMemoryReached
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.IEvent`2[Microsoft.FSharp.Control.FSharpHandler`1[Microsoft.FSharp.Core.Unit],Microsoft.FSharp.Core.Unit] get_MaxMemoryReached()
 FSharp.Compiler.SourceCodeServices.FSharpChecker: Microsoft.FSharp.Control.IEvent`2[Microsoft.FSharp.Control.FSharpHandler`1[System.Tuple`2[System.String,Microsoft.FSharp.Core.FSharpOption`1[System.Object]]],System.Tuple`2[System.String,Microsoft.FSharp.Core.FSharpOption`1[System.Object]]] BeforeBackgroundFileCheck
@@ -3422,6 +3422,19 @@ FSharp.Compiler.SourceCodeServices.FSharpProjectOptions: System.String[] get_Sou
 FSharp.Compiler.SourceCodeServices.FSharpProjectOptions: System.Tuple`2[System.String,FSharp.Compiler.SourceCodeServices.FSharpProjectOptions][] ReferencedProjects
 FSharp.Compiler.SourceCodeServices.FSharpProjectOptions: System.Tuple`2[System.String,FSharp.Compiler.SourceCodeServices.FSharpProjectOptions][] get_ReferencedProjects()
 FSharp.Compiler.SourceCodeServices.FSharpProjectOptions: Void .ctor(System.String, Microsoft.FSharp.Core.FSharpOption`1[System.String], System.String[], System.String[], System.Tuple`2[System.String,FSharp.Compiler.SourceCodeServices.FSharpProjectOptions][], Boolean, Boolean, System.DateTime, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SourceCodeServices.FSharpUnresolvedReferencesSet], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Text.Range,System.String,System.String]], Microsoft.FSharp.Core.FSharpOption`1[System.Object], Microsoft.FSharp.Core.FSharpOption`1[System.Int64])
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: Boolean Equals(FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem)
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: Boolean Equals(System.Object)
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: FSharp.Compiler.SourceCodeServices.SemanticClassificationType Type
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Type()
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: Int32 GetHashCode()
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: Int32 GetHashCode(System.Collections.IEqualityComparer)
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem: Void .ctor(System.Tuple`2[FSharp.Compiler.Text.Range,FSharp.Compiler.SourceCodeServices.SemanticClassificationType])
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationView
+FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationView: Void ForEach(Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.SourceCodeServices.FSharpSemanticClassificationItem,Microsoft.FSharp.Core.Unit])
 FSharp.Compiler.SourceCodeServices.FSharpSourceTokenizer
 FSharp.Compiler.SourceCodeServices.FSharpSourceTokenizer: FSharp.Compiler.SourceCodeServices.FSharpLineTokenizer CreateBufferTokenizer(Microsoft.FSharp.Core.FSharpFunc`2[System.Tuple`3[System.Char[],System.Int32,System.Int32],System.Int32])
 FSharp.Compiler.SourceCodeServices.FSharpSourceTokenizer: FSharp.Compiler.SourceCodeServices.FSharpLineTokenizer CreateLineTokenizer(System.String)
@@ -5365,121 +5378,8 @@ FSharp.Compiler.SourceCodeServices.ScopeKind: Int32 GetHashCode(System.Collectio
 FSharp.Compiler.SourceCodeServices.ScopeKind: Int32 Tag
 FSharp.Compiler.SourceCodeServices.ScopeKind: Int32 get_Tag()
 FSharp.Compiler.SourceCodeServices.ScopeKind: System.String ToString()
+FSharp.Compiler.SourceCodeServices.SimplifyNames
 FSharp.Compiler.SourceCodeServices.SemanticClassificationType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 ComputationExpression
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 ConstructorForReferenceType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 ConstructorForValueType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Delegate
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 DisposableLocalValue
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 DisposableTopLevelValue
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 DisposableType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Enumeration
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Event
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Exception
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 ExtensionMethod
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Field
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Function
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Interface
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 IntrinsicFunction
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Literal
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 LocalValue
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Method
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Module
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 MutableRecordField
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 MutableVar
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 NamedArgument
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Namespace
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Operator
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Plaintext
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Printf
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Property
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 RecordField
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 RecordFieldAsFunction
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 ReferenceType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Type
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 TypeArgument
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 TypeDef
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 UnionCase
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 UnionCaseField
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 Value
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags: Int32 ValueType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean Equals(FSharp.Compiler.SourceCodeServices.SemanticClassificationType)
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean Equals(System.Object)
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsComputationExpression
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsConstructorForReferenceType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsConstructorForValueType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsDelegate
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsDisposableLocalValue
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsDisposableTopLevelValue
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsDisposableType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsEnumeration
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsEvent
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsException
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsExtensionMethod
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsField
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsFunction
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsInterface
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsIntrinsicFunction
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsLiteral
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsLocalValue
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsMethod
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsModule
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsMutableRecordField
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsMutableVar
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsNamedArgument
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsNamespace
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsOperator
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsPlaintext
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsPrintf
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsProperty
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsRecordField
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsRecordFieldAsFunction
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsReferenceType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsTypeArgument
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsTypeDef
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsUnionCase
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsUnionCaseField
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsValue
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean IsValueType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsComputationExpression()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsConstructorForReferenceType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsConstructorForValueType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsDelegate()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsDisposableLocalValue()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsDisposableTopLevelValue()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsDisposableType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsEnumeration()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsEvent()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsException()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsExtensionMethod()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsField()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsFunction()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsInterface()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsIntrinsicFunction()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsLiteral()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsLocalValue()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsMethod()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsModule()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsMutableRecordField()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsMutableVar()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsNamedArgument()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsNamespace()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsOperator()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsPlaintext()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsPrintf()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsProperty()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsRecordField()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsRecordFieldAsFunction()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsReferenceType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsTypeArgument()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsTypeDef()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsUnionCase()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsUnionCaseField()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsValue()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Boolean get_IsValueType()
 FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType ComputationExpression
 FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType ConstructorForReferenceType
 FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType ConstructorForValueType
@@ -5517,53 +5417,7 @@ FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.S
 FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType UnionCaseField
 FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType Value
 FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType ValueType
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_ComputationExpression()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_ConstructorForReferenceType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_ConstructorForValueType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Delegate()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_DisposableLocalValue()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_DisposableTopLevelValue()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_DisposableType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Enumeration()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Event()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Exception()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_ExtensionMethod()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Field()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Function()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Interface()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_IntrinsicFunction()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Literal()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_LocalValue()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Method()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Module()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_MutableRecordField()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_MutableVar()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_NamedArgument()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Namespace()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Operator()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Plaintext()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Printf()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Property()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_RecordField()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_RecordFieldAsFunction()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_ReferenceType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Type()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_TypeArgument()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_TypeDef()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_UnionCase()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_UnionCaseField()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_Value()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType get_ValueType()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: FSharp.Compiler.SourceCodeServices.SemanticClassificationType+Tags
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Int32 CompareTo(FSharp.Compiler.SourceCodeServices.SemanticClassificationType)
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Int32 CompareTo(System.Object)
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Int32 CompareTo(System.Object, System.Collections.IComparer)
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Int32 GetHashCode()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Int32 GetHashCode(System.Collections.IEqualityComparer)
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Int32 Tag
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Int32 get_Tag()
-FSharp.Compiler.SourceCodeServices.SemanticClassificationType: System.String ToString()
-FSharp.Compiler.SourceCodeServices.SimplifyNames
+FSharp.Compiler.SourceCodeServices.SemanticClassificationType: Int32 value__
 FSharp.Compiler.SourceCodeServices.SimplifyNames+SimplifiableRange: Boolean Equals(SimplifiableRange)
 FSharp.Compiler.SourceCodeServices.SimplifyNames+SimplifiableRange: Boolean Equals(System.Object)
 FSharp.Compiler.SourceCodeServices.SimplifyNames+SimplifiableRange: Boolean Equals(System.Object, System.Collections.IEqualityComparer)

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -66,6 +66,7 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.DisposableLocalValue
         | SemanticClassificationType.LocalValue -> ClassificationTypeNames.LocalName
         | SemanticClassificationType.Plaintext -> ClassificationTypeNames.Text
+        | _ -> failwith "Compiler Bug: Unknown classification type"
 
 module internal ClassificationDefinitions =
 

--- a/vsintegration/src/FSharp.LanguageService/Colorize.fs
+++ b/vsintegration/src/FSharp.LanguageService/Colorize.fs
@@ -86,7 +86,7 @@ module internal ColorStateLookup_DEPRECATED =
 type internal FSharpScanner_DEPRECATED(makeLineTokenizer : string -> FSharpLineTokenizer) =
     let mutable lineTokenizer = makeLineTokenizer ""
 
-    let mutable extraColorizations : IDictionary<Line0, struct (range * SemanticClassificationType)[] > option = None
+    let mutable extraColorizations : IDictionary<Line0, FSharpSemanticClassificationItem[] > option = None
 
     /// Decode compiler FSharpTokenColorKind into VS TokenColor.
     let lookupTokenColor colorKind =
@@ -147,11 +147,11 @@ type internal FSharpScanner_DEPRECATED(makeLineTokenizer : string -> FSharpLineT
         lineTokenizer <- makeLineTokenizer lineText
 
     /// Adjust the set of extra colorizations and return a sorted list of affected lines.
-    member _.SetExtraColorizations (tokens: struct (range * SemanticClassificationType)[]) =
+    member _.SetExtraColorizations (tokens: FSharpSemanticClassificationItem[]) =
         if tokens.Length = 0 && extraColorizations.IsNone then
             [| |]
         else
-            let newExtraColorizationsKeyed = dict (tokens |> Array.groupBy (fun struct (r, _) -> Line.toZ r.StartLine))
+            let newExtraColorizationsKeyed = dict (tokens |> Array.groupBy (fun item -> Line.toZ item.Range.StartLine))
             let oldExtraColorizationsKeyedOpt = extraColorizations
             extraColorizations <- Some newExtraColorizationsKeyed
             let changedLines =

--- a/vsintegration/tests/UnitTests/SemanticColorizationServiceTests.fs
+++ b/vsintegration/tests/UnitTests/SemanticColorizationServiceTests.fs
@@ -31,7 +31,7 @@ type SemanticClassificationServiceTests() =
     let checker = FSharpChecker.Create()
     let perfOptions = { LanguageServicePerformanceOptions.Default with AllowStaleCompletionResults = false }
 
-    let getRanges (source: string) : struct (range * SemanticClassificationType) list =
+    let getRanges (source: string) : FSharpSemanticClassificationItem list =
         asyncMaybe {
 
             let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, 0, SourceText.From(source), projectOptions, perfOptions, "")
@@ -46,16 +46,16 @@ type SemanticClassificationServiceTests() =
         let ranges = getRanges fileContents
         let line = text.Lines.GetLinePosition (fileContents.IndexOf(marker) + marker.Length - 1)
         let markerPos = Pos.mkPos (Line.fromZ line.Line) (line.Character + marker.Length - 1)
-        match ranges |> List.tryFind (fun struct (range, _) -> Range.rangeContainsPos range markerPos) with
+        match ranges |> List.tryFind (fun item -> Range.rangeContainsPos item.Range markerPos) with
         | None -> Assert.Fail("Cannot find colorization data for end of marker")
-        | Some(_, ty) -> Assert.AreEqual(classificationType, FSharpClassificationTypes.getClassificationTypeName ty, "Classification data doesn't match for end of marker")
+        | Some item -> Assert.AreEqual(classificationType, FSharpClassificationTypes.getClassificationTypeName item.Type, "Classification data doesn't match for end of marker")
 
     let verifyNoClassificationDataAtEndOfMarker(fileContents: string, marker: string, classificationType: string) =
         let text = SourceText.From(fileContents)
         let ranges = getRanges fileContents
         let line = text.Lines.GetLinePosition (fileContents.IndexOf(marker) + marker.Length - 1)
         let markerPos = Pos.mkPos (Line.fromZ line.Line) (line.Character + marker.Length - 1)
-        let anyData = ranges |> List.exists (fun struct (range, sct) -> Range.rangeContainsPos range markerPos && ((FSharpClassificationTypes.getClassificationTypeName sct) = classificationType))
+        let anyData = ranges |> List.exists (fun item -> Range.rangeContainsPos item.Range markerPos && ((FSharpClassificationTypes.getClassificationTypeName item.Type) = classificationType))
         Assert.False(anyData, "Classification data was found when it wasn't expected.")
 
     [<TestCase("(*1*)", ClassificationTypeNames.StructName)>]


### PR DESCRIPTION
Fixes #10212

This PR introduces the `SemanticClassificationKeyStore` which stores the semantic classification results in a memory-mapped file similar to `ItemKeyStore`.

TODO
- [ ] Test and compare memory consumption before and after

cc: @TIHan 