### PR TITLE
try adding dependency manager resolutions to the typecheck config

### DIFF
--- a/src/fsharp/ScriptClosure.fs
+++ b/src/fsharp/ScriptClosure.fs
@@ -242,6 +242,13 @@ module ScriptPreprocessClosure =
                                             tcConfigB.AddIncludePath(m, folder, "")
                                         tcConfigB.packageManagerLines <- PackageManagerLine.SetLinesAsProcessed packageManagerKey tcConfigB.packageManagerLines
                                         tcConfig <- TcConfig.Create(tcConfigB, validate=false)
+
+                                    if not (Seq.isEmpty result.Resolutions) then
+                                        let tcConfigB = tcConfig.CloneToBuilder()
+                                        for resolution in result.Resolutions do
+                                            tcConfigB.AddReferencedAssemblyByPath(m, resolution)
+                                        tcConfig <- TcConfig.Create(tcConfigB, validate = false)
+
                                     for script in result.SourceFiles do
                                         let scriptText = File.ReadAllText script
                                         loadScripts.Add script |> ignore

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1497,6 +1497,8 @@ type internal FsiDynamicCompiler
                             tcConfigB.packageManagerLines <- PackageManagerLine.SetLinesAsProcessed packageManagerKey tcConfigB.packageManagerLines
                             for folder in result.Roots do
                                 tcConfigB.AddIncludePath(m, folder, "")
+                            for resolution in result.Resolutions do
+                                tcConfigB.AddReferencedAssemblyByPath(m, resolution)
                             let scripts = result.SourceFiles |> Seq.toList
                             if not (isNil scripts) then
                                 fsiDynamicCompiler.EvalSourceFiles(ctok, istate, m, scripts, lexResourceManager, errorLogger)


### PR DESCRIPTION
Might address #10762, but I need to figure out where a test would go.

The thought was that we could register the resolved dlls in the typechecker's reference list, but then I needed a range to use and figured the range of the package manager expression that caused the reference was the natural one to use.