### PR TITLE
Rename SemanticModel to BoundModel in IncrementalBuild

### DIFF
--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -213,21 +213,21 @@ type TcInfoState =
         | PartialState tcInfo -> tcInfo
         | FullState(tcInfo, _) -> tcInfo
 
-/// Semantic model of an underlying syntax tree.
+/// Bound model of an underlying syntax and typed tree.
 [<Sealed>]
 type BoundModel private (tcConfig: TcConfig,
-                            tcGlobals: TcGlobals,
-                            tcImports: TcImports,
-                            keepAssemblyContents, keepAllBackgroundResolutions,
-                            maxTimeShareMilliseconds, keepAllBackgroundSymbolUses,
-                            enableBackgroundItemKeyStoreAndSemanticClassification,
-                            enablePartialTypeChecking,
-                            beforeFileChecked: Event<string>,
-                            fileChecked: Event<string>,
-                            prevTcInfo: TcInfo,
-                            prevTcInfoOptional: Eventually<TcInfoOptional option>,
-                            syntaxTreeOpt: SyntaxTree option,
-                            lazyTcInfoState: TcInfoState option ref) =
+                         tcGlobals: TcGlobals,
+                         tcImports: TcImports,
+                         keepAssemblyContents, keepAllBackgroundResolutions,
+                         maxTimeShareMilliseconds, keepAllBackgroundSymbolUses,
+                         enableBackgroundItemKeyStoreAndSemanticClassification,
+                         enablePartialTypeChecking,
+                         beforeFileChecked: Event<string>,
+                         fileChecked: Event<string>,
+                         prevTcInfo: TcInfo,
+                         prevTcInfoOptional: Eventually<TcInfoOptional option>,
+                         syntaxTreeOpt: SyntaxTree option,
+                         lazyTcInfoState: TcInfoState option ref) =
 
     let defaultTypeCheck () =
         eventually {
@@ -305,7 +305,7 @@ type BoundModel private (tcConfig: TcConfig,
                     | _ -> return None
                 }
             return
-                SemanticModel(
+                BoundModel(
                     tcConfig,
                     tcGlobals,
                     tcImports,
@@ -334,7 +334,7 @@ type BoundModel private (tcConfig: TcConfig,
                 | FullState(_, tcInfoOptional) -> FullState(finishTcInfo, tcInfoOptional)
 
             return
-                SemanticModel(
+                BoundModel(
                     tcConfig,
                     tcGlobals,
                     tcImports,
@@ -516,7 +516,7 @@ type BoundModel private (tcConfig: TcConfig,
                          prevTcInfo: TcInfo,
                          prevTcInfoOptional: Eventually<TcInfoOptional option>,
                          syntaxTreeOpt: SyntaxTree option) =
-        SemanticModel(tcConfig, tcGlobals, tcImports, 
+        BoundModel(tcConfig, tcGlobals, tcImports, 
                       keepAssemblyContents, keepAllBackgroundResolutions, 
                       maxTimeShareMilliseconds, keepAllBackgroundSymbolUses,
                       enableBackgroundItemKeyStoreAndSemanticClassification,
@@ -579,33 +579,33 @@ type FrameworkImportsCache(size) =
 
 /// Represents the interim state of checking an assembly
 [<Sealed>]
-type PartialCheckResults private (semanticModel: BoundModel, timeStamp: DateTime) = 
+type PartialCheckResults private (boundModel: BoundModel, timeStamp: DateTime) = 
 
     let eval ctok (work: Eventually<'T>) =
         match work with
         | Eventually.Done res -> res
         | _ -> Eventually.force ctok work
 
-    member _.TcImports = semanticModel.TcImports
-    member _.TcGlobals = semanticModel.TcGlobals
-    member _.TcConfig = semanticModel.TcConfig
+    member _.TcImports = boundModel.TcImports
+    member _.TcGlobals = boundModel.TcGlobals
+    member _.TcConfig = boundModel.TcConfig
 
     member _.TimeStamp = timeStamp
 
-    member _.TcInfo ctok = semanticModel.TcInfo |> eval ctok
+    member _.TcInfo ctok = boundModel.TcInfo |> eval ctok
 
-    member _.TcInfoWithOptional ctok = semanticModel.TcInfoWithOptional |> eval ctok
+    member _.TcInfoWithOptional ctok = boundModel.TcInfoWithOptional |> eval ctok
 
     member _.TryGetItemKeyStore ctok =
-        let _, info = semanticModel.TcInfoWithOptional |> eval ctok
+        let _, info = boundModel.TcInfoWithOptional |> eval ctok
         info.itemKeyStore
 
     member _.GetSemanticClassification ctok =
-        let _, info = semanticModel.TcInfoWithOptional |> eval ctok
+        let _, info = boundModel.TcInfoWithOptional |> eval ctok
         info.semanticClassification
 
-    static member Create (semanticModel: BoundModel, timestamp) = 
-        PartialCheckResults(semanticModel, timestamp)
+    static member Create (boundModel: BoundModel, timestamp) = 
+        PartialCheckResults(boundModel, timestamp)
 
 [<AutoOpen>]
 module Utilities = 
@@ -803,18 +803,18 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                 beforeFileChecked, fileChecked, tcInfo, Eventually.Done (Some tcInfoOptional), None) }
                 
     /// Type check all files.     
-    let TypeCheckTask ctok (prevSemanticModel: BoundModel) syntaxTree: Eventually<BoundModel> =
+    let TypeCheckTask ctok (prevBoundModel: BoundModel) syntaxTree: Eventually<BoundModel> =
         eventually {
             RequireCompilationThread ctok
-            let! semanticModel = prevSemanticModel.Next(syntaxTree)
+            let! boundModel = prevBoundModel.Next(syntaxTree)
             // Eagerly type check
             // We need to do this to keep the expected behavior of events (namely fileChecked) when checking a file/project.
-            let! _ = semanticModel.GetState(enablePartialTypeChecking)
-            return semanticModel
+            let! _ = boundModel.GetState(enablePartialTypeChecking)
+            return boundModel
         }
 
     /// Finish up the typechecking to produce outputs for the rest of the compilation process
-    let FinalizeTypeCheckTask ctok (semanticModels: BoundModel[]) = 
+    let FinalizeTypeCheckTask ctok (boundModels: BoundModel[]) = 
       cancellable {
         DoesNotRequireCompilerThreadTokenAndCouldPossiblyBeMadeConcurrent  ctok
 
@@ -822,22 +822,22 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         use _holder = new CompilationGlobalsScope(errorLogger, BuildPhase.TypeCheck)
 
         // Get the state at the end of the type-checking of the last file
-        let finalSemanticModel = semanticModels.[semanticModels.Length-1]
+        let finalBoundModel = boundModels.[boundModels.Length-1]
 
-        let finalInfo = finalSemanticModel.TcInfo |> Eventually.force ctok
+        let finalInfo = finalBoundModel.TcInfo |> Eventually.force ctok
 
         // Finish the checking
         let (_tcEnvAtEndOfLastFile, topAttrs, mimpls, _), tcState = 
             let results = 
-                semanticModels 
+                boundModels 
                 |> List.ofArray 
-                |> List.map (fun semanticModel -> 
+                |> List.map (fun boundModel -> 
                     let tcInfo, latestImplFile =
                         if enablePartialTypeChecking then
-                            let tcInfo = semanticModel.TcInfo |> Eventually.force ctok
+                            let tcInfo = boundModel.TcInfo |> Eventually.force ctok
                             tcInfo, None
                         else
-                            let tcInfo, tcInfoOptional = semanticModel.TcInfoWithOptional |> Eventually.force ctok
+                            let tcInfo, tcInfoOptional = boundModel.TcInfoWithOptional |> Eventually.force ctok
                             tcInfo, tcInfoOptional.latestImplFile
                     tcInfo.tcEnvAtEndOfFile, defaultArg tcInfo.topAttribs EmptyTopAttrs, latestImplFile, tcInfo.latestCcuSigForFile)
             TypeCheckMultipleInputsFinish (results, finalInfo.tcState)
@@ -897,8 +897,8 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                 errorRecoveryNoRange e
                 mkSimpleAssemblyRef assemblyName, None, None
 
-        let finalSemanticModelWithErrors = finalSemanticModel.Finish((errorLogger.GetErrors() :: finalInfo.tcErrorsRev), Some topAttrs) |> Eventually.force ctok
-        return ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt, finalSemanticModelWithErrors
+        let finalBoundModelWithErrors = finalBoundModel.Finish((errorLogger.GetErrors() :: finalInfo.tcErrorsRev), Some topAttrs) |> Eventually.force ctok
+        return ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt, finalBoundModelWithErrors
       }
 
     // END OF BUILD TASK FUNCTIONS
@@ -914,7 +914,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     (*
         The data below represents a dependency graph.
         
-        ReferencedAssembliesStamps => FileStamps => SemanticModels => FinalizedSemanticModel
+        ReferencedAssembliesStamps => FileStamps => BoundModels => FinalizedBoundModel
     *)
 
     // stampedFileNames represent the real stamps of the files.
@@ -922,23 +922,23 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     let stampedFileNames = Array.init fileNames.Length (fun _ -> DateTime.MinValue)
     let logicalStampedFileNames = Array.init fileNames.Length (fun _ -> DateTime.MinValue)
     let stampedReferencedAssemblies = Array.init referencedAssemblies.Length (fun _ -> DateTime.MinValue)
-    let mutable initialSemanticModel = None
-    let semanticModels = Array.zeroCreate<BoundModel option> fileNames.Length
-    let mutable finalizedSemanticModel = None
+    let mutable initialBoundModel = None
+    let boundModels = Array.zeroCreate<BoundModel option> fileNames.Length
+    let mutable finalizedBoundModel = None
 
     let computeStampedFileName (cache: TimeStampCache) (ctok: CompilationThreadToken) slot fileInfo cont =
         let currentStamp = stampedFileNames.[slot]
         let stamp = StampFileNameTask cache ctok fileInfo
 
         if currentStamp <> stamp then
-            match semanticModels.[slot] with
+            match boundModels.[slot] with
             // This prevents an implementation file that has a backing signature file from invalidating the rest of the build.
-            | Some(semanticModel) when enablePartialTypeChecking && semanticModel.BackingSignature.IsSome ->
+            | Some(boundModel) when enablePartialTypeChecking && boundModel.BackingSignature.IsSome ->
                 stampedFileNames.[slot] <- StampFileNameTask cache ctok fileInfo
-                semanticModel.Invalidate()
+                boundModel.Invalidate()
             | _ ->
                 // Something changed, the finalized view of the project must be invalidated.
-                finalizedSemanticModel <- None
+                finalizedBoundModel <- None
 
                 // Invalidate the file and all files below it.
                 stampedFileNames.[slot..]
@@ -946,10 +946,10 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                     let stamp = StampFileNameTask cache ctok fileNames.[slot + j]
                     stampedFileNames.[slot + j] <- stamp
                     logicalStampedFileNames.[slot + j] <- stamp
-                    semanticModels.[slot + j] <- None
+                    boundModels.[slot + j] <- None
                 )
 
-        if semanticModels.[slot].IsNone then
+        if boundModels.[slot].IsNone then
             cont slot fileInfo
 
     let computeStampedFileNames (cache: TimeStampCache) (ctok: CompilationThreadToken) =
@@ -972,14 +972,14 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         
         if referencesUpdated then
             // Something changed, the finalized view of the project must be invalidated.
-            // This is the only place where the initial semantic model will be invalidated.
-            initialSemanticModel <- None
-            finalizedSemanticModel <- None
+            // This is the only place where the initial bound model will be invalidated.
+            initialBoundModel <- None
+            finalizedBoundModel <- None
 
             for i = 0 to stampedFileNames.Length - 1 do
                 stampedFileNames.[i] <- DateTime.MinValue
                 logicalStampedFileNames.[i] <- DateTime.MinValue
-                semanticModels.[i] <- None
+                boundModels.[i] <- None
 
     let getStampedFileNames cache ctok =
         computeStampedFileNames cache ctok
@@ -989,61 +989,61 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         computeStampedReferencedAssemblies cache ctok
         stampedReferencedAssemblies
 
-    let computeInitialSemanticModel (ctok: CompilationThreadToken) =
+    let computeInitialBoundModel (ctok: CompilationThreadToken) =
         cancellable {
-            match initialSemanticModel with
+            match initialBoundModel with
             | None ->
                 let! result = CombineImportedAssembliesTask ctok
-                initialSemanticModel <- Some result
+                initialBoundModel <- Some result
                 return result
             | Some result ->
                 return result
         }
 
-    let computeSemanticModel (cache: TimeStampCache) (ctok: CompilationThreadToken) (slot: int) =
+    let computeBoundModel (cache: TimeStampCache) (ctok: CompilationThreadToken) (slot: int) =
         if IncrementalBuild.injectCancellationFault then Cancellable.canceled ()
         else
 
         cancellable {         
-            let! initial = computeInitialSemanticModel ctok
+            let! initial = computeInitialBoundModel ctok
 
             let fileInfo = fileNames.[slot]
 
             computeStampedFileName cache ctok slot fileInfo (fun slot fileInfo ->
-                let prevSemanticModel =
+                let prevBoundModel =
                     match slot with
                     | 0 (* first file *) -> initial
                     | _ ->
-                        match semanticModels.[slot - 1] with
-                        | Some(prevSemanticModel) -> prevSemanticModel
+                        match boundModels.[slot - 1] with
+                        | Some(prevBoundModel) -> prevBoundModel
                         | _ -> 
-                            // This shouldn't happen, but on the off-chance, just grab the initial semantic model.
+                            // This shouldn't happen, but on the off-chance, just grab the initial bound model.
                             initial
 
-                let semanticModel = TypeCheckTask ctok prevSemanticModel (ParseTask ctok fileInfo) |> Eventually.force ctok
+                let boundModel = TypeCheckTask ctok prevBoundModel (ParseTask ctok fileInfo) |> Eventually.force ctok
                     
-                semanticModels.[slot] <- Some semanticModel
+                boundModels.[slot] <- Some boundModel
             )
         }
 
-    let computeSemanticModels (cache: TimeStampCache) (ctok: CompilationThreadToken) =
+    let computeBoundModels (cache: TimeStampCache) (ctok: CompilationThreadToken) =
         cancellable {
             for slot = 0 to fileNames.Length - 1 do
-                do! computeSemanticModel cache ctok slot
+                do! computeBoundModel cache ctok slot
         }
 
-    let computeFinalizedSemanticModel (cache: TimeStampCache) (ctok: CompilationThreadToken) =
+    let computeFinalizedBoundModel (cache: TimeStampCache) (ctok: CompilationThreadToken) =
         cancellable {
-            let! _ = computeSemanticModels cache ctok
+            let! _ = computeBoundModels cache ctok
 
-            match finalizedSemanticModel with
+            match finalizedBoundModel with
             | Some result -> return result
             | _ ->
-                let semanticModels = semanticModels |> Array.choose id
+                let boundModels = boundModels |> Array.choose id
             
-                let! result = FinalizeTypeCheckTask ctok semanticModels 
+                let! result = FinalizeTypeCheckTask ctok boundModels 
                 let result = (result, DateTime.UtcNow)
-                finalizedSemanticModel <- Some result
+                finalizedBoundModel <- Some result
                 return result
         }
 
@@ -1052,9 +1052,9 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
             computeStampedReferencedAssemblies cache ctok
             computeStampedFileNames cache ctok
 
-            match semanticModels |> Array.tryFindIndex (fun x -> x.IsNone) with
+            match boundModels |> Array.tryFindIndex (fun x -> x.IsNone) with
             | Some slot ->
-                do! computeSemanticModel cache ctok slot
+                do! computeBoundModel cache ctok slot
                 return true
             | _ ->
                 return false
@@ -1063,16 +1063,16 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     let tryGetBeforeSlot slot =
         match slot with
         | 0 (* first file *) ->
-            match initialSemanticModel with
+            match initialBoundModel with
             | Some initial ->
                 (initial, DateTime.MinValue)
                 |> Some
             | _ ->
                 None
         | _ ->
-            match semanticModels.[slot - 1] with
-            | Some semanticModel ->
-                (semanticModel, stampedFileNames.[slot - 1])
+            match boundModels.[slot - 1] with
+            | Some boundModel ->
+                (boundModel, stampedFileNames.[slot - 1])
                 |> Some
             | _ ->
                 None
@@ -1082,14 +1082,14 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
             cancellable {
                 computeStampedReferencedAssemblies cache ctok
 
-                let! result = computeInitialSemanticModel ctok
+                let! result = computeInitialBoundModel ctok
                 return Some(result, DateTime.MinValue)
             }
         else         
             let evalUpTo =
                 cancellable {
                     for slot = 0 to targetSlot do
-                        do! computeSemanticModel cache ctok slot
+                        do! computeBoundModel cache ctok slot
                 }
             cancellable {
                 computeStampedReferencedAssemblies cache ctok
@@ -1097,9 +1097,9 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                 let! _ = evalUpTo
 
                 return 
-                    semanticModels.[targetSlot]
-                    |> Option.map (fun semanticModel ->
-                        (semanticModel, stampedFileNames.[targetSlot])
+                    boundModels.[targetSlot]
+                    |> Option.map (fun boundModel ->
+                        (boundModel, stampedFileNames.[targetSlot])
                     )
             }
 
@@ -1107,7 +1107,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         cancellable {
             computeStampedReferencedAssemblies cache ctok
 
-            let! res = computeFinalizedSemanticModel cache ctok
+            let! res = computeFinalizedBoundModel cache ctok
             return Some res
         }
 
@@ -1158,7 +1158,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         let result = tryGetBeforeSlot slotOfFile
         
         match result with
-        | Some (semanticModel, timestamp) -> Some (PartialCheckResults.Create (semanticModel, timestamp))
+        | Some (boundModel, timestamp) -> Some (PartialCheckResults.Create (boundModel, timestamp))
         | _ -> None
         
     
@@ -1174,7 +1174,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         let! result = eval cache ctok (slotOfFile - 1)
         
         match result with
-        | Some (semanticModel, timestamp) -> return PartialCheckResults.Create (semanticModel, timestamp)
+        | Some (boundModel, timestamp) -> return PartialCheckResults.Create (boundModel, timestamp)
         | None -> return! failwith "Build was not evaluated, expected the results to be ready after 'Eval' (GetCheckResultsBeforeSlotInProject)."
       }
 
@@ -1205,8 +1205,8 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         let cache = TimeStampCache defaultTimeStamp
 
         match! tryGetFinalized cache ctok with
-        | Some ((ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt, semanticModel), timestamp) -> 
-            return PartialCheckResults.Create (semanticModel, timestamp), ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt
+        | Some ((ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt, boundModel), timestamp) -> 
+            return PartialCheckResults.Create (boundModel, timestamp), ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt
         | None -> 
             let msg = "Build was not evaluated, expected the results to be ready after 'tryGetFinalized')."
             return! failwith msg


### PR DESCRIPTION
This is just a rename. We agreed that `SemanticModel` isn't necessarily an accurate name; therefore `BoundModel` is more accurate.