### PR TITLE
Remove call to clean everything stored in FCS during each test run in signature help tests

### DIFF
--- a/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
@@ -180,6 +180,10 @@ let assertSignatureHelpForFunctionApplication (fileContents: string) (marker: st
         Assert.AreEqual(expectedArgumentCount, sigHelp.ArgumentCount)
         Assert.AreEqual(expectedArgumentIndex, sigHelp.ArgumentIndex)
 
+[<TearDown>]
+let ClearCaches() =
+    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
+
 [<TestFixture>]
 module ``Gives signature help in method calls`` =
 

--- a/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
@@ -132,8 +132,6 @@ let assertSignatureHelpForMethodCalls (fileContents: string) (marker: string) (e
                     caretPosition,
                     triggerChar)
                 |> Async.RunSynchronously
-                       
-            checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
             match triggered with 
             | None -> None
             | Some data -> Some (data.ApplicableSpan.ToString(),data.ArgumentIndex,data.ArgumentCount,data.ArgumentName)
@@ -176,9 +174,6 @@ let assertSignatureHelpForFunctionApplication (fileContents: string) (marker: st
             adjustedColumnInSource,
             filePath)
         |> Async.RunSynchronously
-
-    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-
     match sigHelp with
     | None -> Assert.Fail("Expected signature help")
     | Some sigHelp ->


### PR DESCRIPTION
This significantly improved testing times on my local machine. Let's hope it passes CI?