### PR TITLE
Fix 10923 - There is a load order dependency when using #r and assembly dependencies

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -61,6 +61,7 @@ open FSharp.Compiler.TypedTreeOps
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.XmlDoc
 open Internal.Utilities
+open Internal.Utilities.FSharpEnvironment
 
 // Prevents warnings of experimental APIs - we are using FSharpLexer
 #nowarn "57"
@@ -1938,21 +1939,29 @@ module internal MagicAssemblyResolution =
 
                    // As a last resort, try to find the reference without an extension
                    match tcImports.TryFindExistingFullyQualifiedPathByExactAssemblyRef(ctok, ILAssemblyRef.Create(simpleAssemName,None,None,false,None,None)) with
-                   | Some(resolvedPath) -> 
+                   | Some(resolvedPath) ->
                        OkResult([],Choice1Of2 resolvedPath)
-                   | None -> 
+                   | None ->
 
                    ErrorResult([],Failure (FSIstrings.SR.fsiFailedToResolveAssembly(simpleAssemName)))
 
-               match overallSearchResult with 
+               match overallSearchResult with
                | ErrorResult _ -> null
-               | OkResult _ -> 
+               | OkResult _ ->
                    let res = CommitOperationResult overallSearchResult
-                   match res with 
-                   | Choice1Of2 assemblyName -> 
+                   match res with
+                   | Choice1Of2 assemblyName ->
                        if simpleAssemName <> "Mono.Posix" then fsiConsoleOutput.uprintfn "%s" (FSIstrings.SR.fsiBindingSessionTo(assemblyName))
-                       assemblyLoadFrom assemblyName
-                   | Choice2Of2 assembly -> 
+                       if isRunningOnCoreClr then
+                         assemblyLoadFrom assemblyName
+                       else
+                         try
+                           let an = AssemblyName.GetAssemblyName(assemblyName)
+                           an.CodeBase <- assemblyName
+                           Assembly.Load an
+                         with | _ ->
+                           assemblyLoadFrom assemblyName
+                   | Choice2Of2 assembly ->
                        assembly
 
            with e ->


### PR DESCRIPTION
The never ending pursuit of loader corner cases highlights this little beauty.

Fix: #10923 

There is a circumstance that can occur on the Desktop CLR when we have the exact same assembly load twice from different assemblies.  Once loaded by standard dependency resolution _in the Load Context_ and again loaded by LoadFrom _in the LoadFrom Context_.

This PR addresses that by: "Loading #r assemblies using their assembly name with a codebase set to the path of the file.  This gives us the desired behaviour of first seeing if an assembly with this identity is already loaded as well as loading the assembly into the Load context allowing subsequent binds to use it for resolution.

In the case that the assembly is not reachable locally and the path is less trusted we fall back to use SafeLoadFrom.  On the coreclr we do what we did before.