### PR TITLE
Don't trigger 'make binding recursive' in members

### DIFF
--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -127,7 +127,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
 
             override _.VisitBinding(_path, defaultTraverse, binding) =
                 match binding with
-                | SynBinding(_, _, _, _, _, _, _, _, _, expr, _range, _) as b when rangeContainsPos b.RangeOfBindingWithRhs pos ->
+                | SynBinding(_, _, _, _, _, _, SynValData (None, _, _), _, _, expr, _range, _) as b when rangeContainsPos b.RangeOfBindingWithRhs pos ->
                     match tryGetIdentRangeFromBinding b with
                     | Some range -> walkBinding expr range
                     | None -> None


### PR DESCRIPTION
fixes https://github.com/dotnet/fsharp/issues/11194

Won't trigger for static member like in the report:

![image](https://user-images.githubusercontent.com/6309070/110542189-99b78100-80dd-11eb-97e4-6dd4d9b5b513.png)

Will still trigger on functions:
![image](https://user-images.githubusercontent.com/6309070/110542217-a2a85280-80dd-11eb-915e-a490affcc2f3.png)
