### PR TITLE
Added TypeDef table for mrpBigness - fixes error opening binary file

### DIFF
--- a/src/fsharp/absil/ilread.fs
+++ b/src/fsharp/absil/ilread.fs
@@ -3405,6 +3405,7 @@ let openMetadataReader (fileName, mdfile: BinaryFile, metadataPhysLoc, peinfo, p
       codedBigness 2 TableNames.Assembly
     
     let mrpBigness = 
+      codedBigness 3 TableNames.TypeDef ||
       codedBigness 3 TableNames.TypeRef ||
       codedBigness 3 TableNames.ModuleRef ||
       codedBigness 3 TableNames.Method ||


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/11190

The fix is interesting. According to the ECMA-335 spec about the MemberRef table:

### II.22.25 MemberRef : 0x0A 
The MemberRef table combines two sorts of references, to Methods and to Fields of a class, known as 
‘MethodRef’ and ‘FieldRef’, respectively. The MemberRef table has the following columns: 

- Class (an index into the MethodDef, ModuleRef,TypeDef, TypeRef, or TypeSpec tables; more precisely, a MemberRefParent (§II.24.2.6) coded index) 
- Name (an index into the String heap) 
- Signature (an index into the Blob heap)

The part to note is `MethodDef, ModuleRef,TypeDef, TypeRef, or TypeSpec tables`. Our IL reader was not including the TypeDef bit in calculating the `mrpBigness` which determines the size of a `MemberRefParent`. The size is important because it is used to calculate the offsets of each table. If the size is incorrect, everything comes crashing down. In our case, we were off by '2'.