### PR TITLE
Fix10880 - ValueTuple can't be cast to System.IComparable<ValueTuple>

### DIFF
--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -106,6 +106,30 @@ type SkipUnrefInterfaces = Yes | No
 /// Collect the set of immediate declared interface types for an F# type, but do not
 /// traverse the type hierarchy to collect further interfaces.
 let rec GetImmediateInterfacesOfType skipUnref g amap m ty =
+
+    let getInterfaces ty (tcref:TyconRef) tinst =
+        match metadataOfTy g ty with
+        #if !NO_EXTENSIONTYPING
+        | ProvidedTypeMetadata info ->
+            [ for ity in info.ProvidedType.PApplyArray((fun st -> st.GetInterfaces()), "GetInterfaces", m) do
+                yield Import.ImportProvidedType amap m ity ]
+        #endif
+        | ILTypeMetadata (TILObjectReprData(scoref, _, tdef)) ->
+            // ImportILType may fail for an interface if the assembly load set is incomplete and the interface
+            // comes from another assembly. In this case we simply skip the interface:
+            // if we don't skip it, then compilation will just fail here, and if type checking
+            // succeeds with fewer non-dereferencable interfaces reported then it would have
+            // succeeded with more reported. There are pathological corner cases where this
+            // doesn't apply: e.g. for mscorlib interfaces like IComparable, but we can always
+            // assume those are present.
+            tdef.Implements |> List.choose (fun ity ->
+                if skipUnref = SkipUnrefInterfaces.No || CanImportILType scoref amap m ity then
+                    Some (ImportILType scoref amap m tinst ity)
+                else
+                    None)
+        | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata ->
+            tcref.ImmediateInterfaceTypesOfFSharpTycon |> List.map (instType (mkInstForAppTy g ty))
+
     let itys =
         match tryAppTy g ty with
         | ValueSome(tcref, tinst) ->
@@ -123,31 +147,17 @@ let rec GetImmediateInterfacesOfType skipUnref g amap m ty =
                   yield mkAppTy g.system_GenericIComparable_tcref [ty]
                   yield mkAppTy g.system_GenericIEquatable_tcref [ty]]
             else
-                match metadataOfTy g ty with
-#if !NO_EXTENSIONTYPING
-                | ProvidedTypeMetadata info ->
-                    [ for ity in info.ProvidedType.PApplyArray((fun st -> st.GetInterfaces()), "GetInterfaces", m) do
-                          yield Import.ImportProvidedType amap m ity ]
-#endif
-                | ILTypeMetadata (TILObjectReprData(scoref, _, tdef)) ->
+                getInterfaces ty tcref tinst
+        | _ ->
+            let tyWithMetadata = convertToTypeWithMetadataIfPossible g ty
+            match tryAppTy g tyWithMetadata with
+            | ValueSome (tcref, tinst) ->
+                if isAnyTupleTy g ty then
+                    getInterfaces tyWithMetadata tcref tinst
+                else
+                    []
+            | _ -> []
 
-                    // ImportILType may fail for an interface if the assembly load set is incomplete and the interface
-                    // comes from another assembly. In this case we simply skip the interface:
-                    // if we don't skip it, then compilation will just fail here, and if type checking
-                    // succeeds with fewer non-dereferencable interfaces reported then it would have
-                    // succeeded with more reported. There are pathological corner cases where this
-                    // doesn't apply: e.g. for mscorlib interfaces like IComparable, but we can always
-                    // assume those are present.
-                    tdef.Implements |> List.choose (fun ity ->
-                         if skipUnref = SkipUnrefInterfaces.No || CanImportILType scoref amap m ity then
-                             Some (ImportILType scoref amap m tinst ity)
-                         else None)
-
-                | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata ->
-                    tcref.ImmediateInterfaceTypesOfFSharpTycon |> List.map (instType (mkInstForAppTy g ty))
-        | _ -> []
-
-    
     // NOTE: Anonymous record types are not directly considered to implement IComparable,
     // IComparable<T> or IEquatable<T>. This is because whether they support these interfaces depend on their
     // consitutent types, which may not yet be known in type inference.

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -109,11 +109,11 @@ let rec GetImmediateInterfacesOfType skipUnref g amap m ty =
 
     let getInterfaces ty (tcref:TyconRef) tinst =
         match metadataOfTy g ty with
-        #if !NO_EXTENSIONTYPING
+#if !NO_EXTENSIONTYPING
         | ProvidedTypeMetadata info ->
             [ for ity in info.ProvidedType.PApplyArray((fun st -> st.GetInterfaces()), "GetInterfaces", m) do
                 yield Import.ImportProvidedType amap m ity ]
-        #endif
+#endif
         | ILTypeMetadata (TILObjectReprData(scoref, _, tdef)) ->
             // ImportILType may fail for an interface if the assembly load set is incomplete and the interface
             // comes from another assembly. In this case we simply skip the interface:

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="Language\CompilerDirectiveTests.fs" />
     <Compile Include="Language\CodeQuotationTests.fs" />
     <Compile Include="Language\ComputationExpressionTests.fs" />
+    <Compile Include="Language\CastingTests.fs" />
     <Compile Include="ConstraintSolver\PrimitiveConstraints.fs" />
     <Compile Include="ConstraintSolver\MemberConstraints.fs" />
     <Compile Include="Interop\SimpleInteropTests.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Language/CastingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CastingTests.fs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests
+
+open Xunit
+open FSharp.Test.Utilities.Compiler
+
+module CastingTests =
+
+    [<Fact>]
+    let ``Compile: ValueTuple.Create(1,1) :> IComparable<ValueTuple<int,int>>`` () =
+        FSharp """
+module One
+open System
+
+let y = ValueTuple.Create(1,1) :> IComparable<ValueTuple<int,int>>
+printfn "%A" y
+    """
+     |> ignoreWarnings
+     |> compile
+     |> shouldSucceed
+
+    [<Fact>]
+    let ``Compile: struct (1,2) :> IComparable<ValueTuple<int,int>>`` () =
+        FSharp """
+module One
+open System
+
+let y = struct (1,2) :> IComparable<ValueTuple<int,int>>
+printfn "%A" y
+        """
+         |> ignoreWarnings
+         |> compile
+         |> shouldSucceed
+
+    [<Fact>]
+    let ``Compile: let x = struct (1,3); x :> IComparable<ValueTuple<int,int>>`` () =
+        FSharp """
+module One
+open System
+
+let y = struct (1,3) :> IComparable<ValueTuple<int,int>>
+printfn "%A" y
+        """
+         |> ignoreWarnings
+         |> compile
+         |> shouldSucceed
+
+    [<Fact>]
+    let ``Script: ValueTuple.Create(0,0) :> IComparable<ValueTuple<int,int>>`` () =
+        Fsx """
+module One
+open System
+
+let y = ValueTuple.Create(1,1) :> IComparable<ValueTuple<int,int>>
+printfn "%A" y
+        """
+         |> ignoreWarnings
+         |> compile
+         |> shouldSucceed
+
+    [<Fact>]
+    let ``Script: struct (1,2) :> IComparable<ValueTuple<int,int>>`` () =
+        Fsx """
+module One
+open System
+
+let y = struct (0,0) :> IComparable<ValueTuple<int,int>>
+printfn "%A" y
+        """
+         |> ignoreWarnings
+         |> compile
+         |> shouldSucceed
+
+    [<Fact>]
+    let ``Script: let x = struct (1,3); x :> IComparable<ValueTuple<int,int>>`` () =
+        Fsx """
+module One
+open System
+
+let x = struct (1,3)
+let y = x :> IComparable<ValueTuple<int,int>>
+printfn "%A" y
+        """
+         |> ignoreWarnings
+         |> compile
+         |> shouldSucceed
+
+    [<Fact>]
+    let ``Compile: (box (System.ValueTuple.Create(1,2)) :?> System.IComparable<System.ValueTuple<int,int>>)`` () =
+        FSharp """
+module One
+open System
+
+let y = (box (System.ValueTuple.Create(1,2)) :?> System.IComparable<System.ValueTuple<int,int>>)
+printfn "%A" y
+    """
+     |> ignoreWarnings
+     |> compile
+     |> shouldSucceed
+
+    [<Fact>]
+    let ``Script: (box (System.ValueTuple.Create(1,2)) :?> System.IComparable<System.ValueTuple<int,int>>)`` () =
+        FSharp """
+module One
+open System
+
+let y = (box (System.ValueTuple.Create(1,2)) :?> System.IComparable<System.ValueTuple<int,int>>)
+printfn "%A" y
+    """
+     |> ignoreWarnings
+     |> compile
+     |> shouldSucceed


### PR DESCRIPTION
This fixes #10880 - ValueTuple can't be cast to System.IComparable<ValueTuple>.

And adds a couple of unit tests.

It doesn't fix reference tuples.  I need to investigate that a bit more.
Reference Tuples do not implement IComparable<Tuple<T, U>>  so I don't think it can ever work.