### PR TITLE
Update fsharp.core preparatory for shipping

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>5</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>2</FSBuildVersion>
+    <FSBuildVersion>1</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- F# Language version -->
     <FSLanguageVersion>$(FSMajorVersion).$(FSMinorVersion)</FSLanguageVersion>


### PR DESCRIPTION
Update FSharp.Core package version to 5.0.1.  We will ship it at the same to as FSharp.Compiler.Service. 

This is necessary, because fcs branch contains all of dev16.9 branch, and so we should ensure that the FSharp.Core matches the compiler.