### PR TITLE
Build FSI and FSC using AppHost

### DIFF
--- a/FSharpTests.Directory.Build.props
+++ b/FSharpTests.Directory.Build.props
@@ -22,12 +22,12 @@
     <FscToolPath>$([System.IO.Path]::GetDirectoryName('$(DOTNET_HOST_PATH)'))</FscToolPath>
     <FscToolExe Condition="'$(OS)' != 'Unix'">dotnet.exe</FscToolExe>
     <FscToolExe Condition="'$(OS)' == 'Unix'">dotnet</FscToolExe>
-    <DotnetFscCompilerPath>$(MSBuildThisFileDirectory)artifacts\bin\fsc\$(Configuration)\netcoreapp3.1\fsc.exe</DotnetFscCompilerPath>
+    <DotnetFscCompilerPath>$(MSBuildThisFileDirectory)artifacts\bin\fsc\$(Configuration)\netcoreapp3.1\fsc.dll</DotnetFscCompilerPath>
 
     <FsiToolPath>$([System.IO.Path]::GetDirectoryName('$(DOTNET_HOST_PATH)'))</FsiToolPath>
     <FsiToolExe Condition="'$(OS)' != 'Unix'">dotnet.exe</FsiToolExe>
     <FsiToolExe Condition="'$(OS)' == 'Unix'">dotnet</FsiToolExe>
-    <DotnetFsiCompilerPath>$(MSBuildThisFileDirectory)artifacts\bin\fsi\$(Configuration)\netcoreapp3.1\fsi.exe</DotnetFsiCompilerPath>
+    <DotnetFsiCompilerPath>$(MSBuildThisFileDirectory)artifacts\bin\fsi\$(Configuration)\netcoreapp3.1\fsi.dll</DotnetFsiCompilerPath>
   </PropertyGroup>
 
   <!-- SDK targets override -->

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -186,7 +186,7 @@ function Update-Arguments() {
             $script:bootstrap = $True
         }
     } else {
-        if (-Not (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.exe") -or (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.runtimeconfig.json")) {
+        if (-Not (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.dll") -or (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.runtimeconfig.json")) {
             $script:bootstrap = $True
         }
     }

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -15,29 +15,42 @@ module AssemblyCheck =
     let private devVersionPattern = new Regex(@"-(ci|dev)", RegexOptions.Compiled)
 
     let verifyEmbeddedPdb (filename:string)  =
-        use fileStream = File.OpenRead(filename)
-        let reader = new PEReader(fileStream)
-        let mutable hasEmbeddedPdb = false
+        let isManagedDll =
+            try
+                // Is il assembly? throws if not
+                let _ = AssemblyName.GetAssemblyName(filename).Version
+                true
+            with
+            | :? System.BadImageFormatException -> false       // uninterested in embedded pdbs for native dlls
 
-        try
-            for entry in reader.ReadDebugDirectory() do
-                match entry.Type with
-                | DebugDirectoryEntryType.CodeView ->
-                    let _ = reader.ReadCodeViewDebugDirectoryData(entry)
-                    ()
+        if isManagedDll then
+            use fileStream = File.OpenRead(filename)
+            let reader = new PEReader(fileStream)
+            let mutable hasEmbeddedPdb = false
 
-                | DebugDirectoryEntryType.EmbeddedPortablePdb ->
-                    let _ = reader.ReadEmbeddedPortablePdbDebugDirectoryData(entry)
-                    hasEmbeddedPdb <- true
-                    ()
+            try
+                for entry in reader.ReadDebugDirectory() do
+                    match entry.Type with
+                    | DebugDirectoryEntryType.CodeView ->
+                        let _ = reader.ReadCodeViewDebugDirectoryData(entry)
+                        ()
 
-                | DebugDirectoryEntryType.PdbChecksum ->
-                    let _ = reader.ReadPdbChecksumDebugDirectoryData(entry)
-                    ()
+                    | DebugDirectoryEntryType.EmbeddedPortablePdb ->
+                        let _ = reader.ReadEmbeddedPortablePdbDebugDirectoryData(entry)
+                        hasEmbeddedPdb <- true
+                        ()
 
-                | _ -> ()
-        with | e -> printfn "Error validating assembly %s\nMessage: %s" filename (e.ToString())
-        hasEmbeddedPdb
+                    | DebugDirectoryEntryType.PdbChecksum ->
+                        let _ = reader.ReadPdbChecksumDebugDirectoryData(entry)
+                        ()
+
+                    | _ -> ()
+            with
+            | e -> printfn "Error validating assembly %s\nMessage: %s" filename (e.ToString())
+
+            hasEmbeddedPdb
+        else
+            true
 
     let verifyAssemblies (binariesPath:string) =
 
@@ -72,7 +85,7 @@ module AssemblyCheck =
                     assemblyVersion = versionZero || assemblyVersion = versionOne
                 with | :? System.BadImageFormatException ->
                     // fsc.exe and fsi.exe are il on the desktop and native on the coreclr
-                    Set.contains (Path.GetFileName(a)) maybeNativeExe)
+                    Set.contains (Path.GetFileName(a)) maybeNativeExe |> not)
 
         if failedVersionCheck.Length > 0 then
             printfn "The following assemblies had a version of %A or %A" versionZero versionOne

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -70,9 +70,9 @@ module AssemblyCheck =
                 try
                     let assemblyVersion = AssemblyName.GetAssemblyName(a).Version
                     assemblyVersion = versionZero || assemblyVersion = versionOne
-                with | ?: System.BadImageFormatException ->
+                with | :? System.BadImageFormatException ->
                     // fsc.exe and fsi.exe are il on the desktop and native on the coreclr
-                    Set.contains (Path.GetFileName(a)) maybeNativeExe))
+                    Set.contains (Path.GetFileName(a)) maybeNativeExe)
 
         if failedVersionCheck.Length > 0 then
             printfn "The following assemblies had a version of %A or %A" versionZero versionOne

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -59,7 +59,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup Condition="'$(DisableAutoSetFscCompilerPath)' != 'true' and '$(DOTNET_HOST_PATH)' != ''">
     <FscToolPath Condition="'$(FscToolPath)' == ''">$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))</FscToolPath>
     <FscToolExe Condition="'$(FscToolExe)' == ''">$([System.IO.Path]::GetFileName($(DOTNET_HOST_PATH)))</FscToolExe>
-    <DotnetFscCompilerPath Condition="'$(DotnetFscCompilerPath)' == '' and Exists('$(MSBuildThisFileDirectory)fsc.dll'">"$(MSBuildThisFileDirectory)fsc.dll"</DotnetFscCompilerPath>
+    <DotnetFscCompilerPath Condition="'$(DotnetFscCompilerPath)' == ''">"$(MSBuildThisFileDirectory)fsc.dll"</DotnetFscCompilerPath>
 
     <FsiToolPath Condition="'$(FsiToolPath)' == ''">$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))</FsiToolPath>
     <FsiToolExe Condition="'$(FsiToolExe)' == ''">$([System.IO.Path]::GetFileName($(DOTNET_HOST_PATH)))</FsiToolExe>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -59,11 +59,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup Condition="'$(DisableAutoSetFscCompilerPath)' != 'true' and '$(DOTNET_HOST_PATH)' != ''">
     <FscToolPath Condition="'$(FscToolPath)' == ''">$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))</FscToolPath>
     <FscToolExe Condition="'$(FscToolExe)' == ''">$([System.IO.Path]::GetFileName($(DOTNET_HOST_PATH)))</FscToolExe>
-    <DotnetFscCompilerPath Condition="'$(DotnetFscCompilerPath)' == ''">"$(MSBuildThisFileDirectory)fsc.exe"</DotnetFscCompilerPath>
+    <DotnetFscCompilerPath Condition="'$(DotnetFscCompilerPath)' == '' and Exists('$(MSBuildThisFileDirectory)fsc.dll'">"$(MSBuildThisFileDirectory)fsc.dll"</DotnetFscCompilerPath>
 
     <FsiToolPath Condition="'$(FsiToolPath)' == ''">$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))</FsiToolPath>
     <FsiToolExe Condition="'$(FsiToolExe)' == ''">$([System.IO.Path]::GetFileName($(DOTNET_HOST_PATH)))</FsiToolExe>
-    <DotnetFsiCompilerPath Condition="'$(DotnetFscCompilerPath)' == ''">"$(MSBuildThisFileDirectory)fsi.exe"</DotnetFsiCompilerPath>
+    <DotnetFsiCompilerPath Condition="'$(DotnetFscCompilerPath)' == ''">"$(MSBuildThisFileDirectory)fsi.dll"</DotnetFsiCompilerPath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DisableImplicitSystemValueTupleReference)' != 'true'

--- a/src/fsharp/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -46,8 +46,8 @@
             this approach gives a very small deployment. Which is kind of necessary.
         -->
         <!-- assemblies -->
-        <file src="fsc\$Configuration$\netcoreapp3.1\fsc.exe"                                             target="lib\netcoreapp3.1" />
-        <file src="fsi\$Configuration$\netcoreapp3.1\fsi.exe"                                             target="lib\netcoreapp3.1" />
+        <file src="fsc\$Configuration$\netcoreapp3.1\fsc.dll"                                             target="lib\netcoreapp3.1" />
+        <file src="fsi\$Configuration$\netcoreapp3.1\fsi.dll"                                             target="lib\netcoreapp3.1" />
         <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.dll"                            target="lib\netcoreapp3.1" />
         <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.xml"                            target="lib\netcoreapp3.1" />
         <file src="FSharp.Compiler.Private\$Configuration$\netstandard2.0\FSharp.Compiler.Private.dll"    target="lib\netcoreapp3.1" />

--- a/src/fsharp/fsc/fsc.fsproj
+++ b/src/fsharp/fsc/fsc.fsproj
@@ -7,12 +7,11 @@
     <TargetFrameworks Condition="'$(ProtoTargetFramework)' != ''">$(ProtoTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
-    <TargetExt>.exe</TargetExt>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <OtherFlags>$(OtherFlags) --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <NGenBinary>true</NGenBinary>
-    <UseAppHost>false</UseAppHost>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -7,13 +7,12 @@
     <TargetFrameworks Condition="'$(ProtoTargetFramework)' != ''">$(ProtoTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(ProtoTargetFramework)' == ''">net472;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
-    <TargetExt>.exe</TargetExt>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <OtherFlags>--warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <Win32Resource>fsi.res</Win32Resource>
     <NGenBinary>true</NGenBinary>
-    <UseAppHost>false</UseAppHost>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -239,7 +239,7 @@ let main argv = 0"""
         let args =
             options
             |> Array.append defaultProjectOptions.OtherOptions
-            |> Array.append [| "fsc.exe"; inputFilePath; "-o:" + outputFilePath; (if isExe then "--target:exe" else "--target:library"); "--nowin32manifest" |]
+            |> Array.append [| "fsc.dll"; inputFilePath; "-o:" + outputFilePath; (if isExe then "--target:exe" else "--target:library"); "--nowin32manifest" |]
         let errors, _ = checker.Compile args |> Async.RunSynchronously
         errors, outputFilePath
 

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -293,7 +293,11 @@ let config configurationName envVars =
         if File.Exists(repoLocalDotnetPath) then repoLocalDotnetPath
         else DOTNET_EXE
 
+#if !NETCOREAPP
     let FSI_PATH = ("fsi" ++ configurationName ++ fsiArchitecture ++ "fsi.exe")
+#else
+    let FSI_PATH = ("fsi" ++ configurationName ++ fsiArchitecture ++ "fsi.dll")
+#endif
     let FSI_FOR_SCRIPTS = requireArtifact FSI_PATH
     let FSI = requireArtifact FSI_PATH
 #if !NETCOREAPP

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -298,8 +298,10 @@ let config configurationName envVars =
     let FSI = requireArtifact FSI_PATH
 #if !NETCOREAPP
     let FSIANYCPU = requireArtifact ("fsiAnyCpu" ++ configurationName ++ "net472" ++ "fsiAnyCpu.exe")
-#endif
     let FSC = requireArtifact ("fsc" ++ configurationName ++ fscArchitecture ++ "fsc.exe")
+#else
+    let FSC = requireArtifact ("fsc" ++ configurationName ++ fscArchitecture ++ "fsc.dll")
+#endif
     let FSCOREDLLPATH = requireArtifact ("FSharp.Core" ++ configurationName ++ fsharpCoreArchitecture ++ "FSharp.Core.dll")
 
     let defaultPlatform =


### PR DESCRIPTION
Since the begining we have built the coreclr versions of fsc and fsi as il .exe files.  The AppHost wasn't introduced at the beginning, and we were in a groove that worked for us.

This changes things so that we build them as fsi.dll and fsc.dll and produce apphost fsi.exe and fsc.exe.

this means that things like this work:
````
C:\Users\codec>c:\kevinransom\fsharp\artifacts\bin\fsi\Release\netcoreapp3.1\fsi.exe

Microsoft (R) F# Interactive version 11.0.0.0 for F# 5.0
Copyright (c) Microsoft Corporation. All Rights Reserved.

For help type #help;;

>  printfn "%s" typeof<int>.Assembly.Location;;
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.10\System.Private.CoreLib.dll
val it : unit = ()

> #quit;;

C:\Users\codec>c:\kevinransom\fsharp\artifacts\bin\fsc\release\netcoreapp3.1\fsc.exe
Microsoft (R) F# Compiler version 11.0.0.0 for F# 5.0
Copyright (c) Microsoft Corporation. All Rights Reserved.

error FS0207: No inputs specified

C:\Users\codec>
````

It should be noted that even after this change, the only supported scenarios for using fsi is via dotnet fsi and fsc is via dotnet build.  The apphost versions will make things a little easier in the repo, and tooling may be a bit easier to write.