### PR TITLE
Fix #11143 - FSharp.Core 5.0.1 should not have FSharp.Core.xml in contentFiles

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -84,19 +84,27 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
     <PackageReference
         Include="FSharp.Core" Version="$(FSharpCoreImplicitPackageVersion)"
-        Condition = "'$(DisableImplicitFSharpCoreReference)' != 'true' and '$(FSharpCoreImplicitPackageVersion)' != ''"/>
+        Condition="'$(DisableImplicitFSharpCoreReference)' != 'true' and '$(FSharpCoreImplicitPackageVersion)' != ''">
+      <ExcludeAssets Condition="'$(FSharpCoreIncludeDocFileInOutput)' != 'true'">contentFiles</ExcludeAssets>
+    </PackageReference>
 
     <PackageReference
         Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersion)"
-        Condition="'$(DisableImplicitFSharpCoreReference)' != 'true' and '$(FSharpCoreImplicitPackageVersion)' == '' and '$(_NETCoreSdkIsPreview)' == 'true' and '$(DisableFSharpCorePreviewCheck)' == 'true'"/>
+        Condition="'$(DisableImplicitFSharpCoreReference)' != 'true' and '$(FSharpCoreImplicitPackageVersion)' == '' and '$(_NETCoreSdkIsPreview)' == 'true' and '$(DisableFSharpCorePreviewCheck)' == 'true'">
+      <ExcludeAssets Condition="'$(FSharpCoreIncludeDocFileInOutput)' != 'true'">contentFiles</ExcludeAssets>
+    </PackageReference>
 
     <PackageReference
         Include="FSharp.Core" Version="$(FSharpCorePreviewPackageVersion)"
-        Condition="'$(DisableImplicitFSharpCoreReference)' != 'true' and '$(FSharpCoreImplicitPackageVersion)' == '' and '$(_NETCoreSdkIsPreview)' == 'true' and '$(DisableFSharpCorePreviewCheck)' != 'true'"/>
+        Condition="'$(DisableImplicitFSharpCoreReference)' != 'true' and '$(FSharpCoreImplicitPackageVersion)' == '' and '$(_NETCoreSdkIsPreview)' == 'true' and '$(DisableFSharpCorePreviewCheck)' != 'true'">
+      <ExcludeAssets Condition="'$(FSharpCoreIncludeDocFileInOutput)' != 'true'">contentFiles</ExcludeAssets>
+    </PackageReference>
 
     <PackageReference
         Include="FSharp.Core" Version="$(FSCorePackageVersion)"
-        Condition="'$(DisableImplicitFSharpCoreReference)' != 'true' and '$(FSharpCoreImplicitPackageVersion)' == '' and '$(_NETCoreSdkIsPreview)' != 'true'"/>
+        Condition="'$(DisableImplicitFSharpCoreReference)' != 'true' and '$(FSharpCoreImplicitPackageVersion)' == '' and '$(_NETCoreSdkIsPreview)' != 'true'">
+      <ExcludeAssets Condition="'$(FSharpCoreIncludeDocFileInOutput)' != 'true'">contentFiles</ExcludeAssets>
+    </PackageReference>
 
   </ItemGroup>
 


### PR DESCRIPTION
Fixes: #11143 - FSharp.Core 5.0.1 should not have FSharp.Core.xml in contentFiles

The FSharp.Core nuget package has been updated to carry FSharp.Core.xml as content, which enables the build to pick it up for tools that want to show help messages for API's.

Content files from nuget packages are automatically referenced which is somewhat unfortunate for FSharp.Core, where the overwhelming majority of apps will not want to redistribute that file.

This change makes including FSharp.Core.xml in build output opt-in.

To ensure that FSharp.Core.xml is included in the distributed app, add this to a PropertyGroup in the build project:
````
    <FSharpCoreIncludeDocFileInOutput>true</FSharpCoreIncludeDocFileInOutput>
````
![image](https://user-images.githubusercontent.com/5175830/109382499-a219eb80-7895-11eb-8e73-5144a7692338.png)

----
![image](https://user-images.githubusercontent.com/5175830/109382597-42701000-7896-11eb-934b-ec1a7b36883a.png)

