### PR TITLE
Fix #10665 --- for test framework

### DIFF
--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -77,6 +77,56 @@ and Compilation = private Compilation of source: string * SourceKind * CompileOu
 [<Sealed;AbstractClass>]
 type CompilerAssert private () =
 
+    // Execute the process pathToExe passing the arguments: arguments with the working directory: workingDir timeout after timeout milliseconds -1 = wait forever
+    // returns exit code, stdio and stderr as string arrays
+    static let executeProcess pathToExe arguments workingDir timeout =
+        match pathToExe with
+        | Some path ->
+            let errorsList = ResizeArray()
+            let outputList = ResizeArray()
+            let mutable errorslock = obj
+            let mutable outputlock = obj
+            let outputDataReceived (message: string) =
+                if not (isNull message) then
+                    lock outputlock (fun () -> outputList.Add(message))
+
+            let errorDataReceived (message: string) =
+                if not (isNull message) then
+                    lock errorslock (fun () -> errorsList.Add(message))
+
+            let psi = ProcessStartInfo()
+            psi.FileName <- path
+            psi.WorkingDirectory <- workingDir
+            psi.RedirectStandardOutput <- true
+            psi.RedirectStandardError <- true
+            psi.Arguments <- arguments
+            psi.CreateNoWindow <- true
+            psi.EnvironmentVariables.Remove("MSBuildSDKsPath")          // Host can sometimes add this, and it can break things
+            psi.UseShellExecute <- false
+
+            use p = new Process()
+            p.StartInfo <- psi
+
+            p.OutputDataReceived.Add(fun a -> outputDataReceived a.Data)
+            p.ErrorDataReceived.Add(fun a ->  errorDataReceived a.Data)
+
+            if p.Start() then
+                p.BeginOutputReadLine()
+                p.BeginErrorReadLine()
+                if not(p.WaitForExit(timeout)) then
+                    // Timed out resolving throw a diagnostic.
+                    raise (new TimeoutException(sprintf "Timeout executing command '%s' '%s'" (psi.FileName) (psi.Arguments)))
+                else
+                    ()
+
+    #if DEBUG
+            File.WriteAllLines(Path.Combine(workingDir, "StandardOutput.txt"), outputList)
+            File.WriteAllLines(Path.Combine(workingDir, "StandardError.txt"), errorsList)
+    #endif
+            p.ExitCode, outputList.ToArray(), errorsList.ToArray()
+
+        | None -> -1, Array.empty, Array.empty
+
     static let checker = FSharpChecker.Create(suggestNamesForErrors=true)
 
     static let config = TestFramework.initializeSuite ()
@@ -119,11 +169,11 @@ type CompilerAssert private () =
 
     static let directoryBuildProps = """
 <Project>
-  <PropertyGroup>
-    <DisableCompilerRedirection>true</DisableCompilerRedirection>
-  </PropertyGroup>
+</Project>
+"""
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+    static let directoryBuildTargets = """
+<Project>
 </Project>
 """
 
@@ -148,6 +198,7 @@ let main argv = 0"""
                 let projectFileName = Path.Combine(projectDirectory, "ProjectFile.fsproj")
                 let programFsFileName = Path.Combine(projectDirectory, "Program.fs")
                 let directoryBuildPropsFileName = Path.Combine(projectDirectory, "Directory.Build.props")
+                let directoryBuildTargetsFileName = Path.Combine(projectDirectory, "Directory.Build.targets")
                 let frameworkReferencesFileName = Path.Combine(projectDirectory, "FrameworkReferences.txt")
 #if NETCOREAPP
                 File.WriteAllText(projectFileName, projectFile.Replace("$TARGETFRAMEWORK", "netcoreapp3.1").Replace("$FSHARPCORELOCATION", pathToFSharpCore))
@@ -156,34 +207,17 @@ let main argv = 0"""
 #endif
                 File.WriteAllText(programFsFileName, programFs)
                 File.WriteAllText(directoryBuildPropsFileName, directoryBuildProps)
+                File.WriteAllText(directoryBuildTargetsFileName, directoryBuildTargets)
 
-                let pInfo = ProcessStartInfo ()
-                pInfo.FileName <- config.DotNetExe
-                pInfo.Arguments <- "build"
-                pInfo.WorkingDirectory <- projectDirectory
-                pInfo.RedirectStandardOutput <- true
-                pInfo.RedirectStandardError <- true
-                pInfo.UseShellExecute <- false
-
-                let p = Process.Start(pInfo)
                 let timeout = 30000
-                let succeeded = p.WaitForExit(timeout)
+                let exitCode, output, errors = executeProcess (Some config.DotNetExe) "build" projectDirectory timeout
 
-                output <- p.StandardOutput.ReadToEnd ()
-                errors <- p.StandardError.ReadToEnd ()
-
-                if not (String.IsNullOrWhiteSpace errors) then
-                    printfn "Output:\n=======\n%s\n" output
-                    printfn "Errors:\n=======\n%s\n" errors
-                    Assert.Fail errors
-                if p.ExitCode <> 0 then
-                    printfn "Output:\n=======\n%s\n" output
-                    printfn "Errors:\n=======\n%s\n" errors
-                    Assert.Fail(sprintf "Program exited with exit code %d" p.ExitCode)
-                if not succeeded then
-                    printfn "Output:\n=======\n%s\n" output
-                    printfn "Errors:\n=======\n%s\n" errors
-                    Assert.Fail(sprintf "Program timed out after %d ms" timeout)
+                if exitCode <> 0 || errors.Length > 0 then
+                    printfn "Output:\n=======\n"
+                    output |> Seq.iter(fun line -> printfn "STDOUT:%s\n" line)
+                    printfn "Errors:\n=======\n"
+                    errors  |> Seq.iter(fun line -> printfn "STDERR:%s\n" line)
+                    Assert.True(false, "Errors produced generating References")
 
                 File.ReadLines(frameworkReferencesFileName) |> Seq.toArray
             with | e ->
@@ -447,14 +481,12 @@ let main argv = 0"""
         (exitCode, stdout.ToString(), stderr.ToString())
 
     static let executeBuiltAppNewProcessAndReturnResult (outputFilePath: string) : (int * string * string) =
-        let mutable pinfo = ProcessStartInfo()
-        pinfo.RedirectStandardError <- true
-        pinfo.RedirectStandardOutput <- true
 #if !NETCOREAPP
-        pinfo.FileName <- outputFilePath
+        let filename = outputFilePath
+        let arguments = ""
 #else
-        pinfo.FileName <- "dotnet"
-        pinfo.Arguments <- outputFilePath
+        let filename = "dotnet"
+        let arguments = outputFilePath
 
         let runtimeconfig = """
 {
@@ -472,18 +504,9 @@ let main argv = 0"""
             { new IDisposable with
               member _.Dispose() = try File.Delete runtimeconfigPath with | _ -> () }
 #endif
-        pinfo.UseShellExecute <- false
-        let p = Process.Start pinfo
-
-        let output = p.StandardOutput.ReadToEnd()
-        let errors = p.StandardError.ReadToEnd()
-
-        let exited = p.WaitForExit(120000)
-
-        let exitCode = if not exited then -2 else p.ExitCode
-
-        (exitCode, output, errors)
-
+        let timeout = 30000
+        let exitCode, output, errors = executeProcess (Some filename) arguments (Path.GetDirectoryName(outputFilePath)) timeout
+        (exitCode, output |> String.concat Environment.NewLine, errors |> String.concat Environment.NewLine)
 
     static member CompileWithErrors(cmpl: Compilation, expectedErrors, ?ignoreWarnings) =
         let ignoreWarnings = defaultArg ignoreWarnings false

--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -15,20 +15,11 @@ module ILChecker =
     let config = initializeSuite ()
 
     let private exec exe args =
-        let startInfo = ProcessStartInfo(exe, String.concat " " args)
-        startInfo.RedirectStandardError <- true
-        startInfo.UseShellExecute <- false
-        let p = Process.Start(startInfo)
-
-        let errors = p.StandardError.ReadToEnd()
-
+        let arguments = args |> String.concat " "
         let timeout = 30000
-        let exited = p.WaitForExit(timeout)
-
-        if not exited then
-            failwith (sprintf "Process hasn't exited after %d milliseconds" timeout)
-
-        errors, p.ExitCode
+        let exitCode, _output, errors = Commands.executeProcess (Some exe) arguments "" timeout
+        let errors = errors |> String.concat Environment.NewLine
+        errors, exitCode
 
     /// Filters i.e ['The system type \'System.ReadOnlySpan`1\' was required but no referenced system DLL contained this type']
     let private filterSpecialComment (text: string) =

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -6,11 +6,60 @@ open Microsoft.Win32
 open System
 open System.IO
 open System.Text.RegularExpressions
+open System.Diagnostics
 open Scripting
 open NUnit.Framework
 
 [<RequireQualifiedAccess>]
 module Commands =
+
+    // Execute the process pathToExe passing the arguments: arguments with the working directory: workingDir timeout after timeout milliseconds -1 = wait forever
+    // returns exit code, stdio and stderr as string arrays
+    let executeProcess pathToExe arguments workingDir timeout =
+        match pathToExe with
+        | Some path ->
+            let errorsList = ResizeArray()
+            let outputList = ResizeArray()
+            let mutable errorslock = obj
+            let mutable outputlock = obj
+            let outputDataReceived (message: string) =
+                if not (isNull message) then
+                    lock outputlock (fun () -> outputList.Add(message))
+
+            let errorDataReceived (message: string) =
+                if not (isNull message) then
+                    lock errorslock (fun () -> errorsList.Add(message))
+
+            let psi = ProcessStartInfo()
+            psi.FileName <- path
+            psi.WorkingDirectory <- workingDir
+            psi.RedirectStandardOutput <- true
+            psi.RedirectStandardError <- true
+            psi.Arguments <- arguments
+            psi.CreateNoWindow <- true
+            psi.EnvironmentVariables.Remove("MSBuildSDKsPath")          // Host can sometimes add this, and it can break things
+            psi.UseShellExecute <- false
+
+            use p = new Process()
+            p.StartInfo <- psi
+
+            p.OutputDataReceived.Add(fun a -> outputDataReceived a.Data)
+            p.ErrorDataReceived.Add(fun a ->  errorDataReceived a.Data)
+
+            if p.Start() then
+                p.BeginOutputReadLine()
+                p.BeginErrorReadLine()
+                if not(p.WaitForExit(timeout)) then
+                    // Timed out resolving throw a diagnostic.
+                    raise (new TimeoutException(sprintf "Timeout executing command '%s' '%s'" (psi.FileName) (psi.Arguments)))
+                else
+                    ()
+    #if DEBUG
+            File.WriteAllLines(Path.Combine(workingDir, "StandardOutput.txt"), outputList)
+            File.WriteAllLines(Path.Combine(workingDir, "StandardError.txt"), errorsList)
+    #endif
+            p.ExitCode, outputList.ToArray(), errorsList.ToArray()
+        | None -> -1, Array.empty, Array.empty
 
     let getfullpath workDir (path:string) =
         let rooted =


### PR DESCRIPTION
Deadlocks are possible in the test framework due to the handling of stdio.  This PR fixes that the CompilerAssert framework components.

I have no idea, why I couldn't get this working over the weekend.  Programming is too mysterious for me.

Fixes #10665 