### PR TITLE
split driver into logical parts

### DIFF
--- a/src/fsharp/BinaryResourceFormats.fs
+++ b/src/fsharp/BinaryResourceFormats.fs
@@ -1,0 +1,232 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module internal FSharp.Compiler.BinaryResourceFormats 
+
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.Internal
+
+// Helpers for generating binary blobs
+module BinaryGenerationUtilities = 
+    // Little-endian encoding of int32 
+    let b0 n =  byte (n &&& 0xFF)
+    let b1 n =  byte ((n >>> 8) &&& 0xFF)
+    let b2 n =  byte ((n >>> 16) &&& 0xFF)
+    let b3 n =  byte ((n >>> 24) &&& 0xFF)
+
+    let i16 (i: int32) = [| b0 i; b1 i |]
+    let i32 (i: int32) = [| b0 i; b1 i; b2 i; b3 i |]
+
+    // Emit the bytes and pad to a 32-bit alignment
+    let Padded initialAlignment (v: byte[]) = 
+        [| yield! v
+           for _ in 1..(4 - (initialAlignment + v.Length) % 4) % 4 do
+               yield 0x0uy |]
+
+// Generate nodes in a .res file format. These are then linked by Abstract IL using linkNativeResources
+module ResFileFormat =
+    open BinaryGenerationUtilities
+
+    let ResFileNode(dwTypeID, dwNameID, wMemFlags, wLangID, data: byte[]) =
+        [| yield! i32 data.Length  // DWORD ResHdr.dwDataSize
+           yield! i32 0x00000020  // dwHeaderSize
+           yield! i32 ((dwTypeID <<< 16) ||| 0x0000FFFF)  // dwTypeID, sizeof(DWORD)
+           yield! i32 ((dwNameID <<< 16) ||| 0x0000FFFF)   // dwNameID, sizeof(DWORD)
+           yield! i32 0x00000000 // DWORD       dwDataVersion
+           yield! i16 wMemFlags // WORD        wMemFlags
+           yield! i16 wLangID   // WORD        wLangID
+           yield! i32 0x00000000 // DWORD       dwVersion
+           yield! i32 0x00000000 // DWORD       dwCharacteristics
+           yield! Padded 0 data |]
+
+    let ResFileHeader() = ResFileNode(0x0, 0x0, 0x0, 0x0, [| |]) 
+
+// Generate the VS_VERSION_INFO structure held in a Win32 Version Resource in a PE file
+//
+// Web reference: http://www.piclist.com/tecHREF/os/win/api/win32/struc/src/str24_5.htm
+module VersionResourceFormat = 
+    open BinaryGenerationUtilities
+
+    let VersionInfoNode(data: byte[]) =
+        [| yield! i16 (data.Length + 2) // wLength : int16 // Specifies the length, in bytes, of the VS_VERSION_INFO structure. 
+           yield! data |]
+
+    let VersionInfoElement(wType, szKey, valueOpt: byte[] option, children: byte[][], isString) =
+        // for String structs, wValueLength represents the word count, not the byte count
+        let wValueLength = (match valueOpt with None -> 0 | Some value -> (if isString then value.Length / 2 else value.Length))
+        VersionInfoNode
+            [| yield! i16 wValueLength // wValueLength: int16. Specifies the length, in words, of the Value member. 
+               yield! i16 wType        // wType : int16 Specifies the type of data in the version resource. 
+               yield! Padded 2 szKey 
+               match valueOpt with 
+               | None -> yield! []
+               | Some value -> yield! Padded 0 value 
+               for child in children do 
+                   yield! child  |]
+
+    let Version(version: ILVersionInfo) = 
+        [| // DWORD dwFileVersionMS
+           // Specifies the most significant 32 bits of the file's binary 
+           // version number. This member is used with dwFileVersionLS to form a 64-bit value used 
+           // for numeric comparisons. 
+           yield! i32 (int32 version.Major <<< 16 ||| int32 version.Minor) 
+           
+           // DWORD dwFileVersionLS 
+           // Specifies the least significant 32 bits of the file's binary 
+           // version number. This member is used with dwFileVersionMS to form a 64-bit value used 
+           // for numeric comparisons. 
+           yield! i32 (int32 version.Build <<< 16 ||| int32 version.Revision) 
+        |]
+
+    let String(string, value) = 
+        let wType = 0x1 // Specifies the type of data in the version resource. 
+        let szKey = Bytes.stringAsUnicodeNullTerminated string
+        VersionInfoElement(wType, szKey, Some (Bytes.stringAsUnicodeNullTerminated value), [| |], true)
+
+    let StringTable(language, strings) = 
+        let wType = 0x1 // Specifies the type of data in the version resource. 
+        let szKey = Bytes.stringAsUnicodeNullTerminated language
+             // Specifies an 8-digit hexadecimal number stored as a Unicode string. 
+                       
+        let children =  
+            [| for string in strings do
+                   yield String string |] 
+        VersionInfoElement(wType, szKey, None, children, false)
+
+    let StringFileInfo(stringTables: #seq<string * #seq<string * string> >) = 
+        let wType = 0x1 // Specifies the type of data in the version resource. 
+        let szKey = Bytes.stringAsUnicodeNullTerminated "StringFileInfo" // Contains the Unicode string StringFileInfo
+        // Contains an array of one or more StringTable structures. 
+        let children =  
+            [| for stringTable in stringTables do
+                   yield StringTable stringTable |] 
+        VersionInfoElement(wType, szKey, None, children, false)
+
+    let VarFileInfo(vars: #seq<int32 * int32>) = 
+        let wType = 0x1 // Specifies the type of data in the version resource. 
+        let szKey = Bytes.stringAsUnicodeNullTerminated "VarFileInfo" // Contains the Unicode string StringFileInfo
+        // Contains an array of one or more StringTable structures. 
+        let children =  
+            [| for (lang, codePage) in vars do
+                   let szKey = Bytes.stringAsUnicodeNullTerminated "Translation"
+                   yield VersionInfoElement(0x0, szKey, Some([| yield! i16 lang
+                                                                yield! i16 codePage |]), [| |], false) |] 
+        VersionInfoElement(wType, szKey, None, children, false)
+
+    let VS_FIXEDFILEINFO(fileVersion: ILVersionInfo, 
+                         productVersion: ILVersionInfo, 
+                         dwFileFlagsMask, 
+                         dwFileFlags, dwFileOS, 
+                         dwFileType, dwFileSubtype, 
+                         lwFileDate: int64) = 
+        let dwStrucVersion = 0x00010000
+        [| // DWORD dwSignature // Contains the value 0xFEEFO4BD. 
+           yield! i32  0xFEEF04BD 
+           
+           // DWORD dwStrucVersion // Specifies the binary version number of this structure. 
+           yield! i32 dwStrucVersion 
+           
+           // DWORD dwFileVersionMS, dwFileVersionLS // Specifies the most/least significant 32 bits of the file's binary version number. 
+           yield! Version fileVersion 
+           
+           // DWORD dwProductVersionMS, dwProductVersionLS // Specifies the most/least significant 32 bits of the file's binary version number. 
+           yield! Version productVersion 
+           
+           // DWORD dwFileFlagsMask // Contains a bitmask that specifies the valid bits in dwFileFlags. 
+           yield! i32 dwFileFlagsMask 
+           
+           // DWORD dwFileFlags // Contains a bitmask that specifies the Boolean attributes of the file. 
+           yield! i32 dwFileFlags 
+                  // VS_FF_DEBUG 0x1L     The file contains debugging information or is compiled with debugging features enabled. 
+                  // VS_FF_INFOINFERRED   The file's version structure was created dynamically; therefore, some of the members 
+                  //                      in this structure may be empty or incorrect. This flag should never be set in a file's 
+                  //                      VS_VERSION_INFO data. 
+                  // VS_FF_PATCHED        The file has been modified and is not identical to the original shipping file of 
+                  //                      the same version number. 
+                  // VS_FF_PRERELEASE     The file is a development version, not a commercially released product. 
+                  // VS_FF_PRIVATEBUILD   The file was not built using standard release procedures. If this flag is 
+                  //                      set, the StringFileInfo structure should contain a PrivateBuild entry. 
+                  // VS_FF_SPECIALBUILD   The file was built by the original company using standard release procedures 
+                  //                      but is a variation of the normal file of the same version number. If this 
+                  //                      flag is set, the StringFileInfo structure should contain a SpecialBuild entry. 
+           
+           //Specifies the operating system for which this file was designed. This member can be one of the following values: Flag 
+           yield! i32 dwFileOS 
+                  //VOS_DOS 0x0001L  The file was designed for MS-DOS. 
+                  //VOS_NT  0x0004L  The file was designed for Windows NT. 
+                  //VOS__WINDOWS16  The file was designed for 16-bit Windows. 
+                  //VOS__WINDOWS32  The file was designed for the Win32 API. 
+                  //VOS_OS216 0x00020000L  The file was designed for 16-bit OS/2. 
+                  //VOS_OS232  0x00030000L  The file was designed for 32-bit OS/2. 
+                  //VOS__PM16  The file was designed for 16-bit Presentation Manager. 
+                  //VOS__PM32  The file was designed for 32-bit Presentation Manager. 
+                  //VOS_UNKNOWN  The operating system for which the file was designed is unknown to Windows. 
+           
+           // Specifies the general type of file. This member can be one of the following values: 
+           yield! i32 dwFileType 
+           
+                //VFT_UNKNOWN The file type is unknown to Windows. 
+                //VFT_APP  The file contains an application. 
+                //VFT_DLL  The file contains a dynamic-link library (DLL). 
+                //VFT_DRV  The file contains a device driver. If dwFileType is VFT_DRV, dwFileSubtype contains a more specific description of the driver. 
+                //VFT_FONT  The file contains a font. If dwFileType is VFT_FONT, dwFileSubtype contains a more specific description of the font file. 
+                //VFT_VXD  The file contains a virtual device. 
+                //VFT_STATIC_LIB  The file contains a static-link library. 
+
+           // Specifies the function of the file. The possible values depend on the value of 
+           // dwFileType. For all values of dwFileType not described in the following list, 
+           // dwFileSubtype is zero. If dwFileType is VFT_DRV, dwFileSubtype can be one of the following values: 
+           yield! i32 dwFileSubtype 
+                //VFT2_UNKNOWN  The driver type is unknown by Windows. 
+                //VFT2_DRV_COMM  The file contains a communications driver. 
+                //VFT2_DRV_PRINTER  The file contains a printer driver. 
+                //VFT2_DRV_KEYBOARD  The file contains a keyboard driver. 
+                //VFT2_DRV_LANGUAGE  The file contains a language driver. 
+                //VFT2_DRV_DISPLAY  The file contains a display driver. 
+                //VFT2_DRV_MOUSE  The file contains a mouse driver. 
+                //VFT2_DRV_NETWORK  The file contains a network driver. 
+                //VFT2_DRV_SYSTEM  The file contains a system driver. 
+                //VFT2_DRV_INSTALLABLE  The file contains an installable driver. 
+                //VFT2_DRV_SOUND  The file contains a sound driver. 
+                //
+                //If dwFileType is VFT_FONT, dwFileSubtype can be one of the following values: 
+                // 
+                //VFT2_UNKNOWN  The font type is unknown by Windows. 
+                //VFT2_FONT_RASTER  The file contains a raster font. 
+                //VFT2_FONT_VECTOR  The file contains a vector font. 
+                //VFT2_FONT_TRUETYPE  The file contains a TrueType font. 
+                //
+                //If dwFileType is VFT_VXD, dwFileSubtype contains the virtual device identifier included in the virtual device control block. 
+           
+           // Specifies the most significant 32 bits of the file's 64-bit binary creation date and time stamp. 
+           yield! i32 (int32 (lwFileDate >>> 32)) 
+           
+           //Specifies the least significant 32 bits of the file's 64-bit binary creation date and time stamp. 
+           yield! i32 (int32 lwFileDate) 
+         |] 
+
+    let VS_VERSION_INFO(fixedFileInfo, stringFileInfo, varFileInfo)  =
+        let wType = 0x0 
+        let szKey = Bytes.stringAsUnicodeNullTerminated "VS_VERSION_INFO" // Contains the Unicode string VS_VERSION_INFO
+        let value = VS_FIXEDFILEINFO (fixedFileInfo)
+        let children =  
+            [| yield StringFileInfo stringFileInfo 
+               yield VarFileInfo varFileInfo 
+            |] 
+        VersionInfoElement(wType, szKey, Some value, children, false)
+       
+    let VS_VERSION_INFO_RESOURCE data = 
+        let dwTypeID = 0x0010
+        let dwNameID = 0x0001
+        let wMemFlags = 0x0030 // REVIEW: HARDWIRED TO ENGLISH
+        let wLangID = 0x0
+        ResFileFormat.ResFileNode(dwTypeID, dwNameID, wMemFlags, wLangID, VS_VERSION_INFO data)
+        
+module ManifestResourceFormat =
+    
+    let VS_MANIFEST_RESOURCE(data, isLibrary) =
+        let dwTypeID = 0x0018
+        let dwNameID = if isLibrary then 0x2 else 0x1
+        let wMemFlags = 0x0
+        let wLangID = 0x0
+        ResFileFormat.ResFileNode(dwTypeID, dwNameID, wMemFlags, wLangID, data)
+

--- a/src/fsharp/BinaryResourceFormats.fsi
+++ b/src/fsharp/BinaryResourceFormats.fsi
@@ -3,7 +3,6 @@
 module internal FSharp.Compiler.BinaryResourceFormats 
 
 open FSharp.Compiler.AbstractIL.IL
-open FSharp.Compiler.AbstractIL.Internal
 
 module VersionResourceFormat = 
 

--- a/src/fsharp/BinaryResourceFormats.fsi
+++ b/src/fsharp/BinaryResourceFormats.fsi
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module internal FSharp.Compiler.BinaryResourceFormats 
+
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.Internal
+
+module VersionResourceFormat = 
+
+    val VS_VERSION_INFO_RESOURCE: 
+        (ILVersionInfo * ILVersionInfo * int32 * int32 * int32 * int32 * int32 * int64) *
+        seq<string * #seq<string * string>> *
+        seq<int32 * int32>
+          -> byte[]
+        
+module ManifestResourceFormat =
+    
+    val VS_MANIFEST_RESOURCE : data: byte[] * isLibrary: bool -> byte[]
+
+module ResFileFormat =
+
+    val ResFileHeader: unit -> byte[]

--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -1159,6 +1159,12 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
         with _ ->
             false
 
+    member tcConfig.GenerateSignatureData = 
+        not tcConfig.standalone && not tcConfig.noSignatureData 
+
+    member tcConfig.GenerateOptimizationData = 
+        tcConfig.GenerateSignatureData
+
 /// Represents a computation to return a TcConfig. Normally this is just a constant immutable TcConfig, 
 /// but for F# Interactive it may be based on an underlying mutable TcConfigBuilder.
 type TcConfigProvider = 

--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -486,6 +486,12 @@ type TcConfig =
     /// Allow forking and subsuequent modification of the TcConfig via a new TcConfigBuilder
     member CloneToBuilder: unit -> TcConfigBuilder
 
+    /// Indicates if the compilation will result in F# signature data resource in the generated binary
+    member GenerateSignatureData: bool 
+
+    /// Indicates if the compilation will result in an F# optimization data resource in the generated binary
+    member GenerateOptimizationData: bool
+
 /// Represents a computation to return a TcConfig. Normally this is just a constant immutable TcConfig,
 /// but for F# Interactive it may be based on an underlying mutable TcConfigBuilder.
 [<Sealed>]

--- a/src/fsharp/CreateILModule.fs
+++ b/src/fsharp/CreateILModule.fs
@@ -1,0 +1,521 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module internal FSharp.Compiler.CreateILModule 
+
+open System
+open System.Collections.Generic
+open System.Diagnostics
+open System.Globalization
+open System.IO
+open System.Reflection
+open System.Text
+open System.Threading
+
+open Internal.Utilities
+open Internal.Utilities.Collections
+open Internal.Utilities.Filename
+open Internal.Utilities.StructuredFormat
+
+open FSharp.Compiler
+open FSharp.Compiler.AbstractIL
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.ILBinaryReader
+open FSharp.Compiler.AbstractIL.Internal
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.Internal.Utils
+open FSharp.Compiler.AbstractIL.Diagnostics
+open FSharp.Compiler.AccessibilityLogic
+open FSharp.Compiler.BinaryResourceFormats
+open FSharp.Compiler.CheckExpressions
+open FSharp.Compiler.CheckDeclarations
+open FSharp.Compiler.CompilerConfig
+open FSharp.Compiler.CompilerDiagnostics
+open FSharp.Compiler.CompilerImports
+open FSharp.Compiler.CompilerOptions
+open FSharp.Compiler.CompilerGlobalState
+open FSharp.Compiler.ErrorLogger
+open FSharp.Compiler.IlxGen
+open FSharp.Compiler.InfoReader
+open FSharp.Compiler.Lib
+open FSharp.Compiler.ParseAndCheckInputs
+open FSharp.Compiler.PrettyNaming
+open FSharp.Compiler.OptimizeInputs
+open FSharp.Compiler.ScriptClosure
+open FSharp.Compiler.SyntaxTree
+open FSharp.Compiler.Range
+open FSharp.Compiler.TypedTree
+open FSharp.Compiler.TypedTreeBasics
+open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.TcGlobals
+open FSharp.Compiler.XmlDocFileWriter
+open FSharp.Compiler.StaticLinking
+open Microsoft.DotNet.DependencyManager
+
+open FSharp.Compiler.AbstractIL.Internal.StrongNameSign
+
+#if !NO_EXTENSIONTYPING
+open FSharp.Compiler.ExtensionTyping
+#endif
+
+//----------------------------------------------------------------------------
+// Helpers for finding attributes
+//----------------------------------------------------------------------------
+
+module AttributeHelpers = 
+
+    /// Try to find an attribute that takes a string argument
+    let TryFindStringAttribute (g: TcGlobals) attrib attribs =
+      match g.TryFindSysAttrib attrib with 
+      | None -> None
+      | Some attribRef -> 
+        match TryFindFSharpAttribute g attribRef attribs with
+        | Some (Attrib(_, _, [ AttribStringArg s ], _, _, _, _))  -> Some (s)
+        | _ -> None
+        
+    let TryFindIntAttribute (g: TcGlobals) attrib attribs =
+      match g.TryFindSysAttrib attrib with 
+      | None -> None
+      | Some attribRef -> 
+        match TryFindFSharpAttribute g attribRef attribs with
+        | Some (Attrib(_, _, [ AttribInt32Arg i ], _, _, _, _)) -> Some (i)
+        | _ -> None
+        
+    let TryFindBoolAttribute (g: TcGlobals) attrib attribs =
+      match g.TryFindSysAttrib attrib with 
+      | None -> None
+      | Some attribRef -> 
+        match TryFindFSharpAttribute g attribRef attribs with
+        | Some (Attrib(_, _, [ AttribBoolArg p ], _, _, _, _)) -> Some (p)
+        | _ -> None
+
+    let (|ILVersion|_|) (versionString: string) =
+        try Some (IL.parseILVersion versionString)
+        with e -> 
+            None
+
+//----------------------------------------------------------------------------
+// ValidateKeySigningAttributes, GetStrongNameSigner
+//----------------------------------------------------------------------------
+
+/// Represents the configuration settings used to perform strong-name signing
+type StrongNameSigningInfo = StrongNameSigningInfo of delaysign: bool * publicsign: bool * signer: string option * container: string option
+
+/// Validate the attributes and configuration settings used to perform strong-name signing
+let ValidateKeySigningAttributes (tcConfig : TcConfig, tcGlobals, topAttrs) =
+    let delaySignAttrib = AttributeHelpers.TryFindBoolAttribute tcGlobals "System.Reflection.AssemblyDelaySignAttribute" topAttrs.assemblyAttrs
+    let signerAttrib = AttributeHelpers.TryFindStringAttribute tcGlobals "System.Reflection.AssemblyKeyFileAttribute" topAttrs.assemblyAttrs
+    let containerAttrib = AttributeHelpers.TryFindStringAttribute tcGlobals "System.Reflection.AssemblyKeyNameAttribute" topAttrs.assemblyAttrs
+    
+    // if delaySign is set via an attribute, validate that it wasn't set via an option
+    let delaysign = 
+        match delaySignAttrib with 
+        | Some delaysign -> 
+          if tcConfig.delaysign then
+            warning(Error(FSComp.SR.fscDelaySignWarning(), rangeCmdArgs)) 
+            tcConfig.delaysign
+          else
+            delaysign
+        | _ -> tcConfig.delaysign
+        
+    // if signer is set via an attribute, validate that it wasn't set via an option
+    let signer = 
+        match signerAttrib with
+        | Some signer -> 
+            if tcConfig.signer.IsSome && tcConfig.signer <> Some signer then
+                warning(Error(FSComp.SR.fscKeyFileWarning(), rangeCmdArgs)) 
+                tcConfig.signer
+            else
+                Some signer
+        | None -> tcConfig.signer
+    
+    // if container is set via an attribute, validate that it wasn't set via an option, and that they keyfile wasn't set
+    // if keyfile was set, use that instead (silently)
+    // REVIEW: This is C# behavior, but it seems kind of sketchy that we fail silently
+    let container = 
+        match containerAttrib with 
+        | Some container -> 
+            if tcConfig.container.IsSome && tcConfig.container <> Some container then
+              warning(Error(FSComp.SR.fscKeyNameWarning(), rangeCmdArgs)) 
+              tcConfig.container
+            else
+              Some container
+        | None -> tcConfig.container
+    
+    StrongNameSigningInfo (delaysign, tcConfig.publicsign, signer, container)
+
+/// Get the object used to perform strong-name signing
+let GetStrongNameSigner signingInfo = 
+    let (StrongNameSigningInfo(delaysign, publicsign, signer, container)) = signingInfo
+    // REVIEW: favor the container over the key file - C# appears to do this
+    match container with
+    | Some container ->
+        Some (ILStrongNameSigner.OpenKeyContainer container)
+    | None ->
+        match signer with 
+        | None -> None
+        | Some s ->
+            try 
+                if publicsign || delaysign then
+                    Some (ILStrongNameSigner.OpenPublicKeyOptions s publicsign)
+                else
+                    Some (ILStrongNameSigner.OpenKeyPairFile s) 
+            with _ -> 
+                // Note :: don't use errorR here since we really want to fail and not produce a binary
+                error(Error(FSComp.SR.fscKeyFileCouldNotBeOpened s, rangeCmdArgs))
+
+//----------------------------------------------------------------------------
+// Building the contents of the finalized IL module
+//----------------------------------------------------------------------------
+
+module MainModuleBuilder = 
+
+    let injectedCompatTypes = 
+      set [ "System.Tuple`1"
+            "System.Tuple`2" 
+            "System.Tuple`3" 
+            "System.Tuple`4"
+            "System.Tuple`5"
+            "System.Tuple`6"
+            "System.Tuple`7"
+            "System.Tuple`8"
+            "System.ITuple"
+            "System.Tuple"
+            "System.Collections.IStructuralComparable"
+            "System.Collections.IStructuralEquatable" ]
+
+    let typesForwardedToMscorlib = 
+      set [ "System.AggregateException"
+            "System.Threading.CancellationTokenRegistration"
+            "System.Threading.CancellationToken"
+            "System.Threading.CancellationTokenSource"
+            "System.Lazy`1"
+            "System.IObservable`1"
+            "System.IObserver`1" ]
+
+    let typesForwardedToSystemNumerics =
+      set [ "System.Numerics.BigInteger" ]
+
+    let createMscorlibExportList (tcGlobals: TcGlobals) =
+      // We want to write forwarders out for all injected types except for System.ITuple, which is internal
+      // Forwarding System.ITuple will cause FxCop failures on 4.0
+      Set.union (Set.filter (fun t -> t <> "System.ITuple") injectedCompatTypes) typesForwardedToMscorlib |>
+          Seq.map (fun t -> mkTypeForwarder (tcGlobals.ilg.primaryAssemblyScopeRef) t (mkILNestedExportedTypes List.empty<ILNestedExportedType>) (mkILCustomAttrs List.empty<ILAttribute>) ILTypeDefAccess.Public ) 
+          |> Seq.toList
+
+    let createSystemNumericsExportList (tcConfig: TcConfig) (tcImports: TcImports) =
+        let refNumericsDllName =
+            if (tcConfig.primaryAssembly.Name = "mscorlib") then "System.Numerics"
+            else "System.Runtime.Numerics"
+        let numericsAssemblyRef =
+            match tcImports.GetImportedAssemblies() |> List.tryFind<ImportedAssembly>(fun a -> a.FSharpViewOfMetadata.AssemblyName = refNumericsDllName) with
+            | Some asm ->
+                match asm.ILScopeRef with 
+                | ILScopeRef.Assembly aref -> Some aref
+                | _ -> None
+            | None -> None
+        match numericsAssemblyRef with
+        | Some aref ->
+            let systemNumericsAssemblyRef = ILAssemblyRef.Create(refNumericsDllName, aref.Hash, aref.PublicKey, aref.Retargetable, aref.Version, aref.Locale)
+            typesForwardedToSystemNumerics |>
+                Seq.map (fun t ->
+                            { ScopeRef = ILScopeRef.Assembly systemNumericsAssemblyRef
+                              Name = t
+                              Attributes = enum<TypeAttributes>(0x00200000) ||| TypeAttributes.Public
+                              Nested = mkILNestedExportedTypes []
+                              CustomAttrsStored = storeILCustomAttrs emptyILCustomAttrs
+                              MetadataIndex = NoMetadataIdx }) |>
+                Seq.toList
+        | None -> []
+
+    let fileVersion findStringAttr (assemblyVersion: ILVersionInfo) =
+        let attrName = "System.Reflection.AssemblyFileVersionAttribute"
+        match findStringAttr attrName with
+        | None -> assemblyVersion
+        | Some (AttributeHelpers.ILVersion v) -> v
+        | Some _ ->
+            // Warning will be reported by CheckExpressions.fs
+            assemblyVersion
+
+    let productVersion findStringAttr (fileVersion: ILVersionInfo) =
+        let attrName = "System.Reflection.AssemblyInformationalVersionAttribute"
+        let toDotted (version: ILVersionInfo) = sprintf "%d.%d.%d.%d" version.Major version.Minor version.Build version.Revision
+        match findStringAttr attrName with
+        | None | Some "" -> fileVersion |> toDotted
+        | Some (AttributeHelpers.ILVersion v) -> v |> toDotted
+        | Some v -> 
+            // Warning will be reported by CheckExpressions.fs
+            v
+
+    let productVersionToILVersionInfo (version: string) : ILVersionInfo =
+        let parseOrZero i (v:string) =
+            let v =
+                // When i = 3 then this is the 4th part of the version.  The last part of the version can be trailed by any characters so we trim them off
+                if i <> 3 then
+                    v
+                else
+                    ((false, ""), v)
+                    ||> Seq.fold(fun (finished, v) c ->
+                        match finished with
+                        | false when Char.IsDigit(c) -> false, v + c.ToString()
+                        | _ -> true, v)
+                    |> snd
+            match System.UInt16.TryParse v with
+            | (true, i) -> i
+            | (false, _) -> 0us
+        let validParts =
+            version.Split('.')
+            |> Array.mapi(fun i v -> parseOrZero i v)
+            |> Seq.toList
+        match validParts @ [0us; 0us; 0us; 0us] with
+        | major :: minor :: build :: rev :: _ -> ILVersionInfo(major, minor, build, rev)
+        | x -> failwithf "error converting product version '%s' to binary, tried '%A' " version x
+
+
+    let CreateMainModule  
+            (ctok, tcConfig: TcConfig, tcGlobals, tcImports: TcImports, 
+             pdbfile, assemblyName, outfile, topAttrs, 
+             sigDataAttributes: ILAttribute list, sigDataResources: ILResource list, optDataResources: ILResource list, 
+             codegenResults, assemVerFromAttrib, metadataVersion, secDecls) =
+
+        RequireCompilationThread ctok
+        let ilTypeDefs = 
+            //let topTypeDef = mkILTypeDefForGlobalFunctions tcGlobals.ilg (mkILMethods [], emptyILFields)
+            mkILTypeDefs codegenResults.ilTypeDefs
+
+        let mainModule = 
+            let hashAlg = AttributeHelpers.TryFindIntAttribute tcGlobals "System.Reflection.AssemblyAlgorithmIdAttribute" topAttrs.assemblyAttrs
+            let locale = AttributeHelpers.TryFindStringAttribute tcGlobals "System.Reflection.AssemblyCultureAttribute" topAttrs.assemblyAttrs
+            let flags =  match AttributeHelpers.TryFindIntAttribute tcGlobals "System.Reflection.AssemblyFlagsAttribute" topAttrs.assemblyAttrs with | Some f -> f | _ -> 0x0
+
+            // You're only allowed to set a locale if the assembly is a library
+            if (locale <> None && locale.Value <> "") && tcConfig.target <> CompilerTarget.Dll then
+              error(Error(FSComp.SR.fscAssemblyCultureAttributeError(), rangeCmdArgs))
+
+            // Add the type forwarders to any .NET DLL post-.NET-2.0, to give binary compatibility
+            let exportedTypesList =
+                if tcConfig.compilingFslib then
+                   List.append (createMscorlibExportList tcGlobals) (createSystemNumericsExportList tcConfig tcImports)
+                else
+                    []
+
+            let ilModuleName = GetGeneratedILModuleName tcConfig.target assemblyName
+            let isDLL = (tcConfig.target = CompilerTarget.Dll || tcConfig.target = CompilerTarget.Module)
+            mkILSimpleModule assemblyName ilModuleName isDLL tcConfig.subsystemVersion tcConfig.useHighEntropyVA ilTypeDefs hashAlg locale flags (mkILExportedTypes exportedTypesList) metadataVersion
+
+        let disableJitOptimizations = not (tcConfig.optSettings.jitOpt())
+
+        let tcVersion = tcConfig.version.GetVersionInfo(tcConfig.implicitIncludeDir)
+
+        let reflectedDefinitionAttrs, reflectedDefinitionResources = 
+            codegenResults.quotationResourceInfo 
+            |> List.map (fun (referencedTypeDefs, reflectedDefinitionBytes) -> 
+                let reflectedDefinitionResourceName = QuotationPickler.SerializedReflectedDefinitionsResourceNameBase+"-"+assemblyName+"-"+string(newUnique())+"-"+string(hash reflectedDefinitionBytes)
+                let reflectedDefinitionAttrs = 
+                    let qf = QuotationTranslator.QuotationGenerationScope.ComputeQuotationFormat tcGlobals 
+                    if qf.SupportsDeserializeEx then
+                        [ mkCompilationMappingAttrForQuotationResource tcGlobals (reflectedDefinitionResourceName, referencedTypeDefs) ]
+                    else 
+                        [  ]
+                let reflectedDefinitionResource = 
+                  { Name=reflectedDefinitionResourceName
+                    Location = ILResourceLocation.Local(ByteStorage.FromByteArray(reflectedDefinitionBytes))
+                    Access= ILResourceAccess.Public
+                    CustomAttrsStored = storeILCustomAttrs emptyILCustomAttrs
+                    MetadataIndex = NoMetadataIdx }
+                reflectedDefinitionAttrs, reflectedDefinitionResource) 
+            |> List.unzip
+            |> (fun (attrs, resource) -> List.concat attrs, resource)
+
+        let manifestAttrs = 
+            mkILCustomAttrs
+                 [ if not tcConfig.internConstantStrings then 
+                       yield mkILCustomAttribute tcGlobals.ilg
+                                 (tcGlobals.FindSysILTypeRef "System.Runtime.CompilerServices.CompilationRelaxationsAttribute", 
+                                  [tcGlobals.ilg.typ_Int32], [ILAttribElem.Int32( 8)], []) 
+                   yield! sigDataAttributes
+                   yield! codegenResults.ilAssemAttrs
+                   if Option.isSome pdbfile then
+                       yield (tcGlobals.mkDebuggableAttributeV2 (tcConfig.jitTracking, tcConfig.ignoreSymbolStoreSequencePoints, disableJitOptimizations, false (* enableEnC *) )) 
+                   yield! reflectedDefinitionAttrs ]
+
+        // Make the manifest of the assembly
+        let manifest = 
+             if tcConfig.target = CompilerTarget.Module then None else
+             let man = mainModule.ManifestOfAssembly
+             let ver = 
+                 match assemVerFromAttrib with 
+                 | None -> tcVersion
+                 | Some v -> v
+             Some { man with Version= Some ver
+                             CustomAttrsStored = storeILCustomAttrs manifestAttrs
+                             DisableJitOptimizations=disableJitOptimizations
+                             JitTracking= tcConfig.jitTracking
+                             IgnoreSymbolStoreSequencePoints = tcConfig.ignoreSymbolStoreSequencePoints
+                             SecurityDeclsStored=storeILSecurityDecls secDecls } 
+
+        let resources = 
+          mkILResources 
+            [ for file in tcConfig.embedResources do
+                 let name, bytes, pub = 
+                         let file, name, pub = TcConfigBuilder.SplitCommandLineResourceInfo file
+                         let file = tcConfig.ResolveSourceFile(rangeStartup, file, tcConfig.implicitIncludeDir)
+                         let bytes = FileSystem.ReadAllBytesShim file
+                         name, bytes, pub
+                 yield { Name=name 
+                         Location=ILResourceLocation.Local(ByteStorage.FromByteArray(bytes))
+                         Access=pub 
+                         CustomAttrsStored=storeILCustomAttrs emptyILCustomAttrs 
+                         MetadataIndex = NoMetadataIdx }
+               
+              yield! reflectedDefinitionResources
+              yield! sigDataResources
+              yield! optDataResources
+              for ri in tcConfig.linkResources do 
+                 let file, name, pub = TcConfigBuilder.SplitCommandLineResourceInfo ri
+                 yield { Name=name 
+                         Location=ILResourceLocation.File(ILModuleRef.Create(name=file, hasMetadata=false, hash=Some (sha1HashBytes (FileSystem.ReadAllBytesShim file))), 0)
+                         Access=pub 
+                         CustomAttrsStored=storeILCustomAttrs emptyILCustomAttrs
+                         MetadataIndex = NoMetadataIdx } ]
+
+        let assemblyVersion = 
+            match tcConfig.version with
+            | VersionNone -> assemVerFromAttrib
+            | _ -> Some tcVersion
+
+        let findAttribute name =
+            AttributeHelpers.TryFindStringAttribute tcGlobals name topAttrs.assemblyAttrs 
+
+        //NOTE: the culture string can be turned into a number using this:
+        //    sprintf "%04x" (CultureInfo.GetCultureInfo("en").KeyboardLayoutId )
+        let assemblyVersionResources assemblyVersion =
+            match assemblyVersion with 
+            | None -> []
+            | Some assemblyVersion ->
+                let FindAttribute key attrib = 
+                    match findAttribute attrib with
+                    | Some text  -> [(key, text)]
+                    | _ -> []
+
+                let fileVersionInfo = fileVersion findAttribute assemblyVersion
+
+                let productVersionString = productVersion findAttribute fileVersionInfo
+
+                let stringFileInfo = 
+                     // 000004b0:
+                     // Specifies an 8-digit hexadecimal number stored as a Unicode string. The 
+                     // four most significant digits represent the language identifier. The four least 
+                     // significant digits represent the code page for which the data is formatted. 
+                     // Each Microsoft Standard Language identifier contains two parts: the low-order 10 bits 
+                     // specify the major language, and the high-order 6 bits specify the sublanguage. 
+                     // For a table of valid identifiers see Language Identifiers.                                           //
+                     // see e.g. http://msdn.microsoft.com/en-us/library/aa912040.aspx 0000 is neutral and 04b0(hex)=1252(dec) is the code page.
+                      [ ("000004b0", [ yield ("Assembly Version", (sprintf "%d.%d.%d.%d" assemblyVersion.Major assemblyVersion.Minor assemblyVersion.Build assemblyVersion.Revision))
+                                       yield ("FileVersion", (sprintf "%d.%d.%d.%d" fileVersionInfo.Major fileVersionInfo.Minor fileVersionInfo.Build fileVersionInfo.Revision))
+                                       yield ("ProductVersion", productVersionString)
+                                       match tcConfig.outputFile with
+                                       | Some f -> yield ("OriginalFilename", Path.GetFileName f)
+                                       | None -> ()
+                                       yield! FindAttribute "Comments" "System.Reflection.AssemblyDescriptionAttribute" 
+                                       yield! FindAttribute "FileDescription" "System.Reflection.AssemblyTitleAttribute" 
+                                       yield! FindAttribute "ProductName" "System.Reflection.AssemblyProductAttribute" 
+                                       yield! FindAttribute "CompanyName" "System.Reflection.AssemblyCompanyAttribute" 
+                                       yield! FindAttribute "LegalCopyright" "System.Reflection.AssemblyCopyrightAttribute" 
+                                       yield! FindAttribute "LegalTrademarks" "System.Reflection.AssemblyTrademarkAttribute" ]) ]
+
+                // These entries listed in the MSDN documentation as "standard" string entries are not yet settable
+
+                // InternalName: 
+                //     The Value member identifies the file's internal name, if one exists. For example, this 
+                //     string could contain the module name for Windows dynamic-link libraries (DLLs), a virtual 
+                //     device name for Windows virtual devices, or a device name for MS-DOS device drivers. 
+                // OriginalFilename: 
+                //     The Value member identifies the original name of the file, not including a path. This 
+                //     enables an application to determine whether a file has been renamed by a user. This name 
+                //     may not be MS-DOS 8.3-format if the file is specific to a non-FAT file system. 
+                // PrivateBuild: 
+                //     The Value member describes by whom, where, and why this private version of the 
+                //     file was built. This string should only be present if the VS_FF_PRIVATEBUILD flag 
+                //     is set in the dwFileFlags member of the VS_FIXEDFILEINFO structure. For example, 
+                //     Value could be 'Built by OSCAR on \OSCAR2'. 
+                // SpecialBuild: 
+                //     The Value member describes how this version of the file differs from the normal version. 
+                //     This entry should only be present if the VS_FF_SPECIALBUILD flag is set in the dwFileFlags 
+                //     member of the VS_FIXEDFILEINFO structure. For example, Value could be 'Private build 
+                //     for Olivetti solving mouse problems on M250 and M250E computers'. 
+
+                // "If you use the Var structure to list the languages your application 
+                // or DLL supports instead of using multiple version resources, 
+                // use the Value member to contain an array of DWORD values indicating the 
+                // language and code page combinations supported by this file. The 
+                // low-order word of each DWORD must contain a Microsoft language identifier, 
+                // and the high-order word must contain the IBM code page number. 
+                // Either high-order or low-order word can be zero, indicating that 
+                // the file is language or code page independent. If the Var structure is 
+                // omitted, the file will be interpreted as both language and code page independent. "
+                let varFileInfo = [ (0x0, 0x04b0)  ]
+
+                let fixedFileInfo = 
+                    let dwFileFlagsMask = 0x3f // REVIEW: HARDWIRED
+                    let dwFileFlags = 0x00 // REVIEW: HARDWIRED
+                    let dwFileOS = 0x04 // REVIEW: HARDWIRED
+                    let dwFileType = 0x01 // REVIEW: HARDWIRED
+                    let dwFileSubtype = 0x00 // REVIEW: HARDWIRED
+                    let lwFileDate = 0x00L // REVIEW: HARDWIRED
+                    (fileVersionInfo, productVersionString |> productVersionToILVersionInfo, dwFileFlagsMask, dwFileFlags, dwFileOS, dwFileType, dwFileSubtype, lwFileDate)
+
+                let vsVersionInfoResource = 
+                    VersionResourceFormat.VS_VERSION_INFO_RESOURCE(fixedFileInfo, stringFileInfo, varFileInfo)
+
+                let resource = 
+                    [| yield! ResFileFormat.ResFileHeader()
+                       yield! vsVersionInfoResource |]
+
+                [ resource ]
+
+        // a user cannot specify both win32res and win32manifest
+        if not(tcConfig.win32manifest = "") && not(tcConfig.win32res = "") then
+            error(Error(FSComp.SR.fscTwoResourceManifests(), rangeCmdArgs))
+
+        let win32Manifest =
+            // use custom manifest if provided
+            if not(tcConfig.win32manifest = "") then tcConfig.win32manifest
+
+            // don't embed a manifest if target is not an exe, if manifest is specifically excluded, if another native resource is being included, or if running on mono
+            elif not(tcConfig.target.IsExe) || not(tcConfig.includewin32manifest) || not(tcConfig.win32res = "") || runningOnMono then ""
+            // otherwise, include the default manifest
+            else
+                let path = Path.Combine(System.AppContext.BaseDirectory, @"default.win32manifest")
+                if File.Exists(path) then path
+                else Path.Combine(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(), @"default.win32manifest")
+
+        let nativeResources = 
+            [ for av in assemblyVersionResources assemblyVersion do
+                  yield ILNativeResource.Out av
+              if not(tcConfig.win32res = "") then
+                  yield ILNativeResource.Out (FileSystem.ReadAllBytesShim tcConfig.win32res) 
+              if tcConfig.includewin32manifest && not(win32Manifest = "") && not runningOnMono then
+                  yield  ILNativeResource.Out [| yield! ResFileFormat.ResFileHeader() 
+                                                 yield! (ManifestResourceFormat.VS_MANIFEST_RESOURCE((FileSystem.ReadAllBytesShim win32Manifest), tcConfig.target = CompilerTarget.Dll)) |]]
+
+        // Add attributes, version number, resources etc. 
+        {mainModule with 
+              StackReserveSize = tcConfig.stackReserveSize
+              Name = (if tcConfig.target = CompilerTarget.Module then Filename.fileNameOfPath outfile else mainModule.Name)
+              SubSystemFlags = (if tcConfig.target = CompilerTarget.WinExe then 2 else 3) 
+              Resources= resources
+              ImageBase = (match tcConfig.baseAddress with None -> 0x00400000l | Some b -> b)
+              IsDLL=(tcConfig.target = CompilerTarget.Dll || tcConfig.target=CompilerTarget.Module)
+              Platform = tcConfig.platform 
+              Is32Bit=(match tcConfig.platform with Some X86 -> true | _ -> false)
+              Is64Bit=(match tcConfig.platform with Some AMD64 | Some IA64 -> true | _ -> false)          
+              Is32BitPreferred = if tcConfig.prefer32Bit && not tcConfig.target.IsExe then (error(Error(FSComp.SR.invalidPlatformTarget(), rangeCmdArgs))) else tcConfig.prefer32Bit
+              CustomAttrsStored= 
+                  storeILCustomAttrs
+                    (mkILCustomAttrs 
+                      [ if tcConfig.target = CompilerTarget.Module then 
+                           yield! sigDataAttributes 
+                        yield! codegenResults.ilNetModuleAttrs ])
+              NativeResources=nativeResources
+              Manifest = manifest }
+

--- a/src/fsharp/CreateILModule.fsi
+++ b/src/fsharp/CreateILModule.fsi
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module internal FSharp.Compiler.CreateILModule 
+
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.Internal.StrongNameSign
+open FSharp.Compiler.CheckDeclarations
+open FSharp.Compiler.CompilerConfig
+open FSharp.Compiler.CompilerImports
+open FSharp.Compiler.IlxGen
+open FSharp.Compiler.TcGlobals
+open FSharp.Compiler.TypedTree
+
+/// Represents the configuration settings used to perform strong-name signing
+type StrongNameSigningInfo 
+
+/// Validate the attributes and configuration settings used to perform strong-name signing
+val ValidateKeySigningAttributes: tcConfig:TcConfig * tcGlobals:TcGlobals * TopAttribs -> StrongNameSigningInfo
+
+/// Get the object used to perform strong-name signing
+val GetStrongNameSigner: signingInfo: StrongNameSigningInfo -> ILStrongNameSigner option
+
+module AttributeHelpers =
+    val TryFindStringAttribute: g: TcGlobals -> attrib: string -> attribs: Attribs -> string option
+
+module MainModuleBuilder =
+    
+    /// Put together all the pieces of information to create the overall IL ModuleDef for
+    /// the generated assembly
+    val CreateMainModule:
+        ctok: CompilationThreadToken *
+        tcConfig: TcConfig * 
+        tcGlobals: TcGlobals * 
+        tcImports: TcImports * 
+        pdbfile: 't option * 
+        assemblyName: string * 
+        outfile: string * 
+        topAttrs: TopAttribs * 
+        sigDataAttributes: ILAttribute list *
+        sigDataResources: ILResource list *
+        optDataResources: ILResource list *
+        codegenResults: IlxGenResults * 
+        assemVerFromAttrib: ILVersionInfo option *
+        metadataVersion: string *
+        secDecls: ILSecurityDecls 
+          -> ILModuleDef
+
+    /// For unit testing
+    val fileVersion: findStringAttr: (string -> string option) -> assemblyVersion: ILVersionInfo -> ILVersionInfo
+
+    /// For unit testing
+    val productVersion: findStringAttr: (string -> string option) -> fileVersion: ILVersionInfo -> string
+
+    /// For unit testing
+    val productVersionToILVersionInfo: string -> ILVersionInfo

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -625,17 +625,17 @@
     <Compile Include="..\BinaryResourceFormats.fs">
       <Link>Driver\BinaryResourceFormats.fs</Link>
     </Compile>
-    <Compile Include="..\CreateILModule.fsi">
-      <Link>Driver\CreateILModule.fsi</Link>
-    </Compile>
-    <Compile Include="..\CreateILModule.fs">
-      <Link>Driver\CreateILModule.fs</Link>
-    </Compile>
     <Compile Include="..\StaticLinking.fsi">
       <Link>Driver\StaticLinking.fsi</Link>
     </Compile>
     <Compile Include="..\StaticLinking.fs">
       <Link>Driver\StaticLinking.fs</Link>
+    </Compile>
+    <Compile Include="..\CreateILModule.fsi">
+      <Link>Driver\CreateILModule.fsi</Link>
+    </Compile>
+    <Compile Include="..\CreateILModule.fs">
+      <Link>Driver\CreateILModule.fs</Link>
     </Compile>
     <Compile Include="..\fsc.fsi">
       <Link>Driver\fsc.fsi</Link>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -613,6 +613,30 @@
     <Compile Include="..\OptimizeInputs.fs">
       <Link>Driver\OptimizeInputs.fs</Link>
     </Compile>
+    <Compile Include="..\XmlDocFileWriter.fsi">
+      <Link>Driver\XmlDocFileWriter.fsi</Link>
+    </Compile>
+    <Compile Include="..\XmlDocFileWriter.fs">
+      <Link>Driver\XmlDocFileWriter.fs</Link>
+    </Compile>
+    <Compile Include="..\BinaryResourceFormats.fsi">
+      <Link>Driver\BinaryResourceFormats.fsi</Link>
+    </Compile>
+    <Compile Include="..\BinaryResourceFormats.fs">
+      <Link>Driver\BinaryResourceFormats.fs</Link>
+    </Compile>
+    <Compile Include="..\CreateILModule.fsi">
+      <Link>Driver\CreateILModule.fsi</Link>
+    </Compile>
+    <Compile Include="..\CreateILModule.fs">
+      <Link>Driver\CreateILModule.fs</Link>
+    </Compile>
+    <Compile Include="..\StaticLinking.fsi">
+      <Link>Driver\StaticLinking.fsi</Link>
+    </Compile>
+    <Compile Include="..\StaticLinking.fs">
+      <Link>Driver\StaticLinking.fs</Link>
+    </Compile>
     <Compile Include="..\fsc.fsi">
       <Link>Driver\fsc.fsi</Link>
     </Compile>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -388,6 +388,9 @@
     <Compile Include="$(FsYaccOutputFolder)\lex.fs">
       <Link>ParserAndUntypedAST\FsLexOutput\lex.fs</Link>
     </Compile>
+    <Compile Include="..\LexFilter.fsi">
+      <Link>ParserAndUntypedAST\LexFilter.fsi</Link>
+    </Compile>
     <Compile Include="..\LexFilter.fs">
       <Link>ParserAndUntypedAST\LexFilter.fs</Link>
     </Compile>

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -632,6 +632,30 @@
     <Compile Include="..\OptimizeInputs.fs">
       <Link>Driver\OptimizeInputs.fs</Link>
     </Compile>
+    <Compile Include="..\XmlDocFileWriter.fsi">
+      <Link>Driver\XmlDocFileWriter.fsi</Link>
+    </Compile>
+    <Compile Include="..\XmlDocFileWriter.fs">
+      <Link>Driver\XmlDocFileWriter.fs</Link>
+    </Compile>
+    <Compile Include="..\BinaryResourceFormats.fsi">
+      <Link>Driver\BinaryResourceFormats.fsi</Link>
+    </Compile>
+    <Compile Include="..\BinaryResourceFormats.fs">
+      <Link>Driver\BinaryResourceFormats.fs</Link>
+    </Compile>
+    <Compile Include="..\StaticLinking.fsi">
+      <Link>Driver\StaticLinking.fsi</Link>
+    </Compile>
+    <Compile Include="..\StaticLinking.fs">
+      <Link>Driver\StaticLinking.fs</Link>
+    </Compile>
+    <Compile Include="..\CreateILModule.fsi">
+      <Link>Driver\CreateILModule.fsi</Link>
+    </Compile>
+    <Compile Include="..\CreateILModule.fs">
+      <Link>Driver\CreateILModule.fs</Link>
+    </Compile>
     <Compile Include="..\fsc.fsi">
       <Link>Driver\fsc.fsi</Link>
     </Compile>

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -384,10 +384,13 @@
       <Link>ParserAndUntypedAST\lexhelp.fs</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pplex.fs">
-      <Link>ParserAndUntypedAST\FsLex\pplex.fsl</Link>
+      <Link>ParserAndUntypedAST\FsLexOutput\pplex.fsl</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)lex.fs">
-      <Link>ParserAndUntypedAST\FsLex\lex.fs</Link>
+      <Link>ParserAndUntypedAST\FsLexOutput\lex.fs</Link>
+    </Compile>
+    <Compile Include="..\LexFilter.fsi">
+      <Link>ParserAndUntypedAST\LexFilter.fsi</Link>
     </Compile>
     <Compile Include="..\LexFilter.fs">
       <Link>ParserAndUntypedAST\LexFilter.fs</Link>

--- a/src/fsharp/LegacyHostedCompilerForTesting.fs
+++ b/src/fsharp/LegacyHostedCompilerForTesting.fs
@@ -65,7 +65,7 @@ type internal InProcCompiler(legacyReferenceResolver) =
             { new Exiter with
                  member this.Exit n = exitCode <- n; raise StopProcessing }
         try 
-            typecheckAndCompile(ctok, argv, legacyReferenceResolver, false, ReduceMemoryFlag.Yes, CopyFSharpCoreFlag.Yes, exiter, loggerProvider.Provider, None, None)
+            mainCompile(ctok, argv, legacyReferenceResolver, false, ReduceMemoryFlag.Yes, CopyFSharpCoreFlag.Yes, exiter, loggerProvider.Provider, None, None)
         with 
             | StopProcessing -> ()
             | ReportedError _  | WrappedError(ReportedError _,_)  ->

--- a/src/fsharp/LexFilter.fsi
+++ b/src/fsharp/LexFilter.fsi
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All Rights Reserved. See License.txt in the project root for license information.
+
+/// LexFilter - process the token stream prior to parsing.
+/// Implements the offside rule and a couple of other lexical transformations.
+module internal FSharp.Compiler.LexFilter
+
+open Internal.Utilities.Text.Lexing
+open FSharp.Compiler.Lexhelp
+open FSharp.Compiler.Parser
+
+/// Match the close of '>' of a set of type parameters.
+/// This is done for tokens such as '>>' by smashing the token
+val (|TyparsCloseOp|_|) : txt: string -> ((bool -> token)[] * token option) option
+
+/// A stateful filter over the token stream that adjusts it for indentation-aware syntax rules
+/// Process the token stream prior to parsing. Implements the offside rule and other lexical transformations.
+type LexFilter =
+    
+    /// Create a lex filter
+    new: lightStatus: LightSyntaxStatus * compilingFsLib: bool * lexer: (LexBuffer<char> -> token) * lexbuf: LexBuffer<char> -> LexFilter
+
+    /// The LexBuffer associated with the filter
+    member LexBuffer: LexBuffer<char>
+
+    /// Get the next token
+    member GetToken: unit -> token

--- a/src/fsharp/OptimizeInputs.fs
+++ b/src/fsharp/OptimizeInputs.fs
@@ -4,34 +4,22 @@
 
 module internal FSharp.Compiler.OptimizeInputs
 
-open System
-open System.IO
-
 open FSharp.Compiler 
 open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
-open FSharp.Compiler.AbstractIL.ILPdbWriter
 open FSharp.Compiler.AbstractIL.Internal.Library 
-open FSharp.Compiler.AbstractIL.Internal.Utils
-open FSharp.Compiler.AbstractIL.Extensions.ILX
 open FSharp.Compiler.AbstractIL.Diagnostics
 open FSharp.Compiler.CompilerConfig
-open FSharp.Compiler.CompilerDiagnostics
 open FSharp.Compiler.CompilerImports
 open FSharp.Compiler.CompilerOptions
-open FSharp.Compiler.Features
 open FSharp.Compiler.IlxGen
-open FSharp.Compiler.Lib
 open FSharp.Compiler.Range
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps 
 open FSharp.Compiler.CheckDeclarations
-open FSharp.Compiler.ErrorLogger
 
-open Internal.Utilities
 open Internal.Utilities.StructuredFormat
-
 
 //----------------------------------------------------------------------------
 // PrintWholeAssemblyImplementation

--- a/src/fsharp/StaticLinking.fs
+++ b/src/fsharp/StaticLinking.fs
@@ -1,0 +1,516 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+/// Optional static linking of all DLLs that depend on the F# Library, plus other specified DLLs
+module internal FSharp.Compiler.StaticLinking
+
+open System
+
+open FSharp.Compiler.AbstractIL
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.ILBinaryReader
+open FSharp.Compiler.CompilerConfig
+open FSharp.Compiler.CompilerImports
+open FSharp.Compiler.CompilerOptions
+open FSharp.Compiler.ErrorLogger
+open FSharp.Compiler.Lib
+open FSharp.Compiler.OptimizeInputs
+open FSharp.Compiler.Range
+open FSharp.Compiler.TypedTree
+open FSharp.Compiler.TypedTreeBasics
+open Internal.Utilities
+open Internal.Utilities.Collections
+
+#if !NO_EXTENSIONTYPING
+open FSharp.Compiler.ExtensionTyping
+#endif
+
+// Handles TypeForwarding for the generated IL model
+type TypeForwarding (tcImports: TcImports) =
+
+    // Make a dictionary of ccus passed to the compiler will be looked up by qualified assembly name
+    let ccuThunksQualifiedName =
+        tcImports.GetCcusInDeclOrder()
+        |> List.choose (fun ccuThunk -> ccuThunk.QualifiedName |> Option.map (fun v -> v, ccuThunk))
+        |> dict
+
+    // If we can't type forward using exact assembly match, we need to rely on the loader (Policy, Configuration or the coreclr load heuristics), so use try simple name
+    let ccuThunksSimpleName =
+        tcImports.GetCcusInDeclOrder()
+        |> List.choose (fun ccuThunk -> 
+            if String.IsNullOrEmpty(ccuThunk.AssemblyName) then
+                None
+            else
+                Some (ccuThunk.AssemblyName, ccuThunk))
+        |> dict
+
+    let followTypeForwardForILTypeRef (tref:ILTypeRef) =
+        let typename =
+            let parts =  tref.FullName.Split([|'.'|])
+            match parts.Length with
+            | 0 -> None
+            | 1 -> Some (Array.empty<string>, parts.[0])
+            | n -> Some (parts.[0..n-2], parts.[n-1])
+
+        let  scoref = tref.Scope
+        match scoref with
+        | ILScopeRef.Assembly scope ->
+            match ccuThunksQualifiedName.TryGetValue(scope.QualifiedName) with
+            | true, ccu ->
+                match typename with
+                | Some (parts, name) ->
+                    let forwarded = ccu.TryForward(parts, name)
+                    let result =
+                        match forwarded with
+                        | Some fwd -> fwd.CompilationPath.ILScopeRef
+                        | None -> scoref
+                    result
+                | None -> scoref
+            | false, _ ->
+                // Couldn't find an assembly with the version so try using a simple name
+                match ccuThunksSimpleName.TryGetValue(scope.Name) with
+                | true, ccu ->
+                    match typename with
+                    | Some (parts, name) ->
+                        let forwarded = ccu.TryForward(parts, name)
+                        let result =
+                            match forwarded with
+                            | Some fwd -> fwd.CompilationPath.ILScopeRef
+                            | None -> scoref
+                        result
+                    | None -> scoref
+                | false, _ -> scoref
+        | _ -> scoref
+
+    let typeForwardILTypeRef (tref: ILTypeRef) =
+        let scoref1 = tref.Scope
+        let scoref2 = followTypeForwardForILTypeRef tref
+        if scoref1 === scoref2 then tref
+        else ILTypeRef.Create (scoref2, tref.Enclosing, tref.Name)
+
+    member __.TypeForwardILTypeRef tref = typeForwardILTypeRef tref
+
+let debugStaticLinking = condition "FSHARP_DEBUG_STATIC_LINKING"
+
+let StaticLinkILModules (tcConfig:TcConfig, ilGlobals, tcImports, ilxMainModule, dependentILModules: (CcuThunk option * ILModuleDef) list) = 
+    if isNil dependentILModules then 
+        ilxMainModule, (fun x -> x) 
+    else
+        let typeForwarding = new TypeForwarding(tcImports)
+
+        // Check no dependent assemblies use quotations   
+        let dependentCcuUsingQuotations = dependentILModules |> List.tryPick (function (Some ccu, _) when ccu.UsesFSharp20PlusQuotations -> Some ccu | _ -> None)   
+        match dependentCcuUsingQuotations with   
+        | Some ccu -> error(Error(FSComp.SR.fscQuotationLiteralsStaticLinking(ccu.AssemblyName), rangeStartup))   
+        | None -> ()  
+                
+        // Check we're not static linking a .EXE
+        if dependentILModules |> List.exists (fun (_, x) -> not x.IsDLL)  then 
+            error(Error(FSComp.SR.fscStaticLinkingNoEXE(), rangeStartup))
+
+        // Check we're not static linking something that is not pure IL
+        if dependentILModules |> List.exists (fun (_, x) -> not x.IsILOnly)  then 
+            error(Error(FSComp.SR.fscStaticLinkingNoMixedDLL(), rangeStartup))
+
+        // The set of short names for the all dependent assemblies
+        let assems = 
+            set [ for (_, m) in dependentILModules  do
+                    match m.Manifest with 
+                    | Some m -> yield m.Name 
+                    | _ -> () ]
+            
+        // A rewriter which rewrites scope references to things in dependent assemblies to be local references 
+        let rewriteExternalRefsToLocalRefs x = 
+            if assems.Contains (getNameOfScopeRef x) then ILScopeRef.Local else x
+
+        let savedManifestAttrs = 
+            [ for (_, depILModule) in dependentILModules do 
+                match depILModule.Manifest with 
+                | Some m -> 
+                    for ca in m.CustomAttrs.AsArray do
+                        if ca.Method.MethodRef.DeclaringTypeRef.FullName = typeof<CompilationMappingAttribute>.FullName then 
+                            yield ca
+                | _ -> () ]
+
+        let savedResources = 
+            let allResources = [ for (ccu, m) in dependentILModules do for r in m.Resources.AsList do yield (ccu, r) ]
+            // Don't save interface, optimization or resource definitions for provider-generated assemblies.
+            // These are "fake".
+            let isProvided (ccu: CcuThunk option) = 
+#if !NO_EXTENSIONTYPING
+                match ccu with 
+                | Some c -> c.IsProviderGenerated 
+                | None -> false
+#else
+                ignore ccu
+                false
+#endif
+
+            // Save only the interface/optimization attributes of generated data 
+            let intfDataResources, others = allResources |> List.partition (snd >> IsSignatureDataResource)
+            let intfDataResources = 
+                [ for (ccu, r) in intfDataResources do 
+                     if tcConfig.GenerateSignatureData && not (isProvided ccu) then 
+                         yield r ]
+
+            let optDataResources, others = others |> List.partition (snd >> IsOptimizationDataResource)
+            let optDataResources = 
+                [ for (ccu, r) in optDataResources do 
+                    if tcConfig.GenerateOptimizationData && not (isProvided ccu) then 
+                        yield r ]
+
+            let otherResources = others |> List.map snd 
+
+            let result = intfDataResources@optDataResources@otherResources
+            result
+
+        let moduls = ilxMainModule :: (List.map snd dependentILModules)
+
+        let savedNativeResources = 
+            [ //yield! ilxMainModule.NativeResources 
+                for m in moduls do 
+                    yield! m.NativeResources ]
+
+        let topTypeDefs, normalTypeDefs = 
+            moduls 
+            |> List.map (fun m -> m.TypeDefs.AsList |> List.partition (fun td -> isTypeNameForGlobalFunctions td.Name)) 
+            |> List.unzip
+
+        let topTypeDef = 
+            let topTypeDefs = List.concat topTypeDefs
+            mkILTypeDefForGlobalFunctions ilGlobals
+                (mkILMethods (topTypeDefs |> List.collect (fun td -> td.Methods.AsList)), 
+                mkILFields (topTypeDefs |> List.collect (fun td -> td.Fields.AsList)))
+
+        let ilxMainModule =
+            let main =
+                { ilxMainModule with
+                    Manifest = (let m = ilxMainModule.ManifestOfAssembly in Some {m with CustomAttrsStored = storeILCustomAttrs (mkILCustomAttrs (m.CustomAttrs.AsList @ savedManifestAttrs)) })
+                    CustomAttrsStored = storeILCustomAttrs (mkILCustomAttrs [ for m in moduls do yield! m.CustomAttrs.AsArray ])
+                    TypeDefs = mkILTypeDefs (topTypeDef :: List.concat normalTypeDefs)
+                    Resources = mkILResources (savedResources @ ilxMainModule.Resources.AsList)
+                    NativeResources = savedNativeResources }
+            Morphs.morphILTypeRefsInILModuleMemoized ilGlobals typeForwarding.TypeForwardILTypeRef main
+
+        ilxMainModule, rewriteExternalRefsToLocalRefs
+
+[<NoEquality; NoComparison>]
+type Node = 
+    { name: string
+      data: ILModuleDef 
+      ccu: option<CcuThunk>
+      refs: ILReferences
+      mutable edges: list<Node> 
+      mutable visited: bool }
+
+// Find all IL modules that are to be statically linked given the static linking roots.
+let FindDependentILModulesForStaticLinking (ctok, tcConfig: TcConfig, tcImports: TcImports, ilGlobals: ILGlobals, ilxMainModule) = 
+    if not tcConfig.standalone && tcConfig.extraStaticLinkRoots.IsEmpty then 
+        []
+    else
+        // Recursively find all referenced modules and add them to a module graph 
+        let depModuleTable = HashMultiMap(0, HashIdentity.Structural)
+        let dummyEntry nm =
+            { refs = IL.emptyILRefs 
+              name=nm
+              ccu=None
+              data=ilxMainModule // any old module
+              edges = [] 
+              visited = true }
+        let assumedIndependentSet = set [ "mscorlib";  "System"; "System.Core"; "System.Xml"; "Microsoft.Build.Framework"; "Microsoft.Build.Utilities"; "netstandard" ]
+
+        begin 
+            let mutable remaining = (computeILRefs ilGlobals ilxMainModule).AssemblyReferences
+            while not (isNil remaining) do
+                let ilAssemRef = List.head remaining
+                remaining <- List.tail remaining
+                if assumedIndependentSet.Contains ilAssemRef.Name || (ilAssemRef.PublicKey = Some ecmaPublicKey) then 
+                    depModuleTable.[ilAssemRef.Name] <- dummyEntry ilAssemRef.Name
+                else
+                    if not (depModuleTable.ContainsKey ilAssemRef.Name) then
+                        match tcImports.TryFindDllInfo(ctok, Range.rangeStartup, ilAssemRef.Name, lookupOnly=false) with 
+                        | Some dllInfo ->
+                            let ccu = 
+                                match tcImports.FindCcuFromAssemblyRef (ctok, Range.rangeStartup, ilAssemRef) with 
+                                | ResolvedCcu ccu -> Some ccu
+                                | UnresolvedCcu(_ccuName) -> None
+
+                            let fileName = dllInfo.FileName
+                            let modul = 
+                                let pdbDirPathOption = 
+                                    // We open the pdb file if one exists parallel to the binary we 
+                                    // are reading, so that --standalone will preserve debug information. 
+                                    if tcConfig.openDebugInformationForLaterStaticLinking then 
+                                        let pdbDir = (try Filename.directoryName fileName with _ -> ".") 
+                                        let pdbFile = (try Filename.chopExtension fileName with _ -> fileName)+".pdb" 
+                                        if FileSystem.SafeExists pdbFile then 
+                                            Some pdbDir
+                                        else 
+                                            None 
+                                    else   
+                                        None
+
+                                let opts : ILReaderOptions = 
+                                    { metadataOnly = MetadataOnlyFlag.No // turn this off here as we need the actual IL code
+                                      reduceMemoryUsage = tcConfig.reduceMemoryUsage
+                                      pdbDirPath = pdbDirPathOption
+                                      tryGetMetadataSnapshot = (fun _ -> None) } 
+
+                                let reader = ILBinaryReader.OpenILModuleReader dllInfo.FileName opts
+                                reader.ILModuleDef
+
+                            let refs = 
+                                if ilAssemRef.Name = GetFSharpCoreLibraryName() then 
+                                    IL.emptyILRefs 
+                                elif not modul.IsILOnly then 
+                                    warning(Error(FSComp.SR.fscIgnoringMixedWhenLinking ilAssemRef.Name, rangeStartup))
+                                    IL.emptyILRefs 
+                                else
+                                    { AssemblyReferences = dllInfo.ILAssemblyRefs 
+                                      ModuleReferences = [] }
+
+                            depModuleTable.[ilAssemRef.Name] <- 
+                                { refs=refs
+                                  name=ilAssemRef.Name
+                                  ccu=ccu
+                                  data=modul 
+                                  edges = [] 
+                                  visited = false }
+
+                            // Push the new work items
+                            remaining <- refs.AssemblyReferences @ remaining
+
+                        | None -> 
+                            warning(Error(FSComp.SR.fscAssumeStaticLinkContainsNoDependencies(ilAssemRef.Name), rangeStartup)) 
+                            depModuleTable.[ilAssemRef.Name] <- dummyEntry ilAssemRef.Name
+            done
+        end
+
+        ReportTime tcConfig "Find dependencies"
+
+        // Add edges from modules to the modules that depend on them 
+        for (KeyValue(_, n)) in depModuleTable do 
+            for aref in n.refs.AssemblyReferences do
+                let n2 = depModuleTable.[aref.Name] 
+                n2.edges <- n :: n2.edges
+                    
+        // Find everything that depends on FSharp.Core
+        let roots = 
+            [ if tcConfig.standalone && depModuleTable.ContainsKey (GetFSharpCoreLibraryName()) then 
+                  yield depModuleTable.[GetFSharpCoreLibraryName()]
+              for n in tcConfig.extraStaticLinkRoots  do
+                  match depModuleTable.TryFind n with 
+                  | Some x -> yield x
+                  | None -> error(Error(FSComp.SR.fscAssemblyNotFoundInDependencySet n, rangeStartup)) 
+            ]
+                              
+        let mutable remaining = roots
+        [ while not (isNil remaining) do
+            let n = List.head remaining
+            remaining <- List.tail remaining
+            if not n.visited then 
+                n.visited <- true
+                remaining <- n.edges @ remaining
+                yield (n.ccu, n.data)  ]
+
+// Add all provider-generated assemblies into the static linking set
+let FindProviderGeneratedILModules (ctok, tcImports: TcImports, providerGeneratedAssemblies: (ImportedBinary * _) list) = 
+    [ for (importedBinary, provAssemStaticLinkInfo) in providerGeneratedAssemblies do 
+        let ilAssemRef =
+            match importedBinary.ILScopeRef with
+            | ILScopeRef.Assembly aref -> aref
+            | _ -> failwith "Invalid ILScopeRef, expected ILScopeRef.Assembly"
+        if debugStaticLinking then printfn "adding provider-generated assembly '%s' into static linking set" ilAssemRef.Name
+        match tcImports.TryFindDllInfo(ctok, Range.rangeStartup, ilAssemRef.Name, lookupOnly=false) with 
+        | Some dllInfo ->
+            let ccu = 
+                match tcImports.FindCcuFromAssemblyRef (ctok, Range.rangeStartup, ilAssemRef) with 
+                | ResolvedCcu ccu -> Some ccu
+                | UnresolvedCcu(_ccuName) -> None
+
+            let modul = dllInfo.RawMetadata.TryGetILModuleDef().Value
+            yield (ccu, dllInfo.ILScopeRef, modul), (ilAssemRef.Name, provAssemStaticLinkInfo)
+        | None -> () ]
+
+// Compute a static linker. This only captures tcImports (a large data structure) if
+// static linking is enabled. Normally this is not the case, which lets us collect tcImports
+// prior to this point.
+let StaticLink (ctok, tcConfig: TcConfig, tcImports: TcImports, ilGlobals: ILGlobals) = 
+
+#if !NO_EXTENSIONTYPING
+    let providerGeneratedAssemblies =
+
+        [ // Add all EST-generated assemblies into the static linking set
+            for KeyValue(_, importedBinary: ImportedBinary) in tcImports.DllTable do
+                if importedBinary.IsProviderGenerated then 
+                    match importedBinary.ProviderGeneratedStaticLinkMap with 
+                    | None -> ()
+                    | Some provAssemStaticLinkInfo -> yield (importedBinary, provAssemStaticLinkInfo) ]
+#endif
+    if not tcConfig.standalone && tcConfig.extraStaticLinkRoots.IsEmpty 
+#if !NO_EXTENSIONTYPING
+            && providerGeneratedAssemblies.IsEmpty 
+#endif
+            then 
+        (fun ilxMainModule -> ilxMainModule)
+    else 
+        (fun ilxMainModule  ->
+            ReportTime tcConfig "Find assembly references"
+
+            let dependentILModules = FindDependentILModulesForStaticLinking (ctok, tcConfig, tcImports, ilGlobals, ilxMainModule)
+
+            ReportTime tcConfig "Static link"
+
+#if !NO_EXTENSIONTYPING
+            Morphs.enableMorphCustomAttributeData()
+            let providerGeneratedILModules =  FindProviderGeneratedILModules (ctok, tcImports, providerGeneratedAssemblies) 
+
+            // Transform the ILTypeRefs references in the IL of all provider-generated assemblies so that the references
+            // are now local.
+            let providerGeneratedILModules = 
+               
+                providerGeneratedILModules |> List.map (fun ((ccu, ilOrigScopeRef, ilModule), (_, localProvAssemStaticLinkInfo)) -> 
+                    let ilAssemStaticLinkMap = 
+                        dict [ for (_, (_, provAssemStaticLinkInfo)) in providerGeneratedILModules do 
+                                    for KeyValue(k, v) in provAssemStaticLinkInfo.ILTypeMap do 
+                                        yield (k, v)
+                               for KeyValue(k, v) in localProvAssemStaticLinkInfo.ILTypeMap do
+                                   yield (ILTypeRef.Create(ILScopeRef.Local, k.Enclosing, k.Name), v) ]
+
+                    let ilModule = 
+                        ilModule |> Morphs.morphILTypeRefsInILModuleMemoized ilGlobals (fun tref -> 
+                                if debugStaticLinking then printfn "deciding whether to rewrite type ref %A" tref.QualifiedName 
+                                let ok, v = ilAssemStaticLinkMap.TryGetValue tref
+                                if ok then 
+                                    if debugStaticLinking then printfn "rewriting type ref %A to %A" tref.QualifiedName v.QualifiedName
+                                    v
+                                else 
+                                    tref)
+                    (ccu, ilOrigScopeRef, ilModule))
+
+            // Relocate provider generated type definitions into the expected shape for the [<Generate>] declarations in an assembly
+            let providerGeneratedILModules, ilxMainModule = 
+                  // Build a dictionary of all remapped IL type defs 
+                  let ilOrigTyRefsForProviderGeneratedTypesToRelocate = 
+                      let rec walk acc (ProviderGeneratedType(ilOrigTyRef, _, xs) as node) = List.fold walk ((ilOrigTyRef, node) :: acc) xs 
+                      dict (Seq.fold walk [] tcImports.ProviderGeneratedTypeRoots)
+
+                  // Build a dictionary of all IL type defs, mapping ilOrigTyRef --> ilTypeDef
+                  let allTypeDefsInProviderGeneratedAssemblies = 
+                      let rec loop ilOrigTyRef (ilTypeDef: ILTypeDef) = 
+                          seq { yield (ilOrigTyRef, ilTypeDef) 
+                                for ntdef in ilTypeDef.NestedTypes do 
+                                    yield! loop (mkILTyRefInTyRef (ilOrigTyRef, ntdef.Name)) ntdef }
+                      dict [ 
+                          for (_ccu, ilOrigScopeRef, ilModule) in providerGeneratedILModules do 
+                              for td in ilModule.TypeDefs do 
+                                  yield! loop (mkILTyRef (ilOrigScopeRef, td.Name)) td ]
+
+
+                  // Debugging output
+                  if debugStaticLinking then 
+                      for (ProviderGeneratedType(ilOrigTyRef, _, _)) in tcImports.ProviderGeneratedTypeRoots do
+                          printfn "Have [<Generate>] root '%s'" ilOrigTyRef.QualifiedName
+
+                  // Build the ILTypeDefs for generated types, starting with the roots 
+                  let generatedILTypeDefs = 
+                      let rec buildRelocatedGeneratedType (ProviderGeneratedType(ilOrigTyRef, ilTgtTyRef, ch)) = 
+                          let isNested = not (isNil ilTgtTyRef.Enclosing)
+                          match allTypeDefsInProviderGeneratedAssemblies.TryGetValue ilOrigTyRef with
+                          | true, ilOrigTypeDef ->
+                              if debugStaticLinking then printfn "Relocating %s to %s " ilOrigTyRef.QualifiedName ilTgtTyRef.QualifiedName
+                              let ilOrigTypeDef = 
+                                if isNested then
+                                    ilOrigTypeDef
+                                        .WithAccess(match ilOrigTypeDef.Access with 
+                                                    | ILTypeDefAccess.Public -> ILTypeDefAccess.Nested ILMemberAccess.Public
+                                                    | ILTypeDefAccess.Private -> ILTypeDefAccess.Nested ILMemberAccess.Private
+                                                    | _ -> ilOrigTypeDef.Access)
+                                else ilOrigTypeDef
+                              ilOrigTypeDef.With(name = ilTgtTyRef.Name,
+                                                 nestedTypes = mkILTypeDefs (List.map buildRelocatedGeneratedType ch))
+                          | _ ->
+                              // If there is no matching IL type definition, then make a simple container class
+                              if debugStaticLinking then 
+                                  printfn "Generating simple class '%s' because we didn't find an original type '%s' in a provider generated assembly" 
+                                      ilTgtTyRef.QualifiedName ilOrigTyRef.QualifiedName
+
+                              let access = (if isNested  then ILTypeDefAccess.Nested ILMemberAccess.Public else ILTypeDefAccess.Public)
+                              let tdefs = mkILTypeDefs (List.map buildRelocatedGeneratedType ch)
+                              mkILSimpleClass ilGlobals (ilTgtTyRef.Name, access, emptyILMethods, emptyILFields, tdefs, emptyILProperties, emptyILEvents, emptyILCustomAttrs, ILTypeInit.OnAny) 
+
+                      [ for (ProviderGeneratedType(_, ilTgtTyRef, _) as node) in tcImports.ProviderGeneratedTypeRoots  do
+                           yield (ilTgtTyRef, buildRelocatedGeneratedType node) ]
+                  
+                  // Implant all the generated type definitions into the ilxMainModule (generating a new ilxMainModule)
+                  let ilxMainModule = 
+
+                      /// Split the list into left, middle and right parts at the first element satisfying 'p'. If no element matches return
+                      /// 'None' for the middle part.
+                      let trySplitFind p xs = 
+                          let rec loop xs acc = 
+                              match xs with 
+                              | [] -> List.rev acc, None, [] 
+                              | h :: t -> if p h then List.rev acc, Some h, t else loop t (h :: acc)
+                          loop xs []
+
+                      /// Implant the (nested) type definition 'td' at path 'enc' in 'tdefs'. 
+                      let rec implantTypeDef isNested (tdefs: ILTypeDefs) (enc: string list) (td: ILTypeDef) = 
+                          match enc with 
+                          | [] -> addILTypeDef td tdefs
+                          | h :: t -> 
+                               let tdefs = tdefs.AsList
+                               let (ltdefs, htd, rtdefs) = 
+                                   match tdefs |> trySplitFind (fun td -> td.Name = h) with 
+                                   | (ltdefs, None, rtdefs) -> 
+                                       let access = if isNested  then ILTypeDefAccess.Nested ILMemberAccess.Public else ILTypeDefAccess.Public
+                                       let fresh = mkILSimpleClass ilGlobals (h, access, emptyILMethods, emptyILFields, emptyILTypeDefs, emptyILProperties, emptyILEvents, emptyILCustomAttrs, ILTypeInit.OnAny)
+                                       (ltdefs, fresh, rtdefs)
+                                   | (ltdefs, Some htd, rtdefs) -> 
+                                       (ltdefs, htd, rtdefs)
+                               let htd = htd.With(nestedTypes = implantTypeDef true htd.NestedTypes t td)
+                               mkILTypeDefs (ltdefs @ [htd] @ rtdefs)
+
+                      let newTypeDefs = 
+                          (ilxMainModule.TypeDefs, generatedILTypeDefs) ||> List.fold (fun acc (ilTgtTyRef, td) -> 
+                              if debugStaticLinking then printfn "implanting '%s' at '%s'" td.Name ilTgtTyRef.QualifiedName 
+                              implantTypeDef false acc ilTgtTyRef.Enclosing td) 
+                      { ilxMainModule with TypeDefs = newTypeDefs } 
+                  
+                  // Remove any ILTypeDefs from the provider generated modules if they have been relocated because of a [<Generate>] declaration.
+                  let providerGeneratedILModules = 
+                      providerGeneratedILModules |> List.map (fun (ccu, ilOrigScopeRef, ilModule) -> 
+                          let ilTypeDefsAfterRemovingRelocatedTypes = 
+                              let rec rw enc (tdefs: ILTypeDefs) = 
+                                  mkILTypeDefs
+                                   [ for tdef in tdefs do 
+                                        let ilOrigTyRef = mkILNestedTyRef (ilOrigScopeRef, enc, tdef.Name)
+                                        if  not (ilOrigTyRefsForProviderGeneratedTypesToRelocate.ContainsKey ilOrigTyRef) then
+                                          if debugStaticLinking then printfn "Keep provided type %s in place because it wasn't relocated" ilOrigTyRef.QualifiedName
+                                          yield tdef.With(nestedTypes = rw (enc@[tdef.Name]) tdef.NestedTypes) ]
+                              rw [] ilModule.TypeDefs
+                          (ccu, { ilModule with TypeDefs = ilTypeDefsAfterRemovingRelocatedTypes }))
+
+                  providerGeneratedILModules, ilxMainModule
+             
+            Morphs.disableMorphCustomAttributeData()
+#else
+            let providerGeneratedILModules = []
+#endif
+
+            // Glue all this stuff into ilxMainModule 
+            let ilxMainModule, rewriteExternalRefsToLocalRefs = 
+                  StaticLinkILModules (tcConfig, ilGlobals, tcImports, ilxMainModule, dependentILModules @ providerGeneratedILModules)
+
+            // Rewrite type and assembly references
+            let ilxMainModule =
+                  let isMscorlib = ilGlobals.primaryAssemblyName = PrimaryAssembly.Mscorlib.Name
+                  let validateTargetPlatform (scopeRef : ILScopeRef) = 
+                      let name = getNameOfScopeRef scopeRef
+                      if (not isMscorlib && name = PrimaryAssembly.Mscorlib.Name) then
+                          error (Error(FSComp.SR.fscStaticLinkingNoProfileMismatches(), rangeCmdArgs))
+                      scopeRef
+                  let rewriteAssemblyRefsToMatchLibraries = NormalizeAssemblyRefs (ctok, ilGlobals, tcImports)
+                  Morphs.morphILTypeRefsInILModuleMemoized ilGlobals (Morphs.morphILScopeRefsInILTypeRef (validateTargetPlatform >> rewriteExternalRefsToLocalRefs >> rewriteAssemblyRefsToMatchLibraries)) ilxMainModule
+
+            ilxMainModule)

--- a/src/fsharp/StaticLinking.fsi
+++ b/src/fsharp/StaticLinking.fsi
@@ -3,25 +3,13 @@
 /// Optional static linking of all DLLs that depend on the F# Library, plus other specified DLLs
 module internal FSharp.Compiler.StaticLinking
 
-open System
-
 open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.Internal.Library
-open FSharp.Compiler.AbstractIL.ILBinaryReader
 open FSharp.Compiler.CompilerConfig
 open FSharp.Compiler.CompilerImports
-open FSharp.Compiler.CompilerOptions
-open FSharp.Compiler.ErrorLogger
-open FSharp.Compiler.Lib
-open FSharp.Compiler.OptimizeInputs
-open FSharp.Compiler.Range
-open FSharp.Compiler.TypedTree
-open FSharp.Compiler.TypedTreeBasics
-open Internal.Utilities
-open Internal.Utilities.Collections
 
 // Compute a static linker. This only captures tcImports (a large data structure) if
 // static linking is enabled. Normally this is not the case, which lets us collect tcImports
 // prior to this point.
-val StaticLink: ctok: int * tcConfig: TcConfig * tcImports: TcImports * ilGlobals: ILGlobals -> (ILModuleDef -> ILModuleDef)
+val StaticLink: ctok: CompilationThreadToken * tcConfig: TcConfig * tcImports: TcImports * ilGlobals: ILGlobals -> (ILModuleDef -> ILModuleDef)

--- a/src/fsharp/StaticLinking.fsi
+++ b/src/fsharp/StaticLinking.fsi
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+/// Optional static linking of all DLLs that depend on the F# Library, plus other specified DLLs
+module internal FSharp.Compiler.StaticLinking
+
+open System
+
+open FSharp.Compiler.AbstractIL
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.AbstractIL.ILBinaryReader
+open FSharp.Compiler.CompilerConfig
+open FSharp.Compiler.CompilerImports
+open FSharp.Compiler.CompilerOptions
+open FSharp.Compiler.ErrorLogger
+open FSharp.Compiler.Lib
+open FSharp.Compiler.OptimizeInputs
+open FSharp.Compiler.Range
+open FSharp.Compiler.TypedTree
+open FSharp.Compiler.TypedTreeBasics
+open Internal.Utilities
+open Internal.Utilities.Collections
+
+// Compute a static linker. This only captures tcImports (a large data structure) if
+// static linking is enabled. Normally this is not the case, which lets us collect tcImports
+// prior to this point.
+val StaticLink: ctok: int * tcConfig: TcConfig * tcImports: TcImports * ilGlobals: ILGlobals -> (ILModuleDef -> ILModuleDef)

--- a/src/fsharp/StaticLinking.fsi
+++ b/src/fsharp/StaticLinking.fsi
@@ -3,7 +3,6 @@
 /// Optional static linking of all DLLs that depend on the F# Library, plus other specified DLLs
 module internal FSharp.Compiler.StaticLinking
 
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.CompilerConfig

--- a/src/fsharp/XmlDocFileWriter.fs
+++ b/src/fsharp/XmlDocFileWriter.fs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module internal FSharp.Compiler.XmlDocFileWriter
+
+open System.IO
+open System.Reflection
+open Internal.Utilities
+open FSharp.Compiler
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.ErrorLogger
+open FSharp.Compiler.Lib
+open FSharp.Compiler.Range
+open FSharp.Compiler.TypedTree
+open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.XmlDoc
+
+module XmlDocWriter =
+
+    let hasDoc (doc: XmlDoc) = not doc.IsEmpty
+        
+    let computeXmlDocSigs (tcGlobals, generatedCcu: CcuThunk) =
+        (* the xmlDocSigOf* functions encode type into string to be used in "id" *)
+        let g = tcGlobals
+        let doValSig ptext (v: Val)  = if hasDoc v.XmlDoc then v.XmlDocSig <- XmlDocSigOfVal g false ptext v
+        let doTyconSig ptext (tc: Tycon) = 
+            if (hasDoc tc.XmlDoc) then tc.XmlDocSig <- XmlDocSigOfTycon [ptext; tc.CompiledName]
+            for vref in tc.MembersOfFSharpTyconSorted do 
+                doValSig ptext vref.Deref
+            for uc in tc.UnionCasesArray do
+                if (hasDoc uc.XmlDoc) then uc.XmlDocSig <- XmlDocSigOfUnionCase [ptext; tc.CompiledName; uc.Id.idText]
+            for rf in tc.AllFieldsArray do
+                if (hasDoc rf.XmlDoc) then
+                    rf.XmlDocSig <-
+                        if tc.IsRecordTycon && (not rf.IsStatic) then 
+                            // represents a record field, which is exposed as a property
+                            XmlDocSigOfProperty [ptext; tc.CompiledName; rf.Id.idText]
+                        else
+                            XmlDocSigOfField [ptext; tc.CompiledName; rf.Id.idText]
+
+        let doModuleMemberSig path (m: ModuleOrNamespace) = m.XmlDocSig <- XmlDocSigOfSubModul [path]
+        (* moduleSpec - recurses *)
+        let rec doModuleSig path (mspec: ModuleOrNamespace) = 
+            let mtype = mspec.ModuleOrNamespaceType
+            let path = 
+                (* skip the first item in the path which is the assembly name *)
+                match path with 
+                | None -> Some ""
+                | Some "" -> Some mspec.LogicalName
+                | Some p -> Some (p+"."+mspec.LogicalName)
+            let ptext = match path with None -> "" | Some t -> t
+            if mspec.IsModule then doModuleMemberSig ptext mspec
+            let vals = 
+                mtype.AllValsAndMembers
+                |> Seq.toList
+                |> List.filter (fun x  -> not x.IsCompilerGenerated) 
+                |> List.filter (fun x -> x.MemberInfo.IsNone || x.IsExtensionMember)
+            List.iter (doModuleSig  path)  mtype.ModuleAndNamespaceDefinitions
+            List.iter (doTyconSig  ptext) mtype.ExceptionDefinitions
+            List.iter (doValSig    ptext) vals
+            List.iter (doTyconSig  ptext) mtype.TypeDefinitions
+       
+        doModuleSig None generatedCcu.Contents          
+
+    let writeXmlDoc (assemblyName, generatedCcu: CcuThunk, xmlfile) =
+        if not (Filename.hasSuffixCaseInsensitive "xml" xmlfile ) then 
+            error(Error(FSComp.SR.docfileNoXmlSuffix(), Range.rangeStartup))
+        (* the xmlDocSigOf* functions encode type into string to be used in "id" *)
+        let mutable members = []
+        let addMember id xmlDoc = 
+            if hasDoc xmlDoc then
+                let doc = xmlDoc.GetXmlText()
+                members <- (id, doc) :: members
+        let doVal (v: Val) = addMember v.XmlDocSig v.XmlDoc
+        let doUnionCase (uc: UnionCase) = addMember uc.XmlDocSig uc.XmlDoc
+        let doField (rf: RecdField) = addMember rf.XmlDocSig rf.XmlDoc
+        let doTycon (tc: Tycon) = 
+            addMember tc.XmlDocSig tc.XmlDoc
+            for vref in tc.MembersOfFSharpTyconSorted do 
+                doVal vref.Deref 
+            for uc in tc.UnionCasesArray do
+                doUnionCase uc
+            for rf in tc.AllFieldsArray do
+                doField rf
+
+        let modulMember (m: ModuleOrNamespace) = addMember m.XmlDocSig m.XmlDoc
+        
+        (* moduleSpec - recurses *)
+        let rec doModule (mspec: ModuleOrNamespace) = 
+            let mtype = mspec.ModuleOrNamespaceType
+            if mspec.IsModule then modulMember mspec
+            let vals = 
+                mtype.AllValsAndMembers
+                |> Seq.toList
+                |> List.filter (fun x  -> not x.IsCompilerGenerated) 
+                |> List.filter (fun x -> x.MemberInfo.IsNone || x.IsExtensionMember)
+            List.iter doModule mtype.ModuleAndNamespaceDefinitions
+            List.iter doTycon mtype.ExceptionDefinitions
+            List.iter doVal vals
+            List.iter doTycon mtype.TypeDefinitions
+       
+        doModule generatedCcu.Contents
+
+        use os = File.CreateText xmlfile
+
+        fprintfn os ("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+        fprintfn os ("<doc>")
+        fprintfn os ("<assembly><name>%s</name></assembly>") assemblyName
+        fprintfn os ("<members>")
+        members |> List.iter (fun (id, doc) -> 
+            fprintfn os  "<member name=\"%s\">" id
+            fprintfn os  "%s" doc
+            fprintfn os  "</member>")
+        fprintfn os "</members>" 
+        fprintfn os "</doc>"   
+

--- a/src/fsharp/XmlDocFileWriter.fs
+++ b/src/fsharp/XmlDocFileWriter.fs
@@ -18,8 +18,7 @@ module XmlDocWriter =
 
     let hasDoc (doc: XmlDoc) = not doc.IsEmpty
         
-    let computeXmlDocSigs (tcGlobals, generatedCcu: CcuThunk) =
-        (* the xmlDocSigOf* functions encode type into string to be used in "id" *)
+    let ComputeXmlDocSigs (tcGlobals, generatedCcu: CcuThunk) =
         let g = tcGlobals
         let doValSig ptext (v: Val)  = if hasDoc v.XmlDoc then v.XmlDocSig <- XmlDocSigOfVal g false ptext v
         let doTyconSig ptext (tc: Tycon) = 
@@ -61,10 +60,10 @@ module XmlDocWriter =
        
         doModuleSig None generatedCcu.Contents          
 
-    let writeXmlDoc (assemblyName, generatedCcu: CcuThunk, xmlfile) =
+    let WriteXmlDocFile (assemblyName, generatedCcu: CcuThunk, xmlfile) =
         if not (Filename.hasSuffixCaseInsensitive "xml" xmlfile ) then 
             error(Error(FSComp.SR.docfileNoXmlSuffix(), Range.rangeStartup))
-        (* the xmlDocSigOf* functions encode type into string to be used in "id" *)
+
         let mutable members = []
         let addMember id xmlDoc = 
             if hasDoc xmlDoc then
@@ -84,7 +83,6 @@ module XmlDocWriter =
 
         let modulMember (m: ModuleOrNamespace) = addMember m.XmlDocSig m.XmlDoc
         
-        (* moduleSpec - recurses *)
         let rec doModule (mspec: ModuleOrNamespace) = 
             let mtype = mspec.ModuleOrNamespaceType
             if mspec.IsModule then modulMember mspec

--- a/src/fsharp/XmlDocFileWriter.fsi
+++ b/src/fsharp/XmlDocFileWriter.fsi
@@ -2,18 +2,11 @@
 
 module internal FSharp.Compiler.XmlDocFileWriter
 
-open System.IO
-open System.Reflection
-open Internal.Utilities
-open FSharp.Compiler
-open FSharp.Compiler.AbstractIL.Internal.Library
-open FSharp.Compiler.ErrorLogger
-open FSharp.Compiler.Lib
-open FSharp.Compiler.Range
 open FSharp.Compiler.TypedTree
-open FSharp.Compiler.TypedTreeOps
-open FSharp.Compiler.XmlDoc
+open FSharp.Compiler.TcGlobals
 
 module XmlDocWriter =
 
-    val writeXmlDoc: assemblyName: int * generatedCcu: CcuThunk * xmlfile: string -> unit
+    val computeXmlDocSigs: tcGlobals: TcGlobals * generatedCcu: CcuThunk -> unit
+
+    val writeXmlDoc: assemblyName: string * generatedCcu: CcuThunk * xmlfile: string -> unit

--- a/src/fsharp/XmlDocFileWriter.fsi
+++ b/src/fsharp/XmlDocFileWriter.fsi
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module internal FSharp.Compiler.XmlDocFileWriter
+
+open System.IO
+open System.Reflection
+open Internal.Utilities
+open FSharp.Compiler
+open FSharp.Compiler.AbstractIL.Internal.Library
+open FSharp.Compiler.ErrorLogger
+open FSharp.Compiler.Lib
+open FSharp.Compiler.Range
+open FSharp.Compiler.TypedTree
+open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.XmlDoc
+
+module XmlDocWriter =
+
+    val writeXmlDoc: assemblyName: int * generatedCcu: CcuThunk * xmlfile: string -> unit

--- a/src/fsharp/XmlDocFileWriter.fsi
+++ b/src/fsharp/XmlDocFileWriter.fsi
@@ -7,6 +7,6 @@ open FSharp.Compiler.TcGlobals
 
 module XmlDocWriter =
 
-    val computeXmlDocSigs: tcGlobals: TcGlobals * generatedCcu: CcuThunk -> unit
+    val ComputeXmlDocSigs: tcGlobals: TcGlobals * generatedCcu: CcuThunk -> unit
 
-    val writeXmlDoc: assemblyName: string * generatedCcu: CcuThunk * xmlfile: string -> unit
+    val WriteXmlDocFile: assemblyName: string * generatedCcu: CcuThunk * xmlfile: string -> unit

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -736,12 +736,12 @@ let main2(Args (ctok, tcGlobals, tcImports: TcImports, frameworkTcImports, gener
 
     ReportTime tcConfig ("Write XML document signatures")
     if tcConfig.xmlDocOutputFile.IsSome then 
-        XmlDocWriter.computeXmlDocSigs (tcGlobals, generatedCcu) 
+        XmlDocWriter.ComputeXmlDocSigs (tcGlobals, generatedCcu) 
 
     ReportTime tcConfig ("Write XML docs")
     tcConfig.xmlDocOutputFile |> Option.iter (fun xmlFile -> 
         let xmlFile = tcConfig.MakePathAbsolute xmlFile
-        XmlDocWriter.writeXmlDoc (assemblyName, generatedCcu, xmlFile))
+        XmlDocWriter.WriteXmlDocFile (assemblyName, generatedCcu, xmlFile))
 
     // Pass on only the minimum information required for the next phase
     Args (ctok, tcConfig, tcImports, frameworkTcImports, tcGlobals, errorLogger, generatedCcu, outfile, typedImplFiles, topAttrs, pdbfile, assemblyName, assemVerFromAttrib, signingInfo, exiter)

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -21,7 +21,6 @@ open System.Text
 open System.Threading
 
 open Internal.Utilities
-open Internal.Utilities.Collections
 open Internal.Utilities.Filename
 open Internal.Utilities.StructuredFormat
 
@@ -29,10 +28,7 @@ open FSharp.Compiler
 open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILBinaryReader
-open FSharp.Compiler.AbstractIL.Internal
 open FSharp.Compiler.AbstractIL.Internal.Library
-open FSharp.Compiler.AbstractIL.Internal.Utils
-open FSharp.Compiler.AbstractIL.Diagnostics
 open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.CheckExpressions
 open FSharp.Compiler.CheckDeclarations
@@ -41,6 +37,7 @@ open FSharp.Compiler.CompilerDiagnostics
 open FSharp.Compiler.CompilerImports
 open FSharp.Compiler.CompilerOptions
 open FSharp.Compiler.CompilerGlobalState
+open FSharp.Compiler.CreateILModule
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.IlxGen
 open FSharp.Compiler.InfoReader
@@ -52,19 +49,11 @@ open FSharp.Compiler.ScriptClosure
 open FSharp.Compiler.SyntaxTree
 open FSharp.Compiler.Range
 open FSharp.Compiler.TypedTree
-open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps
 open FSharp.Compiler.TcGlobals
-open FSharp.Compiler.XmlDoc
+open FSharp.Compiler.XmlDocFileWriter
+open FSharp.Compiler.StaticLinking
 open Microsoft.DotNet.DependencyManager
-
-open FSharp.Compiler.AbstractIL.Internal.StrongNameSign
-
-#if !NO_EXTENSIONTYPING
-open FSharp.Compiler.ExtensionTyping
-#endif
-
-#nowarn "45" // This method will be made public in the underlying IL because it may implement an interface or override a method
 
 //----------------------------------------------------------------------------
 // Reporting - warnings, errors
@@ -178,26 +167,6 @@ let AbortOnError (errorLogger: ErrorLogger, exiter : Exiter) =
     if errorLogger.ErrorCount > 0 then
         exiter.Exit 1
 
-//----------------------------------------------------------------------------
-// DisposablesTracker
-//----------------------------------------------------------------------------
-
-/// Track a set of resources to cleanup
-type DisposablesTracker() = 
-
-    let items = Stack<IDisposable>()
-
-    member this.Register i = items.Push i
-
-    interface IDisposable with
-
-        member this.Dispose() = 
-            let l = List.ofSeq items
-            items.Clear()
-            for i in l do 
-                try i.Dispose() with _ -> ()
-
-
 let TypeCheck (ctok, tcConfig, tcImports, tcGlobals, errorLogger: ErrorLogger, assemblyName, niceNameGen, tcEnv0, inputs, exiter: Exiter) =
     try 
         if isNil inputs then error(Error(FSComp.SR.fscNoImplementationFiles(), Range.rangeStartup))
@@ -256,7 +225,14 @@ let AdjustForScriptCompile(ctok, tcConfigB: TcConfigBuilder, commandLineSourceFi
 
     List.rev allSources
 
-let ProcessCommandLineFlags (tcConfigB: TcConfigBuilder, setProcessThreadLocals, lcidFromCodePage, argv) =
+let SetProcessThreadLocals tcConfigB =
+    match tcConfigB.preferredUiLang with
+    | Some s -> Thread.CurrentThread.CurrentUICulture <- new CultureInfo(s)
+    | None -> ()
+    if tcConfigB.utf8output then 
+        Console.OutputEncoding <- Encoding.UTF8
+
+let ProcessCommandLineFlags (tcConfigB: TcConfigBuilder, lcidFromCodePage, argv) =
     let mutable inputFilesRef = []
     let collect name = 
         let lower = String.lowercase name
@@ -289,7 +265,7 @@ let ProcessCommandLineFlags (tcConfigB: TcConfigBuilder, setProcessThreadLocals,
     | Some _ -> ()
     | None -> tcConfigB.lcid <- lcidFromCodePage
 
-    setProcessThreadLocals tcConfigB
+    SetProcessThreadLocals tcConfigB
 
     (* step - get dll references *)
     let dllFiles, sourceFiles = inputFiles |> List.map(fun p -> trimQuotes p) |> List.partition Filename.isDll
@@ -300,6 +276,43 @@ let ProcessCommandLineFlags (tcConfigB: TcConfigBuilder, setProcessThreadLocals,
     dllFiles |> List.iter (fun f->tcConfigB.AddReferencedAssemblyByPath(rangeStartup, f))
     sourceFiles
 
+let EncodeSignatureData(tcConfig: TcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, isIncrementalBuild) = 
+    if tcConfig.GenerateSignatureData then 
+        let resource = WriteSignatureData (tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, isIncrementalBuild)
+        // The resource gets written to a file for FSharp.Core
+        let useDataFiles = (tcConfig.useOptimizationDataFile || tcGlobals.compilingFslib) && not isIncrementalBuild
+        if useDataFiles then 
+            let sigDataFileName = (Filename.chopExtension outfile)+".sigdata"
+            let bytes = resource.GetBytes()
+            use fileStream = File.Create(sigDataFileName, bytes.Length)
+            bytes.CopyTo fileStream
+        let resources = 
+            [ resource ]
+        let sigAttr = mkSignatureDataVersionAttr tcGlobals (IL.parseILVersion Internal.Utilities.FSharpEnvironment.FSharpBinaryMetadataFormatRevision) 
+        [sigAttr], resources
+      else 
+        [], []
+
+let EncodeOptimizationData(tcGlobals, tcConfig: TcConfig, outfile, exportRemapping, data, isIncrementalBuild) = 
+    if tcConfig.GenerateOptimizationData then 
+        let data = map2Of2 (Optimizer.RemapOptimizationInfo tcGlobals exportRemapping) data
+        // As with the sigdata file, the optdata gets written to a file for FSharp.Core
+        let useDataFiles = (tcConfig.useOptimizationDataFile || tcGlobals.compilingFslib) && not isIncrementalBuild
+        if useDataFiles then 
+            let ccu, modulInfo = data
+            let bytes = TypedTreePickle.pickleObjWithDanglingCcus isIncrementalBuild outfile tcGlobals ccu Optimizer.p_CcuOptimizationInfo modulInfo
+            let optDataFileName = (Filename.chopExtension outfile)+".optdata"
+            File.WriteAllBytes(optDataFileName, bytes)
+        let (ccu, optData) = 
+            if tcConfig.onlyEssentialOptimizationData then 
+                map2Of2 Optimizer.AbstractOptimizationInfoToEssentials data 
+            else 
+                data
+        [ WriteOptimizationData (tcGlobals, outfile, isIncrementalBuild, ccu, optData) ]
+    else
+        [ ]
+
+/// Write a .fsi file for the --sig option
 module InterfaceFileWriter =
 
     let BuildInitialDisplayEnvForSigFileGeneration tcGlobals = 
@@ -335,1359 +348,6 @@ module InterfaceFileWriter =
        
         if tcConfig.printSignatureFile <> "" then os.Dispose()
 
-module XmlDocWriter =
-
-    let hasDoc (doc: XmlDoc) = not doc.IsEmpty
-        
-    let computeXmlDocSigs (tcGlobals, generatedCcu: CcuThunk) =
-        (* the xmlDocSigOf* functions encode type into string to be used in "id" *)
-        let g = tcGlobals
-        let doValSig ptext (v: Val)  = if hasDoc v.XmlDoc then v.XmlDocSig <- XmlDocSigOfVal g false ptext v
-        let doTyconSig ptext (tc: Tycon) = 
-            if (hasDoc tc.XmlDoc) then tc.XmlDocSig <- XmlDocSigOfTycon [ptext; tc.CompiledName]
-            for vref in tc.MembersOfFSharpTyconSorted do 
-                doValSig ptext vref.Deref
-            for uc in tc.UnionCasesArray do
-                if (hasDoc uc.XmlDoc) then uc.XmlDocSig <- XmlDocSigOfUnionCase [ptext; tc.CompiledName; uc.Id.idText]
-            for rf in tc.AllFieldsArray do
-                if (hasDoc rf.XmlDoc) then
-                    rf.XmlDocSig <-
-                        if tc.IsRecordTycon && (not rf.IsStatic) then 
-                            // represents a record field, which is exposed as a property
-                            XmlDocSigOfProperty [ptext; tc.CompiledName; rf.Id.idText]
-                        else
-                            XmlDocSigOfField [ptext; tc.CompiledName; rf.Id.idText]
-
-        let doModuleMemberSig path (m: ModuleOrNamespace) = m.XmlDocSig <- XmlDocSigOfSubModul [path]
-        (* moduleSpec - recurses *)
-        let rec doModuleSig path (mspec: ModuleOrNamespace) = 
-            let mtype = mspec.ModuleOrNamespaceType
-            let path = 
-                (* skip the first item in the path which is the assembly name *)
-                match path with 
-                | None -> Some ""
-                | Some "" -> Some mspec.LogicalName
-                | Some p -> Some (p+"."+mspec.LogicalName)
-            let ptext = match path with None -> "" | Some t -> t
-            if mspec.IsModule then doModuleMemberSig ptext mspec
-            let vals = 
-                mtype.AllValsAndMembers
-                |> Seq.toList
-                |> List.filter (fun x  -> not x.IsCompilerGenerated) 
-                |> List.filter (fun x -> x.MemberInfo.IsNone || x.IsExtensionMember)
-            List.iter (doModuleSig  path)  mtype.ModuleAndNamespaceDefinitions
-            List.iter (doTyconSig  ptext) mtype.ExceptionDefinitions
-            List.iter (doValSig    ptext) vals
-            List.iter (doTyconSig  ptext) mtype.TypeDefinitions
-       
-        doModuleSig None generatedCcu.Contents          
-
-    let writeXmlDoc (assemblyName, generatedCcu: CcuThunk, xmlfile) =
-        if not (Filename.hasSuffixCaseInsensitive "xml" xmlfile ) then 
-            error(Error(FSComp.SR.docfileNoXmlSuffix(), Range.rangeStartup))
-        (* the xmlDocSigOf* functions encode type into string to be used in "id" *)
-        let mutable members = []
-        let addMember id xmlDoc = 
-            if hasDoc xmlDoc then
-                let doc = xmlDoc.GetXmlText()
-                members <- (id, doc) :: members
-        let doVal (v: Val) = addMember v.XmlDocSig v.XmlDoc
-        let doUnionCase (uc: UnionCase) = addMember uc.XmlDocSig uc.XmlDoc
-        let doField (rf: RecdField) = addMember rf.XmlDocSig rf.XmlDoc
-        let doTycon (tc: Tycon) = 
-            addMember tc.XmlDocSig tc.XmlDoc
-            for vref in tc.MembersOfFSharpTyconSorted do 
-                doVal vref.Deref 
-            for uc in tc.UnionCasesArray do
-                doUnionCase uc
-            for rf in tc.AllFieldsArray do
-                doField rf
-
-        let modulMember (m: ModuleOrNamespace) = addMember m.XmlDocSig m.XmlDoc
-        
-        (* moduleSpec - recurses *)
-        let rec doModule (mspec: ModuleOrNamespace) = 
-            let mtype = mspec.ModuleOrNamespaceType
-            if mspec.IsModule then modulMember mspec
-            let vals = 
-                mtype.AllValsAndMembers
-                |> Seq.toList
-                |> List.filter (fun x  -> not x.IsCompilerGenerated) 
-                |> List.filter (fun x -> x.MemberInfo.IsNone || x.IsExtensionMember)
-            List.iter doModule mtype.ModuleAndNamespaceDefinitions
-            List.iter doTycon mtype.ExceptionDefinitions
-            List.iter doVal vals
-            List.iter doTycon mtype.TypeDefinitions
-       
-        doModule generatedCcu.Contents
-
-        use os = File.CreateText xmlfile
-
-        fprintfn os ("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
-        fprintfn os ("<doc>")
-        fprintfn os ("<assembly><name>%s</name></assembly>") assemblyName
-        fprintfn os ("<members>")
-        members |> List.iter (fun (id, doc) -> 
-            fprintfn os  "<member name=\"%s\">" id
-            fprintfn os  "%s" doc
-            fprintfn os  "</member>")
-        fprintfn os "</members>" 
-        fprintfn os "</doc>"   
-
-
-let DefaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()).Value
-
-let GenerateInterfaceData(tcConfig: TcConfig) = 
-    not tcConfig.standalone && not tcConfig.noSignatureData 
-
-let EncodeInterfaceData(tcConfig: TcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, isIncrementalBuild) = 
-    if GenerateInterfaceData tcConfig then 
-        let resource = WriteSignatureData (tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, isIncrementalBuild)
-        // The resource gets written to a file for FSharp.Core
-        let useDataFiles = (tcConfig.useOptimizationDataFile || tcGlobals.compilingFslib) && not isIncrementalBuild
-        if useDataFiles then 
-            let sigDataFileName = (Filename.chopExtension outfile)+".sigdata"
-            let bytes = resource.GetBytes()
-            use fileStream = File.Create(sigDataFileName, bytes.Length)
-            bytes.CopyTo fileStream
-        let resources = 
-            [ resource ]
-        let sigAttr = mkSignatureDataVersionAttr tcGlobals (IL.parseILVersion Internal.Utilities.FSharpEnvironment.FSharpBinaryMetadataFormatRevision) 
-        [sigAttr], resources
-      else 
-        [], []
-
-let GenerateOptimizationData tcConfig = 
-    GenerateInterfaceData tcConfig 
-
-let EncodeOptimizationData(tcGlobals, tcConfig: TcConfig, outfile, exportRemapping, data, isIncrementalBuild) = 
-    if GenerateOptimizationData tcConfig then 
-        let data = map2Of2 (Optimizer.RemapOptimizationInfo tcGlobals exportRemapping) data
-        // As with the sigdata file, the optdata gets written to a file for FSharp.Core
-        let useDataFiles = (tcConfig.useOptimizationDataFile || tcGlobals.compilingFslib) && not isIncrementalBuild
-        if useDataFiles then 
-            let ccu, modulInfo = data
-            let bytes = TypedTreePickle.pickleObjWithDanglingCcus isIncrementalBuild outfile tcGlobals ccu Optimizer.p_CcuOptimizationInfo modulInfo
-            let optDataFileName = (Filename.chopExtension outfile)+".optdata"
-            File.WriteAllBytes(optDataFileName, bytes)
-        let (ccu, optData) = 
-            if tcConfig.onlyEssentialOptimizationData then 
-                map2Of2 Optimizer.AbstractOptimizationInfoToEssentials data 
-            else 
-                data
-        [ WriteOptimizationData (tcGlobals, outfile, isIncrementalBuild, ccu, optData) ]
-    else
-        [ ]
-
-//----------------------------------------------------------------------------
-// .res file format, for encoding the assembly version attribute. 
-//--------------------------------------------------------------------------
-
-// Helpers for generating binary blobs
-module BinaryGenerationUtilities = 
-    // Little-endian encoding of int32 
-    let b0 n =  byte (n &&& 0xFF)
-    let b1 n =  byte ((n >>> 8) &&& 0xFF)
-    let b2 n =  byte ((n >>> 16) &&& 0xFF)
-    let b3 n =  byte ((n >>> 24) &&& 0xFF)
-
-    let i16 (i: int32) = [| b0 i; b1 i |]
-    let i32 (i: int32) = [| b0 i; b1 i; b2 i; b3 i |]
-
-    // Emit the bytes and pad to a 32-bit alignment
-    let Padded initialAlignment (v: byte[]) = 
-        [| yield! v
-           for _ in 1..(4 - (initialAlignment + v.Length) % 4) % 4 do
-               yield 0x0uy |]
-
-// Generate nodes in a .res file format. These are then linked by Abstract IL using linkNativeResources
-module ResFileFormat =
-    open BinaryGenerationUtilities
-
-    let ResFileNode(dwTypeID, dwNameID, wMemFlags, wLangID, data: byte[]) =
-        [| yield! i32 data.Length  // DWORD ResHdr.dwDataSize
-           yield! i32 0x00000020  // dwHeaderSize
-           yield! i32 ((dwTypeID <<< 16) ||| 0x0000FFFF)  // dwTypeID, sizeof(DWORD)
-           yield! i32 ((dwNameID <<< 16) ||| 0x0000FFFF)   // dwNameID, sizeof(DWORD)
-           yield! i32 0x00000000 // DWORD       dwDataVersion
-           yield! i16 wMemFlags // WORD        wMemFlags
-           yield! i16 wLangID   // WORD        wLangID
-           yield! i32 0x00000000 // DWORD       dwVersion
-           yield! i32 0x00000000 // DWORD       dwCharacteristics
-           yield! Padded 0 data |]
-
-    let ResFileHeader() = ResFileNode(0x0, 0x0, 0x0, 0x0, [| |]) 
-
-// Generate the VS_VERSION_INFO structure held in a Win32 Version Resource in a PE file
-//
-// Web reference: http://www.piclist.com/tecHREF/os/win/api/win32/struc/src/str24_5.htm
-module VersionResourceFormat = 
-    open BinaryGenerationUtilities
-
-    let VersionInfoNode(data: byte[]) =
-        [| yield! i16 (data.Length + 2) // wLength : int16 // Specifies the length, in bytes, of the VS_VERSION_INFO structure. 
-           yield! data |]
-
-    let VersionInfoElement(wType, szKey, valueOpt: byte[] option, children: byte[][], isString) =
-        // for String structs, wValueLength represents the word count, not the byte count
-        let wValueLength = (match valueOpt with None -> 0 | Some value -> (if isString then value.Length / 2 else value.Length))
-        VersionInfoNode
-            [| yield! i16 wValueLength // wValueLength: int16. Specifies the length, in words, of the Value member. 
-               yield! i16 wType        // wType : int16 Specifies the type of data in the version resource. 
-               yield! Padded 2 szKey 
-               match valueOpt with 
-               | None -> yield! []
-               | Some value -> yield! Padded 0 value 
-               for child in children do 
-                   yield! child  |]
-
-    let Version(version: ILVersionInfo) = 
-        [| // DWORD dwFileVersionMS
-           // Specifies the most significant 32 bits of the file's binary 
-           // version number. This member is used with dwFileVersionLS to form a 64-bit value used 
-           // for numeric comparisons. 
-           yield! i32 (int32 version.Major <<< 16 ||| int32 version.Minor) 
-           
-           // DWORD dwFileVersionLS 
-           // Specifies the least significant 32 bits of the file's binary 
-           // version number. This member is used with dwFileVersionMS to form a 64-bit value used 
-           // for numeric comparisons. 
-           yield! i32 (int32 version.Build <<< 16 ||| int32 version.Revision) 
-        |]
-
-    let String(string, value) = 
-        let wType = 0x1 // Specifies the type of data in the version resource. 
-        let szKey = Bytes.stringAsUnicodeNullTerminated string
-        VersionInfoElement(wType, szKey, Some (Bytes.stringAsUnicodeNullTerminated value), [| |], true)
-
-    let StringTable(language, strings) = 
-        let wType = 0x1 // Specifies the type of data in the version resource. 
-        let szKey = Bytes.stringAsUnicodeNullTerminated language
-             // Specifies an 8-digit hexadecimal number stored as a Unicode string. 
-                       
-        let children =  
-            [| for string in strings do
-                   yield String string |] 
-        VersionInfoElement(wType, szKey, None, children, false)
-
-    let StringFileInfo(stringTables: #seq<string * #seq<string * string> >) = 
-        let wType = 0x1 // Specifies the type of data in the version resource. 
-        let szKey = Bytes.stringAsUnicodeNullTerminated "StringFileInfo" // Contains the Unicode string StringFileInfo
-        // Contains an array of one or more StringTable structures. 
-        let children =  
-            [| for stringTable in stringTables do
-                   yield StringTable stringTable |] 
-        VersionInfoElement(wType, szKey, None, children, false)
-
-    let VarFileInfo(vars: #seq<int32 * int32>) = 
-        let wType = 0x1 // Specifies the type of data in the version resource. 
-        let szKey = Bytes.stringAsUnicodeNullTerminated "VarFileInfo" // Contains the Unicode string StringFileInfo
-        // Contains an array of one or more StringTable structures. 
-        let children =  
-            [| for (lang, codePage) in vars do
-                   let szKey = Bytes.stringAsUnicodeNullTerminated "Translation"
-                   yield VersionInfoElement(0x0, szKey, Some([| yield! i16 lang
-                                                                yield! i16 codePage |]), [| |], false) |] 
-        VersionInfoElement(wType, szKey, None, children, false)
-
-    let VS_FIXEDFILEINFO(fileVersion: ILVersionInfo, 
-                         productVersion: ILVersionInfo, 
-                         dwFileFlagsMask, 
-                         dwFileFlags, dwFileOS, 
-                         dwFileType, dwFileSubtype, 
-                         lwFileDate: int64) = 
-        let dwStrucVersion = 0x00010000
-        [| // DWORD dwSignature // Contains the value 0xFEEFO4BD. 
-           yield! i32  0xFEEF04BD 
-           
-           // DWORD dwStrucVersion // Specifies the binary version number of this structure. 
-           yield! i32 dwStrucVersion 
-           
-           // DWORD dwFileVersionMS, dwFileVersionLS // Specifies the most/least significant 32 bits of the file's binary version number. 
-           yield! Version fileVersion 
-           
-           // DWORD dwProductVersionMS, dwProductVersionLS // Specifies the most/least significant 32 bits of the file's binary version number. 
-           yield! Version productVersion 
-           
-           // DWORD dwFileFlagsMask // Contains a bitmask that specifies the valid bits in dwFileFlags. 
-           yield! i32 dwFileFlagsMask 
-           
-           // DWORD dwFileFlags // Contains a bitmask that specifies the Boolean attributes of the file. 
-           yield! i32 dwFileFlags 
-                  // VS_FF_DEBUG 0x1L     The file contains debugging information or is compiled with debugging features enabled. 
-                  // VS_FF_INFOINFERRED   The file's version structure was created dynamically; therefore, some of the members 
-                  //                      in this structure may be empty or incorrect. This flag should never be set in a file's 
-                  //                      VS_VERSION_INFO data. 
-                  // VS_FF_PATCHED        The file has been modified and is not identical to the original shipping file of 
-                  //                      the same version number. 
-                  // VS_FF_PRERELEASE     The file is a development version, not a commercially released product. 
-                  // VS_FF_PRIVATEBUILD   The file was not built using standard release procedures. If this flag is 
-                  //                      set, the StringFileInfo structure should contain a PrivateBuild entry. 
-                  // VS_FF_SPECIALBUILD   The file was built by the original company using standard release procedures 
-                  //                      but is a variation of the normal file of the same version number. If this 
-                  //                      flag is set, the StringFileInfo structure should contain a SpecialBuild entry. 
-           
-           //Specifies the operating system for which this file was designed. This member can be one of the following values: Flag 
-           yield! i32 dwFileOS 
-                  //VOS_DOS 0x0001L  The file was designed for MS-DOS. 
-                  //VOS_NT  0x0004L  The file was designed for Windows NT. 
-                  //VOS__WINDOWS16  The file was designed for 16-bit Windows. 
-                  //VOS__WINDOWS32  The file was designed for the Win32 API. 
-                  //VOS_OS216 0x00020000L  The file was designed for 16-bit OS/2. 
-                  //VOS_OS232  0x00030000L  The file was designed for 32-bit OS/2. 
-                  //VOS__PM16  The file was designed for 16-bit Presentation Manager. 
-                  //VOS__PM32  The file was designed for 32-bit Presentation Manager. 
-                  //VOS_UNKNOWN  The operating system for which the file was designed is unknown to Windows. 
-           
-           // Specifies the general type of file. This member can be one of the following values: 
-           yield! i32 dwFileType 
-           
-                //VFT_UNKNOWN The file type is unknown to Windows. 
-                //VFT_APP  The file contains an application. 
-                //VFT_DLL  The file contains a dynamic-link library (DLL). 
-                //VFT_DRV  The file contains a device driver. If dwFileType is VFT_DRV, dwFileSubtype contains a more specific description of the driver. 
-                //VFT_FONT  The file contains a font. If dwFileType is VFT_FONT, dwFileSubtype contains a more specific description of the font file. 
-                //VFT_VXD  The file contains a virtual device. 
-                //VFT_STATIC_LIB  The file contains a static-link library. 
-
-           // Specifies the function of the file. The possible values depend on the value of 
-           // dwFileType. For all values of dwFileType not described in the following list, 
-           // dwFileSubtype is zero. If dwFileType is VFT_DRV, dwFileSubtype can be one of the following values: 
-           yield! i32 dwFileSubtype 
-                //VFT2_UNKNOWN  The driver type is unknown by Windows. 
-                //VFT2_DRV_COMM  The file contains a communications driver. 
-                //VFT2_DRV_PRINTER  The file contains a printer driver. 
-                //VFT2_DRV_KEYBOARD  The file contains a keyboard driver. 
-                //VFT2_DRV_LANGUAGE  The file contains a language driver. 
-                //VFT2_DRV_DISPLAY  The file contains a display driver. 
-                //VFT2_DRV_MOUSE  The file contains a mouse driver. 
-                //VFT2_DRV_NETWORK  The file contains a network driver. 
-                //VFT2_DRV_SYSTEM  The file contains a system driver. 
-                //VFT2_DRV_INSTALLABLE  The file contains an installable driver. 
-                //VFT2_DRV_SOUND  The file contains a sound driver. 
-                //
-                //If dwFileType is VFT_FONT, dwFileSubtype can be one of the following values: 
-                // 
-                //VFT2_UNKNOWN  The font type is unknown by Windows. 
-                //VFT2_FONT_RASTER  The file contains a raster font. 
-                //VFT2_FONT_VECTOR  The file contains a vector font. 
-                //VFT2_FONT_TRUETYPE  The file contains a TrueType font. 
-                //
-                //If dwFileType is VFT_VXD, dwFileSubtype contains the virtual device identifier included in the virtual device control block. 
-           
-           // Specifies the most significant 32 bits of the file's 64-bit binary creation date and time stamp. 
-           yield! i32 (int32 (lwFileDate >>> 32)) 
-           
-           //Specifies the least significant 32 bits of the file's 64-bit binary creation date and time stamp. 
-           yield! i32 (int32 lwFileDate) 
-         |] 
-
-
-    let VS_VERSION_INFO(fixedFileInfo, stringFileInfo, varFileInfo)  =
-        let wType = 0x0 
-        let szKey = Bytes.stringAsUnicodeNullTerminated "VS_VERSION_INFO" // Contains the Unicode string VS_VERSION_INFO
-        let value = VS_FIXEDFILEINFO (fixedFileInfo)
-        let children =  
-            [| yield StringFileInfo stringFileInfo 
-               yield VarFileInfo varFileInfo 
-            |] 
-        VersionInfoElement(wType, szKey, Some value, children, false)
-       
-    let VS_VERSION_INFO_RESOURCE data = 
-        let dwTypeID = 0x0010
-        let dwNameID = 0x0001
-        let wMemFlags = 0x0030 // REVIEW: HARDWIRED TO ENGLISH
-        let wLangID = 0x0
-        ResFileFormat.ResFileNode(dwTypeID, dwNameID, wMemFlags, wLangID, VS_VERSION_INFO data)
-        
-module ManifestResourceFormat =
-    
-    let VS_MANIFEST_RESOURCE(data, isLibrary) =
-        let dwTypeID = 0x0018
-        let dwNameID = if isLibrary then 0x2 else 0x1
-        let wMemFlags = 0x0
-        let wLangID = 0x0
-        ResFileFormat.ResFileNode(dwTypeID, dwNameID, wMemFlags, wLangID, data)
-
-//----------------------------------------------------------------------------
-// Helpers for finding attributes
-//----------------------------------------------------------------------------
-
-module AttributeHelpers = 
-
-    /// Try to find an attribute that takes a string argument
-    let TryFindStringAttribute (g: TcGlobals) attrib attribs =
-      match g.TryFindSysAttrib attrib with 
-      | None -> None
-      | Some attribRef -> 
-        match TryFindFSharpAttribute g attribRef attribs with
-        | Some (Attrib(_, _, [ AttribStringArg s ], _, _, _, _))  -> Some (s)
-        | _ -> None
-        
-    let TryFindIntAttribute (g: TcGlobals) attrib attribs =
-      match g.TryFindSysAttrib attrib with 
-      | None -> None
-      | Some attribRef -> 
-        match TryFindFSharpAttribute g attribRef attribs with
-        | Some (Attrib(_, _, [ AttribInt32Arg i ], _, _, _, _)) -> Some (i)
-        | _ -> None
-        
-    let TryFindBoolAttribute (g: TcGlobals) attrib attribs =
-      match g.TryFindSysAttrib attrib with 
-      | None -> None
-      | Some attribRef -> 
-        match TryFindFSharpAttribute g attribRef attribs with
-        | Some (Attrib(_, _, [ AttribBoolArg p ], _, _, _, _)) -> Some (p)
-        | _ -> None
-
-    let (|ILVersion|_|) (versionString: string) =
-        try Some (IL.parseILVersion versionString)
-        with e -> 
-            None
-
-    // Try to find an AssemblyVersion attribute 
-    let TryFindVersionAttribute g attrib attribName attribs deterministic =
-        match TryFindStringAttribute g attrib attribs with
-        | Some versionString ->
-             if deterministic && versionString.Contains("*") then
-                 errorR(Error(FSComp.SR.fscAssemblyWildcardAndDeterminism(attribName, versionString), Range.rangeStartup))
-             try Some (IL.parseILVersion versionString)
-             with e ->
-                 // Warning will be reported by CheckExpressions.fs
-                 None
-        | _ -> None
-
-//----------------------------------------------------------------------------
-// Building the contents of the finalized IL module
-//----------------------------------------------------------------------------
-
-module MainModuleBuilder = 
-
-    let injectedCompatTypes = 
-      set [ "System.Tuple`1"
-            "System.Tuple`2" 
-            "System.Tuple`3" 
-            "System.Tuple`4"
-            "System.Tuple`5"
-            "System.Tuple`6"
-            "System.Tuple`7"
-            "System.Tuple`8"
-            "System.ITuple"
-            "System.Tuple"
-            "System.Collections.IStructuralComparable"
-            "System.Collections.IStructuralEquatable" ]
-
-    let typesForwardedToMscorlib = 
-      set [ "System.AggregateException"
-            "System.Threading.CancellationTokenRegistration"
-            "System.Threading.CancellationToken"
-            "System.Threading.CancellationTokenSource"
-            "System.Lazy`1"
-            "System.IObservable`1"
-            "System.IObserver`1" ]
-
-    let typesForwardedToSystemNumerics =
-      set [ "System.Numerics.BigInteger" ]
-
-    let createMscorlibExportList (tcGlobals: TcGlobals) =
-      // We want to write forwarders out for all injected types except for System.ITuple, which is internal
-      // Forwarding System.ITuple will cause FxCop failures on 4.0
-      Set.union (Set.filter (fun t -> t <> "System.ITuple") injectedCompatTypes) typesForwardedToMscorlib |>
-          Seq.map (fun t -> mkTypeForwarder (tcGlobals.ilg.primaryAssemblyScopeRef) t (mkILNestedExportedTypes List.empty<ILNestedExportedType>) (mkILCustomAttrs List.empty<ILAttribute>) ILTypeDefAccess.Public ) 
-          |> Seq.toList
-
-    let createSystemNumericsExportList (tcConfig: TcConfig) (tcImports: TcImports) =
-        let refNumericsDllName =
-            if (tcConfig.primaryAssembly.Name = "mscorlib") then "System.Numerics"
-            else "System.Runtime.Numerics"
-        let numericsAssemblyRef =
-            match tcImports.GetImportedAssemblies() |> List.tryFind<ImportedAssembly>(fun a -> a.FSharpViewOfMetadata.AssemblyName = refNumericsDllName) with
-            | Some asm ->
-                match asm.ILScopeRef with 
-                | ILScopeRef.Assembly aref -> Some aref
-                | _ -> None
-            | None -> None
-        match numericsAssemblyRef with
-        | Some aref ->
-            let systemNumericsAssemblyRef = ILAssemblyRef.Create(refNumericsDllName, aref.Hash, aref.PublicKey, aref.Retargetable, aref.Version, aref.Locale)
-            typesForwardedToSystemNumerics |>
-                Seq.map (fun t ->
-                            { ScopeRef = ILScopeRef.Assembly systemNumericsAssemblyRef
-                              Name = t
-                              Attributes = enum<TypeAttributes>(0x00200000) ||| TypeAttributes.Public
-                              Nested = mkILNestedExportedTypes []
-                              CustomAttrsStored = storeILCustomAttrs emptyILCustomAttrs
-                              MetadataIndex = NoMetadataIdx }) |>
-                Seq.toList
-        | None -> []
-
-    let fileVersion findStringAttr (assemblyVersion: ILVersionInfo) =
-        let attrName = "System.Reflection.AssemblyFileVersionAttribute"
-        match findStringAttr attrName with
-        | None -> assemblyVersion
-        | Some (AttributeHelpers.ILVersion v) -> v
-        | Some _ ->
-            // Warning will be reported by CheckExpressions.fs
-            assemblyVersion
-
-    let productVersion findStringAttr (fileVersion: ILVersionInfo) =
-        let attrName = "System.Reflection.AssemblyInformationalVersionAttribute"
-        let toDotted (version: ILVersionInfo) = sprintf "%d.%d.%d.%d" version.Major version.Minor version.Build version.Revision
-        match findStringAttr attrName with
-        | None | Some "" -> fileVersion |> toDotted
-        | Some (AttributeHelpers.ILVersion v) -> v |> toDotted
-        | Some v -> 
-            // Warning will be reported by CheckExpressions.fs
-            v
-
-    let productVersionToILVersionInfo (version: string) : ILVersionInfo =
-        let parseOrZero i (v:string) =
-            let v =
-                // When i = 3 then this is the 4th part of the version.  The last part of the version can be trailed by any characters so we trim them off
-                if i <> 3 then
-                    v
-                else
-                    ((false, ""), v)
-                    ||> Seq.fold(fun (finished, v) c ->
-                        match finished with
-                        | false when Char.IsDigit(c) -> false, v + c.ToString()
-                        | _ -> true, v)
-                    |> snd
-            match System.UInt16.TryParse v with
-            | (true, i) -> i
-            | (false, _) -> 0us
-        let validParts =
-            version.Split('.')
-            |> Array.mapi(fun i v -> parseOrZero i v)
-            |> Seq.toList
-        match validParts @ [0us; 0us; 0us; 0us] with
-        | major :: minor :: build :: rev :: _ -> ILVersionInfo(major, minor, build, rev)
-        | x -> failwithf "error converting product version '%s' to binary, tried '%A' " version x
-
-
-    let CreateMainModule  
-            (ctok, tcConfig: TcConfig, tcGlobals, tcImports: TcImports, 
-             pdbfile, assemblyName, outfile, topAttrs, 
-             (iattrs, intfDataResources), optDataResources, 
-             codegenResults, assemVerFromAttrib, metadataVersion, secDecls) =
-
-        RequireCompilationThread ctok
-        let ilTypeDefs = 
-            //let topTypeDef = mkILTypeDefForGlobalFunctions tcGlobals.ilg (mkILMethods [], emptyILFields)
-            mkILTypeDefs codegenResults.ilTypeDefs
-
-        let mainModule = 
-            let hashAlg = AttributeHelpers.TryFindIntAttribute tcGlobals "System.Reflection.AssemblyAlgorithmIdAttribute" topAttrs.assemblyAttrs
-            let locale = AttributeHelpers.TryFindStringAttribute tcGlobals "System.Reflection.AssemblyCultureAttribute" topAttrs.assemblyAttrs
-            let flags =  match AttributeHelpers.TryFindIntAttribute tcGlobals "System.Reflection.AssemblyFlagsAttribute" topAttrs.assemblyAttrs with | Some f -> f | _ -> 0x0
-
-            // You're only allowed to set a locale if the assembly is a library
-            if (locale <> None && locale.Value <> "") && tcConfig.target <> CompilerTarget.Dll then
-              error(Error(FSComp.SR.fscAssemblyCultureAttributeError(), rangeCmdArgs))
-
-            // Add the type forwarders to any .NET DLL post-.NET-2.0, to give binary compatibility
-            let exportedTypesList =
-                if tcConfig.compilingFslib then
-                   List.append (createMscorlibExportList tcGlobals) (createSystemNumericsExportList tcConfig tcImports)
-                else
-                    []
-
-            let ilModuleName = GetGeneratedILModuleName tcConfig.target assemblyName
-            let isDLL = (tcConfig.target = CompilerTarget.Dll || tcConfig.target = CompilerTarget.Module)
-            mkILSimpleModule assemblyName ilModuleName isDLL tcConfig.subsystemVersion tcConfig.useHighEntropyVA ilTypeDefs hashAlg locale flags (mkILExportedTypes exportedTypesList) metadataVersion
-
-        let disableJitOptimizations = not (tcConfig.optSettings.jitOpt())
-
-        let tcVersion = tcConfig.version.GetVersionInfo(tcConfig.implicitIncludeDir)
-
-        let reflectedDefinitionAttrs, reflectedDefinitionResources = 
-            codegenResults.quotationResourceInfo 
-            |> List.map (fun (referencedTypeDefs, reflectedDefinitionBytes) -> 
-                let reflectedDefinitionResourceName = QuotationPickler.SerializedReflectedDefinitionsResourceNameBase+"-"+assemblyName+"-"+string(newUnique())+"-"+string(hash reflectedDefinitionBytes)
-                let reflectedDefinitionAttrs = 
-                    let qf = QuotationTranslator.QuotationGenerationScope.ComputeQuotationFormat tcGlobals 
-                    if qf.SupportsDeserializeEx then
-                        [ mkCompilationMappingAttrForQuotationResource tcGlobals (reflectedDefinitionResourceName, referencedTypeDefs) ]
-                    else 
-                        [  ]
-                let reflectedDefinitionResource = 
-                  { Name=reflectedDefinitionResourceName
-                    Location = ILResourceLocation.Local(ByteStorage.FromByteArray(reflectedDefinitionBytes))
-                    Access= ILResourceAccess.Public
-                    CustomAttrsStored = storeILCustomAttrs emptyILCustomAttrs
-                    MetadataIndex = NoMetadataIdx }
-                reflectedDefinitionAttrs, reflectedDefinitionResource) 
-            |> List.unzip
-            |> (fun (attrs, resource) -> List.concat attrs, resource)
-
-        let manifestAttrs = 
-            mkILCustomAttrs
-                 [ if not tcConfig.internConstantStrings then 
-                       yield mkILCustomAttribute tcGlobals.ilg
-                                 (tcGlobals.FindSysILTypeRef "System.Runtime.CompilerServices.CompilationRelaxationsAttribute", 
-                                  [tcGlobals.ilg.typ_Int32], [ILAttribElem.Int32( 8)], []) 
-                   yield! iattrs
-                   yield! codegenResults.ilAssemAttrs
-                   if Option.isSome pdbfile then
-                       yield (tcGlobals.mkDebuggableAttributeV2 (tcConfig.jitTracking, tcConfig.ignoreSymbolStoreSequencePoints, disableJitOptimizations, false (* enableEnC *) )) 
-                   yield! reflectedDefinitionAttrs ]
-
-        // Make the manifest of the assembly
-        let manifest = 
-             if tcConfig.target = CompilerTarget.Module then None else
-             let man = mainModule.ManifestOfAssembly
-             let ver = 
-                 match assemVerFromAttrib with 
-                 | None -> tcVersion
-                 | Some v -> v
-             Some { man with Version= Some ver
-                             CustomAttrsStored = storeILCustomAttrs manifestAttrs
-                             DisableJitOptimizations=disableJitOptimizations
-                             JitTracking= tcConfig.jitTracking
-                             IgnoreSymbolStoreSequencePoints = tcConfig.ignoreSymbolStoreSequencePoints
-                             SecurityDeclsStored=storeILSecurityDecls secDecls } 
-
-        let resources = 
-          mkILResources 
-            [ for file in tcConfig.embedResources do
-                 let name, bytes, pub = 
-                         let file, name, pub = TcConfigBuilder.SplitCommandLineResourceInfo file
-                         let file = tcConfig.ResolveSourceFile(rangeStartup, file, tcConfig.implicitIncludeDir)
-                         let bytes = FileSystem.ReadAllBytesShim file
-                         name, bytes, pub
-                 yield { Name=name 
-                         Location=ILResourceLocation.Local(ByteStorage.FromByteArray(bytes))
-                         Access=pub 
-                         CustomAttrsStored=storeILCustomAttrs emptyILCustomAttrs 
-                         MetadataIndex = NoMetadataIdx }
-               
-              yield! reflectedDefinitionResources
-              yield! intfDataResources
-              yield! optDataResources
-              for ri in tcConfig.linkResources do 
-                 let file, name, pub = TcConfigBuilder.SplitCommandLineResourceInfo ri
-                 yield { Name=name 
-                         Location=ILResourceLocation.File(ILModuleRef.Create(name=file, hasMetadata=false, hash=Some (sha1HashBytes (FileSystem.ReadAllBytesShim file))), 0)
-                         Access=pub 
-                         CustomAttrsStored=storeILCustomAttrs emptyILCustomAttrs
-                         MetadataIndex = NoMetadataIdx } ]
-
-        let assemblyVersion = 
-            match tcConfig.version with
-            | VersionNone -> assemVerFromAttrib
-            | _ -> Some tcVersion
-
-        let findAttribute name =
-            AttributeHelpers.TryFindStringAttribute tcGlobals name topAttrs.assemblyAttrs 
-
-
-        //NOTE: the culture string can be turned into a number using this:
-        //    sprintf "%04x" (CultureInfo.GetCultureInfo("en").KeyboardLayoutId )
-        let assemblyVersionResources findAttr assemblyVersion =
-            match assemblyVersion with 
-            | None -> []
-            | Some assemblyVersion ->
-                let FindAttribute key attrib = 
-                    match findAttr attrib with
-                    | Some text  -> [(key, text)]
-                    | _ -> []
-
-                let fileVersionInfo = fileVersion findAttr assemblyVersion
-
-                let productVersionString = productVersion findAttr fileVersionInfo
-
-                let stringFileInfo = 
-                     // 000004b0:
-                     // Specifies an 8-digit hexadecimal number stored as a Unicode string. The 
-                     // four most significant digits represent the language identifier. The four least 
-                     // significant digits represent the code page for which the data is formatted. 
-                     // Each Microsoft Standard Language identifier contains two parts: the low-order 10 bits 
-                     // specify the major language, and the high-order 6 bits specify the sublanguage. 
-                     // For a table of valid identifiers see Language Identifiers.                                           //
-                     // see e.g. http://msdn.microsoft.com/en-us/library/aa912040.aspx 0000 is neutral and 04b0(hex)=1252(dec) is the code page.
-                      [ ("000004b0", [ yield ("Assembly Version", (sprintf "%d.%d.%d.%d" assemblyVersion.Major assemblyVersion.Minor assemblyVersion.Build assemblyVersion.Revision))
-                                       yield ("FileVersion", (sprintf "%d.%d.%d.%d" fileVersionInfo.Major fileVersionInfo.Minor fileVersionInfo.Build fileVersionInfo.Revision))
-                                       yield ("ProductVersion", productVersionString)
-                                       match tcConfig.outputFile with
-                                       | Some f -> yield ("OriginalFilename", Path.GetFileName f)
-                                       | None -> ()
-                                       yield! FindAttribute "Comments" "System.Reflection.AssemblyDescriptionAttribute" 
-                                       yield! FindAttribute "FileDescription" "System.Reflection.AssemblyTitleAttribute" 
-                                       yield! FindAttribute "ProductName" "System.Reflection.AssemblyProductAttribute" 
-                                       yield! FindAttribute "CompanyName" "System.Reflection.AssemblyCompanyAttribute" 
-                                       yield! FindAttribute "LegalCopyright" "System.Reflection.AssemblyCopyrightAttribute" 
-                                       yield! FindAttribute "LegalTrademarks" "System.Reflection.AssemblyTrademarkAttribute" ]) ]
-
-                // These entries listed in the MSDN documentation as "standard" string entries are not yet settable
-
-                // InternalName: 
-                //     The Value member identifies the file's internal name, if one exists. For example, this 
-                //     string could contain the module name for Windows dynamic-link libraries (DLLs), a virtual 
-                //     device name for Windows virtual devices, or a device name for MS-DOS device drivers. 
-                // OriginalFilename: 
-                //     The Value member identifies the original name of the file, not including a path. This 
-                //     enables an application to determine whether a file has been renamed by a user. This name 
-                //     may not be MS-DOS 8.3-format if the file is specific to a non-FAT file system. 
-                // PrivateBuild: 
-                //     The Value member describes by whom, where, and why this private version of the 
-                //     file was built. This string should only be present if the VS_FF_PRIVATEBUILD flag 
-                //     is set in the dwFileFlags member of the VS_FIXEDFILEINFO structure. For example, 
-                //     Value could be 'Built by OSCAR on \OSCAR2'. 
-                // SpecialBuild: 
-                //     The Value member describes how this version of the file differs from the normal version. 
-                //     This entry should only be present if the VS_FF_SPECIALBUILD flag is set in the dwFileFlags 
-                //     member of the VS_FIXEDFILEINFO structure. For example, Value could be 'Private build 
-                //     for Olivetti solving mouse problems on M250 and M250E computers'. 
-
-                // "If you use the Var structure to list the languages your application 
-                // or DLL supports instead of using multiple version resources, 
-                // use the Value member to contain an array of DWORD values indicating the 
-                // language and code page combinations supported by this file. The 
-                // low-order word of each DWORD must contain a Microsoft language identifier, 
-                // and the high-order word must contain the IBM code page number. 
-                // Either high-order or low-order word can be zero, indicating that 
-                // the file is language or code page independent. If the Var structure is 
-                // omitted, the file will be interpreted as both language and code page independent. "
-                let varFileInfo = [ (0x0, 0x04b0)  ]
-
-                let fixedFileInfo = 
-                    let dwFileFlagsMask = 0x3f // REVIEW: HARDWIRED
-                    let dwFileFlags = 0x00 // REVIEW: HARDWIRED
-                    let dwFileOS = 0x04 // REVIEW: HARDWIRED
-                    let dwFileType = 0x01 // REVIEW: HARDWIRED
-                    let dwFileSubtype = 0x00 // REVIEW: HARDWIRED
-                    let lwFileDate = 0x00L // REVIEW: HARDWIRED
-                    (fileVersionInfo, productVersionString |> productVersionToILVersionInfo, dwFileFlagsMask, dwFileFlags, dwFileOS, dwFileType, dwFileSubtype, lwFileDate)
-
-                let vsVersionInfoResource = 
-                    VersionResourceFormat.VS_VERSION_INFO_RESOURCE(fixedFileInfo, stringFileInfo, varFileInfo)
-
-                let resource = 
-                    [| yield! ResFileFormat.ResFileHeader()
-                       yield! vsVersionInfoResource |]
-
-                [ resource ]
-
-        // a user cannot specify both win32res and win32manifest
-        if not(tcConfig.win32manifest = "") && not(tcConfig.win32res = "") then
-            error(Error(FSComp.SR.fscTwoResourceManifests(), rangeCmdArgs))
-
-        let win32Manifest =
-            // use custom manifest if provided
-            if not(tcConfig.win32manifest = "") then tcConfig.win32manifest
-
-            // don't embed a manifest if target is not an exe, if manifest is specifically excluded, if another native resource is being included, or if running on mono
-            elif not(tcConfig.target.IsExe) || not(tcConfig.includewin32manifest) || not(tcConfig.win32res = "") || runningOnMono then ""
-            // otherwise, include the default manifest
-            else
-                let path = Path.Combine(System.AppContext.BaseDirectory, @"default.win32manifest")
-                if File.Exists(path) then path
-                else Path.Combine(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(), @"default.win32manifest")
-
-        let nativeResources = 
-            [ for av in assemblyVersionResources findAttribute assemblyVersion do
-                  yield ILNativeResource.Out av
-              if not(tcConfig.win32res = "") then
-                  yield ILNativeResource.Out (FileSystem.ReadAllBytesShim tcConfig.win32res) 
-              if tcConfig.includewin32manifest && not(win32Manifest = "") && not runningOnMono then
-                  yield  ILNativeResource.Out [| yield! ResFileFormat.ResFileHeader() 
-                                                 yield! (ManifestResourceFormat.VS_MANIFEST_RESOURCE((FileSystem.ReadAllBytesShim win32Manifest), tcConfig.target = CompilerTarget.Dll)) |]]
-
-        // Add attributes, version number, resources etc. 
-        {mainModule with 
-              StackReserveSize = tcConfig.stackReserveSize
-              Name = (if tcConfig.target = CompilerTarget.Module then Filename.fileNameOfPath outfile else mainModule.Name)
-              SubSystemFlags = (if tcConfig.target = CompilerTarget.WinExe then 2 else 3) 
-              Resources= resources
-              ImageBase = (match tcConfig.baseAddress with None -> 0x00400000l | Some b -> b)
-              IsDLL=(tcConfig.target = CompilerTarget.Dll || tcConfig.target=CompilerTarget.Module)
-              Platform = tcConfig.platform 
-              Is32Bit=(match tcConfig.platform with Some X86 -> true | _ -> false)
-              Is64Bit=(match tcConfig.platform with Some AMD64 | Some IA64 -> true | _ -> false)          
-              Is32BitPreferred = if tcConfig.prefer32Bit && not tcConfig.target.IsExe then (error(Error(FSComp.SR.invalidPlatformTarget(), rangeCmdArgs))) else tcConfig.prefer32Bit
-              CustomAttrsStored= 
-                  storeILCustomAttrs
-                    (mkILCustomAttrs 
-                      [ if tcConfig.target = CompilerTarget.Module then 
-                           yield! iattrs 
-                        yield! codegenResults.ilNetModuleAttrs ])
-              NativeResources=nativeResources
-              Manifest = manifest }
-
-
-//----------------------------------------------------------------------------
-// Static linking
-//----------------------------------------------------------------------------
-
-/// Optional static linking of all DLLs that depend on the F# Library, plus other specified DLLs
-module StaticLinker =
-
-    // Handles TypeForwarding for the generated IL model
-    type TypeForwarding (tcImports: TcImports) =
-
-        // Make a dictionary of ccus passed to the compiler will be looked up by qualified assembly name
-        let ccuThunksQualifiedName =
-            tcImports.GetCcusInDeclOrder()
-            |> List.choose (fun ccuThunk -> ccuThunk.QualifiedName |> Option.map (fun v -> v, ccuThunk))
-            |> dict
-
-        // If we can't type forward using exact assembly match, we need to rely on the loader (Policy, Configuration or the coreclr load heuristics), so use try simple name
-        let ccuThunksSimpleName =
-            tcImports.GetCcusInDeclOrder()
-            |> List.choose (fun ccuThunk -> 
-                if String.IsNullOrEmpty(ccuThunk.AssemblyName) then
-                    None
-                else
-                    Some (ccuThunk.AssemblyName, ccuThunk))
-            |> dict
-
-        let followTypeForwardForILTypeRef (tref:ILTypeRef) =
-            let typename =
-                let parts =  tref.FullName.Split([|'.'|])
-                match parts.Length with
-                | 0 -> None
-                | 1 -> Some (Array.empty<string>, parts.[0])
-                | n -> Some (parts.[0..n-2], parts.[n-1])
-
-            let  scoref = tref.Scope
-            match scoref with
-            | ILScopeRef.Assembly scope ->
-                match ccuThunksQualifiedName.TryGetValue(scope.QualifiedName) with
-                | true, ccu ->
-                    match typename with
-                    | Some (parts, name) ->
-                        let forwarded = ccu.TryForward(parts, name)
-                        let result =
-                            match forwarded with
-                            | Some fwd -> fwd.CompilationPath.ILScopeRef
-                            | None -> scoref
-                        result
-                    | None -> scoref
-                | false, _ ->
-                    // Couldn't find an assembly with the version so try using a simple name
-                    match ccuThunksSimpleName.TryGetValue(scope.Name) with
-                    | true, ccu ->
-                        match typename with
-                        | Some (parts, name) ->
-                            let forwarded = ccu.TryForward(parts, name)
-                            let result =
-                                match forwarded with
-                                | Some fwd -> fwd.CompilationPath.ILScopeRef
-                                | None -> scoref
-                            result
-                        | None -> scoref
-                    | false, _ -> scoref
-            | _ -> scoref
-
-        let typeForwardILTypeRef (tref: ILTypeRef) =
-            let scoref1 = tref.Scope
-            let scoref2 = followTypeForwardForILTypeRef tref
-            if scoref1 === scoref2 then tref
-            else ILTypeRef.Create (scoref2, tref.Enclosing, tref.Name)
-
-        member __.TypeForwardILTypeRef tref = typeForwardILTypeRef tref
-
-    let debugStaticLinking = condition "FSHARP_DEBUG_STATIC_LINKING"
-
-    let StaticLinkILModules (tcConfig:TcConfig, ilGlobals, tcImports, ilxMainModule, dependentILModules: (CcuThunk option * ILModuleDef) list) = 
-        if isNil dependentILModules then 
-            ilxMainModule, (fun x -> x) 
-        else
-            let typeForwarding = new TypeForwarding(tcImports)
-
-            // Check no dependent assemblies use quotations   
-            let dependentCcuUsingQuotations = dependentILModules |> List.tryPick (function (Some ccu, _) when ccu.UsesFSharp20PlusQuotations -> Some ccu | _ -> None)   
-            match dependentCcuUsingQuotations with   
-            | Some ccu -> error(Error(FSComp.SR.fscQuotationLiteralsStaticLinking(ccu.AssemblyName), rangeStartup))   
-            | None -> ()  
-                
-            // Check we're not static linking a .EXE
-            if dependentILModules |> List.exists (fun (_, x) -> not x.IsDLL)  then 
-                error(Error(FSComp.SR.fscStaticLinkingNoEXE(), rangeStartup))
-
-            // Check we're not static linking something that is not pure IL
-            if dependentILModules |> List.exists (fun (_, x) -> not x.IsILOnly)  then 
-                error(Error(FSComp.SR.fscStaticLinkingNoMixedDLL(), rangeStartup))
-
-            // The set of short names for the all dependent assemblies
-            let assems = 
-                set [ for (_, m) in dependentILModules  do
-                         match m.Manifest with 
-                         | Some m -> yield m.Name 
-                         | _ -> () ]
-            
-            // A rewriter which rewrites scope references to things in dependent assemblies to be local references 
-            let rewriteExternalRefsToLocalRefs x = 
-                if assems.Contains (getNameOfScopeRef x) then ILScopeRef.Local else x
-
-            let savedManifestAttrs = 
-                [ for (_, depILModule) in dependentILModules do 
-                    match depILModule.Manifest with 
-                    | Some m -> 
-                        for ca in m.CustomAttrs.AsArray do
-                           if ca.Method.MethodRef.DeclaringTypeRef.FullName = typeof<CompilationMappingAttribute>.FullName then 
-                               yield ca
-                    | _ -> () ]
-
-            let savedResources = 
-                let allResources = [ for (ccu, m) in dependentILModules do for r in m.Resources.AsList do yield (ccu, r) ]
-                // Don't save interface, optimization or resource definitions for provider-generated assemblies.
-                // These are "fake".
-                let isProvided (ccu: CcuThunk option) = 
-#if !NO_EXTENSIONTYPING
-                    match ccu with 
-                    | Some c -> c.IsProviderGenerated 
-                    | None -> false
-#else
-                    ignore ccu
-                    false
-#endif
-
-                // Save only the interface/optimization attributes of generated data 
-                let intfDataResources, others = allResources |> List.partition (snd >> IsSignatureDataResource)
-                let intfDataResources = 
-                    [ for (ccu, r) in intfDataResources do 
-                          if GenerateInterfaceData tcConfig && not (isProvided ccu) then 
-                              yield r ]
-
-                let optDataResources, others = others |> List.partition (snd >> IsOptimizationDataResource)
-                let optDataResources = 
-                    [ for (ccu, r) in optDataResources do 
-                          if GenerateOptimizationData tcConfig && not (isProvided ccu) then 
-                              yield r ]
-
-                let otherResources = others |> List.map snd 
-
-                let result = intfDataResources@optDataResources@otherResources
-                result
-
-            let moduls = ilxMainModule :: (List.map snd dependentILModules)
-
-            let savedNativeResources = 
-                [ //yield! ilxMainModule.NativeResources 
-                  for m in moduls do 
-                      yield! m.NativeResources ]
-
-            let topTypeDefs, normalTypeDefs = 
-                moduls 
-                |> List.map (fun m -> m.TypeDefs.AsList |> List.partition (fun td -> isTypeNameForGlobalFunctions td.Name)) 
-                |> List.unzip
-
-            let topTypeDef = 
-                let topTypeDefs = List.concat topTypeDefs
-                mkILTypeDefForGlobalFunctions ilGlobals
-                   (mkILMethods (topTypeDefs |> List.collect (fun td -> td.Methods.AsList)), 
-                    mkILFields (topTypeDefs |> List.collect (fun td -> td.Fields.AsList)))
-
-            let ilxMainModule =
-                let main =
-                    { ilxMainModule with
-                        Manifest = (let m = ilxMainModule.ManifestOfAssembly in Some {m with CustomAttrsStored = storeILCustomAttrs (mkILCustomAttrs (m.CustomAttrs.AsList @ savedManifestAttrs)) })
-                        CustomAttrsStored = storeILCustomAttrs (mkILCustomAttrs [ for m in moduls do yield! m.CustomAttrs.AsArray ])
-                        TypeDefs = mkILTypeDefs (topTypeDef :: List.concat normalTypeDefs)
-                        Resources = mkILResources (savedResources @ ilxMainModule.Resources.AsList)
-                        NativeResources = savedNativeResources }
-                Morphs.morphILTypeRefsInILModuleMemoized ilGlobals typeForwarding.TypeForwardILTypeRef main
-
-            ilxMainModule, rewriteExternalRefsToLocalRefs
-
-    [<NoEquality; NoComparison>]
-    type Node = 
-        { name: string
-          data: ILModuleDef 
-          ccu: option<CcuThunk>
-          refs: ILReferences
-          mutable edges: list<Node> 
-          mutable visited: bool }
-
-    // Find all IL modules that are to be statically linked given the static linking roots.
-    let FindDependentILModulesForStaticLinking (ctok, tcConfig: TcConfig, tcImports: TcImports, ilGlobals: ILGlobals, ilxMainModule) = 
-        if not tcConfig.standalone && tcConfig.extraStaticLinkRoots.IsEmpty then 
-            []
-        else
-            // Recursively find all referenced modules and add them to a module graph 
-            let depModuleTable = HashMultiMap(0, HashIdentity.Structural)
-            let dummyEntry nm =
-                { refs = IL.emptyILRefs 
-                  name=nm
-                  ccu=None
-                  data=ilxMainModule // any old module
-                  edges = [] 
-                  visited = true }
-            let assumedIndependentSet = set [ "mscorlib";  "System"; "System.Core"; "System.Xml"; "Microsoft.Build.Framework"; "Microsoft.Build.Utilities"; "netstandard" ]
-
-            begin 
-                let mutable remaining = (computeILRefs ilGlobals ilxMainModule).AssemblyReferences
-                while not (isNil remaining) do
-                    let ilAssemRef = List.head remaining
-                    remaining <- List.tail remaining
-                    if assumedIndependentSet.Contains ilAssemRef.Name || (ilAssemRef.PublicKey = Some ecmaPublicKey) then 
-                        depModuleTable.[ilAssemRef.Name] <- dummyEntry ilAssemRef.Name
-                    else
-                        if not (depModuleTable.ContainsKey ilAssemRef.Name) then
-                            match tcImports.TryFindDllInfo(ctok, Range.rangeStartup, ilAssemRef.Name, lookupOnly=false) with 
-                            | Some dllInfo ->
-                                let ccu = 
-                                    match tcImports.FindCcuFromAssemblyRef (ctok, Range.rangeStartup, ilAssemRef) with 
-                                    | ResolvedCcu ccu -> Some ccu
-                                    | UnresolvedCcu(_ccuName) -> None
-
-                                let fileName = dllInfo.FileName
-                                let modul = 
-                                    let pdbDirPathOption = 
-                                        // We open the pdb file if one exists parallel to the binary we 
-                                        // are reading, so that --standalone will preserve debug information. 
-                                        if tcConfig.openDebugInformationForLaterStaticLinking then 
-                                            let pdbDir = (try Filename.directoryName fileName with _ -> ".") 
-                                            let pdbFile = (try Filename.chopExtension fileName with _ -> fileName)+".pdb" 
-                                            if FileSystem.SafeExists pdbFile then 
-                                                if verbose then dprintf "reading PDB file %s from directory %s during static linking\n" pdbFile pdbDir
-                                                Some pdbDir
-                                            else 
-                                                None 
-                                        else   
-                                            None
-
-                                    let opts : ILReaderOptions = 
-                                        { metadataOnly = MetadataOnlyFlag.No // turn this off here as we need the actual IL code
-                                          reduceMemoryUsage = tcConfig.reduceMemoryUsage
-                                          pdbDirPath = pdbDirPathOption
-                                          tryGetMetadataSnapshot = (fun _ -> None) } 
-
-                                    let reader = ILBinaryReader.OpenILModuleReader dllInfo.FileName opts
-                                    reader.ILModuleDef
-
-                                let refs = 
-                                    if ilAssemRef.Name = GetFSharpCoreLibraryName() then 
-                                        IL.emptyILRefs 
-                                    elif not modul.IsILOnly then 
-                                        warning(Error(FSComp.SR.fscIgnoringMixedWhenLinking ilAssemRef.Name, rangeStartup))
-                                        IL.emptyILRefs 
-                                    else
-                                        { AssemblyReferences = dllInfo.ILAssemblyRefs 
-                                          ModuleReferences = [] }
-
-                                depModuleTable.[ilAssemRef.Name] <- 
-                                    { refs=refs
-                                      name=ilAssemRef.Name
-                                      ccu=ccu
-                                      data=modul 
-                                      edges = [] 
-                                      visited = false }
-
-                                // Push the new work items
-                                remaining <- refs.AssemblyReferences @ remaining
-
-                            | None -> 
-                                warning(Error(FSComp.SR.fscAssumeStaticLinkContainsNoDependencies(ilAssemRef.Name), rangeStartup)) 
-                                depModuleTable.[ilAssemRef.Name] <- dummyEntry ilAssemRef.Name
-                done
-            end
-
-            ReportTime tcConfig "Find dependencies"
-
-            // Add edges from modules to the modules that depend on them 
-            for (KeyValue(_, n)) in depModuleTable do 
-                for aref in n.refs.AssemblyReferences do
-                    let n2 = depModuleTable.[aref.Name] 
-                    n2.edges <- n :: n2.edges
-                    
-            // Find everything that depends on FSharp.Core
-            let roots = 
-                [ if tcConfig.standalone && depModuleTable.ContainsKey (GetFSharpCoreLibraryName()) then 
-                      yield depModuleTable.[GetFSharpCoreLibraryName()]
-                  for n in tcConfig.extraStaticLinkRoots  do
-                      match depModuleTable.TryFind n with 
-                      | Some x -> yield x
-                      | None -> error(Error(FSComp.SR.fscAssemblyNotFoundInDependencySet n, rangeStartup)) 
-                ]
-                              
-            let mutable remaining = roots
-            [ while not (isNil remaining) do
-                let n = List.head remaining
-                remaining <- List.tail remaining
-                if not n.visited then 
-                    if verbose then dprintn ("Module "+n.name+" depends on "+GetFSharpCoreLibraryName())
-                    n.visited <- true
-                    remaining <- n.edges @ remaining
-                    yield (n.ccu, n.data)  ]
-
-    // Add all provider-generated assemblies into the static linking set
-    let FindProviderGeneratedILModules (ctok, tcImports: TcImports, providerGeneratedAssemblies: (ImportedBinary * _) list) = 
-        [ for (importedBinary, provAssemStaticLinkInfo) in providerGeneratedAssemblies do 
-              let ilAssemRef =
-                match importedBinary.ILScopeRef with
-                | ILScopeRef.Assembly aref -> aref
-                | _ -> failwith "Invalid ILScopeRef, expected ILScopeRef.Assembly"
-              if debugStaticLinking then printfn "adding provider-generated assembly '%s' into static linking set" ilAssemRef.Name
-              match tcImports.TryFindDllInfo(ctok, Range.rangeStartup, ilAssemRef.Name, lookupOnly=false) with 
-              | Some dllInfo ->
-                  let ccu = 
-                      match tcImports.FindCcuFromAssemblyRef (ctok, Range.rangeStartup, ilAssemRef) with 
-                      | ResolvedCcu ccu -> Some ccu
-                      | UnresolvedCcu(_ccuName) -> None
-
-                  let modul = dllInfo.RawMetadata.TryGetILModuleDef().Value
-                  yield (ccu, dllInfo.ILScopeRef, modul), (ilAssemRef.Name, provAssemStaticLinkInfo)
-              | None -> () ]
-
-    // Compute a static linker. This only captures tcImports (a large data structure) if
-    // static linking is enabled. Normally this is not the case, which lets us collect tcImports
-    // prior to this point.
-    let StaticLink (ctok, tcConfig: TcConfig, tcImports: TcImports, ilGlobals: ILGlobals) = 
-
-#if !NO_EXTENSIONTYPING
-        let providerGeneratedAssemblies =
-
-            [ // Add all EST-generated assemblies into the static linking set
-                for KeyValue(_, importedBinary: ImportedBinary) in tcImports.DllTable do
-                    if importedBinary.IsProviderGenerated then 
-                        match importedBinary.ProviderGeneratedStaticLinkMap with 
-                        | None -> ()
-                        | Some provAssemStaticLinkInfo -> yield (importedBinary, provAssemStaticLinkInfo) ]
-#endif
-        if not tcConfig.standalone && tcConfig.extraStaticLinkRoots.IsEmpty 
-#if !NO_EXTENSIONTYPING
-             && providerGeneratedAssemblies.IsEmpty 
-#endif
-             then 
-            (fun ilxMainModule -> ilxMainModule)
-        else 
-            (fun ilxMainModule  ->
-              ReportTime tcConfig "Find assembly references"
-
-              let dependentILModules = FindDependentILModulesForStaticLinking (ctok, tcConfig, tcImports, ilGlobals, ilxMainModule)
-
-              ReportTime tcConfig "Static link"
-
-#if !NO_EXTENSIONTYPING
-              Morphs.enableMorphCustomAttributeData()
-              let providerGeneratedILModules =  FindProviderGeneratedILModules (ctok, tcImports, providerGeneratedAssemblies) 
-
-              // Transform the ILTypeRefs references in the IL of all provider-generated assemblies so that the references
-              // are now local.
-              let providerGeneratedILModules = 
-               
-                  providerGeneratedILModules |> List.map (fun ((ccu, ilOrigScopeRef, ilModule), (_, localProvAssemStaticLinkInfo)) -> 
-                      let ilAssemStaticLinkMap = 
-                          dict [ for (_, (_, provAssemStaticLinkInfo)) in providerGeneratedILModules do 
-                                     for KeyValue(k, v) in provAssemStaticLinkInfo.ILTypeMap do 
-                                         yield (k, v)
-                                 for KeyValue(k, v) in localProvAssemStaticLinkInfo.ILTypeMap do
-                                     yield (ILTypeRef.Create(ILScopeRef.Local, k.Enclosing, k.Name), v) ]
-
-                      let ilModule = 
-                          ilModule |> Morphs.morphILTypeRefsInILModuleMemoized ilGlobals (fun tref -> 
-                                  if debugStaticLinking then printfn "deciding whether to rewrite type ref %A" tref.QualifiedName 
-                                  let ok, v = ilAssemStaticLinkMap.TryGetValue tref
-                                  if ok then 
-                                      if debugStaticLinking then printfn "rewriting type ref %A to %A" tref.QualifiedName v.QualifiedName
-                                      v
-                                  else 
-                                      tref)
-                      (ccu, ilOrigScopeRef, ilModule))
-
-              // Relocate provider generated type definitions into the expected shape for the [<Generate>] declarations in an assembly
-              let providerGeneratedILModules, ilxMainModule = 
-                  // Build a dictionary of all remapped IL type defs 
-                  let ilOrigTyRefsForProviderGeneratedTypesToRelocate = 
-                      let rec walk acc (ProviderGeneratedType(ilOrigTyRef, _, xs) as node) = List.fold walk ((ilOrigTyRef, node) :: acc) xs 
-                      dict (Seq.fold walk [] tcImports.ProviderGeneratedTypeRoots)
-
-                  // Build a dictionary of all IL type defs, mapping ilOrigTyRef --> ilTypeDef
-                  let allTypeDefsInProviderGeneratedAssemblies = 
-                      let rec loop ilOrigTyRef (ilTypeDef: ILTypeDef) = 
-                          seq { yield (ilOrigTyRef, ilTypeDef) 
-                                for ntdef in ilTypeDef.NestedTypes do 
-                                    yield! loop (mkILTyRefInTyRef (ilOrigTyRef, ntdef.Name)) ntdef }
-                      dict [ 
-                          for (_ccu, ilOrigScopeRef, ilModule) in providerGeneratedILModules do 
-                              for td in ilModule.TypeDefs do 
-                                  yield! loop (mkILTyRef (ilOrigScopeRef, td.Name)) td ]
-
-
-                  // Debugging output
-                  if debugStaticLinking then 
-                      for (ProviderGeneratedType(ilOrigTyRef, _, _)) in tcImports.ProviderGeneratedTypeRoots do
-                          printfn "Have [<Generate>] root '%s'" ilOrigTyRef.QualifiedName
-
-                  // Build the ILTypeDefs for generated types, starting with the roots 
-                  let generatedILTypeDefs = 
-                      let rec buildRelocatedGeneratedType (ProviderGeneratedType(ilOrigTyRef, ilTgtTyRef, ch)) = 
-                          let isNested = not (isNil ilTgtTyRef.Enclosing)
-                          match allTypeDefsInProviderGeneratedAssemblies.TryGetValue ilOrigTyRef with
-                          | true, ilOrigTypeDef ->
-                              if debugStaticLinking then printfn "Relocating %s to %s " ilOrigTyRef.QualifiedName ilTgtTyRef.QualifiedName
-                              let ilOrigTypeDef = 
-                                if isNested then
-                                    ilOrigTypeDef
-                                        .WithAccess(match ilOrigTypeDef.Access with 
-                                                    | ILTypeDefAccess.Public -> ILTypeDefAccess.Nested ILMemberAccess.Public
-                                                    | ILTypeDefAccess.Private -> ILTypeDefAccess.Nested ILMemberAccess.Private
-                                                    | _ -> ilOrigTypeDef.Access)
-                                else ilOrigTypeDef
-                              ilOrigTypeDef.With(name = ilTgtTyRef.Name,
-                                                 nestedTypes = mkILTypeDefs (List.map buildRelocatedGeneratedType ch))
-                          | _ ->
-                              // If there is no matching IL type definition, then make a simple container class
-                              if debugStaticLinking then 
-                                  printfn "Generating simple class '%s' because we didn't find an original type '%s' in a provider generated assembly" 
-                                      ilTgtTyRef.QualifiedName ilOrigTyRef.QualifiedName
-
-                              let access = (if isNested  then ILTypeDefAccess.Nested ILMemberAccess.Public else ILTypeDefAccess.Public)
-                              let tdefs = mkILTypeDefs (List.map buildRelocatedGeneratedType ch)
-                              mkILSimpleClass ilGlobals (ilTgtTyRef.Name, access, emptyILMethods, emptyILFields, tdefs, emptyILProperties, emptyILEvents, emptyILCustomAttrs, ILTypeInit.OnAny) 
-
-                      [ for (ProviderGeneratedType(_, ilTgtTyRef, _) as node) in tcImports.ProviderGeneratedTypeRoots  do
-                           yield (ilTgtTyRef, buildRelocatedGeneratedType node) ]
-                  
-                  // Implant all the generated type definitions into the ilxMainModule (generating a new ilxMainModule)
-                  let ilxMainModule = 
-
-                      /// Split the list into left, middle and right parts at the first element satisfying 'p'. If no element matches return
-                      /// 'None' for the middle part.
-                      let trySplitFind p xs = 
-                          let rec loop xs acc = 
-                              match xs with 
-                              | [] -> List.rev acc, None, [] 
-                              | h :: t -> if p h then List.rev acc, Some h, t else loop t (h :: acc)
-                          loop xs []
-
-                      /// Implant the (nested) type definition 'td' at path 'enc' in 'tdefs'. 
-                      let rec implantTypeDef isNested (tdefs: ILTypeDefs) (enc: string list) (td: ILTypeDef) = 
-                          match enc with 
-                          | [] -> addILTypeDef td tdefs
-                          | h :: t -> 
-                               let tdefs = tdefs.AsList
-                               let (ltdefs, htd, rtdefs) = 
-                                   match tdefs |> trySplitFind (fun td -> td.Name = h) with 
-                                   | (ltdefs, None, rtdefs) -> 
-                                       let access = if isNested  then ILTypeDefAccess.Nested ILMemberAccess.Public else ILTypeDefAccess.Public
-                                       let fresh = mkILSimpleClass ilGlobals (h, access, emptyILMethods, emptyILFields, emptyILTypeDefs, emptyILProperties, emptyILEvents, emptyILCustomAttrs, ILTypeInit.OnAny)
-                                       (ltdefs, fresh, rtdefs)
-                                   | (ltdefs, Some htd, rtdefs) -> 
-                                       (ltdefs, htd, rtdefs)
-                               let htd = htd.With(nestedTypes = implantTypeDef true htd.NestedTypes t td)
-                               mkILTypeDefs (ltdefs @ [htd] @ rtdefs)
-
-                      let newTypeDefs = 
-                          (ilxMainModule.TypeDefs, generatedILTypeDefs) ||> List.fold (fun acc (ilTgtTyRef, td) -> 
-                              if debugStaticLinking then printfn "implanting '%s' at '%s'" td.Name ilTgtTyRef.QualifiedName 
-                              implantTypeDef false acc ilTgtTyRef.Enclosing td) 
-                      { ilxMainModule with TypeDefs = newTypeDefs } 
-                  
-                  // Remove any ILTypeDefs from the provider generated modules if they have been relocated because of a [<Generate>] declaration.
-                  let providerGeneratedILModules = 
-                      providerGeneratedILModules |> List.map (fun (ccu, ilOrigScopeRef, ilModule) -> 
-                          let ilTypeDefsAfterRemovingRelocatedTypes = 
-                              let rec rw enc (tdefs: ILTypeDefs) = 
-                                  mkILTypeDefs
-                                   [ for tdef in tdefs do 
-                                        let ilOrigTyRef = mkILNestedTyRef (ilOrigScopeRef, enc, tdef.Name)
-                                        if  not (ilOrigTyRefsForProviderGeneratedTypesToRelocate.ContainsKey ilOrigTyRef) then
-                                          if debugStaticLinking then printfn "Keep provided type %s in place because it wasn't relocated" ilOrigTyRef.QualifiedName
-                                          yield tdef.With(nestedTypes = rw (enc@[tdef.Name]) tdef.NestedTypes) ]
-                              rw [] ilModule.TypeDefs
-                          (ccu, { ilModule with TypeDefs = ilTypeDefsAfterRemovingRelocatedTypes }))
-
-                  providerGeneratedILModules, ilxMainModule
-             
-              Morphs.disableMorphCustomAttributeData()
-#else
-              let providerGeneratedILModules = []
-#endif
-
-              // Glue all this stuff into ilxMainModule 
-              let ilxMainModule, rewriteExternalRefsToLocalRefs = 
-                  StaticLinkILModules (tcConfig, ilGlobals, tcImports, ilxMainModule, dependentILModules @ providerGeneratedILModules)
-
-              // Rewrite type and assembly references
-              let ilxMainModule =
-                  let isMscorlib = ilGlobals.primaryAssemblyName = PrimaryAssembly.Mscorlib.Name
-                  let validateTargetPlatform (scopeRef : ILScopeRef) = 
-                      let name = getNameOfScopeRef scopeRef
-                      if (not isMscorlib && name = PrimaryAssembly.Mscorlib.Name) then
-                          error (Error(FSComp.SR.fscStaticLinkingNoProfileMismatches(), rangeCmdArgs))
-                      scopeRef
-                  let rewriteAssemblyRefsToMatchLibraries = NormalizeAssemblyRefs (ctok, ilGlobals, tcImports)
-                  Morphs.morphILTypeRefsInILModuleMemoized ilGlobals (Morphs.morphILScopeRefsInILTypeRef (validateTargetPlatform >> rewriteExternalRefsToLocalRefs >> rewriteAssemblyRefsToMatchLibraries)) ilxMainModule
-
-              ilxMainModule)
-  
-//----------------------------------------------------------------------------
-// ValidateKeySigningAttributes, GetStrongNameSigner
-//----------------------------------------------------------------------------
-
-type StrongNameSigningInfo = StrongNameSigningInfo of (* delaysign:*) bool * (* publicsign:*) bool * (*signer:*)  string option * (*container:*) string option
-
-let ValidateKeySigningAttributes (tcConfig : TcConfig, tcGlobals, topAttrs) =
-    let delaySignAttrib = AttributeHelpers.TryFindBoolAttribute tcGlobals "System.Reflection.AssemblyDelaySignAttribute" topAttrs.assemblyAttrs
-    let signerAttrib = AttributeHelpers.TryFindStringAttribute tcGlobals "System.Reflection.AssemblyKeyFileAttribute" topAttrs.assemblyAttrs
-    let containerAttrib = AttributeHelpers.TryFindStringAttribute tcGlobals "System.Reflection.AssemblyKeyNameAttribute" topAttrs.assemblyAttrs
-    
-    // if delaySign is set via an attribute, validate that it wasn't set via an option
-    let delaysign = 
-        match delaySignAttrib with 
-        | Some delaysign -> 
-          if tcConfig.delaysign then
-            warning(Error(FSComp.SR.fscDelaySignWarning(), rangeCmdArgs)) 
-            tcConfig.delaysign
-          else
-            delaysign
-        | _ -> tcConfig.delaysign
-        
-    // if signer is set via an attribute, validate that it wasn't set via an option
-    let signer = 
-        match signerAttrib with
-        | Some signer -> 
-            if tcConfig.signer.IsSome && tcConfig.signer <> Some signer then
-                warning(Error(FSComp.SR.fscKeyFileWarning(), rangeCmdArgs)) 
-                tcConfig.signer
-            else
-                Some signer
-        | None -> tcConfig.signer
-    
-    // if container is set via an attribute, validate that it wasn't set via an option, and that they keyfile wasn't set
-    // if keyfile was set, use that instead (silently)
-    // REVIEW: This is C# behavior, but it seems kind of sketchy that we fail silently
-    let container = 
-        match containerAttrib with 
-        | Some container -> 
-            if tcConfig.container.IsSome && tcConfig.container <> Some container then
-              warning(Error(FSComp.SR.fscKeyNameWarning(), rangeCmdArgs)) 
-              tcConfig.container
-            else
-              Some container
-        | None -> tcConfig.container
-    
-    StrongNameSigningInfo (delaysign, tcConfig.publicsign, signer, container)
-
-/// Checks if specified file name is absolute path. If yes - returns the name as is, otherwise makes full path using tcConfig.implicitIncludeDir as base.
-let expandFileNameIfNeeded (tcConfig : TcConfig) name = 
-    if FileSystem.IsPathRootedShim name then 
-        name 
-    else 
-        Path.Combine(tcConfig.implicitIncludeDir, name)
-
-let GetStrongNameSigner signingInfo = 
-    let (StrongNameSigningInfo(delaysign, publicsign, signer, container)) = signingInfo
-    // REVIEW: favor the container over the key file - C# appears to do this
-    match container with
-    | Some container ->
-        Some (ILStrongNameSigner.OpenKeyContainer container)
-    | None ->
-        match signer with 
-        | None -> None
-        | Some s ->
-            try 
-                if publicsign || delaysign then
-                    Some (ILStrongNameSigner.OpenPublicKeyOptions s publicsign)
-                else
-                    Some (ILStrongNameSigner.OpenKeyPairFile s) 
-            with _ -> 
-                // Note :: don't use errorR here since we really want to fail and not produce a binary
-                error(Error(FSComp.SR.fscKeyFileCouldNotBeOpened s, rangeCmdArgs))
-
 //----------------------------------------------------------------------------
 // CopyFSharpCore
 //----------------------------------------------------------------------------
@@ -1716,16 +376,37 @@ let CopyFSharpCore(outFile: string, referencedDlls: AssemblyReference list) =
         else
             errorR(Error(FSComp.SR.fsharpCoreNotFoundToBeCopied(), rangeCmdArgs))
 
+// Try to find an AssemblyVersion attribute 
+let TryFindVersionAttribute g attrib attribName attribs deterministic =
+    match AttributeHelpers.TryFindStringAttribute g attrib attribs with
+    | Some versionString ->
+         if deterministic && versionString.Contains("*") then
+             errorR(Error(FSComp.SR.fscAssemblyWildcardAndDeterminism(attribName, versionString), Range.rangeStartup))
+         try Some (IL.parseILVersion versionString)
+         with e ->
+             // Warning will be reported by CheckExpressions.fs
+             None
+    | _ -> None
+
 //----------------------------------------------------------------------------
-// Main phases of compilation
+// Main phases of compilation. These are written as separate functions with explicit argument passing
+// to ensure transient objects are eligible for GC and only actual required information
+// is propagated.
 //-----------------------------------------------------------------------------
 
 [<NoEquality; NoComparison>]
 type Args<'T> = Args  of 'T
 
-let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, 
+/// First phase of compilation. 
+///   - Set up console encoding and code page settings
+///   - Process command line, flags and collect filenames
+///   - Resolve assemblies
+///   - Import assemblies
+///   - Parse source files
+///   - Check the inputs
+let main1(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, 
           reduceMemoryUsage: ReduceMemoryFlag, defaultCopyFSharpCore: CopyFSharpCoreFlag, 
-          exiter: Exiter, errorLoggerProvider : ErrorLoggerProvider, disposables : DisposablesTracker) = 
+          exiter: Exiter, errorLoggerProvider: ErrorLoggerProvider, disposables: DisposablesTracker) = 
 
     // See Bug 735819 
     let lcidFromCodePage =
@@ -1738,22 +419,13 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
             None
 
     let directoryBuildingFrom = Directory.GetCurrentDirectory()
-    let setProcessThreadLocals tcConfigB =
-                    match tcConfigB.preferredUiLang with
-                    | Some s -> Thread.CurrentThread.CurrentUICulture <- new CultureInfo(s)
-                    | None -> ()
-                    if tcConfigB.utf8output then 
-                        Console.OutputEncoding <- Encoding.UTF8
-
-    let displayBannerIfNeeded tcConfigB =
-                    // display the banner text, if necessary
-                    if not bannerAlreadyPrinted then 
-                        DisplayBannerText tcConfigB
 
     let tryGetMetadataSnapshot = (fun _ -> None)
 
+    let defaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()).Value
+
     let tcConfigB = 
-       TcConfigBuilder.CreateNew(legacyReferenceResolver, DefaultFSharpBinariesDir, 
+       TcConfigBuilder.CreateNew(legacyReferenceResolver, defaultFSharpBinariesDir, 
           reduceMemoryUsage=reduceMemoryUsage, implicitIncludeDir=directoryBuildingFrom, 
           isInteractive=false, isInvalidationSupported=false, 
           defaultCopyFSharpCore=defaultCopyFSharpCore, 
@@ -1773,14 +445,14 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
 
     let dependencyProvider = new DependencyProvider()
 
-    // process command line, flags and collect filenames 
+    // Process command line, flags and collect filenames 
     let sourceFiles = 
 
         // The ParseCompilerOptions function calls imperative function to process "real" args
         // Rather than start processing, just collect names, then process them. 
         try 
             let sourceFiles = 
-                let files = ProcessCommandLineFlags (tcConfigB, setProcessThreadLocals, lcidFromCodePage, argv)
+                let files = ProcessCommandLineFlags (tcConfigB, lcidFromCodePage, argv)
                 AdjustForScriptCompile(ctok, tcConfigB, files, lexResourceManager, dependencyProvider)
             sourceFiles
 
@@ -1790,7 +462,10 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
             exiter.Exit 1 
     
     tcConfigB.conditionalCompilationDefines <- "COMPILED" :: tcConfigB.conditionalCompilationDefines 
-    displayBannerIfNeeded tcConfigB
+
+    // Display the banner text, if necessary
+    if not bannerAlreadyPrinted then 
+        DisplayBannerText tcConfigB
 
     // Create tcGlobals and frameworkTcImports
     let outfile, pdbfile, assemblyName = 
@@ -1895,65 +570,23 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
 
     Args (ctok, tcGlobals, tcImports, frameworkTcImports, tcState.Ccu, typedAssembly, topAttrs, tcConfig, outfile, pdbfile, assemblyName, errorLogger, exiter)
 
-let main1(Args (ctok, tcGlobals, tcImports: TcImports, frameworkTcImports, generatedCcu: CcuThunk, typedImplFiles, topAttrs, tcConfig: TcConfig, outfile, pdbfile, assemblyName, errorLogger, exiter: Exiter)) =
-
-    if tcConfig.typeCheckOnly then exiter.Exit 0
-    
-    generatedCcu.Contents.SetAttribs(generatedCcu.Contents.Attribs @ topAttrs.assemblyAttrs)
-
-    use unwindPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.CodeGen
-    let signingInfo = ValidateKeySigningAttributes (tcConfig, tcGlobals, topAttrs)
-    
-    AbortOnError(errorLogger, exiter)
-
-    // Build an updated errorLogger that filters according to the scopedPragmas. Then install
-    // it as the updated global error logger and never remove it
-    let oldLogger = errorLogger
-    let errorLogger = 
-        let scopedPragmas = [ for (TImplFile (_, pragmas, _, _, _, _)) in typedImplFiles do yield! pragmas ]
-        GetErrorLoggerFilteringByScopedPragmas(true, scopedPragmas, oldLogger)
-
-    let _unwindEL_3 = PushErrorLoggerPhaseUntilUnwind(fun _ -> errorLogger)
-
-    // Try to find an AssemblyVersion attribute 
-    let assemVerFromAttrib = 
-        match AttributeHelpers.TryFindVersionAttribute tcGlobals "System.Reflection.AssemblyVersionAttribute" "AssemblyVersionAttribute" topAttrs.assemblyAttrs tcConfig.deterministic with
-        | Some v -> 
-           match tcConfig.version with 
-           | VersionNone -> Some v
-           | _ -> warning(Error(FSComp.SR.fscAssemblyVersionAttributeIgnored(), Range.rangeStartup)); None
-        | _ -> None
-
-    // write interface, xmldoc
-    begin
-      ReportTime tcConfig ("Write Interface File")
-      use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Output
-      if tcConfig.printSignature   then InterfaceFileWriter.WriteInterfaceFile (tcGlobals, tcConfig, InfoReader(tcGlobals, tcImports.GetImportMap()), typedImplFiles)
-
-      ReportTime tcConfig ("Write XML document signatures")
-      if tcConfig.xmlDocOutputFile.IsSome then 
-          XmlDocWriter.computeXmlDocSigs (tcGlobals, generatedCcu) 
-
-      ReportTime tcConfig ("Write XML docs")
-      tcConfig.xmlDocOutputFile |> Option.iter ( fun xmlFile -> 
-          let xmlFile = tcConfig.MakePathAbsolute xmlFile
-          XmlDocWriter.writeXmlDoc (assemblyName, generatedCcu, xmlFile)
-        )
-      ReportTime tcConfig ("Write HTML docs")
-    end
-
-    // Pass on only the minimum information required for the next phase
-    Args (ctok, tcConfig, tcImports, frameworkTcImports, tcGlobals, errorLogger, generatedCcu, outfile, typedImplFiles, topAttrs, pdbfile, assemblyName, assemVerFromAttrib, signingInfo, exiter)
-
-
-// This is for the compile-from-AST feature of FCS.
-// TODO: consider extracting TC in standalone phase to avoid duplication
-let main0OfAst (ctok, legacyReferenceResolver, reduceMemoryUsage, assemblyName, target, outfile, pdbFile, dllReferences, noframework, exiter, errorLoggerProvider: ErrorLoggerProvider, disposables : DisposablesTracker, inputs : ParsedInput list) =
+/// Alternative first phase of compilation.  This is for the compile-from-AST feature of FCS.
+///   - Import assemblies
+///   - Check the inputs
+let main1OfAst
+       (ctok, legacyReferenceResolver, reduceMemoryUsage, assemblyName, target,
+        outfile, pdbFile, dllReferences,
+        noframework, exiter: Exiter,
+        errorLoggerProvider: ErrorLoggerProvider,
+        disposables: DisposablesTracker,
+        inputs: ParsedInput list) =
 
     let tryGetMetadataSnapshot = (fun _ -> None)
 
+    let defaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()).Value
+
     let tcConfigB = 
-        TcConfigBuilder.CreateNew(legacyReferenceResolver, DefaultFSharpBinariesDir, 
+        TcConfigBuilder.CreateNew(legacyReferenceResolver, defaultFSharpBinariesDir, 
             reduceMemoryUsage=reduceMemoryUsage, implicitIncludeDir=Directory.GetCurrentDirectory(), 
             isInteractive=false, isInvalidationSupported=false, 
             defaultCopyFSharpCore=CopyFSharpCoreFlag.No, 
@@ -2045,9 +678,65 @@ let main0OfAst (ctok, legacyReferenceResolver, reduceMemoryUsage, assemblyName, 
 
     Args (ctok, tcGlobals, tcImports, frameworkTcImports, tcState.Ccu, typedAssembly, topAttrs, tcConfig, outfile, pdbFile, assemblyName, errorLogger, exiter)
 
-  
-/// Phase 2a: encode signature data, optimize, encode optimization data
-let main2a(Args (ctok, tcConfig, tcImports, frameworkTcImports: TcImports, tcGlobals, 
+
+/// Second phase of compilation.
+///   - Write the signature file, check some attributes
+let main2(Args (ctok, tcGlobals, tcImports: TcImports, frameworkTcImports, generatedCcu: CcuThunk, typedImplFiles, topAttrs, tcConfig: TcConfig, outfile, pdbfile, assemblyName, errorLogger, exiter: Exiter)) =
+
+    if tcConfig.typeCheckOnly then exiter.Exit 0
+    
+    generatedCcu.Contents.SetAttribs(generatedCcu.Contents.Attribs @ topAttrs.assemblyAttrs)
+
+    use unwindPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.CodeGen
+    let signingInfo = ValidateKeySigningAttributes (tcConfig, tcGlobals, topAttrs)
+    
+    AbortOnError(errorLogger, exiter)
+
+    // Build an updated errorLogger that filters according to the scopedPragmas. Then install
+    // it as the updated global error logger and never remove it
+    let oldLogger = errorLogger
+    let errorLogger = 
+        let scopedPragmas = [ for (TImplFile (_, pragmas, _, _, _, _)) in typedImplFiles do yield! pragmas ]
+        GetErrorLoggerFilteringByScopedPragmas(true, scopedPragmas, oldLogger)
+
+    let _unwindEL_3 = PushErrorLoggerPhaseUntilUnwind(fun _ -> errorLogger)
+
+    // Try to find an AssemblyVersion attribute 
+    let assemVerFromAttrib = 
+        match TryFindVersionAttribute tcGlobals "System.Reflection.AssemblyVersionAttribute" "AssemblyVersionAttribute" topAttrs.assemblyAttrs tcConfig.deterministic with
+        | Some v -> 
+           match tcConfig.version with 
+           | VersionNone -> Some v
+           | _ -> warning(Error(FSComp.SR.fscAssemblyVersionAttributeIgnored(), Range.rangeStartup)); None
+        | _ -> None
+
+    // write interface, xmldoc
+    begin
+      ReportTime tcConfig ("Write Interface File")
+      use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Output
+      if tcConfig.printSignature then InterfaceFileWriter.WriteInterfaceFile (tcGlobals, tcConfig, InfoReader(tcGlobals, tcImports.GetImportMap()), typedImplFiles)
+
+      ReportTime tcConfig ("Write XML document signatures")
+      if tcConfig.xmlDocOutputFile.IsSome then 
+          XmlDocWriter.computeXmlDocSigs (tcGlobals, generatedCcu) 
+
+      ReportTime tcConfig ("Write XML docs")
+      tcConfig.xmlDocOutputFile |> Option.iter ( fun xmlFile -> 
+          let xmlFile = tcConfig.MakePathAbsolute xmlFile
+          XmlDocWriter.writeXmlDoc (assemblyName, generatedCcu, xmlFile)
+        )
+      ReportTime tcConfig ("Write HTML docs")
+    end
+
+    // Pass on only the minimum information required for the next phase
+    Args (ctok, tcConfig, tcImports, frameworkTcImports, tcGlobals, errorLogger, generatedCcu, outfile, typedImplFiles, topAttrs, pdbfile, assemblyName, assemVerFromAttrib, signingInfo, exiter)
+
+
+/// Third phase of compilation.
+///   - encode signature data
+///   - optimize
+///   - encode optimization data
+let main3(Args (ctok, tcConfig, tcImports, frameworkTcImports: TcImports, tcGlobals, 
                  errorLogger: ErrorLogger, generatedCcu: CcuThunk, outfile, typedImplFiles, 
                  topAttrs, pdbfile, assemblyName, assemVerFromAttrib, signingInfo, exiter: Exiter)) = 
       
@@ -2057,7 +746,7 @@ let main2a(Args (ctok, tcConfig, tcImports, frameworkTcImports: TcImports, tcGlo
     
     let sigDataAttributes, sigDataResources = 
       try
-        EncodeInterfaceData(tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, false)
+        EncodeSignatureData(tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, false)
       with e -> 
         errorRecoveryNoRange e
         exiter.Exit 1
@@ -2090,14 +779,15 @@ let main2a(Args (ctok, tcConfig, tcImports, frameworkTcImports: TcImports, tcGlo
     // Pass on only the minimum information required for the next phase
     Args (ctok, tcConfig, tcImports, tcGlobals, errorLogger, 
           generatedCcu, outfile, optimizedImpls, topAttrs, pdbfile, assemblyName, 
-          (sigDataAttributes, sigDataResources), optDataResources, assemVerFromAttrib, signingInfo, metadataVersion, exiter)
+          sigDataAttributes, sigDataResources, optDataResources, assemVerFromAttrib, signingInfo, metadataVersion, exiter)
 
-/// Phase 2b: IL code generation
-let main2b 
+/// Fourth phase of compilation.
+///   -  IL code generation
+let main4 
       (tcImportsCapture,dynamicAssemblyCreator) 
       (Args (ctok, tcConfig: TcConfig, tcImports, tcGlobals: TcGlobals, errorLogger, 
              generatedCcu: CcuThunk, outfile, optimizedImpls, topAttrs, pdbfile, assemblyName, 
-             idata, optDataResources, assemVerFromAttrib, signingInfo, metadataVersion, exiter: Exiter)) = 
+             sigDataAttributes, sigDataResources, optDataResources, assemVerFromAttrib, signingInfo, metadataVersion, exiter: Exiter)) = 
 
     match tcImportsCapture with 
     | None -> ()
@@ -2107,7 +797,7 @@ let main2b
     let ilGlobals = tcGlobals.ilg
     if tcConfig.standalone && generatedCcu.UsesFSharp20PlusQuotations then    
         error(Error(FSComp.SR.fscQuotationLiteralsStaticLinking0(), rangeStartup))  
-    let staticLinker = StaticLinker.StaticLink (ctok, tcConfig, tcImports, ilGlobals)
+    let staticLinker = StaticLink (ctok, tcConfig, tcImports, ilGlobals)
 
     // Generate IL code
     ReportTime tcConfig "TAST -> IL"
@@ -2121,15 +811,21 @@ let main2b
     let permissionSets = codegenResults.permissionSets
     let secDecls = mkILSecurityDecls permissionSets 
 
-    let ilxMainModule = MainModuleBuilder.CreateMainModule (ctok, tcConfig, tcGlobals, tcImports, pdbfile, assemblyName, outfile, topAttrs, idata, optDataResources, codegenResults, assemVerFromAttrib, metadataVersion, secDecls)
+    let ilxMainModule = 
+        MainModuleBuilder.CreateMainModule
+            (ctok, tcConfig, tcGlobals, tcImports, 
+             pdbfile, assemblyName, outfile, topAttrs,
+             sigDataAttributes, sigDataResources, optDataResources,
+             codegenResults, assemVerFromAttrib, metadataVersion, secDecls)
 
     AbortOnError(errorLogger, exiter)
 
     // Pass on only the minimum information required for the next phase
     Args (ctok, tcConfig, tcImports, tcGlobals, errorLogger, staticLinker, outfile, pdbfile, ilxMainModule, signingInfo, exiter)
 
-/// Phase 3: static linking
-let main3(Args (ctok, tcConfig, tcImports, tcGlobals, errorLogger: ErrorLogger, staticLinker, outfile, pdbfile, ilxMainModule, signingInfo, exiter: Exiter)) = 
+/// Fifth phase of compilation.
+///   -  static linking
+let main5(Args (ctok, tcConfig, tcImports, tcGlobals, errorLogger: ErrorLogger, staticLinker, outfile, pdbfile, ilxMainModule, signingInfo, exiter: Exiter)) = 
         
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Output
 
@@ -2145,8 +841,9 @@ let main3(Args (ctok, tcConfig, tcImports, tcGlobals, errorLogger: ErrorLogger, 
     // Pass on only the minimum information required for the next phase
     Args (ctok, tcConfig, tcImports, tcGlobals, errorLogger, ilxMainModule, outfile, pdbfile, signingInfo, exiter)
 
-/// Phase 4: write the binaries
-let main4 dynamicAssemblyCreator (Args (ctok, tcConfig,  tcImports: TcImports, tcGlobals: TcGlobals, 
+/// Sixth phase of compilation.
+///   -  write the binaries
+let main6 dynamicAssemblyCreator (Args (ctok, tcConfig,  tcImports: TcImports, tcGlobals: TcGlobals, 
                                         errorLogger: ErrorLogger, ilxMainModule, outfile, pdbfile, 
                                         signingInfo, exiter: Exiter)) = 
 
@@ -2205,12 +902,8 @@ let main4 dynamicAssemblyCreator (Args (ctok, tcConfig,  tcImports: TcImports, t
 
     ReportTime tcConfig "Exiting"
 
-//----------------------------------------------------------------------------
-// Entry points to compilation
-//-----------------------------------------------------------------------------
-
-/// Entry point typecheckAndCompile
-let typecheckAndCompile 
+/// The main (non-incremental) compilation entry point used by fsc.exe
+let mainCompile 
        (ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, reduceMemoryUsage, 
         defaultCopyFSharpCore, exiter: Exiter, loggerProvider, tcImportsCapture, dynamicAssemblyCreator) =
 
@@ -2223,32 +916,24 @@ let typecheckAndCompile
                     System.Console.SetOut(savedOut)
                 with _ -> ()}
 
-    main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, reduceMemoryUsage, defaultCopyFSharpCore, exiter, loggerProvider, d)
-    |> main1
-    |> main2a
-    |> main2b (tcImportsCapture,dynamicAssemblyCreator)
-    |> main3 
-    |> main4 dynamicAssemblyCreator
+    main1(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, reduceMemoryUsage, defaultCopyFSharpCore, exiter, loggerProvider, d)
+    |> main2
+    |> main3
+    |> main4 (tcImportsCapture,dynamicAssemblyCreator)
+    |> main5 
+    |> main6 dynamicAssemblyCreator
 
-
+/// An additional compilation entry point used by FSharp.Compiler.Service taking syntax trees as input
 let compileOfAst 
        (ctok, legacyReferenceResolver, reduceMemoryUsage, assemblyName, target, 
         targetDll, targetPdb, dependencies, noframework, exiter, loggerProvider, inputs, tcImportsCapture, dynamicAssemblyCreator) = 
 
     use d = new DisposablesTracker()
-    main0OfAst (ctok, legacyReferenceResolver, reduceMemoryUsage, assemblyName, target, targetDll, targetPdb, 
+    main1OfAst (ctok, legacyReferenceResolver, reduceMemoryUsage, assemblyName, target, targetDll, targetPdb, 
                 dependencies, noframework, exiter, loggerProvider, d, inputs)
-    |> main1
-    |> main2a
-    |> main2b (tcImportsCapture, dynamicAssemblyCreator)
+    |> main2
     |> main3
-    |> main4 dynamicAssemblyCreator
-
-let mainCompile 
-        (ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, reduceMemoryUsage, 
-         defaultCopyFSharpCore, exiter, loggerProvider, tcImportsCapture, dynamicAssemblyCreator) = 
-
-    typecheckAndCompile
-       (ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, reduceMemoryUsage, 
-        defaultCopyFSharpCore, exiter, loggerProvider, tcImportsCapture, dynamicAssemblyCreator)
+    |> main4 (tcImportsCapture, dynamicAssemblyCreator)
+    |> main5
+    |> main6 dynamicAssemblyCreator
 

--- a/src/fsharp/fsc.fsi
+++ b/src/fsharp/fsc.fsi
@@ -22,34 +22,23 @@ type ErrorLoggerProvider =
     new : unit -> ErrorLoggerProvider
     abstract CreateErrorLoggerUpToMaxErrors : tcConfigBuilder : TcConfigBuilder * exiter : Exiter -> ErrorLogger
 
-type StrongNameSigningInfo 
+/// The default ErrorLoggerProvider implementation, reporting messages to the Console up to the maxerrors maximum
+type ConsoleLoggerProvider = 
+    new : unit -> ConsoleLoggerProvider
+    inherit ErrorLoggerProvider
 
-val EncodeInterfaceData: tcConfig:TcConfig * tcGlobals:TcGlobals * exportRemapping:Remap * generatedCcu: CcuThunk * outfile: string * isIncrementalBuild: bool -> ILAttribute list * ILResource list
+/// Encode the F# interface data into a set of IL attributes and resources
+val EncodeSignatureData:
+    tcConfig:TcConfig *
+    tcGlobals:TcGlobals *
+    exportRemapping:Remap *
+    generatedCcu: CcuThunk *
+    outfile: string *
+    isIncrementalBuild: bool
+      -> ILAttribute list * ILResource list
 
-val ValidateKeySigningAttributes : tcConfig:TcConfig * tcGlobals:TcGlobals * TopAttribs -> StrongNameSigningInfo
-
-val GetStrongNameSigner : StrongNameSigningInfo -> ILStrongNameSigner option
-
-/// Process the given set of command line arguments
-val internal ProcessCommandLineFlags : TcConfigBuilder * setProcessThreadLocals:(TcConfigBuilder -> unit) * lcidFromCodePage : int option * argv:string[] -> string list
-
-//---------------------------------------------------------------------------
-// The entry point used by fsc.exe
-
-val typecheckAndCompile : 
-    ctok: CompilationThreadToken *
-    argv : string[] * 
-    legacyReferenceResolver: ReferenceResolver.Resolver * 
-    bannerAlreadyPrinted : bool * 
-    reduceMemoryUsage: ReduceMemoryFlag * 
-    defaultCopyFSharpCore: CopyFSharpCoreFlag * 
-    exiter : Exiter *
-    loggerProvider: ErrorLoggerProvider *
-    tcImportsCapture: (TcImports -> unit) option *
-    dynamicAssemblyCreator: (TcGlobals * string * ILModuleDef -> unit) option
-      -> unit
-
-val mainCompile : 
+/// The main (non-incremental) compilation entry point used by fsc.exe
+val mainCompile: 
     ctok: CompilationThreadToken *
     argv: string[] * 
     legacyReferenceResolver: ReferenceResolver.Resolver * 
@@ -62,7 +51,8 @@ val mainCompile :
     dynamicAssemblyCreator: (TcGlobals * string * ILModuleDef -> unit) option
       -> unit
 
-val compileOfAst : 
+/// An additional compilation entry point used by FSharp.Compiler.Service taking syntax trees as input
+val compileOfAst: 
     ctok: CompilationThreadToken *
     legacyReferenceResolver: ReferenceResolver.Resolver * 
     reduceMemoryUsage: ReduceMemoryFlag * 
@@ -86,14 +76,3 @@ type InProcErrorLoggerProvider =
     member CapturedWarnings : Diagnostic[]
     member CapturedErrors : Diagnostic[]
 
-/// The default ErrorLogger implementation, reporting messages to the Console up to the maxerrors maximum
-type ConsoleLoggerProvider = 
-    new : unit -> ConsoleLoggerProvider
-    inherit ErrorLoggerProvider
-
-// For unit testing
-module internal MainModuleBuilder =
-    
-    val fileVersion: findStringAttr: (string -> string option) -> assemblyVersion: ILVersionInfo -> ILVersionInfo
-    val productVersion: findStringAttr: (string -> string option) -> fileVersion: ILVersionInfo -> string
-    val productVersionToILVersionInfo: string -> ILVersionInfo

--- a/src/fsharp/fscmain.fs
+++ b/src/fsharp/fscmain.fs
@@ -17,18 +17,33 @@ open FSharp.Compiler.AbstractIL.Internal.Library
 [<Dependency("FSharp.Compiler.Private",LoadHint.Always)>] 
 do ()
 
+[<EntryPoint>]
+let main(argv) =
+    
+    // Set the garbage collector to batch mode, which improves overall performance.
+    System.Runtime.GCSettings.LatencyMode <- System.Runtime.GCLatencyMode.Batch
+    
+    // Set the initial phase to garbage collector to batch mode, which improves overall performance.
+    use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parameter
 
-module Driver = 
-    let main argv = 
+    // An SDL recommendation
+    Lib.UnmanagedProcessExecutionOptions.EnableHeapTerminationOnCorruption()
 
+    try 
+
+        // We are on a compilation thread
         let ctok = AssumeCompilationThreadWithoutEvidence ()
 
+        // The F# compiler expects 'argv' to include the executable name, though it makes no use of it.
+        let argv = Array.append [| "fsc.exe" |] argv
+        
         // Check for --pause as the very first step so that a compiler can be attached here.
         let pauseFlag = argv |> Array.exists  (fun x -> x = "/pause" || x = "--pause")
         if pauseFlag then 
             System.Console.WriteLine("Press return to continue...")
             System.Console.ReadLine() |> ignore
 
+        // Set up things for the --times testing flag
 #if !FX_NO_APP_DOMAINS
         let timesFlag = argv |> Array.exists  (fun x -> x = "/times" || x = "--times")
         if timesFlag then 
@@ -42,6 +57,8 @@ module Driver =
                     stats.weakByteFileCount)
 #endif
 
+        // This object gets invoked when two many errors have been accumulated, or an abort-on-error condition
+        // has been reached (e.g. type checking failed, so don't proceed to optimization).
         let quitProcessExiter = 
             { new Exiter with 
                 member x.Exit(n) =                    
@@ -49,9 +66,10 @@ module Driver =
                       exit n
                     with _ -> 
                       ()            
-                    failwithf "%s" <| FSComp.SR.elSysEnvExitDidntExit() 
+                    failwithf "%s" (FSComp.SR.elSysEnvExitDidntExit())
             }
 
+        // Get the handler for legacy resolution of references via MSBuild.
         let legacyReferenceResolver = 
 #if CROSS_PLATFORM_COMPILER
             SimulatedMSBuildReferenceResolver.SimulatedMSBuildResolver
@@ -59,6 +77,8 @@ module Driver =
             LegacyMSBuildReferenceResolver.getResolver()
 #endif
 
+        // Perform the main compilation.
+        //
         // This is the only place where ReduceMemoryFlag.No is set. This is because fsc.exe is not a long-running process and
         // thus we can use file-locking memory mapped files.
         //
@@ -66,15 +86,7 @@ module Driver =
         mainCompile (ctok, argv, legacyReferenceResolver, (*bannerAlreadyPrinted*)false, ReduceMemoryFlag.No, CopyFSharpCoreFlag.Yes, quitProcessExiter, ConsoleLoggerProvider(), None, None)
         0 
 
-[<EntryPoint>]
-let main(argv) =
-    System.Runtime.GCSettings.LatencyMode <- System.Runtime.GCLatencyMode.Batch
-    use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parameter
-
-    Lib.UnmanagedProcessExecutionOptions.EnableHeapTerminationOnCorruption() (* SDL recommendation *)
-
-    try 
-        Driver.main(Array.append [| "fsc.exe" |] argv)
     with e -> 
+        // Last-chance error recovery (note, with a poor error range)
         errorRecovery e FSharp.Compiler.Range.range0
         1

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2128,8 +2128,8 @@ type internal FsiInteractionProcessor
 
             let input = 
                 Lexhelp.reusingLexbufForParsing tokenizer.LexBuffer (fun () -> 
-                    let lexerWhichSavesLastToken lexbuf = 
-                        let tok = tokenizer.Lexer lexbuf
+                    let lexerWhichSavesLastToken _lexbuf = 
+                        let tok = tokenizer.GetToken()
                         lastToken <- tok
                         tok                        
                     Parser.interaction lexerWhichSavesLastToken tokenizer.LexBuffer)
@@ -2142,7 +2142,7 @@ type internal FsiInteractionProcessor
                 let mutable tok = Parser.ELSE (* <-- any token <> SEMICOLON_SEMICOLON will do *)
                 while (match tok with  Parser.SEMICOLON_SEMICOLON -> false | _ -> true) 
                       && not tokenizer.LexBuffer.IsPastEndOfStream do
-                    tok <- tokenizer.Lexer tokenizer.LexBuffer
+                    tok <- tokenizer.GetToken()
 
             stopProcessingRecovery e range0    
             None
@@ -2382,7 +2382,7 @@ type internal FsiInteractionProcessor
 
     let parseExpression (tokenizer:LexFilter.LexFilter) =
         reusingLexbufForParsing tokenizer.LexBuffer (fun () ->
-            Parser.typedSeqExprEOF tokenizer.Lexer tokenizer.LexBuffer)
+            Parser.typedSeqExprEOF (fun _ -> tokenizer.GetToken()) tokenizer.LexBuffer)
 
     let mainThreadProcessParsedExpression ctok errorLogger (expr, istate) = 
       istate |> InteractiveCatch errorLogger (fun istate ->

--- a/src/fsharp/lib.fs
+++ b/src/fsharp/lib.fs
@@ -2,13 +2,13 @@
 
 module internal FSharp.Compiler.Lib
 
+open System
 open System.IO
 open System.Collections.Generic
 open System.Runtime.InteropServices
 open Internal.Utilities
 open FSharp.Compiler.AbstractIL.Internal 
 open FSharp.Compiler.AbstractIL.Internal.Library
-
 
 /// is this the developer-debug build? 
 let debug = false 
@@ -565,3 +565,19 @@ type MaybeLazy<'T> =
         | Lazy x -> x.Force()
 
 let inline vsnd ((_, y): struct('T * 'T)) = y
+
+/// Track a set of resources to cleanup
+type DisposablesTracker() = 
+
+    let items = Stack<IDisposable>()
+
+    /// Regsiter some items to dispose
+    member _.Register i = items.Push i
+
+    interface IDisposable with
+
+        member _.Dispose() = 
+            let l = List.ofSeq items
+            items.Clear()
+            for i in l do 
+                try i.Dispose() with _ -> ()

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -20,6 +20,7 @@ open FSharp.Compiler.CompilerDiagnostics
 open FSharp.Compiler.CompilerGlobalState
 open FSharp.Compiler.CompilerImports
 open FSharp.Compiler.CompilerOptions
+open FSharp.Compiler.CreateILModule
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.NameResolution
 open FSharp.Compiler.ParseAndCheckInputs
@@ -608,7 +609,7 @@ type RawFSharpAssemblyDataBackedByLanguageService (tcConfig, tcGlobals, tcState:
     let exportRemapping = MakeExportRemapping generatedCcu generatedCcu.Contents
                       
     let sigData = 
-        let _sigDataAttributes, sigDataResources = Driver.EncodeInterfaceData(tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, true)
+        let _sigDataAttributes, sigDataResources = Driver.EncodeSignatureData(tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, true)
         [ for r in sigDataResources  do
             let ccuName = GetSignatureDataResourceName r
             yield (ccuName, (fun () -> r.GetBytes())) ]
@@ -851,8 +852,8 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                     let ilAssemRef = 
                         let publicKey = 
                             try 
-                                let signingInfo = Driver.ValidateKeySigningAttributes (tcConfig, tcGlobals, topAttrs)
-                                match Driver.GetStrongNameSigner signingInfo with 
+                                let signingInfo = ValidateKeySigningAttributes (tcConfig, tcGlobals, topAttrs)
+                                match GetStrongNameSigner signingInfo with 
                                 | None -> None
                                 | Some s -> Some (PublicKey.KeyAsToken(s.PublicKey))
                             with e -> 

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -1528,7 +1528,8 @@ module Lexer =
             let lexer = Lexer.token lexargs canSkipTrivia
 
             if canUseLexFilter then
-                LexFilter.LexFilter(lexargs.lightStatus, isCompilingFSharpCore, lexer, lexbuf).Lexer
+                let lexFilter = LexFilter.LexFilter(lexargs.lightStatus, isCompilingFSharpCore, lexer, lexbuf)
+                (fun _ -> lexFilter.GetToken())
             else
                 lexer
 

--- a/tests/FSharp.Compiler.UnitTests/ProductVersion.fs
+++ b/tests/FSharp.Compiler.UnitTests/ProductVersion.fs
@@ -7,7 +7,7 @@ open Xunit
 open FSharp.Test.Utilities
 
 open FSharp.Compiler.AbstractIL.IL
-open FSharp.Compiler.Driver.MainModuleBuilder
+open FSharp.Compiler.CreateILModule.MainModuleBuilder
 
 #nowarn "3180"
 

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/times/times01.fs
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/times/times01.fs
@@ -20,7 +20,6 @@ namespace N2
 //<Expects status="success">TIME:.+Delta:.+Mem:.+G0:.+G1:.+G2:.+\[Typecheck\]</Expects>
 //<Expects status="success">TIME:.+Delta:.+Mem:.+G0:.+G1:.+G2:.+\[Typechecked\]</Expects>
 //<Expects status="success">TIME:.+Delta:.+Mem:.+G0:.+G1:.+G2:.+\[Write XML docs\]</Expects>
-//<Expects status="success">TIME:.+Delta:.+Mem:.+G0:.+G1:.+G2:.+\[Write HTML docs\]</Expects>
 //<Expects status="success">TIME:.+Delta:.+Mem:.+G0:.+G1:.+G2:.+\[Encode Interface Data\]</Expects>
 //<Expects status="success">TIME:.+Delta:.+Mem:.+G0:.+G1:.+G2:.+\[TAST -> IL\]</Expects>
 //<Expects status="success">ilwrite: TIME.+Write Started</Expects>


### PR DESCRIPTION
Based on the F# community compiler session walkthrough to make things simpler and more coherent for the newcomer

Splits fsc.fs into these:

      XmlDocFileWriter.fsi
      XmlDocFileWriter.fs
      BinaryResourceFormats.fsi
      BinaryResourceFormats.fs
      StaticLinking.fsi
      StaticLinking.fs
      CreateILModule.fsi
      CreateILModule.fs
      fsc.fsi
      fsc.fs

Also 
* tidies up fsc.fs
* adds LexFilter.fsi

