### PR TITLE
Fix 10882 -- Add WarnOn support to build

### DIFF
--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -84,6 +84,16 @@ type public Fsc () as this =
     let mutable vslcid : string = null
     let mutable utf8output : bool = false
 
+
+    /// Trim whitespace ... spaces, tabs, newlines,returns, Double quotes and single quotes
+    let wsCharsToTrim = [| ' '; '\t'; '\"'; '\'' |]
+    let splitAndWsTrim (s:string) =
+        match s with
+        | null -> [||]
+        | _ ->
+            let array = s.Split([| ';'; ','; '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
+            array |> Array.map(fun item -> item.Trim(wsCharsToTrim)) |> Array.filter(fun s -> not (String.IsNullOrEmpty s))
+
     // See bug 6483; this makes parallel build faster, and is fine to set unconditionally
     do this.YieldDuringToolExecution <- true
 
@@ -174,13 +184,11 @@ type public Fsc () as this =
         if references <> null then 
             for item in references do
                 builder.AppendSwitchIfNotNull("-r:", item.ItemSpec)
-        // ReferencePath
-        let referencePathArray = // create a array of strings
-            match referencePath with
-            | null -> null
-            | _ -> referencePath.Split([|';'; ','|], StringSplitOptions.RemoveEmptyEntries)
 
-        builder.AppendSwitchIfNotNull("--lib:", referencePathArray, ",")   
+        match referencePath with
+        | null -> ()
+        | _ -> builder.AppendSwitchIfNotNull("--lib:", referencePath |> splitAndWsTrim, ",")
+
         // TargetType
         builder.AppendSwitchIfNotNull("--target:", 
             if targetType = null then null else
@@ -194,35 +202,28 @@ type public Fsc () as this =
         // NoWarn
         match disabledWarnings with
         | null -> ()
-        | _ -> builder.AppendSwitchIfNotNull("--nowarn:", disabledWarnings.Split([|' '; ';'; ','; '\r'; '\n'|], StringSplitOptions.RemoveEmptyEntries), ",")
+        | _ -> builder.AppendSwitchIfNotNull("--nowarn:", disabledWarnings |> splitAndWsTrim, ",")
         
         // WarningLevel
         builder.AppendSwitchIfNotNull("--warn:", warningLevel)
 
-        // warnOn
-        let warnOnArray =
-            match warnOn with
-            | null -> [||]
-            | _ -> warnOn.Split([|' '; ';'; ','|], StringSplitOptions.RemoveEmptyEntries)
-
-        builder.AppendSwitchIfNotNull("--warnon:", warnOnArray, ",")
+        match warnOn with
+        | null -> ()
+        | _ -> builder.AppendSwitchIfNotNull("--warnon:", warnOn |> splitAndWsTrim, ",")
 
         // TreatWarningsAsErrors
         if treatWarningsAsErrors then
             builder.AppendSwitch("--warnaserror")
 
-        // WarningsAsErrors
-        let warningsAsErrorsArray =
-            match warningsAsErrors with
-            | null -> [||]
-            | _ -> warningsAsErrors.Split([|' '; ';'; ','|], StringSplitOptions.RemoveEmptyEntries)
-
-        builder.AppendSwitchIfNotNull("--warnaserror:", warningsAsErrorsArray, ",")
+        // WarnAsErrors
+        match warningsAsErrors with
+        | null -> ()
+        | _ -> builder.AppendSwitchIfNotNull("--warnaserror:", warningsAsErrors |> splitAndWsTrim, ",")
 
         // WarningsNotAsErrors
         match warningsNotAsErrors with
         | null -> ()
-        | _ -> builder.AppendSwitchIfNotNull("--warnaserror-:", warningsNotAsErrors.Split([|' '; ';'; ','|], StringSplitOptions.RemoveEmptyEntries), ",")
+        | _ -> builder.AppendSwitchIfNotNull("--warnaserror-:", warningsNotAsErrors |> splitAndWsTrim, ",")
 
         // Win32ResourceFile
         builder.AppendSwitchIfNotNull("--win32res:", win32res)
@@ -260,7 +261,7 @@ type public Fsc () as this =
         
         match pathMap with
         | null -> ()
-        | _ -> builder.AppendSwitchIfNotNull("--pathmap:", pathMap.Split([|';'; ','|], StringSplitOptions.RemoveEmptyEntries), ",")
+        | _ -> builder.AppendSwitchIfNotNull("--pathmap:", pathMap |> splitAndWsTrim, ",")
 
         if deterministic then
             builder.AppendSwitch("--deterministic+")

--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -77,6 +77,7 @@ type public Fsc () as this =
     let mutable warningsNotAsErrors : string = null
     let mutable versionFile : string = null
     let mutable warningLevel : string = null
+    let mutable warnOn : string = null
     let mutable win32res : string = null
     let mutable win32manifest : string = null
     let mutable vserrors : bool = false
@@ -198,17 +199,23 @@ type public Fsc () as this =
         // WarningLevel
         builder.AppendSwitchIfNotNull("--warn:", warningLevel)
 
+        // warnOn
+        let warnOnArray =
+            match warnOn with
+            | null -> [||]
+            | _ -> warnOn.Split([|' '; ';'; ','|], StringSplitOptions.RemoveEmptyEntries)
+
+        builder.AppendSwitchIfNotNull("--warnon:", warnOnArray, ",")
+
         // TreatWarningsAsErrors
         if treatWarningsAsErrors then
             builder.AppendSwitch("--warnaserror")
 
         // WarningsAsErrors
-        // Change warning 76, HashReferenceNotAllowedInNonScript/HashDirectiveNotAllowedInNonScript/HashIncludeNotAllowedInNonScript, into an error
-        // REVIEW: why is this logic here? In any case these are errors already by default!
         let warningsAsErrorsArray =
             match warningsAsErrors with
-            | null -> [|"76"|]
-            | _ -> (warningsAsErrors + " 76 ").Split([|' '; ';'; ','|], StringSplitOptions.RemoveEmptyEntries)
+            | null -> [||]
+            | _ -> warningsAsErrors.Split([|' '; ';'; ','|], StringSplitOptions.RemoveEmptyEntries)
 
         builder.AppendSwitchIfNotNull("--warnaserror:", warningsAsErrorsArray, ",")
 
@@ -504,6 +511,10 @@ type public Fsc () as this =
     member fsc.WarningsNotAsErrors
         with get() = warningsNotAsErrors
         and set(s) = warningsNotAsErrors <- s
+
+    member fsc.WarnOn 
+        with get() = warnOn
+        and set(s) = warnOn <- s
 
     member fsc.VisualStudioStyleErrors
         with get() = vserrors

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -40,7 +40,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
     <WarningLevel Condition=" '$(WarningLevel)' == '' ">3</WarningLevel>
     <WarningsAsErrors>3239;$(WarningsAsErrors)</WarningsAsErrors>
-    <WarnOn>$(WarnOn);3390</WarnOn>
     <UseStandardResourceNames Condition=" '$(UseStandardResourceNames)' == '' ">true</UseStandardResourceNames>
     <FsiExec Condition=" '$(FsiExec)' == '' ">true</FsiExec>
   </PropertyGroup>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -40,6 +40,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
     <WarningLevel Condition=" '$(WarningLevel)' == '' ">3</WarningLevel>
     <WarningsAsErrors>3239;$(WarningsAsErrors)</WarningsAsErrors>
+    <WarnOn>$(WarnOn);3390</WarnOn>
     <UseStandardResourceNames Condition=" '$(UseStandardResourceNames)' == '' ">true</UseStandardResourceNames>
     <FsiExec Condition=" '$(FsiExec)' == '' ">true</FsiExec>
   </PropertyGroup>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -328,6 +328,7 @@ this file.
               VisualStudioStyleErrors="$(VisualStudioStyleErrors)"
               WarningLevel="$(WarningLevel)"
               WarningsAsErrors="$(WarningsAsErrors)"
+              WarnOn="$(WarnOn)"
               Win32ManifestFile="$(Win32Manifest)"
               Win32ResourceFile="$(Win32Resource)">
           <Output TaskParameter="CommandLineArgs" ItemName="FscCommandLineArgs" />

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
 $if$ ($targetframeworkversion$ == 4.5)    <TargetFramework>net45</TargetFramework>$endif$$if$ ($targetframeworkversion$ == 4.6)    <TargetFramework>net46</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.6.1)    <TargetFramework>net461</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.6.2)    <TargetFramework>net462</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7)    <TargetFramework>net47</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7.1)    <TargetFramework>net471</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7.2)    <TargetFramework>net472</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.8)    <TargetFramework>net48</TargetFramework> $endif$
 $if$ ($safeprojectname$ != $projectname$)    <RootNamespace>$safeprojectname$</RootNamespace> $endif$
+    <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
@@ -3,6 +3,7 @@
 $if$ ($targetframeworkversion$ == 4.5)    <TargetFramework>net45</TargetFramework>$endif$$if$ ($targetframeworkversion$ == 4.6)    <TargetFramework>net46</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.6.1)    <TargetFramework>net461</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.6.2)    <TargetFramework>net462</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7)    <TargetFramework>net47</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7.1)    <TargetFramework>net471</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7.2)    <TargetFramework>net472</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.8)    <TargetFramework>net48</TargetFramework> $endif$
 $if$ ($safeprojectname$ != $projectname$)    <RootNamespace>$safeprojectname$</RootNamespace> $endif$
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
 $if$ ($targetframeworkversion$ == 4.5)    <TargetFramework>net45</TargetFramework>$endif$$if$ ($targetframeworkversion$ == 4.6)    <TargetFramework>net46</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.6.1)    <TargetFramework>net461</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.6.2)    <TargetFramework>net462</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7)    <TargetFramework>net47</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7.1)    <TargetFramework>net471</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.7.2)    <TargetFramework>net472</TargetFramework> $endif$$if$ ($targetframeworkversion$ == 4.8)    <TargetFramework>net48</TargetFramework> $endif$
 $if$ ($safeprojectname$ != $projectname$)    <RootNamespace>$safeprojectname$</RootNamespace> $endif$
+    <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/tests/UnitTests/Tests.Build.fs
+++ b/vsintegration/tests/UnitTests/Tests.Build.fs
@@ -560,7 +560,7 @@ type Build() =
         tool.DebugType <- "full"
         tool.DefineConstants <- [| MakeTaskItem "FOO=3"
                                    MakeTaskItem "BAR=4" |]
-        tool.DisabledWarnings <- "52 109"
+        tool.DisabledWarnings <- "52,109"
         tool.VersionFile <- "src/version"
         tool.DocumentationFile <- "foo.xml"
         tool.GenerateInterfaceFile <- "foo.fsi"
@@ -667,3 +667,29 @@ type Build() =
         AssertEqual expectedFlags hostObject.Flags 
         let expectedSources = [| "foo.fs"; "C:\\Program Files\\spaces.fs" |]
         AssertEqual expectedSources hostObject.Sources
+
+    [<Test>]
+    member public this.``DisabledWarnings build property``() =
+        let tool = new FSharp.Build.Fsc()
+        tool.DisabledWarnings <- "
+        
+        \n52,,\n,,,109,110;\r73
+        
+        ,
+        
+        ;
+        85;
+        "
+        let cmd = tool.InternalGenerateResponseFileCommands()
+        printfn "cmd=\"%s\"" cmd
+
+        let expected =
+            "--optimize+" + Environment.NewLine +
+            "--nowarn:52,109,110,73,85" + Environment.NewLine +
+            "--fullpaths" + Environment.NewLine +
+            "--flaterrors" + Environment.NewLine +
+            "--highentropyva-" + Environment.NewLine  +
+            "--nocopyfsharpcore"
+
+        AssertEqual expected cmd
+

--- a/vsintegration/tests/UnitTests/Tests.Build.fs
+++ b/vsintegration/tests/UnitTests/Tests.Build.fs
@@ -79,7 +79,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--codepage:65001" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -95,7 +94,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("-g" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -111,7 +109,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--debug:pdbonly" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -129,7 +126,6 @@ type Build() =
         AssertEqual ("--define:FOO=3" + Environment.NewLine +
                      "--define:BAR=4" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -145,7 +141,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--nowarn:52,109" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -160,7 +155,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -175,7 +169,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--warnaserror-:52,109" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -192,7 +185,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--versionfile:src/version" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -208,7 +200,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--doc:foo.xml" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -224,7 +215,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--sig:foo.fsi" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -240,7 +230,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--keyfile:key.txt" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -256,7 +245,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--noframework" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -271,7 +259,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize-" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -287,7 +274,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         // REVIEW we don't put the default, is that desired?
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -302,7 +288,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -320,7 +305,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("-o:oUt.dll" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -336,7 +320,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--pdb:out.pdb" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -352,7 +335,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--platform:x64" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -368,7 +350,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--platform:x86" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -385,7 +366,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "-r:" + dll + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -402,7 +382,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--lib:c:\\sd\\staging\\tools\\nunit\\,c:\\Foo" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -419,7 +398,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--lib:c:\\program files,c:\\sd\\staging\\tools\\nunit,c:\\Foo" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -435,7 +413,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--resource:Foo.resources" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -452,7 +429,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -471,7 +447,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--target:library" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -487,7 +462,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--target:winexe" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -503,7 +477,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
                      "--target:module" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -517,7 +490,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--utf8output" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -532,7 +504,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--win32res:foo.res" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -547,7 +518,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--win32manifest:foo.manifest" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -562,7 +532,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva+" + Environment.NewLine +
@@ -576,7 +545,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror:76" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--subsystemversion:6.02" + Environment.NewLine +
@@ -643,7 +611,6 @@ type Build() =
             "--nowarn:52,109" + Environment.NewLine +
             "--warn:4" + Environment.NewLine +
             "--warnaserror" + Environment.NewLine +
-            "--warnaserror:76" + Environment.NewLine +
             "--vserrors" + Environment.NewLine +
             "--utf8output" + Environment.NewLine +
             "--fullpaths" + Environment.NewLine +
@@ -687,7 +654,6 @@ type Build() =
             "--nowarn:52,109"
             "--warn:4"
             "--warnaserror"
-            "--warnaserror:76"
             "--vserrors"
             "--utf8output"
             "--fullpaths"


### PR DESCRIPTION
Fixes: #10882

1.  Adds support for WarnOn property to build task
2. Update targets file to set it
3. Warning #76 is in fact already an error, so stop the build task from setting it, and update tests that notice that it has been set.
4. Enable off by default warning:3390 when updating to latest tooling.

/cc @baronfel 