### PR TITLE
[release/dev16.10] bump build version to keep VS insertions happy

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>5</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>1</FSBuildVersion>
+    <FSBuildVersion>2</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- F# Language version -->
     <FSLanguageVersion>$(FSMajorVersion).$(FSMinorVersion)</FSLanguageVersion>


### PR DESCRIPTION
The VS 16.10 builds currently have F# package versions 11.4.2, but the latest values of 11.4.1 won't insert properly because it _looks_ like a package downgrade from the installer's perspective, so we have to make sure that we don't drop this number (it can stay the same, though.)