### PR TITLE
fsi anycpu

### DIFF
--- a/src/fsharp/fsc/fsc.fsproj
+++ b/src/fsharp/fsc/fsc.fsproj
@@ -14,10 +14,6 @@
     <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PlatformTarget>x86</PlatformTarget>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\fscmain.fs">
       <Link>fscmain.fs</Link>
@@ -45,5 +41,11 @@
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
     <PackageReference Include="System.Security.Principal" Version="$(SystemSecurityPrincipalVersion)" />
   </ItemGroup>
+
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="@(MySourceFiles)"
+          DestinationFiles="c:\MyProject\Destination"
+    />
+  </Target>
 
 </Project>

--- a/src/fsharp/fsi/App.config
+++ b/src/fsharp/fsi/App.config
@@ -2,6 +2,7 @@
 <configuration>
   <runtime>
     <legacyUnhandledExceptionPolicy enabled="true" />
+    <gcAllowVeryLargeObjects enabled="true" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -665,7 +665,6 @@ type internal FsiCommandLineOptions(fsi: FsiEvaluationSessionHostConfig,
 
     // Additional fsi options are list below.
     // In the "--help", these options can be printed either before (fsiUsagePrefix) or after (fsiUsageSuffix) the core options.
-
     let displayHelpFsi tcConfigB (blocks:CompilerOptionBlock list) =
         DisplayBannerText tcConfigB;
         fprintfn fsiConsoleOutput.Out ""
@@ -797,7 +796,7 @@ type internal FsiCommandLineOptions(fsi: FsiEvaluationSessionHostConfig,
         fsiConsoleOutput.uprintnfn "%s" (tcConfigB.productNameForBannerText)
         fsiConsoleOutput.uprintfnn "%s" (FSComp.SR.optsCopyright())
         fsiConsoleOutput.uprintfn  "%s" (FSIstrings.SR.fsiBanner3())
-     
+
     member _.ShowHelp(m) =
         let helpLine = sprintf "%s --help" executableFileNameWithoutExtension.Value
 

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PlatformTarget>x86</PlatformTarget>
     <DefineConstants>$(DefineConstants);FSI_SHADOW_COPY_REFERENCES;FSI_SERVER</DefineConstants>
   </PropertyGroup>
 

--- a/src/fsharp/fsi/fsimain.fs
+++ b/src/fsharp/fsi/fsimain.fs
@@ -143,7 +143,7 @@ let StartServer (fsiSession : FsiEvaluationSession) (fsiServerName) =
 //----------------------------------------------------------------------------
 
 let evaluateSession(argv: string[]) = 
-#if DEBUG  
+#if DEBUG
     if argv |> Array.exists  (fun x -> x = "/pause" || x = "--pause") then 
         Console.WriteLine("Press any key to continue...")
         Console.ReadKey() |> ignore

--- a/src/fsharp/fsiAnyCpu/fsiAnyCpu.fsproj
+++ b/src/fsharp/fsiAnyCpu/fsiAnyCpu.fsproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <TargetExt>.exe</TargetExt>
     <NoWarn>$(NoWarn);44;45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
@@ -16,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);FSI_SHADOW_COPY_REFERENCES;FSI_SERVER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FSI_SHADOW_COPY_REFERENCES;FSI_SERVER;FSI_ANYCPU_DEPRECATED</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.VS.FSI/Properties.resx
+++ b/vsintegration/src/FSharp.VS.FSI/Properties.resx
@@ -118,12 +118,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FSharpInteractive64Bit" xml:space="preserve">
-    <value>64-bit F# Interactive</value>
-  </data>
-  <data name="FSharpInteractive64BitDescr" xml:space="preserve">
-    <value>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</value>
-  </data>
   <data name="FSharpInteractiveOptions" xml:space="preserve">
     <value>F# Interactive options</value>
   </data>

--- a/vsintegration/src/FSharp.VS.FSI/fsiLanguageService.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiLanguageService.fs
@@ -32,11 +32,6 @@ type FsiPropertyPage() =
     inherit DialogPage()
 
     [<ResourceCategory(SRProperties.FSharpInteractiveMisc)>]
-    [<ResourceDisplayName(SRProperties.FSharpInteractive64Bit)>]
-    [<ResourceDescription(SRProperties.FSharpInteractive64BitDescr)>]
-    member this.FsiPreferAnyCPUVersion with get() = SessionsProperties.useAnyCpuVersion and set (x:bool) = SessionsProperties.useAnyCpuVersion <- x
-
-    [<ResourceCategory(SRProperties.FSharpInteractiveMisc)>]
     [<ResourceDisplayName(SRProperties.FSharpInteractiveOptions)>]
     [<ResourceDescription(SRProperties.FSharpInteractiveOptionsDescr)>]
     member this.FsiCommandLineArgs with get() = SessionsProperties.fsiArgs and set (x:string) = SessionsProperties.fsiArgs <- x

--- a/vsintegration/src/FSharp.VS.FSI/sessions.fs
+++ b/vsintegration/src/FSharp.VS.FSI/sessions.fs
@@ -63,7 +63,6 @@ let timeoutApp descr timeoutMS (f : 'a -> 'b) (arg:'a) =
     r
 
 module SessionsProperties = 
-    let mutable useAnyCpuVersion = true // 64-bit by default
     let mutable fsiUseNetCore = false
     let mutable fsiArgs = "--optimize"
     let mutable fsiShadowCopy = true
@@ -138,8 +137,7 @@ let determineFsiPath () =
             raise (SessionError (VFSIstrings.SR.couldNotFindFsiExe exe))
         exe, arg, false, false
     else
-        let fsiExeName () = 
-            if SessionsProperties.useAnyCpuVersion then "fsiAnyCpu.exe" else "fsi.exe"
+        let fsiExeName () = "fsi.exe"
 
         // Use the VS-extension-installed development path if available, relative to the location of this assembly
         let determineFsiRelativePath1 () =

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.cs.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.cs.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">64bitový F# Interactive</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">V případě nastavení na true a za předpokladu, že aktuální počítač je 64bitový, se F# Interactive spustí jako 64bitový proces. (V opačném případě je F# Interactive 32bitový proces.)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Různé</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.de.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.de.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">64-Bit-Version von F# Interactive</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">Wenn diese Einstellung auf "True" gesetzt ist und der aktuelle Computer eine 64-Bit-Version ist, müssen Sie F# Interactive als einen 64-Bit-Prozess ausführen (Andernfalls ist F# Interactive ein 32-Bit-Prozess).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Verschiedene</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.es.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.es.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">F# interactivo de 64 bits</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">Si se establece en True y la máquina actual es de 64 bits, F# interactivo se ejecuta como proceso de 64 bits; de lo contrario, se ejecuta como proceso de 32 bits.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Varios</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.fr.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.fr.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">F# Interactive 64 bits</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">Si la valeur est true et que l'ordinateur actuel est de type 64 bits, exécutez F# Interactive en tant que processus 64 bits.  (Sinon, F# Interactive est un processus 32 bits.)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Divers</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.it.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.it.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">F# Interactive a 64 bit</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">Se impostato su true, e il computer corrente è a 64 bit, eseguire F# Interactive come processo a 64 bit. In caso contrario, F# Interactive è un processo a 32 bit.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Varie</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ja.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ja.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">64 ビット F# インタラクティブ</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">true に設定されていて、現在のコンピューターが 64 ビットである場合は、F# インタラクティブを 64 ビット プロセスで実行してください (そうしないと、F# インタラクティブは 32 ビット プロセスになります)。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">その他</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ko.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ko.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">64비트 F# 대화형</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">true로 설정하는 경우 현재 컴퓨터가 64비트이면 F# 대화형을 64비트 프로세스로 실행하고, 그렇지 않으면 F# 대화형이 32비트 프로세스로 실행됩니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">기타</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pl.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pl.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">64-bitowe narzędzie F# Interactive</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">Jeśli ustawiono wartość true i obecnie jest używany komputer 64-bitowy, należy uruchomić narzędzie F# Interactive jako proces 64-bitowy. W przeciwnym razie narzędzie F# Interactive zostanie uruchomione jako proces 32-bitowy.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Różne</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pt-BR.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pt-BR.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">F# Interativo de 64 bits</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">Se estiver definido como true, e o computador atual for 64 bits, execute o F# Interativo como um processo de 64 bits. (Caso contrário, o F# Interactive será um processo de 32 bits.)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Diversos</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ru.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ru.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">F# Interactive, 64-разрядная версия</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">Если задано значение true и текущий компьютер является 64-разрядным, F# Interactive запускается как 64-разрядный процесс.  (В остальных случая F# Interactive является 32-разрядным процессом.)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Прочее</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.tr.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.tr.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">64 bit F# Etkileşimli</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">True olarak ayarlanırsa ve geçerli makine 64 bit ise F# Etkileşimli'yi 64 bit işlem olarak çalıştırın. (Aksi takdirde F# Etkileşimli 32 bit işlemdir.)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">Çeşitli</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hans.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">64 位 F# 交互窗口</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">如果设为 true，且当前计算机是 64 位的，则将 F# 交互窗口作为 64 位进程运行。(否则，F# 交互为 32 位进程。)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">杂项</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hant.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Properties.resx">
     <body>
-      <trans-unit id="FSharpInteractive64Bit">
-        <source>64-bit F# Interactive</source>
-        <target state="translated">64 位元 F# 互動</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FSharpInteractive64BitDescr">
-        <source>If set to true, and the current machine is 64-bit, then run F# Interactive as a 64-bit process.  (Otherwise, F# Interactive is a 32-bit process.)</source>
-        <target state="translated">如果設為 true，並且目前電腦為 64 位元，則 F# 互動會當做 64 位元處理序來執行 (反之，F# 互動則為 32 位元處理序)。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FSharpInteractiveMisc">
         <source>Misc</source>
         <target state="translated">其他</target>


### PR DESCRIPTION
This pr makes fsi run anycpu rather than 32bit, we will continue to deploy the fsianycpu.exe to keep existing scripts running until dev17.0 when we will remove it.

Additionally this PR:
- Removes the 64 bit Fsi option from VS, and adds     <gcAllowVeryLargeObjects enabled="true" /> to the desktop fsi.exe.config
- Makes fsc anycpu


 