### PR TITLE
Correct range of SynModuleOrNamespace with DeclaredNamespace.

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1155,7 +1155,10 @@ fileModuleImpl:
       (fun (isRec, path, xml) -> 
         match path with 
         | [] -> ParsedImplFileFragment.AnonModule($1, m)  
-        | _ -> ParsedImplFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, xml, [], m)) } 
+        | _ ->
+            let lastDeclRange = List.tryLast $1 |> Option.map (fun decl -> decl.Range) |> Option.defaultValue (rhs parseState 1)
+            let m = mkRange lastDeclRange.FileName (lhs parseState).Start lastDeclRange.End
+            ParsedImplFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, xml, [], m)) } 
 
 
 /* A collection/block of definitions or expressions making up a module or namespace, possibly empty */

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -433,10 +433,8 @@ let coreLibAssemblyName =
 #endif
 
 let assertRange
-    (expectedStartLine: int)
-    (expectedStartColumn: int)
-    (expectedEndLine: int)
-    (expectedEndColumn: int)
+    (expectedStartLine: int, expectedStartColumn: int)
+    (expectedEndLine: int, expectedEndColumn: int)
     (actualRange: range)
     : unit =
     Assert.AreEqual(Position.mkPos expectedStartLine expectedStartColumn, actualRange.Start)

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -432,3 +432,12 @@ let coreLibAssemblyName =
     "mscorlib"
 #endif
 
+let assertRange
+    (expectedStartLine: int)
+    (expectedStartColumn: int)
+    (expectedEndLine: int)
+    (expectedEndColumn: int)
+    (actualRange: range)
+    : unit =
+    Assert.AreEqual(Position.mkPos expectedStartLine expectedStartColumn, actualRange.Start)
+    Assert.AreEqual(Position.mkPos expectedEndLine expectedEndColumn, actualRange.End)

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -277,8 +277,8 @@ module SyntaxExpressions =
                         ])
                     ])
                 ]))) ->
-            assertRange 2 4 3 14 doRange
-            assertRange 4 4 5 18 doBangRange
+            assertRange (2, 4) (3, 14) doRange
+            assertRange (4, 4) (5, 18) doBangRange
         | _ ->
             failwith "Could not find SynExpr.Do"
 
@@ -401,7 +401,7 @@ type Teq<'a, 'b>
 
         match parseResults with
         | Some (ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(kind = SynModuleOrNamespaceKind.DeclaredNamespace; range = r) ]))) ->
-            assertRange 1 0 4 8 r
+            assertRange (1, 0) (4, 8) r
         | _ -> failwith "Could not get valid AST"
         
     [<Test>]
@@ -422,6 +422,6 @@ let x = 42
         | Some (ParsedInput.ImplFile (ParsedImplFileInput (modules = [
             SynModuleOrNamespace.SynModuleOrNamespace(kind = SynModuleOrNamespaceKind.DeclaredNamespace; range = r1)
             SynModuleOrNamespace.SynModuleOrNamespace(kind = SynModuleOrNamespaceKind.DeclaredNamespace; range = r2) ]))) ->
-            assertRange 1 0 4 20 r1
-            assertRange 6 0 8 10 r2
+            assertRange (1, 0) (4, 20) r1
+            assertRange (6, 0) (8, 10) r2
         | _ -> failwith "Could not get valid AST"        


### PR DESCRIPTION
Constructs a range starting from the namespace token until the last module declaration.

Fixes #7680.