### PR TITLE
some better debug-mode parse diagnostics on syntax error

### DIFF
--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -567,6 +567,8 @@ let LoadedSourceNotFoundIgnoringE() = DeclareResourceString("LoadedSourceNotFoun
 let MSBuildReferenceResolutionErrorE() = DeclareResourceString("MSBuildReferenceResolutionError", "%s%s")
 let TargetInvocationExceptionWrapperE() = DeclareResourceString("TargetInvocationExceptionWrapper", "%s")
 
+let mutable showParserStackOnParseError = false
+
 let getErrorString key = SR.GetString key
 
 let (|InvalidArgument|_|) (exn: exn) = match exn with :? ArgumentException as e -> Some e.Message | _ -> None
@@ -1146,6 +1148,14 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
                   let result = sprintf "%+A" unknown
                   Debug.Assert(false, result)
                   result
+
+          if showParserStackOnParseError then
+              printfn "parser stack:" 
+              for rps in ctxt.ReducibleProductions do 
+                  printfn "   ----" 
+                  //printfn "   state %d" state
+                  for rp in rps do
+                      printfn "       non-terminal %+A: ... " (Parser.prodIdxToNonTerminal rp)
 
           match ctxt.CurrentToken with 
           | None -> os.Append(UnexpectedEndOfInputE().Format) |> ignore

--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -567,7 +567,9 @@ let LoadedSourceNotFoundIgnoringE() = DeclareResourceString("LoadedSourceNotFoun
 let MSBuildReferenceResolutionErrorE() = DeclareResourceString("MSBuildReferenceResolutionError", "%s%s")
 let TargetInvocationExceptionWrapperE() = DeclareResourceString("TargetInvocationExceptionWrapper", "%s")
 
+#if DEBUG
 let mutable showParserStackOnParseError = false
+#endif
 
 let getErrorString key = SR.GetString key
 
@@ -1149,6 +1151,7 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
                   Debug.Assert(false, result)
                   result
 
+#if DEBUG
           if showParserStackOnParseError then
               printfn "parser stack:" 
               for rps in ctxt.ReducibleProductions do 
@@ -1156,6 +1159,7 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
                   //printfn "   state %d" state
                   for rp in rps do
                       printfn "       non-terminal %+A: ... " (Parser.prodIdxToNonTerminal rp)
+#endif
 
           match ctxt.CurrentToken with 
           | None -> os.Append(UnexpectedEndOfInputE().Format) |> ignore

--- a/src/fsharp/CompilerDiagnostics.fsi
+++ b/src/fsharp/CompilerDiagnostics.fsi
@@ -13,6 +13,9 @@ module internal CompilerService =
     val showAssertForUnexpectedException: bool ref
 #endif // DEBUG
 
+/// For extra diagnostics 
+val mutable showParserStackOnParseError: bool
+
 /// This exception is an old-style way of reporting a diagnostic
 exception HashIncludeNotAllowedInNonScript of range
 

--- a/src/fsharp/CompilerDiagnostics.fsi
+++ b/src/fsharp/CompilerDiagnostics.fsi
@@ -11,10 +11,10 @@ open FSharp.Compiler.SyntaxTree
 #if DEBUG
 module internal CompilerService =
     val showAssertForUnexpectedException: bool ref
-#endif // DEBUG
 
 /// For extra diagnostics 
 val mutable showParserStackOnParseError: bool
+#endif // DEBUG
 
 /// This exception is an old-style way of reporting a diagnostic
 exception HashIncludeNotAllowedInNonScript of range

--- a/src/fsharp/CompilerOptions.fs
+++ b/src/fsharp/CompilerOptions.fs
@@ -1043,6 +1043,7 @@ let testFlag tcConfigB =
                 | "DumpDebugInfo"    -> tcConfigB.dumpDebugInfo <- true
                 | "ShowLoadedAssemblies" -> tcConfigB.showLoadedAssemblies <- true
                 | "ContinueAfterParseFailure" -> tcConfigB.continueAfterParseFailure <- true
+                | "ShowParserStackOnParseError" -> showParserStackOnParseError <- true
                 | str                -> warning(Error(FSComp.SR.optsUnknownArgumentToTheTestSwitch str, rangeCmdArgs))), None,
              None)
 

--- a/src/fsharp/CompilerOptions.fs
+++ b/src/fsharp/CompilerOptions.fs
@@ -1043,7 +1043,9 @@ let testFlag tcConfigB =
                 | "DumpDebugInfo"    -> tcConfigB.dumpDebugInfo <- true
                 | "ShowLoadedAssemblies" -> tcConfigB.showLoadedAssemblies <- true
                 | "ContinueAfterParseFailure" -> tcConfigB.continueAfterParseFailure <- true
+#if DEBUG
                 | "ShowParserStackOnParseError" -> showParserStackOnParseError <- true
+#endif
                 | str                -> warning(Error(FSComp.SR.optsUnknownArgumentToTheTestSwitch str, rangeCmdArgs))), None,
              None)
 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -538,17 +538,17 @@ let main1(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
             let inputT, stateT = DeduplicateParsedInputModuleName state input 
             (inputT, x), stateT)
 
-    if tcConfig.parseOnly then exiter.Exit 0 
-
-    if not tcConfig.continueAfterParseFailure then 
-        AbortOnError(errorLogger, exiter)
-
     // Print the AST if requested
     if tcConfig.printAst then                
         for (input, _filename) in inputs do 
             printf "AST:\n"
             printfn "%+A" input
             printf "\n"
+
+    if tcConfig.parseOnly then exiter.Exit 0 
+
+    if not tcConfig.continueAfterParseFailure then 
+        AbortOnError(errorLogger, exiter)
 
     // Apply any nowarn flags
     let tcConfig =


### PR DESCRIPTION
I worked with @auduchinok today to discuss how to improve parser error recovery

This adds a debug-mode test flag to show the parser stack on parse failure, for use when debugging parser rules
parser stack:

    fsc.exe --test:ShowParserStackOnParseError

Also rejigs the internal-use-only flag `--ast` to show the ast even if parsing has failed, so we can inspect the nodes produced

Typical output of `--test:ShowParserStackOnParseError` is as follows.  The information is limited but actually very useful to understand what's going on.  https://github.com/fsprojects/FsLexYacc/issues/138 covers actually printing the full rules but needs an FsLex update

What this shows is that at the point where the syntax error happens, one of four `unionCaseReprElements` parser rules is still active (this is after an `OF` token).  We got to this state by the states shown from the bottom up (only 12 are shown). That is we were parsing one of these:

    tyconDefnRhsBlock  
    classDefnBlockKindUnspecified
  
then tokens arrived that pushed the various further states involving rules for `unionTypeRepr` and `attrUnionCaseDecls` and `unionCaseReprElements` on to the stack.


```
   ----
       non-terminal NONTERM_unionCaseReprElements: ...
   ----
       non-terminal NONTERM_unionCaseReprElements: ...
       non-terminal NONTERM_unionCaseReprElements: ...
   ----
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
   ----
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
   ----
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
   ----
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
       non-terminal NONTERM_attrUnionCaseDecl: ...
   ----
       non-terminal NONTERM_attrUnionCaseDecls: ...
   ----
       non-terminal NONTERM_attrUnionCaseDecls: ...
       non-terminal NONTERM_attrUnionCaseDecls: ...
   ----
       non-terminal NONTERM_unionTypeRepr: ...
   ----
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
   ----
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_classDefnMember: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
       non-terminal NONTERM_tyconDefnOrSpfnSimpleRepr: ...
   ----
       non-terminal NONTERM_tyconDefnRhsBlock: ...
       non-terminal NONTERM_tyconDefnRhsBlock: ...
       non-terminal NONTERM_classDefnBlockKindUnspecified: ...
       non-terminal NONTERM_classDefnBlockKindUnspecified: ...
```
