### PR TITLE
Wrap function tooltip in function sighelp in parens

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -376,7 +376,13 @@ type internal FSharpSignatureHelpProvider
                             |]
                             |> ResizeArray
 
+                        if argument.Type.IsFunctionType then
+                            display.Add(TaggedText(TextTags.Punctuation, "("))
+
                         display.AddRange(tt)
+
+                        if argument.Type.IsFunctionType then
+                            display.Add(TaggedText(TextTags.Punctuation, ")"))
 
                         let info =
                             { ParameterName = argument.DisplayName


### PR DESCRIPTION
I left this out intentionally, but it was just too jarring not to use parentheses for function parameters after dogfooding the feature in the compiler a bit.

Before:

![image](https://user-images.githubusercontent.com/6309070/102661753-57ac1e00-4132-11eb-853c-d848a893b2bc.png)

After:

![image](https://user-images.githubusercontent.com/6309070/102661779-61358600-4132-11eb-9b99-41a9a6efcc1a.png)
