### PR TITLE
Remove ToLowerInvariant allocation when computing SimpleAssemblyNameIs

### DIFF
--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -228,10 +228,12 @@ type AssemblyReference =
 
     member x.SimpleAssemblyNameIs name = 
         (String.Compare(fileNameWithoutExtensionWithValidate false x.Text, name, StringComparison.OrdinalIgnoreCase) = 0) ||
-        (let text = x.Text.ToLowerInvariant()
-         not (text.Contains "/") && not (text.Contains "\\") && not (text.Contains ".dll") && not (text.Contains ".exe") &&
-           try let aname = System.Reflection.AssemblyName x.Text in aname.Name = name 
-           with _ -> false) 
+        not (x.Text.Contains "/") &&
+        not (x.Text.Contains "\\") &&
+        not (x.Text.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase)) &&
+        not (x.Text.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase)) &&
+        (try let aname = System.Reflection.AssemblyName x.Text in aname.Name = name 
+         with _ -> false)
 
     override x.ToString() = sprintf "AssemblyReference(%s)" x.Text
 


### PR DESCRIPTION
Should fix https://github.com/dotnet/fsharp/issues/10899

I didn't profile this again but I don't think that's necessary. This will do pretty much the same CPU work in terms of actual comparisons, but it won't have the additional overhead of allocating a new string just to compare the file suffix