### PR TITLE
Add offet in WrapExpressionInParentheses fix

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/WrapExpressionInParentheses.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/WrapExpressionInParentheses.fs
@@ -31,7 +31,6 @@ type internal FSharpWrapExpressionInParenthesesFixProvider() =
                     title,
                     (fun (cancellationToken: CancellationToken) ->
                         async {
-                            let! cancellationToken = Async.CancellationToken
                             let! sourceText = context.Document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                             return context.Document.WithText(getChangedText sourceText)
                         } |> RoslynHelpers.StartAsyncAsTask(cancellationToken)),

--- a/vsintegration/src/FSharp.Editor/CodeFix/WrapExpressionInParentheses.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/WrapExpressionInParentheses.fs
@@ -24,7 +24,7 @@ type internal FSharpWrapExpressionInParenthesesFixProvider() =
 
             let getChangedText (sourceText: SourceText) =
                 sourceText.WithChanges(TextChange(TextSpan(context.Span.Start, 0), "("))
-                          .WithChanges(TextChange(TextSpan(context.Span.End, 0), ")"))
+                          .WithChanges(TextChange(TextSpan(context.Span.End + 1, 0), ")"))
 
             context.RegisterCodeFix(
                 CodeAction.Create(


### PR DESCRIPTION
There was a subtle bug in here that would cause the fixer to fail on this code:

```fsharp
type C() =
    member _.P = "Phillip"

printfn "Hello %s" C().P
```

The reason it would work when parentheses were at the end is because it would insert a parenthesis one space before, but the end parenthesis would make it look like it worked. The offset is needed because we already inserted a new character at the end.