### PR TITLE
Symbols: Fix IsProperty*Method, IsEvent*Method for names consisting only of the prefix

### DIFF
--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -1715,8 +1715,11 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
     member _.IsEventAddMethod = 
         if isUnresolved() then false else 
         match d with 
-        | M m when m.LogicalName.StartsWithOrdinal("add_") -> 
-            let eventName = m.LogicalName.[4..]
+        | M m ->
+            let logicalName = m.LogicalName
+            logicalName.Length > 4 && logicalName.StartsWithOrdinal("add_") &&
+
+            let eventName = logicalName.[4..]
             let entityTy = generalizedTyconRef m.DeclaringTyconRef
             not (isNil (cenv.infoReader.GetImmediateIntrinsicEventsOfType (Some eventName, AccessibleFromSomeFSharpCode, range0, entityTy))) ||
             let declaringTy = generalizedTyconRef m.DeclaringTyconRef
@@ -1729,8 +1732,11 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
     member _.IsEventRemoveMethod = 
         if isUnresolved() then false else 
         match d with 
-        | M m when m.LogicalName.StartsWithOrdinal("remove_") -> 
-            let eventName = m.LogicalName.[7..]
+        | M m ->
+            let logicalName = m.LogicalName
+            logicalName.Length > 4 && logicalName.StartsWithOrdinal("remove_") &&
+
+            let eventName = logicalName.[7..]
             let entityTy = generalizedTyconRef m.DeclaringTyconRef
             not (isNil (cenv.infoReader.GetImmediateIntrinsicEventsOfType (Some eventName, AccessibleFromSomeFSharpCode, range0, entityTy))) ||
             let declaringTy = generalizedTyconRef m.DeclaringTyconRef
@@ -1742,8 +1748,11 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
     member _.IsPropertyGetterMethod = 
         if isUnresolved() then false else 
         match d with 
-        | M m when m.LogicalName.StartsWithOrdinal("get_") -> 
-            let propName = PrettyNaming.ChopPropertyName(m.LogicalName) 
+        | M m ->
+            let logicalName = m.LogicalName
+            logicalName.Length > 4 && logicalName.StartsWithOrdinal("get_") &&
+
+            let propName = PrettyNaming.ChopPropertyName(logicalName)
             let declaringTy = generalizedTyconRef m.DeclaringTyconRef
             not (isNil (GetImmediateIntrinsicPropInfosOfType (Some propName, AccessibleFromSomeFSharpCode) cenv.g cenv.amap range0 declaringTy))
         | V v -> v.IsPropertyGetterMethod
@@ -1752,9 +1761,11 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
     member _.IsPropertySetterMethod = 
         if isUnresolved() then false else 
         match d with 
-        // Look for a matching property with the right name. 
-        | M m when m.LogicalName.StartsWithOrdinal("set_") -> 
-            let propName = PrettyNaming.ChopPropertyName(m.LogicalName) 
+        | M m ->
+            let logicalName = m.LogicalName
+            logicalName.Length > 4 && logicalName.StartsWithOrdinal("set_") &&
+
+            let propName = PrettyNaming.ChopPropertyName(logicalName) 
             let declaringTy = generalizedTyconRef m.DeclaringTyconRef
             not (isNil (GetImmediateIntrinsicPropInfosOfType (Some propName, AccessibleFromSomeFSharpCode) cenv.g cenv.amap range0 declaringTy))
         | V v -> v.IsPropertySetterMethod


### PR DESCRIPTION
Fixes exception in `FSharpMemberOrFunctionOrValue.get_IsPropertyGetterMethod` on the `get_` member:
```fsharp
type Test =
    abstract get_ : unit -> unit

t.get_()
```

Fixes https://github.com/JetBrains/fsharp-support/issues/227.