### PR TITLE
Create never.fs

### DIFF
--- a/src/fsharp/FSharp.Core/never.fs
+++ b/src/fsharp/FSharp.Core/never.fs
@@ -1,0 +1,29 @@
+namespace Microsoft.FSharp.Core
+
+module TypeRegulate =
+
+
+    // Type for can't show up
+    [<Struct; NoComparison; NoEquality>]
+    type Never = 
+          |Never
+          static member NoneNeverId(_: Never) = (); 
+          static member NoneNeverId(x: int) = x
+          static member NoneNeverId<'t>(x: 't) = x
+
+    // checked if param is `Never`, when `Never` a error should raise
+    let inline nnid x = 
+        let inline fob(_:^t) x = ((^t or ^x or ^r): (static member NoneNeverId: ^x -> ^r) x)
+        if true then x
+            else (fob Never) Unchecked.defaultof<_>
+
+
+    // A Goup function for setting type range: the type should belong to `TBelong`, but not `TAgainst`
+    type TypeDiffer<'TBelong, 'TAgainst> =
+            
+        static member Assign(x: 'TBelong) = x
+        static member Assign(_: 'TAgainst) = Never 
+
+        static member inline Id x =     
+            let inline assign(_:^t) x = ((^t or ^x or ^r): (static member Assign: ^x -> ^r) x)
+            (assign Unchecked.defaultof<TypeDiffer<'TBelong, 'TAgainst>>) x


### PR DESCRIPTION
TypeRegulate module, use type inference, if the  inferred result is `Never`, raise error FS0043. 
the function `nnid`  do for raising error when `Never`. 
`TypeDiffer` the type to regulate admittance. 
Issue: [https://github.com/fsharp/fslang-suggestions/issues/935]