### PR TITLE
[WIP] - Resolving ONNX runtime fails

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -665,17 +665,17 @@
     <Compile Include="..\FxResolver.fs">
       <Link>Driver\FxResolver.fs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi">
+        <Link>Driver\NativeDllResolveHandler.fsi</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs">
+        <Link>Driver\NativeDllResolveHandler.fs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fsi">
       <Link>Driver\AssemblyResolveHandler.fsi</Link>
     </Compile>
     <Compile Include="..\Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs">
       <Link>Driver\AssemblyResolveHandler.fs</Link>
-    </Compile>
-    <Compile Include="..\Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi">
-      <Link>Driver\NativeDllResolveHandler.fsi</Link>
-    </Compile>
-    <Compile Include="..\Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs">
-      <Link>Driver\NativeDllResolveHandler.fs</Link>
     </Compile>
     <Compile Include="..\Microsoft.DotNet.DependencyManager/DependencyProvider.fsi">
       <Link>Driver\DependencyProvider.fsi</Link>

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs
@@ -36,9 +36,11 @@ type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProb
 
     do eventInfo.AddEventHandler(defaultAssemblyLoadContext, handler)
 
-    member _.ResolveAssemblyNetStandard (ctxt: 'T) (assemblyName: AssemblyName): Assembly =
+    member this.ResolveAssemblyNetStandard (ctxt: 'T) (assemblyName: AssemblyName): Assembly =
         let loadAssembly path =
-            loadFromAssemblyPathMethod.Invoke(ctxt, [| path |]) :?> Assembly
+            let assembly = loadFromAssemblyPathMethod.Invoke(ctxt, [| path |]) :?> Assembly
+            (this :> IRegisterResolvers).RegisterAssemblyNativeResolvers(assembly)
+            assembly
 
         let assemblyPaths =
             match assemblyProbingPaths with
@@ -58,7 +60,7 @@ type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProb
 
     interface IRegisterResolvers with
         member _.RegisterAssemblyNativeResolvers(assembly: Assembly) =
-            ignore assembly
+            nativeHandler.RegisterAssemblyNativeResolvers(assembly)
 
         member _.RegisterPackageRoots(roots: string seq) =
             nativeHandler.RegisterPackageRoots(roots)

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs
@@ -17,7 +17,7 @@ open System.Runtime.Loader
 type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProbe, nativeProbingRoots: NativeResolutionProbe) as this =
 
     let nativeHandler =
-        new NativeDllResolveHandler(nativeProbingRoots)
+        new NativeDllResolveHandler(nativeProbingRoots) :> IRegisterResolvers
 
     let assemblyLoadContextType: Type = Type.GetType("System.Runtime.Loader.AssemblyLoadContext, System.Runtime.Loader", false)
 

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fs
@@ -17,7 +17,7 @@ open System.Runtime.Loader
 type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProbe, nativeProbingRoots: NativeResolutionProbe) as this =
 
     let nativeHandler =
-        new NativeDllResolveHandler(nativeProbingRoots) :> IRegisterResolvers
+        new NativeDllResolveHandler(nativeProbingRoots)
 
     let assemblyLoadContextType: Type = Type.GetType("System.Runtime.Loader.AssemblyLoadContext, System.Runtime.Loader", false)
 
@@ -65,7 +65,7 @@ type AssemblyResolveHandlerCoreclr (assemblyProbingPaths: AssemblyResolutionProb
 
     interface IDisposable with
         member _.Dispose() =
-            (nativeHandler :> IDisposable).Dispose()
+            nativeHandler.Dispose()
             eventInfo.RemoveEventHandler(defaultAssemblyLoadContext, handler)
 
 /// Type that encapsulates AssemblyResolveHandler for managed packages

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fsi
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/AssemblyResolveHandler.fsi
@@ -12,6 +12,8 @@ type AssemblyResolutionProbe = delegate of Unit -> seq<string>
 type AssemblyResolveHandler =
 
     /// Construct a new DependencyProvider
-    new: assemblyProbingPaths: AssemblyResolutionProbe -> AssemblyResolveHandler
+    new: assemblyProbingPaths: AssemblyResolutionProbe * NativeResolutionProbe -> AssemblyResolveHandler
+
+    member internal RefreshPathsInEnvironment: string seq -> unit
 
     interface IDisposable

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/Microsoft.DotNet.DependencyManager.fsproj
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/Microsoft.DotNet.DependencyManager.fsproj
@@ -24,10 +24,10 @@
     <EmbeddedText Include="..\utils\UtilsStrings.txt" />
     <Compile Include="..\utils\RidHelpers.fs" />
     <Compile Include="..\utils\CompilerLocationUtils.fs" />
-    <Compile Include="AssemblyResolveHandler.fsi" />
-    <Compile Include="AssemblyResolveHandler.fs" />
     <Compile Include="NativeDllResolveHandler.fsi" />
     <Compile Include="NativeDllResolveHandler.fs" />
+    <Compile Include="AssemblyResolveHandler.fsi" />
+    <Compile Include="AssemblyResolveHandler.fs" />
     <Compile Include="DependencyProvider.fsi" />
     <Compile Include="DependencyProvider.fs" />
   </ItemGroup>

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs
@@ -110,6 +110,11 @@ type NativeDllResolveHandlerCoreClr (nativeProbingRoots: NativeResolutionProbe) 
         Func<Assembly, string, IntPtr> (resolveUnmanagedDll), 
         assemblyLoadContextType.GetProperty("Default", BindingFlags.Static ||| BindingFlags.Public).GetValue(null, null)
 
+    let loadHandler = new AssemblyLoadEventHandler(fun _ (args: AssemblyLoadEventArgs) ->
+        printfn "Loaded: %s" (args.LoadedAssembly.Location))
+
+    do AppDomain.CurrentDomain.add_AssemblyLoad(loadHandler)
+
     do eventInfo.AddEventHandler(defaultAssemblyLoadContext, handler)
 
     let ensureTrailingPathSeparator (p: string) =

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fs
@@ -24,9 +24,14 @@ type NativeDllResolveHandlerCoreClr (nativeProbingRoots: NativeResolutionProbe) 
 
     static let pathLock = new obj()
 
+    let nativeLibraryType: Type = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices", false)
+    let nativeDllImportResolverType: Type = Type.GetType("System.Runtime.InteropServices.DllImportResolver, System.Runtime.InteropServices", false)
+
     let nativeLibraryTryLoad =
-        let nativeLibraryType: Type = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices", false)
         nativeLibraryType.GetMethod("TryLoad", [| typeof<string>; typeof<IntPtr>.MakeByRefType() |])
+
+    let _nativeLibrarySetDllImportResolver =
+        nativeLibraryType.GetMethod("SetDllImportResolver", [| typeof<Assembly>; nativeDllImportResolverType |])
 
     let loadNativeLibrary path =
         let arguments = [| path:>obj; IntPtr.Zero:>obj |]
@@ -132,6 +137,22 @@ type NativeDllResolveHandlerCoreClr (nativeProbingRoots: NativeResolutionProbe) 
                 let probe = useOSSpecificDirectorySeparator (ensureTrailingPathSeparator probePath)
                 let path = ensureTrailingPathSeparator (Environment.GetEnvironmentVariable("PATH"))
                 if path.Contains(probe) then Environment.SetEnvironmentVariable("PATH", path.Replace(probe, "")))
+
+    static member private ImportResolver<'T>(libraryName:string, assembly:Assembly, searchPath: 'T) : IntPtr =
+     //(*DllImportSearchPath? searchPath*)
+     (*
+            IntPtr libHandle = IntPtr.Zero;
+            if (libraryName == MyLibrary)
+            {
+                // Try using the system library 'libmylibrary.so.5'
+                NativeLibrary.TryLoad("libmylibrary.so.5", assembly, DllImportSearchPath.System32, out libHandle);
+            }
+            return libHandle;
+     *)
+        ignore libraryName
+        ignore assembly
+        ignore searchPath
+        IntPtr.Zero
 
     interface IRegisterResolvers with
         member _.RegisterAssemblyNativeResolvers(assembly: Assembly) =

--- a/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi
+++ b/src/fsharp/Microsoft.DotNet.DependencyManager/NativeDllResolveHandler.fsi
@@ -3,10 +3,16 @@
 namespace Microsoft.DotNet.DependencyManager
 
 open System
+open System.Reflection
 
 /// Signature for Native library resolution probe callback
 /// host implements this, it's job is to return a list of package roots to probe.
 type NativeResolutionProbe = delegate of Unit -> seq<string>
+
+type IRegisterResolvers =
+    inherit IDisposable
+    abstract RegisterAssemblyNativeResolvers: Assembly -> unit
+    abstract RegisterPackageRoots: string seq -> unit
 
 // Cut down AssemblyLoadContext, for loading native libraries
 type NativeDllResolveHandler =
@@ -14,6 +20,5 @@ type NativeDllResolveHandler =
     /// Construct a new NativeDllResolveHandler
     new: nativeProbingRoots: NativeResolutionProbe -> NativeDllResolveHandler
 
-    member internal RefreshPathsInEnvironment: string seq -> unit
-
+    interface IRegisterResolvers
     interface IDisposable

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -472,7 +472,7 @@ printfn ""%A"" result
         resolverPackageRoots <- result.Roots
         resolverReferences <- result.Resolutions
 
-        use _assemblyResolver = new AssemblyResolveHandler(AssemblyResolutionProbe(assemblyProbingPaths))
+        use _assemblyResolver = new AssemblyResolveHandler(AssemblyResolutionProbe(assemblyProbingPaths), NativeResolutionProbe(nativeProbingRoots))
 
         // Build and execute script
         let referenceText =
@@ -643,9 +643,14 @@ x |> Seq.iter(fun r ->
             assemblyFound <- true
             Seq.empty<string>
 
+        let mutable nativeFound = false
+        let nativeProbingRoots () =
+            nativeFound <- true
+            Seq.empty<string>
+
         // Set up AssemblyResolver to resolve dll's
         do
-            use dp = new AssemblyResolveHandler(AssemblyResolutionProbe(assemblyProbingPaths))
+            use dp = new AssemblyResolveHandler(AssemblyResolutionProbe(assemblyProbingPaths), NativeResolutionProbe(nativeProbingRoots))
 
             // Invoking a non-existent assembly causes a probe. which should invoke the call back
             try Assembly.Load("NoneSuchAssembly") |> ignore with _ -> ()


### PR DESCRIPTION
fixes https://github.com/dotnet/fsharp/issues/10856

The never ending quest to narrow down package management corner cases continues ...

So ... the Microsoft.ML.Onnx.Runtime nuget package carries a native dll ````onnxruntime.dll````.

The Microsoft.ML.OnnxRuntime.Managed has dll, that has a pinvoke dependency on ````onnxruntime.dll````.

What happened:

- The when the pinvoke was invoked, the coreclr tries to load the ````onnxruntime.dll```` and it finds the one shipped with windows in ````c:\windows\system32````.

This happens because the coreclr native dll loader has a probing heuristic, local directory, whatever is in the deps.json file, then delegate to the os loader, which examines the path.  Which obviously ends up looking in system32 and loads from there.

The version in the sindows\system32 is old, and doesn't have the same entry points as are found in the later versions, so the pinvoke failed.

The package manager already added the search paths of packages to the process level environment variable, however, we added them to the tail end of the path which meant the OS loader found the system32 implementation first.  Obviously we want the package manager to be able to override the environmental set up and thus, we modified how we generate the path to include the package manager discovered probing path at the start of the process level path environment variable.

Following this change the nuget package version of ````onnxruntime.dll```` will be loaded for scripts that specify
````
#r "nuget:Microsoft.ML.Onnx.Runtime"


