### PR TITLE
Remove dependency on Microsoft.Build library

### DIFF
--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -49,7 +49,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />

--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -577,9 +577,11 @@ type public Fsc () as this =
                                                         CultureInfo.InvariantCulture)
                         unbox ret
                     with
-                    | :? TargetInvocationException as tie when (match tie.InnerException with | :? Microsoft.Build.Exceptions.BuildAbortedException -> true | _ -> false) ->
+                    // ok, this is what happens when VS IDE cancels the build, no need to assert, just log the build-canceled error and return -1 to denote task failed
+                    // Do a string compare on the type name to do eliminate a compile time dependency on Microsoft.Build.dll
+                    | :? TargetInvocationException as tie when not (isNull tie.InnerException) && (tie.InnerException).GetType().FullName = "Microsoft.Build.Exceptions.BuildAbortedException" ->
                         fsc.Log.LogError(tie.InnerException.Message, [| |])
-                        -1  // ok, this is what happens when VS IDE cancels the build, no need to assert, just log the build-canceled error and return -1 to denote task failed
+                        -1
                     | e -> reraise()
 
                 let baseCallDelegate = Func<int>(fun () -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands) )


### PR DESCRIPTION
This is a bit weird ...  FSharp.Build.dll is built targetting netstandard2.0 and has a dependency on Microsoft.Build.dll.  Microsoft.Build.dll does not have a netstandard2.0 lib.  So, I don't know why the build succeeds, however, it does and has for a very long time.

If you look at the references for  FSharp.Build.dll they include desktop framework references, mscorlib etc ...

This PR corrects that by eliminating the dependency on Microsoft.Build.dll, the only type FSharp.Build actually used was a type match with : ````Microsoft.Build.Exceptions.BuildAbortedException````.   Instead of the type match, this PR replaces it with a type name comparison.
