### PR TITLE
Make Microsoft.DotNet.DependencyManager nonstandard 2.0 only

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
+++ b/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
@@ -110,7 +110,7 @@ folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp"
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\netstandard2.0\Microsoft.FSharp.NetSdk.targets"
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\netstandard2.0\Microsoft.FSharp.Overrides.NetSdk.targets"
   file source="$(BinariesFolder)\FSharp.Build\$(Configuration)\netstandard2.0\Microsoft.FSharp.Targets"
-  file source="$(BinariesFolder)\Microsoft.DotNet.DependencyManager\$(Configuration)\net472\Microsoft.DotNet.DependencyManager.dll" vs.file.ngen=no vs.file.ngenArchitecture=All vs.file.ngenPriority=2
+  file source="$(BinariesFolder)\Microsoft.DotNet.DependencyManager\$(Configuration)\netstandard2.0\Microsoft.DotNet.DependencyManager.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
 
 @(_BuiltSwrLines)
 ]]>

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs
@@ -22,9 +22,8 @@ type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProb
 
     let eventInfo, handler, defaultAssemblyLoadContext =
         let eventInfo = assemblyLoadContextType.GetEvent("Resolving")
-        let ty = this.GetType()
         let mi =
-            let gmi = ty.GetMethod("ResolveAssemblyNetStandard", BindingFlags.Instance ||| BindingFlags.NonPublic)
+            let gmi = this.GetType().GetMethod("ResolveAssemblyNetStandard", BindingFlags.Instance ||| BindingFlags.NonPublic)
             gmi.MakeGenericMethod(assemblyLoadContextType)
 
         eventInfo,

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/DependencyProvider.fs
@@ -11,10 +11,10 @@ open Internal.Utilities.FSharpEnvironment
 open Microsoft.FSharp.Reflection
 open System.Collections.Concurrent
 
-module Option = 
+module Option =
 
     /// Convert string into Option string where null and String.Empty result in None
-    let ofString s = 
+    let ofString s =
         if String.IsNullOrEmpty(s) then None
         else Some(s)
 

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/Microsoft.DotNet.DependencyManager.fsproj
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/Microsoft.DotNet.DependencyManager.fsproj
@@ -4,9 +4,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.DotNet.DependencyManager</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs
@@ -14,23 +14,23 @@ open Internal.Utilities.FSharpEnvironment
 /// host implements this, it's job is to return a list of package roots to probe.
 type NativeResolutionProbe = delegate of Unit -> seq<string>
 
-#if NETSTANDARD
-open System.Runtime.Loader
-
-// Cut down AssemblyLoadContext, for loading native libraries
-type NativeAssemblyLoadContext () =
-    inherit AssemblyLoadContext()
-
-    member this.LoadNativeLibrary(path: string): IntPtr =
-        base.LoadUnmanagedDllFromPath(path)
-
-    override _.Load(_path: AssemblyName): Assembly =
-        raise (NotImplementedException())
-
-    static member NativeLoadContext = new NativeAssemblyLoadContext()
-
 /// Type that encapsulates Native library probing for managed packages
 type NativeDllResolveHandlerCoreClr (nativeProbingRoots: NativeResolutionProbe) =
+
+    let nativeLibraryTryLoad =
+        let nativeLibraryType: Type = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices", false)
+        if not (isNull nativeLibraryType) then
+            nativeLibraryType.GetMethod("TryLoad", [| typeof<string>; typeof<IntPtr>.MakeByRefType() |])
+        else
+            Unchecked.defaultof<MethodInfo>
+
+    let loadNativeLibrary path =
+        let arguments = [| path:>obj; IntPtr.Zero:>obj |]
+        if nativeLibraryTryLoad.Invoke(null, arguments) :?> bool then
+            arguments.[1] :?> IntPtr
+        else
+            IntPtr.Zero
+
     let probingFileNames (name: string) =
         // coreclr native library probing algorithm: https://github.com/dotnet/coreclr/blob/9773db1e7b1acb3ec75c9cc0e36bd62dcbacd6d5/src/System.Private.CoreLib/shared/System/Runtime/Loader/LibraryNameVariation.Unix.cs
         let isRooted = Path.IsPathRooted name
@@ -64,7 +64,7 @@ type NativeDllResolveHandlerCoreClr (nativeProbingRoots: NativeResolutionProbe) 
                             yield (sprintf "%s%s" p name)
         |]
 
-    let _resolveUnmanagedDll (_: Assembly) (name: string): IntPtr =
+    let resolveUnmanagedDll (_: Assembly) (name: string): IntPtr =
         // Enumerate probing roots looking for a dll that matches the probing name in the probed locations
         let probeForNativeLibrary root rid name =
             // Look for name in root
@@ -89,35 +89,38 @@ type NativeDllResolveHandlerCoreClr (nativeProbingRoots: NativeResolutionProbe) 
                             RidHelpers.probingRids |> Seq.tryPick(fun rid -> probeForNativeLibrary root rid name)))
 
         match probe with
-        | Some path -> NativeAssemblyLoadContext.NativeLoadContext.LoadNativeLibrary(path)
+        | Some path -> loadNativeLibrary(path)
         | None -> IntPtr.Zero
 
     // netstandard 2.1 has this property, unfortunately we don't build with that yet
     //public event Func<Assembly, string, IntPtr> ResolvingUnmanagedDll
-    let eventInfo = typeof<AssemblyLoadContext>.GetEvent("ResolvingUnmanagedDll")
-    let handler = Func<Assembly, string, IntPtr> (_resolveUnmanagedDll)
+    let assemblyLoadContextType: Type = Type.GetType("System.Runtime.Loader.AssemblyLoadContext, System.Runtime.Loader", false)
+    let eventInfo, handler, defaultAssemblyLoadContext =
+        if not (isNull assemblyLoadContextType) then
+            assemblyLoadContextType.GetEvent("ResolvingUnmanagedDll"), 
+            Func<Assembly, string, IntPtr> (resolveUnmanagedDll), 
+            assemblyLoadContextType.GetProperty("Default", BindingFlags.Static ||| BindingFlags.Public).GetValue(null, null)
+        else
+            Unchecked.defaultof<EventInfo>, Unchecked.defaultof<Func<Assembly, string, IntPtr>>, Unchecked.defaultof<_>
 
     do
         if not (isNull eventInfo) then
-            eventInfo.AddEventHandler(AssemblyLoadContext.Default, handler)
+            eventInfo.AddEventHandler(defaultAssemblyLoadContext, handler)
 
     interface IDisposable with
         member _x.Dispose() =
             if not (isNull eventInfo) then
-                eventInfo.RemoveEventHandler(AssemblyLoadContext.Default, handler)
-            ()
-#endif
+                eventInfo.RemoveEventHandler(defaultAssemblyLoadContext, handler)
 
-type NativeDllResolveHandler (_nativeProbingRoots: NativeResolutionProbe) =
+
+type NativeDllResolveHandler (nativeProbingRoots: NativeResolutionProbe) =
     let handler: IDisposable option =
-#if NETSTANDARD
         if isRunningOnCoreClr then
-            Some (new NativeDllResolveHandlerCoreClr(_nativeProbingRoots) :> IDisposable)
+            Some (new NativeDllResolveHandlerCoreClr(nativeProbingRoots) :> IDisposable)
         else
-#endif
             None
 
-    let appendSemiColon (p:string) =
+    let appendSemiColon (p: string) =
         if not(p.EndsWith(";", StringComparison.OrdinalIgnoreCase)) then
             p + ";"
         else

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi
@@ -12,7 +12,7 @@ type NativeResolutionProbe = delegate of Unit -> seq<string>
 type NativeDllResolveHandler =
 
     /// Construct a new NativeDllResolveHandler
-    new: _nativeProbingRoots: NativeResolutionProbe -> NativeDllResolveHandler
+    new: nativeProbingRoots: NativeResolutionProbe -> NativeDllResolveHandler
 
     member internal RefreshPathsInEnvironment: string seq -> unit
 

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -95,7 +95,7 @@
       <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>2</NgenPriority>
       <Private>True</Private>
-      <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
+      <AdditionalProperties>TargetFramework=netstandard2.0</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>


### PR DESCRIPTION
So ... life is hard ... and dependencies are tricky and make me squirm ...

Over over the last few years the coreclr has added 
- AssemblyLoadContext
- NativeDll Loading apis

These APIs do not exist on the desktop .NetFrameork, and I'm pretty sure they don't exist on Mono too.  The assembly and native assembly resolution features are pretty popular with our notebook users, for example the ML and Spark libraries make heavy use of native libraries.

Because Visual Studio still depends on the desktop framework, any tool loaded by it, can be at best NetStandard2.0, which doesn't have a viable AssemblyLoadContext or the Native dll loading Apis at all.

If you NGEN an assembly that contains a type reference to AssemblyLoadContext, it will fails with an error.  For example NGEN on fcs.exe will fail because of this ... sorry about that ....

This has been an issue for quite a lot of months, it finally percolated to a point where we have spent some time on it.  The solution we have gone with is to use alternate Native Loader Api's and to use only reflection to access ALC and the Native Library API's.  We thought for quite a while that the only way forward would be using RefEmit to generate a bunch of code ... luckily we don't have to go with that madness.

The reason this became important is that we want to eliminate FSharp.Compiler.Private and FSharp.Compiler.Private.Scripting move to FSharp.Compiler.Service and so being able to NGEN fcs.dll is pretty important to us.

Anyway, that is why this resurfaced again.  The name is so I could WIP it and run the tests on Linux and MacOS.

Additional, build Microsoft.DotNet.DependencyManager with Netstandard2.0 only