### PR TITLE
Fix issue11175

### DIFF
--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -82,13 +82,13 @@ type DependencyManagerInteractiveTests() =
         let idm = dp.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
 
         if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-            let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data"|], reportError, "net472")
+            let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"|], reportError, "net472")
             Assert.Equal(true, result.Success)
             Assert.Equal(1, result.Resolutions |> Seq.length)
             Assert.Equal(1, result.SourceFiles |> Seq.length)
             Assert.Equal(2, result.Roots |> Seq.length)
 
-        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data"|], reportError, "net5.0")
+        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"|], reportError, "net5.0")
         Assert.Equal(true, result.Success)
         Assert.Equal(1, result.Resolutions |> Seq.length)
         Assert.Equal(1, result.SourceFiles |> Seq.length)
@@ -164,7 +164,7 @@ type DependencyManagerInteractiveTests() =
 
         let idm1 = dp1.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
         if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-            let result1 = dp1.Resolve(idm1, ".fsx", [|"r", "FSharp.Data"|], reportError, "net472")
+            let result1 = dp1.Resolve(idm1, ".fsx", [|"r", "FSharp.Data,3.3.3"|], reportError, "net472")
             Assert.Equal(true, result1.Success)
             Assert.Equal(1, result1.Resolutions |> Seq.length)
             Assert.True((result1.Resolutions |> Seq.head).Contains("/net45/"))
@@ -173,7 +173,7 @@ type DependencyManagerInteractiveTests() =
             Assert.True((result1.Roots |> Seq.head).EndsWith("/fsharp.data/3.3.3/"))
             Assert.True((result1.Roots |> Seq.last).EndsWith("/microsoft.netframework.referenceassemblies/1.0.0/"))
 
-        let result2 = dp1.Resolve(idm1, ".fsx", [|"r", "FSharp.Data, 3.3.3"|], reportError, "net5.0")
+        let result2 = dp1.Resolve(idm1, ".fsx", [|"r", "FSharp.Data,3.3.3"|], reportError, "net5.0")
         Assert.Equal(true, result2.Success)
         Assert.Equal(1, result2.Resolutions |> Seq.length)
         let expected2 = "/netstandard2.0/"
@@ -584,13 +584,13 @@ x |> Seq.iter(fun r ->
         let idm = dp.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
 
         if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-            let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data"|], reportError, "net472")
+            let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"|], reportError, "net472")
             Assert.Equal(true, result.Success)
             Assert.Equal(1, result.Resolutions |> Seq.length)
             Assert.Equal(1, result.SourceFiles |> Seq.length)
             Assert.Equal(2, result.Roots |> Seq.length)
 
-        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data"|], reportError, "net5.0")
+        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"|], reportError, "net5.0")
         Assert.Equal(true, result.Success)
         Assert.Equal(1, result.Resolutions |> Seq.length)
         Assert.Equal(1, result.SourceFiles |> Seq.length)
@@ -819,7 +819,7 @@ x |> Seq.iter(fun r ->
             ResolvingErrorReport (report)
 
         let idm = dp.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
-        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data"|], reportError, "net5.0", timeout=0)           // Fail in 0 milliseconds
+        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"|], reportError, "net5.0", timeout=0)           // Fail in 0 milliseconds
         Assert.Equal(false, result.Success)
         Assert.Equal(foundCorrectError, true)
         Assert.Equal(foundWrongError, false)
@@ -842,7 +842,7 @@ x |> Seq.iter(fun r ->
             ResolvingErrorReport (report)
 
         let idm = dp.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
-        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data"; "r", "timeout=0"|], reportError, "net5.0", null, "", "", "", -1)           // Wait forever
+        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"; "r", "timeout=0"|], reportError, "net5.0", null, "", "", "", -1)           // Wait forever
         Assert.Equal(false, result.Success)
         Assert.Equal(foundCorrectError, true)
         Assert.Equal(foundWrongError, false)
@@ -865,7 +865,7 @@ x |> Seq.iter(fun r ->
             ResolvingErrorReport (report)
 
         let idm = dp.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
-        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data"; "r", "timeout=none"|], reportError, "net5.0", null, "", "", "", -1)           // Wait forever
+        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"; "r", "timeout=none"|], reportError, "net5.0", null, "", "", "", -1)           // Wait forever
         Assert.Equal(true, result.Success)
         Assert.Equal(foundCorrectError, false)
         Assert.Equal(foundWrongError, false)


### PR DESCRIPTION
Fixes #11175 
This was caused by FSharp.Data getting updated yesterday and we were not specifying a specific version to select.  The fix is to pin the test cases to a specific version of FSharp.Data.

Thanks