### PR TITLE
Removed reactor dependency on already created incremental builds.

### DIFF
--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -715,8 +715,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         cache.GetFileTimeStamp filename
 
     /// Parse the given file and return the given input.
-    let ParseTask ctok (sourceRange: range, filename: string, isLastCompiland) =
-        DoesNotRequireCompilerThreadTokenAndCouldPossiblyBeMadeConcurrent  ctok
+    let ParseTask (sourceRange: range, filename: string, isLastCompiland) =
         SyntaxTree(tcConfig, fileParsed, lexResourceManager, sourceRange, filename, isLastCompiland)
         
     /// Timestamps of referenced assemblies are taken from the file's timestamp.
@@ -1026,7 +1025,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                             // This shouldn't happen, but on the off-chance, just grab the initial bound model.
                             initial
 
-                let boundModel = TypeCheckTask ctok prevBoundModel (ParseTask ctok fileInfo) |> Eventually.force ctok
+                let boundModel = TypeCheckTask ctok prevBoundModel (ParseTask fileInfo) |> Eventually.force ctok
                     
                 boundModels.[slot] <- Some boundModel
             )
@@ -1256,14 +1255,12 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     member this.ContainsFile(filename: string) =
         (this.TryGetSlotOfFileName filename).IsSome
       
-    member builder.GetParseResultsForFile (ctok: CompilationThreadToken, filename) =
-      cancellable {
+    member builder.GetParseResultsForFile (filename) =
         let slotOfFile = builder.GetSlotOfFileName filename
         let results = fileNames.[slotOfFile]
         // re-parse on demand instead of retaining
-        let syntaxTree = ParseTask ctok results
-        return syntaxTree.Parse None
-      }
+        let syntaxTree = ParseTask results
+        syntaxTree.Parse None
 
     member _.SourceFiles  = sourceFiles  |> List.map (fun (_, f, _) -> f)
 

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -220,7 +220,7 @@ type internal IncrementalBuilder =
       /// Await the untyped parse results for a particular slot in the vector of parse results.
       ///
       /// This may be a marginally long-running operation (parses are relatively quick, only one file needs to be parsed)
-      member GetParseResultsForFile: CompilationThreadToken * filename:string -> Cancellable<ParsedInput option * range * string * (PhasedDiagnostic * FSharpDiagnosticSeverity)[]>
+      member GetParseResultsForFile: filename:string -> ParsedInput option * range * string * (PhasedDiagnostic * FSharpDiagnosticSeverity)[]
 
       /// Create the incremental builder
       static member TryCreateIncrementalBuilderForProjectOptions:

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -460,17 +460,24 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
 
     /// Fetch the parse information from the background compiler (which checks w.r.t. the FileSystem API)
     member _.GetBackgroundParseResultsForFileInProject(filename, options, userOpName) =
-        reactor.EnqueueAndAwaitOpAsync(userOpName, "GetBackgroundParseResultsForFileInProject ", filename, fun ctok -> 
-            cancellable {
-                let! builderOpt, creationDiags = getOrCreateBuilder (ctok, options, userOpName)
-                match builderOpt with
-                | None -> return FSharpParseFileResults(creationDiags, None, true, [| |])
-                | Some builder -> 
-                    let! parseTreeOpt,_,_,parseDiags = builder.GetParseResultsForFile (ctok, filename)
-                    let diagnostics = [| yield! creationDiags; yield! DiagnosticHelpers.CreateDiagnostics (builder.TcConfig.errorSeverityOptions, false, filename, parseDiags, suggestNamesForErrors) |]
-                    return FSharpParseFileResults(diagnostics = diagnostics, input = parseTreeOpt, parseHadErrors = false, dependencyFiles = builder.AllDependenciesDeprecated)
-            }
-        )
+        let execWithReactorAsync action = reactor.EnqueueAndAwaitOpAsync(userOpName, "GetBackgroundParseResultsForFileInProject ", filename, action)
+        let getBuilder options =
+            match tryGetBuilder options with
+            | Some (builderOpt,creationDiags) -> 
+                Logger.Log LogCompilerFunctionId.Service_IncrementalBuildersCache_GettingCache
+                async { return builderOpt,creationDiags }
+            | _ ->
+                execWithReactorAsync (fun ctok -> getOrCreateBuilder (ctok, options, userOpName))
+
+        async {
+            let! builderOpt, creationDiags = getBuilder options
+            match builderOpt with
+            | None -> return FSharpParseFileResults(creationDiags, None, true, [| |])
+            | Some builder -> 
+                let parseTreeOpt,_,_,parseDiags = builder.GetParseResultsForFile (filename)
+                let diagnostics = [| yield! creationDiags; yield! DiagnosticHelpers.CreateDiagnostics (builder.TcConfig.errorSeverityOptions, false, filename, parseDiags, suggestNamesForErrors) |]
+                return FSharpParseFileResults(diagnostics = diagnostics, input = parseTreeOpt, parseHadErrors = false, dependencyFiles = builder.AllDependenciesDeprecated)
+        }
 
     member _.GetCachedCheckFileResult(builder: IncrementalBuilder, filename, sourceText: ISourceText, options) =
         // Check the cache. We can only use cached results when there is no work to do to bring the background builder up-to-date
@@ -624,11 +631,19 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     /// Type-check the result obtained by parsing. Force the evaluation of the antecedent type checking context if needed.
     member bc.CheckFileInProject(parseResults: FSharpParseFileResults, filename, fileVersion, sourceText: ISourceText, options, userOpName) =
         let execWithReactorAsync action = reactor.EnqueueAndAwaitOpAsync(userOpName, "CheckFileInProject", filename, action)
+        let getBuilder options =
+            match tryGetBuilder options with
+            | Some (builderOpt,creationDiags) -> 
+                Logger.Log LogCompilerFunctionId.Service_IncrementalBuildersCache_GettingCache
+                async { return builderOpt,creationDiags }
+            | _ ->
+                execWithReactorAsync (fun ctok -> getOrCreateBuilder (ctok, options, userOpName))
+
         async {
             try 
                 if implicitlyStartBackgroundWork then 
                     reactor.CancelBackgroundOp() // cancel the background work, since we will start new work after we're done
-                let! builderOpt,creationDiags = execWithReactorAsync (fun ctok -> getOrCreateBuilder (ctok, options, userOpName))
+                let! builderOpt,creationDiags = getBuilder options
                 match builderOpt with
                 | None -> return FSharpCheckFileAnswer.Succeeded (FSharpCheckFileResults.MakeEmpty(filename, creationDiags, keepAssemblyContents))
                 | Some builder -> 
@@ -654,6 +669,13 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     /// Parses and checks the source file and returns untyped AST and check results.
     member bc.ParseAndCheckFileInProject (filename:string, fileVersion, sourceText: ISourceText, options:FSharpProjectOptions, userOpName) =
         let execWithReactorAsync action = reactor.EnqueueAndAwaitOpAsync(userOpName, "ParseAndCheckFileInProject", filename, action)
+        let getBuilder options =
+            match tryGetBuilder options with
+            | Some (builderOpt,creationDiags) -> 
+                Logger.Log LogCompilerFunctionId.Service_IncrementalBuildersCache_GettingCache
+                async { return builderOpt,creationDiags }
+            | _ ->
+                execWithReactorAsync (fun ctok -> getOrCreateBuilder (ctok, options, userOpName))
         async {
             try 
                 let strGuid = "_ProjectId=" + (options.ProjectId |> Option.defaultValue "null")
@@ -663,7 +685,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                     Logger.LogMessage (filename + strGuid + "-Cancelling background work") LogCompilerFunctionId.Service_ParseAndCheckFileInProject
                     reactor.CancelBackgroundOp() // cancel the background work, since we will start new work after we're done
 
-                let! builderOpt,creationDiags = execWithReactorAsync (fun ctok -> getOrCreateBuilder (ctok, options, userOpName))
+                let! builderOpt,creationDiags = getBuilder options
                 match builderOpt with
                 | None -> 
                     Logger.LogBlockMessageStop (filename + strGuid + "-Failed_Aborted") LogCompilerFunctionId.Service_ParseAndCheckFileInProject
@@ -714,7 +736,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                 let typedResults = FSharpCheckFileResults.MakeEmpty(filename, creationDiags, keepAssemblyContents)
                 return (parseResults, typedResults)
             | Some builder -> 
-                let! (parseTreeOpt, _, _, parseDiags) = builder.GetParseResultsForFile (ctok, filename)
+                let (parseTreeOpt, _, _, parseDiags) = builder.GetParseResultsForFile (filename)
                 let! tcProj = builder.GetFullCheckResultsAfterFileInProject (ctok, filename)
 
                 let tcInfo, tcInfoOptional = tcProj.TcInfoWithOptional ctok


### PR DESCRIPTION
This is a first in the series of steps to try reduce the number of queued tasks for the reactor thread in FCS.
It also removes the compilation thread token dependency for parsing files in the background build(incremental build).