### PR TITLE
fix 10505 -- stringbuilder/iformatable

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -4555,8 +4555,13 @@ namespace Microsoft.FSharp.Core
                 | _ -> value.ToString()
 
              // other commmon mscorlib reference types
-             when 'T : StringBuilder = let x = (# "" value : StringBuilder #) in x.ToString()
-             when 'T : IFormattable = let x = (# "" value : IFormattable #) in x.ToString(null, CultureInfo.InvariantCulture)
+             when 'T : StringBuilder =
+                if value = unsafeDefault<'T> then ""
+                else let x = (# "" value : StringBuilder #) in x.ToString()
+
+             when 'T : IFormattable =
+                if value = unsafeDefault<'T> then ""
+                else let x = (# "" value : IFormattable #) in x.ToString(null, CultureInfo.InvariantCulture)
 
         [<NoDynamicInvocation(isLegacy=true)>]
         [<CompiledName("ToChar")>]

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
@@ -6,6 +6,7 @@
 namespace FSharp.Core.UnitTests.Operators
 
 open System
+open System.Text
 open System.Globalization
 open System.Threading
 
@@ -754,6 +755,12 @@ type OperatorsModule2() =
         let result = Operators.string (null:string)
         Assert.AreEqual("", result)
 
+        let result = Operators.string (null:StringBuilder)
+        Assert.AreEqual("", result)
+
+        let result = Operators.string (null:IFormattable)
+        Assert.AreEqual("", result)
+
         // value type
         let result = Operators.string 100
         Assert.AreEqual("100", result)
@@ -800,6 +807,8 @@ type OperatorsModule2() =
 
         // reset the culture
         Thread.CurrentThread.CurrentCulture <- currentCI
+
+
 
     [<Fact>]
     member _.``string: don't raise FS0670 anymore``() =


### PR DESCRIPTION
The recent fix for issue 10505 - https://github.com/dotnet/fsharp/issues/10505
overlooked stringbuilder and iformattable, 

Sorry about that here's the fix.