### PR TITLE
Add range of do keyword to SynExpr.Do.

### DIFF
--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -5281,7 +5281,7 @@ let TcMutRecDefnsEscapeCheck (binds: MutRecShapes<_, _, _>) env =
 
 let CheckLetOrDoInNamespace binds m =
     match binds with 
-    | [ Binding (None, (StandaloneExpression | DoBinding), false, false, [], _, _, _, None, (SynExpr.Do (SynExpr.Const (SynConst.Unit, _), _) | SynExpr.Const (SynConst.Unit, _)), _, _) ] ->
+    | [ Binding (None, (StandaloneExpression | DoBinding), false, false, [], _, _, _, None, (SynExpr.Do (SynExpr.Const (SynConst.Unit, _), _, _) | SynExpr.Const (SynConst.Unit, _)), _, _) ] ->
         ()
     | [] -> 
         error(NumberedError(FSComp.SR.tcNamespaceCannotContainValues(), m)) 

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -5683,7 +5683,7 @@ and TcExprUndelayed cenv overallTy env tpenv (synExpr: SynExpr) =
             // this will type-check the first expression over again.
             TcExpr cenv overallTy env tpenv otherExpr
 
-    | SynExpr.Do (synInnerExpr, m) ->
+    | SynExpr.Do (synInnerExpr, _, m) ->
         UnifyTypes cenv env m overallTy cenv.g.unit_ty
         TcStmtThatCantBeCtorBody cenv env tpenv synInnerExpr
 

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -695,6 +695,7 @@ type SynExpr =
     /// F# syntax: do expr
     | Do of
         expr: SynExpr *
+        keywordRange: range *
         range: range
 
     /// F# syntax: assert expr

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -643,7 +643,7 @@ let rec synExprContainsError inpExpr =
           | SynExpr.ArrayOrListOfSeqExpr (_, e, _)
           | SynExpr.Typed (e, _, _)
           | SynExpr.FromParseError (e, _)
-          | SynExpr.Do (e, _)
+          | SynExpr.Do (e, _, _)
           | SynExpr.Assert (e, _)
           | SynExpr.DotGet (e, _, _, _)
           | SynExpr.LongIdentSet (_, e, _)

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -3387,7 +3387,10 @@ declExpr:
 
   | hardwhiteDoBinding %prec expr_let
      { let e = snd $1
-       SynExpr.Do (e, unionRanges (rhs parseState 1).StartRange e.Range) }
+       let doKeywordRange = 
+           match fst $1 with
+           | BindingSet.BindingSetPreAttrs(m, _, _, _, _) -> m
+       SynExpr.Do (e, doKeywordRange, unionRanges (rhs parseState 1).StartRange e.Range) }
 
   | anonMatchingExpr %prec expr_function
       { $1 }

--- a/src/fsharp/service/ServiceAssemblyContent.fs
+++ b/src/fsharp/service/ServiceAssemblyContent.fs
@@ -563,7 +563,7 @@ module ParsedInput =
             | SynExpr.YieldOrReturn (_, e, _)
             | SynExpr.ArrayOrListOfSeqExpr (_, e, _)
             | SynExpr.CompExpr (_, _, e, _)
-            | SynExpr.Do (e, _)
+            | SynExpr.Do (e, _, _)
             | SynExpr.Assert (e, _)
             | SynExpr.Lazy (e, _)
             | SynExpr.YieldOrReturnFrom (_, e, _) -> walkExpr e

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -814,7 +814,7 @@ module InterfaceStubGenerator =
 
                 | SynExpr.Lazy (synExpr, _range) ->
                     walkExpr synExpr
-                | SynExpr.Do (synExpr, _range) ->
+                | SynExpr.Do (synExpr, _, _range) ->
                     walkExpr synExpr
                 | SynExpr.Assert (synExpr, _range) -> 
                     walkExpr synExpr

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -412,7 +412,7 @@ module public AstTraversal =
                      yield! synMatchClauseList |> List.map (fun x -> dive x x.RangeOfGuardAndRhs (traverseSynMatchClause path))]
                     |> pick expr
 
-                | SynExpr.Do (synExpr, _range) -> traverseSynExpr synExpr
+                | SynExpr.Do (synExpr, _, _range) -> traverseSynExpr synExpr
 
                 | SynExpr.Assert (synExpr, _range) -> traverseSynExpr synExpr
 

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -229,7 +229,7 @@ module Structure =
             | SynExpr.InferredDowncast (e, _)
             | SynExpr.InferredUpcast (e, _)
             | SynExpr.DotGet (e, _, _, _)
-            | SynExpr.Do (e, _)
+            | SynExpr.Do (e, _, _)
             | SynExpr.Typed (e, _, _)
             | SynExpr.DotIndexedGet (e, _, _, _) -> 
                 parseExpr e

--- a/src/fsharp/service/ServiceUntypedParse.fs
+++ b/src/fsharp/service/ServiceUntypedParse.fs
@@ -429,7 +429,7 @@ type FSharpParseFileResults(errors: FSharpDiagnostic[], input: ParsedInput optio
                   | SynExpr.Typed (e, _, _)
                   | SynExpr.FromParseError (e, _) 
                   | SynExpr.DiscardAfterMissingQualificationAfterDot (e, _) 
-                  | SynExpr.Do (e, _)
+                  | SynExpr.Do (e, _, _)
                   | SynExpr.Assert (e, _)
                   | SynExpr.Fixed (e, _)
                   | SynExpr.DotGet (e, _, _, _) 
@@ -1094,7 +1094,7 @@ module UntypedParseImpl =
                 List.tryPick walkClause synMatchClauseList
             | SynExpr.Match (_, e, synMatchClauseList, _) -> 
                 walkExprWithKind parentKind e |> Option.orElse (List.tryPick walkClause synMatchClauseList)
-            | SynExpr.Do (e, _) -> walkExprWithKind parentKind e
+            | SynExpr.Do (e, _, _) -> walkExprWithKind parentKind e
             | SynExpr.Assert (e, _) -> walkExprWithKind parentKind e
             | SynExpr.App (_, _, e1, e2, _) -> List.tryPick (walkExprWithKind parentKind) [e1; e2]
             | SynExpr.TypeApp (e, _, tys, _, _, _, _) -> 

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -6873,7 +6873,9 @@ FSharp.Compiler.SyntaxTree+SynExpr+DiscardAfterMissingQualificationAfterDot: FSh
 FSharp.Compiler.SyntaxTree+SynExpr+DiscardAfterMissingQualificationAfterDot: FSharp.Compiler.Text.Range range
 FSharp.Compiler.SyntaxTree+SynExpr+DiscardAfterMissingQualificationAfterDot: SynExpr expr
 FSharp.Compiler.SyntaxTree+SynExpr+DiscardAfterMissingQualificationAfterDot: SynExpr get_expr()
+FSharp.Compiler.SyntaxTree+SynExpr+Do: FSharp.Compiler.Text.Range get_keywordRange()
 FSharp.Compiler.SyntaxTree+SynExpr+Do: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.SyntaxTree+SynExpr+Do: FSharp.Compiler.Text.Range keywordRange
 FSharp.Compiler.SyntaxTree+SynExpr+Do: FSharp.Compiler.Text.Range range
 FSharp.Compiler.SyntaxTree+SynExpr+Do: SynExpr expr
 FSharp.Compiler.SyntaxTree+SynExpr+Do: SynExpr get_expr()
@@ -7572,7 +7574,7 @@ FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewAssert(SynExpr, FSharp.Compiler.T
 FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewCompExpr(Boolean, Microsoft.FSharp.Core.FSharpRef`1[System.Boolean], SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewConst(SynConst, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewDiscardAfterMissingQualificationAfterDot(SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewDo(SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewDo(SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewDoBang(SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewDotGet(SynExpr, FSharp.Compiler.Text.Range, LongIdentWithDots, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTree+SynExpr: SynExpr NewDotIndexedGet(SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTree+SynIndexerArg], FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)


### PR DESCRIPTION
This is related to https://github.com/dotnet/fsharp/issues/10198.
A different keyword than mentioned in the issue but the concept still stands.

Having this information would be useful to solve https://github.com/fsprojects/fantomas/issues/1343.

Let me know what you think @cartermp.