### PR TITLE
Generate signature files for all input sources via compiler flag

### DIFF
--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -371,6 +371,7 @@ type TcConfigBuilder =
       mutable reportNumDecls: bool
       mutable printSignature: bool
       mutable printSignatureFile: string
+      mutable printAllSignatureFiles: bool
       mutable xmlDocOutputFile: string option
       mutable stats: bool
       mutable generateFilterBlocks: bool (* don't generate filter blocks due to bugs on Mono *)
@@ -574,6 +575,7 @@ type TcConfigBuilder =
           reportNumDecls = false
           printSignature = false
           printSignatureFile = ""
+          printAllSignatureFiles = false
           xmlDocOutputFile = None
           stats = false
           generateFilterBlocks = false (* don't generate filter blocks *)
@@ -959,6 +961,7 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
     member x.reportNumDecls = data.reportNumDecls
     member x.printSignature = data.printSignature
     member x.printSignatureFile = data.printSignatureFile
+    member x.printAllSignatureFiles = data.printAllSignatureFiles
     member x.xmlDocOutputFile = data.xmlDocOutputFile
     member x.stats = data.stats
     member x.generateFilterBlocks = data.generateFilterBlocks

--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -184,6 +184,7 @@ type TcConfigBuilder =
       mutable reportNumDecls: bool
       mutable printSignature: bool
       mutable printSignatureFile: string
+      mutable printAllSignatureFiles: bool
       mutable xmlDocOutputFile: string option
       mutable stats: bool
       mutable generateFilterBlocks: bool 
@@ -373,6 +374,7 @@ type TcConfig =
     member reportNumDecls: bool
     member printSignature: bool
     member printSignatureFile: string
+    member printAllSignatureFiles: bool
     member xmlDocOutputFile: string option
     member stats: bool
     member generateFilterBlocks: bool 

--- a/src/fsharp/CompilerOptions.fs
+++ b/src/fsharp/CompilerOptions.fs
@@ -66,8 +66,8 @@ type OptionSpec =
     | OptionHelp of (CompilerOptionBlock list -> unit)                      // like OptionUnit, but given the "options"
     | OptionGeneral of (string list -> bool) * (string list -> string list) // Applies? * (ApplyReturningResidualArgs)
 
-and  CompilerOption      = CompilerOption of string * string * OptionSpec * Option<exn> * string option
-and  CompilerOptionBlock = PublicOptions  of string * CompilerOption list | PrivateOptions of CompilerOption list
+and  CompilerOption      = CompilerOption of name: string * argumentDescriptionString: string * actionSpec: OptionSpec * deprecationError: Option<exn> * helpText: string option
+and  CompilerOptionBlock = PublicOptions  of heading: string * options: CompilerOption list | PrivateOptions of options: CompilerOption list
 
 let GetOptionsOfBlock block = 
     match block with 
@@ -279,7 +279,6 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
         processArg (responseFileOptions @ t)
 
     | opt :: t ->  
-
         let optToken, argString = parseOption opt
 
         let reportDeprecatedOption errOpt =
@@ -515,6 +514,9 @@ let setSignatureFile tcConfigB s =
     tcConfigB.printSignature <- true 
     tcConfigB.printSignatureFile <- s
 
+let setAllSignatureFiles tcConfigB () =
+    tcConfigB.printAllSignatureFiles <- true
+
 // option tags
 let tagString = "<string>"
 let tagExe = "exe"
@@ -715,8 +717,13 @@ let outputFileFlagsFsc (tcConfigB: TcConfigBuilder) =
         CompilerOption
            ("sig", tagFile,
             OptionString (setSignatureFile tcConfigB), None,
-            Some (FSComp.SR.optsSig()))    
-                           
+            Some (FSComp.SR.optsSig()))
+
+        CompilerOption
+           ("allsigs", tagNone,
+            OptionUnit (setAllSignatureFiles tcConfigB), None,
+            Some (FSComp.SR.optsAllSigs()))
+
         CompilerOption
            ("nocopyfsharpcore", tagNone,
             OptionUnit (fun () -> tcConfigB.copyFSharpCore <- CopyFSharpCoreFlag.No), None,

--- a/src/fsharp/CompilerOptions.fsi
+++ b/src/fsharp/CompilerOptions.fsi
@@ -31,13 +31,12 @@ type OptionSpec =
     | OptionHelp of (CompilerOptionBlock list -> unit)                      // like OptionUnit, but given the "options"
     | OptionGeneral of (string list -> bool) * (string list -> string list) // Applies? * (ApplyReturningResidualArgs)
 
-and  CompilerOption      = 
-    /// CompilerOption(name, argumentDescriptionString, actionSpec, exceptionOpt, helpTextOpt
-    | CompilerOption of string * string * OptionSpec * Option<exn> * string option
+and  CompilerOption      =
+    | CompilerOption of name: string * argumentDescriptionString: string * actionSpec: OptionSpec * deprecationError: Option<exn> * helpText: string option
 
-and  CompilerOptionBlock = 
-    | PublicOptions  of string * CompilerOption list 
-    | PrivateOptions of CompilerOption list
+and  CompilerOptionBlock =
+    | PublicOptions  of heading: string * options: CompilerOption list
+    | PrivateOptions of options: CompilerOption list
 
 val PrintCompilerOptionBlocks: CompilerOptionBlock list -> unit  // for printing usage
 

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -851,6 +851,7 @@ optsPlatform,"Limit which platforms this code can run on: x86, Itanium, x64, any
 optsNoOpt,"Only include optimization information essential for implementing inlined constructs. Inhibits cross-module inlining but improves binary compatibility."
 optsNoInterface,"Don't add a resource to the generated assembly containing F#-specific metadata"
 optsSig,"Print the inferred interface of the assembly to a file"
+optsAllSigs,"Print the inferred interfaces of all compilation files to associated signature files"
 optsReference,"Reference an assembly (Short form: -r)"
 optsCompilerTool,"Reference an assembly or directory containing a design time tool (Short form: -t)"
 optsWin32icon,"Specify a Win32 icon file (.ico)"

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -309,23 +309,52 @@ let ProcessCommandLineFlags (tcConfigB: TcConfigBuilder, lcidFromCodePage, argv)
 /// Write a .fsi file for the --sig option
 module InterfaceFileWriter =
 
-    let WriteInterfaceFile (tcGlobals, tcConfig: TcConfig, infoReader, declaredImpls) =
+    let WriteInterfaceFile (tcGlobals, tcConfig: TcConfig, infoReader, declaredImpls: TypedImplFile list) =
+        // there are two modes here:
+        // * write one unified sig file to a given path, or
+        // * write individual sig files to paths matching their impl files
+        let denv = DisplayEnv.InitialForSigFileGeneration tcGlobals
+        let denv = { denv with shrinkOverloads = false; printVerboseSignatures = true }
 
-        /// Use a UTF-8 Encoding with no Byte Order Mark
-        let os = 
-            if tcConfig.printSignatureFile="" then Console.Out
-            else (File.CreateText tcConfig.printSignatureFile :> TextWriter)
+        let writeToFile os (TImplFile (_, _, mexpr, _, _, _)) =
+          writeViaBuffer os (fun os s -> Printf.bprintf os "%s\n\n" s)
+            (NicePrint.layoutInferredSigOfModuleExpr true denv infoReader AccessibleFromSomewhere range0 mexpr |> Display.squashTo 80 |> LayoutRender.showL)
 
-        if tcConfig.printSignatureFile <> "" && not (List.exists (Filename.checkSuffix tcConfig.printSignatureFile) FSharpLightSyntaxFileSuffixes) then
-            fprintfn os "#light" 
-            fprintfn os "" 
+        let writeHeader filePath os =
+            if filePath <> "" && not (List.exists (Filename.checkSuffix filePath) FSharpLightSyntaxFileSuffixes) then
+                fprintfn os "#light"
+                fprintfn os ""
 
-        for (TImplFile (_, _, mexpr, _, _, _)) in declaredImpls do
-            let denv = DisplayEnv.InitialForSigFileGeneration tcGlobals
-            writeViaBuffer os (fun os s -> Printf.bprintf os "%s\n\n" s)
-              (NicePrint.layoutInferredSigOfModuleExpr true { denv with printVerboseSignatures = true } infoReader AccessibleFromSomewhere range0 mexpr |> Display.squashTo 80 |> LayoutRender.showL)
-       
-        if tcConfig.printSignatureFile <> "" then os.Dispose()
+        let writeAllToSameFile declaredImpls =
+            /// Use a UTF-8 Encoding with no Byte Order Mark
+            let os =
+                if tcConfig.printSignatureFile = "" then Console.Out
+                else (File.CreateText tcConfig.printSignatureFile :> TextWriter)
+
+            writeHeader tcConfig.printSignatureFile os
+
+            for impl in declaredImpls do
+                writeToFile os impl
+
+            if tcConfig.printSignatureFile <> "" then os.Dispose()
+
+        let extensionForFile (filePath: string) =
+            if (List.exists (Filename.checkSuffix filePath) mlCompatSuffixes)
+            then ".mli"
+            else ".fsi"
+
+        let writeToSeparateFiles (declaredImpls: TypedImplFile list) =
+            for (TImplFile (name, _, _, _, _, _) as impl) in declaredImpls do
+                let filename = System.IO.Path.ChangeExtension(name.Range.FileName, extensionForFile name.Range.FileName)
+                printfn "writing impl file to %s" filename
+                use os = File.CreateText filename :> TextWriter
+                writeHeader filename os
+                writeToFile os impl
+
+        if tcConfig.printSignature
+        then writeAllToSameFile declaredImpls
+        else if tcConfig.printAllSignatureFiles
+        then writeToSeparateFiles declaredImpls
 
 //----------------------------------------------------------------------------
 // CopyFSharpCore
@@ -707,7 +736,7 @@ let main2(Args (ctok, tcGlobals, tcImports: TcImports, frameworkTcImports, gener
     // write interface, xmldoc
     ReportTime tcConfig ("Write Interface File")
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Output
-    if tcConfig.printSignature then InterfaceFileWriter.WriteInterfaceFile (tcGlobals, tcConfig, InfoReader(tcGlobals, tcImports.GetImportMap()), typedImplFiles)
+    if tcConfig.printSignature || tcConfig.printAllSignatureFiles then InterfaceFileWriter.WriteInterfaceFile (tcGlobals, tcConfig, InfoReader(tcGlobals, tcImports.GetImportMap()), typedImplFiles)
 
     ReportTime tcConfig ("Write XML document signatures")
     if tcConfig.xmlDocOutputFile.IsSome then 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -328,8 +328,10 @@ module InterfaceFileWriter =
         let writeAllToSameFile declaredImpls =
             /// Use a UTF-8 Encoding with no Byte Order Mark
             let os =
-                if tcConfig.printSignatureFile = "" then Console.Out
-                else (File.CreateText tcConfig.printSignatureFile :> TextWriter)
+                if tcConfig.printSignatureFile = "" then
+                    Console.Out
+                else
+                    File.CreateText tcConfig.printSignatureFile :> TextWriter
 
             writeHeader tcConfig.printSignatureFile os
 
@@ -339,9 +341,10 @@ module InterfaceFileWriter =
             if tcConfig.printSignatureFile <> "" then os.Dispose()
 
         let extensionForFile (filePath: string) =
-            if (List.exists (Filename.checkSuffix filePath) mlCompatSuffixes)
-            then ".mli"
-            else ".fsi"
+            if (List.exists (Filename.checkSuffix filePath) mlCompatSuffixes) then
+                ".mli"
+            else
+                ".fsi"
 
         let writeToSeparateFiles (declaredImpls: TypedImplFile list) =
             for (TImplFile (name, _, _, _, _, _) as impl) in declaredImpls do
@@ -351,10 +354,10 @@ module InterfaceFileWriter =
                 writeHeader filename os
                 writeToFile os impl
 
-        if tcConfig.printSignature
-        then writeAllToSameFile declaredImpls
-        else if tcConfig.printAllSignatureFiles
-        then writeToSeparateFiles declaredImpls
+        if tcConfig.printSignature then
+            writeAllToSameFile declaredImpls
+        else if tcConfig.printAllSignatureFiles then
+            writeToSeparateFiles declaredImpls
 
 //----------------------------------------------------------------------------
 // CopyFSharpCore

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -247,6 +247,11 @@
         <target state="translated">Hlavička zdroje začínající na posunu {0} má chybný formát.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Zobrazte si povolené hodnoty verze jazyka a pak zadejte požadovanou verzi, například latest nebo preview.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -247,6 +247,11 @@
         <target state="translated">Der Ressourcenheader, der am Offset {0} beginnt, ist fehlerhaft formatiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Zeigen Sie die zulässigen Werte für die Sprachversion an. Geben Sie die Sprachversion als "latest" oder "preview" an.</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -247,6 +247,11 @@
         <target state="translated">El encabezado de los recursos que comienza en el desplazamiento {0} está mal formado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Mostrar los valores permitidos para la versión de idioma, especificar la versión de idioma como "latest" "preview"</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -247,6 +247,11 @@
         <target state="translated">L'en-tête de ressource commençant au décalage {0} est mal formé.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Afficher les valeurs autorisées pour la version du langage, spécifier la version du langage comme 'dernière' ou 'préversion'</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -247,6 +247,11 @@
         <target state="translated">L'intestazione di risorsa che inizia a partire dall'offset {0} non è valida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Visualizza i valori consentiti per la versione del linguaggio. Specificare la versione del linguaggio, ad esempio 'latest' o 'preview'</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -247,6 +247,11 @@
         <target state="translated">オフセット {0} で始まるリソース ヘッダーの形式に誤りがあります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">言語バージョンで許可された値を表示し、'最新' や 'プレビュー' などの言語バージョンを指定する</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -247,6 +247,11 @@
         <target state="translated">오프셋 {0}에서 시작하는 리소스 헤더의 형식이 잘못되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">언어 버전의 허용된 값을 표시하고 '최신' 또는 '미리 보기'와 같은 언어 버전을 지정합니다.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -247,6 +247,11 @@
         <target state="translated">Nagłówek zasobu rozpoczynający się od przesunięcia {0} jest nieprawidłowo sformułowany.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Wyświetl dozwolone wartości dla wersji językowej; określ wersję językową, np. „latest” lub „preview”</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -247,6 +247,11 @@
         <target state="translated">O cabeçalho do recurso que começa no deslocamento {0} está malformado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Exibe os valores permitidos para a versão do idioma, especifica a versão do idioma, como 'mais recente ' ou 'prévia'</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -247,6 +247,11 @@
         <target state="translated">Заголовок ресурса некорректен начиная со смещения {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Отображение допустимых значений для версии языка. Укажите версию языка, например, "latest" или "preview".</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -247,6 +247,11 @@
         <target state="translated">{0} uzaklığında başlayan kaynak üst bilgisi hatalı biçimlendirilmiş.</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">Dil sürümü için izin verilen değerleri görüntüleyin, dil sürümünü 'en son' veya 'önizleme' örneklerindeki gibi belirtin</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -247,6 +247,11 @@
         <target state="translated">以偏移量 {0} 开始的资源标头格式不正确。</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">显示语言版本的允许值，指定语言版本，如“最新”或“预览”</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -247,6 +247,11 @@
         <target state="translated">從位移 {0} 開始的資源標頭格式錯誤。</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsAllSigs">
+        <source>Print the inferred interfaces of all compilation files to associated signature files</source>
+        <target state="new">Print the inferred interfaces of all compilation files to associated signature files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="optsLangVersion">
         <source>Display the allowed values for language version, specify language version such as 'latest' or 'preview'</source>
         <target state="translated">顯示語言版本允許的值，指定 'latest' 或 'preview' 等語言版本</target>

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/help/help40.437.1033.bsl
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/help/help40.437.1033.bsl
@@ -34,6 +34,9 @@ Copyright (c) Microsoft Corporation. All Rights Reserved.
                                          F#-specific metadata
 --sig:<file>                             Print the inferred interface of the
                                          assembly to a file
+--allsigs                                Print the inferred interfaces of all
+                                         compilation files to associated
+                                         signature files
 --nocopyfsharpcore                       Don't copy FSharp.Core.dll along the
                                          produced binaries
 


### PR DESCRIPTION
This PR adds a compiler flag, config property, and implementation for a new compiler capability: the ability to generate all matching signature files for a lit of input sources. We already had the ability to generate a combined signature file, but this style of signature is not very useful from a design or tooling point of view, as it doesn't help with establishing module boundaries file-to-file within the project.

The new flag determines the name of the signature file from the name of the input source file, handling ml-style files by generating `.mli` and F# files by generating `.fsi`.

I've also annotated some of the options types with field names for better debugging.