### PR TITLE
Remove some needless uses of ToString() in FSharp.Editor

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/AddMissingEqualsToTypeDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddMissingEqualsToTypeDefinition.fs
@@ -33,12 +33,10 @@ type internal FSharpAddMissingEqualsToTypeDefinitionCodeFixProvider() =
             // This won't ever actually happen, but eh why not
             do! Option.guard (pos > 0)
 
-            let mutable ch = sourceText.GetSubText(TextSpan(pos, 1)).ToString().[0]
-
+            let mutable ch = sourceText.[pos]
             while pos > 0 && Char.IsWhiteSpace(ch) do
                 pos <- pos - 1
-                let text = sourceText.GetSubText(TextSpan(pos, 1))
-                ch <- text.ToString().[0]
+                ch <- sourceText.[pos]
 
             let title = SR.AddMissingEqualsToTypeDefinition()
 

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddMissingFunKeyword.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddMissingFunKeyword.fs
@@ -37,13 +37,13 @@ type internal FSharpAddMissingFunKeywordCodeFixProvider
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
 
             let adjustedPosition =
-                let rec loop str pos =
-                    if not (String.IsNullOrWhiteSpace(str)) then
+                let rec loop ch pos =
+                    if not (Char.IsWhiteSpace(ch)) then
                         pos
                     else
-                        loop (sourceText.GetSubText(TextSpan(pos - 1, 1)).ToString()) (pos - 1)
+                        loop sourceText.[pos] (pos - 1)
 
-                loop (sourceText.GetSubText(TextSpan(context.Span.Start - 1, 1)).ToString()) context.Span.Start
+                loop sourceText.[context.Span.Start - 1] context.Span.Start
 
             let! intendedArgLexerSymbol = Tokenizer.getSymbolAtPosition (document.Id, sourceText, adjustedPosition, document.FilePath, defines, SymbolLookupKind.Greedy, false, false)
             let! intendedArgSpan = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, intendedArgLexerSymbol.Range)

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddMissingRecToMutuallyRecFunctions.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddMissingRecToMutuallyRecFunctions.fs
@@ -49,13 +49,13 @@ type internal FSharpAddMissingRecToMutuallyRecFunctionsCodeFixProvider
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
 
             let funcStartPos =
-                let rec loop str pos =
-                    if not (String.IsNullOrWhiteSpace(str)) then
+                let rec loop ch pos =
+                    if not (Char.IsWhiteSpace(ch)) then
                         pos
                     else
-                        loop (sourceText.GetSubText(TextSpan(pos + 1, 1)).ToString()) (pos + 1)
+                        loop sourceText.[pos + 1] (pos + 1)
 
-                loop (sourceText.GetSubText(TextSpan(context.Span.End + 1, 1)).ToString()) (context.Span.End  + 1)
+                loop sourceText.[context.Span.End + 1] (context.Span.End  + 1)
 
             let! funcLexerSymbol = Tokenizer.getSymbolAtPosition (context.Document.Id, sourceText, funcStartPos, context.Document.FilePath, defines, SymbolLookupKind.Greedy, false, false)
             let! funcNameSpan = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, funcLexerSymbol.Range)

--- a/vsintegration/src/FSharp.Editor/CodeFix/ChangePrefixNegationToInfixSubtraction.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ChangePrefixNegationToInfixSubtraction.fs
@@ -31,12 +31,10 @@ type internal FSharpChangePrefixNegationToInfixSubtractionodeFixProvider() =
             // This won't ever actually happen, but eh why not
             do! Option.guard (pos < sourceText.Length)
 
-            let mutable ch = sourceText.GetSubText(TextSpan(pos, 1)).ToString().[0]
-
+            let mutable ch = sourceText.[pos]
             while pos < sourceText.Length && Char.IsWhiteSpace(ch) do
                 pos <- pos + 1
-                let text = sourceText.GetSubText(TextSpan(pos, 1))
-                ch <- text.ToString().[0]
+                ch <- sourceText.[pos]
 
             // Bail if this isn't a negation
             do! Option.guard (ch = '-')

--- a/vsintegration/src/FSharp.Editor/CodeFix/FixIndexerAccess.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/FixIndexerAccess.fs
@@ -34,9 +34,8 @@ type internal FSharpFixIndexerAccessCodeFixProvider() =
                             let mutable span = context.Span
 
                             let notStartOfBracket (span: TextSpan) =
-                                let t = TextSpan(span.Start, span.Length + 1)
-                                let s = sourceText.GetSubText(t).ToString()
-                                s.[s.Length-1] <> '['
+                                let t = sourceText.GetSubText(TextSpan(span.Start, span.Length + 1))
+                                t.[t.Length-1] <> '['
 
                             // skip all braces and blanks until we find [
                             while span.End < sourceText.Length && notStartOfBracket span do

--- a/vsintegration/src/FSharp.Editor/CodeFix/ReplaceWithSuggestion.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ReplaceWithSuggestion.fs
@@ -42,9 +42,10 @@ type internal FSharpReplaceWithSuggestionCodeFixProvider
             let caretLinePos = sourceText.Lines.GetLinePosition(pos)            
             let caretLine = sourceText.Lines.GetLineFromPosition(pos)
             let fcsCaretLineNumber = Line.fromZ caretLinePos.Line
-            let partialName = QuickParse.GetPartialLongNameEx(caretLine.ToString(), caretLinePos.Character - 1)
+            let lineText = caretLine.ToString()
+            let partialName = QuickParse.GetPartialLongNameEx(lineText, caretLinePos.Character - 1)
                 
-            let declInfo = checkFileResults.GetDeclarationListInfo(Some parseFileResults, fcsCaretLineNumber, caretLine.ToString(), partialName)
+            let declInfo = checkFileResults.GetDeclarationListInfo(Some parseFileResults, fcsCaretLineNumber, lineText, partialName)
             let addNames (addToBuffer:string -> unit) = 
                 for item in declInfo.Items do
                     addToBuffer item.Name

--- a/vsintegration/src/FSharp.Editor/CodeFix/UseMutationWhenValueIsMutable.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/UseMutationWhenValueIsMutable.fs
@@ -53,12 +53,12 @@ type internal FSharpUseMutationWhenValueIsMutableFixProvider
                 let title = SR.UseMutationWhenValueIsMutable()
                 let! symbolSpan = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, symbolUse.RangeAlternate)
                 let mutable pos = symbolSpan.End
-                let mutable ch = sourceText.GetSubText(pos).ToString()
+                let mutable ch = sourceText.[pos]
 
                 // We're looking for the possibly erroneous '='
-                while pos <= context.Span.Length && ch <> "=" do
+                while pos <= context.Span.Length && ch <> '=' do
                     pos <- pos + 1
-                    ch <- sourceText.GetSubText(pos).ToString()
+                    ch <- sourceText.[pos]
 
                 let codeFix =
                     CodeFixHelpers.createTextChangeCodeFix(

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -114,13 +114,13 @@ type internal FSharpCompletionProvider
             let caretLine = textLines.GetLineFromPosition(caretPosition)
             let fcsCaretLineNumber = Line.fromZ caretLinePos.Line  // Roslyn line numbers are zero-based, FSharp.Compiler.Service line numbers are 1-based
             let caretLineColumn = caretLinePos.Character
-            let partialName = QuickParse.GetPartialLongNameEx(caretLine.ToString(), caretLineColumn - 1) 
+            let line = caretLine.ToString()
+            let partialName = QuickParse.GetPartialLongNameEx(line, caretLineColumn - 1) 
             let getAllSymbols() =
                 getAllSymbols checkFileResults 
                 |> List.filter (fun assemblySymbol ->
                      assemblySymbol.FullName.Contains "." && not (PrettyNaming.IsOperatorName assemblySymbol.Symbol.DisplayName))
-            let declarations = checkFileResults.GetDeclarationListInfo(Some(parseResults), fcsCaretLineNumber, caretLine.ToString(), 
-                                                                       partialName, getAllSymbols)
+            let declarations = checkFileResults.GetDeclarationListInfo(Some(parseResults), fcsCaretLineNumber, line, partialName, getAllSymbols)
             let results = List<Completion.CompletionItem>()
             
             declarationItems <-
@@ -192,12 +192,10 @@ type internal FSharpCompletionProvider
 
             
             if results.Count > 0 && not declarations.IsForType && not declarations.IsError && List.isEmpty partialName.QualifyingIdents then
-                let lineStr = textLines.[caretLinePos.Line].ToString()
-
                 let completionContext =
                     parseResults.ParseTree 
                     |> Option.bind (fun parseTree ->
-                         UntypedParseImpl.TryGetCompletionContext(Pos.fromZ caretLinePos.Line caretLinePos.Character, parseTree, lineStr))
+                         UntypedParseImpl.TryGetCompletionContext(Pos.fromZ caretLinePos.Line caretLinePos.Character, parseTree, line))
 
                 match completionContext with
                 | None -> results.AddRange(keywordCompletionItems)

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -81,7 +81,7 @@ type internal FSharpSignatureHelpProvider
             let isStaticArgTip =
                 let parenLine, parenCol = Pos.toZ paramLocations.OpenParenLocation 
                 assert (parenLine < textLines.Count)
-                let parenLineText = textLines.[parenLine].ToString()
+                let parenLineText = textLines.[parenLine].Text
                 parenCol < parenLineText.Length && parenLineText.[parenCol] = '<'
 
             let filteredMethods =
@@ -232,6 +232,7 @@ type internal FSharpSignatureHelpProvider
         asyncMaybe {
             let textLine = sourceText.Lines.GetLineFromPosition(adjustedColumnInSource)
             let textLinePos = sourceText.Lines.GetLinePosition(adjustedColumnInSource)
+            let textLineText = textLine.ToString()
             let pos = mkPos (Line.fromZ textLinePos.Line) textLinePos.Character
             let textLinePos = sourceText.Lines.GetLinePosition(adjustedColumnInSource)
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
@@ -247,7 +248,7 @@ type internal FSharpSignatureHelpProvider
                 }
 
             let! lexerSymbol = Tokenizer.getSymbolAtPosition(documentId, sourceText, possibleApplicableSymbolEndColumn, filePath, defines, SymbolLookupKind.Greedy, false, false)
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineText, lexerSymbol.FullIsland)
 
             let isValid (mfv: FSharpMemberOrFunctionOrValue) =
                 not (PrettyNaming.IsOperatorName mfv.DisplayName) &&
@@ -256,7 +257,7 @@ type internal FSharpSignatureHelpProvider
 
             match symbolUse.Symbol with
             | :? FSharpMemberOrFunctionOrValue as mfv when isValid mfv ->
-                let tooltip = checkFileResults.GetStructuredToolTipText(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, FSharpTokenTag.IDENT)
+                let tooltip = checkFileResults.GetStructuredToolTipText(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineText, lexerSymbol.FullIsland, FSharpTokenTag.IDENT)
                 match tooltip with
                 | FSharpToolTipText []
                 | FSharpToolTipText [FSharpStructuredToolTipElement.None] -> return! None
@@ -453,26 +454,20 @@ type internal FSharpSignatureHelpProvider
             let! parseResults, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, options, perfOptions, userOpName = userOpName)
 
             let adjustedColumnInSource =
-                let rec loop s c =
-                    if String.IsNullOrWhiteSpace(s.ToString()) then
-                        loop (sourceText.GetSubText(c - 1)) (c - 1)
+                let rec loop ch pos =
+                    if Char.IsWhiteSpace(ch) then
+                        loop sourceText.[pos - 1] (pos - 1)
                     else
-                        c
-                let startText =
-                    if caretPosition = sourceText.Length then
-                        sourceText.GetSubText(caretPosition)
-                    else
-                        sourceText.GetSubText(TextSpan(caretPosition, 1))
-                
-                loop startText caretPosition
+                        pos
+                loop sourceText.[caretPosition - 1] caretPosition
 
-            let adjustedColumnString = sourceText.GetSubText(TextSpan(adjustedColumnInSource, 1)).ToString()
+            let adjustedColumnChar = sourceText.[adjustedColumnInSource]
 
             match triggerTypedChar with
             // Generally ' ' indicates a function application, but it's also used commonly after a comma in a method call.
             // This means that the adjusted position relative to the caret could be a ',' or a ')' or '>',
             // which would mean we're already inside of a method call - not a function argument. So we bail if that's the case.
-            | Some ' ' when adjustedColumnString <> "," && adjustedColumnString <> ")" && adjustedColumnString <> ">" ->
+            | Some ' ' when adjustedColumnChar <> ',' && adjustedColumnChar <> ')' && adjustedColumnChar <> '>' ->
                 return!
                     FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
                         parseResults,

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -447,8 +447,6 @@ type internal FSharpSignatureHelpProvider
         ) =
         asyncMaybe {
             let textLines = sourceText.Lines
-            let caretLinePos = textLines.GetLinePosition(caretPosition)
-            let caretLineColumn = caretLinePos.Character
             let perfOptions = document.FSharpOptions.LanguageServicePerformance
 
             let! parseResults, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, options, perfOptions, userOpName = userOpName)
@@ -459,9 +457,11 @@ type internal FSharpSignatureHelpProvider
                         loop sourceText.[pos - 1] (pos - 1)
                     else
                         pos
-                loop sourceText.[caretPosition - 1] caretPosition
+                loop sourceText.[caretPosition] caretPosition
 
             let adjustedColumnChar = sourceText.[adjustedColumnInSource]
+            let caretLinePos = textLines.GetLinePosition(adjustedColumnInSource)
+            let caretLineColumn = caretLinePos.Character
 
             match triggerTypedChar with
             // Generally ' ' indicates a function application, but it's also used commonly after a comma in a method call.

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -467,7 +467,7 @@ type internal FSharpSignatureHelpProvider
             // Generally ' ' indicates a function application, but it's also used commonly after a comma in a method call.
             // This means that the adjusted position relative to the caret could be a ',' or a ')' or '>',
             // which would mean we're already inside of a method call - not a function argument. So we bail if that's the case.
-            | Some ' ' when adjustedColumnChar <> ',' && adjustedColumnChar <> ')' && adjustedColumnChar <> '>' ->
+            | Some ' ' when adjustedColumnChar <> ',' && adjustedColumnChar <> '(' && adjustedColumnChar <> '<' ->
                 return!
                     FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
                         parseResults,

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -459,7 +459,7 @@ type internal FSharpSignatureHelpProvider
                         loop sourceText.[pos - 1] (pos - 1)
                     else
                         pos
-                loop sourceText.[caretPosition] caretPosition
+                loop sourceText.[caretPosition - 1] (caretPosition - 1)
 
             let adjustedColumnChar = sourceText.[adjustedColumnInSource]
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -128,7 +128,7 @@ module internal SymbolHelpers =
             let textLine = sourceText.Lines.GetLineFromPosition(symbolSpan.Start)
             let textLinePos = sourceText.Lines.GetLinePosition(symbolSpan.Start)
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.Text.ToString(), symbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland)
             let! declLoc = symbolUse.GetDeclarationLocation(document)
             let newText = textChanger originalText
             // defer finding all symbol uses throughout the solution

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -225,6 +225,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
             let textLine = sourceText.Lines.GetLineFromPosition position
             let textLinePos = sourceText.Lines.GetLinePosition position
+            let textLineString = textLine.ToString()
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let lineText = (sourceText.Lines.GetLineFromPosition position).ToString()  
             
@@ -235,7 +236,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
             let! lexerSymbol = Tokenizer.getSymbolAtPosition (originDocument.Id, sourceText, position,originDocument.FilePath, defines, SymbolLookupKind.Greedy, false, false)
             let idRange = lexerSymbol.Ident.idRange
 
-            let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, preferSignature)
+            let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineString, lexerSymbol.FullIsland, preferSignature)
             let! targetSymbolUse = checkFileResults.GetSymbolUseAtLocation (fcsTextLineNumber, idRange.EndColumn, lineText, lexerSymbol.FullIsland)
 
             match declarations with
@@ -276,7 +277,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
                         let navItem = FSharpGoToDefinitionNavigableItem (implDocument, implTextSpan)
                         return (navItem, idRange)
                     else // jump from implementation to the corresponding signature
-                        let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, true)
+                        let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineString, lexerSymbol.FullIsland, true)
                         match declarations with
                         | FSharpFindDeclResult.DeclFound targetRange -> 
                             let! sigDocument = originDocument.Project.Solution.TryGetDocumentFromPath targetRange.FileName

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -179,14 +179,15 @@ type internal FSharpAsyncQuickInfoSource
             let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, options, languageServicePerformanceOptions, userOpName=FSharpQuickInfo.userOpName)
             let textLine = sourceText.Lines.GetLineFromPosition position
             let textLineNumber = textLine.LineNumber + 1 // Roslyn line numbers are zero-based
+            let textLineString = textLine.ToString()
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
             let! symbol = Tokenizer.getSymbolAtPosition (documentId, sourceText, position, filePath, defines, SymbolLookupKind.Precise, true, true)
-            let res = checkFileResults.GetStructuredToolTipText (textLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland, FSharpTokenTag.IDENT)
+            let res = checkFileResults.GetStructuredToolTipText (textLineNumber, symbol.Ident.idRange.EndColumn, textLineString, symbol.FullIsland, FSharpTokenTag.IDENT)
             match res with
             | FSharpToolTipText []
             | FSharpToolTipText [FSharpStructuredToolTipElement.None] -> return! None
             | _ ->
-                let! symbolUse = checkFileResults.GetSymbolUseAtLocation (textLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland)
+                let! symbolUse = checkFileResults.GetSymbolUseAtLocation (textLineNumber, symbol.Ident.idRange.EndColumn, textLineString, symbol.FullIsland)
                 let! symbolSpan = RoslynHelpers.TryFSharpRangeToTextSpan (sourceText, symbol.Range)
                 return { StructuredText = res
                          Span = symbolSpan

--- a/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
@@ -258,7 +258,7 @@ type foo5 = N1.T<Param1=1,ParamIgnored= >
             
     match sb.ToString() with
     | "" -> ()
-    | errorText -> Assert.Fail errorText
+    | errorText -> Assert.Fail errorText    
 
 [<Test>]
 let ``single argument function application``() =


### PR DESCRIPTION
Noticed in the completion provider that we did some needless ToString()'ing and then found more of that