### PR TITLE
Fixed find all references on properties

### DIFF
--- a/src/fsharp/service/ItemKey.fs
+++ b/src/fsharp/service/ItemKey.fs
@@ -295,7 +295,16 @@ and [<Sealed>] ItemKeyStoreBuilder() =
 
         match item with
         | Item.Value vref ->
-            writeValRef vref
+            if vref.IsPropertyGetterMethod || vref.IsPropertySetterMethod then
+                writeString ItemKeyTags.itemProperty
+                writeString vref.PropertyName
+                match vref.DeclaringEntity with
+                | ParentRef.Parent parent ->
+                    writeEntityRef parent
+                | _ ->
+                    ()
+            else
+                writeValRef vref
 
         | Item.UnionCase(info, _) -> 
             writeString ItemKeyTags.typeUnionCase
@@ -352,8 +361,11 @@ and [<Sealed>] ItemKeyStoreBuilder() =
         | Item.Property(nm, infos) ->
             writeString ItemKeyTags.itemProperty
             writeString nm
-            infos
-            |> List.iter (fun info -> writeEntityRef info.DeclaringTyconRef)
+            match infos |> List.tryHead with
+            | Some info ->
+                writeEntityRef info.DeclaringTyconRef
+            | _ ->
+                ()
 
         | Item.TypeVar(_, typar) ->
             writeTypar true typar


### PR DESCRIPTION
Resolves https://github.com/dotnet/fsharp/issues/9984 and https://github.com/dotnet/fsharp/issues/10811

Pretty straight-forward fix. The definition symbol and usage symbol are different and now they should be equivalent.