### PR TITLE
Map: Optimize away `isinst` check

### DIFF
--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -41,9 +41,11 @@ module MapTree =
         if isEmpty m then
             acc
         else
-            match m.Height with
-            | 1 -> acc + 1
-            | _ -> let mn = asNode m in sizeAux (sizeAux (acc+1) mn.Left) mn.Right 
+            if m.Height = 1 then
+                acc + 1
+            else
+                let mn = asNode m
+                sizeAux (sizeAux (acc+1) mn.Left) mn.Right 
             
     let size x = sizeAux 0 x
 
@@ -128,12 +130,11 @@ module MapTree =
         if isEmpty m then MapTree(k,v)
         else
             let c = comparer.Compare(k,m.Key)
-            match m.Height with
-            | 1 ->
+            if m.Height = 1 then
                 if c < 0   then MapTreeNode (k,v,empty,m,2) :> MapTree<'Key, 'Value>
                 elif c = 0 then MapTree(k,v)
                 else            MapTreeNode (k,v,m,empty,2) :> MapTree<'Key, 'Value> 
-            | _ ->
+            else
                 let mn = asNode m
                 if c < 0 then rebalance (add comparer k v mn.Left) mn.Key mn.Value mn.Right
                 elif c = 0 then MapTreeNode(k,v,mn.Left,mn.Right,mn.Height) :> MapTree<'Key, 'Value>
@@ -145,9 +146,8 @@ module MapTree =
             let c = comparer.Compare(k, m.Key)
             if c = 0 then v <- m.Value; true
             else
-                match m.Height with
-                | 1 -> false
-                | _ ->
+                if m.Height = 1 then false
+                else
                     let mn = asNode m
                     tryGetValue comparer k &v (if c < 0 then mn.Left else mn.Right)
                 
@@ -175,15 +175,14 @@ module MapTree =
     let rec partitionAux (comparer: IComparer<'Key>) (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) acc = 
         if isEmpty m then acc
         else
-            match m.Height with        
-            | 1 -> partition1 comparer f m.Key m.Value acc
-            | _ ->
+            if m.Height = 1 then        
+                partition1 comparer f m.Key m.Value acc
+            else
                 let mn = asNode m
                 let acc = partitionAux comparer f mn.Right acc 
                 let acc = partition1 comparer f mn.Key mn.Value acc
                 partitionAux comparer f mn.Left acc
             
-
     let partition (comparer: IComparer<'Key>) f m =
         partitionAux comparer (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m (empty, empty)
 
@@ -193,9 +192,9 @@ module MapTree =
     let rec filterAux (comparer: IComparer<'Key>) (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) acc = 
         if isEmpty m then acc
         else
-            match m.Height with 
-            | 1 -> filter1 comparer f m.Key m.Value acc
-            | _ ->
+            if m.Height = 1 then  
+                filter1 comparer f m.Key m.Value acc
+            else
                 let mn = asNode m
                 let acc = filterAux comparer f mn.Left acc
                 let acc = filter1 comparer f mn.Key mn.Value acc
@@ -208,9 +207,9 @@ module MapTree =
     let rec spliceOutSuccessor (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then failwith "internal error: Map.spliceOutSuccessor"
         else
-            match m.Height with
-            | 1 -> m.Key, m.Value, empty
-            | _ ->
+            if m.Height = 1 then
+                m.Key, m.Value, empty
+            else
                 let mn = asNode m
                 if isEmpty mn.Left then mn.Key, mn.Value, mn.Right
                 else let k3, v3, l' = spliceOutSuccessor mn.Left in k3, v3, mk l' mn.Key mn.Value mn.Right
@@ -219,9 +218,9 @@ module MapTree =
         if isEmpty m then empty
         else
             let c = comparer.Compare(k, m.Key)
-            match m.Height with 
-            | 1 -> if c = 0 then empty else m
-            | _ ->
+            if m.Height = 1 then 
+                if c = 0 then empty else m
+            else
                 let mn = asNode m 
                 if c < 0 then rebalance (remove comparer k mn.Left) mn.Key mn.Value mn.Right
                 elif c = 0 then
@@ -239,8 +238,7 @@ module MapTree =
                 | None -> m
                 | Some v -> MapTree (k, v)
         else
-            match m.Height with
-            | 1 ->
+            if m.Height = 1 then
                 let c = comparer.Compare(k, m.Key)
                 if c < 0 then
                     match u None with
@@ -254,7 +252,7 @@ module MapTree =
                     match u None with
                     | None -> m
                     | Some v -> MapTreeNode (k, v, m, empty, 2) :> MapTree<'Key,'Value>
-            | _ ->
+            else
                 let mn = asNode m
                 let c = comparer.Compare(k, mn.Key)
                 if c < 0 then
@@ -275,9 +273,9 @@ module MapTree =
         if isEmpty m then false
         else
             let c = comparer.Compare(k, m.Key)
-            match m.Height with 
-            | 1 -> c = 0
-            | _ ->
+            if m.Height = 1 then 
+                c = 0
+            else
                 let mn = asNode m
                 if c < 0 then mem comparer k mn.Left
                 else (c = 0 || mem comparer k mn.Right)
@@ -286,9 +284,9 @@ module MapTree =
     let rec iterOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) =
         if isEmpty m then ()
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value)
+            else
                 let mn = asNode m
                 iterOpt f mn.Left; f.Invoke (mn.Key, mn.Value); iterOpt f mn.Right
             
@@ -299,9 +297,9 @@ module MapTree =
     let rec tryPickOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) =
         if isEmpty m then None
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value)
+            else
                 let mn = asNode m
                 match tryPickOpt f mn.Left with 
                 | Some _ as res -> res 
@@ -318,9 +316,9 @@ module MapTree =
     let rec existsOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then false
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value)
+            else
                 let mn = asNode m
                 existsOpt f mn.Left || f.Invoke (mn.Key, mn.Value) || existsOpt f mn.Right
             
@@ -331,9 +329,9 @@ module MapTree =
     let rec forallOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then true
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value)
+            else
                 let mn = asNode m
                 forallOpt f mn.Left && f.Invoke (mn.Key, mn.Value) && forallOpt f mn.Right
             
@@ -345,9 +343,9 @@ module MapTree =
     let rec map (f:'Value -> 'Result) (m: MapTree<'Key, 'Value>) : MapTree<'Key, 'Result> = 
         if isEmpty m then empty
         else
-            match m.Height with 
-            | 1 -> MapTree (m.Key, f m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                MapTree (m.Key, f m.Value)
+            else
                 let mn = asNode m
                 let l2 = map f mn.Left 
                 let v2 = f mn.Value
@@ -357,9 +355,9 @@ module MapTree =
     let rec mapiOpt (f: OptimizedClosures.FSharpFunc<'Key, 'Value, 'Result>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then empty
         else
-            match m.Height with
-            | 1 -> MapTree (m.Key, f.Invoke (m.Key, m.Value))
-            | _ ->
+            if m.Height = 1 then
+                MapTree (m.Key, f.Invoke (m.Key, m.Value))
+            else
                 let mn = asNode m
                 let l2 = mapiOpt f mn.Left
                 let v2 = f.Invoke (mn.Key, mn.Value) 
@@ -373,9 +371,9 @@ module MapTree =
     let rec foldBackOpt (f: OptimizedClosures.FSharpFunc<_, _, _, _>) (m: MapTree<'Key, 'Value>) x = 
         if isEmpty m then x
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value, x)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value, x)
+            else
                 let mn = asNode m
                 let x = foldBackOpt f mn.Right x
                 let x = f.Invoke (mn.Key, mn.Value, x)
@@ -388,9 +386,9 @@ module MapTree =
     let rec foldOpt (f: OptimizedClosures.FSharpFunc<_, _, _, _>) x (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then x
         else
-            match m.Height with 
-            | 1 -> f.Invoke (x, m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (x, m.Key, m.Value)
+            else
                 let mn = asNode m
                 let x = foldOpt f x mn.Left
                 let x = f.Invoke (x, mn.Key, mn.Value)
@@ -403,13 +401,12 @@ module MapTree =
         let rec foldFromTo (f: OptimizedClosures.FSharpFunc<_, _, _, _>) (m: MapTree<'Key, 'Value>) x = 
             if isEmpty m then x
             else
-                match m.Height with 
-                | 1 ->
+                if m.Height = 1 then 
                     let cLoKey = comparer.Compare(lo, m.Key)
                     let cKeyHi = comparer.Compare(m.Key, hi)
                     let x = if cLoKey <= 0 && cKeyHi <= 0 then f.Invoke (m.Key, m.Value, x) else x
                     x
-                | _ ->
+                else
                     let mn = asNode m
                     let cLoKey = comparer.Compare(lo, mn.Key)
                     let cKeyHi = comparer.Compare(mn.Key, hi)
@@ -427,9 +424,9 @@ module MapTree =
         let rec loop (m: MapTree<'Key, 'Value>) acc = 
             if isEmpty m then acc
             else
-                match m.Height with
-                | 1 -> (m.Key, m.Value) :: acc
-                | _ ->
+                if m.Height = 1 then
+                    (m.Key, m.Value) :: acc
+                else
                     let mn = asNode m
                     loop mn.Left ((mn.Key, mn.Value) :: loop mn.Right acc)
                 
@@ -483,9 +480,9 @@ module MapTree =
         | m :: rest ->
             if isEmpty m then collapseLHS rest
             else
-                match m.Height with
-                | 1 -> stack
-                | _ ->
+                if m.Height = 1 then
+                    stack
+                else
                     let mn = asNode m
                     collapseLHS (mn.Left :: MapTree (mn.Key, mn.Value) :: mn.Right :: rest)
 
@@ -497,15 +494,20 @@ module MapTree =
 
     let alreadyFinished() =
         raise (InvalidOperationException(SR.GetString(SR.enumerationAlreadyFinished)))
+        
+    let unexpectedStackForCurrent() =
+        failwith "Please report error: Map iterator, unexpected stack for current"
+        
+    let unexpectedStackForMoveNext() =
+        failwith "Please report error: Map iterator, unexpected stack for moveNext"
 
     let current i =
         if i.started then
             match i.stack with
             | []     -> alreadyFinished()
             | m :: _ ->
-                match m.Height with
-                | 1 -> new KeyValuePair<_, _>(m.Key, m.Value)
-                | _ -> failwith "Please report error: Map iterator, unexpected stack for current"
+                if m.Height = 1 then KeyValuePair<_, _>(m.Key, m.Value)
+                else unexpectedStackForCurrent()
         else
             notStarted()
 
@@ -514,11 +516,10 @@ module MapTree =
             match i.stack with
             | [] -> false
             | m :: rest ->
-                match m.Height with
-                | 1 ->
+                if m.Height = 1 then
                     i.stack <- collapseLHS rest
                     not i.stack.IsEmpty
-                | _ -> failwith "Please report error: Map iterator, unexpected stack for moveNext"
+                else unexpectedStackForMoveNext()
         else
             i.started <- true  (* The first call to MoveNext "starts" the enumeration. *)
             not i.stack.IsEmpty

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -73,11 +73,11 @@ module MapTree =
                (totalSizeOnMapLookup / float numLookups))
            System.Console.WriteLine("#largestMapSize = {0}, largestMapStackTrace = {1}", largestMapSize, largestMapStackTrace)
 
-    let MapTree n = 
+    let MapTree (k,v) = 
         report()
         numOnes <- numOnes + 1
         totalSizeOnNodeCreation <- totalSizeOnNodeCreation + 1.0
-        MapTree n
+        MapTree (k,v)
 
     let MapTreeNode (x, l, v, r, h) = 
         report()

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -5,25 +5,27 @@ namespace Microsoft.FSharp.Collections
 open System
 open System.Collections.Generic
 open System.Diagnostics
+open System.Runtime.CompilerServices
 open System.Text
 open Microsoft.FSharp.Core
 open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
 
 [<NoEquality; NoComparison>]
 [<AllowNullLiteral>]
-type internal MapTree<'Key, 'Value>(k: 'Key, v: 'Value) =
+type internal MapTree<'Key, 'Value>(k: 'Key, v: 'Value, h: int) =
+    member _.Height = h
     member _.Key = k
     member _.Value = v
-
+    new(k: 'Key, v: 'Value) = MapTree(k,v,1)
+    
 [<NoEquality; NoComparison>]
 [<Sealed>]
 [<AllowNullLiteral>]
 type internal MapTreeNode<'Key, 'Value>(k:'Key, v:'Value, left:MapTree<'Key, 'Value>, right: MapTree<'Key, 'Value>, h: int) =
-    inherit MapTree<'Key,'Value>(k, v)
-
+    inherit MapTree<'Key,'Value>(k, v, h)
     member _.Left = left
     member _.Right = right
-    member _.Height = h
+    
     
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module MapTree = 
@@ -32,14 +34,17 @@ module MapTree =
     
     let inline isEmpty (m:MapTree<'Key, 'Value>) = isNull m
         
+    let inline private asNode(value:MapTree<'Key,'Value>) : MapTreeNode<'Key,'Value> =
+        value :?> MapTreeNode<'Key,'Value>
+        
     let rec sizeAux acc (m:MapTree<'Key, 'Value>) = 
         if isEmpty m then
             acc
         else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn -> sizeAux (sizeAux (acc+1) mn.Left) mn.Right 
-            | _ -> acc + 1
-
+            match m.Height with
+            | 1 -> acc + 1
+            | _ -> let mn = asNode m in sizeAux (sizeAux (acc+1) mn.Left) mn.Right 
+            
     let size x = sizeAux 0 x
 
 #if TRACE_SETS_AND_MAPS
@@ -82,10 +87,7 @@ module MapTree =
 
     let inline height (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then 0
-        else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn -> mn.Height
-            | _ -> 1
+        else m.Height
     
     [<Literal>]
     let tolerance = 2
@@ -98,9 +100,6 @@ module MapTree =
             MapTree(k,v)
         else
             MapTreeNode(k,v,l,r,m+1) :> MapTree<'Key, 'Value>  // new map is higher by 1 than the highest
-    
-    let inline private asNode(value:MapTree<'Key,'Value>) : MapTreeNode<'Key,'Value> =
-        value :?> MapTreeNode<'Key,'Value>
         
     let rebalance t1 (k: 'Key) (v: 'Value) t2 : MapTree<'Key, 'Value> =
         let t1h = height t1
@@ -129,33 +128,39 @@ module MapTree =
         if isEmpty m then MapTree(k,v)
         else
             let c = comparer.Compare(k,m.Key)
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn ->
-                if c < 0 then rebalance (add comparer k v mn.Left) mn.Key mn.Value mn.Right
-                elif c = 0 then MapTreeNode(k,v,mn.Left,mn.Right,mn.Height) :> MapTree<'Key, 'Value>
-                else rebalance mn.Left mn.Key mn.Value (add comparer k v mn.Right)
-            | _ ->
+            match m.Height with
+            | 1 ->
                 if c < 0   then MapTreeNode (k,v,empty,m,2) :> MapTree<'Key, 'Value>
                 elif c = 0 then MapTree(k,v)
                 else            MapTreeNode (k,v,m,empty,2) :> MapTree<'Key, 'Value> 
-
+            | _ ->
+                let mn = asNode m
+                if c < 0 then rebalance (add comparer k v mn.Left) mn.Key mn.Value mn.Right
+                elif c = 0 then MapTreeNode(k,v,mn.Left,mn.Right,mn.Height) :> MapTree<'Key, 'Value>
+                else rebalance mn.Left mn.Key mn.Value (add comparer k v mn.Right)
+                
     let rec tryGetValue (comparer: IComparer<'Key>) k (v: byref<'Value>) (m: MapTree<'Key, 'Value>) =                     
         if isEmpty m then false
         else
             let c = comparer.Compare(k, m.Key)
             if c = 0 then v <- m.Value; true
             else
-                match m with
-                | :? MapTreeNode<'Key, 'Value> as mn ->
+                match m.Height with
+                | 1 -> false
+                | _ ->
+                    let mn = asNode m
                     tryGetValue comparer k &v (if c < 0 then mn.Left else mn.Right)
-                | _ -> false
-
+                
+    [<MethodImpl(MethodImplOptions.NoInlining)>]
+    let throwKeyNotFound() = raise (KeyNotFoundException())
+    
+    [<MethodImpl(MethodImplOptions.NoInlining)>]
     let find (comparer: IComparer<'Key>) k (m: MapTree<'Key, 'Value>) =
         let mutable v = Unchecked.defaultof<'Value>
         if tryGetValue comparer k &v m then
             v
         else
-            raise (KeyNotFoundException())
+            throwKeyNotFound()
 
     let tryFind (comparer: IComparer<'Key>) k (m: MapTree<'Key, 'Value>) = 
         let mutable v = Unchecked.defaultof<'Value>
@@ -170,12 +175,14 @@ module MapTree =
     let rec partitionAux (comparer: IComparer<'Key>) (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) acc = 
         if isEmpty m then acc
         else
-            match m with        
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with        
+            | 1 -> partition1 comparer f m.Key m.Value acc
+            | _ ->
+                let mn = asNode m
                 let acc = partitionAux comparer f mn.Right acc 
                 let acc = partition1 comparer f mn.Key mn.Value acc
                 partitionAux comparer f mn.Left acc
-            | _ -> partition1 comparer f m.Key m.Value acc
+            
 
     let partition (comparer: IComparer<'Key>) f m =
         partitionAux comparer (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m (empty, empty)
@@ -186,12 +193,14 @@ module MapTree =
     let rec filterAux (comparer: IComparer<'Key>) (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) acc = 
         if isEmpty m then acc
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> filter1 comparer f m.Key m.Value acc
+            | _ ->
+                let mn = asNode m
                 let acc = filterAux comparer f mn.Left acc
                 let acc = filter1 comparer f mn.Key mn.Value acc
                 filterAux comparer f mn.Right acc
-            | _ -> filter1 comparer f m.Key m.Value acc
+            
 
     let filter (comparer: IComparer<'Key>) f m =
         filterAux comparer (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m empty
@@ -199,18 +208,21 @@ module MapTree =
     let rec spliceOutSuccessor (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then failwith "internal error: Map.spliceOutSuccessor"
         else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with
+            | 1 -> m.Key, m.Value, empty
+            | _ ->
+                let mn = asNode m
                 if isEmpty mn.Left then mn.Key, mn.Value, mn.Right
                 else let k3, v3, l' = spliceOutSuccessor mn.Left in k3, v3, mk l' mn.Key mn.Value mn.Right
-            | _ -> m.Key, m.Value, empty
 
     let rec remove (comparer: IComparer<'Key>) k (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then empty
         else
             let c = comparer.Compare(k, m.Key)
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> if c = 0 then empty else m
+            | _ ->
+                let mn = asNode m 
                 if c < 0 then rebalance (remove comparer k mn.Left) mn.Key mn.Value mn.Right
                 elif c = 0 then
                     if isEmpty mn.Left then mn.Right
@@ -219,8 +231,7 @@ module MapTree =
                         let sk, sv, r' = spliceOutSuccessor mn.Right 
                         mk mn.Left sk sv r'
                 else rebalance mn.Left mn.Key mn.Value (remove comparer k mn.Right)
-            | _ ->
-                if c = 0 then empty else m
+            
 
     let rec change (comparer: IComparer<'Key>) k (u: 'Value option -> 'Value option) (m: MapTree<'Key, 'Value>) : MapTree<'Key,'Value> =
         if isEmpty m then
@@ -228,8 +239,23 @@ module MapTree =
                 | None -> m
                 | Some v -> MapTree (k, v)
         else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with
+            | 1 ->
+                let c = comparer.Compare(k, m.Key)
+                if c < 0 then
+                    match u None with
+                    | None -> m
+                    | Some v -> MapTreeNode (k, v, empty, m, 2) :> MapTree<'Key,'Value>
+                elif c = 0 then
+                    match u (Some m.Value) with
+                    | None -> empty
+                    | Some v -> MapTree (k, v)
+                else
+                    match u None with
+                    | None -> m
+                    | Some v -> MapTreeNode (k, v, m, empty, 2) :> MapTree<'Key,'Value>
+            | _ ->
+                let mn = asNode m
                 let c = comparer.Compare(k, mn.Key)
                 if c < 0 then
                     rebalance (change comparer k u mn.Left) mn.Key mn.Value mn.Right
@@ -244,37 +270,28 @@ module MapTree =
                     | Some v -> MapTreeNode (k, v, mn.Left, mn.Right, mn.Height) :> MapTree<'Key,'Value>
                 else
                     rebalance mn.Left mn.Key mn.Value (change comparer k u mn.Right)
-            | _ ->
-                let c = comparer.Compare(k, m.Key)
-                if c < 0 then
-                    match u None with
-                    | None -> m
-                    | Some v -> MapTreeNode (k, v, empty, m, 2) :> MapTree<'Key,'Value>
-                elif c = 0 then
-                    match u (Some m.Value) with
-                    | None -> empty
-                    | Some v -> MapTree (k, v)
-                else
-                    match u None with
-                    | None -> m
-                    | Some v -> MapTreeNode (k, v, m, empty, 2) :> MapTree<'Key,'Value>
 
     let rec mem (comparer: IComparer<'Key>) k (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then false
         else
             let c = comparer.Compare(k, m.Key)
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> c = 0
+            | _ ->
+                let mn = asNode m
                 if c < 0 then mem comparer k mn.Left
                 else (c = 0 || mem comparer k mn.Right)
-            | _ -> c = 0
+            
 
     let rec iterOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) =
         if isEmpty m then ()
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn -> iterOpt f mn.Left; f.Invoke (mn.Key, mn.Value); iterOpt f mn.Right
-            | _ -> f.Invoke (m.Key, m.Value)
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
+                iterOpt f mn.Left; f.Invoke (mn.Key, mn.Value); iterOpt f mn.Right
+            
 
     let iter f m =
         iterOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m
@@ -282,8 +299,10 @@ module MapTree =
     let rec tryPickOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) =
         if isEmpty m then None
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
                 match tryPickOpt f mn.Left with 
                 | Some _ as res -> res 
                 | None -> 
@@ -291,7 +310,7 @@ module MapTree =
                 | Some _ as res -> res 
                 | None -> 
                 tryPickOpt f mn.Right
-            | _ -> f.Invoke (m.Key, m.Value)
+            
 
     let tryPick f m =
         tryPickOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m
@@ -299,9 +318,12 @@ module MapTree =
     let rec existsOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then false
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn -> existsOpt f mn.Left || f.Invoke (mn.Key, mn.Value) || existsOpt f mn.Right
-            | _ -> f.Invoke (m.Key, m.Value)
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
+                existsOpt f mn.Left || f.Invoke (mn.Key, mn.Value) || existsOpt f mn.Right
+            
 
     let exists f m =
         existsOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m
@@ -309,9 +331,12 @@ module MapTree =
     let rec forallOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then true
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn -> forallOpt f mn.Left && f.Invoke (mn.Key, mn.Value) && forallOpt f mn.Right
-            | _ -> f.Invoke (m.Key, m.Value)
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
+                forallOpt f mn.Left && f.Invoke (mn.Key, mn.Value) && forallOpt f mn.Right
+            
             
 
     let forall f m =
@@ -320,24 +345,27 @@ module MapTree =
     let rec map (f:'Value -> 'Result) (m: MapTree<'Key, 'Value>) : MapTree<'Key, 'Result> = 
         if isEmpty m then empty
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn -> 
+            match m.Height with 
+            | 1 -> MapTree (m.Key, f m.Value)
+            | _ ->
+                let mn = asNode m
                 let l2 = map f mn.Left 
                 let v2 = f mn.Value
                 let r2 = map f mn.Right
                 MapTreeNode (mn.Key, v2, l2, r2, mn.Height) :> MapTree<'Key, 'Result>
-            | _ -> MapTree (m.Key, f m.Value)
 
     let rec mapiOpt (f: OptimizedClosures.FSharpFunc<'Key, 'Value, 'Result>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then empty
         else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with
+            | 1 -> MapTree (m.Key, f.Invoke (m.Key, m.Value))
+            | _ ->
+                let mn = asNode m
                 let l2 = mapiOpt f mn.Left
                 let v2 = f.Invoke (mn.Key, mn.Value) 
                 let r2 = mapiOpt f mn.Right
                 MapTreeNode (mn.Key, v2, l2, r2, mn.Height) :> MapTree<'Key, 'Result>
-            | _ -> MapTree (m.Key, f.Invoke (m.Key, m.Value))
+            
 
     let mapi f m =
         mapiOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m
@@ -345,12 +373,14 @@ module MapTree =
     let rec foldBackOpt (f: OptimizedClosures.FSharpFunc<_, _, _, _>) (m: MapTree<'Key, 'Value>) x = 
         if isEmpty m then x
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value, x)
+            | _ ->
+                let mn = asNode m
                 let x = foldBackOpt f mn.Right x
                 let x = f.Invoke (mn.Key, mn.Value, x)
                 foldBackOpt f mn.Left x
-            | _ -> f.Invoke (m.Key, m.Value, x)
+            
 
     let foldBack f m x =
         foldBackOpt (OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt f) m x
@@ -358,12 +388,13 @@ module MapTree =
     let rec foldOpt (f: OptimizedClosures.FSharpFunc<_, _, _, _>) x (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then x
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> f.Invoke (x, m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
                 let x = foldOpt f x mn.Left
                 let x = f.Invoke (x, mn.Key, mn.Value)
                 foldOpt f x mn.Right
-            | _ -> f.Invoke (x, m.Key, m.Value)
 
     let fold f x m =
         foldOpt (OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt f) x m
@@ -372,18 +403,19 @@ module MapTree =
         let rec foldFromTo (f: OptimizedClosures.FSharpFunc<_, _, _, _>) (m: MapTree<'Key, 'Value>) x = 
             if isEmpty m then x
             else
-                match m with 
-                | :? MapTreeNode<'Key, 'Value> as mn ->
+                match m.Height with 
+                | 1 ->
+                    let cLoKey = comparer.Compare(lo, m.Key)
+                    let cKeyHi = comparer.Compare(m.Key, hi)
+                    let x = if cLoKey <= 0 && cKeyHi <= 0 then f.Invoke (m.Key, m.Value, x) else x
+                    x
+                | _ ->
+                    let mn = asNode m
                     let cLoKey = comparer.Compare(lo, mn.Key)
                     let cKeyHi = comparer.Compare(mn.Key, hi)
                     let x = if cLoKey < 0 then foldFromTo f mn.Left x else x
                     let x = if cLoKey <= 0 && cKeyHi <= 0 then f.Invoke (mn.Key, mn.Value, x) else x
                     let x = if cKeyHi < 0 then foldFromTo f mn.Right x else x
-                    x
-                | _ ->
-                    let cLoKey = comparer.Compare(lo, m.Key)
-                    let cKeyHi = comparer.Compare(m.Key, hi)
-                    let x = if cLoKey <= 0 && cKeyHi <= 0 then f.Invoke (m.Key, m.Value, x) else x
                     x
 
         if comparer.Compare(lo, hi) = 1 then x else foldFromTo f m x
@@ -395,9 +427,12 @@ module MapTree =
         let rec loop (m: MapTree<'Key, 'Value>) acc = 
             if isEmpty m then acc
             else
-                match m with
-                | :? MapTreeNode<'Key, 'Value> as mn -> loop mn.Left ((mn.Key, mn.Value) :: loop mn.Right acc)
-                | _ -> (m.Key, m.Value) :: acc
+                match m.Height with
+                | 1 -> (m.Key, m.Value) :: acc
+                | _ ->
+                    let mn = asNode m
+                    loop mn.Left ((mn.Key, mn.Value) :: loop mn.Right acc)
+                
         loop m []
 
     let toArray m =
@@ -448,9 +483,11 @@ module MapTree =
         | m :: rest ->
             if isEmpty m then collapseLHS rest
             else
-                match m with
-                | :? MapTreeNode<'Key, 'Value> as mn -> collapseLHS (mn.Left :: MapTree (mn.Key, mn.Value) :: mn.Right :: rest)
-                | _ -> stack
+                match m.Height with
+                | 1 -> stack
+                | _ ->
+                    let mn = asNode m
+                    collapseLHS (mn.Left :: MapTree (mn.Key, mn.Value) :: mn.Right :: rest)
 
     let mkIterator m =
         { stack = collapseLHS [m]; started = false }
@@ -466,9 +503,9 @@ module MapTree =
             match i.stack with
             | []     -> alreadyFinished()
             | m :: _ ->
-                match m with
-                | :? MapTreeNode<'Key, 'Value> -> failwith "Please report error: Map iterator, unexpected stack for current"
-                | _ -> new KeyValuePair<_, _>(m.Key, m.Value)
+                match m.Height with
+                | 1 -> new KeyValuePair<_, _>(m.Key, m.Value)
+                | _ -> failwith "Please report error: Map iterator, unexpected stack for current"
         else
             notStarted()
 
@@ -477,11 +514,11 @@ module MapTree =
             match i.stack with
             | [] -> false
             | m :: rest ->
-                match m with
-                | :? MapTreeNode<'Key, 'Value> -> failwith "Please report error: Map iterator, unexpected stack for moveNext"
-                | _ ->
+                match m.Height with
+                | 1 ->
                     i.stack <- collapseLHS rest
                     not i.stack.IsEmpty
+                | _ -> failwith "Please report error: Map iterator, unexpected stack for moveNext"
         else
             i.started <- true  (* The first call to MoveNext "starts" the enumeration. *)
             not i.stack.IsEmpty


### PR DESCRIPTION
Following a discussion here https://github.com/dotnet/fsharp/pull/10768

Found a simple perf gain at the cost of 2 bytes per a Map item. A significant gain in `getItem/contains/add` due to replacement of `isinst` by `int32` equality check. Benchmarked against current main.

The change is to store the height in leaves and share the field with nodes. Use it as an implicit tag (a leaf when `height = 1`) instead of the type check. Compared to the old discussion, when Left/Right were proposed to be stored in a universal node, this adds 4 bytes to leaves or 2 bytes per item on average (vs 16/8).

The tradeoff is basically the only thing to consider. Code changes are trivial.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.200-preview.20601.7
  [Host] : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT DEBUG
  After  : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT
  Before : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT

MaxRelativeError=0.01  Arguments=/p:Optimize=true  IterationCount=20  
IterationTime=250.0000 ms  WarmupCount=1  

```
|      Method |    Job | BuildConfiguration |  Size |          Mean |        Error |       StdDev | Rank |    Gen 0 |  Gen 1 | Gen 2 | Allocated | Code Size |
|------------ |------- |------------------- |------ |--------------:|-------------:|-------------:|-----:|---------:|-------:|------:|----------:|----------:|
|     **getItem** |  **After** |         **LocalBuild** |   **100** |      **28.34 ns** |     **0.291 ns** |     **0.324 ns** |    **1** |        **-** |      **-** |     **-** |         **-** |      **93 B** |
|     getItem | Before |            Default |   100 |      36.48 ns |     0.206 ns |     0.212 ns |    2 |        - |      - |     - |         - |     119 B |
|     **getItem** |  **After** |         **LocalBuild** | **10000** |      **60.40 ns** |     **0.365 ns** |     **0.421 ns** |    **3** |        **-** |      **-** |     **-** |         **-** |      **93 B** |
|     getItem | Before |            Default | 10000 |      82.42 ns |     0.446 ns |     0.513 ns |    4 |        - |      - |     - |         - |     119 B |
|             |        |                    |       |               |              |              |      |          |        |       |           |           |
| **containsKey** |  **After** |         **LocalBuild** |   **100** |      **24.95 ns** |     **0.231 ns** |     **0.266 ns** |    **1** |        **-** |      **-** |     **-** |         **-** |     **155 B** |
| containsKey | Before |            Default |   100 |      29.23 ns |     0.385 ns |     0.412 ns |    2 |        - |      - |     - |         - |     175 B |
| **containsKey** |  **After** |         **LocalBuild** | **10000** |      **46.19 ns** |     **0.292 ns** |     **0.337 ns** |    **3** |        **-** |      **-** |     **-** |         **-** |     **155 B** |
| containsKey | Before |            Default | 10000 |      53.00 ns |     0.177 ns |     0.196 ns |    4 |        - |      - |     - |         - |     175 B |
|             |        |                    |       |               |              |              |      |          |        |       |           |           |
|   **itemCount** |  **After** |         **LocalBuild** |   **100** |     **179.55 ns** |     **1.426 ns** |     **1.643 ns** |    **1** |        **-** |      **-** |     **-** |         **-** |      **81 B** |
|   itemCount | Before |            Default |   100 |     217.68 ns |     1.816 ns |     1.865 ns |    2 |        - |      - |     - |         - |      96 B |
|   **itemCount** |  **After** |         **LocalBuild** | **10000** |  **33,454.41 ns** | **1,561.752 ns** | **1,798.516 ns** |    **3** |        **-** |      **-** |     **-** |         **-** |      **81 B** |
|   itemCount | Before |            Default | 10000 |  34,357.14 ns |   374.999 ns |   431.850 ns |    3 |        - |      - |     - |         - |      96 B |
|             |        |                    |       |               |              |              |      |          |        |       |           |           |
| **iterForeach** |  **After** |         **LocalBuild** |   **100** |   **3,223.95 ns** |    **23.071 ns** |    **23.692 ns** |    **2** |   **1.0311** |      **-** |     **-** |    **6520 B** |     **283 B** |
| iterForeach | Before |            Default |   100 |   3,082.44 ns |    28.212 ns |    30.186 ns |    1 |   0.9704 |      - |     - |    6120 B |     283 B |
| **iterForeach** |  **After** |         **LocalBuild** | **10000** | **336,049.08 ns** | **1,375.830 ns** | **1,472.123 ns** |    **4** | **101.0638** |      **-** |     **-** |  **640120 B** |     **283 B** |
| iterForeach | Before |            Default | 10000 | 317,291.41 ns |   511.972 ns |   525.758 ns |    3 |  95.6633 |      - |     - |  600120 B |     283 B |
|             |        |                    |       |               |              |              |      |          |        |       |           |           |
|     **addItem** |  **After** |         **LocalBuild** |   **100** |     **145.75 ns** |     **0.811 ns** |     **0.934 ns** |    **1** |   **0.0590** |      **-** |     **-** |     **374 B** |     **601 B** |
|     addItem | Before |            Default |   100 |     170.09 ns |     2.717 ns |     2.907 ns |    2 |   0.0584 |      - |     - |     369 B |     603 B |
|     **addItem** |  **After** |         **LocalBuild** | **10000** |  **36,414.43 ns** |   **415.002 ns** |   **477.917 ns** |    **3** |  **11.0000** | **3.6250** |     **-** |   **69724 B** |     **601 B** |
|     addItem | Before |            Default | 10000 |  37,677.58 ns |   103.857 ns |   111.126 ns |    4 |  11.0000 | 3.2500 |     - |   69324 B |     603 B |
|             |        |                    |       |               |              |              |      |          |        |       |           |           |
|  **removeItem** |  **After** |         **LocalBuild** |   **100** |      **12.33 ns** |     **0.114 ns** |     **0.112 ns** |    **1** |   **0.0064** |      **-** |     **-** |      **40 B** |     **425 B** |
|  removeItem | Before |            Default |   100 |      12.22 ns |     0.076 ns |     0.081 ns |    1 |   0.0064 |      - |     - |      40 B |     443 B |
|  **removeItem** |  **After** |         **LocalBuild** | **10000** |   **1,189.82 ns** |     **6.181 ns** |     **7.118 ns** |    **2** |   **0.6345** |      **-** |     **-** |    **4000 B** |     **425 B** |
|  removeItem | Before |            Default | 10000 |   1,188.84 ns |     7.846 ns |     8.720 ns |    2 |   0.6345 |      - |     - |    4000 B |     443 B |

