### PR TITLE
de - unrollover 16.9

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
-    "rollForward": "minor"
+    "version": "5.0.100"
   },
   "tools": {
     "dotnet": "5.0.100",

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -4062,11 +4062,6 @@
         <target state="translated">メンバーとローカル クラスの束縛はどちらも '{0}' という名前を使用しています</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsEqualsMissingInTypeDefinition">
-        <source>Unexpected token in type definition. Expected '=' after the type '{0}'.</source>
-        <target state="new">Unexpected token in type definition. Expected '=' after the type '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcTypeAbbreviationsCannotHaveInterfaceDeclaration">
         <source>Type abbreviations cannot have interface declarations</source>
         <target state="translated">型略称にインターフェイスの宣言を含めることはできません</target>
@@ -7620,11 +7615,6 @@
       <trans-unit id="packageManagerUnknown">
         <source>Package manager key '{0}' was not registered in {1}. Currently registered: {2}</source>
         <target state="translated">パッケージ マネージャー キー '{0}' は {1} に登録されていませんでした。現在登録済み: {2}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="packageManagerError">
-        <source>{0}</source>
-        <target state="translated">{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="couldNotLoadDependencyManagerExtension">


### PR DESCRIPTION
Because of issues:  https://github.com/dotnet/fsharp/issues/10932, https://github.com/dotnet/fsharp/issues/10931

internal builds are failing due to these issues, in order to unblock our insertion pipeline, this PR removes the rollover option in the release/dev16.9 branch.
