### PR TITLE
Fix FSharpNavigationDeclarationItem for ValField

### DIFF
--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -226,8 +226,8 @@ module NavigationImpl =
                          match memb with
                          | SynMemberDefn.LetBindings(binds, _, _, _) -> List.collect (processBinding false enclosingEntityKind false) binds
                          | SynMemberDefn.Member(bind, _) -> processBinding true enclosingEntityKind false bind
-                         | SynMemberDefn.ValField(Field(_, _, Some(rcid), ty, _, _, access, _), _) ->
-                             [ createMember(rcid, FieldDecl, FSharpGlyph.Field, ty.Range, enclosingEntityKind, false, access) ]
+                         | SynMemberDefn.ValField(Field(_, _, Some(rcid), _, _, _, access, range), _) ->
+                             [ createMember(rcid, FieldDecl, FSharpGlyph.Field, range, enclosingEntityKind, false, access) ]
                          | SynMemberDefn.AutoProperty(_attribs,_isStatic,id,_tyOpt,_propKind,_,_xmlDoc, access,_synExpr, _, _) -> 
                              [ createMember(id, FieldDecl, FSharpGlyph.Field, id.idRange, enclosingEntityKind, false, access) ]
                          | SynMemberDefn.AbstractSlot(ValSpfn(_, id, _, ty, _, _, _, _, access, _, _), _, _) ->


### PR DESCRIPTION
During debugging of  https://github.com/ionide/ionide-vscode-fsharp/issues/722 I've noticed that `FSharpNavigationDeclarationItem` for ValFields was containing a range of the type signature (in the case of the original issue - `int`) rather than a range of the field.

This PR fixes it. 