### PR TITLE
Provide a mechanism for pinning type signatures formats during printing

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -657,12 +657,22 @@ module private PrintTypes =
         | TType_app (tc, args) when tc.IsMeasureableReprTycon && List.forall (isDimensionless denv.g) args ->
           layoutTypeWithInfoAndPrec denv env prec (reduceTyconRefMeasureableOrProvided denv.g tc args)
 
-        // Layout a type application 
-        | TType_app (tc, args) -> 
-          layoutTypeAppWithInfoAndPrec denv env (layoutTyconRef denv tc) prec tc.IsPrefixDisplay args 
+        // Layout a type application
+        | TType_app (tc, args) ->
+          let usePrefix =
+              match denv.genericParameterStyle with
+              | GenericParameterStyle.Implicit -> tc.IsPrefixDisplay
+              | GenericParameterStyle.Prefix -> true
+              | GenericParameterStyle.Suffix -> false
+          layoutTypeAppWithInfoAndPrec denv env (layoutTyconRef denv tc) prec usePrefix args
 
-        | TType_ucase (UnionCaseRef(tc, _), args) -> 
-          layoutTypeAppWithInfoAndPrec denv env (layoutTyconRef denv tc) prec tc.IsPrefixDisplay args 
+        | TType_ucase (UnionCaseRef(tc, _), args) ->
+          let usePrefix =
+              match denv.genericParameterStyle with
+              | GenericParameterStyle.Implicit -> tc.IsPrefixDisplay
+              | GenericParameterStyle.Prefix -> true
+              | GenericParameterStyle.Suffix -> false
+          layoutTypeAppWithInfoAndPrec denv env (layoutTyconRef denv tc) prec usePrefix args
 
         // Layout a tuple type 
         | TType_anon (anonInfo, tys) ->

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -2737,6 +2737,11 @@ module SimplifyTypes =
 // Print Signatures/Types
 //-------------------------------------------------------------------------- 
 
+type GenericParameterStyle =
+| Implicit
+| Prefix
+| Suffix
+
 [<NoEquality; NoComparison>]
 type DisplayEnv = 
     { includeStaticParametersInTypeNames: bool
@@ -2763,7 +2768,8 @@ type DisplayEnv =
       printVerboseSignatures : bool
       g: TcGlobals
       contextAccessibility: Accessibility
-      generatedValueLayout : (Val -> layout option) }
+      generatedValueLayout : (Val -> layout option)
+      genericParameterStyle: GenericParameterStyle }
 
     member x.SetOpenPaths paths = 
         { x with 
@@ -2807,6 +2813,9 @@ type DisplayEnv =
 
     member denv.AddAccessibility access =
         { denv with contextAccessibility = combineAccess denv.contextAccessibility access }
+
+    member denv.UseGenericParameterStyle style =
+        { denv with genericParameterStyle = style }
 
 let (+.+) s1 s2 = if s1 = "" then s2 else s1+"."+s2
 

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -2802,7 +2802,8 @@ type DisplayEnv =
         printVerboseSignatures = false
         g = tcGlobals
         contextAccessibility = taccessPublic
-        generatedValueLayout = (fun _ -> None) }
+        generatedValueLayout = (fun _ -> None)
+        genericParameterStyle = GenericParameterStyle.Implicit }
 
 
     member denv.AddOpenPath path = 

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -2738,9 +2738,9 @@ module SimplifyTypes =
 //-------------------------------------------------------------------------- 
 
 type GenericParameterStyle =
-| Implicit
-| Prefix
-| Suffix
+    | Implicit
+    | Prefix
+    | Suffix
 
 [<NoEquality; NoComparison>]
 type DisplayEnv = 

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -960,6 +960,11 @@ module PrettyTypes =
 
     val PrettifyInstAndCurriedSig : TcGlobals -> TyparInst * TTypes * CurriedArgInfos * TType -> (TyparInst * TTypes * CurriedArgInfos * TType) * TyparConstraintsWithTypars
 
+type GenericParameterStyle =
+| Implicit
+| Prefix
+| Suffix
+
 [<NoEquality; NoComparison>]
 type DisplayEnv = 
     { includeStaticParametersInTypeNames : bool
@@ -986,7 +991,8 @@ type DisplayEnv =
       printVerboseSignatures : bool
       g: TcGlobals
       contextAccessibility: Accessibility
-      generatedValueLayout:(Val -> layout option) }
+      generatedValueLayout:(Val -> layout option)
+      genericParameterStyle: GenericParameterStyle }
 
     member SetOpenPaths: string list list -> DisplayEnv
 
@@ -997,6 +1003,8 @@ type DisplayEnv =
     member AddOpenPath : string list  -> DisplayEnv
 
     member AddOpenModuleOrNamespace : ModuleOrNamespaceRef   -> DisplayEnv
+
+    member UseGenericParameterStyle : GenericParameterStyle -> DisplayEnv
 
 val tagEntityRefName: xref: EntityRef -> name: string -> StructuredFormat.TaggedText
 

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -960,9 +960,13 @@ module PrettyTypes =
 
     val PrettifyInstAndCurriedSig : TcGlobals -> TyparInst * TTypes * CurriedArgInfos * TType -> (TyparInst * TTypes * CurriedArgInfos * TType) * TyparConstraintsWithTypars
 
+/// Describes how generic type parameters in a type will be formatted during printing
 type GenericParameterStyle =
+/// Use the IsPrefixDisplay member of the TyCon to determine the style
 | Implicit
+/// Force the prefix style: List<int>
 | Prefix
+/// Force the suffix style: int List
 | Suffix
 
 [<NoEquality; NoComparison>]

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -962,12 +962,12 @@ module PrettyTypes =
 
 /// Describes how generic type parameters in a type will be formatted during printing
 type GenericParameterStyle =
-/// Use the IsPrefixDisplay member of the TyCon to determine the style
-| Implicit
-/// Force the prefix style: List<int>
-| Prefix
-/// Force the suffix style: int List
-| Suffix
+    /// Use the IsPrefixDisplay member of the TyCon to determine the style
+    | Implicit
+    /// Force the prefix style: List<int>
+    | Prefix
+    /// Force the suffix style: int List
+    | Suffix
 
 [<NoEquality; NoComparison>]
 type DisplayEnv = 

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -995,7 +995,7 @@ type DisplayEnv =
       printVerboseSignatures : bool
       g: TcGlobals
       contextAccessibility: Accessibility
-      generatedValueLayout:(Val -> layout option)
+      generatedValueLayout: (Val -> layout option)
       genericParameterStyle: GenericParameterStyle }
 
     member SetOpenPaths: string list list -> DisplayEnv

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -208,6 +208,11 @@ type FSharpDisplayContext(denv: TcGlobals -> DisplayEnv) =
     member x.WithShortTypeNames shortNames =
          FSharpDisplayContext(fun g -> { denv g with shortTypeNames = shortNames })
 
+    member x.WithPrefixGenericParameters () =
+        FSharpDisplayContext(fun g -> { denv g with genericParameterStyle = GenericParameterStyle.Prefix }  )
+
+    member x.WithSuffixGenericParameters () =
+        FSharpDisplayContext(fun g -> { denv g with genericParameterStyle = GenericParameterStyle.Suffix }  )
 
 // delay the realization of 'item' in case it is unresolved
 type FSharpSymbol(cenv: SymbolEnv, item: (unit -> Item), access: (FSharpSymbol -> CcuThunk -> AccessorDomain -> bool)) =

--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -56,7 +56,15 @@ type FSharpDisplayContext =
 
     member WithShortTypeNames: bool -> FSharpDisplayContext
 
-/// Represents a symbol in checked F# source code or a compiled .NET component. 
+    /// Causes type signatures to be formatted with prefix-style generic parameters,
+    /// for example `list<int>`.
+    member WithPrefixGenericParameters: unit -> FSharpDisplayContext
+
+    /// Causes type signatures to be formatted with suffix-style generic parameters,
+    /// for example `int list`
+    member WithSuffixGenericParameters: unit -> FSharpDisplayContext
+
+/// Represents a symbol in checked F# source code or a compiled .NET component.
 ///
 /// The subtype of the symbol may reveal further information and can be one of FSharpEntity, FSharpUnionCase
 /// FSharpField, FSharpGenericParameter, FSharpStaticParameter, FSharpMemberOrFunctionOrValue, FSharpParameter,

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -21583,6 +21583,8 @@ FSharp.Compiler.SourceCodeServices.FSharpDelegateSignature: System.String ToStri
 FSharp.Compiler.SourceCodeServices.FSharpDisplayContext: FSharp.Compiler.SourceCodeServices.FSharpDisplayContext Empty
 FSharp.Compiler.SourceCodeServices.FSharpDisplayContext: FSharp.Compiler.SourceCodeServices.FSharpDisplayContext WithShortTypeNames(Boolean)
 FSharp.Compiler.SourceCodeServices.FSharpDisplayContext: FSharp.Compiler.SourceCodeServices.FSharpDisplayContext get_Empty()
+FSharp.Compiler.SourceCodeServices.FSharpDisplayContext: FSharp.Compiler.SourceCodeServices.FSharpDisplayContext WithPrefixGenericParameters()
+FSharp.Compiler.SourceCodeServices.FSharpDisplayContext: FSharp.Compiler.SourceCodeServices.FSharpDisplayContext WithSuffixGenericParameters()
 FSharp.Compiler.SourceCodeServices.FSharpEnclosingEntityKind+Tags: Int32 Class
 FSharp.Compiler.SourceCodeServices.FSharpEnclosingEntityKind+Tags: Int32 DU
 FSharp.Compiler.SourceCodeServices.FSharpEnclosingEntityKind+Tags: Int32 Enum


### PR DESCRIPTION
In FSAC we have some pretty convoluted logic for undoing the compiler's default printing of generic type parameters for types that use the suffix form (ie `int list`).

We'd love a way to explicit ask NicePrint to render the type signature in a given way, either prefix or suffix, regardless of the derived flag on the type itself.

To that end, this PR:

* introduces a flag on DisplayEnv that represents the rendering mode, defaulting to delegating to the flag on the type,
* provides a way for an FCS consumer to configure the display environment to prefix or suffix mode, and
* uses the flag to potentially overwrite the prefix/suffix logic when a type with generic parameters is printed.