### PR TITLE
Fix triggering the outer application's signature help when triggering an inner application inside a lambda

### DIFF
--- a/src/fsharp/service/ServiceUntypedParse.fs
+++ b/src/fsharp/service/ServiceUntypedParse.fs
@@ -170,14 +170,18 @@ type FSharpParseFileResults(errors: FSharpDiagnostic[], input: ParsedInput optio
                 member _.VisitExpr(_, _, defaultTraverse, expr) =
                     match expr with
                     | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.Ident ident, _, _), argExpr, _) when rangeContainsPos argExpr.Range pos ->
-                        if ident.idText = "op_PipeRight" then
-                            Some (ident, 1)
-                        elif ident.idText = "op_PipeRight2" then
-                            Some (ident, 2)
-                        elif ident.idText = "op_PipeRight3" then
-                            Some (ident, 3)
-                        else
+                        match argExpr with
+                        | SynExpr.App(_, _, _, SynExpr.Paren(expr, _, _, _), _) when rangeContainsPos expr.Range pos ->
                             None
+                        | _ ->
+                            if ident.idText = "op_PipeRight" then
+                                Some (ident, 1)
+                            elif ident.idText = "op_PipeRight2" then
+                                Some (ident, 2)
+                            elif ident.idText = "op_PipeRight3" then
+                                Some (ident, 3)
+                            else
+                                None
                     | _ -> defaultTraverse expr
             })
         | None -> None
@@ -216,6 +220,13 @@ type FSharpParseFileResults(errors: FSharpDiagnostic[], input: ParsedInput optio
                 match argExpr with
                 | SynExpr.App (_, _, _, _, range) when rangeContainsPos range pos ->
                     getIdentRangeForFuncExprInApp traverseSynExpr argExpr pos
+
+                | SynExpr.Paren(SynExpr.Lambda(_, _, _args, body, _, _), _, _, _) when rangeContainsPos body.Range pos -> 
+                    getIdentRangeForFuncExprInApp traverseSynExpr body pos
+
+                // Figure out a way to generalize this around parens?
+                //| SynExpr.Paren(expr, _, _, _) when rangeContainsPos expr.Range pos -> 
+                //    getIdentRangeForFuncExprInApp traverseSynExpr expr pos
                 | _ ->
                     match funcExpr with
                     | SynExpr.App (_, true, _, _, _) when rangeContainsPos argExpr.Range pos ->
@@ -227,6 +238,17 @@ type FSharpParseFileResults(errors: FSharpDiagnostic[], input: ParsedInput optio
                         // Generally, we want to dive into the func expr to get the range
                         // of the identifier of the function we're after
                         getIdentRangeForFuncExprInApp traverseSynExpr funcExpr pos
+
+            | SynExpr.LetOrUse(_, _, bindings, body, range) when rangeContainsPos range pos  ->
+                let binding =
+                    bindings
+                    |> List.tryFind (fun x -> rangeContainsPos x.RangeOfBindingAndRhs pos)
+                match binding with
+                | Some(SynBinding.Binding(_, _, _, _, _, _, _, _, _, expr, _, _)) ->
+                    getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+                | None ->
+                    getIdentRangeForFuncExprInApp traverseSynExpr body pos
+
             | expr ->
                 traverseSynExpr expr
                 |> Option.map (fun expr -> expr)

--- a/src/fsharp/service/ServiceUntypedParse.fs
+++ b/src/fsharp/service/ServiceUntypedParse.fs
@@ -224,9 +224,6 @@ type FSharpParseFileResults(errors: FSharpDiagnostic[], input: ParsedInput optio
                 | SynExpr.Paren(SynExpr.Lambda(_, _, _args, body, _, _), _, _, _) when rangeContainsPos body.Range pos -> 
                     getIdentRangeForFuncExprInApp traverseSynExpr body pos
 
-                // Figure out a way to generalize this around parens?
-                //| SynExpr.Paren(expr, _, _, _) when rangeContainsPos expr.Range pos -> 
-                //    getIdentRangeForFuncExprInApp traverseSynExpr expr pos
                 | _ ->
                     match funcExpr with
                     | SynExpr.App (_, true, _, _, _) when rangeContainsPos argExpr.Range pos ->

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -251,8 +251,6 @@ type internal FSharpSignatureHelpProvider
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineText, lexerSymbol.FullIsland)
 
             let isValid (mfv: FSharpMemberOrFunctionOrValue) =
-                // TODO check if it is a keyword - nested inside parens case!
-                // TODO check classification data similar to completion provider
                 not (PrettyNaming.IsOperatorName mfv.DisplayName) &&
                 not mfv.IsProperty &&
                 mfv.CurriedParameterGroups.Count > 0

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -251,6 +251,8 @@ type internal FSharpSignatureHelpProvider
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineText, lexerSymbol.FullIsland)
 
             let isValid (mfv: FSharpMemberOrFunctionOrValue) =
+                // TODO check if it is a keyword - nested inside parens case!
+                // TODO check classification data similar to completion provider
                 not (PrettyNaming.IsOperatorName mfv.DisplayName) &&
                 not mfv.IsProperty &&
                 mfv.CurriedParameterGroups.Count > 0


### PR DESCRIPTION
Fixes the remaining issue as reported here: https://github.com/dotnet/fsharp/issues/10941

Now it triggers the right signature help:

![image](https://user-images.githubusercontent.com/6309070/105943727-c3798480-6016-11eb-9eaa-833576ed9741.png)
