### PR TITLE
Refactor everything but the type provider tests in signature help testing

### DIFF
--- a/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
@@ -337,7 +337,8 @@ let _ = System.DateTime(1L,
         assertSignatureHelpForMethodCalls fileContents marker (Some ("[10..31)", 1, 2, None ))
 
 [<Test>]
-let ShouldGiveSignatureHelpAtCorrectMarkers() =
+let ``type provider static parameter tests``() =
+    // This is old code and I'm too lazy to move it all out. - Phillip Carter
     let manyTestCases = 
         [
           ( """

--- a/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
@@ -120,34 +120,257 @@ let GetCompletionTypeNamesFromXmlString (xml:string) =
     use project = CreateProject xml
     GetCompletionTypeNamesFromCursorPosition project
 
-[<Test>]
-let ShouldGiveSignatureHelpAtCorrectMarkers() =
-    let manyTestCases = 
-        [ ("""
+let assertSignatureHelpForMethodCalls (fileContents: string) (marker: string) (expected: (string * int * int * string option) option) =
+    let caretPosition = fileContents.IndexOf(marker) + marker.Length
+    let triggerChar = if marker ="," then Some ',' elif marker = "(" then Some '(' elif marker = "<" then Some '<' else None
+    let sourceText = SourceText.From(fileContents)
+    let textLines = sourceText.Lines
+    let caretLinePos = textLines.GetLinePosition(caretPosition)
+    let caretLineColumn = caretLinePos.Character
+    let perfOptions = LanguageServicePerformanceOptions.Default
+    let textVersionHash = 0
+               
+    let parseResults, _, checkFileResults =
+        let x =
+            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
+            |> Async.RunSynchronously
+
+        if x.IsNone then
+            Assert.Fail("Could not parse and check document.")
+        x.Value
+
+    let actual = 
+        let paramInfoLocations = parseResults.FindNoteworthyParamInfoLocations(Pos.fromZ caretLinePos.Line caretLineColumn)
+        match paramInfoLocations with
+        | None -> None
+        | Some paramInfoLocations ->
+            let triggered =
+                FSharpSignatureHelpProvider.ProvideMethodsAsyncAux(
+                    caretLinePos,
+                    caretLineColumn,
+                    paramInfoLocations,
+                    checkFileResults,
+                    DefaultDocumentationProvider,
+                    sourceText,
+                    caretPosition,
+                    triggerChar)
+                |> Async.RunSynchronously
+                       
+            checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
+            match triggered with 
+            | None -> None
+            | Some data -> Some (data.ApplicableSpan.ToString(),data.ArgumentIndex,data.ArgumentCount,data.ArgumentName)
+
+    Assert.AreEqual(expected, actual)
+
+let assertSignatureHelpForFunctionApplication (fileContents: string) (marker: string) expectedArgumentCount expectedArgumentIndex =
+    let caretPosition = fileContents.LastIndexOf(marker) + marker.Length
+    let sourceText = SourceText.From(fileContents)
+    let perfOptions = LanguageServicePerformanceOptions.Default
+    let textVersionHash = 0
+    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
+    
+    let parseResults, _, checkFileResults =
+        let x =
+            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
+            |> Async.RunSynchronously
+
+        if x.IsNone then
+            Assert.Fail("Could not parse and check document.")
+        x.Value
+
+    
+    let adjustedColumnInSource =
+        let rec loop s c =
+            if String.IsNullOrWhiteSpace(s.ToString()) then
+                loop (sourceText.GetSubText(c - 1)) (c - 1)
+            else
+                c
+        let startText =
+            if caretPosition = sourceText.Length then
+                sourceText.GetSubText(caretPosition)
+            else
+                sourceText.GetSubText(TextSpan(caretPosition, 1))
+        
+        loop startText caretPosition
+    
+    let sigHelp =
+        FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
+            parseResults,
+            checkFileResults,
+            documentId,
+            [],
+            DefaultDocumentationProvider,
+            sourceText,
+            caretPosition,
+            adjustedColumnInSource,
+            filePath)
+        |> Async.RunSynchronously
+
+    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
+
+    match sigHelp with
+    | None -> Assert.Fail("Expected signature help")
+    | Some sigHelp ->
+        Assert.AreEqual(expectedArgumentCount, sigHelp.ArgumentCount)
+        Assert.AreEqual(expectedArgumentIndex, sigHelp.ArgumentIndex)
+
+
+[<TestFixture>]
+module ``Gives signature help in method calls`` =
+
+    [<Test>]
+    let ``dot``() =
+        let fileContents = """
 //1
 System.Console.WriteLine(format="Hello, {0}",arg0="World")
-""",
-            [(".", None); 
-             ("System", None); 
-             ("WriteLine", None);
-             ("(", Some ("[7..64)", 0, 2, Some "format")); 
-             ("format", Some ("[7..64)", 0, 2, Some "format"));
-             (",", None);
-             ("""",""", Some ("[7..64)", 1, 2, Some "arg0"));
-             ("arg0", Some ("[7..64)", 1, 2, Some "arg0"));
-             ("arg0=", Some ("[7..64)", 1, 2, Some "arg0")); 
-             ("World", Some ("[7..64)", 1, 2, Some "arg0"));
-             (")", Some("[7..64)", 0, 2, Some "format"))]);
-          ( """
+"""
+        let marker = "."
+        assertSignatureHelpForMethodCalls fileContents marker None
+
+    [<Test>]
+    let ``System``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        let marker = "System"
+        assertSignatureHelpForMethodCalls fileContents marker None
+
+    [<Test>]
+    let ``WriteLine``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        let marker = "WriteLine"
+        assertSignatureHelpForMethodCalls fileContents marker None
+
+    [<Test>]
+    let ``open paren``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        let marker = "("
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[7..64)", 0, 2, Some "format"))
+
+    [<Test>]
+    let ``named arg``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        let marker = "format"
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[7..64)", 0, 2, Some "format"))
+
+    [<Test>]
+    let ``comma``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        let marker = ","
+        assertSignatureHelpForMethodCalls fileContents marker None
+
+    [<Test>]
+    let ``second comma``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        assertSignatureHelpForMethodCalls fileContents """",""" (Some ("[7..64)", 1, 2, Some "arg0"))
+
+    [<Test>]
+    let ``second named arg``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        let marker = "arg0"
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[7..64)", 1, 2, Some "arg0"))
+
+    [<Test>]
+    let ``second named arg equals``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        let marker = "arg0="
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[7..64)", 1, 2, Some "arg0"))
+
+    [<Test>]
+    let ``World``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+"""
+        let marker = "World"
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[7..64)", 1, 2, Some "arg0"))
+
+    [<Test>]
+    let ``end paren``() =
+        let fileContents = """
+//1
+System.Console.WriteLine(format="Hello, {0}",arg0="World")
+    """
+        let marker = ")"
+        assertSignatureHelpForMethodCalls fileContents marker (Some("[7..64)", 0, 2, Some "format"))
+
+[<TestFixture>]
+module ``Signature help with list literals, parens, etc`` =
+    [<Test>]
+    let ``Open paren``() =
+        let fileContents = """
 //2
 open System
 Console.WriteLine([(1,2)])
-""",
-            [
-             ("WriteLine(", Some ("[20..45)", 0, 0, None));
-             (",", None); 
-             ("[(", Some ("[20..45)", 0, 1, None))
-            ]);
+"""
+        let marker = "WriteLine("
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[20..45)", 0, 0, None))
+
+    [<Test>]
+    let ``comma``() =
+        let fileContents = """
+//2
+open System
+Console.WriteLine([(1,2)])
+"""
+        let marker = ","
+        assertSignatureHelpForMethodCalls fileContents marker None
+
+    [<Test>]
+    let ``list and tuple bracket pair start``() =
+        let fileContents = """
+//2
+open System
+Console.WriteLine([(1,2)])
+"""
+        let marker = "[("
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[20..45)", 0, 1, None))
+
+[<TestFixture>]
+module ``Unfinished parentheses`` =
+    [<Test>]
+    let ``Unfinished parentheses``() =
+        let fileContents = """
+let _ = System.DateTime(
+"""
+        let marker = "let _ = System.DateTime("
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[10..26)", 0, 0, None))
+
+    [<Test>]
+    let ``Unfinished parentheses with comma``() =
+        let fileContents = """
+let _ = System.DateTime(1L,
+"""
+        let marker = "let _ = System.DateTime(1L,"
+        assertSignatureHelpForMethodCalls fileContents marker (Some ("[10..31)", 1, 2, None ))
+
+[<Test>]
+let ShouldGiveSignatureHelpAtCorrectMarkers() =
+    let manyTestCases = 
+        [
           ( """
 //3
 type foo = N1.T< 
@@ -195,465 +418,119 @@ type foo5 = N1.T<Param1=1,ParamIgnored= >
              ("type foo5 = N1.T<Param1=1,", Some ("[132..160)", 1, 2, Some "ParamIgnored"));
              ("type foo5 = N1.T<Param1=1,ParamIgnored",Some ("[132..160)", 1, 2, Some "ParamIgnored"));
              ("type foo5 = N1.T<Param1=1,ParamIgnored=",Some ("[132..160)", 1, 2, Some "ParamIgnored"))])
-//Test case 5
-          ( """let _ = System.DateTime(""",
-            [("let _ = System.DateTime(",  Some ("[8..24)", 0, 0, None)) ])
-          ( """let _ = System.DateTime(1L,""",
-            [("let _ = System.DateTime(1L,", Some ("[8..27)", 1, 2, None )) ])
           ]
 
-    let sb = StringBuilder()
     for (fileContents, testCases) in manyTestCases do
-      printfn "Test case: fileContents = %s..." fileContents.[2..4]
-      
-      let actual = 
-        [ for (marker, expected) in testCases do
-            printfn "Test case: marker = %s" marker 
-            let caretPosition = fileContents.IndexOf(marker) + marker.Length
-            let triggerChar = if marker ="," then Some ',' elif marker = "(" then Some '(' elif marker = "<" then Some '<' else None
-            let sourceText = SourceText.From(fileContents)
-            let textLines = sourceText.Lines
-            let caretLinePos = textLines.GetLinePosition(caretPosition)
-            let caretLineColumn = caretLinePos.Character
-            let perfOptions = LanguageServicePerformanceOptions.Default
-            let textVersionHash = 0
-            
-            let parseResults, _, checkFileResults =
-                let x =
-                    checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
-                    |> Async.RunSynchronously
+        for (marker, expected) in testCases do
+            assertSignatureHelpForMethodCalls fileContents marker expected
 
-                if x.IsNone then
-                    Assert.Fail("Could not parse and check document.")
-                x.Value
-
-            let actual = 
-                let paramInfoLocations = parseResults.FindNoteworthyParamInfoLocations(Pos.fromZ caretLinePos.Line caretLineColumn)
-                match paramInfoLocations with
-                | None -> None
-                | Some paramInfoLocations ->
-                    let triggered =
-                        FSharpSignatureHelpProvider.ProvideMethodsAsyncAux(
-                            caretLinePos,
-                            caretLineColumn,
-                            paramInfoLocations,
-                            checkFileResults,
-                            DefaultDocumentationProvider,
-                            sourceText,
-                            caretPosition,
-                            triggerChar)
-                        |> Async.RunSynchronously
-                    
-                    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-                    match triggered with 
-                    | None -> None
-                    | Some data -> Some (data.ApplicableSpan.ToString(),data.ArgumentIndex,data.ArgumentCount,data.ArgumentName)
-
-            if expected <> actual then 
-                sb.AppendLine(sprintf "FSharpCompletionProvider.ProvideMethodsAsyncAux() gave unexpected results, expected %A, got %A" expected actual) |> ignore
-            yield (marker, actual) ]
-
-      printfn "(\"\"\"%s\n\"\"\",\n%s)" fileContents ((sprintf "%A" actual).Replace("null","None"))
-        
-            
-    match sb.ToString() with
-    | "" -> ()
-    | errorText -> Assert.Fail errorText    
-
-[<Test>]
-let ``single argument function application``() =
-    let fileContents = """
+[<TestFixture>]
+module ``Function argument applications`` =
+    [<Test>]
+    let ``single argument function application``() =
+        let fileContents = """
 sqrt 
-"""
-    let marker = "sqrt "
-    let caretPosition = fileContents.IndexOf(marker) + marker.Length
-    let sourceText = SourceText.From(fileContents)
-    let perfOptions = LanguageServicePerformanceOptions.Default
-    let textVersionHash = 0
-    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
-    
-    let parseResults, _, checkFileResults =
-        let x =
-            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
-            |> Async.RunSynchronously
+    """
+        let marker = "sqrt "
+        assertSignatureHelpForFunctionApplication fileContents marker 1 0
 
-        if x.IsNone then
-            Assert.Fail("Could not parse and check document.")
-        x.Value
-
-    
-    let adjustedColumnInSource =
-        let rec loop s c =
-            if String.IsNullOrWhiteSpace(s.ToString()) then
-                loop (sourceText.GetSubText(c - 1)) (c - 1)
-            else
-                c
-        let startText =
-            if caretPosition = sourceText.Length then
-                sourceText.GetSubText(caretPosition)
-            else
-                sourceText.GetSubText(TextSpan(caretPosition, 1))
-        
-        loop startText caretPosition
-    
-    let sigHelp =
-        FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
-            parseResults,
-            checkFileResults,
-            documentId,
-            [],
-            DefaultDocumentationProvider,
-            sourceText,
-            caretPosition,
-            adjustedColumnInSource,
-            filePath)
-        |> Async.RunSynchronously
-
-    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-
-    match sigHelp with
-    | None -> Assert.Fail("Expected signature help")
-    | Some sigHelp ->
-        Assert.AreEqual(1, sigHelp.ArgumentCount)
-        Assert.AreEqual(0, sigHelp.ArgumentIndex)
-
-[<Test>]
-let ``multi-argument function application``() =
-    let fileContents = """
+    [<Test>]
+    let ``multi-argument function application``() =
+        let fileContents = """
 let add2 x y = x + y
 add2 1 
-"""
-    let marker = "add2 1 "
-    let caretPosition = fileContents.IndexOf(marker) + marker.Length
-    let sourceText = SourceText.From(fileContents)
-    let perfOptions = LanguageServicePerformanceOptions.Default
-    let textVersionHash = 0
-    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
-    
-    let parseResults, _, checkFileResults =
-        let x =
-            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
-            |> Async.RunSynchronously
+    """
+        let marker = "add2 1 "
+        assertSignatureHelpForFunctionApplication fileContents marker 2 1
 
-        if x.IsNone then
-            Assert.Fail("Could not parse and check document.")
-        x.Value
-
-    let adjustedColumnInSource =
-        let rec loop s c =
-            if String.IsNullOrWhiteSpace(s.ToString()) then
-                loop (sourceText.GetSubText(c - 1)) (c - 1)
-            else
-                c
-        let startText =
-            if caretPosition = sourceText.Length then
-                sourceText.GetSubText(caretPosition)
-            else
-                sourceText.GetSubText(TextSpan(caretPosition, 1))
-        
-        loop startText caretPosition
-    
-    let sigHelp =
-        FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
-            parseResults,
-            checkFileResults,
-            documentId,
-            [],
-            DefaultDocumentationProvider,
-            sourceText,
-            caretPosition,
-            adjustedColumnInSource,
-            filePath)
-        |> Async.RunSynchronously
-
-    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-
-    match sigHelp with
-    | None -> Assert.Fail("Expected signature help")
-    | Some sigHelp ->
-        Assert.AreEqual(2, sigHelp.ArgumentCount)
-        Assert.AreEqual(1, sigHelp.ArgumentIndex)
-
-[<Test>]
-let ``qualified function application``() =
-    let fileContents = """
+    [<Test>]
+    let ``qualified function application``() =
+        let fileContents = """
 module M =
     let f x = x
 M.f 
-"""
-    let marker = "M.f "
-    let caretPosition = fileContents.IndexOf(marker) + marker.Length
-    let sourceText = SourceText.From(fileContents)
-    let perfOptions = LanguageServicePerformanceOptions.Default
-    let textVersionHash = 0
-    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
-    
-    let parseResults, _, checkFileResults =
-        let x =
-            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
-            |> Async.RunSynchronously
+    """
+        let marker = "M.f "
+        assertSignatureHelpForFunctionApplication fileContents marker 1 0
 
-        if x.IsNone then
-            Assert.Fail("Could not parse and check document.")
-        x.Value
-
-    let adjustedColumnInSource =
-        let rec loop s c =
-            if String.IsNullOrWhiteSpace(s.ToString()) then
-                loop (sourceText.GetSubText(c - 1)) (c - 1)
-            else
-                c
-        let startText =
-            if caretPosition = sourceText.Length then
-                sourceText.GetSubText(caretPosition)
-            else
-                sourceText.GetSubText(TextSpan(caretPosition, 1))
-    
-        loop startText caretPosition
-
-    let sigHelp =
-        FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
-            parseResults,
-            checkFileResults,
-            documentId,
-            [],
-            DefaultDocumentationProvider,
-            sourceText,
-            caretPosition,
-            adjustedColumnInSource,
-            filePath)
-        |> Async.RunSynchronously
-
-    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-
-    match sigHelp with
-    | None -> Assert.Fail("Expected signature help")
-    | Some sigHelp ->
-        Assert.AreEqual(1, sigHelp.ArgumentCount)
-        Assert.AreEqual(0, sigHelp.ArgumentIndex)
-
-[<Test>]
-let ``function application in single pipeline with no additional args``() =
-    let fileContents = """
+    [<Test>]
+    let ``function application in single pipeline with no additional args``() =
+        let fileContents = """
 [1..10] |> id 
-"""
-    let marker = "id "
-    let caretPosition = fileContents.IndexOf(marker) + marker.Length
-    let sourceText = SourceText.From(fileContents)
-    let perfOptions = LanguageServicePerformanceOptions.Default
-    let textVersionHash = 0
-    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
+    """
+        let marker = "id "
+        let caretPosition = fileContents.IndexOf(marker) + marker.Length
+        let sourceText = SourceText.From(fileContents)
+        let perfOptions = LanguageServicePerformanceOptions.Default
+        let textVersionHash = 0
+        let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
     
-    let parseResults, _, checkFileResults =
-        let x =
-            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
+        let parseResults, _, checkFileResults =
+            let x =
+                checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
+                |> Async.RunSynchronously
+
+            if x.IsNone then
+                Assert.Fail("Could not parse and check document.")
+            x.Value
+    
+        let adjustedColumnInSource =
+            let rec loop s c =
+                if String.IsNullOrWhiteSpace(s.ToString()) then
+                    loop (sourceText.GetSubText(c - 1)) (c - 1)
+                else
+                    c
+            let startText =
+                if caretPosition = sourceText.Length then
+                    sourceText.GetSubText(caretPosition)
+                else
+                    sourceText.GetSubText(TextSpan(caretPosition, 1))
+    
+            loop startText caretPosition
+
+        let sigHelp =
+            FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
+                parseResults,
+                checkFileResults,
+                documentId,
+                [],
+                DefaultDocumentationProvider,
+                sourceText,
+                caretPosition,
+                adjustedColumnInSource,
+                filePath)
             |> Async.RunSynchronously
 
-        if x.IsNone then
-            Assert.Fail("Could not parse and check document.")
-        x.Value
-    
-    let adjustedColumnInSource =
-        let rec loop s c =
-            if String.IsNullOrWhiteSpace(s.ToString()) then
-                loop (sourceText.GetSubText(c - 1)) (c - 1)
-            else
-                c
-        let startText =
-            if caretPosition = sourceText.Length then
-                sourceText.GetSubText(caretPosition)
-            else
-                sourceText.GetSubText(TextSpan(caretPosition, 1))
-    
-        loop startText caretPosition
+        checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
 
-    let sigHelp =
-        FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
-            parseResults,
-            checkFileResults,
-            documentId,
-            [],
-            DefaultDocumentationProvider,
-            sourceText,
-            caretPosition,
-            adjustedColumnInSource,
-            filePath)
-        |> Async.RunSynchronously
+        Assert.True(sigHelp.IsNone, "No signature help is expected because there are no additional args to apply.")
 
-    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-
-    Assert.True(sigHelp.IsNone, "No signature help is expected because there are no additional args to apply.")
-
-[<Test>]
-let ``function application in single pipeline with an additional argument``() =
-    let fileContents = """
+    [<Test>]
+    let ``function application in single pipeline with an additional argument``() =
+        let fileContents = """
 [1..10] |> List.map  
-"""
-    let marker = "List.map "
-    let caretPosition = fileContents.IndexOf(marker) + marker.Length
-    let sourceText = SourceText.From(fileContents)
-    let perfOptions = LanguageServicePerformanceOptions.Default
-    let textVersionHash = 0
-    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
-    
-    let parseResults, _, checkFileResults =
-        let x =
-            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
-            |> Async.RunSynchronously
+    """
+        let marker = "List.map "
+        assertSignatureHelpForFunctionApplication fileContents marker 1 0
 
-        if x.IsNone then
-            Assert.Fail("Could not parse and check document.")
-        x.Value
-    
-    let adjustedColumnInSource =
-        let rec loop s c =
-            if String.IsNullOrWhiteSpace(s.ToString()) then
-                loop (sourceText.GetSubText(c - 1)) (c - 1)
-            else
-                c
-        let startText =
-            if caretPosition = sourceText.Length then
-                sourceText.GetSubText(caretPosition)
-            else
-                sourceText.GetSubText(TextSpan(caretPosition, 1))
-    
-        loop startText caretPosition
-
-    let sigHelp =
-        FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
-            parseResults,
-            checkFileResults,
-            documentId,
-            [],
-            DefaultDocumentationProvider,
-            sourceText,
-            caretPosition,
-            adjustedColumnInSource,
-            filePath)
-        |> Async.RunSynchronously
-
-    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-
-    match sigHelp with
-    | None -> Assert.Fail("Expected signature help")
-    | Some sigHelp ->
-        Assert.AreEqual(1, sigHelp.ArgumentCount)
-        Assert.AreEqual(0, sigHelp.ArgumentIndex)
-
-[<Test>]
-let ``function application in middle of pipeline with an additional argument``() =
-    let fileContents = """
+    [<Test>]
+    let ``function application in middle of pipeline with an additional argument``() =
+        let fileContents = """
 [1..10]
 |> List.map 
 |> List.filer (fun x -> x > 3)
-"""
-    let marker = "List.map "
-    let caretPosition = fileContents.IndexOf(marker) + marker.Length
-    let sourceText = SourceText.From(fileContents)
-    let perfOptions = LanguageServicePerformanceOptions.Default
-    let textVersionHash = 0
-    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
-    
-    let parseResults, _, checkFileResults =
-        let x =
-            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
-            |> Async.RunSynchronously
+    """
+        let marker = "List.map "
+        assertSignatureHelpForFunctionApplication fileContents marker 1 0
 
-        if x.IsNone then
-            Assert.Fail("Could not parse and check document.")
-        x.Value
-    
-    let adjustedColumnInSource =
-        let rec loop s c =
-            if String.IsNullOrWhiteSpace(s.ToString()) then
-                loop (sourceText.GetSubText(c - 1)) (c - 1)
-            else
-                c
-        let startText =
-            if caretPosition = sourceText.Length then
-                sourceText.GetSubText(caretPosition)
-            else
-                sourceText.GetSubText(TextSpan(caretPosition, 1))
-    
-        loop startText caretPosition
-
-    let sigHelp =
-        FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
-            parseResults,
-            checkFileResults,
-            documentId,
-            [],
-            DefaultDocumentationProvider,
-            sourceText,
-            caretPosition,
-            adjustedColumnInSource,
-            filePath)
-        |> Async.RunSynchronously
-
-    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-
-    match sigHelp with
-    | None -> Assert.Fail("Expected signature help")
-    | Some sigHelp ->
-        Assert.AreEqual(1, sigHelp.ArgumentCount)
-        Assert.AreEqual(0, sigHelp.ArgumentIndex)
-
-[<Test>]
-let ``function application with function as parameter``() =
-    let fileContents = """
+    [<Test>]
+    let ``function application with function as parameter``() =
+        let fileContents = """
 let derp (f: int -> int -> int) x = f x 1
 derp 
 """
-    let marker = "derp "
-    let caretPosition = fileContents.LastIndexOf(marker) + marker.Length
-    let sourceText = SourceText.From(fileContents)
-    let perfOptions = LanguageServicePerformanceOptions.Default
-    let textVersionHash = 0
-    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
-    
-    let parseResults, _, checkFileResults =
-        let x =
-            checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText, projectOptions, perfOptions, "TestSignatureHelpProvider")
-            |> Async.RunSynchronously
-
-        if x.IsNone then
-            Assert.Fail("Could not parse and check document.")
-        x.Value
-    
-    let adjustedColumnInSource =
-        let rec loop s c =
-            if String.IsNullOrWhiteSpace(s.ToString()) then
-                loop (sourceText.GetSubText(c - 1)) (c - 1)
-            else
-                c
-        let startText =
-            if caretPosition = sourceText.Length then
-                sourceText.GetSubText(caretPosition)
-            else
-                sourceText.GetSubText(TextSpan(caretPosition, 1))
-    
-        loop startText caretPosition
-
-    let sigHelp =
-        FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
-            parseResults,
-            checkFileResults,
-            documentId,
-            [],
-            DefaultDocumentationProvider,
-            sourceText,
-            caretPosition,
-            adjustedColumnInSource,
-            filePath)
-        |> Async.RunSynchronously
-
-    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-
-    match sigHelp with
-    | None -> Assert.Fail("Expected signature help")
-    | Some sigHelp ->
-        Assert.AreEqual(2, sigHelp.ArgumentCount)
-        Assert.AreEqual(0, sigHelp.ArgumentIndex)
+        let marker = "derp "
+        assertSignatureHelpForFunctionApplication fileContents marker 2 0
 
 // migrated from legacy test
 [<Test>]


### PR DESCRIPTION
In the event that anything unrelated to static parameters in type providers aren't regressed in signature help, this should significantly ease adjusting tests and debugging broken ones.