### PR TITLE
parameterize windows machine queue name

### DIFF
--- a/INTERNAL.md
+++ b/INTERNAL.md
@@ -7,6 +7,10 @@ Note that usually only the most recent link in each section is interesting.  Old
 The PR build definition can be found [here](https://dev.azure.com/dnceng/public/_build?definitionId=496) or by
 navigating through an existing PR.
 
+There is also a duplicate scouting PR build that is identical to the normal PR build _except_ that it uses a different Windows
+machine queue that always has the next preview build of Visual Studio installed.  This is to hopefully get ahead of any breaking
+API changes.  That build definition is [here](https://dev.azure.com/dnceng/public/_build?definitionId=961).
+
 ## Signed Build Definitions
 
 [VS 16.4 to current](https://dev.azure.com/dnceng/internal/_build?definitionId=499&_a=summary)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,7 +191,12 @@ stages:
         # Windows
         - job: Windows
           pool:
-            vmImage: windows-latest
+            # The PR build definition sets this variable:
+            #   WindowsMachineQueueName=BuildPool.Windows.10.Amd64.VS2019.Open
+            # and there is an alternate build definition that sets this to a queue that is always scouting the
+            # next preview of Visual Studio.
+            name: NetCorePublic-Pool
+            queue: $(WindowsMachineQueueName)
           timeoutInMinutes: 120
           strategy:
             maxParallel: 4


### PR DESCRIPTION
Parameterize the Windows queue name for PR builds.  I also duplicated the existing PR build to one that uses a queue with preview builds of Visual Studio installed.

Marked as draft while I work through the new build definition woes.