### PR TITLE
Ignore bad quickinfo test

### DIFF
--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -3243,7 +3243,7 @@ query."
                     }"""
         this.AssertQuickInfoInQuery (fileContent, "(*Mark*)", "custom operation: minBy ('Value)")
 
-    [<Test>]
+    [<Test; Ignore("Multiple failures due to CancellationTokenSource being disposed. Bad test")>]
     [<Category("Query")>]
     // QuickInfo works in a large query (using many operators)
     member public this.``Query.WithinLargeQuery``() =


### PR DESCRIPTION
This test showed up as another CI failures, and it has also caused failures in builds that are _not_ PRs: https://runfo.azurewebsites.net/search/tests/?bq=definition%3Afsharp-ci%20%20started%3A~7%20kind%3A!pr&tq=name%3A%22query.withinlargequery%22

Like the other recently-disabled tests, this has an implicit dependency on some timing on the host machine that is invalidated on a queue of lower-quality machines.