### PR TITLE
Update build.cmd -noVisualStudio to match unix build

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -192,15 +192,12 @@ function Update-Arguments() {
     }
 }
 
-function BuildSolution() {
-    # VisualFSharp.sln can't be built with dotnet due to WPF, WinForms and VSIX build task dependencies
-    $solution = "VisualFSharp.sln"
-
-    Write-Host "$($solution):"
+function BuildSolution([string] $solutionName) {
+    Write-Host "$( $solutionName):"
 
     $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
 
-    $projects = Join-Path $RepoRoot $solution
+    $projects = Join-Path $RepoRoot  $solutionName
     $officialBuildId = if ($official) { $env:BUILD_BUILDNUMBER } else { "" }
     $toolsetBuildProj = InitializeToolset
     $quietRestore = !$ci
@@ -297,32 +294,6 @@ function TestUsingXUnit([string] $testProject, [string] $targetFramework, [strin
 
 function TestUsingNUnit([string] $testProject, [string] $targetFramework, [string]$testadapterpath) {
     TestUsingMsBuild -testProject $testProject -targetFramework $targetFramework -testadapterpath $testadapterpath -noTestFilter $false
-}
-
-function BuildCompiler() {
-    if ($bootstrapTfm -eq "netcoreapp3.1") {
-        $dotnetPath = InitializeDotNetCli
-        $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
-        $fscProject = "`"$RepoRoot\src\fsharp\fsc\fsc.fsproj`""
-        $fsiProject = "`"$RepoRoot\src\fsharp\fsi\fsi.fsproj`""
-
-        $argNoRestore = if ($norestore) { " --no-restore" } else { "" }
-        $argNoIncremental = if ($rebuild) { " --no-incremental" } else { "" }
-
-        if ($binaryLog) {
-            $logFilePath = Join-Path $LogDir "fscBootstrapLog.binlog"
-            $args += " /bl:$logFilePath"
-        }
-        $args = "build $fscProject -c $configuration -v $verbosity -f netcoreapp3.1" + $argNoRestore + $argNoIncremental
-        Exec-Console $dotnetExe $args
-
-        if ($binaryLog) {
-            $logFilePath = Join-Path $LogDir "fsiBootstrapLog.binlog"
-            $args += " /bl:$logFilePath"
-        }
-        $args = "build $fsiProject -c $configuration -v $verbosity -f netcoreapp3.1" + $argNoRestore + $argNoIncremental
-        Exec-Console $dotnetExe $args
-    }
 }
 
 function Prepare-TempDir() {
@@ -474,9 +445,9 @@ try {
     $script:BuildMessage = "Failure building product"
     if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish) {
         if ($noVisualStudio) {
-            BuildCompiler
+            BuildSolution "FSharp.sln"
         } else {
-            BuildSolution
+            BuildSolution "VisualFSharp.sln"
         }
     }
 

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -193,7 +193,7 @@ function Update-Arguments() {
 }
 
 function BuildSolution([string] $solutionName) {
-    Write-Host "$( $solutionName):"
+    Write-Host "${solutionName}:"
 
     $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
 


### PR DESCRIPTION
I was investigating https://github.com/dotnet/fsharp/issues/10914 and noticed that on `-noVisualStudio` we don't match what unix does. That switch also builds the compiler twice. I think that we should have `-noVisualStudio` just build `FSharp.sln` like we do on Unix.