### PR TITLE
Track the signaturehelp session kind in signature help

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -33,12 +33,17 @@ type SignatureHelpItem =
       Parameters: SignatureHelpParameterInfo[]
       MainDescription: ResizeArray<RoslynTaggedText> }
 
+type CurrentSignatureHelpSessionKind =
+    | FunctionApplication
+    | MethodCall
+
 type SignatureHelpData =
     { SignatureHelpItems: SignatureHelpItem[]
       ApplicableSpan: TextSpan
       ArgumentIndex: int
       ArgumentCount: int
-      ArgumentName: string option }
+      ArgumentName: string option
+      CurrentSignatureHelpSessionKind: CurrentSignatureHelpSessionKind }
 
 [<Shared>]
 [<Export(typeof<IFSharpSignatureHelpProvider>)>]
@@ -55,6 +60,8 @@ type internal FSharpSignatureHelpProvider
 
     static let oneColAfter (lp: LinePosition) = LinePosition(lp.Line,lp.Character+1)
     static let oneColBefore (lp: LinePosition) = LinePosition(lp.Line,max 0 (lp.Character-1))
+
+    let mutable possibleCurrentSignatureHelpSessionKind = None
 
     static member internal ProvideMethodsAsyncAux
         (
@@ -212,7 +219,8 @@ type internal FSharpSignatureHelpProvider
                       ApplicableSpan = applicableSpan
                       ArgumentIndex = argumentIndex
                       ArgumentCount = argumentCount
-                      ArgumentName = argumentName }
+                      ArgumentName = argumentName
+                      CurrentSignatureHelpSessionKind = MethodCall }
 
                 return! Some data
     }
@@ -425,7 +433,8 @@ type internal FSharpSignatureHelpProvider
                           ApplicableSpan = TextSpan(symbolSpan.End, caretPosition - symbolSpan.End)
                           ArgumentIndex = argumentIndex
                           ArgumentCount = displayArgs.Count
-                          ArgumentName = None }
+                          ArgumentName = None
+                          CurrentSignatureHelpSessionKind = FunctionApplication }
 
                     return! Some data
             | _ ->
@@ -443,7 +452,8 @@ type internal FSharpSignatureHelpProvider
             options: FSharpProjectOptions,
             filePath: string,
             textVersionHash: int,
-            triggerTypedChar: char option
+            triggerTypedChar: char option,
+            possibleCurrentSignatureHelpSessionKind: CurrentSignatureHelpSessionKind option
         ) =
         asyncMaybe {
             let textLines = sourceText.Lines
@@ -463,11 +473,23 @@ type internal FSharpSignatureHelpProvider
 
             let adjustedColumnChar = sourceText.[adjustedColumnInSource]
 
-            match triggerTypedChar with
+            match triggerTypedChar, possibleCurrentSignatureHelpSessionKind with
             // Generally ' ' indicates a function application, but it's also used commonly after a comma in a method call.
             // This means that the adjusted position relative to the caret could be a ',' or a '(' or '<',
             // which would mean we're already inside of a method call - not a function argument. So we bail if that's the case.
-            | Some ' ' when adjustedColumnChar <> ',' && adjustedColumnChar <> '(' && adjustedColumnChar <> '<' ->
+            | Some ' ', None when adjustedColumnChar <> ',' && adjustedColumnChar <> '(' && adjustedColumnChar <> '<' ->
+                return!
+                    FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
+                        parseResults,
+                        checkFileResults,
+                        document.Id,
+                        defines,
+                        documentationBuilder,
+                        sourceText,
+                        caretPosition,
+                        adjustedColumnInSource,
+                        filePath)
+            | _, Some FunctionApplication when adjustedColumnChar <> ',' && adjustedColumnChar <> '(' && adjustedColumnChar <> '<' ->
                 return!
                     FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
                         parseResults,
@@ -510,46 +532,63 @@ type internal FSharpSignatureHelpProvider
                         Some triggerInfo.TriggerCharacter.Value
                     else None
 
-                let! signatureHelpData =
-                    FSharpSignatureHelpProvider.ProvideSignatureHelp(
-                        document,
-                        defines,
-                        checker,
-                        documentationBuilder,
-                        sourceText,
-                        position,
-                        projectOptions,
-                        document.FilePath,
-                        textVersion.GetHashCode(),
-                        triggerTypedChar)
-                let items =
-                    signatureHelpData.SignatureHelpItems
-                    |> Array.map (fun item ->
-                        let parameters =
-                            item.Parameters
-                            |> Array.map (fun paramInfo ->
-                                FSharpSignatureHelpParameter(
-                                    paramInfo.ParameterName,
-                                    paramInfo.IsOptional,
-                                    documentationFactory = (fun _ -> paramInfo.Documentation :> seq<_>),
-                                    displayParts = paramInfo.DisplayParts))
+                let doWork () =
+                    async {
+                        let! signatureHelpDataOpt =
+                            FSharpSignatureHelpProvider.ProvideSignatureHelp(
+                                document,
+                                defines,
+                                checker,
+                                documentationBuilder,
+                                sourceText,
+                                position,
+                                projectOptions,
+                                document.FilePath,
+                                textVersion.GetHashCode(),
+                                triggerTypedChar,
+                                possibleCurrentSignatureHelpSessionKind)
+                        match signatureHelpDataOpt with
+                        | None ->
+                            possibleCurrentSignatureHelpSessionKind <- None
+                            return None
+                        | Some signatureHelpData ->
+                            let items =
+                                signatureHelpData.SignatureHelpItems
+                                |> Array.map (fun item ->
+                                    let parameters =
+                                        item.Parameters
+                                        |> Array.map (fun paramInfo ->
+                                            FSharpSignatureHelpParameter(
+                                                paramInfo.ParameterName,
+                                                paramInfo.IsOptional,
+                                                documentationFactory = (fun _ -> paramInfo.Documentation :> seq<_>),
+                                                displayParts = paramInfo.DisplayParts))
                                             
-                        FSharpSignatureHelpItem(
-                            isVariadic=item.HasParamArrayArg,
-                            documentationFactory=(fun _ -> item.Documentation :> seq<_>),
-                            prefixParts=item.PrefixParts,
-                            separatorParts=item.SeparatorParts,
-                            suffixParts=item.SuffixParts,
-                            parameters=parameters,
-                            descriptionParts=item.MainDescription))
-                                    
-                return
-                    FSharpSignatureHelpItems(
-                        items,
-                        signatureHelpData.ApplicableSpan,
-                        signatureHelpData.ArgumentIndex,
-                        signatureHelpData.ArgumentCount,
-                        Option.toObj signatureHelpData.ArgumentName)
+                                    FSharpSignatureHelpItem(
+                                        isVariadic=item.HasParamArrayArg,
+                                        documentationFactory=(fun _ -> item.Documentation :> seq<_>),
+                                        prefixParts=item.PrefixParts,
+                                        separatorParts=item.SeparatorParts,
+                                        suffixParts=item.SuffixParts,
+                                        parameters=parameters,
+                                        descriptionParts=item.MainDescription))
+                            
+                            match signatureHelpData.CurrentSignatureHelpSessionKind with
+                            | MethodCall ->
+                                possibleCurrentSignatureHelpSessionKind <- Some MethodCall
+                            | FunctionApplication ->
+                                possibleCurrentSignatureHelpSessionKind <- Some FunctionApplication
+
+                            return
+                                FSharpSignatureHelpItems(
+                                    items,
+                                    signatureHelpData.ApplicableSpan,
+                                    signatureHelpData.ArgumentIndex,
+                                    signatureHelpData.ArgumentCount,
+                                    Option.toObj signatureHelpData.ArgumentName)
+                                |> Some
+                    }
+                return! doWork ()
             } 
             |> Async.map Option.toObj
             |> RoslynHelpers.StartAsyncAsTask cancellationToken


### PR DESCRIPTION
This one was a little bit of a doozy.

Addresses the first issue mentioned in https://github.com/dotnet/fsharp/issues/10957

What this does is it tracks:

* If we're already in a signature help session
* Which _kind_ it is - F# function application or a method call

It then adjusts the state of the session based on what we're trying to do.

I'm not 100% confident in this PR yet. Will need to test it out some more. But it seems to do what I wanted to do, which is it **keeps the tooltip up in both kinds of signature help sessions**.

![sig-help-both](https://user-images.githubusercontent.com/6309070/106216875-e3c95080-6188-11eb-88d1-3d1fe50a9635.gif)
