### PR TITLE
Several more tweaks to signature help

### DIFF
--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -158,6 +158,8 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
             SyntaxTraversal.Traverse(pos, input, { new SyntaxVisitorBase<_>() with
                 member _.VisitExpr(_, traverseSynExpr, defaultTraverse, expr) =
                     match expr with
+                    | SynExpr.TypeApp (_, _, _, _, _, _, range) when rangeContainsPos range pos ->
+                        Some range
                     | SynExpr.App(_, _, _, SynExpr.CompExpr (_, _, expr, _), range) when rangeContainsPos range pos ->
                         traverseSynExpr expr
                     | SynExpr.App (_, _, _, _, range) when rangeContainsPos range pos ->
@@ -174,6 +176,9 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
             | SynExpr.LongIdent (_, _, _, range) -> Some range
 
             | SynExpr.Paren (expr, _, _, range) when rangeContainsPos range pos ->
+                getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+
+            | SynExpr.TypeApp (expr, _, _, _, _, _, _) ->
                 getIdentRangeForFuncExprInApp traverseSynExpr expr pos
 
             | SynExpr.App (_, _, funcExpr, argExpr, _) ->
@@ -269,6 +274,8 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         SyntaxTraversal.Traverse(pos, input, { new SyntaxVisitorBase<_>() with
             member _.VisitExpr(_, traverseSynExpr, defaultTraverse, expr) =
                 match expr with
+                | SynExpr.TypeApp (expr, _, _, _, _, _, range) when rangeContainsPos range pos ->
+                    getIdentRangeForFuncExprInApp traverseSynExpr expr pos
                 | SynExpr.App (_, _, _funcExpr, _, range) as app when rangeContainsPos range pos ->
                     getIdentRangeForFuncExprInApp traverseSynExpr app pos
                 | _ -> defaultTraverse expr

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -476,7 +476,7 @@ type internal FSharpSignatureHelpProvider
             // Generally ' ' indicates a function application, but it's also used commonly after a comma in a method call.
             // This means that the adjusted position relative to the caret could be a ',' or a '(' or '<',
             // which would mean we're already inside of a method call - not a function argument. So we bail if that's the case.
-            | Some ' ', None when adjustedColumnChar <> ',' && adjustedColumnChar <> '(' && adjustedColumnChar <> '<' ->
+            | Some ' ', _ when adjustedColumnChar <> ',' && adjustedColumnChar <> '(' && adjustedColumnChar <> '<' ->
                 return!
                     FSharpSignatureHelpProvider.ProvideParametersAsyncAux(
                         parseResults,


### PR DESCRIPTION
Addresses the following additional cases in https://github.com/dotnet/fsharp/issues/10941

```fsharp
type C() =
    member _.M(x) = ()


let c = C()
c.M(sqrt)// <<- caret is after 't'!
```

Before this PR: tooltip for `M`
After this PR: tooltip for `sqrt`

```fsharp
    /// Tries to cast an object to a given type; throws with the given error message if it fails.
    let tryConvert<'T> (descriptor: string) (value: obj) : 'T =
        try
            Convert.ChangeType(value, typeof<'T>) :?> 'T
        with ex ->
            let msg = sprintf "Unable to convert '%s' with value %A" descriptor value
            raise (new Exception(msg, ex))

    // Tooltip does NOT show when the generic argument is present:
    let result= (box 123) |> tryConvert<string> // <<- caret is here
```

Before this PR: no tooltip
After this PR: tooltip for `tryConvert`