### PR TITLE
Set: comparer optimization

### DIFF
--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -108,6 +108,9 @@
     <Compile Include="array3.fs">
       <Link>Collections/array3.fs</Link>
     </Compile>
+    <Compile Include="mapsetcmp.fs">
+      <Link>Collections/mapsetcmp.fs</Link>
+    </Compile>
     <Compile Include="map.fsi">
       <Link>Collections/map.fsi</Link>
     </Compile>

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -2,11 +2,8 @@
 namespace Microsoft.FSharp.Collections
 
 open System
-open System.Collections
 open System.Collections.Generic
 open System.Diagnostics
-open System.Numerics
-open System.Reflection
 open System.Runtime.CompilerServices
 open System.Text
 open Microsoft.FSharp.Core
@@ -30,120 +27,10 @@ type internal MapTreeNode<'Key, 'Value>(k:'Key, v:'Value, left:MapTree<'Key, 'Va
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module MapTree = 
+    open MapSetDefaultComparison
     
     let empty = null
    
-    type CompareHelper<'T when 'T : comparison>() =
-        static let c = LanguagePrimitives.FastGenericComparer
-        
-        // A constrained call to IComparable<'T>.CompareTo                
-        static member private CompareCG<'U when  'U :> IComparable<'U>>(l:'U, r:'U):int = l.CompareTo(r)
-
-        // A call to IComparable.CompareTo
-        static member private CompareC<'U when  'U :> IComparable>(l:'U, r:'U):int = l.CompareTo(r)
-
-        static member val CompareToDlg : Func<'T,'T,int> =
-                let dlg =
-                    let ty = typeof<'T>
-                    try 
-                        let normalCmp =
-                            not (typeof<IStructuralComparable>.IsAssignableFrom(ty))
-                            && isNull (Attribute.GetCustomAttribute(ty, typeof<NoComparisonAttribute>))
-                            && isNull (Attribute.GetCustomAttribute(ty, typeof<StructuralComparisonAttribute>))
-                            && not (ty.IsArray)
-                             
-                        // See #816, IComparable<'T> actually does not satisfy comparison constraint, but it should be preferred 
-                        if typeof<IComparable<'T>>.IsAssignableFrom(ty) then 
-                            let m =
-                                typeof<CompareHelper<'T>>.GetMethod("CompareCG", BindingFlags.NonPublic ||| BindingFlags.Static)
-                                    .MakeGenericMethod([|ty|])
-                            Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
-                        elif typeof<IComparable>.IsAssignableFrom(ty) && normalCmp then 
-                            let m =
-                                typeof<CompareHelper<'T>>.GetMethod("CompareC", BindingFlags.NonPublic ||| BindingFlags.Static)
-                                    .MakeGenericMethod([|typeof<'T>|])
-                            Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
-                        else null
-                    with _ -> null
-                dlg
-            with get
-            
-        // If backed by static readonly field that will be JIT-time constant
-        static member val IsIComparable = not(isNull CompareHelper<'T>.CompareToDlg) with get
-            
-        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
-        static member Compare(l:'T, r:'T):int =
-            // Should use IsIComparable when it's backed by static readonly field
-            if isNull CompareHelper<'T>.CompareToDlg then
-                c.Compare(l, r)
-            else
-                CompareHelper<'T>.CompareToDlg.Invoke(l,r)
-            
-    // Constructors are not inlined by F#, but JIT could inline them.
-    // This is what we need here, because LanguagePrimitives.FastGenericComparer.Compare
-    // has a .tail prefix that breaks the typeof(T)==typeof(...) JIT optimization in cmp
-    // A struct with a single int field should be lowered by JIT.
-    [<Struct>]
-    [<NoEquality; NoComparison>] 
-    type Comparison<'T when 'T : comparison> =
-        struct
-            val Value: int
-            [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
-            new(l:'T,r:'T) = { Value = CompareHelper<'T>.Compare(l, r) }
-        end
-        
-    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
-    let cmp<'T when 'T : comparison> (l:'T) (r:'T) : int =
-        // See the pattern explanation: https://github.com/dotnet/runtime/blob/4b8d10154c39b1f56424d4ba2068a3150d90d475/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs#L14
-        // All types that implement IComparable<'T> and are accessible here without additional dependencies should be in the list 
-        if Type.op_Equality(typeof<'T>, typeof<sbyte>) then unbox<sbyte>(box(l)).CompareTo(unbox<sbyte>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<int16>) then unbox<int16>(box(l)).CompareTo(unbox<int16>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<int32>) then unbox<int32>(box(l)).CompareTo(unbox<int32>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<int64>) then unbox<int64>(box(l)).CompareTo(unbox<int64>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<byte>) then unbox<byte>(box(l)).CompareTo(unbox<byte>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<uint16>) then unbox<uint16>(box(l)).CompareTo(unbox<uint16>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<uint32>) then unbox<uint32>(box(l)).CompareTo(unbox<uint32>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<uint64>) then unbox<uint64>(box(l)).CompareTo(unbox<uint64>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<nativeint>) then
-            unbox<nativeint>(box(l)).ToInt64().CompareTo( (unbox<nativeint>(box(r))).ToInt64())
-        else if Type.op_Equality(typeof<'T>, typeof<unativeint>) then
-            unbox<unativeint>(box(l)).ToUInt64().CompareTo( (unbox<unativeint>(box(r))).ToUInt64())
-        else if Type.op_Equality(typeof<'T>, typeof<bool>) then unbox<bool>(box(l)).CompareTo(unbox<bool>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<char>) then unbox<char>(box(l)).CompareTo(unbox<char>(box(r)))
-        
-        // F# rules for floats
-        else if Type.op_Equality(typeof<'T>, typeof<float>) then
-            let l = unbox<float>(box(l))
-            let r = unbox<float>(box(r))
-            if  l < r then (-1)
-            elif l > r then (1)
-            elif l = r then (0)
-            elif r = r then (-1)
-            elif l = l then (1)
-            else 0
-        else if Type.op_Equality(typeof<'T>, typeof<float32>) then
-            let l = unbox<float32>(box(l))
-            let r = unbox<float32>(box(r))
-            if  l < r then (-1)
-            elif l > r then (1)
-            elif l = r then (0)
-            elif r = r then (-1)
-            elif l = l then (1)
-            else 0
-        else if Type.op_Equality(typeof<'T>, typeof<decimal>) then unbox<decimal>(box(l)).CompareTo(unbox<decimal>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<DateTime>) then unbox<DateTime>(box(l)).CompareTo(unbox<DateTime>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<DateTimeOffset>) then unbox<DateTimeOffset>(box(l)).CompareTo(unbox<DateTimeOffset>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<TimeSpan>) then unbox<TimeSpan>(box(l)).CompareTo(unbox<TimeSpan>(box(r)))
-        
-        else if Type.op_Equality(typeof<'T>, typeof<BigInteger>) then unbox<BigInteger>(box(l)).CompareTo(unbox<BigInteger>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<Guid>) then unbox<Guid>(box(l)).CompareTo(unbox<Guid>(box(r)))
-        
-        else if Type.op_Equality(typeof<'T>, typeof<string>) then
-            // same as in GenericComparisonFast
-            String.CompareOrdinal(unbox<string>(box(l)),(unbox<string>(box(r))))
-        
-        else Comparison(l,r).Value
-
     let inline isEmpty (m:MapTree<'Key, 'Value>) = isNull m
         
     let inline private asNode(value:MapTree<'Key,'Value>) : MapTreeNode<'Key,'Value> =
@@ -865,7 +752,7 @@ type Map<[<EqualityConditionalOn>]'Key, [<EqualityConditionalOn; ComparisonCondi
             | :? Map<'Key, 'Value>  as m2->
                 Seq.compareWith 
                    (fun (kvp1 : KeyValuePair<_, _>) (kvp2 : KeyValuePair<_, _>)-> 
-                       let c = MapTree.cmp kvp1.Key kvp2.Key in 
+                       let c = MapSetDefaultComparison.cmp kvp1.Key kvp2.Key in 
                        if c <> 0 then c else Unchecked.compare kvp1.Value kvp2.Value)
                    m m2 
             | _ -> 

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -41,9 +41,11 @@ module MapTree =
         if isEmpty m then
             acc
         else
-            match m.Height with
-            | 1 -> acc + 1
-            | _ -> let mn = asNode m in sizeAux (sizeAux (acc+1) mn.Left) mn.Right 
+            if m.Height = 1 then
+                acc + 1
+            else
+                let mn = asNode m
+                sizeAux (sizeAux (acc+1) mn.Left) mn.Right 
             
     let size x = sizeAux 0 x
 
@@ -128,12 +130,11 @@ module MapTree =
         if isEmpty m then MapTree(k,v)
         else
             let c = comparer.Compare(k,m.Key)
-            match m.Height with
-            | 1 ->
+            if m.Height = 1 then
                 if c < 0   then MapTreeNode (k,v,empty,m,2) :> MapTree<'Key, 'Value>
                 elif c = 0 then MapTree(k,v)
                 else            MapTreeNode (k,v,m,empty,2) :> MapTree<'Key, 'Value> 
-            | _ ->
+            else
                 let mn = asNode m
                 if c < 0 then rebalance (add comparer k v mn.Left) mn.Key mn.Value mn.Right
                 elif c = 0 then MapTreeNode(k,v,mn.Left,mn.Right,mn.Height) :> MapTree<'Key, 'Value>
@@ -145,9 +146,8 @@ module MapTree =
             let c = comparer.Compare(k, m.Key)
             if c = 0 then v <- m.Value; true
             else
-                match m.Height with
-                | 1 -> false
-                | _ ->
+                if m.Height = 1 then false
+                else
                     let mn = asNode m
                     tryGetValue comparer k &v (if c < 0 then mn.Left else mn.Right)
                 
@@ -175,15 +175,14 @@ module MapTree =
     let rec partitionAux (comparer: IComparer<'Key>) (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) acc = 
         if isEmpty m then acc
         else
-            match m.Height with        
-            | 1 -> partition1 comparer f m.Key m.Value acc
-            | _ ->
+            if m.Height = 1 then        
+                partition1 comparer f m.Key m.Value acc
+            else
                 let mn = asNode m
                 let acc = partitionAux comparer f mn.Right acc 
                 let acc = partition1 comparer f mn.Key mn.Value acc
                 partitionAux comparer f mn.Left acc
             
-
     let partition (comparer: IComparer<'Key>) f m =
         partitionAux comparer (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m (empty, empty)
 
@@ -193,9 +192,9 @@ module MapTree =
     let rec filterAux (comparer: IComparer<'Key>) (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) acc = 
         if isEmpty m then acc
         else
-            match m.Height with 
-            | 1 -> filter1 comparer f m.Key m.Value acc
-            | _ ->
+            if m.Height = 1 then  
+                filter1 comparer f m.Key m.Value acc
+            else
                 let mn = asNode m
                 let acc = filterAux comparer f mn.Left acc
                 let acc = filter1 comparer f mn.Key mn.Value acc
@@ -208,9 +207,9 @@ module MapTree =
     let rec spliceOutSuccessor (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then failwith "internal error: Map.spliceOutSuccessor"
         else
-            match m.Height with
-            | 1 -> m.Key, m.Value, empty
-            | _ ->
+            if m.Height = 1 then
+                m.Key, m.Value, empty
+            else
                 let mn = asNode m
                 if isEmpty mn.Left then mn.Key, mn.Value, mn.Right
                 else let k3, v3, l' = spliceOutSuccessor mn.Left in k3, v3, mk l' mn.Key mn.Value mn.Right
@@ -219,9 +218,9 @@ module MapTree =
         if isEmpty m then empty
         else
             let c = comparer.Compare(k, m.Key)
-            match m.Height with 
-            | 1 -> if c = 0 then empty else m
-            | _ ->
+            if m.Height = 1 then 
+                if c = 0 then empty else m
+            else
                 let mn = asNode m 
                 if c < 0 then rebalance (remove comparer k mn.Left) mn.Key mn.Value mn.Right
                 elif c = 0 then
@@ -239,8 +238,7 @@ module MapTree =
                 | None -> m
                 | Some v -> MapTree (k, v)
         else
-            match m.Height with
-            | 1 ->
+            if m.Height = 1 then
                 let c = comparer.Compare(k, m.Key)
                 if c < 0 then
                     match u None with
@@ -254,7 +252,7 @@ module MapTree =
                     match u None with
                     | None -> m
                     | Some v -> MapTreeNode (k, v, m, empty, 2) :> MapTree<'Key,'Value>
-            | _ ->
+            else
                 let mn = asNode m
                 let c = comparer.Compare(k, mn.Key)
                 if c < 0 then
@@ -275,9 +273,9 @@ module MapTree =
         if isEmpty m then false
         else
             let c = comparer.Compare(k, m.Key)
-            match m.Height with 
-            | 1 -> c = 0
-            | _ ->
+            if m.Height = 1 then 
+                c = 0
+            else
                 let mn = asNode m
                 if c < 0 then mem comparer k mn.Left
                 else (c = 0 || mem comparer k mn.Right)
@@ -286,9 +284,9 @@ module MapTree =
     let rec iterOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) =
         if isEmpty m then ()
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value)
+            else
                 let mn = asNode m
                 iterOpt f mn.Left; f.Invoke (mn.Key, mn.Value); iterOpt f mn.Right
             
@@ -299,9 +297,9 @@ module MapTree =
     let rec tryPickOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) =
         if isEmpty m then None
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value)
+            else
                 let mn = asNode m
                 match tryPickOpt f mn.Left with 
                 | Some _ as res -> res 
@@ -318,9 +316,9 @@ module MapTree =
     let rec existsOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then false
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value)
+            else
                 let mn = asNode m
                 existsOpt f mn.Left || f.Invoke (mn.Key, mn.Value) || existsOpt f mn.Right
             
@@ -331,9 +329,9 @@ module MapTree =
     let rec forallOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then true
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value)
+            else
                 let mn = asNode m
                 forallOpt f mn.Left && f.Invoke (mn.Key, mn.Value) && forallOpt f mn.Right
             
@@ -345,9 +343,9 @@ module MapTree =
     let rec map (f:'Value -> 'Result) (m: MapTree<'Key, 'Value>) : MapTree<'Key, 'Result> = 
         if isEmpty m then empty
         else
-            match m.Height with 
-            | 1 -> MapTree (m.Key, f m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                MapTree (m.Key, f m.Value)
+            else
                 let mn = asNode m
                 let l2 = map f mn.Left 
                 let v2 = f mn.Value
@@ -357,9 +355,9 @@ module MapTree =
     let rec mapiOpt (f: OptimizedClosures.FSharpFunc<'Key, 'Value, 'Result>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then empty
         else
-            match m.Height with
-            | 1 -> MapTree (m.Key, f.Invoke (m.Key, m.Value))
-            | _ ->
+            if m.Height = 1 then
+                MapTree (m.Key, f.Invoke (m.Key, m.Value))
+            else
                 let mn = asNode m
                 let l2 = mapiOpt f mn.Left
                 let v2 = f.Invoke (mn.Key, mn.Value) 
@@ -373,9 +371,9 @@ module MapTree =
     let rec foldBackOpt (f: OptimizedClosures.FSharpFunc<_, _, _, _>) (m: MapTree<'Key, 'Value>) x = 
         if isEmpty m then x
         else
-            match m.Height with 
-            | 1 -> f.Invoke (m.Key, m.Value, x)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (m.Key, m.Value, x)
+            else
                 let mn = asNode m
                 let x = foldBackOpt f mn.Right x
                 let x = f.Invoke (mn.Key, mn.Value, x)
@@ -388,9 +386,9 @@ module MapTree =
     let rec foldOpt (f: OptimizedClosures.FSharpFunc<_, _, _, _>) x (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then x
         else
-            match m.Height with 
-            | 1 -> f.Invoke (x, m.Key, m.Value)
-            | _ ->
+            if m.Height = 1 then 
+                f.Invoke (x, m.Key, m.Value)
+            else
                 let mn = asNode m
                 let x = foldOpt f x mn.Left
                 let x = f.Invoke (x, mn.Key, mn.Value)
@@ -403,13 +401,12 @@ module MapTree =
         let rec foldFromTo (f: OptimizedClosures.FSharpFunc<_, _, _, _>) (m: MapTree<'Key, 'Value>) x = 
             if isEmpty m then x
             else
-                match m.Height with 
-                | 1 ->
+                if m.Height = 1 then 
                     let cLoKey = comparer.Compare(lo, m.Key)
                     let cKeyHi = comparer.Compare(m.Key, hi)
                     let x = if cLoKey <= 0 && cKeyHi <= 0 then f.Invoke (m.Key, m.Value, x) else x
                     x
-                | _ ->
+                else
                     let mn = asNode m
                     let cLoKey = comparer.Compare(lo, mn.Key)
                     let cKeyHi = comparer.Compare(mn.Key, hi)
@@ -427,9 +424,9 @@ module MapTree =
         let rec loop (m: MapTree<'Key, 'Value>) acc = 
             if isEmpty m then acc
             else
-                match m.Height with
-                | 1 -> (m.Key, m.Value) :: acc
-                | _ ->
+                if m.Height = 1 then
+                    (m.Key, m.Value) :: acc
+                else
                     let mn = asNode m
                     loop mn.Left ((mn.Key, mn.Value) :: loop mn.Right acc)
                 
@@ -483,9 +480,9 @@ module MapTree =
         | m :: rest ->
             if isEmpty m then collapseLHS rest
             else
-                match m.Height with
-                | 1 -> stack
-                | _ ->
+                if m.Height = 1 then
+                    stack
+                else
                     let mn = asNode m
                     collapseLHS (mn.Left :: MapTree (mn.Key, mn.Value) :: mn.Right :: rest)
 
@@ -497,15 +494,20 @@ module MapTree =
 
     let alreadyFinished() =
         raise (InvalidOperationException(SR.GetString(SR.enumerationAlreadyFinished)))
+        
+    let unexpectedStackForCurrent() =
+        failwith "Please report error: Map iterator, unexpected stack for current"
+        
+    let unexpectedStackForMoveNext() =
+        failwith "Please report error: Map iterator, unexpected stack for moveNext"
 
     let current i =
         if i.started then
             match i.stack with
             | []     -> alreadyFinished()
             | m :: _ ->
-                match m.Height with
-                | 1 -> new KeyValuePair<_, _>(m.Key, m.Value)
-                | _ -> failwith "Please report error: Map iterator, unexpected stack for current"
+                if m.Height = 1 then KeyValuePair<_, _>(m.Key, m.Value)
+                else unexpectedStackForCurrent()
         else
             notStarted()
 
@@ -514,11 +516,10 @@ module MapTree =
             match i.stack with
             | [] -> false
             | m :: rest ->
-                match m.Height with
-                | 1 ->
+                if m.Height = 1 then
                     i.stack <- collapseLHS rest
                     not i.stack.IsEmpty
-                | _ -> failwith "Please report error: Map iterator, unexpected stack for moveNext"
+                else unexpectedStackForMoveNext()
         else
             i.started <- true  (* The first call to MoveNext "starts" the enumeration. *)
             not i.stack.IsEmpty

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -39,7 +39,7 @@ module MapTree =
         static member private CompareCG<'U when  'U :> IComparable<'U>>(l:'U, r:'U):int = l.CompareTo(r)
 
         // A call to IComparable.CompareTo
-        static member private CompareC<'U when  'U :> IComparable>(l:'U, r:'U):int = l.CompareTo(r)
+//        static member private CompareC<'U when  'U :> IComparable>(l:'U, r:'U):int = l.CompareTo(r)
 
         static member val CompareToDlg : Func<'T,'T,int> =
                 let dlg =
@@ -50,11 +50,11 @@ module MapTree =
                                 typeof<CompareHelper<'T>>.GetMethod("CompareCG", BindingFlags.NonPublic ||| BindingFlags.Static)
                                     .MakeGenericMethod([|typeof<'T>|])
                             Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
-                        elif typeof<IComparable>.IsAssignableFrom(typeof<'T>) then 
-                            let m =
-                                typeof<CompareHelper<'T>>.GetMethod("CompareC", BindingFlags.NonPublic ||| BindingFlags.Static)
-                                    .MakeGenericMethod([|typeof<'T>|])
-                            Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
+//                        elif typeof<IComparable>.IsAssignableFrom(typeof<'T>) then 
+//                            let m =
+//                                typeof<CompareHelper<'T>>.GetMethod("CompareC", BindingFlags.NonPublic ||| BindingFlags.Static)
+//                                    .MakeGenericMethod([|typeof<'T>|])
+//                            Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
                         else null
                     with _ -> null
                 dlg

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -46,23 +46,23 @@ module MapTree =
                 let dlg =
                     let ty = typeof<'T>
                     try 
-                        if not (typeof<IStructuralComparable>.IsAssignableFrom(ty))
-                             && isNull (Attribute.GetCustomAttribute(ty, typeof<NoComparisonAttribute>))
-                             && isNull (Attribute.GetCustomAttribute(ty, typeof<StructuralComparisonAttribute>))
-                             && not (ty.IsArray) then
-                        
-                            // See #816, IComparable<'T> actually does not satisfy comparison constraint, but it should be preferred 
-                            if typeof<IComparable<'T>>.IsAssignableFrom(ty) then 
-                                let m =
-                                    typeof<CompareHelper<'T>>.GetMethod("CompareCG", BindingFlags.NonPublic ||| BindingFlags.Static)
-                                        .MakeGenericMethod([|ty|])
-                                Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
-                            elif typeof<IComparable>.IsAssignableFrom(ty) then 
-                                let m =
-                                    typeof<CompareHelper<'T>>.GetMethod("CompareC", BindingFlags.NonPublic ||| BindingFlags.Static)
-                                        .MakeGenericMethod([|typeof<'T>|])
-                                Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
-                            else null
+                        let normalCmp =
+                            not (typeof<IStructuralComparable>.IsAssignableFrom(ty))
+                            && isNull (Attribute.GetCustomAttribute(ty, typeof<NoComparisonAttribute>))
+                            && isNull (Attribute.GetCustomAttribute(ty, typeof<StructuralComparisonAttribute>))
+                            && not (ty.IsArray)
+                             
+                        // See #816, IComparable<'T> actually does not satisfy comparison constraint, but it should be preferred 
+                        if typeof<IComparable<'T>>.IsAssignableFrom(ty) then 
+                            let m =
+                                typeof<CompareHelper<'T>>.GetMethod("CompareCG", BindingFlags.NonPublic ||| BindingFlags.Static)
+                                    .MakeGenericMethod([|ty|])
+                            Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
+                        elif typeof<IComparable>.IsAssignableFrom(ty) && normalCmp then 
+                            let m =
+                                typeof<CompareHelper<'T>>.GetMethod("CompareC", BindingFlags.NonPublic ||| BindingFlags.Static)
+                                    .MakeGenericMethod([|typeof<'T>|])
+                            Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
                         else null
                     with _ -> null
                 dlg

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -96,24 +96,32 @@ module MapTree =
         else if Type.op_Equality(typeof<'T>, typeof<uint16>) then unbox<uint16>(box(l)).CompareTo(unbox<uint16>(box(r)))
         else if Type.op_Equality(typeof<'T>, typeof<uint32>) then unbox<uint32>(box(l)).CompareTo(unbox<uint32>(box(r)))
         else if Type.op_Equality(typeof<'T>, typeof<uint64>) then unbox<uint64>(box(l)).CompareTo(unbox<uint64>(box(r)))
-        else if Type.op_Equality(typeof<'T>, typeof<nativeint>) then if (# "clt" l r : bool #) then (-1) else (# "cgt" l r : int #)
-        else if Type.op_Equality(typeof<'T>, typeof<unativeint>) then if (# "clt" l r : bool #) then (-1) else (# "cgt" l r : int #)
+        else if Type.op_Equality(typeof<'T>, typeof<nativeint>) then
+            unbox<nativeint>(box(l)).ToInt64().CompareTo( (unbox<nativeint>(box(r))).ToInt64())
+        else if Type.op_Equality(typeof<'T>, typeof<unativeint>) then
+            unbox<unativeint>(box(l)).ToUInt64().CompareTo( (unbox<unativeint>(box(r))).ToUInt64())
         else if Type.op_Equality(typeof<'T>, typeof<bool>) then unbox<bool>(box(l)).CompareTo(unbox<bool>(box(r)))
         else if Type.op_Equality(typeof<'T>, typeof<char>) then unbox<char>(box(l)).CompareTo(unbox<char>(box(r)))
         
         // F# rules for floats
         else if Type.op_Equality(typeof<'T>, typeof<float>) then
-            if   (# "clt" l r : bool #) then (-1)
-            elif (# "cgt" l r : bool #) then (1)
-            elif (# "ceq" l r : bool #) then (0)
-            elif (# "ceq" r r : bool #) then (-1)
-            else (# "ceq" l l : int #)
+            let l = unbox<float>(box(l))
+            let r = unbox<float>(box(r))
+            if  l < r then (-1)
+            elif l > r then (1)
+            elif l = r then (0)
+            elif r = r then (-1)
+            elif l = l then (1)
+            else 0
         else if Type.op_Equality(typeof<'T>, typeof<float32>) then
-            if   (# "clt" l r : bool #) then (-1)
-            elif (# "cgt" l r : bool #) then (1)
-            elif (# "ceq" l r : bool #) then (0)
-            elif (# "ceq" r r : bool #) then (-1)
-            else (# "ceq" l l : int #)
+            let l = unbox<float32>(box(l))
+            let r = unbox<float32>(box(r))
+            if  l < r then (-1)
+            elif l > r then (1)
+            elif l = r then (0)
+            elif r = r then (-1)
+            elif l = l then (1)
+            else 0
         else if Type.op_Equality(typeof<'T>, typeof<decimal>) then unbox<decimal>(box(l)).CompareTo(unbox<decimal>(box(r)))
         else if Type.op_Equality(typeof<'T>, typeof<DateTime>) then unbox<DateTime>(box(l)).CompareTo(unbox<DateTime>(box(r)))
         else if Type.op_Equality(typeof<'T>, typeof<DateTimeOffset>) then unbox<DateTimeOffset>(box(l)).CompareTo(unbox<DateTimeOffset>(box(r)))

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -73,11 +73,11 @@ module MapTree =
                (totalSizeOnMapLookup / float numLookups))
            System.Console.WriteLine("#largestMapSize = {0}, largestMapStackTrace = {1}", largestMapSize, largestMapStackTrace)
 
-    let MapTree n = 
+    let MapTree (k,v) = 
         report()
         numOnes <- numOnes + 1
         totalSizeOnNodeCreation <- totalSizeOnNodeCreation + 1.0
-        MapTree n
+        MapTree (k,v)
 
     let MapTreeNode (x, l, v, r, h) = 
         report()

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -5,25 +5,27 @@ namespace Microsoft.FSharp.Collections
 open System
 open System.Collections.Generic
 open System.Diagnostics
+open System.Runtime.CompilerServices
 open System.Text
 open Microsoft.FSharp.Core
 open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
 
 [<NoEquality; NoComparison>]
 [<AllowNullLiteral>]
-type internal MapTree<'Key, 'Value>(k: 'Key, v: 'Value) =
+type internal MapTree<'Key, 'Value>(k: 'Key, v: 'Value, h: int) =
+    member _.Height = h
     member _.Key = k
     member _.Value = v
-
+    new(k: 'Key, v: 'Value) = MapTree(k,v,1)
+    
 [<NoEquality; NoComparison>]
 [<Sealed>]
 [<AllowNullLiteral>]
 type internal MapTreeNode<'Key, 'Value>(k:'Key, v:'Value, left:MapTree<'Key, 'Value>, right: MapTree<'Key, 'Value>, h: int) =
-    inherit MapTree<'Key,'Value>(k, v)
-
+    inherit MapTree<'Key,'Value>(k, v, h)
     member _.Left = left
     member _.Right = right
-    member _.Height = h
+    
     
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module MapTree = 
@@ -32,14 +34,17 @@ module MapTree =
     
     let inline isEmpty (m:MapTree<'Key, 'Value>) = isNull m
         
+    let inline private asNode(value:MapTree<'Key,'Value>) : MapTreeNode<'Key,'Value> =
+        value :?> MapTreeNode<'Key,'Value>
+        
     let rec sizeAux acc (m:MapTree<'Key, 'Value>) = 
         if isEmpty m then
             acc
         else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn -> sizeAux (sizeAux (acc+1) mn.Left) mn.Right 
-            | _ -> acc + 1
-
+            match m.Height with
+            | 1 -> acc + 1
+            | _ -> let mn = asNode m in sizeAux (sizeAux (acc+1) mn.Left) mn.Right 
+            
     let size x = sizeAux 0 x
 
 #if TRACE_SETS_AND_MAPS
@@ -82,10 +87,7 @@ module MapTree =
 
     let inline height (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then 0
-        else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn -> mn.Height
-            | _ -> 1
+        else m.Height
     
     [<Literal>]
     let tolerance = 2
@@ -98,9 +100,6 @@ module MapTree =
             MapTree(k,v)
         else
             MapTreeNode(k,v,l,r,m+1) :> MapTree<'Key, 'Value>  // new map is higher by 1 than the highest
-    
-    let inline private asNode(value:MapTree<'Key,'Value>) : MapTreeNode<'Key,'Value> =
-        value :?> MapTreeNode<'Key,'Value>
         
     let rebalance t1 (k: 'Key) (v: 'Value) t2 : MapTree<'Key, 'Value> =
         let t1h = height t1
@@ -129,33 +128,39 @@ module MapTree =
         if isEmpty m then MapTree(k,v)
         else
             let c = comparer.Compare(k,m.Key)
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn ->
-                if c < 0 then rebalance (add comparer k v mn.Left) mn.Key mn.Value mn.Right
-                elif c = 0 then MapTreeNode(k,v,mn.Left,mn.Right,mn.Height) :> MapTree<'Key, 'Value>
-                else rebalance mn.Left mn.Key mn.Value (add comparer k v mn.Right)
-            | _ ->
+            match m.Height with
+            | 1 ->
                 if c < 0   then MapTreeNode (k,v,empty,m,2) :> MapTree<'Key, 'Value>
                 elif c = 0 then MapTree(k,v)
                 else            MapTreeNode (k,v,m,empty,2) :> MapTree<'Key, 'Value> 
-
+            | _ ->
+                let mn = asNode m
+                if c < 0 then rebalance (add comparer k v mn.Left) mn.Key mn.Value mn.Right
+                elif c = 0 then MapTreeNode(k,v,mn.Left,mn.Right,mn.Height) :> MapTree<'Key, 'Value>
+                else rebalance mn.Left mn.Key mn.Value (add comparer k v mn.Right)
+                
     let rec tryGetValue (comparer: IComparer<'Key>) k (v: byref<'Value>) (m: MapTree<'Key, 'Value>) =                     
         if isEmpty m then false
         else
             let c = comparer.Compare(k, m.Key)
             if c = 0 then v <- m.Value; true
             else
-                match m with
-                | :? MapTreeNode<'Key, 'Value> as mn ->
+                match m.Height with
+                | 1 -> false
+                | _ ->
+                    let mn = asNode m
                     tryGetValue comparer k &v (if c < 0 then mn.Left else mn.Right)
-                | _ -> false
-
+                
+    [<MethodImpl(MethodImplOptions.NoInlining)>]
+    let throwKeyNotFound() = raise (KeyNotFoundException())
+    
+    [<MethodImpl(MethodImplOptions.NoInlining)>]
     let find (comparer: IComparer<'Key>) k (m: MapTree<'Key, 'Value>) =
         let mutable v = Unchecked.defaultof<'Value>
         if tryGetValue comparer k &v m then
             v
         else
-            raise (KeyNotFoundException())
+            throwKeyNotFound()
 
     let tryFind (comparer: IComparer<'Key>) k (m: MapTree<'Key, 'Value>) = 
         let mutable v = Unchecked.defaultof<'Value>
@@ -170,12 +175,14 @@ module MapTree =
     let rec partitionAux (comparer: IComparer<'Key>) (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) acc = 
         if isEmpty m then acc
         else
-            match m with        
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with        
+            | 1 -> partition1 comparer f m.Key m.Value acc
+            | _ ->
+                let mn = asNode m
                 let acc = partitionAux comparer f mn.Right acc 
                 let acc = partition1 comparer f mn.Key mn.Value acc
                 partitionAux comparer f mn.Left acc
-            | _ -> partition1 comparer f m.Key m.Value acc
+            
 
     let partition (comparer: IComparer<'Key>) f m =
         partitionAux comparer (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m (empty, empty)
@@ -186,12 +193,14 @@ module MapTree =
     let rec filterAux (comparer: IComparer<'Key>) (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) acc = 
         if isEmpty m then acc
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> filter1 comparer f m.Key m.Value acc
+            | _ ->
+                let mn = asNode m
                 let acc = filterAux comparer f mn.Left acc
                 let acc = filter1 comparer f mn.Key mn.Value acc
                 filterAux comparer f mn.Right acc
-            | _ -> filter1 comparer f m.Key m.Value acc
+            
 
     let filter (comparer: IComparer<'Key>) f m =
         filterAux comparer (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m empty
@@ -199,18 +208,21 @@ module MapTree =
     let rec spliceOutSuccessor (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then failwith "internal error: Map.spliceOutSuccessor"
         else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with
+            | 1 -> m.Key, m.Value, empty
+            | _ ->
+                let mn = asNode m
                 if isEmpty mn.Left then mn.Key, mn.Value, mn.Right
                 else let k3, v3, l' = spliceOutSuccessor mn.Left in k3, v3, mk l' mn.Key mn.Value mn.Right
-            | _ -> m.Key, m.Value, empty
 
     let rec remove (comparer: IComparer<'Key>) k (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then empty
         else
             let c = comparer.Compare(k, m.Key)
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> if c = 0 then empty else m
+            | _ ->
+                let mn = asNode m 
                 if c < 0 then rebalance (remove comparer k mn.Left) mn.Key mn.Value mn.Right
                 elif c = 0 then
                     if isEmpty mn.Left then mn.Right
@@ -219,8 +231,7 @@ module MapTree =
                         let sk, sv, r' = spliceOutSuccessor mn.Right 
                         mk mn.Left sk sv r'
                 else rebalance mn.Left mn.Key mn.Value (remove comparer k mn.Right)
-            | _ ->
-                if c = 0 then empty else m
+            
 
     let rec change (comparer: IComparer<'Key>) k (u: 'Value option -> 'Value option) (m: MapTree<'Key, 'Value>) : MapTree<'Key,'Value> =
         if isEmpty m then
@@ -228,8 +239,23 @@ module MapTree =
                 | None -> m
                 | Some v -> MapTree (k, v)
         else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with
+            | 1 ->
+                let c = comparer.Compare(k, m.Key)
+                if c < 0 then
+                    match u None with
+                    | None -> m
+                    | Some v -> MapTreeNode (k, v, empty, m, 2) :> MapTree<'Key,'Value>
+                elif c = 0 then
+                    match u (Some m.Value) with
+                    | None -> empty
+                    | Some v -> MapTree (k, v)
+                else
+                    match u None with
+                    | None -> m
+                    | Some v -> MapTreeNode (k, v, m, empty, 2) :> MapTree<'Key,'Value>
+            | _ ->
+                let mn = asNode m
                 let c = comparer.Compare(k, mn.Key)
                 if c < 0 then
                     rebalance (change comparer k u mn.Left) mn.Key mn.Value mn.Right
@@ -244,37 +270,28 @@ module MapTree =
                     | Some v -> MapTreeNode (k, v, mn.Left, mn.Right, mn.Height) :> MapTree<'Key,'Value>
                 else
                     rebalance mn.Left mn.Key mn.Value (change comparer k u mn.Right)
-            | _ ->
-                let c = comparer.Compare(k, m.Key)
-                if c < 0 then
-                    match u None with
-                    | None -> m
-                    | Some v -> MapTreeNode (k, v, empty, m, 2) :> MapTree<'Key,'Value>
-                elif c = 0 then
-                    match u (Some m.Value) with
-                    | None -> empty
-                    | Some v -> MapTree (k, v)
-                else
-                    match u None with
-                    | None -> m
-                    | Some v -> MapTreeNode (k, v, m, empty, 2) :> MapTree<'Key,'Value>
 
     let rec mem (comparer: IComparer<'Key>) k (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then false
         else
             let c = comparer.Compare(k, m.Key)
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> c = 0
+            | _ ->
+                let mn = asNode m
                 if c < 0 then mem comparer k mn.Left
                 else (c = 0 || mem comparer k mn.Right)
-            | _ -> c = 0
+            
 
     let rec iterOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) =
         if isEmpty m then ()
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn -> iterOpt f mn.Left; f.Invoke (mn.Key, mn.Value); iterOpt f mn.Right
-            | _ -> f.Invoke (m.Key, m.Value)
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
+                iterOpt f mn.Left; f.Invoke (mn.Key, mn.Value); iterOpt f mn.Right
+            
 
     let iter f m =
         iterOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m
@@ -282,8 +299,10 @@ module MapTree =
     let rec tryPickOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) =
         if isEmpty m then None
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
                 match tryPickOpt f mn.Left with 
                 | Some _ as res -> res 
                 | None -> 
@@ -291,7 +310,7 @@ module MapTree =
                 | Some _ as res -> res 
                 | None -> 
                 tryPickOpt f mn.Right
-            | _ -> f.Invoke (m.Key, m.Value)
+            
 
     let tryPick f m =
         tryPickOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m
@@ -299,9 +318,12 @@ module MapTree =
     let rec existsOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then false
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn -> existsOpt f mn.Left || f.Invoke (mn.Key, mn.Value) || existsOpt f mn.Right
-            | _ -> f.Invoke (m.Key, m.Value)
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
+                existsOpt f mn.Left || f.Invoke (mn.Key, mn.Value) || existsOpt f mn.Right
+            
 
     let exists f m =
         existsOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m
@@ -309,9 +331,12 @@ module MapTree =
     let rec forallOpt (f: OptimizedClosures.FSharpFunc<_, _, _>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then true
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn -> forallOpt f mn.Left && f.Invoke (mn.Key, mn.Value) && forallOpt f mn.Right
-            | _ -> f.Invoke (m.Key, m.Value)
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
+                forallOpt f mn.Left && f.Invoke (mn.Key, mn.Value) && forallOpt f mn.Right
+            
             
 
     let forall f m =
@@ -320,24 +345,27 @@ module MapTree =
     let rec map (f:'Value -> 'Result) (m: MapTree<'Key, 'Value>) : MapTree<'Key, 'Result> = 
         if isEmpty m then empty
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn -> 
+            match m.Height with 
+            | 1 -> MapTree (m.Key, f m.Value)
+            | _ ->
+                let mn = asNode m
                 let l2 = map f mn.Left 
                 let v2 = f mn.Value
                 let r2 = map f mn.Right
                 MapTreeNode (mn.Key, v2, l2, r2, mn.Height) :> MapTree<'Key, 'Result>
-            | _ -> MapTree (m.Key, f m.Value)
 
     let rec mapiOpt (f: OptimizedClosures.FSharpFunc<'Key, 'Value, 'Result>) (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then empty
         else
-            match m with
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with
+            | 1 -> MapTree (m.Key, f.Invoke (m.Key, m.Value))
+            | _ ->
+                let mn = asNode m
                 let l2 = mapiOpt f mn.Left
                 let v2 = f.Invoke (mn.Key, mn.Value) 
                 let r2 = mapiOpt f mn.Right
                 MapTreeNode (mn.Key, v2, l2, r2, mn.Height) :> MapTree<'Key, 'Result>
-            | _ -> MapTree (m.Key, f.Invoke (m.Key, m.Value))
+            
 
     let mapi f m =
         mapiOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m
@@ -345,12 +373,14 @@ module MapTree =
     let rec foldBackOpt (f: OptimizedClosures.FSharpFunc<_, _, _, _>) (m: MapTree<'Key, 'Value>) x = 
         if isEmpty m then x
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> f.Invoke (m.Key, m.Value, x)
+            | _ ->
+                let mn = asNode m
                 let x = foldBackOpt f mn.Right x
                 let x = f.Invoke (mn.Key, mn.Value, x)
                 foldBackOpt f mn.Left x
-            | _ -> f.Invoke (m.Key, m.Value, x)
+            
 
     let foldBack f m x =
         foldBackOpt (OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt f) m x
@@ -358,12 +388,13 @@ module MapTree =
     let rec foldOpt (f: OptimizedClosures.FSharpFunc<_, _, _, _>) x (m: MapTree<'Key, 'Value>) = 
         if isEmpty m then x
         else
-            match m with 
-            | :? MapTreeNode<'Key, 'Value> as mn ->
+            match m.Height with 
+            | 1 -> f.Invoke (x, m.Key, m.Value)
+            | _ ->
+                let mn = asNode m
                 let x = foldOpt f x mn.Left
                 let x = f.Invoke (x, mn.Key, mn.Value)
                 foldOpt f x mn.Right
-            | _ -> f.Invoke (x, m.Key, m.Value)
 
     let fold f x m =
         foldOpt (OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt f) x m
@@ -372,18 +403,19 @@ module MapTree =
         let rec foldFromTo (f: OptimizedClosures.FSharpFunc<_, _, _, _>) (m: MapTree<'Key, 'Value>) x = 
             if isEmpty m then x
             else
-                match m with 
-                | :? MapTreeNode<'Key, 'Value> as mn ->
+                match m.Height with 
+                | 1 ->
+                    let cLoKey = comparer.Compare(lo, m.Key)
+                    let cKeyHi = comparer.Compare(m.Key, hi)
+                    let x = if cLoKey <= 0 && cKeyHi <= 0 then f.Invoke (m.Key, m.Value, x) else x
+                    x
+                | _ ->
+                    let mn = asNode m
                     let cLoKey = comparer.Compare(lo, mn.Key)
                     let cKeyHi = comparer.Compare(mn.Key, hi)
                     let x = if cLoKey < 0 then foldFromTo f mn.Left x else x
                     let x = if cLoKey <= 0 && cKeyHi <= 0 then f.Invoke (mn.Key, mn.Value, x) else x
                     let x = if cKeyHi < 0 then foldFromTo f mn.Right x else x
-                    x
-                | _ ->
-                    let cLoKey = comparer.Compare(lo, m.Key)
-                    let cKeyHi = comparer.Compare(m.Key, hi)
-                    let x = if cLoKey <= 0 && cKeyHi <= 0 then f.Invoke (m.Key, m.Value, x) else x
                     x
 
         if comparer.Compare(lo, hi) = 1 then x else foldFromTo f m x
@@ -395,9 +427,12 @@ module MapTree =
         let rec loop (m: MapTree<'Key, 'Value>) acc = 
             if isEmpty m then acc
             else
-                match m with
-                | :? MapTreeNode<'Key, 'Value> as mn -> loop mn.Left ((mn.Key, mn.Value) :: loop mn.Right acc)
-                | _ -> (m.Key, m.Value) :: acc
+                match m.Height with
+                | 1 -> (m.Key, m.Value) :: acc
+                | _ ->
+                    let mn = asNode m
+                    loop mn.Left ((mn.Key, mn.Value) :: loop mn.Right acc)
+                
         loop m []
 
     let toArray m =
@@ -448,9 +483,11 @@ module MapTree =
         | m :: rest ->
             if isEmpty m then collapseLHS rest
             else
-                match m with
-                | :? MapTreeNode<'Key, 'Value> as mn -> collapseLHS (mn.Left :: MapTree (mn.Key, mn.Value) :: mn.Right :: rest)
-                | _ -> stack
+                match m.Height with
+                | 1 -> stack
+                | _ ->
+                    let mn = asNode m
+                    collapseLHS (mn.Left :: MapTree (mn.Key, mn.Value) :: mn.Right :: rest)
 
     let mkIterator m =
         { stack = collapseLHS [m]; started = false }
@@ -466,9 +503,9 @@ module MapTree =
             match i.stack with
             | []     -> alreadyFinished()
             | m :: _ ->
-                match m with
-                | :? MapTreeNode<'Key, 'Value> -> failwith "Please report error: Map iterator, unexpected stack for current"
-                | _ -> new KeyValuePair<_, _>(m.Key, m.Value)
+                match m.Height with
+                | 1 -> new KeyValuePair<_, _>(m.Key, m.Value)
+                | _ -> failwith "Please report error: Map iterator, unexpected stack for current"
         else
             notStarted()
 
@@ -477,11 +514,11 @@ module MapTree =
             match i.stack with
             | [] -> false
             | m :: rest ->
-                match m with
-                | :? MapTreeNode<'Key, 'Value> -> failwith "Please report error: Map iterator, unexpected stack for moveNext"
-                | _ ->
+                match m.Height with
+                | 1 ->
                     i.stack <- collapseLHS rest
                     not i.stack.IsEmpty
+                | _ -> failwith "Please report error: Map iterator, unexpected stack for moveNext"
         else
             i.started <- true  (* The first call to MoveNext "starts" the enumeration. *)
             not i.stack.IsEmpty

--- a/src/fsharp/FSharp.Core/mapsetcmp.fs
+++ b/src/fsharp/FSharp.Core/mapsetcmp.fs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+namespace Microsoft.FSharp.Collections
+
+open System
+open System.Collections
+open System.Numerics
+open System.Reflection
+open System.Runtime.CompilerServices
+open Microsoft.FSharp.Core
+open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
+
+module internal MapSetDefaultComparison = 
+    type CompareHelper<'T when 'T : comparison>() =
+        static let c = LanguagePrimitives.FastGenericComparer
+        
+        // A constrained call to IComparable<'T>.CompareTo                
+        static member private CompareCG<'U when  'U :> IComparable<'U>>(l:'U, r:'U):int = l.CompareTo(r)
+
+        // A call to IComparable.CompareTo
+        static member private CompareC<'U when  'U :> IComparable>(l:'U, r:'U):int = l.CompareTo(r)
+
+        static member val CompareToDlg : Func<'T,'T,int> =
+                let dlg =
+                    let ty = typeof<'T>
+                    try 
+                        let normalCmp =
+                            not (typeof<IStructuralComparable>.IsAssignableFrom(ty))
+                            && isNull (Attribute.GetCustomAttribute(ty, typeof<NoComparisonAttribute>))
+                            && isNull (Attribute.GetCustomAttribute(ty, typeof<StructuralComparisonAttribute>))
+                            && not (ty.IsArray)
+                             
+                        // See #816, IComparable<'T> actually does not satisfy comparison constraint, but it should be preferred 
+                        if typeof<IComparable<'T>>.IsAssignableFrom(ty) then 
+                            let m =
+                                typeof<CompareHelper<'T>>.GetMethod("CompareCG", BindingFlags.NonPublic ||| BindingFlags.Static)
+                                    .MakeGenericMethod([|ty|])
+                            Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
+                        elif typeof<IComparable>.IsAssignableFrom(ty) && normalCmp then 
+                            let m =
+                                typeof<CompareHelper<'T>>.GetMethod("CompareC", BindingFlags.NonPublic ||| BindingFlags.Static)
+                                    .MakeGenericMethod([|typeof<'T>|])
+                            Delegate.CreateDelegate(typeof<Func<'T,'T,int>>, m) :?> Func<'T,'T,int>
+                        else null
+                    with _ -> null
+                dlg
+            with get
+            
+        // If backed by static readonly field that will be JIT-time constant
+        static member val IsIComparable = not(isNull CompareHelper<'T>.CompareToDlg) with get
+            
+        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+        static member Compare(l:'T, r:'T):int =
+            // Should use IsIComparable when it's backed by static readonly field
+            if isNull CompareHelper<'T>.CompareToDlg then
+                c.Compare(l, r)
+            else
+                CompareHelper<'T>.CompareToDlg.Invoke(l,r)
+            
+    // Constructors are not inlined by F#, but JIT could inline them.
+    // This is what we need here, because LanguagePrimitives.FastGenericComparer.Compare
+    // has a .tail prefix that breaks the typeof(T)==typeof(...) JIT optimization in cmp
+    // A struct with a single int field should be lowered by JIT.
+    [<Struct>]
+    [<NoEquality; NoComparison>] 
+    type Comparison<'T when 'T : comparison> =
+        struct
+            val Value: int
+            [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+            new(l:'T,r:'T) = { Value = CompareHelper<'T>.Compare(l, r) }
+        end
+        
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
+    let cmp<'T when 'T : comparison> (l:'T) (r:'T) : int =
+        // See the pattern explanation: https://github.com/dotnet/runtime/blob/4b8d10154c39b1f56424d4ba2068a3150d90d475/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs#L14
+        // All types that implement IComparable<'T> and are accessible here without additional dependencies should be in the list 
+        if Type.op_Equality(typeof<'T>, typeof<sbyte>) then unbox<sbyte>(box(l)).CompareTo(unbox<sbyte>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<int16>) then unbox<int16>(box(l)).CompareTo(unbox<int16>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<int32>) then unbox<int32>(box(l)).CompareTo(unbox<int32>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<int64>) then unbox<int64>(box(l)).CompareTo(unbox<int64>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<byte>) then unbox<byte>(box(l)).CompareTo(unbox<byte>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<uint16>) then unbox<uint16>(box(l)).CompareTo(unbox<uint16>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<uint32>) then unbox<uint32>(box(l)).CompareTo(unbox<uint32>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<uint64>) then unbox<uint64>(box(l)).CompareTo(unbox<uint64>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<nativeint>) then
+            unbox<nativeint>(box(l)).ToInt64().CompareTo( (unbox<nativeint>(box(r))).ToInt64())
+        else if Type.op_Equality(typeof<'T>, typeof<unativeint>) then
+            unbox<unativeint>(box(l)).ToUInt64().CompareTo( (unbox<unativeint>(box(r))).ToUInt64())
+        else if Type.op_Equality(typeof<'T>, typeof<bool>) then unbox<bool>(box(l)).CompareTo(unbox<bool>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<char>) then unbox<char>(box(l)).CompareTo(unbox<char>(box(r)))
+        
+        // F# rules for floats
+        else if Type.op_Equality(typeof<'T>, typeof<float>) then
+            let l = unbox<float>(box(l))
+            let r = unbox<float>(box(r))
+            if  l < r then (-1)
+            elif l > r then (1)
+            elif l = r then (0)
+            elif r = r then (-1)
+            elif l = l then (1)
+            else 0
+        else if Type.op_Equality(typeof<'T>, typeof<float32>) then
+            let l = unbox<float32>(box(l))
+            let r = unbox<float32>(box(r))
+            if  l < r then (-1)
+            elif l > r then (1)
+            elif l = r then (0)
+            elif r = r then (-1)
+            elif l = l then (1)
+            else 0
+        else if Type.op_Equality(typeof<'T>, typeof<decimal>) then unbox<decimal>(box(l)).CompareTo(unbox<decimal>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<DateTime>) then unbox<DateTime>(box(l)).CompareTo(unbox<DateTime>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<DateTimeOffset>) then unbox<DateTimeOffset>(box(l)).CompareTo(unbox<DateTimeOffset>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<TimeSpan>) then unbox<TimeSpan>(box(l)).CompareTo(unbox<TimeSpan>(box(r)))
+        
+        else if Type.op_Equality(typeof<'T>, typeof<BigInteger>) then unbox<BigInteger>(box(l)).CompareTo(unbox<BigInteger>(box(r)))
+        else if Type.op_Equality(typeof<'T>, typeof<Guid>) then unbox<Guid>(box(l)).CompareTo(unbox<Guid>(box(r)))
+        
+        else if Type.op_Equality(typeof<'T>, typeof<string>) then
+            // same as in GenericComparisonFast
+            String.CompareOrdinal(unbox<string>(box(l)),(unbox<string>(box(r))))
+        
+        else Comparison(l,r).Value

--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -145,7 +145,6 @@ module internal SetTree =
             let c = comparer.Compare(k, t.Key)
             if t.Height = 1 then
                 // nb. no check for rebalance needed for small trees, also be sure to reuse node already allocated 
-                let c = comparer.Compare(k, t.Key) 
                 if c < 0   then SetTreeNode (k, empty, t, 2) :> SetTree<'T>
                 elif c = 0 then t
                 else            SetTreeNode (k, t, empty, 2) :> SetTree<'T>

--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -16,19 +16,19 @@ open Microsoft.FSharp.Collections
 
 [<NoEquality; NoComparison>]
 [<AllowNullLiteral>]
-type internal SetTree<'T>(k: 'T) =
+type internal SetTree<'T>(k: 'T, h: int) =
+    member _.Height = h
     member _.Key = k
-
+    new(k: 'T) = SetTree(k,1)
+    
 [<NoEquality; NoComparison>]
 [<Sealed>]
 [<AllowNullLiteral>]
 type internal SetTreeNode<'T>(v:'T, left:SetTree<'T>, right: SetTree<'T>, h: int) =
-    inherit SetTree<'T>(v)
-
+    inherit SetTree<'T>(v,h)
     member _.Left = left
     member _.Right = right
-    member _.Height = h
-
+    
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module internal SetTree = 
     
@@ -36,13 +36,18 @@ module internal SetTree =
     
     let inline isEmpty (t:SetTree<'T>) = isNull t
 
+    let inline private asNode(value:SetTree<'T>) : SetTreeNode<'T> =
+        value :?> SetTreeNode<'T>
+                
     let rec countAux (t:SetTree<'T>) acc = 
         if isEmpty t then
             acc
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> countAux tn.Left (countAux tn.Right (acc+1))
-            | _ -> acc+1
+            if t.Height = 1 then
+                acc + 1
+            else
+                let tn = asNode t
+                countAux tn.Left (countAux tn.Right (acc+1)) 
 
     let count s = countAux s 0
 
@@ -84,22 +89,19 @@ module internal SetTree =
 
     let inline height (t:SetTree<'T>) = 
         if isEmpty t then 0
-        else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> tn.Height
-            | _ -> 1
+        else t.Height 
 
 #if CHECKED
     let rec checkInvariant (t:SetTree<'T>) =
         // A good sanity check, loss of balance can hit perf
         if isEmpty t then true
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn  ->
+            if t.Height = 1 then true
+            else
+                let tn = asNode t
                 let h1 = height tn.Left 
                 let h2 = height tn.Right 
                 (-2 <= (h1 - h2) && (h1 - h2) <= 2) && checkInvariant tn.Left && checkInvariant tn.Right
-            | _ -> true
 #endif
 
     [<Literal>]
@@ -114,9 +116,6 @@ module internal SetTree =
         else
             SetTreeNode (k, l, r, m+1) :> SetTree<'T>
 
-    let inline private asNode(value:SetTree<'T>) : SetTreeNode<'T> =
-        value :?> SetTreeNode<'T>
-        
     let rebalance t1 v t2 =
         let t1h = height t1 
         let t2h = height t2 
@@ -144,17 +143,17 @@ module internal SetTree =
         if isEmpty t then SetTree k
         else
             let c = comparer.Compare(k, t.Key)
-            match t with
-            | :? SetTreeNode<'T> as tn ->
-                if   c < 0 then rebalance (add comparer k tn.Left) tn.Key tn.Right
-                elif c = 0 then t
-                else            rebalance tn.Left tn.Key (add comparer k tn.Right)
-            | _ -> 
+            if t.Height = 1 then
                 // nb. no check for rebalance needed for small trees, also be sure to reuse node already allocated 
                 let c = comparer.Compare(k, t.Key) 
                 if c < 0   then SetTreeNode (k, empty, t, 2) :> SetTree<'T>
                 elif c = 0 then t
                 else            SetTreeNode (k, t, empty, 2) :> SetTree<'T>
+            else
+                let tn = asNode t
+                if   c < 0 then rebalance (add comparer k tn.Left) tn.Key tn.Right
+                elif c = 0 then t
+                else            rebalance tn.Left tn.Key (add comparer k tn.Right)
 
     let rec balance comparer (t1:SetTree<'T>) k (t2:SetTree<'T>) =
         // Given t1 < k < t2 where t1 and t2 are "balanced", 
@@ -163,10 +162,12 @@ module internal SetTree =
         if isEmpty t1 then add comparer k t2 // drop t1 = empty
         elif isEmpty t2 then add comparer k t1 // drop t2 = empty
         else
-            match t1 with
-            | :? SetTreeNode<'T> as t1n ->
-                match t2 with
-                | :? SetTreeNode<'T> as t2n ->
+            if t1.Height = 1 then add comparer k (add comparer t1.Key t2)
+            else
+                let t1n = asNode t1
+                if t2.Height = 1 then add comparer k (add comparer t2.Key t1)
+                else
+                    let t2n = asNode t2
                     // Have:  (t1l < k1 < t1r) < k < (t2l < k2 < t2r)
                     // Either (a) h1, h2 differ by at most 2 - no rebalance needed.
                     //        (b) h1 too small, i.e. h1+2 < h2
@@ -182,16 +183,19 @@ module internal SetTree =
                     else
                         // case: a, h1 and h2 meet balance requirement 
                         mk t1 k t2
-                | _ -> add comparer k (add comparer t2.Key t1)
-            | _ -> add comparer k (add comparer t1.Key t2)
 
     let rec split (comparer: IComparer<'T>) pivot (t:SetTree<'T>) =
         // Given a pivot and a set t
         // Return { x in t s.t. x < pivot }, pivot in t?, { x in t s.t. x > pivot } 
         if isEmpty t then empty, false, empty
         else
-            match t with
-            | :? SetTreeNode<'T> as tn ->
+            if t.Height = 1 then
+                let c = comparer.Compare(t.Key, pivot)
+                if   c < 0 then t, false, empty // singleton under pivot 
+                elif c = 0 then empty, true, empty // singleton is    pivot 
+                else            empty, false, t        // singleton over  pivot
+            else
+                let tn = asNode t
                 let c = comparer.Compare(pivot, tn.Key)
                 if   c < 0 then // pivot t1 
                     let t11Lo, havePivot, t11Hi = split comparer pivot tn.Left
@@ -201,27 +205,24 @@ module internal SetTree =
                 else            // pivot t2 
                     let t12Lo, havePivot, t12Hi = split comparer pivot tn.Right
                     balance comparer tn.Left tn.Key t12Lo, havePivot, t12Hi
-            | _ ->
-                let c = comparer.Compare(t.Key, pivot)
-                if   c < 0 then t, false, empty // singleton under pivot 
-                elif c = 0 then empty, true, empty // singleton is    pivot 
-                else            empty, false, t        // singleton over  pivot 
 
     let rec spliceOutSuccessor (t:SetTree<'T>) = 
         if isEmpty t then failwith "internal error: Set.spliceOutSuccessor"
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn ->
+            if t.Height = 1 then t.Key, empty
+            else
+                let tn = asNode t
                 if isEmpty tn.Left then tn.Key, tn.Right
                 else let k3, l' = spliceOutSuccessor tn.Left in k3, mk l' tn.Key tn.Right
-            | _ -> t.Key, empty
 
     let rec remove (comparer: IComparer<'T>) k (t:SetTree<'T>) = 
         if isEmpty t then t
         else
             let c = comparer.Compare(k, t.Key)
-            match t with 
-            | :? SetTreeNode<'T> as tn ->
+            if t.Height = 1 then
+                if c = 0 then empty else t
+            else
+                let tn = asNode t
                 if   c < 0 then rebalance (remove comparer k tn.Left) tn.Key tn.Right
                 elif c = 0 then
                     if isEmpty tn.Left then tn.Right
@@ -229,63 +230,64 @@ module internal SetTree =
                     else
                         let sk, r' = spliceOutSuccessor tn.Right 
                         mk tn.Left sk r'
-                else rebalance tn.Left tn.Key (remove comparer k tn.Right)
-            | _ ->  
-                if   c = 0 then empty
-                else t
+                else rebalance tn.Left tn.Key (remove comparer k tn.Right)               
 
     let rec mem (comparer: IComparer<'T>) k (t:SetTree<'T>) = 
         if isEmpty t then false
         else
             let c = comparer.Compare(k, t.Key) 
-            match t with 
-            | :? SetTreeNode<'T> as tn ->
+            if t.Height = 1 then (c = 0)
+            else
+                let tn = asNode t
                 if   c < 0 then mem comparer k tn.Left
                 elif c = 0 then true
                 else mem comparer k tn.Right
-            | _ -> (c = 0)
 
     let rec iter f (t:SetTree<'T>) = 
         if isEmpty t then ()
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> iter f tn.Left; f tn.Key; iter f tn.Right
-            | _ -> f t.Key 
+            if t.Height = 1 then f t.Key
+            else
+                let tn = asNode t
+                iter f tn.Left; f tn.Key; iter f tn.Right 
 
     let rec foldBackOpt (f:OptimizedClosures.FSharpFunc<_, _, _>) (t:SetTree<'T>) x = 
         if isEmpty t then x
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> foldBackOpt f tn.Left (f.Invoke(tn.Key, (foldBackOpt f tn.Right x)))
-            | _ -> f.Invoke(t.Key, x)
+            if t.Height = 1 then f.Invoke(t.Key, x)
+            else
+                let tn = asNode t
+                foldBackOpt f tn.Left (f.Invoke(tn.Key, (foldBackOpt f tn.Right x)))
 
     let foldBack f m x = foldBackOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) m x
 
     let rec foldOpt (f:OptimizedClosures.FSharpFunc<_, _, _>) x (t:SetTree<'T>) = 
         if isEmpty t then x
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> 
+            if t.Height = 1 then f.Invoke(x, t.Key)
+            else
+                let tn = asNode t 
                 let x = foldOpt f x tn.Left in 
                 let x = f.Invoke(x, tn.Key)
                 foldOpt f x tn.Right
-            | _ -> f.Invoke(x, t.Key)
 
     let fold f x m = foldOpt (OptimizedClosures.FSharpFunc<_, _, _>.Adapt f) x m
 
     let rec forall f (t:SetTree<'T>) = 
         if isEmpty t then true
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> f tn.Key && forall f tn.Left && forall f tn.Right
-            | _ -> f t.Key
+            if t.Height = 1 then f t.Key
+            else
+                let tn = asNode t
+                f tn.Key && forall f tn.Left && forall f tn.Right
 
     let rec exists f (t:SetTree<'T>) = 
         if isEmpty t then false
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> f tn.Key || exists f tn.Left || exists f tn.Right
-            | _ -> f t.Key
+            if t.Height = 1 then f t.Key
+            else
+                let tn = asNode t
+                f tn.Key || exists f tn.Left || exists f tn.Right
 
     let subset comparer a b  =
         forall (fun x -> mem comparer x b) a
@@ -296,11 +298,12 @@ module internal SetTree =
     let rec filterAux comparer f (t:SetTree<'T>) acc = 
         if isEmpty t then acc
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn ->
+            if t.Height = 1 then
+                if f t.Key then add comparer t.Key acc else acc
+            else
+                let tn = asNode t
                 let acc = if f tn.Key then add comparer tn.Key acc else acc 
                 filterAux comparer f tn.Left (filterAux comparer f tn.Right acc)
-            | _ -> if f t.Key then add comparer t.Key acc else acc
 
     let filter comparer f s = filterAux comparer f s empty
 
@@ -309,9 +312,10 @@ module internal SetTree =
         else
             if isEmpty t then acc
             else
-                match t with 
-                | :? SetTreeNode<'T> as tn -> diffAux comparer tn.Left (diffAux comparer tn.Right (remove comparer tn.Key acc))
-                | _ -> remove comparer t.Key acc
+                if t.Height = 1 then remove comparer t.Key acc
+                else
+                    let tn = asNode t
+                    diffAux comparer tn.Left (diffAux comparer tn.Right (remove comparer tn.Key acc)) 
 
     let diff comparer a b = diffAux comparer b a
 
@@ -320,10 +324,12 @@ module internal SetTree =
         if isEmpty t1 then t2
         elif isEmpty t2 then t1
         else
-            match t1 with
-            | :? SetTreeNode<'T> as t1n ->
-                match t2 with
-                | :? SetTreeNode<'T> as t2n -> // (t1l < k < t1r) AND (t2l < k2 < t2r) 
+            if t1.Height = 1 then add comparer t1.Key t2
+            else
+                let t1n = asNode t1
+                if t2.Height = 1 then add comparer t2.Key t1
+                else
+                    let t2n = asNode t2 // (t1l < k < t1r) AND (t2l < k2 < t2r) 
                     // Divide and Conquer:
                     //   Suppose t1 is largest.
                     //   Split t2 using pivot k1 into lo and hi.
@@ -334,19 +340,17 @@ module internal SetTree =
                     else
                         let lo, _, hi = split comparer t2n.Key t1 in
                         balance comparer (union comparer t2n.Left lo) t2n.Key (union comparer t2n.Right hi)
-                | _ -> add comparer t2.Key t1
-            | _ -> add comparer t1.Key t2
 
     let rec intersectionAux comparer b (t:SetTree<'T>) acc = 
         if isEmpty t then acc
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> 
+            if t.Height = 1 then
+                if mem comparer t.Key b then add comparer t.Key acc else acc
+            else
+                let tn = asNode t 
                 let acc = intersectionAux comparer b tn.Right acc 
                 let acc = if mem comparer tn.Key b then add comparer tn.Key acc else acc 
                 intersectionAux comparer b tn.Left acc
-            | _ -> 
-                if mem comparer t.Key b then add comparer t.Key acc else acc
 
     let intersection comparer a b = intersectionAux comparer b a empty
 
@@ -355,42 +359,46 @@ module internal SetTree =
     let rec partitionAux comparer f (t:SetTree<'T>) acc = 
         if isEmpty t then acc
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> 
+            if t.Height = 1 then partition1 comparer f t.Key acc
+            else
+                let tn = asNode t 
                 let acc = partitionAux comparer f tn.Right acc 
                 let acc = partition1 comparer f tn.Key acc
                 partitionAux comparer f tn.Left acc
-            | _ -> partition1 comparer f t.Key acc
 
     let partition comparer f s = partitionAux comparer f s (empty, empty)
 
     let rec minimumElementAux (t:SetTree<'T>) n = 
         if isEmpty t then n
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> minimumElementAux tn.Left tn.Key
-            | _ -> t.Key
+            if t.Height = 1 then t.Key
+            else
+                let tn = asNode t
+                minimumElementAux tn.Left tn.Key
 
     and minimumElementOpt (t:SetTree<'T>) = 
         if isEmpty t then None
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> Some(minimumElementAux tn.Left tn.Key)
-            | _ -> Some t.Key
+            if t.Height = 1 then Some t.Key
+            else
+                let tn = asNode t
+                Some(minimumElementAux tn.Left tn.Key) 
 
     and maximumElementAux (t:SetTree<'T>) n = 
         if isEmpty t then n
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> maximumElementAux tn.Right tn.Key
-            | _ -> t.Key
+            if t.Height = 1 then t.Key
+            else
+                let tn = asNode t
+                maximumElementAux tn.Right tn.Key 
 
     and maximumElementOpt (t:SetTree<'T>) = 
         if isEmpty t then None
         else
-            match t with 
-            | :? SetTreeNode<'T> as tn -> Some(maximumElementAux tn.Right tn.Key)
-            | _ -> Some t.Key
+            if t.Height = 1 then Some t.Key
+            else
+                let tn = asNode t
+                Some(maximumElementAux tn.Right tn.Key)
 
     let minimumElement s = 
         match minimumElementOpt s with 
@@ -418,9 +426,10 @@ module internal SetTree =
         | x :: rest ->
             if isEmpty x then collapseLHS rest
             else
-                match x with
-                | :? SetTreeNode<'T> as xn-> collapseLHS (xn.Left :: SetTree xn.Key :: xn.Right :: rest)
-                | _ -> stack
+                if x.Height = 1 then stack
+                else
+                    let xn = asNode x
+                    collapseLHS (xn.Left :: SetTree xn.Key :: xn.Right :: rest)
 
     let mkIterator s = { stack = collapseLHS [s]; started = false }
 
@@ -436,16 +445,19 @@ module internal SetTree =
         else
             notStarted()
 
+    let unexpectedStackForMoveNext() = failwith "Please report error: Set iterator, unexpected stack for moveNext" 
+    let unexpectedstateInSetTreeCompareStacks() = failwith "unexpected state in SetTree.compareStacks"
+    
     let rec moveNext i =
         if i.started then
             match i.stack with
             | [] -> false
             | t :: rest ->
-                match t with
-                | :? SetTreeNode<'T> -> failwith "Please report error: Set iterator, unexpected stack for moveNext"
-                | _ -> 
+                if t.Height = 1 then
                     i.stack <- collapseLHS rest
-                    not i.stack.IsEmpty 
+                    not i.stack.IsEmpty
+                else
+                    unexpectedStackForMoveNext()
         else
             i.started <- true; // The first call to MoveNext "starts" the enumeration.
             not i.stack.IsEmpty 
@@ -466,16 +478,18 @@ module internal SetTree =
         let cont() =
             match l1, l2 with 
             | (x1 :: t1), _ when not (isEmpty x1) ->
-                match x1 with
-                | :? SetTreeNode<'T> as x1n ->
+                if x1.Height = 1 then
+                    compareStacks comparer (empty :: SetTree x1.Key :: t1) l2
+                else
+                    let x1n = asNode x1
                     compareStacks comparer (x1n.Left :: (SetTreeNode (x1n.Key, empty, x1n.Right, 0) :> SetTree<'T>) :: t1) l2
-                | _ -> compareStacks comparer (empty :: SetTree x1.Key :: t1) l2
             | _, (x2 :: t2) when not (isEmpty x2) ->
-                match x2 with
-                | :? SetTreeNode<'T> as x2n ->
+                if x2.Height = 1 then
+                    compareStacks comparer l1 (empty :: SetTree x2.Key :: t2)
+                else
+                    let x2n = asNode x2
                     compareStacks comparer l1 (x2n.Left :: (SetTreeNode (x2n.Key, empty, x2n.Right, 0) :> SetTree<'T>  ) :: t2)
-                | _ -> compareStacks comparer l1 (empty :: SetTree x2.Key :: t2)
-            | _ -> failwith "unexpected state in SetTree.compareStacks"
+            | _ -> unexpectedstateInSetTreeCompareStacks()
         
         match l1, l2 with 
         | [], [] ->  0
@@ -487,30 +501,30 @@ module internal SetTree =
                 else cont()
             elif isEmpty x2 then cont()
             else
-                match x1 with
-                | :? SetTreeNode<'T> as x1n ->
-                    if isEmpty x1n.Left then
-                        match x2 with
-                        | :? SetTreeNode<'T> as x2n ->
-                            if isEmpty x2n.Left then
-                                let c = comparer.Compare(x1n.Key, x2n.Key) 
-                                if c <> 0 then c else compareStacks comparer (x1n.Right :: t1) (x2n.Right :: t2)
-                            else cont()
-                        | _ ->
-                            let c = comparer.Compare(x1n.Key, x2.Key) 
-                            if c <> 0 then c else compareStacks comparer (x1n.Right :: t1) (empty :: t2)
-                    else cont()
-                | _ ->
-                    match x2 with
-                    | :? SetTreeNode<'T> as x2n ->
+                if x1.Height = 1 then
+                    if x2.Height = 1 then
+                        let c = comparer.Compare(x1.Key, x2.Key) 
+                        if c <> 0 then c else compareStacks comparer t1 t2
+                    else
+                        let x2n = asNode x2
                         if isEmpty x2n.Left then
                             let c = comparer.Compare(x1.Key, x2n.Key) 
                             if c <> 0 then c else compareStacks comparer (empty :: t1) (x2n.Right :: t2)
                         else cont()
-                    | _ ->
-                        let c = comparer.Compare(x1.Key, x2.Key) 
-                        if c <> 0 then c else compareStacks comparer t1 t2
-                                
+                else
+                    let x1n = asNode x1
+                    if isEmpty x1n.Left then
+                        if x2.Height = 1 then
+                            let c = comparer.Compare(x1n.Key, x2.Key) 
+                            if c <> 0 then c else compareStacks comparer (x1n.Right :: t1) (empty :: t2)
+                        else
+                            let x2n = asNode x2
+                            if isEmpty x2n.Left then
+                                let c = comparer.Compare(x1n.Key, x2n.Key) 
+                                if c <> 0 then c else compareStacks comparer (x1n.Right :: t1) (x2n.Right :: t2)
+                            else cont()
+                    else cont()
+            
     let compare comparer (t1:SetTree<'T>) (t2:SetTree<'T>) = 
         if isEmpty t1 then
             if isEmpty t2 then 0
@@ -526,9 +540,10 @@ module internal SetTree =
         let rec loop (t':SetTree<'T>) acc =
             if isEmpty t' then acc
             else
-                match t' with 
-                | :? SetTreeNode<'T> as tn -> loop tn.Left (tn.Key :: loop tn.Right acc)
-                | _ ->  t'.Key :: acc
+                if t'.Height = 1 then t'.Key :: acc
+                else
+                    let tn = asNode t
+                    loop tn.Left (tn.Key :: loop tn.Right acc)
         loop t []
 
     let copyToArray s (arr: _[]) i =

--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -531,7 +531,9 @@ module internal SetTree =
             else -1
         else
             if isEmpty t2 then 1
-            else compareStacks [t1] [t2]
+            else
+                let c = compareStacks [t1] [t2]
+                if c > 0 then 1 else if c = 0 then 0 else -1
 
     let choose s =
         minimumElement s

--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -325,9 +325,9 @@ module internal SetTree =
         else
             if t1.Height = 1 then add comparer t1.Key t2
             else
-                let t1n = asNode t1
                 if t2.Height = 1 then add comparer t2.Key t1
                 else
+                    let t1n = asNode t1
                     let t2n = asNode t2 // (t1l < k < t1r) AND (t2l < k2 < t2r) 
                     // Divide and Conquer:
                     //   Suppose t1 is largest.
@@ -541,7 +541,7 @@ module internal SetTree =
             else
                 if t'.Height = 1 then t'.Key :: acc
                 else
-                    let tn = asNode t
+                    let tn = asNode t'
                     loop tn.Left (tn.Key :: loop tn.Right acc)
         loop t []
 


### PR DESCRIPTION
Same as #10855

The job `Main50` includes previous [PR](https://github.com/dotnet/fsharp/pull/10860)

|                         Method |     Job | BuildConfiguration | Size |         Mean |        Error |       StdDev | Ratio | RatioSD | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------- |-------- |------------------- |----- |-------------:|-------------:|-------------:|------:|--------:|-----:|-------:|------:|------:|----------:|
|                 containsKeyInt |   After |              After |  100 |     21.14 ns |     0.779 ns |     0.121 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|                 containsKeyInt |  Main50 |             Main50 |  100 |     28.95 ns |     1.199 ns |     0.311 ns |  1.37 |    0.02 |    2 |      - |     - |     - |         - |
|                 containsKeyInt | NuGet50 |            NuGet50 |  100 |     46.82 ns |     1.132 ns |     0.175 ns |  2.21 |    0.02 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|             containsKeyIntLike |   After |              After |  100 |     59.67 ns |     1.831 ns |     0.476 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|             containsKeyIntLike |  Main50 |             Main50 |  100 |    248.88 ns |     5.699 ns |     1.480 ns |  4.17 |    0.05 |    2 | 0.0525 |     - |     - |     331 B |
|             containsKeyIntLike | NuGet50 |            NuGet50 |  100 |    257.99 ns |     3.747 ns |     0.973 ns |  4.32 |    0.03 |    3 | 0.0526 |     - |     - |     331 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|              containsKeyString |   After |              After |  100 |     53.97 ns |     2.617 ns |     0.680 ns |  1.00 |    0.00 |    2 |      - |     - |     - |         - |
|              containsKeyString |  Main50 |             Main50 |  100 |     43.48 ns |     2.182 ns |     0.567 ns |  0.81 |    0.01 |    1 |      - |     - |     - |         - |
|              containsKeyString | NuGet50 |            NuGet50 |  100 |     73.30 ns |     2.800 ns |     0.727 ns |  1.36 |    0.01 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|             containsKeyRefLike |   After |              After |  100 |    146.72 ns |    10.741 ns |     2.789 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|             containsKeyRefLike |  Main50 |             Main50 |  100 |    229.40 ns |     5.506 ns |     0.852 ns |  1.56 |    0.03 |    2 |      - |     - |     - |         - |
|             containsKeyRefLike | NuGet50 |            NuGet50 |  100 |    249.09 ns |    10.063 ns |     1.557 ns |  1.69 |    0.03 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|           containsKeyIntRecord |   After |              After |  100 |    102.18 ns |     2.399 ns |     0.623 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|           containsKeyIntRecord |  Main50 |             Main50 |  100 |    233.32 ns |     8.690 ns |     1.345 ns |  2.28 |    0.03 |    2 | 0.0526 |     - |     - |     331 B |
|           containsKeyIntRecord | NuGet50 |            NuGet50 |  100 |    237.66 ns |     8.665 ns |     2.250 ns |  2.33 |    0.01 |    2 | 0.0519 |     - |     - |     331 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|        containsKeyIntRefRecord |   After |              After |  100 |    153.52 ns |     1.265 ns |     0.329 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|        containsKeyIntRefRecord |  Main50 |             Main50 |  100 |    204.53 ns |     6.879 ns |     1.064 ns |  1.33 |    0.01 |    2 |      - |     - |     - |         - |
|        containsKeyIntRefRecord | NuGet50 |            NuGet50 |  100 |    218.81 ns |     4.612 ns |     1.198 ns |  1.43 |    0.00 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|    containsKeyIntLikeNonGenCmp |   After |              After |  100 |     94.30 ns |     3.296 ns |     0.856 ns |  1.00 |    0.00 |    1 | 0.0262 |     - |     - |     166 B |
|    containsKeyIntLikeNonGenCmp |  Main50 |             Main50 |  100 |    238.60 ns |     3.182 ns |     0.826 ns |  2.53 |    0.02 |    2 | 0.0524 |     - |     - |     331 B |
|    containsKeyIntLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |    240.68 ns |    13.277 ns |     2.055 ns |  2.56 |    0.03 |    2 | 0.0521 |     - |     - |     331 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|    containsKeyRefLikeNonGenCmp |   After |              After |  100 |    182.53 ns |     1.547 ns |     0.239 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|    containsKeyRefLikeNonGenCmp |  Main50 |             Main50 |  100 |    231.61 ns |     5.116 ns |     0.792 ns |  1.27 |    0.00 |    2 |      - |     - |     - |         - |
|    containsKeyRefLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |    259.06 ns |    30.456 ns |     4.713 ns |  1.42 |    0.02 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                   itemCountInt |   After |              After |  100 |    246.34 ns |     6.113 ns |     1.588 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|                   itemCountInt |  Main50 |             Main50 |  100 |    245.57 ns |     9.633 ns |     1.491 ns |  1.00 |    0.01 |    1 |      - |     - |     - |         - |
|                   itemCountInt | NuGet50 |            NuGet50 |  100 |    504.93 ns |    23.024 ns |     5.979 ns |  2.05 |    0.02 |    2 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|               itemCountIntLike |   After |              After |  100 |    248.94 ns |    11.787 ns |     3.061 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|               itemCountIntLike |  Main50 |             Main50 |  100 |    247.55 ns |     3.088 ns |     0.802 ns |  0.99 |    0.01 |    1 |      - |     - |     - |         - |
|               itemCountIntLike | NuGet50 |            NuGet50 |  100 |    511.33 ns |    24.590 ns |     6.386 ns |  2.05 |    0.03 |    2 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                itemCountString |   After |              After |  100 |    220.37 ns |     5.541 ns |     1.439 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|                itemCountString |  Main50 |             Main50 |  100 |    275.03 ns |   101.002 ns |    26.230 ns |  1.25 |    0.13 |    2 |      - |     - |     - |         - |
|                itemCountString | NuGet50 |            NuGet50 |  100 |    656.19 ns |    39.166 ns |    10.171 ns |  2.98 |    0.06 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|               itemCountRefLike |   After |              After |  100 |    223.71 ns |    10.711 ns |     1.658 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|               itemCountRefLike |  Main50 |             Main50 |  100 |    232.75 ns |    44.043 ns |     6.816 ns |  1.04 |    0.03 |    2 |      - |     - |     - |         - |
|               itemCountRefLike | NuGet50 |            NuGet50 |  100 |    597.86 ns |     7.059 ns |     1.092 ns |  2.67 |    0.02 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|             itemCountIntRecord |   After |              After |  100 |    246.47 ns |     4.839 ns |     0.749 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|             itemCountIntRecord |  Main50 |             Main50 |  100 |    251.68 ns |     5.412 ns |     1.405 ns |  1.02 |    0.01 |    2 |      - |     - |     - |         - |
|             itemCountIntRecord | NuGet50 |            NuGet50 |  100 |    512.38 ns |    16.553 ns |     4.299 ns |  2.07 |    0.02 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|          itemCountIntRefRecord |   After |              After |  100 |    223.56 ns |     7.727 ns |     2.007 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|          itemCountIntRefRecord |  Main50 |             Main50 |  100 |    234.66 ns |    23.713 ns |     6.158 ns |  1.05 |    0.03 |    2 |      - |     - |     - |         - |
|          itemCountIntRefRecord | NuGet50 |            NuGet50 |  100 |    590.23 ns |    11.160 ns |     2.898 ns |  2.64 |    0.03 |    3 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|      itemCountIntLikeNonGenCmp |   After |              After |  100 |    246.00 ns |     3.057 ns |     0.794 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|      itemCountIntLikeNonGenCmp |  Main50 |             Main50 |  100 |    252.91 ns |    33.318 ns |     5.156 ns |  1.03 |    0.02 |    1 |      - |     - |     - |         - |
|      itemCountIntLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |    508.31 ns |    14.288 ns |     3.710 ns |  2.07 |    0.01 |    2 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|      itemCountRefLikeNonGenCmp |   After |              After |  100 |    227.10 ns |    25.343 ns |     3.922 ns |  1.00 |    0.00 |    1 |      - |     - |     - |         - |
|      itemCountRefLikeNonGenCmp |  Main50 |             Main50 |  100 |    229.97 ns |    17.960 ns |     4.664 ns |  1.01 |    0.01 |    1 |      - |     - |     - |         - |
|      itemCountRefLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |    589.75 ns |    20.821 ns |     3.222 ns |  2.60 |    0.03 |    2 |      - |     - |     - |         - |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|              maximumElementInt |   After |              After |  100 |     17.88 ns |     0.358 ns |     0.055 ns |  1.00 |    0.00 |    1 | 0.0042 |     - |     - |      26 B |
|              maximumElementInt |  Main50 |             Main50 |  100 |     18.23 ns |     0.739 ns |     0.114 ns |  1.02 |    0.00 |    2 | 0.0041 |     - |     - |      26 B |
|              maximumElementInt | NuGet50 |            NuGet50 |  100 |     40.90 ns |     1.787 ns |     0.464 ns |  2.28 |    0.02 |    3 | 0.0041 |     - |     - |      26 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|          maximumElementIntLike |   After |              After |  100 |     18.44 ns |     0.296 ns |     0.077 ns |  1.00 |    0.00 |    1 | 0.0042 |     - |     - |      26 B |
|          maximumElementIntLike |  Main50 |             Main50 |  100 |     19.00 ns |     1.713 ns |     0.265 ns |  1.03 |    0.01 |    2 | 0.0041 |     - |     - |      26 B |
|          maximumElementIntLike | NuGet50 |            NuGet50 |  100 |     40.59 ns |     1.399 ns |     0.363 ns |  2.20 |    0.02 |    3 | 0.0041 |     - |     - |      26 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|           maximumElementString |   After |              After |  100 |     27.09 ns |     0.640 ns |     0.166 ns |  1.00 |    0.00 |    1 | 0.0041 |     - |     - |      26 B |
|           maximumElementString |  Main50 |             Main50 |  100 |     28.31 ns |     0.553 ns |     0.086 ns |  1.04 |    0.01 |    2 | 0.0041 |     - |     - |      26 B |
|           maximumElementString | NuGet50 |            NuGet50 |  100 |     61.37 ns |     0.794 ns |     0.123 ns |  2.26 |    0.01 |    3 | 0.0040 |     - |     - |      26 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|          maximumElementRefLike |   After |              After |  100 |     26.51 ns |     1.453 ns |     0.377 ns |  1.00 |    0.00 |    1 | 0.0041 |     - |     - |      26 B |
|          maximumElementRefLike |  Main50 |             Main50 |  100 |     27.01 ns |     0.422 ns |     0.110 ns |  1.02 |    0.02 |    1 | 0.0041 |     - |     - |      26 B |
|          maximumElementRefLike | NuGet50 |            NuGet50 |  100 |     55.84 ns |     3.147 ns |     0.817 ns |  2.11 |    0.05 |    2 | 0.0041 |     - |     - |      26 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|        maximumElementIntRecord |   After |              After |  100 |     19.60 ns |     1.537 ns |     0.238 ns |  1.00 |    0.00 |    1 | 0.0042 |     - |     - |      26 B |
|        maximumElementIntRecord |  Main50 |             Main50 |  100 |     20.40 ns |     0.529 ns |     0.137 ns |  1.04 |    0.01 |    2 | 0.0042 |     - |     - |      26 B |
|        maximumElementIntRecord | NuGet50 |            NuGet50 |  100 |     42.66 ns |     0.841 ns |     0.218 ns |  2.18 |    0.02 |    3 | 0.0040 |     - |     - |      26 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|     maximumElementIntRefRecord |   After |              After |  100 |     25.98 ns |     0.350 ns |     0.091 ns |  1.00 |    0.00 |    1 | 0.0042 |     - |     - |      26 B |
|     maximumElementIntRefRecord |  Main50 |             Main50 |  100 |     27.13 ns |     1.662 ns |     0.432 ns |  1.04 |    0.02 |    2 | 0.0042 |     - |     - |      26 B |
|     maximumElementIntRefRecord | NuGet50 |            NuGet50 |  100 |     55.47 ns |     3.145 ns |     0.817 ns |  2.14 |    0.04 |    3 | 0.0042 |     - |     - |      26 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
| maximumElementIntLikeNonGenCmp |   After |              After |  100 |     18.59 ns |     0.261 ns |     0.068 ns |  1.00 |    0.00 |    1 | 0.0041 |     - |     - |      26 B |
| maximumElementIntLikeNonGenCmp |  Main50 |             Main50 |  100 |     18.78 ns |     1.821 ns |     0.473 ns |  1.01 |    0.02 |    1 | 0.0041 |     - |     - |      26 B |
| maximumElementIntLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |     40.25 ns |     0.616 ns |     0.160 ns |  2.17 |    0.01 |    2 | 0.0040 |     - |     - |      26 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
| maximumElementRefLikeNonGenCmp |   After |              After |  100 |     25.94 ns |     0.787 ns |     0.122 ns |  1.00 |    0.00 |    1 | 0.0042 |     - |     - |      26 B |
| maximumElementRefLikeNonGenCmp |  Main50 |             Main50 |  100 |     26.39 ns |     1.779 ns |     0.275 ns |  1.02 |    0.01 |    2 | 0.0041 |     - |     - |      26 B |
| maximumElementRefLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |     55.08 ns |     1.256 ns |     0.326 ns |  2.12 |    0.02 |    3 | 0.0042 |     - |     - |      26 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                      subsetInt |   After |              After |  100 |  2,051.29 ns |    35.383 ns |     5.475 ns |  1.00 |    0.00 |    1 |      - |     - |     - |      24 B |
|                      subsetInt |  Main50 |             Main50 |  100 |  3,498.46 ns |   372.447 ns |    96.723 ns |  1.70 |    0.05 |    2 |      - |     - |     - |      32 B |
|                      subsetInt | NuGet50 |            NuGet50 |  100 |  5,202.80 ns |   254.615 ns |    39.402 ns |  2.54 |    0.02 |    3 |      - |     - |     - |      32 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                  subsetIntLike |   After |              After |  100 |  6,212.42 ns |   118.741 ns |    18.375 ns |  1.00 |    0.00 |    1 |      - |     - |     - |      24 B |
|                  subsetIntLike |  Main50 |             Main50 |  100 | 23,036.75 ns |   762.015 ns |   117.923 ns |  3.71 |    0.02 |    2 | 4.4643 |     - |     - |   28304 B |
|                  subsetIntLike | NuGet50 |            NuGet50 |  100 | 23,672.89 ns | 1,304.249 ns |   201.834 ns |  3.81 |    0.03 |    3 | 4.4643 |     - |     - |   28304 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                   subsetString |   After |              After |  100 |  7,616.72 ns |   670.060 ns |   174.012 ns |  1.00 |    0.00 |    2 |      - |     - |     - |      24 B |
|                   subsetString |  Main50 |             Main50 |  100 |  6,297.17 ns |   572.451 ns |    88.587 ns |  0.83 |    0.02 |    1 |      - |     - |     - |      32 B |
|                   subsetString | NuGet50 |            NuGet50 |  100 | 11,107.61 ns |   679.342 ns |   176.423 ns |  1.46 |    0.04 |    3 |      - |     - |     - |      32 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                  subsetRefLike |   After |              After |  100 | 14,694.03 ns | 1,003.062 ns |   260.492 ns |  1.00 |    0.00 |    1 |      - |     - |     - |      24 B |
|                  subsetRefLike |  Main50 |             Main50 |  100 | 21,880.39 ns | 1,480.699 ns |   229.140 ns |  1.50 |    0.01 |    2 |      - |     - |     - |      32 B |
|                  subsetRefLike | NuGet50 |            NuGet50 |  100 | 23,467.05 ns |   362.949 ns |    94.257 ns |  1.60 |    0.03 |    3 |      - |     - |     - |      32 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                subsetIntRecord |   After |              After |  100 |  9,933.68 ns |   748.450 ns |   194.370 ns |  1.00 |    0.00 |    1 |      - |     - |     - |      24 B |
|                subsetIntRecord |  Main50 |             Main50 |  100 | 22,088.66 ns | 1,598.081 ns |   415.017 ns |  2.22 |    0.07 |    2 | 4.4386 |     - |     - |   28304 B |
|                subsetIntRecord | NuGet50 |            NuGet50 |  100 | 22,824.28 ns |   366.871 ns |    95.275 ns |  2.30 |    0.04 |    3 | 4.4158 |     - |     - |   28304 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|             subsetIntRefRecord |   After |              After |  100 | 15,277.12 ns | 1,171.248 ns |   181.252 ns |  1.00 |    0.00 |    1 |      - |     - |     - |      24 B |
|             subsetIntRefRecord |  Main50 |             Main50 |  100 | 19,046.62 ns | 4,661.956 ns |   721.443 ns |  1.25 |    0.04 |    2 |      - |     - |     - |      32 B |
|             subsetIntRefRecord | NuGet50 |            NuGet50 |  100 | 21,030.96 ns | 1,166.956 ns |   180.588 ns |  1.38 |    0.02 |    3 |      - |     - |     - |      32 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|         subsetIntLikeNonGenCmp |   After |              After |  100 | 10,238.06 ns | 1,185.034 ns |   183.385 ns |  1.00 |    0.00 |    1 | 2.2549 |     - |     - |   14160 B |
|         subsetIntLikeNonGenCmp |  Main50 |             Main50 |  100 | 22,550.10 ns |   639.132 ns |   165.981 ns |  2.21 |    0.03 |    2 | 4.4964 |     - |     - |   28304 B |
|         subsetIntLikeNonGenCmp | NuGet50 |            NuGet50 |  100 | 23,215.94 ns | 1,003.751 ns |   260.671 ns |  2.27 |    0.05 |    3 | 4.4561 |     - |     - |   28304 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|         subsetRefLikeNonGenCmp |   After |              After |  100 | 17,748.72 ns | 2,141.129 ns |   556.044 ns |  1.00 |    0.00 |    1 |      - |     - |     - |      24 B |
|         subsetRefLikeNonGenCmp |  Main50 |             Main50 |  100 | 21,749.73 ns |   809.943 ns |   125.340 ns |  1.22 |    0.04 |    2 |      - |     - |     - |      32 B |
|         subsetRefLikeNonGenCmp | NuGet50 |            NuGet50 |  100 | 23,310.08 ns |   701.306 ns |   182.127 ns |  1.31 |    0.04 |    3 |      - |     - |     - |      32 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                 iterForeachInt |   After |              After |  100 |  2,882.68 ns |    86.863 ns |    22.558 ns |  1.00 |    0.00 |    1 | 0.9613 |     - |     - |    6120 B |
|                 iterForeachInt |  Main50 |             Main50 |  100 |  2,866.85 ns |    31.590 ns |     4.889 ns |  1.00 |    0.01 |    1 | 0.9687 |     - |     - |    6120 B |
|                 iterForeachInt | NuGet50 |            NuGet50 |  100 |  3,734.34 ns |   127.105 ns |    33.009 ns |  1.30 |    0.01 |    2 | 0.9711 |     - |     - |    6120 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|             iterForeachIntLike |   After |              After |  100 |  2,968.21 ns |   164.854 ns |    25.511 ns |  1.00 |    0.00 |    1 | 1.0268 |     - |     - |    6520 B |
|             iterForeachIntLike |  Main50 |             Main50 |  100 |  2,932.10 ns |   234.194 ns |    60.820 ns |  0.99 |    0.02 |    1 | 1.0376 |     - |     - |    6520 B |
|             iterForeachIntLike | NuGet50 |            NuGet50 |  100 |  4,012.36 ns | 1,041.075 ns |   270.364 ns |  1.36 |    0.09 |    2 | 0.9700 |     - |     - |    6120 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|              iterForeachString |   After |              After |  100 |  4,063.74 ns |   193.425 ns |    50.232 ns |  1.00 |    0.00 |    1 | 1.0545 |     - |     - |    6648 B |
|              iterForeachString |  Main50 |             Main50 |  100 |  4,029.88 ns |   733.674 ns |   190.533 ns |  0.99 |    0.05 |    1 | 1.0582 |     - |     - |    6648 B |
|              iterForeachString | NuGet50 |            NuGet50 |  100 |  7,417.41 ns | 7,389.587 ns | 1,919.052 ns |  1.82 |    0.45 |    2 | 0.9717 |     - |     - |    6240 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|             iterForeachRefLike |   After |              After |  100 |  3,828.63 ns |   248.600 ns |    64.561 ns |  1.00 |    0.00 |    1 | 1.0317 |     - |     - |    6520 B |
|             iterForeachRefLike |  Main50 |             Main50 |  100 |  3,904.19 ns |   112.273 ns |    29.157 ns |  1.02 |    0.02 |    1 | 1.0265 |     - |     - |    6520 B |
|             iterForeachRefLike | NuGet50 |            NuGet50 |  100 |  5,668.76 ns |   311.854 ns |    48.260 ns |  1.49 |    0.04 |    2 | 0.9582 |     - |     - |    6120 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|           iterForeachIntRecord |   After |              After |  100 |  3,050.29 ns |   366.091 ns |    95.073 ns |  1.00 |    0.00 |    2 | 1.0303 |     - |     - |    6520 B |
|           iterForeachIntRecord |  Main50 |             Main50 |  100 |  2,885.37 ns |    48.793 ns |    12.672 ns |  0.95 |    0.03 |    1 | 1.0370 |     - |     - |    6520 B |
|           iterForeachIntRecord | NuGet50 |            NuGet50 |  100 |  3,704.86 ns |   414.489 ns |    64.143 ns |  1.20 |    0.04 |    3 | 0.9717 |     - |     - |    6120 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|        iterForeachIntRefRecord |   After |              After |  100 |  4,037.39 ns |   448.080 ns |   116.365 ns |  1.00 |    0.00 |    2 | 1.0219 |     - |     - |    6520 B |
|        iterForeachIntRefRecord |  Main50 |             Main50 |  100 |  3,707.80 ns |    87.314 ns |    22.675 ns |  0.92 |    0.02 |    1 | 1.0218 |     - |     - |    6520 B |
|        iterForeachIntRefRecord | NuGet50 |            NuGet50 |  100 |  5,362.05 ns |   214.266 ns |    33.158 ns |  1.33 |    0.05 |    3 | 0.9587 |     - |     - |    6120 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|    iterForeachIntLikeNonGenCmp |   After |              After |  100 |  3,024.86 ns |   319.624 ns |    83.005 ns |  1.00 |    0.00 |    1 | 1.0348 |     - |     - |    6520 B |
|    iterForeachIntLikeNonGenCmp |  Main50 |             Main50 |  100 |  3,099.94 ns |   566.126 ns |   147.021 ns |  1.02 |    0.03 |    1 | 1.0287 |     - |     - |    6520 B |
|    iterForeachIntLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |  3,702.69 ns |    92.776 ns |    14.357 ns |  1.21 |    0.02 |    2 | 0.9655 |     - |     - |    6120 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|    iterForeachRefLikeNonGenCmp |   After |              After |  100 |  3,771.33 ns |   319.688 ns |    83.022 ns |  1.00 |    0.00 |    1 | 1.0389 |     - |     - |    6520 B |
|    iterForeachRefLikeNonGenCmp |  Main50 |             Main50 |  100 |  3,813.37 ns |   190.766 ns |    49.541 ns |  1.01 |    0.01 |    1 | 1.0246 |     - |     - |    6520 B |
|    iterForeachRefLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |  5,369.98 ns |   219.536 ns |    57.013 ns |  1.42 |    0.05 |    2 | 0.9576 |     - |     - |    6120 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                     addItemInt |   After |              After |  100 |    145.69 ns |    20.735 ns |     3.209 ns |  1.00 |    0.00 |    1 | 0.0422 |     - |     - |     267 B |
|                     addItemInt |  Main50 |             Main50 |  100 |    155.03 ns |     6.993 ns |     1.816 ns |  1.06 |    0.02 |    2 | 0.0440 |     - |     - |     276 B |
|                     addItemInt | NuGet50 |            NuGet50 |  100 |    345.31 ns |    10.391 ns |     2.699 ns |  2.37 |    0.03 |    3 | 0.0426 |     - |     - |     276 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                 addItemIntLike |   After |              After |  100 |    196.43 ns |    53.962 ns |    14.014 ns |  1.00 |    0.00 |    1 | 0.0494 |     - |     - |     314 B |
|                 addItemIntLike |  Main50 |             Main50 |  100 |    376.28 ns |    36.135 ns |     5.592 ns |  1.90 |    0.15 |    2 | 0.1039 |     - |     - |     654 B |
|                 addItemIntLike | NuGet50 |            NuGet50 |  100 |    570.06 ns |    15.813 ns |     4.106 ns |  2.91 |    0.18 |    3 | 0.1020 |     - |     - |     654 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                  addItemString |   After |              After |  100 |    158.36 ns |     5.331 ns |     1.384 ns |  1.00 |    0.00 |    2 | 0.0403 |     - |     - |     256 B |
|                  addItemString |  Main50 |             Main50 |  100 |    154.95 ns |     7.394 ns |     1.144 ns |  0.98 |    0.00 |    1 | 0.0421 |     - |     - |     265 B |
|                  addItemString | NuGet50 |            NuGet50 |  100 |    380.02 ns |   177.948 ns |    27.538 ns |  2.39 |    0.16 |    3 | 0.0421 |     - |     - |     265 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                 addItemRefLike |   After |              After |  100 |    280.26 ns |     6.311 ns |     1.639 ns |  1.00 |    0.00 |    1 | 0.0497 |     - |     - |     314 B |
|                 addItemRefLike |  Main50 |             Main50 |  100 |    374.78 ns |    18.688 ns |     4.853 ns |  1.34 |    0.02 |    2 | 0.0505 |     - |     - |     322 B |
|                 addItemRefLike | NuGet50 |            NuGet50 |  100 |    644.28 ns |    25.687 ns |     6.671 ns |  2.30 |    0.02 |    3 | 0.0509 |     - |     - |     322 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|               addItemIntRecord |   After |              After |  100 |    229.07 ns |     7.084 ns |     1.096 ns |  1.00 |    0.00 |    1 | 0.0496 |     - |     - |     314 B |
|               addItemIntRecord |  Main50 |             Main50 |  100 |    365.65 ns |     8.342 ns |     2.166 ns |  1.59 |    0.01 |    2 | 0.1025 |     - |     - |     654 B |
|               addItemIntRecord | NuGet50 |            NuGet50 |  100 |    536.58 ns |     5.678 ns |     0.879 ns |  2.34 |    0.01 |    3 | 0.1018 |     - |     - |     654 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|            addItemIntRefRecord |   After |              After |  100 |    291.92 ns |     9.717 ns |     2.523 ns |  1.00 |    0.00 |    1 | 0.0489 |     - |     - |     314 B |
|            addItemIntRefRecord |  Main50 |             Main50 |  100 |    349.90 ns |    43.973 ns |    11.420 ns |  1.20 |    0.04 |    2 | 0.0506 |     - |     - |     322 B |
|            addItemIntRefRecord | NuGet50 |            NuGet50 |  100 |    588.60 ns |     6.167 ns |     1.602 ns |  2.02 |    0.02 |    3 | 0.0500 |     - |     - |     322 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|        addItemIntLikeNonGenCmp |   After |              After |  100 |    223.55 ns |     7.309 ns |     1.898 ns |  1.00 |    0.00 |    1 | 0.0755 |     - |     - |     479 B |
|        addItemIntLikeNonGenCmp |  Main50 |             Main50 |  100 |    371.68 ns |    10.334 ns |     1.599 ns |  1.66 |    0.02 |    2 | 0.1027 |     - |     - |     654 B |
|        addItemIntLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |    571.63 ns |    44.259 ns |    11.494 ns |  2.56 |    0.06 |    3 | 0.1018 |     - |     - |     654 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|        addItemRefLikeNonGenCmp |   After |              After |  100 |    315.47 ns |     7.478 ns |     1.157 ns |  1.00 |    0.00 |    1 | 0.0487 |     - |     - |     314 B |
|        addItemRefLikeNonGenCmp |  Main50 |             Main50 |  100 |    365.18 ns |     6.263 ns |     0.969 ns |  1.16 |    0.01 |    2 | 0.0511 |     - |     - |     322 B |
|        addItemRefLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |    630.63 ns |    19.000 ns |     4.934 ns |  2.00 |    0.02 |    3 | 0.0504 |     - |     - |     322 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|                  removeItemInt |   After |              After |  100 |     98.80 ns |     7.370 ns |     1.914 ns |  1.00 |    0.00 |    2 | 0.0335 |     - |     - |     211 B |
|                  removeItemInt |  Main50 |             Main50 |  100 |     95.20 ns |     2.173 ns |     0.564 ns |  0.96 |    0.02 |    1 | 0.0350 |     - |     - |     220 B |
|                  removeItemInt | NuGet50 |            NuGet50 |  100 |    254.62 ns |    64.828 ns |    10.032 ns |  2.58 |    0.14 |    3 | 0.0346 |     - |     - |     220 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|              removeItemIntLike |   After |              After |  100 |    127.18 ns |     2.706 ns |     0.419 ns |  1.00 |    0.00 |    1 | 0.0388 |     - |     - |     246 B |
|              removeItemIntLike |  Main50 |             Main50 |  100 |    242.89 ns |     4.362 ns |     1.133 ns |  1.91 |    0.01 |    2 | 0.0738 |     - |     - |     466 B |
|              removeItemIntLike | NuGet50 |            NuGet50 |  100 |    410.11 ns |     5.409 ns |     1.405 ns |  3.23 |    0.01 |    3 | 0.0734 |     - |     - |     466 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|               removeItemString |   After |              After |  100 |    203.71 ns |    15.080 ns |     2.334 ns |  1.00 |    0.00 |    2 | 0.0494 |     - |     - |     314 B |
|               removeItemString |  Main50 |             Main50 |  100 |    191.98 ns |     2.614 ns |     0.405 ns |  0.94 |    0.01 |    1 | 0.0508 |     - |     - |     322 B |
|               removeItemString | NuGet50 |            NuGet50 |  100 |    479.61 ns |    35.166 ns |     9.133 ns |  2.36 |    0.07 |    3 | 0.0500 |     - |     - |     322 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|              removeItemRefLike |   After |              After |  100 |    181.82 ns |     8.525 ns |     1.319 ns |  1.00 |    0.00 |    1 | 0.0392 |     - |     - |     246 B |
|              removeItemRefLike |  Main50 |             Main50 |  100 |    245.63 ns |     6.343 ns |     1.647 ns |  1.35 |    0.01 |    2 | 0.0395 |     - |     - |     255 B |
|              removeItemRefLike | NuGet50 |            NuGet50 |  100 |    455.84 ns |    15.967 ns |     2.471 ns |  2.51 |    0.03 |    3 | 0.0386 |     - |     - |     255 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|            removeItemIntRecord |   After |              After |  100 |    143.44 ns |     1.979 ns |     0.306 ns |  1.00 |    0.00 |    1 | 0.0387 |     - |     - |     246 B |
|            removeItemIntRecord |  Main50 |             Main50 |  100 |    228.74 ns |    23.071 ns |     5.991 ns |  1.58 |    0.02 |    2 | 0.0734 |     - |     - |     466 B |
|            removeItemIntRecord | NuGet50 |            NuGet50 |  100 |    381.86 ns |     7.295 ns |     1.894 ns |  2.66 |    0.01 |    3 | 0.0737 |     - |     - |     466 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|         removeItemIntRefRecord |   After |              After |  100 |    195.07 ns |     7.819 ns |     1.210 ns |  1.00 |    0.00 |    1 | 0.0387 |     - |     - |     246 B |
|         removeItemIntRefRecord |  Main50 |             Main50 |  100 |    222.92 ns |    29.455 ns |     4.558 ns |  1.14 |    0.02 |    2 | 0.0404 |     - |     - |     255 B |
|         removeItemIntRefRecord | NuGet50 |            NuGet50 |  100 |    438.37 ns |    22.268 ns |     3.446 ns |  2.25 |    0.01 |    3 | 0.0398 |     - |     - |     255 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|     removeItemIntLikeNonGenCmp |   After |              After |  100 |    138.98 ns |     9.356 ns |     2.430 ns |  1.00 |    0.00 |    1 | 0.0555 |     - |     - |     352 B |
|     removeItemIntLikeNonGenCmp |  Main50 |             Main50 |  100 |    242.05 ns |     3.054 ns |     0.793 ns |  1.74 |    0.03 |    2 | 0.0737 |     - |     - |     466 B |
|     removeItemIntLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |    396.52 ns |     2.919 ns |     0.452 ns |  2.84 |    0.05 |    3 | 0.0738 |     - |     - |     466 B |
|                                |         |                    |      |              |              |              |       |         |      |        |       |       |           |
|     removeItemRefLikeNonGenCmp |   After |              After |  100 |    207.36 ns |    10.499 ns |     2.727 ns |  1.00 |    0.00 |    1 | 0.0392 |     - |     - |     246 B |
|     removeItemRefLikeNonGenCmp |  Main50 |             Main50 |  100 |    248.32 ns |    17.190 ns |     4.464 ns |  1.20 |    0.03 |    2 | 0.0402 |     - |     - |     255 B |
|     removeItemRefLikeNonGenCmp | NuGet50 |            NuGet50 |  100 |    465.90 ns |    68.785 ns |    10.644 ns |  2.26 |    0.04 |    3 | 0.0385 |     - |     - |     255 B |
