### PR TITLE
Point the nuget + web proxy hint to the documentation 

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -168,6 +168,6 @@ See the "Debugging The Compiler" section of this [article](https://medium.com/@w
 
 ## Addendum: configuring a proxy server
 
-If you are behind a proxy server, NuGet client tool must be configured to use it, Nuget.config documention for configuring proxy server:
+If you are behind a proxy server, NuGet client tool must be configured to use it:
 
-    [https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file)
+See the Nuget config file documention for use with a proxy server [https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file)

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -170,4 +170,4 @@ See the "Debugging The Compiler" section of this [article](https://medium.com/@w
 
 If you are behind a proxy server, NuGet client tool must be configured to use it, Nuget.config documention for configuring proxy server:
 
-    https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file
+    [https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file)

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -168,11 +168,6 @@ See the "Debugging The Compiler" section of this [article](https://medium.com/@w
 
 ## Addendum: configuring a proxy server
 
-If you are behind a proxy server, NuGet client tool must be configured to use it:
+If you are behind a proxy server, NuGet client tool must be configured to use it, Nuget.config documention for configuring proxy server:
 
-```
-.nuget\nuget.exe config -set http_proxy=proxy.domain.com:8080 -ConfigFile NuGet.Config
-.nuget\nuget.exe config -set http_proxy.user=user_name -ConfigFile NuGet.Config
-.nuget\nuget.exe config -set http_proxy.password=user_password -ConfigFile NuGet.Config
-```
-Where you should set proper proxy address, user name and password.
+    https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file


### PR DESCRIPTION
Instead of the brief hint about using nuget with a web proxy direct users to the nuget documentation where these settings are discussed.