### PR TITLE
Teach the compiler how to discover more kinds of parameter names 

### DIFF
--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -3250,6 +3250,23 @@ module EstablishTypeDefinitionCores =
         let paramNames =
             match synTyconRepr with 
             | SynTypeDefnSimpleRepr.General (TyconDelegate (_ty, arity), _, _, _, _, _, _, _) -> arity.ArgNames
+            | SynTypeDefnSimpleRepr.General (TyconUnspecified, _, _, _, _, _, Some synPats, _) ->
+                let rec patName (p: SynSimplePat) =
+                    match p with
+                    | SynSimplePat.Id (id, _, _, _, _, _) -> id.idText
+                    | SynSimplePat.Typed(pat, _, _) -> patName pat
+                    | SynSimplePat.Attrib(pat, _, _) -> patName pat
+
+                let rec pats (p: SynSimplePats) =
+                    match p with
+                    | SynSimplePats.SimplePats (ps, _) -> ps
+                    | SynSimplePats.Typed (ps, _, _) -> pats ps
+
+                let patNames =
+                    pats synPats
+                    |> List.map patName
+
+                patNames
             | _ -> []
         let doc = doc.ToXmlDoc(true, Some paramNames )
         Construct.NewTycon

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -175,6 +175,10 @@ let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
                 let altNameRefCell = Some (ref (Undecided (mkSynId m (synArgNameGenerator.New()))))
                 let item = mkSynIdGetWithAlt m id altNameRefCell
                 false, altNameRefCell, id, item
+            | SynPat.Named(_, ident, _, _, _) ->
+                // named pats should be referred to as their name in docs, tooltips, etc.
+                let item = mkSynIdGet m ident.idText
+                false, None, ident, item
             | _ ->
                 let nm = synArgNameGenerator.New()
                 let id = mkSynId m nm

--- a/tests/FSharp.Compiler.ComponentTests/Language/XmlComments.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/XmlComments.fs
@@ -13,14 +13,14 @@ module XmlCommentChecking =
 /// <summary>
 let x = 1
 
-/// 
+///
 /// <summary>Yo</summary>
 /// <remark>Yo</rem>
 module M =
     /// <summary> <
     let y = 1
 
-        """ 
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile
@@ -39,7 +39,7 @@ module M =
     /// <summary> Return <paramref name="b" /> </summary>
     /// <param name="a"> the parameter </param>
     let f a = a
-        """ 
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile
@@ -55,7 +55,7 @@ module M =
     /// <summary> Return <paramref name="b" /> </summary>
     /// <param name="b"> the parameter </param>
     let f a = a
-        """ 
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile
@@ -74,7 +74,7 @@ module M =
     /// <param name="a"> the parameter </param>
     /// <param name="a"> the parameter </param>
     let f a = a
-        """ 
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile
@@ -90,7 +90,7 @@ module M =
     /// <summary> Return <paramref/> </summary>
     /// <param> the parameter </param>
     let f a = a
-        """ 
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile
@@ -118,7 +118,7 @@ module M =
         /// <summary> The instance method</summary>
         /// <param name="p2"> the other parameter </param>
          member x.OtherM((a,b): (string * string), p2: string) = ((a,b), p2)
-        """ 
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile
@@ -137,7 +137,7 @@ module M =
          let _unused = (x1, x2)
 
          member x.M(p1: string, p2: string) = (p1, p2)
-        """ 
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile
@@ -156,7 +156,24 @@ module M =
          let _unused = (x1, x2)
 
          member x.M(p1: string, p2: string) = (p1, p2)
-        """ 
+        """
+         |> withXmlCommentChecking
+         |> ignoreWarnings
+         |> compile
+         |> shouldSucceed
+         |> withDiagnostics [ ]
+
+    [<Fact>]
+    let ``valid parameter names are reported for documented implicit constructor`` () =
+        Fsx"""
+    /// <summary> The type with an implicit constructor with visibility</summary>
+    /// <param name="x1"> the first parameter </param>
+    /// <param name="x2"> the second parameter </param>
+    type C (x1: string, x2: string) =
+         let _unused = (x1, x2)
+
+         member x.M(p1: string, p2: string) = (p1, p2)
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile
@@ -170,7 +187,21 @@ module M =
     /// <param name="sender"> The sender</param>
     /// <param name="args"> The args</param>
     type C = delegate of sender: obj * args: int -> C
-        """ 
+        """
+         |> withXmlCommentChecking
+         |> ignoreWarnings
+         |> compile
+         |> shouldSucceed
+         |> withDiagnostics [ ]
+
+    [<Fact>]
+    let ``function parameters use names from as patterns`` () =
+        Fsx"""
+        type Thing = Inner of s: string
+        /// <summary> A function with an extracted inner value</summary>
+        /// <param name="inner"> The innver value to unwrap</param>
+        let doer ((Inner s) as inner) = ignore s; ignore inner
+        """
          |> withXmlCommentChecking
          |> ignoreWarnings
          |> compile


### PR DESCRIPTION
These commits enable the following script to compile using the locally-built fsi and the `--warnon:3900` flag without warning about missing parameters, fixing #10809:

```fsharp
type Thing = Inner of string

/// <summary>does the thing</summary>
/// <param name="s">the thing to do!</param>
let doer (Thing.Inner s) = ()

/// <summary>gives you a friendly greeting</summary>
/// <param name="pal">your good mate</param>
type Buddy(pal: string) = 
    do
        printfn $"hi, {pal}"
```

The first commit expands the set of type constructors that `TcTyconDefnCore_Phase1A_BuildInitialTycon` knows how to extract pattern names for to include `TyconUnspecified`, because that's what came through when debugging the above script. I am unsure if this is the correct Tycon to be looking for here, but the overall pattern traversal to extract names seems easy enough.

The second commit is a bit more ambiguous to me. I've changed the way `SynValData` is inferred for bindings (specifically the constructor of a `SynSimplePat` from a `SynPat`) so that a `Paren(LongIdent(pat))` can be constructed.  That is, applications like `(Thing.Inner s)` will return a simple pat with the name of the inner application, in this case `s`. I am unsure if this is a) correct, and b) safe because I recognize that applying a LongIdent to the incoming value in this case is like saying `let (Thing.Inner s) = anon_incoming_value` and returning the inner s, but I'm trying to strike a balance between the usability of the doc-checking feature and the correctness of my change.

Finally, I'm unsure where tests for these sorts of changes should go and would appreciate any pointers in that direction.