### PR TITLE
Fix sdk refs

### DIFF
--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -214,7 +214,6 @@ type TcConfigBuilder =
       mutable includewin32manifest: bool
       mutable linkResources: string list
       mutable legacyReferenceResolver: LegacyReferenceResolver
-      mutable fxResolver: FxResolver
       mutable showFullPaths: bool
       mutable errorStyle: ErrorStyle
       mutable utf8output: bool
@@ -257,6 +256,8 @@ type TcConfigBuilder =
       mutable copyFSharpCore: CopyFSharpCoreFlag
       mutable shadowCopyReferences: bool
       mutable useSdkRefs: bool
+      mutable fxResolver: FxResolver
+      mutable rangeForErrors: range
       mutable sdkDirOverride: string option
 
       /// A function to call to try to get an object that acts as a snapshot of the metadata section of a .NET binary,
@@ -276,16 +277,17 @@ type TcConfigBuilder =
 
     static member Initial: TcConfigBuilder
 
-    static member CreateNew: 
+    static member CreateNew:
         legacyReferenceResolver: LegacyReferenceResolver *
-        fxResolver: FxResolver *
         defaultFSharpBinariesDir: string * 
         reduceMemoryUsage: ReduceMemoryFlag * 
         implicitIncludeDir: string * 
         isInteractive: bool * 
         isInvalidationSupported: bool *
         defaultCopyFSharpCore: CopyFSharpCoreFlag *
-        tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot
+        tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot *
+        sdkDirOverride: string option *
+        rangeForErrors: range
           -> TcConfigBuilder
 
     member DecideNames: string list -> outfile: string * pdbfile: string option * assemblyName: string 
@@ -316,6 +318,9 @@ type TcConfigBuilder =
     member AddReferenceDirective: dependencyProvider: DependencyProvider * m: range * path: string * directive: Directive -> unit
 
     member AddLoadedSource: m: range * originalPath: string * pathLoadedFrom: string -> unit
+
+    member FxResolver: FxResolver
+
 
 /// Immutable TcConfig, modifications are made via a TcConfigBuilder
 [<Sealed>]

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -841,7 +841,7 @@ type internal FsiCommandLineOptions(fsi: FsiEvaluationSessionHostConfig,
     member _.WriteReferencesAndExit = writeReferencesAndExit
 
     member _.DependencyProvider = dependencyProvider
-    member _.FxResolver = tcConfigB.fxResolver
+    member _.FxResolver = tcConfigB.FxResolver
 
 /// Set the current ui culture for the current thread.
 let internal SetCurrentUICultureForThread (lcid : int option) =
@@ -2757,21 +2757,17 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         | None -> SimulatedMSBuildReferenceResolver.getResolver()
         | Some rr -> rr
 
-    // We know the target framework up front
-    let assumeDotNetFramework = not FSharpEnvironment.isRunningOnCoreClr
-
-    let fxResolver = FxResolver(Some assumeDotNetFramework, currentDirectory, rangeForErrors=range0, useSdkRefs=true, isInteractive=true, sdkDirOverride=None)
-
     let tcConfigB =
-        TcConfigBuilder.CreateNew(legacyReferenceResolver, 
-            fxResolver,
-            defaultFSharpBinariesDir=defaultFSharpBinariesDir, 
-            reduceMemoryUsage=ReduceMemoryFlag.Yes, 
-            implicitIncludeDir=currentDirectory, 
-            isInteractive=true, 
-            isInvalidationSupported=false, 
-            defaultCopyFSharpCore=CopyFSharpCoreFlag.No, 
-            tryGetMetadataSnapshot=tryGetMetadataSnapshot)
+        TcConfigBuilder.CreateNew(legacyReferenceResolver,
+            defaultFSharpBinariesDir=defaultFSharpBinariesDir,
+            reduceMemoryUsage=ReduceMemoryFlag.Yes,
+            implicitIncludeDir=currentDirectory,
+            isInteractive=true,
+            isInvalidationSupported=false,
+            defaultCopyFSharpCore=CopyFSharpCoreFlag.No,
+            tryGetMetadataSnapshot=tryGetMetadataSnapshot,
+            sdkDirOverride=None,
+            rangeForErrors=range0)
 
     let tcConfigP = TcConfigProvider.BasedOnMutableBuilder(tcConfigB)
     do tcConfigB.resolutionEnvironment <- LegacyResolutionEnvironment.CompilationAndEvaluation // See Bug 3608
@@ -2803,7 +2799,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let updateBannerText() =
       tcConfigB.productNameForBannerText <- FSIstrings.SR.fsiProductName(FSharpEnvironment.FSharpBannerVersion)
-  
+
     do updateBannerText() // setting the correct banner so that 'fsi -?' display the right thing
 
     let fsiOptions = FsiCommandLineOptions(fsi, argv, tcConfigB, fsiConsoleOutput)


### PR DESCRIPTION
A recent PR changed the code dealing with DefaultReferences in fsi and ide tooling, the change broke the --sdkrefs- switch.

This code moves things around a bit, and re-enables the switch.

