### PR TITLE
Fix #10893 - FSI: Could not load file or assembly Azure.ResourceManager.Resources

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1880,11 +1880,10 @@ module internal MagicAssemblyResolution =
                // Special case: Mono Windows Forms attempts to load an assembly called something like "Windows.Forms.resources"
                // We can't resolve this, so don't try.
                // REVIEW: Suggest 4481, delete this special case.
-               if simpleAssemName.EndsWith(".resources",StringComparison.OrdinalIgnoreCase) || 
-                    // See F# 1.0 Product Studio bug 1171
-                    simpleAssemName.EndsWith(".XmlSerializers",StringComparison.OrdinalIgnoreCase) || 
-                    (runningOnMono && simpleAssemName = "UIAutomationWinforms") then null else
-
+               if (runningOnMono && simpleAssemName.EndsWith(".resources",StringComparison.OrdinalIgnoreCase)) ||
+                  simpleAssemName.EndsWith(".XmlSerializers", StringComparison.OrdinalIgnoreCase) ||
+                  (runningOnMono && simpleAssemName = "UIAutomationWinforms") then null
+               else
                // Special case: Is this the global unique dynamic assembly for FSI code? In this case just
                // return the dynamic assembly itself.       
                if fsiDynamicCompiler.DynamicAssemblyName = simpleAssemName then fsiDynamicCompiler.DynamicAssembly else

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -318,6 +318,19 @@ typeof<System.Device.Gpio.GpioController>.Assembly.Location
             ()
 
     [<Fact>]
+    member _.``Reference -- Azure.ResourceManager.Resources``() =
+        let code = """
+#r "nuget: Azure.Identity, 1.3.0"
+#r "nuget: Azure.ResourceManager.Resources, 1.0.0-preview.2"
+let creds = Azure.Identity.DefaultAzureCredential()
+let client = Azure.ResourceManager.Resources.ResourcesManagementClient("mySubscriptionId", creds)
+true"""
+        use script = new FSharpScript(additionalArgs=[|"/langversion:preview"|])
+        let opt = script.Eval(code)  |> getValue
+        let value = opt.Value
+        Assert.True(true = downcast value.ReflectionValue)
+
+    [<Fact>]
     member _.``Simple pinvoke should not be impacted by native resolver``() =
         let code = @"
 open System


### PR DESCRIPTION
Amusingly the magic reference resolver specifically didn't load assemblies whose names ended with .resources.  This was because of a mono forms bug.

So if we aren't on mono allow assemblies named .resources to load.