### PR TITLE
Implement walking of Attribute super types to check AttributeUsage

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -43,6 +43,7 @@
     <Compile Include="ErrorMessages\WrongSyntaxInForLoop.fs" />
     <Compile Include="ErrorMessages\ConfusingTypeName.fs" />
     <Compile Include="Language\RegressionTests.fs" />
+    <Compile Include="Language\AttributeCheckingTests.fs" />
     <Compile Include="Language\XmlComments.fs" />
     <Compile Include="Language\CompilerDirectiveTests.fs" />
     <Compile Include="Language\CodeQuotationTests.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Language/AttributeCheckingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/AttributeCheckingTests.fs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.AttributeChecking
+
+open Xunit
+open FSharp.Test.Utilities.Compiler
+
+[<TestFixture>]
+module AttributeCheckingTests =
+
+        [<Fact>]
+    let ``attributes check inherited AllowMultiple`` () =
+        Fsx"""
+open System
+
+[<AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)>]
+type HttpMethodAttribute() = inherit Attribute()
+type HttpGetAttribute() = inherit HttpMethodAttribute()
+
+[<HttpGet; HttpGet>] // this shouldn't error like 
+[<HttpMethod; HttpMethod>] // this doesn't
+type C() =
+    member _.M() = ()
+        """
+         |> ignoreWarnings
+         |> compile
+         |> shouldSucceed
+        

--- a/tests/FSharp.Compiler.ComponentTests/Language/AttributeCheckingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/AttributeCheckingTests.fs
@@ -5,12 +5,11 @@ namespace FSharp.Compiler.ComponentTests.AttributeChecking
 open Xunit
 open FSharp.Test.Utilities.Compiler
 
-[<TestFixture>]
 module AttributeCheckingTests =
 
-        [<Fact>]
+    [<Fact>]
     let ``attributes check inherited AllowMultiple`` () =
-        Fsx"""
+        Fsx """
 open System
 
 [<AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)>]


### PR DESCRIPTION
Closes https://github.com/dotnet/fsharp/issues/9256 by checking all super types of an attribute for AllowMultiple.

This is done by creating a sequence of types that need to be checked for AllowMultiple, and walking that sequence until one of them returns a concrete value for AllowMultiple. This is a pretty simplistic strategy, and I'm not sure how it interacts with the `Inherited` property of AttributeUsage.  I've added a test case as well to prove that this works as expected, though I could certainly use some additional test cases to ensure this works across all cases.  If there is more logic necessary to take `Inherited` into consideration, it should be pretty easy to stop the type-hierarchy traversal just by returning a `Some` value at that level, which would satisfy the `tryPick`.