### PR TITLE
Add option to display pre-lexfilter tokens

### DIFF
--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -364,6 +364,7 @@ type TcConfigBuilder =
       mutable simulateException: string option
       mutable printAst: bool
       mutable tokenizeOnly: bool
+      mutable preLexFilterTokenizeOnly: bool
       mutable testInteractionParser: bool
       mutable reportNumDecls: bool
       mutable printSignature: bool
@@ -532,6 +533,7 @@ type TcConfigBuilder =
           simulateException = None
           printAst = false
           tokenizeOnly = false
+          preLexFilterTokenizeOnly = false
           testInteractionParser = false
           reportNumDecls = false
           printSignature = false
@@ -935,6 +937,7 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
     member x.printAst = data.printAst
     member x.targetFrameworkVersion = targetFrameworkVersionValue
     member x.tokenizeOnly = data.tokenizeOnly
+    member x.preLexFilterTokenizeOnly = data.preLexFilterTokenizeOnly
     member x.testInteractionParser = data.testInteractionParser
     member x.reportNumDecls = data.reportNumDecls
     member x.printSignature = data.printSignature

--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -182,6 +182,7 @@ type TcConfigBuilder =
       mutable simulateException: string option
       mutable printAst: bool
       mutable tokenizeOnly: bool
+      mutable preLexFilterTokenizeOnly: bool
       mutable testInteractionParser: bool
       mutable reportNumDecls: bool
       mutable printSignature: bool
@@ -363,6 +364,7 @@ type TcConfig =
     member simulateException: string option
     member printAst: bool
     member tokenizeOnly: bool
+    member preLexFilterTokenizeOnly: bool
     member testInteractionParser: bool
     member reportNumDecls: bool
     member printSignature: bool

--- a/src/fsharp/CompilerOptions.fs
+++ b/src/fsharp/CompilerOptions.fs
@@ -1135,6 +1135,11 @@ let internalFlags (tcConfigB:TcConfigBuilder) =
        ("tokenize", tagNone,
         OptionUnit (fun () -> tcConfigB.tokenizeOnly <- true),
         Some(InternalCommandLineOption("--tokenize", rangeCmdArgs)), None)
+
+    CompilerOption
+        ("pre-lexfilter-tokenize", tagNone,
+         OptionUnit (fun () -> tcConfigB.preLexFilterTokenizeOnly <- true),
+         Some(InternalCommandLineOption("--pre-lexfilter-tokenize", rangeCmdArgs)), None)
     
     CompilerOption
        ("testInteractionParser", tagNone,


### PR DESCRIPTION
In [this video](https://www.youtube.com/watch?v=3Zr0HNVcooU&t=1032s&ab_channel=F%23SoftwareFoundation), it was suggested that it might be useful to be able to add an option to the compiler to output the tokens pre-lexfilter. This PR adds that option. It follows the naming suggested in the PR, but let me know if you'd like to use different naming.

Here is the source code that I've tested with:

```fsharp
open System

let x = 2 + 4
```

If I run `.\fsc.exe --pre-lexfilter-tokenize .\test.fs`, it outputs:

```
C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1 [pre-lexfilter-tokenize-option +0 ~4 -0 !]> .\fsc.exe --pre-lexfilter-tokenize .\test.fs
Microsoft (R) F# Compiler version 11.0.0.0 for F# 5.0
Copyright (c) Microsoft Corporation. All Rights Reserved.

warning FS0075: The command-line option '--pre-lexfilter-tokenize' is for test purposes only
tokenize - getting one token from test.fs
tokenize - got OPEN @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(1,0)-(1,4)
tokenize - getting one token from test.fs
tokenize - got IDENT @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(1,5)-(1,11)
tokenize - getting one token from test.fs
tokenize - got LET @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,3)
tokenize - getting one token from test.fs
tokenize - got IDENT @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,4)-(3,5)
tokenize - getting one token from test.fs
tokenize - got EQUALS @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,6)-(3,7)
tokenize - getting one token from test.fs
tokenize - got INT32 @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,8)-(3,9)
tokenize - getting one token from test.fs
tokenize - got PLUS_MINUS_OP @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,10)-(3,11)
tokenize - getting one token from test.fs
tokenize - got INT32 @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,12)-(3,13)
tokenize - getting one token from test.fs
tokenize - got EOF @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,13)-(3,13)
```

Conversely, running `.\fsc.exe --tokenize .\test.fs` outputs:

```
C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1 [pre-lexfilter-tokenize-option +0 ~4 -0 !]> .\fsc.exe --tokenize .\test.fs       
Microsoft (R) F# Compiler version 11.0.0.0 for F# 5.0
Copyright (c) Microsoft Corporation. All Rights Reserved.

warning FS0075: The command-line option '--tokenize' is for test purposes only
tokenize - getting one token from test.fs
tokenize - got OPEN @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(1,0)-(1,4)
tokenize - getting one token from test.fs
tokenize - got IDENT @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(1,5)-(1,11)
tokenize - getting one token from test.fs
tokenize - got OBLOCKSEP @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(1,12)-(3,0)
tokenize - getting one token from test.fs
tokenize - got OLET @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,3)
tokenize - getting one token from test.fs
tokenize - got IDENT @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,4)-(3,5)
tokenize - getting one token from test.fs
tokenize - got EQUALS @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,6)-(3,7)
tokenize - getting one token from test.fs
tokenize - got OBLOCKBEGIN @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,8)-(3,9)
tokenize - getting one token from test.fs
tokenize - got INT32 @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,8)-(3,9)
tokenize - getting one token from test.fs
tokenize - got PLUS_MINUS_OP @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,10)-(3,11)
tokenize - getting one token from test.fs
tokenize - got INT32 @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,12)-(3,13)
tokenize - getting one token from test.fs
tokenize - got OBLOCKEND_COMING_SOON @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,13)
tokenize - getting one token from test.fs
tokenize - got OBLOCKEND_COMING_SOON @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,13)
tokenize - getting one token from test.fs
tokenize - got OBLOCKEND_COMING_SOON @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,13)
tokenize - getting one token from test.fs
tokenize - got OBLOCKEND_COMING_SOON @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,13)
tokenize - got OBLOCKEND_COMING_SOON @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,13)
tokenize - getting one token from test.fs
tokenize - got OBLOCKEND_COMING_SOON @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,13)
tokenize - getting one token from test.fs
tokenize - got OBLOCKEND_IS_HERE @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,13)
tokenize - getting one token from test.fs
tokenize - got ODECLEND @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,0)-(3,13)
tokenize - getting one token from test.fs
tokenize - got EOF @ C:\Code\fsharp\artifacts\bin\fsc\Debug\netcoreapp3.1\.\test.fs(3,13)-(3,13)
```