### PR TITLE
Stop continuously building the proto

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -186,7 +186,7 @@ function Update-Arguments() {
             $script:bootstrap = $True
         }
     } else {
-        if (-Not (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.dll") -or (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.runtimeconfig.json")) {
+        if (-Not (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.exe") -or (Test-Path "$ArtifactsDir\Bootstrap\fsc\fsc.runtimeconfig.json")) {
             $script:bootstrap = $True
         }
     }


### PR DESCRIPTION
The recent apphost pr, mistakenly checked against fsc.dll.   Sorry about that, I got ahead of myself.


Don noticed, that because of that, we ended up building the proto compiler, every time a compiler source file changed.


/cc @dsyme 