### PR TITLE
update machine pool for legacy build

### DIFF
--- a/.vsts-signed.yaml
+++ b/.vsts-signed.yaml
@@ -14,7 +14,7 @@ variables:
 jobs:
 - job: Full_Signed
   pool:
-    name: VSEng-MicroBuildVS2019
+    name: VSEngSS-MicroBuildVS2019
   timeoutInMinutes: 300
   variables:
     BuildConfiguration: 'Release'


### PR DESCRIPTION
As per an internal request, we need to migrate our legacy build definition to a new machine pool, and since our legacy build points to dev16.3, that's why we're updating this here.