### PR TITLE
More reactor queue dependency removal

### DIFF
--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -193,10 +193,10 @@ type TimeStampCache(defaultTimeStamp: DateTime) =
         files.[fileName] <- v
         v
 
-    member cache.GetProjectReferenceTimeStamp (pr: IProjectReference, ctok) = 
+    member cache.GetProjectReferenceTimeStamp (pr: IProjectReference) = 
         let ok, v = projects.TryGetValue pr
         if ok then v else 
-        let v = defaultArg (pr.TryGetLogicalTimeStamp (cache, ctok)) defaultTimeStamp
+        let v = defaultArg (pr.TryGetLogicalTimeStamp (cache)) defaultTimeStamp
         projects.[pr] <- v
         v
 
@@ -215,7 +215,7 @@ and IProjectReference =
     ///
     /// The operation returns None only if it is not possible to create an IncrementalBuilder for the project at all, e.g. if there
     /// are fatal errors in the options for the project.
-    abstract TryGetLogicalTimeStamp: TimeStampCache * CompilationThreadToken -> System.DateTime option
+    abstract TryGetLogicalTimeStamp: TimeStampCache -> System.DateTime option
 
 type AssemblyReference = 
     | AssemblyReference of range * string * IProjectReference option

--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -58,7 +58,7 @@ type IRawFSharpAssemblyData =
 type TimeStampCache = 
     new: defaultTimeStamp: DateTime -> TimeStampCache
     member GetFileTimeStamp: string -> DateTime
-    member GetProjectReferenceTimeStamp: IProjectReference * CompilationThreadToken -> DateTime
+    member GetProjectReferenceTimeStamp: IProjectReference -> DateTime
 
 and IProjectReference = 
 
@@ -76,7 +76,7 @@ and IProjectReference =
     ///
     /// The operation returns None only if it is not possible to create an IncrementalBuilder for the project at all, e.g. if there
     /// are fatal errors in the options for the project.
-    abstract TryGetLogicalTimeStamp: TimeStampCache * CompilationThreadToken -> System.DateTime option
+    abstract TryGetLogicalTimeStamp: TimeStampCache -> System.DateTime option
 
 type AssemblyReference = 
     | AssemblyReference of range * string  * IProjectReference option

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1301,10 +1301,8 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
         }
         
     member _.GetLogicalTimeStampForProject(cache) = 
-        let state = currentState
-
-        let t1 = MaxTimeStampInDependencies state cache getStampedReferencedAssemblies
-        let t2 = MaxTimeStampInDependencies state cache getStampedFileNames
+        let t1 = MaxTimeStampInDependencies currentState cache getStampedReferencedAssemblies
+        let t2 = MaxTimeStampInDependencies currentState cache getStampedFileNames
         max t1 t2
         
     member _.TryGetSlotOfFileName(filename: string) =

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1136,7 +1136,8 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                         state <- newState
                 }
             cancellable {
-                let state = computeStampedReferencedAssemblies state cache
+                let newState = computeStampedReferencedAssemblies state cache
+                state <- newState
 
                 let! _ = evalUpTo
 

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -359,6 +359,14 @@ type BoundModel private (tcConfig: TcConfig,
             return state.Partial
         }
 
+    member this.TryTcInfo = 
+        match !lazyTcInfoState with
+        | Some(state) ->
+            match state with
+            | FullState(tcInfo, _)
+            | PartialState(tcInfo) -> Some tcInfo
+        | _ -> None
+
     member this.TcInfoWithOptional =
         eventually {
             let! state = this.GetState(false)
@@ -599,6 +607,8 @@ type PartialCheckResults private (boundModel: BoundModel, timeStamp: DateTime) =
     member _.TimeStamp = timeStamp
 
     member _.TcInfo ctok = boundModel.TcInfo |> eval ctok
+
+    member _.TryTcInfo = boundModel.TryTcInfo
 
     member _.TcInfoWithOptional ctok = boundModel.TcInfoWithOptional |> eval ctok
 

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -106,6 +106,8 @@ type internal PartialCheckResults =
 
     member TcInfo: CompilationThreadToken -> TcInfo
 
+    member TryTcInfo: TcInfo option
+
     /// Can cause a second type-check if `enablePartialTypeChecking` is true in the checker.
     /// Only use when it's absolutely necessary to get rich information on a file.
     member TcInfoWithOptional: CompilationThreadToken -> TcInfo * TcInfoOptional

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -214,7 +214,7 @@ type internal IncrementalBuilder =
       member GetFullCheckResultsAndImplementationsForProject : CompilationThreadToken -> Cancellable<PartialCheckResults * IL.ILAssemblyRef * IRawFSharpAssemblyData option * TypedImplFile list option>
 
       /// Get the logical time stamp that is associated with the output of the project if it were gully built immediately
-      member GetLogicalTimeStampForProject: TimeStampCache * CompilationThreadToken -> DateTime
+      member GetLogicalTimeStampForProject: TimeStampCache -> DateTime
 
       /// Does the given file exist in the builder's pipeline?
       member ContainsFile: filename: string -> bool

--- a/src/fsharp/service/IncrementalBuild.fsi
+++ b/src/fsharp/service/IncrementalBuild.fsi
@@ -175,6 +175,12 @@ type internal IncrementalBuilder =
       /// This is safe for use from non-compiler threads
       member AreCheckResultsBeforeFileInProjectReady: filename:string -> bool
 
+      /// Get the preceding typecheck state of a slot, WITH checking if it is up-to-date w.r.t. However, files will not be parsed or checked.
+      /// the timestamps on files and referenced DLLs prior to this one. Return None if the result is not available or if it is not up-to-date.
+      ///
+      /// This is safe for use from non-compiler threads but the objects returned must in many cases be accessed only from the compiler thread.
+      member TryGetCheckResultsBeforeFileInProject: filename: string -> PartialCheckResults option
+
       /// Get the preceding typecheck state of a slot. Compute the entire type check of the project up
       /// to the necessary point if the result is not available. This may be a long-running operation.
       ///

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -852,7 +852,6 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
 
     /// Get the timestamp that would be on the output if fully built immediately
     member private _.TryGetLogicalTimeStampForProject(cache, options) =
-
         match tryGetBuilder options with
         | Some (Some builder, _) -> Some (builder.GetLogicalTimeStampForProject(cache))
         | _ -> None


### PR DESCRIPTION
This is another change that is going to remove more cases that depend on the reactor queue. It's a little tricky as we need to make a change in incremental builder to grab cached data but also check to see if the data is still valid.

In order to make the internal state of the incremental builder sane, I created an immutable state object that contains all the necessary items such as timestamps, bound models, etc. When we need to update the state, we just update a single value, `currentState`. This makes it a lot easier to rationalize, especially when we want to concurrently grab info from the state.