### PR TITLE
[VS] Partial implementation of Go to definition for external IL symbols

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -46,6 +46,7 @@
     <Compile Include="LanguageService\FSharpCheckerExtensions.fs" />
     <Compile Include="LanguageService\IProjectSite.fs" />
     <Compile Include="LanguageService\ProvideFSharpVersionRegistrationAttribute.fs" />
+    <Compile Include="LanguageService\MetadataAsSource.fs" />
     <Compile Include="LanguageService\FSharpCheckerProvider.fs" />
     <Compile Include="LanguageService\FSharpProjectOptionsManager.fs" />
     <Compile Include="LanguageService\SingleFileWorkspaceMap.fs" />

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpCheckerProvider.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpCheckerProvider.fs
@@ -26,6 +26,8 @@ type internal FSharpCheckerProvider
         settings: EditorOptions
     ) =
 
+    let metadataAsSource = FSharpMetadataAsSourceService()
+
     let tryGetMetadataSnapshot (path, timeStamp) = 
         try
             let md = Microsoft.CodeAnalysis.ExternalAccess.FSharp.LanguageServices.FSharpVisualStudioWorkspaceExtensions.GetMetadata(workspace, path, timeStamp)
@@ -84,4 +86,6 @@ type internal FSharpCheckerProvider
             checker
 
     member this.Checker = checker.Value
+
+    member _.MetadataAsSource = metadataAsSource
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -433,3 +433,5 @@ type internal FSharpProjectOptionsManager
         reactor.SetCpsCommandLineOptions(projectId, sourcePaths, options.ToArray())
 
     member _.Checker = checkerProvider.Checker
+
+    member _.MetadataAsSource = checkerProvider.MetadataAsSource

--- a/vsintegration/src/FSharp.Editor/LanguageService/MetadataAsSource.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/MetadataAsSource.fs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.Threading
+open System.Collections.Immutable
+open System.Diagnostics
+open System.IO
+open System.Linq
+open System.Text
+open System.Runtime.InteropServices
+open System.Reflection.PortableExecutable
+
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.FindSymbols
+open Microsoft.CodeAnalysis.Text
+open Microsoft.CodeAnalysis.Navigation
+open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
+open Microsoft.VisualStudio.ComponentModelHost
+
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.Editor
+open Microsoft.VisualStudio.Threading
+open Microsoft.VisualStudio.Shell
+open Microsoft.VisualStudio.Shell.Interop
+open Microsoft.VisualStudio.TextManager.Interop
+
+open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Text
+
+module internal MetadataAsSource =
+
+    open Microsoft.CodeAnalysis.CSharp
+    open ICSharpCode.Decompiler
+    open ICSharpCode.Decompiler.CSharp
+    open ICSharpCode.Decompiler.Metadata
+    open ICSharpCode.Decompiler.CSharp.Transforms
+    open ICSharpCode.Decompiler.TypeSystem
+
+    let GenerateTemporaryCSharpDocument (asmIdentity: AssemblyIdentity, name: string, metadataReferences) =
+        let rootPath = Path.Combine(Path.GetTempPath(), "MetadataAsSource")
+        let extension = ".cs"
+        let directoryName = Guid.NewGuid().ToString("N")
+        let temporaryFilePath = Path.Combine(rootPath, directoryName, name + extension)
+
+        let projectId = ProjectId.CreateNewId()
+
+        let parseOptions = CSharpParseOptions.Default.WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
+        // Just say it's always a DLL since we probably won't have a Main method
+        let compilationOptions = Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+
+        // We need to include the version information of the assembly so InternalsVisibleTo and stuff works
+        let assemblyInfoDocumentId = DocumentId.CreateNewId(projectId)
+        let assemblyInfoFileName = "AssemblyInfo" + extension
+        let assemblyInfoString = String.Format(@"[assembly: System.Reflection.AssemblyVersion(""{0}"")]", asmIdentity.Version)
+
+        let assemblyInfoSourceTextContainer = SourceText.From(assemblyInfoString, Encoding.UTF8).Container
+
+        let assemblyInfoDocument = 
+            DocumentInfo.Create(
+                assemblyInfoDocumentId,
+                assemblyInfoFileName,
+                loader = TextLoader.From(assemblyInfoSourceTextContainer, VersionStamp.Default))
+
+        let generatedDocumentId = DocumentId.CreateNewId(projectId)
+        let documentInfo = 
+            DocumentInfo.Create(
+                generatedDocumentId,
+                Path.GetFileName(temporaryFilePath),
+                filePath = temporaryFilePath,
+                loader = FileTextLoader(temporaryFilePath, Encoding.UTF8))
+
+        let projectInfo = 
+            ProjectInfo.Create(
+                projectId,
+                VersionStamp.Default,
+                name = asmIdentity.Name,
+                assemblyName = asmIdentity.Name,
+                language = LanguageNames.CSharp,
+                compilationOptions = compilationOptions,
+                parseOptions = parseOptions,
+                documents = [|assemblyInfoDocument;documentInfo|],
+                metadataReferences = metadataReferences)
+
+        (projectInfo, documentInfo)
+
+    let DecompileCSharp (symbolFullTypeName: string, assemblyLocation: string) =
+        let logger = new StringBuilder();
+
+        // Initialize a decompiler with default settings.
+        let decompiler = CSharpDecompiler(assemblyLocation, DecompilerSettings())
+        // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
+        // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
+        decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers())
+
+        let fullTypeName = FullTypeName(symbolFullTypeName)
+
+        // Try to decompile; if an exception is thrown the caller will handle it
+        let mutable text = decompiler.DecompileTypeAsString(fullTypeName)
+
+        text <- text + "#if false // " + Environment.NewLine
+        text <- text + logger.ToString()
+        text <- text + "#endif" + Environment.NewLine
+
+        SourceText.From(text)
+
+    let ShowDocument (filePath, name, serviceProvider: IServiceProvider) =
+        let vsRunningDocumentTable4 = serviceProvider.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable4>()
+        let fileAlreadyOpen = vsRunningDocumentTable4.IsMonikerValid(filePath)
+
+        let openDocumentService = serviceProvider.GetService<SVsUIShellOpenDocument, IVsUIShellOpenDocument>()
+        let mutable localServiceProvider = Unchecked.defaultof<_>
+        let mutable hierarchy = Unchecked.defaultof<_>
+        let mutable itemId = Unchecked.defaultof<_>
+        let mutable windowFrame = Unchecked.defaultof<_>
+        openDocumentService.OpenDocumentViaProject(filePath, ref VSConstants.LOGVIEWID.TextView_guid, &localServiceProvider, &hierarchy, &itemId, &windowFrame) |> ignore
+
+        let componentModel = serviceProvider.GetService<SComponentModel, IComponentModel>()
+        let editorAdaptersFactory = componentModel.GetService<IVsEditorAdaptersFactoryService>();
+        let documentCookie = vsRunningDocumentTable4.GetDocumentCookie(filePath)
+        let vsTextBuffer = vsRunningDocumentTable4.GetDocumentData(documentCookie) :?> IVsTextBuffer
+        let textBuffer = editorAdaptersFactory.GetDataBuffer(vsTextBuffer)
+
+        if not fileAlreadyOpen then
+            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_IsProvisional, true)) |> ignore
+            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_OverrideCaption, name)) |> ignore
+            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_OverrideToolTip, name)) |> ignore
+
+        windowFrame.Show() |> ignore
+
+        let textContainer = textBuffer.AsTextContainer()
+        let mutable workspace = Unchecked.defaultof<_>
+        if Workspace.TryGetWorkspace(textContainer, &workspace) then
+            let solution = workspace.CurrentSolution
+            let documentId = workspace.GetDocumentIdInCurrentContext(textContainer)
+            match box documentId with
+            | null -> None
+            | _ -> solution.GetDocument(documentId) |> Some
+        else
+            None
+
+[<Sealed>]
+type internal FSharpMetadataAsSourceService() =
+
+    member val CSharpFiles = System.Collections.Concurrent.ConcurrentDictionary(StringComparer.OrdinalIgnoreCase)
+
+    member this.ShowCSharpDocument(projInfo: ProjectInfo, docInfo: DocumentInfo, text: Text.SourceText) =
+        let _ =
+            let directoryName = Path.GetDirectoryName(docInfo.FilePath)
+            if Directory.Exists(directoryName) |> not then
+                Directory.CreateDirectory(directoryName) |> ignore
+            use fileStream = new FileStream(docInfo.FilePath, IO.FileMode.Create)
+            use writer = new StreamWriter(fileStream)
+            text.Write(writer)
+
+        this.CSharpFiles.[docInfo.FilePath] <- (projInfo, docInfo)
+
+        MetadataAsSource.ShowDocument(docInfo.FilePath, docInfo.Name, ServiceProvider.GlobalProvider)

--- a/vsintegration/src/FSharp.Editor/LanguageService/SingleFileWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SingleFileWorkspaceMap.fs
@@ -38,13 +38,12 @@ type internal SingleFileWorkspaceMap(workspace: VisualStudioWorkspace,
         projectContext.DisplayName <- projInfo.Name
         projectContext.AddSourceFile(docInfo.FilePath, sourceCodeKind = SourceCodeKind.Regular)
         
-        projInfo.MetadataReferences
-        |> Seq.iter (function
+        for metaRef in projInfo.MetadataReferences do
+            match metaRef with
             | :? PortableExecutableReference as peRef ->
                 projectContext.AddMetadataReference(peRef.FilePath, MetadataReferenceProperties.Assembly)
             | _ ->
                 ()
-        )
 
         projectContext
 

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -8,18 +8,121 @@ open System.Collections.Immutable
 open System.Diagnostics
 open System.IO
 open System.Linq
+open System.Text
 open System.Runtime.InteropServices
+open System.Reflection.PortableExecutable
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.FindSymbols
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.Navigation
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
+open Microsoft.VisualStudio.ComponentModelHost
 
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.Threading
+open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
+open Microsoft.VisualStudio.TextManager.Interop
 
 open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Text
+
+module private CSharpDecompiler =
+
+    open Microsoft.CodeAnalysis.CSharp
+    open ICSharpCode.Decompiler
+    open ICSharpCode.Decompiler.CSharp
+    open ICSharpCode.Decompiler.Metadata
+    open ICSharpCode.Decompiler.CSharp.Transforms
+    open ICSharpCode.Decompiler.TypeSystem
+
+    let GenerateTemporaryCSharpDocument (asmIdentity: AssemblyIdentity, name: string, metadataReferences) =
+        let rootPath = Path.Combine(Path.GetTempPath(), "MetadataAsSource")
+        let extension = ".cs"
+        let directoryName = Guid.NewGuid().ToString("N")
+        let temporaryFilePath = Path.Combine(rootPath, directoryName, name + extension)
+
+        let projectId = ProjectId.CreateNewId()
+
+        let parseOptions = CSharpParseOptions.Default.WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
+        // Just say it's always a DLL since we probably won't have a Main method
+        let compilationOptions = Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+
+        let extension = ".cs"
+
+        // We need to include the version information of the assembly so InternalsVisibleTo and stuff works
+        let assemblyInfoDocumentId = DocumentId.CreateNewId(projectId)
+        let assemblyInfoFileName = "AssemblyInfo" + extension
+        let assemblyInfoString = String.Format(@"[assembly: System.Reflection.AssemblyVersion(""{0}"")]", asmIdentity.Version)
+
+        let assemblyInfoSourceTextContainer = SourceText.From(assemblyInfoString, Encoding.UTF8).Container
+
+        let assemblyInfoDocument = 
+            DocumentInfo.Create(
+                assemblyInfoDocumentId,
+                assemblyInfoFileName,
+                loader = TextLoader.From(assemblyInfoSourceTextContainer, VersionStamp.Default))
+
+        let generatedDocumentId = DocumentId.CreateNewId(projectId)
+        let generatedDocument = 
+            DocumentInfo.Create(
+                generatedDocumentId,
+                Path.GetFileName(temporaryFilePath),
+                filePath = temporaryFilePath,
+                loader = FileTextLoader(temporaryFilePath, Encoding.UTF8))
+
+        let projectInfo = 
+            ProjectInfo.Create(
+                projectId,
+                VersionStamp.Default,
+                name = asmIdentity.Name,
+                assemblyName = asmIdentity.Name,
+                language = LanguageNames.CSharp,
+                compilationOptions = compilationOptions,
+                parseOptions = parseOptions,
+                documents = [|assemblyInfoDocument;generatedDocument|],
+                metadataReferences = metadataReferences)
+
+        (projectInfo, generatedDocumentId)
+
+    let Decompile (document: Document, symbolFullName: string, assemblyLocation: string) =
+        let logger = new StringBuilder();
+
+        // Initialize a decompiler with default settings.
+        let decompiler = CSharpDecompiler(assemblyLocation, DecompilerSettings())
+        // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
+        // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
+        decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers())
+
+        let fullTypeName = FullTypeName(symbolFullName)
+
+        // Try to decompile; if an exception is thrown the caller will handle it
+        let mutable text = decompiler.DecompileTypeAsString(fullTypeName);
+
+        text <- text + "#if false // " + Environment.NewLine;
+        text <- text + logger.ToString();
+        text <- text + "#endif" + Environment.NewLine;
+
+        document.WithText(SourceText.From(text));
+
+    let ShowDocument (document: Document, serviceProvider: IServiceProvider) =
+        let vsRunningDocumentTable4 = serviceProvider.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable4>()
+        let fileAlreadyOpen = vsRunningDocumentTable4.IsMonikerValid(document.FilePath)
+
+        let openDocumentService = serviceProvider.GetService<SVsUIShellOpenDocument, IVsUIShellOpenDocument>()
+        let mutable localServiceProvider = Unchecked.defaultof<_>
+        let mutable hierarchy = Unchecked.defaultof<_>
+        let mutable itemId = Unchecked.defaultof<_>
+        let mutable windowFrame = Unchecked.defaultof<_>
+        openDocumentService.OpenDocumentViaProject(document.FilePath, ref VSConstants.LOGVIEWID.TextView_guid, &localServiceProvider, &hierarchy, &itemId, &windowFrame) |> ignore
+
+        if not fileAlreadyOpen then
+            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_IsProvisional, true)) |> ignore
+            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_OverrideCaption, document.Name)) |> ignore
+            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_OverrideToolTip, document.Name)) |> ignore
+
+        windowFrame.Show() |> ignore
 
 module private Symbol =
     let fullName (root: ISymbol) : string =
@@ -343,7 +446,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
 
     /// Navigate to the positon of the textSpan in the provided document
     /// used by quickinfo link navigation when the tooltip contains the correct destination range.
-    member _.TryNavigateToTextSpan(document: Document, textSpan: TextSpan, statusBar: StatusBar) =
+    member _.TryNavigateToTextSpan(document: Document, textSpan: Microsoft.CodeAnalysis.Text.TextSpan, statusBar: StatusBar) =
         let navigableItem = FSharpGoToDefinitionNavigableItem(document, textSpan)
         let workspace = document.Project.Solution.Workspace
         let navigationService = workspace.Services.GetService<IFSharpDocumentNavigationService>()

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -256,8 +256,8 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
             match declarations with
             | FSharpFindDeclResult.ExternalDecl (assembly, targetExternalSym) ->
                 let projectOpt = originDocument.Project.Solution.Projects |> Seq.tryFind (fun p -> p.AssemblyName.Equals(assembly, StringComparison.OrdinalIgnoreCase))
-                if projectOpt.IsSome then
-                    let project = projectOpt.Value
+                match projectOpt with
+                | Some project ->
                     let! symbols = SymbolFinder.FindSourceDeclarationsAsync(project, fun _ -> true)
 
                     let roslynSymbols =
@@ -274,8 +274,8 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
 
                     let! location = symbol.Locations |> Seq.tryHead
                     return (FSharpGoToDefinitionResult.NavigableItem(FSharpGoToDefinitionNavigableItem(project.GetDocument(location.SourceTree), location.SourceSpan)), idRange)
-                else
-                    let tmpProjInfo, tmpDocId = MetadataAsSource.GenerateTemporaryCSharpDocument(AssemblyIdentity(targetSymbolUse.Symbol.Assembly.QualifiedName), targetSymbolUse.Symbol.DisplayName, originDocument.Project.MetadataReferences)
+                | _ ->
+                    let tmpProjInfo, tmpDocId = MetadataAsSource.generateTemporaryCSharpDocument(AssemblyIdentity(targetSymbolUse.Symbol.Assembly.QualifiedName), targetSymbolUse.Symbol.DisplayName, originDocument.Project.MetadataReferences)
                     return (FSharpGoToDefinitionResult.ExternalAssembly(tmpProjInfo, tmpDocId, targetSymbolUse, targetExternalSym), idRange)
 
             | FSharpFindDeclResult.DeclFound targetRange -> 

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -29,119 +29,6 @@ open Microsoft.VisualStudio.TextManager.Interop
 open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Text
 
-module internal CSharpDecompiler =
-
-    open Microsoft.CodeAnalysis.CSharp
-    open ICSharpCode.Decompiler
-    open ICSharpCode.Decompiler.CSharp
-    open ICSharpCode.Decompiler.Metadata
-    open ICSharpCode.Decompiler.CSharp.Transforms
-    open ICSharpCode.Decompiler.TypeSystem
-
-    let GenerateTemporaryCSharpDocument (asmIdentity: AssemblyIdentity, name: string, metadataReferences) =
-        let rootPath = Path.Combine(Path.GetTempPath(), "MetadataAsSource")
-        let extension = ".cs"
-        let directoryName = Guid.NewGuid().ToString("N")
-        let temporaryFilePath = Path.Combine(rootPath, directoryName, name + extension)
-
-        let projectId = ProjectId.CreateNewId()
-
-        let parseOptions = CSharpParseOptions.Default.WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
-        // Just say it's always a DLL since we probably won't have a Main method
-        let compilationOptions = Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-
-        let extension = ".cs"
-
-        // We need to include the version information of the assembly so InternalsVisibleTo and stuff works
-        let assemblyInfoDocumentId = DocumentId.CreateNewId(projectId)
-        let assemblyInfoFileName = "AssemblyInfo" + extension
-        let assemblyInfoString = String.Format(@"[assembly: System.Reflection.AssemblyVersion(""{0}"")]", asmIdentity.Version)
-
-        let assemblyInfoSourceTextContainer = SourceText.From(assemblyInfoString, Encoding.UTF8).Container
-
-        let assemblyInfoDocument = 
-            DocumentInfo.Create(
-                assemblyInfoDocumentId,
-                assemblyInfoFileName,
-                loader = TextLoader.From(assemblyInfoSourceTextContainer, VersionStamp.Default))
-
-        let generatedDocumentId = DocumentId.CreateNewId(projectId)
-        let generatedDocument = 
-            DocumentInfo.Create(
-                generatedDocumentId,
-                Path.GetFileName(temporaryFilePath),
-                filePath = temporaryFilePath,
-                loader = FileTextLoader(temporaryFilePath, Encoding.UTF8))
-
-        let projectInfo = 
-            ProjectInfo.Create(
-                projectId,
-                VersionStamp.Default,
-                name = asmIdentity.Name,
-                assemblyName = asmIdentity.Name,
-                language = LanguageNames.CSharp,
-                compilationOptions = compilationOptions,
-                parseOptions = parseOptions,
-                documents = [|assemblyInfoDocument;generatedDocument|],
-                metadataReferences = metadataReferences)
-
-        (projectInfo, generatedDocumentId)
-
-    let Decompile (symbolFullName: string, assemblyLocation: string) =
-        let logger = new StringBuilder();
-
-        // Initialize a decompiler with default settings.
-        let decompiler = CSharpDecompiler(assemblyLocation, DecompilerSettings())
-        // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
-        // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
-        decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers())
-
-        let fullTypeName = FullTypeName(symbolFullName)
-
-        // Try to decompile; if an exception is thrown the caller will handle it
-        let mutable text = decompiler.DecompileTypeAsString(fullTypeName)
-
-        text <- text + "#if false // " + Environment.NewLine
-        text <- text + logger.ToString()
-        text <- text + "#endif" + Environment.NewLine
-
-        SourceText.From(text)
-
-    let ShowDocument (filePath, name, serviceProvider: IServiceProvider) =
-        let vsRunningDocumentTable4 = serviceProvider.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable4>()
-        let fileAlreadyOpen = vsRunningDocumentTable4.IsMonikerValid(filePath)
-
-        let openDocumentService = serviceProvider.GetService<SVsUIShellOpenDocument, IVsUIShellOpenDocument>()
-        let mutable localServiceProvider = Unchecked.defaultof<_>
-        let mutable hierarchy = Unchecked.defaultof<_>
-        let mutable itemId = Unchecked.defaultof<_>
-        let mutable windowFrame = Unchecked.defaultof<_>
-        openDocumentService.OpenDocumentViaProject(filePath, ref VSConstants.LOGVIEWID.TextView_guid, &localServiceProvider, &hierarchy, &itemId, &windowFrame) |> ignore
-
-        let componentModel = serviceProvider.GetService<SComponentModel, IComponentModel>()
-        let editorAdaptersFactory = componentModel.GetService<IVsEditorAdaptersFactoryService>();
-        let documentCookie = vsRunningDocumentTable4.GetDocumentCookie(filePath)
-        let vsTextBuffer = vsRunningDocumentTable4.GetDocumentData(documentCookie) :?> IVsTextBuffer
-        let textBuffer = editorAdaptersFactory.GetDataBuffer(vsTextBuffer)
-
-        if not fileAlreadyOpen then
-            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_IsProvisional, true)) |> ignore
-            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_OverrideCaption, name)) |> ignore
-            ErrorHandler.ThrowOnFailure(windowFrame.SetProperty(int __VSFPROPID5.VSFPROPID_OverrideToolTip, name)) |> ignore
-
-        windowFrame.Show() |> ignore
-
-        let textContainer = textBuffer.AsTextContainer()
-        let mutable workspace = Unchecked.defaultof<_>
-        if Workspace.TryGetWorkspace(textContainer, &workspace) then
-            let solution = workspace.CurrentSolution
-            let documentId = workspace.GetDocumentIdInCurrentContext(textContainer)
-            match box documentId with
-            | null -> None
-            | _ -> solution.GetDocument(documentId) |> Some
-        else
-            None
-
 
 module private Symbol =
     let fullName (root: ISymbol) : string =
@@ -270,7 +157,7 @@ type internal FSharpGoToDefinitionNavigableItem(document, sourceSpan) =
 [<RequireQualifiedAccess>]
 type internal FSharpGoToDefinitionResult =
     | NavigableItem of FSharpNavigableItem
-    | ExternalAssembly of ProjectInfo * DocumentId * FSharpSymbolUse
+    | ExternalAssembly of ProjectInfo * DocumentInfo * FSharpSymbolUse * FSharpExternalSymbol
 
 type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpProjectOptionsManager) =
     let userOpName = "GoToDefinition"
@@ -388,8 +275,8 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
                     let! location = symbol.Locations |> Seq.tryHead
                     return (FSharpGoToDefinitionResult.NavigableItem(FSharpGoToDefinitionNavigableItem(project.GetDocument(location.SourceTree), location.SourceSpan)), idRange)
                 else
-                    let tmpProjInfo, tmpDocId = CSharpDecompiler.GenerateTemporaryCSharpDocument(AssemblyIdentity(targetSymbolUse.Symbol.Assembly.QualifiedName), targetSymbolUse.Symbol.DisplayName, originDocument.Project.MetadataReferences)
-                    return (FSharpGoToDefinitionResult.ExternalAssembly(tmpProjInfo, tmpDocId, targetSymbolUse), idRange)
+                    let tmpProjInfo, tmpDocId = MetadataAsSource.GenerateTemporaryCSharpDocument(AssemblyIdentity(targetSymbolUse.Symbol.Assembly.QualifiedName), targetSymbolUse.Symbol.DisplayName, originDocument.Project.MetadataReferences)
+                    return (FSharpGoToDefinitionResult.ExternalAssembly(tmpProjInfo, tmpDocId, targetSymbolUse, targetExternalSym), idRange)
 
             | FSharpFindDeclResult.DeclFound targetRange -> 
                 // if goto definition is called at we are alread at the declaration location of a symbol in

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
@@ -3,6 +3,7 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
+open System.IO
 open System.Threading
 open System.Threading.Tasks
 
@@ -10,6 +11,7 @@ open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Editor
 open Microsoft.CodeAnalysis.Host.Mef
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
+open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
 
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
@@ -30,7 +32,16 @@ type internal FSharpGoToDefinitionService
     interface IFSharpGoToDefinitionService with
         /// Invoked with Peek Definition.
         member _.FindDefinitionsAsync (document: Document, position: int, cancellationToken: CancellationToken) =
-            gtd.FindDefinitionsForPeekTask(document, position, cancellationToken)
+            let task = gtd.FindDefinitionsForPeekTask(document, position, cancellationToken)
+            task.Wait(cancellationToken)
+            let results = task.Result
+            results
+            |> Seq.choose(fun (result, _) ->
+                match result with
+                | FSharpGoToDefinitionResult.NavigableItem(navItem) -> Some navItem
+                | _ -> None
+            )
+            |> Task.FromResult
 
         /// Invoked with Go to Definition.
         /// Try to navigate to the definiton of the symbol at the symbolRange in the originDocument
@@ -44,13 +55,42 @@ type internal FSharpGoToDefinitionService
             // Task.Wait throws an exception if the task is cancelled, so be sure to catch it.
             try
                 // This call to Wait() is fine because we want to be able to provide the error message in the status bar.
-                gtdTask.Wait()
+                gtdTask.Wait(cancellationToken)
                 if gtdTask.Status = TaskStatus.RanToCompletion && gtdTask.Result.IsSome then
-                    let item, _ = gtdTask.Result.Value
-                    gtd.NavigateToItem(item, statusBar)
-
-                    // 'true' means do it, like Sheev Palpatine would want us to.
-                    true
+                    let result, _ = gtdTask.Result.Value
+                    match result with
+                    | FSharpGoToDefinitionResult.NavigableItem(navItem) ->
+                        gtd.NavigateToItem(navItem, statusBar)
+                        // 'true' means do it, like Sheev Palpatine would want us to.
+                        true
+                    | FSharpGoToDefinitionResult.ExternalAssembly(tmpProjInfo, tmpDocId, targetSymbolUse) ->
+                        match targetSymbolUse.Symbol.Assembly.FileName with
+                        | Some targetSymbolAssemblyFileName ->
+                            let text = CSharpDecompiler.Decompile(targetSymbolUse.Symbol.FullName, targetSymbolAssemblyFileName)
+                            let workspace = new AdhocWorkspace(document.Project.Solution.Workspace.Services.HostServices, WorkspaceKind.MetadataAsSource)
+                            let proj = workspace.AddProject(tmpProjInfo)                         
+                            let tmpDoc = proj.GetDocument(tmpDocId)
+                            let _ =
+                                let directoryName = Path.GetDirectoryName(tmpDoc.FilePath)
+                                if Directory.Exists(directoryName) |> not then
+                                    Directory.CreateDirectory(directoryName) |> ignore
+                                use fileStream = new FileStream(tmpDoc.FilePath, IO.FileMode.Create)
+                                use writer = new StreamWriter(fileStream)
+                                text.Write(writer)
+                            
+                            workspace.OpenDocument(tmpDoc.Id, true)
+                            let tmpShownDocOpt = CSharpDecompiler.ShowDocument(tmpDoc.FilePath, tmpDoc.Name, ServiceProvider.GlobalProvider)
+                            match tmpShownDocOpt with
+                            | Some tmpShownDoc ->                             
+                                let navItem = FSharpGoToDefinitionNavigableItem(tmpShownDoc, Text.TextSpan())                               
+                                gtd.NavigateToItem(navItem, statusBar)
+                                true
+                            | _ ->
+                                statusBar.TempMessage (SR.CannotDetermineSymbol())
+                                false
+                        | _ ->
+                            statusBar.TempMessage (SR.CannotDetermineSymbol())
+                            false
                 else 
                     statusBar.TempMessage (SR.CannotDetermineSymbol())
                     false

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
@@ -81,7 +81,7 @@ type internal FSharpGoToDefinitionService
                                     | FSharpExternalSymbol.Property(tyName, _)
                                     | FSharpExternalSymbol.Type(tyName) -> tyName
 
-                                let text = MetadataAsSource.DecompileCSharp(symbolFullTypeName, targetSymbolAssemblyFileName)
+                                let text = MetadataAsSource.decompileCSharp(symbolFullTypeName, targetSymbolAssemblyFileName)
                                 let tmpShownDocOpt = metadataAsSourceService.ShowCSharpDocument(tmpProjInfo, tmpDocInfo, text)
                                 match tmpShownDocOpt with
                                 | Some tmpShownDoc ->

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigableSymbolsService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigableSymbolsService.fs
@@ -58,13 +58,17 @@ type internal FSharpNavigableSymbolSource(checkerProvider: FSharpCheckerProvider
                         statusBar.Clear()
 
                         if gtdTask.Status = TaskStatus.RanToCompletion && gtdTask.Result.IsSome then
-                            let navigableItem, range = gtdTask.Result.Value
+                            let result, range = gtdTask.Result.Value
 
                             let declarationTextSpan = RoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
                             let declarationSpan = Span(declarationTextSpan.Start, declarationTextSpan.Length)
                             let symbolSpan = SnapshotSpan(snapshot, declarationSpan)
 
-                            return FSharpNavigableSymbol(navigableItem, symbolSpan, gtd, statusBar) :> INavigableSymbol
+                            match result with
+                            | FSharpGoToDefinitionResult.NavigableItem(navItem) ->
+                                return FSharpNavigableSymbol(navItem, symbolSpan, gtd, statusBar) :> INavigableSymbol
+                            | _ ->
+                                return null
                         else 
                             statusBar.TempMessage(SR.CannotDetermineSymbol())
 


### PR DESCRIPTION
This is a partial implementation that allows go-to-definition on external IL symbols by generating metadata source files; currently only generating "C#" metadata code.

This is partial, meaning that it doesn't generate a proper metadata-as-source C# file as it is missing formatting and doesn't navigate to the given symbol. We also can't do go-to-def on external "F#" symbols yet.

Roslyn has internal services that could help with the formatting, but there must be additions to F#'s external access in order to take advantage of it. 

I thought about re-using Roslyn's whole metadata-as-source implementation by adding a F# external access API, but we really can't use the API as it relies on `ISymbol`. See here: http://sourceroslyn.io/#Microsoft.CodeAnalysis.Features/MetadataAsSource/IMetadataAsSourceFileService.cs,25