### PR TITLE
Raise error when using active pattern in literal binding

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -9755,6 +9755,9 @@ and TcLetBinding cenv isUse env containerInfo declKind tpenv (synBinds, synBinds
             | _ when inlineFlag.MustInline -> 
                 error(Error(FSComp.SR.tcInvalidInlineSpecification(), m))
 
+            | TPat_query _ when HasFSharpAttribute cenv.g cenv.g.attrib_LiteralAttribute attrs ->
+                error(Error(FSComp.SR.tcLiteralAttributeCannotUseActivePattern(), m))
+
             | _ -> 
 
                 let tmp, _ = mkCompGenLocal m "patternInput" (generalizedTypars +-> tauTy)

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1552,3 +1552,4 @@ forFormatInvalidForInterpolated4,"Interpolated strings used as type IFormattable
 3390,xmlDocDuplicateParameter,"This XML comment is invalid: multiple documentation entries for parameter '%s'"
 3390,xmlDocUnresolvedCrossReference,"This XML comment is invalid: unresolved cross-reference '%s'"
 3390,xmlDocMissingParameter,"This XML comment is incomplete: no documentation for parameter '%s'"
+3391,tcLiteralAttributeCannotUseActivePattern,"A [<Literal>] declaration cannot use an active pattern for its identifier"

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use! se nedá kombinovat s and!.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">Hodnota se nedá přiřadit k jiné hodnotě, která je označená jako literál.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -367,6 +367,11 @@
         <target state="translated">"use!" darf nicht mit "and!" kombiniert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">Ein Wert kann keinem anderen als Literal markierten Wert zugewiesen werden.</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -367,6 +367,11 @@
         <target state="translated">No se puede combinar use! con and!</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">No se puede asignar un valor a otro marcado como literal</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use! ne peut pas être combiné avec and!</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">Impossible d'affecter une valeur à une autre valeur marquée comme littérale</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -367,6 +367,11 @@
         <target state="translated">Non è possibile combinare use! con and!</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">Non è possibile assegnare un valore a un altro valore contrassegnato come letterale</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use! を and! と組み合わせて使用することはできません</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">リテラルとしてマークされた別の値に値を割り当てることはできません</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use!는 and!와 함께 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">리터럴로 표시된 다른 값에 값을 할당할 수 없습니다.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -367,6 +367,11 @@
         <target state="translated">Elementu use! nie można łączyć z elementem and!</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">Nie można przypisać wartości do innej wartości oznaczonej jako literał</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use! não pode ser combinado com and!</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">Não é possível atribuir um valor a outro valor marcado como literal</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use! запрещено сочетать с and!</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">Невозможно присвоить значение другому значению, помеченному как литерал</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use!, and! ile birleştirilemez</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">Sabit değer olarak işaretlenen bir değere başka bir değer atanamaz</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use! 不得与 and! 结合使用</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">无法将值分配给标记为文本的其他值</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -367,6 +367,11 @@
         <target state="translated">use! 不可與 and! 合併</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcLiteralAttributeCannotUseActivePattern">
+        <source>A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</source>
+        <target state="new">A [&lt;Literal&gt;] declaration cannot use an active pattern for its identifier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcLiteralFieldAssignmentNoArg">
         <source>Cannot assign a value to another value marked literal</source>
         <target state="translated">無法將值指派給標記為常值的其他值</target>

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/InvalidLiteralTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/InvalidLiteralTests.fs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.ErrorMessages
+
+open Xunit
+open FSharp.Test.Utilities.Compiler
+
+module ``Invalid literals`` =
+
+    [<Fact>]
+    let ``Using Active Pattern``() =
+        FSharp """
+let (|A|) x = x + 1
+let [<Literal>] (A x) = 1
+        """
+        |> typecheck
+        |> shouldFail
+        |> withSingleDiagnostic (Error 3391, Line 3, Col 17, Line 3, Col 22, "A [<Literal>] declaration cannot use an active pattern for its identifier")

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -29,7 +29,8 @@
     <Compile Include="ErrorMessages\ConstructorTests.fs" />
     <Compile Include="ErrorMessages\DontSuggestTests.fs" />
     <Compile Include="ErrorMessages\ElseBranchHasWrongTypeTests.fs" />
-    <Compile Include="ErrorMessages\InvalidNumericLiteralTests.fs" />
+    <Compile Include="ErrorMessages\InvalidLiteralTests.fs" />
+    <Compile Include="ErrorMessages\InvalidNumericLiteralTests.fs" />    
     <Compile Include="ErrorMessages\MissingElseBranch.fs" />
     <Compile Include="ErrorMessages\MissingExpressionTests.fs" />
     <Compile Include="ErrorMessages\ModuleAbbreviationTests.fs" />


### PR DESCRIPTION
This PR aims to fix https://github.com/dotnet/fsharp/pull/10816, which noted that one can use an active pattern in a `[<Literal>]` binding.

Repro:

```fsharp
let (|A|) x = x + 1
let [<Literal>] (A x) = 1
```

Compiled to:

```fsharp
> let (|A|) x = x + 1;;
val ( |A| ) : x:int -> int

> let [<Literal>] (A x) = 1;;
val x : int = 1
```

With this PR, this now outputs:

```
test.fs(2,17): error FS3391: A [<Literal>] declaration cannot use an active pattern for its identifier
```

This is my very first F# compiler PR (excluding docs), so I'd welcome any feedback.