### PR TITLE
Parser: add recovery for unfinished match clauses

### DIFF
--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -1169,7 +1169,7 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
                   printfn "   ----"
                   //printfn "   state %d" state
                   for rp in rps do
-                      printfn "       non-terminal %+A: ... " (Parser.prodIdxToNonTerminal rp)
+                      printfn "       non-terminal %+A (idx %d): ... " (Parser.prodIdxToNonTerminal rp) rp
 #endif
 
           match ctxt.CurrentToken with

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1015,6 +1015,11 @@ type SynArgPats =
         pats: (Ident * SynPat) list *
         range: range
 
+    member x.Patterns =
+        match x with
+        | Pats pats -> pats
+        | NamePatPairs (pats, _) -> pats |> List.map snd
+
 [<NoEquality; NoComparison;RequireQualifiedAccess>]
 type SynPat =
 

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -1148,6 +1148,8 @@ type SynArgPats =
         pats: (Ident * SynPat) list *
         range: range
 
+    member Patterns: SynPat list
+
 /// Represents a syntax tree for an F# pattern
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynPat =

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -319,6 +319,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <Ident> ident
 %type <SynType> typ typEOF
 %type <SynTypeDefnSig list> tyconSpfnList
+%type <SynArgPats> atomicPatsOrNamePatPairs
 %type <Range * SynExpr> patternResult
 %type <SynExpr> declExpr
 %type <SynExpr> minusExpr
@@ -3100,25 +3101,38 @@ namePatPair:
 
 constrPattern:
   | atomicPatternLongIdent explicitValTyparDecls
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, Some $2, SynArgPats.Pats [], vis, lhs parseState) }
+      { let vis, lid = $1
+        SynPat.LongIdent (lid, None, Some $2, SynArgPats.Pats [], vis, lhs parseState) }
 
   | atomicPatternLongIdent explicitValTyparDecls atomicPatsOrNamePatPairs %prec pat_app
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, Some $2, $3, vis, lhs parseState) }
+      { let vis, lid = $1
+        let m = (rhs2 parseState 1 2, $3.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
+        SynPat.LongIdent (lid, None, Some $2, $3, vis, m) }
 
   | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, Some $2, $4, vis, lhs parseState) }
+      { let vis, lid = $1
+        let m = (rhs2 parseState 1 2, $4.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
+        SynPat.LongIdent (lid, None, Some $2, $4, vis, m) }
 
   | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, Some $2, $4, vis, lhs parseState) }
+      { let vis, lid = $1
+        let m = (rhs2 parseState 1 2, $4.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
+        SynPat.LongIdent (lid, None, Some $2, $4, vis, m) }
 
   | atomicPatternLongIdent atomicPatsOrNamePatPairs %prec pat_app
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, None, $2, vis, lhs parseState) }
+      { let vis, lid = $1
+        let m = (rhs parseState 1, $2.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
+        SynPat.LongIdent (lid, None, None, $2, vis, m) }
 
   | atomicPatternLongIdent HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, None, $3, vis, lhs parseState) }
+      { let vis, lid = $1
+        let m = (rhs parseState 1, $3.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
+        SynPat.LongIdent (lid, None, None, $3, vis, m) }
 
   | atomicPatternLongIdent HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, None, $3, vis, lhs parseState) }
+      { let vis, lid = $1
+        let m = (rhs parseState 1, $3.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
+        SynPat.LongIdent (lid, None, None, $3, vis, m) }
 
   | COLON_QMARK atomTypeOrAnonRecdType  %prec pat_isinst 
       { SynPat.IsInst($2, lhs parseState) }
@@ -3979,7 +3993,7 @@ patternClauses:
      { let pat, guard, patm = $1 
        let clauses, mLast = $4
        let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm
-       (SynMatchClause(pat, guard, None, unitExprFromParseError mLast.EndRange, m, DebugPointAtTarget.Yes) :: clauses), mLast }
+       (SynMatchClause(pat, guard, None, unitExprFromParseError m.EndRange, m, DebugPointAtTarget.Yes) :: clauses), mLast }
 
   | patternAndGuard patternResult BAR error 
      { let pat, guard, patm = $1 
@@ -4002,7 +4016,7 @@ patternClauses:
        let mLast = rhs parseState 2
        let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm
        // silent recovery 
-       [SynMatchClause(pat, guard, None, unitExprFromParseError mLast.EndRange, m, DebugPointAtTarget.Yes)], mLast }
+       [SynMatchClause(pat, guard, None, unitExprFromParseError m.EndRange, m, DebugPointAtTarget.Yes)], mLast }
  
 patternGuard: 
   | WHEN declExpr 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -3975,6 +3975,12 @@ patternClauses:
        let m = unionRanges resultExpr.Range patm
        (SynMatchClause(pat, guard, (Some mArrow), resultExpr, m, DebugPointAtTarget.Yes) :: clauses), mLast }
 
+  | patternAndGuard error BAR patternClauses 
+     { let pat, guard, patm = $1 
+       let clauses, mLast = $4
+       let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm
+       (SynMatchClause(pat, guard, None, unitExprFromParseError mLast.EndRange, m, DebugPointAtTarget.Yes) :: clauses), mLast }
+
   | patternAndGuard patternResult BAR error 
      { let pat, guard, patm = $1 
        let mArrow, resultExpr = $2
@@ -3994,12 +4000,9 @@ patternClauses:
   | patternAndGuard error 
      { let pat, guard, patm = $1 
        let mLast = rhs parseState 2
-       let m = 
-           match guard with 
-           | Some e -> unionRanges patm e.Range 
-           | _ -> patm
+       let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm
        // silent recovery 
-       [SynMatchClause(pat, guard, None, unitExprFromParseError  mLast.EndRange, m, DebugPointAtTarget.Yes)], mLast }
+       [SynMatchClause(pat, guard, None, unitExprFromParseError mLast.EndRange, m, DebugPointAtTarget.Yes)], mLast }
  
 patternGuard: 
   | WHEN declExpr 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -36,6 +36,9 @@ let debugPrint s = ignore s
 
 let exprFromParseError (e:SynExpr) = SynExpr.FromParseError (e, e.Range)
 
+let unitExprFromRange m = SynExpr.Const (SynConst.Unit, m)
+let unitExprFromParseError m = unitExprFromRange m |> exprFromParseError
+
 let patFromParseError (e:SynPat) = SynPat.FromParseError(e, e.Range)
 
 // record bindings returned by the recdExprBindings rule has shape:
@@ -2337,13 +2340,6 @@ opt_explicitValTyparDecls:
   |       
       { SynValTyparDecls(None, true) }
 
-opt_explicitValTyparDecls2: 
-  | explicitValTyparDecls 
-      { Some $1 } 
-
-  | /* EMPTY */      
-      { None }
-
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
 opt_typeConstraints:
@@ -3103,17 +3099,26 @@ namePatPair:
      { ($1, $3) }
 
 constrPattern:
-  | atomicPatternLongIdent explicitValTyparDecls                                                          
+  | atomicPatternLongIdent explicitValTyparDecls
       { let vis, lid = $1 in SynPat.LongIdent (lid, None, Some $2, SynArgPats.Pats [], vis, lhs parseState) }
 
-  | atomicPatternLongIdent opt_explicitValTyparDecls2                     atomicPatsOrNamePatPairs    %prec pat_app 
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, $2, $3, vis, lhs parseState) }
+  | atomicPatternLongIdent explicitValTyparDecls atomicPatsOrNamePatPairs %prec pat_app
+      { let vis, lid = $1 in SynPat.LongIdent (lid, None, Some $2, $3, vis, lhs parseState) }
 
-  | atomicPatternLongIdent opt_explicitValTyparDecls2 HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs                  
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, $2, $4, vis, lhs parseState) }
+  | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
+      { let vis, lid = $1 in SynPat.LongIdent (lid, None, Some $2, $4, vis, lhs parseState) }
 
-  | atomicPatternLongIdent opt_explicitValTyparDecls2 HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs                  
-      { let vis, lid = $1 in SynPat.LongIdent (lid, None, $2, $4, vis, lhs parseState) }
+  | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
+      { let vis, lid = $1 in SynPat.LongIdent (lid, None, Some $2, $4, vis, lhs parseState) }
+
+  | atomicPatternLongIdent atomicPatsOrNamePatPairs %prec pat_app
+      { let vis, lid = $1 in SynPat.LongIdent (lid, None, None, $2, vis, lhs parseState) }
+
+  | atomicPatternLongIdent HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
+      { let vis, lid = $1 in SynPat.LongIdent (lid, None, None, $3, vis, lhs parseState) }
+
+  | atomicPatternLongIdent HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
+      { let vis, lid = $1 in SynPat.LongIdent (lid, None, None, $3, vis, lhs parseState) }
 
   | COLON_QMARK atomTypeOrAnonRecdType  %prec pat_isinst 
       { SynPat.IsInst($2, lhs parseState) }
@@ -3994,7 +3999,7 @@ patternClauses:
            | Some e -> unionRanges patm e.Range 
            | _ -> patm
        // silent recovery 
-       [SynMatchClause(pat, guard, None, SynExpr.Const (SynConst.Unit, mLast.EndRange), m, DebugPointAtTarget.Yes)], mLast }
+       [SynMatchClause(pat, guard, None, unitExprFromParseError  mLast.EndRange, m, DebugPointAtTarget.Yes)], mLast }
  
 patternGuard: 
   | WHEN declExpr 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -36,9 +36,6 @@ let debugPrint s = ignore s
 
 let exprFromParseError (e:SynExpr) = SynExpr.FromParseError (e, e.Range)
 
-let unitExprFromRange m = SynExpr.Const (SynConst.Unit, m)
-let unitExprFromParseError m = unitExprFromRange m |> exprFromParseError
-
 let patFromParseError (e:SynPat) = SynPat.FromParseError(e, e.Range)
 
 // record bindings returned by the recdExprBindings rule has shape:
@@ -319,7 +316,8 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <Ident> ident
 %type <SynType> typ typEOF
 %type <SynTypeDefnSig list> tyconSpfnList
-%type <SynArgPats> atomicPatsOrNamePatPairs
+%type <SynArgPats * Range> atomicPatsOrNamePatPairs
+%type <SynPat list> atomicPatterns
 %type <Range * SynExpr> patternResult
 %type <SynExpr> declExpr
 %type <SynExpr> minusExpr
@@ -3106,33 +3104,39 @@ constrPattern:
 
   | atomicPatternLongIdent explicitValTyparDecls atomicPatsOrNamePatPairs %prec pat_app
       { let vis, lid = $1
-        let m = (rhs2 parseState 1 2, $3.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
-        SynPat.LongIdent (lid, None, Some $2, $3, vis, m) }
+        let args, argsM = $3
+        let m = unionRanges (rhs2 parseState 1 2) argsM
+        SynPat.LongIdent (lid, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
-        let m = (rhs2 parseState 1 2, $4.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
-        SynPat.LongIdent (lid, None, Some $2, $4, vis, m) }
+        let args, argsM = $4
+        let m = unionRanges (rhs2 parseState 1 2) argsM
+        SynPat.LongIdent (lid, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
-        let m = (rhs2 parseState 1 2, $4.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
-        SynPat.LongIdent (lid, None, Some $2, $4, vis, m) }
+        let args, argsM = $4
+        let m = unionRanges (rhs2 parseState 1 2) argsM
+        SynPat.LongIdent (lid, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent atomicPatsOrNamePatPairs %prec pat_app
       { let vis, lid = $1
-        let m = (rhs parseState 1, $2.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
-        SynPat.LongIdent (lid, None, None, $2, vis, m) }
+        let args, argsM = $2
+        let m = unionRanges (rhs parseState 1) argsM
+        SynPat.LongIdent (lid, None, None, args, vis, m) }
 
   | atomicPatternLongIdent HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
-        let m = (rhs parseState 1, $3.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
-        SynPat.LongIdent (lid, None, None, $3, vis, m) }
+        let args, argsM = $3
+        let m = unionRanges (rhs parseState 1) argsM
+        SynPat.LongIdent (lid, None, None, args, vis, m) }
 
   | atomicPatternLongIdent HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
-        let m = (rhs parseState 1, $3.Patterns) ||> unionRangeWithListBy (fun p -> p.Range)
-        SynPat.LongIdent (lid, None, None, $3, vis, m) }
+        let args, argsM = $3
+        let m = unionRanges (rhs parseState 1) argsM
+        SynPat.LongIdent (lid, None, None, args, vis, m) }
 
   | COLON_QMARK atomTypeOrAnonRecdType  %prec pat_isinst 
       { SynPat.IsInst($2, lhs parseState) }
@@ -3142,10 +3146,13 @@ constrPattern:
 
 atomicPatsOrNamePatPairs:
   | LPAREN namePatPairs rparen
-      { SynArgPats.NamePatPairs $2 }
+      { let m = rhs2 parseState 1 3
+        SynArgPats.NamePatPairs $2, m }
 
   | atomicPatterns
-      { SynArgPats.Pats $1 }
+      { let mWhole = rhs parseState 1
+        let m = (mWhole.StartRange, $1) ||> unionRangeWithListBy (fun p -> p.Range)
+        SynArgPats.Pats $1, m }
 
 atomicPatterns: 
   | atomicPattern atomicPatterns %prec pat_args 
@@ -3993,7 +4000,7 @@ patternClauses:
      { let pat, guard, patm = $1 
        let clauses, mLast = $4
        let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm
-       (SynMatchClause(pat, guard, None, unitExprFromParseError m.EndRange, m, DebugPointAtTarget.Yes) :: clauses), mLast }
+       (SynMatchClause(pat, guard, None, arbExpr ("patternClauses1", m.EndRange), m, DebugPointAtTarget.Yes) :: clauses), mLast }
 
   | patternAndGuard patternResult BAR error 
      { let pat, guard, patm = $1 
@@ -4016,7 +4023,7 @@ patternClauses:
        let mLast = rhs parseState 2
        let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm
        // silent recovery 
-       [SynMatchClause(pat, guard, None, unitExprFromParseError m.EndRange, m, DebugPointAtTarget.Yes)], mLast }
+       [SynMatchClause(pat, guard, None, arbExpr ("patternClauses2", m.EndRange), m, DebugPointAtTarget.Yes)], mLast }
  
 patternGuard: 
   | WHEN declExpr 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -3146,8 +3146,7 @@ constrPattern:
 
 atomicPatsOrNamePatPairs:
   | LPAREN namePatPairs rparen
-      { let m = rhs2 parseState 1 3
-        SynArgPats.NamePatPairs $2, m }
+      { SynArgPats.NamePatPairs $2, snd $2 }
 
   | atomicPatterns
       { let mWhole = rhs parseState 1

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -908,6 +908,11 @@ module ParsedInput =
                     if isOnTheRightOfComma elements commas e then Some args else None
             | _ -> None
 
+        let (|SkipFromParseErrorPat|) pat =
+            match pat with
+            | SynPat.FromParseError(pat, _) -> pat
+            | _ -> pat
+
         let walker = 
             { 
                 new SyntaxVisitorBase<_>() with
@@ -980,7 +985,8 @@ module ParsedInput =
                         
                     member _.VisitBinding(_path, defaultTraverse, (SynBinding(headPat = headPat) as synBinding)) = 
                     
-                        let visitParam = function
+                        let visitParam (SkipFromParseErrorPat pat) =
+                            match pat with
                             | SynPat.Named (range = range)
                             | SynPat.As (_, SynPat.Named (range = range), _) when rangeContainsPos range pos -> 
                                 // parameter without type hint, no completion
@@ -999,12 +1005,13 @@ module ParsedInput =
                             | SynArgPats.Pats pats ->
                                 pats |> List.tryPick (fun pat ->
                                     match pat with
+                                    | SynPat.FromParseError(pat, _)
                                     | SynPat.Paren(pat, _) -> 
                                         match pat with
                                         | SynPat.Tuple(_, pats, _) ->
                                             pats |> List.tryPick visitParam
                                         | _ -> visitParam pat
-                                    | SynPat.Wild range | SynPat.FromParseError (_, range) when rangeContainsPos range pos -> 
+                                    | SynPat.Wild range | SynPat.FromParseError (SynPat.Named _, range) when rangeContainsPos range pos -> 
                                         // let foo (x|
                                         Some CompletionContext.Invalid
                                     | _ -> visitParam pat

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -1004,7 +1004,7 @@ module ParsedInput =
                                         | SynPat.Tuple(_, pats, _) ->
                                             pats |> List.tryPick visitParam
                                         | _ -> visitParam pat
-                                    | SynPat.Wild range when rangeContainsPos range pos -> 
+                                    | SynPat.Wild range | SynPat.FromParseError (_, range) when rangeContainsPos range pos -> 
                                         // let foo (x|
                                         Some CompletionContext.Invalid
                                     | _ -> visitParam pat

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -5239,6 +5239,29 @@ FSharp.Compiler.Syntax.DebugPointAtSwitch: Int32 GetHashCode(System.Collections.
 FSharp.Compiler.Syntax.DebugPointAtSwitch: Int32 Tag
 FSharp.Compiler.Syntax.DebugPointAtSwitch: Int32 get_Tag()
 FSharp.Compiler.Syntax.DebugPointAtSwitch: System.String ToString()
+FSharp.Compiler.Syntax.DebugPointAtTarget
+FSharp.Compiler.Syntax.DebugPointAtTarget+Tags: Int32 No
+FSharp.Compiler.Syntax.DebugPointAtTarget+Tags: Int32 Yes
+FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean Equals(FSharp.Compiler.Syntax.DebugPointAtTarget)
+FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean Equals(System.Object)
+FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
+FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean IsNo
+FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean IsYes
+FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean get_IsNo()
+FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean get_IsYes()
+FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget No
+FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget Yes
+FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget get_No()
+FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget get_Yes()
+FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget+Tags
+FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 CompareTo(FSharp.Compiler.Syntax.DebugPointAtTarget)
+FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 CompareTo(System.Object)
+FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 CompareTo(System.Object, System.Collections.IComparer)
+FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 GetHashCode()
+FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 GetHashCode(System.Collections.IEqualityComparer)
+FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 Tag
+FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 get_Tag()
+FSharp.Compiler.Syntax.DebugPointAtTarget: System.String ToString()
 FSharp.Compiler.Syntax.DebugPointAtTry
 FSharp.Compiler.Syntax.DebugPointAtTry+Tags: Int32 Body
 FSharp.Compiler.Syntax.DebugPointAtTry+Tags: Int32 No
@@ -5310,29 +5333,6 @@ FSharp.Compiler.Syntax.DebugPointAtWith: Int32 GetHashCode(System.Collections.IE
 FSharp.Compiler.Syntax.DebugPointAtWith: Int32 Tag
 FSharp.Compiler.Syntax.DebugPointAtWith: Int32 get_Tag()
 FSharp.Compiler.Syntax.DebugPointAtWith: System.String ToString()
-FSharp.Compiler.Syntax.DebugPointAtTarget
-FSharp.Compiler.Syntax.DebugPointAtTarget+Tags: Int32 No
-FSharp.Compiler.Syntax.DebugPointAtTarget+Tags: Int32 Yes
-FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean Equals(FSharp.Compiler.Syntax.DebugPointAtTarget)
-FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean Equals(System.Object)
-FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
-FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean IsNo
-FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean IsYes
-FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean get_IsNo()
-FSharp.Compiler.Syntax.DebugPointAtTarget: Boolean get_IsYes()
-FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget No
-FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget Yes
-FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget get_No()
-FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget get_Yes()
-FSharp.Compiler.Syntax.DebugPointAtTarget: FSharp.Compiler.Syntax.DebugPointAtTarget+Tags
-FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 CompareTo(FSharp.Compiler.Syntax.DebugPointAtTarget)
-FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 CompareTo(System.Object)
-FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 CompareTo(System.Object, System.Collections.IComparer)
-FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 GetHashCode()
-FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 GetHashCode(System.Collections.IEqualityComparer)
-FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 Tag
-FSharp.Compiler.Syntax.DebugPointAtTarget: Int32 get_Tag()
-FSharp.Compiler.Syntax.DebugPointAtTarget: System.String ToString()
 FSharp.Compiler.Syntax.ExprAtomicFlag
 FSharp.Compiler.Syntax.ExprAtomicFlag: FSharp.Compiler.Syntax.ExprAtomicFlag Atomic
 FSharp.Compiler.Syntax.ExprAtomicFlag: FSharp.Compiler.Syntax.ExprAtomicFlag NonAtomic
@@ -5728,6 +5728,8 @@ FSharp.Compiler.Syntax.SynArgPats: FSharp.Compiler.Syntax.SynArgPats+Pats
 FSharp.Compiler.Syntax.SynArgPats: FSharp.Compiler.Syntax.SynArgPats+Tags
 FSharp.Compiler.Syntax.SynArgPats: Int32 Tag
 FSharp.Compiler.Syntax.SynArgPats: Int32 get_Tag()
+FSharp.Compiler.Syntax.SynArgPats: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynPat] Patterns
+FSharp.Compiler.Syntax.SynArgPats: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynPat] get_Patterns()
 FSharp.Compiler.Syntax.SynArgPats: System.String ToString()
 FSharp.Compiler.Syntax.SynAttribute
 FSharp.Compiler.Syntax.SynAttribute: Boolean AppliesToGetterAndSetter

--- a/tests/fsharp/typecheck/sigs/neg104.bsl
+++ b/tests/fsharp/typecheck/sigs/neg104.bsl
@@ -7,7 +7,7 @@ neg104.fs(20,23,20,24): parse error FS0010: Incomplete structured construct at o
 
 neg104.fs(23,25,23,26): parse error FS0010: Incomplete structured construct at or before this point in expression
 
-neg104.fs(26,28,26,29): parse error FS0010: Incomplete structured construct at or before this point in pattern
+neg104.fs(26,28,26,29): parse error FS0010: Incomplete structured construct at or before this point in pattern matching. Expected '->' or other token.
 
 neg104.fs(29,31,29,32): parse error FS0010: Incomplete structured construct at or before this point in pattern matching
 

--- a/tests/fsharp/typecheck/sigs/neg104.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg104.vsbsl
@@ -7,7 +7,7 @@ neg104.fs(20,23,20,24): parse error FS0010: Incomplete structured construct at o
 
 neg104.fs(23,25,23,26): parse error FS0010: Incomplete structured construct at or before this point in expression
 
-neg104.fs(26,28,26,29): parse error FS0010: Incomplete structured construct at or before this point in pattern
+neg104.fs(26,28,26,29): parse error FS0010: Incomplete structured construct at or before this point in pattern matching. Expected '->' or other token.
 
 neg104.fs(29,31,29,32): parse error FS0010: Incomplete structured construct at or before this point in pattern matching
 
@@ -26,8 +26,6 @@ neg104.fs(10,9,10,30): typecheck error FS0750: This construct may only be used w
 neg104.fs(20,9,20,22): typecheck error FS0025: Incomplete pattern matches on this expression.
 
 neg104.fs(23,9,23,22): typecheck error FS0025: Incomplete pattern matches on this expression.
-
-neg104.fs(26,9,26,22): typecheck error FS0025: Incomplete pattern matches on this expression.
 
 neg104.fs(32,21,32,26): typecheck error FS0003: This value is not a function and cannot be applied.
 

--- a/tests/fsharp/typecheck/sigs/neg80.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg80.vsbsl
@@ -2,7 +2,3 @@
 neg80.fsx(79,5,79,6): parse error FS0010: Unexpected symbol '|' in pattern matching
 
 neg80.fsx(79,5,79,6): parse error FS0010: Unexpected symbol '|' in pattern matching
-
-neg80.fsx(79,6,79,6): typecheck error FS0001: All branches of a pattern match expression must return values implicitly convertible to the type of the first branch, which here is 'string'. This branch returns a value of type 'unit'.
-
-neg80.fsx(76,11,76,13): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'Horizontal (_, _)' may indicate a case not covered by the pattern(s).

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/IdentifiersAndKeywords/E_KeywordIdent01.fs
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/IdentifiersAndKeywords/E_KeywordIdent01.fs
@@ -2,7 +2,7 @@
 #light
 
 //<Expects id="FS0010" status="error">Unexpected keyword 'type' in binding</Expects>
-//<Expects id="FS0010" status="error">Unexpected keyword 'class' in pattern</Expects>
+//<Expects id="FS0010" status="error">Unexpected keyword 'class' in binding. Expected '=' or other token.</Expects>
 
 let type = 2
 

--- a/tests/fsharpqa/Source/Conformance/PatternMatching/TypeConstraint/E_typecontraint01.fs
+++ b/tests/fsharpqa/Source/Conformance/PatternMatching/TypeConstraint/E_typecontraint01.fs
@@ -2,8 +2,9 @@
 // Regression test for FSHARP1.0:1525
 // type constraints on pattern matching are deprecated and are now errors (used to be warnings)
 // As of Beta2, we are not even giving the deprecation error.
-//<Expects id="FS0010" span="(20,8-20,10)" status="error">Unexpected symbol ':>' in pattern$</Expects>
-//<Expects id="FS0583" span="(20,5-20,6)" status="error">Unmatched '\('$</Expects>
+//<Expects id="FS0010" span="(21,8-21,10)" status="error">Unexpected symbol ':>' in pattern. Expected '\)' or other token.</Expects>
+//<Expects id="FS0583" span="(21,5-21,6)" status="error">Unmatched '\('$</Expects>
+//<Expects id="FS0222" span="(8,1-9,1)" status="error">Files in libraries or multiple-file applications must begin with a namespace or module declaration, e.g. 'namespace SomeNamespace.SubNamespace' or 'module SomeNamespace.SomeModule'. Only the last source file of an application may omit such a declaration.</Expects>
 type A() = class
            end
          

--- a/tests/fsharpqa/Source/Diagnostics/General/E_UnexpectedSymbol01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/General/E_UnexpectedSymbol01.fs
@@ -1,7 +1,7 @@
 // #Regression #Diagnostics 
 // Regression test for FSHARP1.0:2099
 // Regression test for FSHARP1.0:2670
-//<Expects id="FS0010" span="(18,50-18,52)" status="error">Unexpected symbol '<-' in pattern</Expects>
+//<Expects id="FS0010" span="(18,50-18,52)" status="error">Unexpected symbol '<-' in binding. Expected '=' or other token.</Expects>
 //<Expects id="FS0588" span="(18,42-18,45)" status="error">The block following this 'let' is unfinished. Every code block is an expression and must have a result. 'let' cannot be the final code element in a block. Consider giving this block an explicit result.</Expects>
 //<Expects status="notin">lambda</Expects>
 

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/E_let_id.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/E_let_id.fsx
@@ -1,5 +1,5 @@
 // #Regression #NoMT #FSI 
 // Regression test for FSHARP1.0:5629
-//<Expects status="error" span="(4,6)" id="FS0010">Incomplete structured construct at or before this point in pattern$</Expects>
+//<Expects status="error" span="(4,6)" id="FS0010">Incomplete structured construct at or before this point in binding. Expected '=' or other token.</Expects>
 let f;;
 exit 1;;

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -254,14 +254,11 @@ let getSingleModuleLikeDecl (input: ParsedInput) =
     | _ -> failwith "Could not get module decls"
 
 let getSingleModuleMemberDecls (input: ParsedInput) =
-    match getSingleModuleLikeDecl input with
-    | SynModuleOrNamespace (decls = decls) -> decls
+    let (SynModuleOrNamespace (decls = decls)) = getSingleModuleLikeDecl input
+    decls
 
 let getSingleExprInModule (input: ParsedInput) =
-    match getSingleModuleLikeDecl input with
-    | SynModuleOrNamespace (decls = decls) ->
-
-    match decls with
+    match getSingleModuleMemberDecls input with
     | [ SynModuleDecl.DoExpr (_, expr, _) ] -> expr
     | _ -> failwith "Can't get single expression"
 

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -253,6 +253,19 @@ let getSingleModuleLikeDecl (input: ParsedInput) =
     | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ decl ])) -> decl
     | _ -> failwith "Could not get module decls"
 
+let getSingleModuleMemberDecls (input: ParsedInput) =
+    match getSingleModuleLikeDecl input with
+    | SynModuleOrNamespace (decls = decls) -> decls
+
+let getSingleExprInModule (input: ParsedInput) =
+    match getSingleModuleLikeDecl input with
+    | SynModuleOrNamespace (decls = decls) ->
+
+    match decls with
+    | [ SynModuleDecl.DoExpr (_, expr, _) ] -> expr
+    | _ -> failwith "Can't get single expression"
+
+
 let parseSourceCodeAndGetModule (source: string) =
     parseSourceCode ("test.fsx", source) |> getSingleModuleLikeDecl
 

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -23,11 +23,11 @@ let x = ()
 let ``Union case 01 - of`` () =
     let parseResults = getParseResults """
 type U1 =
-| A of
+    | A of
 
 type U2 =
-| B of
-| C
+    | B of
+    | C
 
 let x = ()
 """

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -51,7 +51,7 @@ match () with
 | x
 """
     match getSingleExprInModule parseResults with
-    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.FromParseError _, _, _) ], _) -> ()
+    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.ArbitraryAfterError _, _, _) ], _) -> ()
     | _ -> failwith "Unexpected tree"
 
 
@@ -63,7 +63,7 @@ match () with
 """
 
     match getSingleExprInModule parseResults with
-    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.FromParseError _, _, _) ], _) -> ()
+    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.ArbitraryAfterError _, _, _) ], _) -> ()
     | _ -> failwith "Unexpected tree"
 
 [<Test>]
@@ -75,5 +75,5 @@ match () with
 """
 
     match getSingleExprInModule parseResults with
-    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.FromParseError _, _, _); _ ], _) -> ()
+    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.ArbitraryAfterError _, _, _); _ ], _) -> ()
     | _ -> failwith "Unexpected tree"

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -77,3 +77,28 @@ match () with
     match getSingleExprInModule parseResults with
     | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.ArbitraryAfterError _, _, _); _ ], _) -> ()
     | _ -> failwith "Unexpected tree"
+
+[<Test>]
+let ``Match clause 04 - Or pat`` () =
+    let parseResults = getParseResults """
+match () with
+| x
+| _ -> ()
+"""
+
+    match getSingleExprInModule parseResults with
+    | SynExpr.Match (_, _, [ SynMatchClause (SynPat.Or _, _, _, SynExpr.Const _, _, _) ], _) -> ()
+    | _ -> failwith "Unexpected tree"
+
+[<Test>]
+let ``Match clause 05 - Missing body`` () =
+    let parseResults = getParseResults """
+match () with
+| x ->
+| _ -> ()
+"""
+
+    match getSingleExprInModule parseResults with
+    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.ArbitraryAfterError _, _, _)
+                             SynMatchClause (_, _, _, SynExpr.Const _, _, _) ], _) -> ()
+    | _ -> failwith "Unexpected tree"

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -65,3 +65,15 @@ match () with
     match getSingleExprInModule parseResults with
     | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.FromParseError _, _, _) ], _) -> ()
     | _ -> failwith "Unexpected tree"
+
+[<Test>]
+let ``Match clause 03 - When`` () =
+    let parseResults = getParseResults """
+match () with
+| x when true
+| _ -> ()
+"""
+
+    match getSingleExprInModule parseResults with
+    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.FromParseError _, _, _); _ ], _) -> ()
+    | _ -> failwith "Unexpected tree"

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -1,46 +1,67 @@
-﻿module Tests.Parser
+﻿module FSharp.Compiler.Service.Tests.Parser.Recovery
 
 open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Syntax
 open NUnit.Framework
 
-module Recovery =
-    [<Test>]
-    let ``Unfinished interface member`` () =
-        let parseResults = getParseResults """
+[<Test>]
+let ``Interface impl - No members`` () =
+    let parseResults = getParseResults """
 type T =
     interface I with
     member x.P2 = ()
 
 let x = ()
 """
-        let (SynModuleOrNamespace (decls = decls)) = getSingleModuleLikeDecl parseResults
-        match decls with
-        | [ SynModuleDecl.Types ([ SynTypeDefn (typeRepr = SynTypeDefnRepr.ObjectModel (members = [ _; _ ])) ], _)
-            SynModuleDecl.Let _ ] -> ()
-        | _ -> failwith "Unexpected tree"
+    match getSingleModuleMemberDecls parseResults with
+    | [ SynModuleDecl.Types ([ SynTypeDefn (typeRepr = SynTypeDefnRepr.ObjectModel (members = [ _; _ ])) ], _)
+        SynModuleDecl.Let _ ] -> ()
+    | _ -> failwith "Unexpected tree"
 
-    [<Test>]
-    let ``Union case 01 - of`` () =
-        let parseResults = getParseResults """
+
+[<Test>]
+let ``Union case 01 - of`` () =
+    let parseResults = getParseResults """
 type U1 =
-    | A of
+| A of
 
 type U2 =
-    | B of
-    | C
+| B of
+| C
 
 let x = ()
-    """
-        let (|UnionWithCases|_|) typeDefn =
-            match typeDefn with
-            | SynTypeDefn (typeRepr = SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Union (unionCases = cases), _)) ->
-                cases |> List.map (fun (SynUnionCase (ident = ident)) -> ident.idText) |> Some
-            | _ -> None
+"""
+    let (|UnionWithCases|_|) typeDefn =
+        match typeDefn with
+        | SynTypeDefn (typeRepr = SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Union (unionCases = cases), _)) ->
+            cases |> List.map (fun (SynUnionCase (ident = ident)) -> ident.idText) |> Some
+        | _ -> None
 
-        let (SynModuleOrNamespace (decls = decls)) = getSingleModuleLikeDecl parseResults
-        match decls with
-        | [ SynModuleDecl.Types ([ UnionWithCases ["A"]], _)
-            SynModuleDecl.Types ([ UnionWithCases ["B"; "C"] ], _)
-            SynModuleDecl.Let _ ] -> ()
-        | _ -> failwith "Unexpected tree"
+    match getSingleModuleMemberDecls parseResults with
+    | [ SynModuleDecl.Types ([ UnionWithCases ["A"]], _)
+        SynModuleDecl.Types ([ UnionWithCases ["B"; "C"] ], _)
+        SynModuleDecl.Let _ ] -> ()
+    | _ -> failwith "Unexpected tree"
+
+
+[<Test>]
+let ``Match clause 01`` () =
+    let parseResults = getParseResults """
+match () with
+| x
+"""
+    match getSingleExprInModule parseResults with
+    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.FromParseError _, _, _) ], _) -> ()
+    | _ -> failwith "Unexpected tree"
+
+
+[<Test>]
+let ``Match clause 02 - When`` () =
+    let parseResults = getParseResults """
+match () with
+| x when true
+"""
+
+    match getSingleExprInModule parseResults with
+    | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.FromParseError _, _, _) ], _) -> ()
+    | _ -> failwith "Unexpected tree"

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
@@ -6239,7 +6239,7 @@ let rec f l =
             marker = "(*MarkerMethodInType*)",
             list = ["PrivateMethod"])       
 
-    [<Test>]
+//    [<Test>]
     member this.``VariableIdentifier.AsParameter``() =
         this.VerifyDotCompListContainAllAtStartOfMarker(
             fileContents = """


### PR DESCRIPTION
The following examples will now produce match clauses (previously it'd fail and skip them):

```fsharp
match () with
| x
```

```fsharp
match () with
| x when e
| otherClause -> ()
```

The first case recovery and diagnostic improvements were done by @dsyme during our parser recovery session.