### PR TITLE
Go figure ... You need to waitforexit() after waitforexit(n) with redirected output

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -192,7 +192,7 @@ module internal Utilities =
                     // Timed out resolving throw a diagnostic.
                     raise (new TimeoutException(SR.timedoutResolvingPackages(psi.FileName, psi.Arguments)))
                 else
-                    ()
+                    p.WaitForExit()
 
 #if DEBUG
             File.WriteAllLines(Path.Combine(workingDir, "StandardOutput.txt"), outputList)

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -53,7 +53,7 @@ module Commands =
                     // Timed out resolving throw a diagnostic.
                     raise (new TimeoutException(sprintf "Timeout executing command '%s' '%s'" (psi.FileName) (psi.Arguments)))
                 else
-                    ()
+                    p.WaitForExit()
     #if DEBUG
             File.WriteAllLines(Path.Combine(workingDir, "StandardOutput.txt"), outputList)
             File.WriteAllLines(Path.Combine(workingDir, "StandardError.txt"), errorsList)


### PR DESCRIPTION
I'm not going to comment on the awesomeness as a design choice.  However, when redirecting output and specifying a non infinite timeout does not wait for async ioto complete before exiting regardless of whether timeout was exceeded ... so call WaitForExit() again, to ensure that async IO completes.

This dotnet framework crazy fact of the day was brought to you by the letters "Gosh Darn" and "Go figure ..."


