### PR TITLE
Fix naming for SynExpr.ArrayOrList expression type parameter

### DIFF
--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -592,7 +592,7 @@ type SynExpr =
 
     /// F# syntax: [ e1; ...; en ], [| e1; ...; en |]
     | ArrayOrList of
-        isList: bool *
+        isArray: bool *
         exprs: SynExpr list *
         range: range
 

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -6842,7 +6842,7 @@ FSharp.Compiler.SyntaxTree+SynExpr+ArbitraryAfterError: FSharp.Compiler.Text.Ran
 FSharp.Compiler.SyntaxTree+SynExpr+ArbitraryAfterError: System.String debugStr
 FSharp.Compiler.SyntaxTree+SynExpr+ArbitraryAfterError: System.String get_debugStr()
 FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: Boolean get_isArray()
-FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: Boolean isList
+FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: Boolean isArray
 FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: FSharp.Compiler.Text.Range range
 FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTree+SynExpr] exprs

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -6841,7 +6841,7 @@ FSharp.Compiler.SyntaxTree+SynExpr+ArbitraryAfterError: FSharp.Compiler.Text.Ran
 FSharp.Compiler.SyntaxTree+SynExpr+ArbitraryAfterError: FSharp.Compiler.Text.Range range
 FSharp.Compiler.SyntaxTree+SynExpr+ArbitraryAfterError: System.String debugStr
 FSharp.Compiler.SyntaxTree+SynExpr+ArbitraryAfterError: System.String get_debugStr()
-FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: Boolean get_isList()
+FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: Boolean get_isArray()
 FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: Boolean isList
 FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.SyntaxTree+SynExpr+ArrayOrList: FSharp.Compiler.Text.Range range


### PR DESCRIPTION

The expression type parameter is named `isList` but is used as `isArray`, which is misleading.
![image](https://user-images.githubusercontent.com/26364714/103446086-a7d7c400-4c8c-11eb-802c-5a0e1db769b5.png)
