### PR TITLE
SyntaxTree: introduce SynTyparDecls

### DIFF
--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -3184,7 +3184,7 @@ module EstablishTypeDefinitionCores =
             |> set
 
     let TcTyconDefnCore_Phase1A_BuildInitialModule cenv envInitial parent typeNames compInfo decls =
-        let (SynComponentInfo(Attributes attribs, _parms, _constraints, longPath, xml, _, vis, im)) = compInfo 
+        let (SynComponentInfo(Attributes attribs, _, _, longPath, xml, _, vis, im)) = compInfo 
         let id = ComputeModuleName longPath
         let modAttrs = TcAttributes cenv envInitial AttributeTargets.ModuleDecl attribs 
         let modKind = ComputeModuleOrNamespaceKind cenv.g true typeNames modAttrs id.idText
@@ -4320,7 +4320,8 @@ module EstablishTypeDefinitionCores =
                match origInfo, tyconOpt with 
                | (typeDefCore, _, _), Some (tycon: Tycon) -> 
                 let (MutRecDefnsPhase1DataForTycon(synTyconInfo, _, _, _, _, _)) = typeDefCore
-                let (SynComponentInfo(_, _, synTyconConstraints, _, _, _, _, _)) = synTyconInfo
+                let (SynComponentInfo(_, TyparsAndConstraints (_, cs1), cs2, _, _, _, _, _)) = synTyconInfo
+                let synTyconConstraints = cs1 @ cs2
                 let envForTycon = AddDeclaredTypars CheckForDuplicateTypars (tycon.Typars m) envForDecls
                 let thisTyconRef = mkLocalTyconRef tycon
                 let envForTycon = MakeInnerEnvForTyconRef envForTycon thisTyconRef false 
@@ -5036,7 +5037,7 @@ let rec TcSignatureElementNonMutRec cenv parent typeNames endm (env: TcEnv) synS
             let env = List.foldBack (AddLocalVal cenv.g cenv.tcSink scopem) idvs env
             return env
 
-        | SynModuleSigDecl.NestedModule(SynComponentInfo(Attributes attribs, _parms, _constraints, longPath, xml, _, vis, im) as compInfo, isRec, mdefs, m) ->
+        | SynModuleSigDecl.NestedModule(SynComponentInfo(Attributes attribs, _, _, longPath, xml, _, vis, im) as compInfo, isRec, mdefs, m) ->
             if isRec then 
                 // Treat 'module rec M = ...' as a single mutually recursive definition group 'module M = ...'
                 let modDecl = SynModuleSigDecl.NestedModule(compInfo, false, mdefs, m)
@@ -5356,7 +5357,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
               let modDecl = SynModuleDecl.NestedModule(compInfo, false, mdefs, isContinuingModule, m)
               return! TcModuleOrNamespaceElementsMutRec cenv parent typeNames m env None [modDecl]
           else
-              let (SynComponentInfo(Attributes attribs, _parms, _constraints, longPath, xml, _, vis, im)) = compInfo
+              let (SynComponentInfo(Attributes attribs, _, _, longPath, xml, _, vis, im)) = compInfo
               let id = ComputeModuleName longPath
 
               let modAttrs = TcAttributes cenv env AttributeTargets.ModuleDecl attribs

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -1811,7 +1811,7 @@ let FreshenAbstractSlot g amap m synTyparDecls absMethInfo =
     let typarsFromAbsSlotAreRigid =
 
         match synTyparDecls with
-        | SynValTyparDecls(synTypars, infer, _) ->
+        | ValTyparDecls(synTypars, _, infer) ->
             if infer && not (isNil synTypars) then
                 errorR(Error(FSComp.SR.tcOverridingMethodRequiresAllOrNoTypeParameters(), m))
 
@@ -3946,7 +3946,7 @@ and TcPseudoMemberSpec cenv newOk env synTypes tpenv memSpfn m =
 
 /// Check a value specification, e.g. in a signature, interface declaration or a constraint
 and TcValSpec cenv env declKind newOk containerInfo memFlagsOpt thisTyOpt tpenv valSpfn attrs =
-    let (SynValSig(_, id, SynValTyparDecls(synTypars, _, synTyparConstraints), ty, valSynInfo, _, _, _, _, _, m)) = valSpfn
+    let (SynValSig(_, id, ValTyparDecls (synTypars, synTyparConstraints, _), ty, valSynInfo, _, _, _, _, _, m)) = valSpfn
     let declaredTypars = TcTyparDecls cenv env synTypars
     let (ContainerInfo(altActualParent, tcrefContainerInfo)) = containerInfo
     let enclosingDeclaredTypars, memberContainerInfo, thisTyOpt, declKind =
@@ -9492,7 +9492,7 @@ and TcLiteral cenv overallTy env tpenv (attrs, synLiteralValExpr) =
 
     else hasLiteralAttr, None
 
-and TcBindingTyparDecls alwaysRigid cenv env tpenv (SynValTyparDecls(synTypars, infer, synTyparConstraints)) =
+and TcBindingTyparDecls alwaysRigid cenv env tpenv (ValTyparDecls(synTypars, synTyparConstraints, infer)) =
     let declaredTypars = TcTyparDecls cenv env synTypars
     let envinner = AddDeclaredTypars CheckForDuplicateTypars declaredTypars env
     let tpenv = TcTyparConstraints cenv NoNewTypars CheckCxs ItemOccurence.UseInType envinner tpenv synTyparConstraints
@@ -10936,7 +10936,7 @@ and TcLetrec overridesOK cenv env tpenv (binds, bindsm, scopem) =
 
 let TcAndPublishValSpec (cenv, env, containerInfo: ContainerInfo, declKind, memFlagsOpt, tpenv, valSpfn) =
 
-  let (SynValSig (Attributes synAttrs, _, SynValTyparDecls (synTypars, synCanInferTypars, _), _, _, isInline, mutableFlag, doc, vis, literalExprOpt, m)) = valSpfn
+  let (SynValSig (Attributes synAttrs, _, ValTyparDecls (synTypars, _, synCanInferTypars), _, _, isInline, mutableFlag, doc, vis, literalExprOpt, m)) = valSpfn
 
   GeneralizationHelpers.CheckDeclaredTyparsPermitted(memFlagsOpt, synTypars, m)
   let canInferTypars = GeneralizationHelpers.ComputeCanInferExtraGeneralizableTypars (containerInfo.ParentRef, synCanInferTypars, memFlagsOpt)

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -303,6 +303,29 @@ type SynTypeConstraint =
        typeArgs: SynType list *
        range: range
 
+[<RequireQualifiedAccess>]
+type SynTyparDecls =
+    | PostfixList of decls: SynTyparDecl list * constraints: SynTypeConstraint list * range: range
+    | PrefixList of decls: SynTyparDecl list * range: range
+    | SinglePrefix of decl: SynTyparDecl * range: range
+
+    member x.TyparDecls =
+        match x with
+        | PostfixList (decls=decls)
+        | PrefixList (decls=decls) -> decls
+        | SinglePrefix (decl, _) -> [decl]
+
+    member x.Constraints =
+        match x with
+        | PostfixList (constraints=constraints) -> constraints
+        | _ -> []
+
+    member x.Range =
+        match x with
+        | PostfixList (range=range)
+        | PrefixList (range=range) -> range
+        | SinglePrefix (range=range) -> range
+
 [<NoEquality; NoComparison;RequireQualifiedAccess>]
 type SynType = 
     
@@ -1391,7 +1414,7 @@ type SynField =
 type SynComponentInfo =
     | SynComponentInfo of
         attributes: SynAttributes *
-        typeParams: SynTyparDecl list *
+        typeParams: SynTyparDecls option *
         constraints: SynTypeConstraint list *
         longId: LongIdent *
         xmlDoc: PreXmlDoc *
@@ -1450,11 +1473,9 @@ type SynArgInfo =
 
 [<NoEquality; NoComparison>]
 type SynValTyparDecls =
-
     | SynValTyparDecls of
-        typars: SynTyparDecl list *
-        canInfer: bool *
-        constraints: SynTypeConstraint list
+        typars: SynTyparDecls option *
+        canInfer: bool
 
 [<NoEquality; NoComparison>]
 type SynReturnInfo =

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -405,6 +405,18 @@ type SynTypeConstraint =
        typeArgs: SynType list *
        range: range
 
+/// List of type parameter declarations with optional type constraints,
+/// enclosed in `< ... >` (postfix) or `( ... )` (prefix), or a single prefix parameter.
+[<RequireQualifiedAccess>]
+type SynTyparDecls =
+    | PostfixList of decls: SynTyparDecl list * constraints: SynTypeConstraint list * range: range
+    | PrefixList of decls: SynTyparDecl list * range: range
+    | SinglePrefix of decl: SynTyparDecl * range: range
+
+    member TyparDecls: SynTyparDecl list
+    member Constraints: SynTypeConstraint list
+    member Range: range
+
 /// Represents a syntax tree for F# types
 [<NoEquality; NoComparison;RequireQualifiedAccess>]
 type SynType = 
@@ -1592,7 +1604,7 @@ type SynField =
 type SynComponentInfo =
     | SynComponentInfo of
         attributes: SynAttributes *
-        typeParams: SynTyparDecl list *
+        typeParams: SynTyparDecls option *
         constraints: SynTypeConstraint list *
         longId: LongIdent *
         xmlDoc: PreXmlDoc *
@@ -1650,11 +1662,9 @@ type SynArgInfo =
 /// Represents the names and other metadata for the type parameters for a member or function
 [<NoEquality; NoComparison>]
 type SynValTyparDecls =
-
     | SynValTyparDecls of
-        typars: SynTyparDecl list *
-        canInfer: bool *
-        constraints: SynTypeConstraint list
+        typars: SynTyparDecls option *
+        canInfer: bool
 
 /// Represents the syntactic elements associated with the "return" of a function or method. 
 [<NoEquality; NoComparison>]

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -387,6 +387,21 @@ let ConcatAttributesLists (attrsLists: SynAttributeList list) =
 let (|Attributes|) synAttributes =
     ConcatAttributesLists synAttributes
 
+let (|TyparDecls|) (typarDecls: SynTyparDecls option) =
+    typarDecls
+    |> Option.map (fun x -> x.TyparDecls)
+    |> Option.defaultValue []
+
+let (|TyparsAndConstraints|) (typarDecls: SynTyparDecls option) =
+    typarDecls
+    |> Option.map (fun x -> x.TyparDecls, x.Constraints)
+    |> Option.defaultValue ([], [])
+
+let (|ValTyparDecls|) (SynValTyparDecls(typarDecls, canInfer)) =
+    typarDecls
+    |> Option.map (fun x -> x.TyparDecls, x.Constraints, canInfer)
+    |> Option.defaultValue ([], [], canInfer)
+
 let rangeOfNonNilAttrs (attrs: SynAttributes) =
     (attrs.Head.Range, attrs.Tail) ||> unionRangeWithListBy (fun a -> a.Range)
 
@@ -594,9 +609,9 @@ let StaticMemberFlags k : SynMemberFlags =
       IsOverrideOrExplicitImpl=false
       IsFinal=false }
 
-let inferredTyparDecls = SynValTyparDecls([], true, [])
+let inferredTyparDecls = SynValTyparDecls(None, true)
 
-let noInferredTypars = SynValTyparDecls([], false, [])
+let noInferredTypars = SynValTyparDecls(None, false)
 
 let rec synExprContainsError inpExpr =
     let rec walkBind (SynBinding(_, _, _, _, _, _, _, _, _, synExpr, _, _)) = walkExpr synExpr

--- a/src/fsharp/SyntaxTreeOps.fsi
+++ b/src/fsharp/SyntaxTreeOps.fsi
@@ -153,6 +153,10 @@ val ConcatAttributesLists: attrsLists:SynAttributeList list -> SynAttribute list
 
 val ( |Attributes| ): synAttributes:SynAttributeList list -> SynAttribute list
 
+val ( |TyparDecls| ): typarDecls: SynTyparDecls option -> SynTyparDecl list
+val ( |TyparsAndConstraints| ): typarDecls: SynTyparDecls option -> SynTyparDecl list * SynTypeConstraint list
+val ( |ValTyparDecls| ): valTyparDecls: SynValTyparDecls -> SynTyparDecl list * SynTypeConstraint list * bool
+
 val rangeOfNonNilAttrs: attrs:SynAttributes -> range
 
 val stripParenTypes: synType:SynType -> SynType

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1509,11 +1509,7 @@ memberFlags:
 typeNameInfo: 
   | opt_attributes tyconNameAndTyparDecls opt_typeConstraints
      { let typars, lid, fixity, vis, xmlDoc = $2
-       let tpcs1 =
-           typars
-           |> Option.map (fun (typars: SynTyparDecls) -> typars.Constraints)
-           |> Option.defaultValue []
-       SynComponentInfo ($1, typars, tpcs1 @ $3, lid, xmlDoc, fixity, vis, rangeOfLid lid) }
+       SynComponentInfo ($1, typars, $3, lid, xmlDoc, fixity, vis, rangeOfLid lid) }
 
 /* Part of a set of type definitions */
 tyconDefnList:  

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -805,7 +805,7 @@ moduleSpfn:
       { let isRec, path, xml, vis = $3 
         if not (isSingleton path) then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsModuleDefnMustBeSimpleName())
         if isRec then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsInvalidUseOfRec())
-        let info = SynComponentInfo($1, [], [], path, xml, false, vis, rhs parseState 3)
+        let info = SynComponentInfo($1, None, [], path, xml, false, vis, rhs parseState 3)
         if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let m = (rhs2 parseState 1 4, $5) ||> unionRangeWithListBy (fun (d: SynModuleSigDecl) -> d.Range)
         SynModuleSigDecl.NestedModule(info, isRec, $5, m) }
@@ -1323,7 +1323,7 @@ moduleDefn:
             [ SynModuleDecl.ModuleAbbrev(List.head path, eqn, (rhs parseState 3, eqn) ||> unionRangeWithListBy (fun id -> id.idRange) ) ]
         | Choice2Of2 def -> 
             if not (isSingleton path) then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsModuleAbbreviationMustBeSimpleName())
-            let info = SynComponentInfo(attribs, [], [], path, xml, false, vis, rhs parseState 3)
+            let info = SynComponentInfo(attribs, None, [], path, xml, false, vis, rhs parseState 3)
             [ SynModuleDecl.NestedModule(info, isRec, def, false, (rhs2 parseState 1 4, def) ||> unionRangeWithListBy (fun d -> d.Range) ) ] }
 
   /* unattached custom attributes */
@@ -1508,9 +1508,12 @@ memberFlags:
 /* The name of a type in a signature or implementation, possibly with type parameters and constraints */
 typeNameInfo: 
   | opt_attributes tyconNameAndTyparDecls opt_typeConstraints
-     { let typars, lid, fixity, tpcs1, vis, xmlDoc = $2 
-       let tpcs2 = $3 
-       SynComponentInfo($1, typars, (tpcs1 @ tpcs2), lid, xmlDoc, fixity, vis, rangeOfLid lid)  }
+     { let typars, lid, fixity, vis, xmlDoc = $2
+       let tpcs1 =
+           typars
+           |> Option.map (fun (typars: SynTyparDecls) -> typars.Constraints)
+           |> Option.defaultValue []
+       SynComponentInfo ($1, typars, tpcs1 @ $3, lid, xmlDoc, fixity, vis, rangeOfLid lid) }
 
 /* Part of a set of type definitions */
 tyconDefnList:  
@@ -2280,18 +2283,20 @@ interfaceMember:
 
 tyconNameAndTyparDecls:  
   | opt_access path 
-      { [], $2.Lid, false, [], $1, grabXmlDoc(parseState, 2) }
+      { None, $2.Lid, false, $1, grabXmlDoc(parseState, 2) }
 
   | opt_access prefixTyparDecls  path
-      { $2, $3.Lid, false, [], $1, grabXmlDoc(parseState, 2) }
+      { Some $2, $3.Lid, false, $1, grabXmlDoc(parseState, 2) }
 
   | opt_access path postfixTyparDecls 
-      { let tps, tpcs = $3 
-        tps, $2.Lid, true, tpcs, $1, grabXmlDoc(parseState, 2) }
+      { Some $3, $2.Lid, true, $1, grabXmlDoc(parseState, 2) }
 
 prefixTyparDecls:
-  | typar { [ SynTyparDecl([], $1) ] }
-  | LPAREN typarDeclList rparen {  List.rev $2 }
+  | typar
+      { SynTyparDecls.SinglePrefix (SynTyparDecl([], $1), rhs parseState 1) }
+
+  | LPAREN typarDeclList rparen
+      { SynTyparDecls.PrefixList (List.rev $2, rhs2 parseState 1 3) }
 
 typarDeclList: 
   | typarDeclList COMMA typarDecl { $3 :: $1 } 
@@ -2305,8 +2310,9 @@ typarDecl :
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
 postfixTyparDecls: 
   | opt_HIGH_PRECEDENCE_TYAPP LESS typarDeclList opt_typeConstraints GREATER 
-      { if not $2 then warning(Error(FSComp.SR.parsNonAdjacentTypars(), rhs2 parseState 2 5))
-        List.rev $3, $4 }
+      { let m = rhs2 parseState 2 5
+        if not $2 then warning(Error(FSComp.SR.parsNonAdjacentTypars(), m))
+        SynTyparDecls.PostfixList (List.rev $3, $4, m) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
@@ -2322,15 +2328,17 @@ explicitValTyparDeclsCore:
 
 explicitValTyparDecls: 
   | opt_HIGH_PRECEDENCE_TYAPP LESS explicitValTyparDeclsCore opt_typeConstraints GREATER 
-      { if not $2 then warning(Error(FSComp.SR.parsNonAdjacentTypars(), rhs2 parseState 2 5))
+      { let m = rhs2 parseState 2 5
+        if not $2 then warning(Error(FSComp.SR.parsNonAdjacentTypars(), m))
         let tps, flex = $3 
-        SynValTyparDecls(tps, flex, $4) }
+        let tps = SynTyparDecls.PostfixList (tps, $4, m)
+        SynValTyparDecls(Some tps, flex) }
 
 opt_explicitValTyparDecls: 
   | explicitValTyparDecls 
       { $1 } 
   |       
-      { SynValTyparDecls([], true, []) }
+      { SynValTyparDecls(None, true) }
 
 opt_explicitValTyparDecls2: 
   | explicitValTyparDecls 

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -494,7 +494,7 @@ module ParsedInput =
                 ifPosInRange r (fun _ -> kind)
                 |> Option.orElse (
                     typars 
-                    |> Option.bind (fun (SynValTyparDecls (typars, _, constraints)) -> 
+                    |> Option.bind (fun (ValTyparDecls (typars, constraints, _)) -> 
                         List.tryPick walkTyparDecl typars
                         |> Option.orElse (List.tryPick walkTypeConstraint constraints)))
                 |> Option.orElse (List.tryPick walkPat pats)
@@ -686,7 +686,7 @@ module ParsedInput =
             | SynTypeDefnSimpleRepr.TypeAbbrev(_, t, _) -> walkType t
             | _ -> None
 
-        and walkComponentInfo isModule (SynComponentInfo(Attributes attrs, typars, constraints, _, _, _, _, r)) =
+        and walkComponentInfo isModule (SynComponentInfo(Attributes attrs, TyparDecls typars, constraints, _, _, _, _, r)) =
             if isModule then None else ifPosInRange r (fun _ -> Some EntityKind.Type)
             |> Option.orElse (
                 List.tryPick walkAttribute attrs
@@ -1213,7 +1213,7 @@ module ParsedInput =
             | SynPat.LongIdent (ident, _, typars, ConstructorPats pats, _, _) ->
                 addLongIdentWithDots ident
                 typars
-                |> Option.iter (fun (SynValTyparDecls (typars, _, constraints)) ->
+                |> Option.iter (fun (ValTyparDecls (typars, constraints, _)) ->
                      List.iter walkTyparDecl typars
                      List.iter walkTypeConstraint constraints)
                 List.iter walkPat pats
@@ -1222,7 +1222,7 @@ module ParsedInput =
             | SynPat.QuoteExpr(e, _) -> walkExpr e
             | _ -> ()
     
-        and walkTypar (SynTypar (_, _, _)) = ()
+        and walkTypar (SynTypar _) = ()
     
         and walkBinding (SynBinding(_, _, _, _, Attributes attrs, _, _, pat, returnInfo, e, _, _)) =
             List.iter walkAttribute attrs
@@ -1446,7 +1446,7 @@ module ParsedInput =
             | SynTypeDefnSimpleRepr.TypeAbbrev (_, t, _) -> walkType t
             | _ -> ()
     
-        and walkComponentInfo isTypeExtensionOrAlias (SynComponentInfo(Attributes attrs, typars, constraints, longIdent, _, _, _, _)) =
+        and walkComponentInfo isTypeExtensionOrAlias (SynComponentInfo(Attributes attrs, TyparDecls typars, constraints, longIdent, _, _, _, _)) =
             List.iter walkAttribute attrs
             List.iter walkTyparDecl typars
             List.iter walkTypeConstraint constraints

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -686,7 +686,8 @@ module ParsedInput =
             | SynTypeDefnSimpleRepr.TypeAbbrev(_, t, _) -> walkType t
             | _ -> None
 
-        and walkComponentInfo isModule (SynComponentInfo(Attributes attrs, TyparDecls typars, constraints, _, _, _, _, r)) =
+        and walkComponentInfo isModule (SynComponentInfo(Attributes attrs, TyparsAndConstraints (typars, cs1), cs2, _, _, _, _, r)) =
+            let constraints = cs1 @ cs2
             if isModule then None else ifPosInRange r (fun _ -> Some EntityKind.Type)
             |> Option.orElse (
                 List.tryPick walkAttribute attrs
@@ -1446,7 +1447,8 @@ module ParsedInput =
             | SynTypeDefnSimpleRepr.TypeAbbrev (_, t, _) -> walkType t
             | _ -> ()
     
-        and walkComponentInfo isTypeExtensionOrAlias (SynComponentInfo(Attributes attrs, TyparDecls typars, constraints, longIdent, _, _, _, _)) =
+        and walkComponentInfo isTypeExtensionOrAlias (SynComponentInfo(Attributes attrs, TyparsAndConstraints (typars, cs1), cs2, longIdent, _, _, _, _)) =
+            let constraints = cs1 @ cs2
             List.iter walkAttribute attrs
             List.iter walkTyparDecl typars
             List.iter walkTypeConstraint constraints

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -535,7 +535,7 @@ module Structure =
                     parseAttributes attrs
             | _ -> ()
 
-        and parseTypeDefn (SynTypeDefn(SynComponentInfo(_, typeArgs, _, _, _, _, _, r), objectModel, members, _, fullrange)) = 
+        and parseTypeDefn (SynTypeDefn(SynComponentInfo(_, TyparDecls typeArgs, _, _, _, _, _, r), objectModel, members, _, fullrange)) = 
            let typeArgsRange = rangeOfTypeArgsElse r typeArgs
            let collapse = Range.endToEnd (Range.modEnd 1 typeArgsRange) fullrange
            match objectModel with
@@ -748,7 +748,7 @@ module Structure =
                 parseTypeDefnSig typeDefSig
             | _ -> ()
 
-        and parseTypeDefnSig (SynTypeDefnSig (SynComponentInfo(attribs, typeArgs, _, longId, _, _, _, r) as __, objectModel, memberSigs, _)) = 
+        and parseTypeDefnSig (SynTypeDefnSig (SynComponentInfo(attribs, TyparDecls typeArgs, _, longId, _, _, _, r) as __, objectModel, memberSigs, _)) = 
             parseAttributes attribs
 
             let makeRanges memberSigs =

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -5809,7 +5809,7 @@ FSharp.Compiler.Syntax.SynByteStringKind: System.String ToString()
 FSharp.Compiler.Syntax.SynComponentInfo
 FSharp.Compiler.Syntax.SynComponentInfo: Boolean get_preferPostfix()
 FSharp.Compiler.Syntax.SynComponentInfo: Boolean preferPostfix
-FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Syntax.SynComponentInfo NewSynComponentInfo(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Xml.PreXmlDoc, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Syntax.SynComponentInfo NewSynComponentInfo(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTyparDecls], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Xml.PreXmlDoc, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range get_range()
@@ -5822,12 +5822,12 @@ FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
-FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] get_typeParams()
-FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] typeParams
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] constraints
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] get_constraints()
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
+FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTyparDecls] get_typeParams()
+FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTyparDecls] typeParams
 FSharp.Compiler.Syntax.SynComponentInfo: System.String ToString()
 FSharp.Compiler.Syntax.SynConst
 FSharp.Compiler.Syntax.SynConst+Bool: Boolean Item
@@ -8037,6 +8037,46 @@ FSharp.Compiler.Syntax.SynTyparDecl: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynTyparDecl: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynTyparDecl: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
 FSharp.Compiler.Syntax.SynTyparDecl: System.String ToString()
+FSharp.Compiler.Syntax.SynTyparDecls
+FSharp.Compiler.Syntax.SynTyparDecls+PostfixList: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynTyparDecls+PostfixList: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynTyparDecls+PostfixList: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] decls
+FSharp.Compiler.Syntax.SynTyparDecls+PostfixList: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] get_decls()
+FSharp.Compiler.Syntax.SynTyparDecls+PostfixList: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] constraints
+FSharp.Compiler.Syntax.SynTyparDecls+PostfixList: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] get_constraints()
+FSharp.Compiler.Syntax.SynTyparDecls+PrefixList: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynTyparDecls+PrefixList: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynTyparDecls+PrefixList: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] decls
+FSharp.Compiler.Syntax.SynTyparDecls+PrefixList: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] get_decls()
+FSharp.Compiler.Syntax.SynTyparDecls+SinglePrefix: FSharp.Compiler.Syntax.SynTyparDecl decl
+FSharp.Compiler.Syntax.SynTyparDecls+SinglePrefix: FSharp.Compiler.Syntax.SynTyparDecl get_decl()
+FSharp.Compiler.Syntax.SynTyparDecls+SinglePrefix: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynTyparDecls+SinglePrefix: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynTyparDecls+Tags: Int32 PostfixList
+FSharp.Compiler.Syntax.SynTyparDecls+Tags: Int32 PrefixList
+FSharp.Compiler.Syntax.SynTyparDecls+Tags: Int32 SinglePrefix
+FSharp.Compiler.Syntax.SynTyparDecls: Boolean IsPostfixList
+FSharp.Compiler.Syntax.SynTyparDecls: Boolean IsPrefixList
+FSharp.Compiler.Syntax.SynTyparDecls: Boolean IsSinglePrefix
+FSharp.Compiler.Syntax.SynTyparDecls: Boolean get_IsPostfixList()
+FSharp.Compiler.Syntax.SynTyparDecls: Boolean get_IsPrefixList()
+FSharp.Compiler.Syntax.SynTyparDecls: Boolean get_IsSinglePrefix()
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Syntax.SynTyparDecls NewPostfixList(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Syntax.SynTyparDecls NewPrefixList(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Syntax.SynTyparDecls NewSinglePrefix(FSharp.Compiler.Syntax.SynTyparDecl, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Syntax.SynTyparDecls+PostfixList
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Syntax.SynTyparDecls+PrefixList
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Syntax.SynTyparDecls+SinglePrefix
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Syntax.SynTyparDecls+Tags
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynTyparDecls: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.Syntax.SynTyparDecls: Int32 Tag
+FSharp.Compiler.Syntax.SynTyparDecls: Int32 get_Tag()
+FSharp.Compiler.Syntax.SynTyparDecls: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] TyparDecls
+FSharp.Compiler.Syntax.SynTyparDecls: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] get_TyparDecls()
+FSharp.Compiler.Syntax.SynTyparDecls: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] Constraints
+FSharp.Compiler.Syntax.SynTyparDecls: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] get_Constraints()
+FSharp.Compiler.Syntax.SynTyparDecls: System.String ToString()
 FSharp.Compiler.Syntax.SynType
 FSharp.Compiler.Syntax.SynType+Anon: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+Anon: FSharp.Compiler.Text.Range range
@@ -8702,13 +8742,11 @@ FSharp.Compiler.Syntax.SynValSig: System.String ToString()
 FSharp.Compiler.Syntax.SynValTyparDecls
 FSharp.Compiler.Syntax.SynValTyparDecls: Boolean canInfer
 FSharp.Compiler.Syntax.SynValTyparDecls: Boolean get_canInfer()
-FSharp.Compiler.Syntax.SynValTyparDecls: FSharp.Compiler.Syntax.SynValTyparDecls NewSynValTyparDecls(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl], Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint])
+FSharp.Compiler.Syntax.SynValTyparDecls: FSharp.Compiler.Syntax.SynValTyparDecls NewSynValTyparDecls(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTyparDecls], Boolean)
 FSharp.Compiler.Syntax.SynValTyparDecls: Int32 Tag
 FSharp.Compiler.Syntax.SynValTyparDecls: Int32 get_Tag()
-FSharp.Compiler.Syntax.SynValTyparDecls: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] get_typars()
-FSharp.Compiler.Syntax.SynValTyparDecls: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl] typars
-FSharp.Compiler.Syntax.SynValTyparDecls: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] constraints
-FSharp.Compiler.Syntax.SynValTyparDecls: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] get_constraints()
+FSharp.Compiler.Syntax.SynValTyparDecls: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTyparDecls] get_typars()
+FSharp.Compiler.Syntax.SynValTyparDecls: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTyparDecls] typars
 FSharp.Compiler.Syntax.SynValTyparDecls: System.String ToString()
 FSharp.Compiler.Syntax.SyntaxNode
 FSharp.Compiler.Syntax.SyntaxNode+SynBinding: FSharp.Compiler.Syntax.SynBinding Item


### PR DESCRIPTION
Similar to https://github.com/dotnet/fsharp/pull/6830, adds type for type parameter declaration lists.