### PR TITLE
Re-enable generating doc comment boilerplate

### DIFF
--- a/vsintegration/src/FSharp.Editor/Commands/XmlDocCommandService.fs
+++ b/vsintegration/src/FSharp.Editor/Commands/XmlDocCommandService.fs
@@ -13,7 +13,7 @@ open Microsoft.VisualStudio.OLE.Interop
 open Microsoft.VisualStudio.Text
 open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.TextManager.Interop
-open Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+open Microsoft.VisualStudio.LanguageServices
 open Microsoft.VisualStudio.Utilities
 open FSharp.Compiler.EditorServices
 
@@ -23,7 +23,7 @@ type internal XmlDocCommandFilter
         filePath: string, 
         checkerProvider: FSharpCheckerProvider,
         projectInfoManager: FSharpProjectOptionsManager,
-        workspace: VisualStudioWorkspaceImpl
+        workspace: VisualStudioWorkspace
      ) =
 
     static let userOpName = "XmlDocCommand"
@@ -120,7 +120,7 @@ type internal XmlDocCommandFilterProvider
     [<ImportingConstructor>] 
     (checkerProvider: FSharpCheckerProvider,
      projectInfoManager: FSharpProjectOptionsManager,
-     workspace: VisualStudioWorkspaceImpl,
+     workspace: VisualStudioWorkspace,
      textDocumentFactoryService: ITextDocumentFactoryService,
      editorFactory: IVsEditorAdaptersFactoryService) =
     interface IWpfTextViewCreationListener with


### PR DESCRIPTION
Closes https://github.com/dotnet/fsharp/issues/11202

This used to be disabled since it was a source of LOH allocations and UI delays. That is no longer a relevant problem, since we use the current document's source text to get a parse tree from, and perf in the IDE is so much better than it was several years ago. This also adds a cancellation token to the call.

![docgen](https://user-images.githubusercontent.com/6309070/110697590-69391b00-81a1-11eb-8b97-0028db988dde.gif)