### PR TITLE
Use ManualResetEvents to track events in recently-disabled mailboxprocessor tests

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -320,7 +320,6 @@ type AsyncModule() =
             let cts = new System.Threading.CancellationTokenSource()
             let go e (flag : bool ref) = async {
                 let! _ = Async.AwaitWaitHandle e
-                sleep 500
                 use! _holder = Async.OnCancel(fun () -> flag := true)
                 while true do
                     do! Async.Sleep 100
@@ -330,7 +329,6 @@ type AsyncModule() =
             let finish = new System.Threading.ManualResetEvent(false)
             let cancelledWasCalled = ref false
             Async.StartWithContinuations(go evt cancelledWasCalled, ignore, ignore, (fun _ -> finish.Set() |> ignore),  cancellationToken = cts.Token)
-            sleep 500
             evt.Set() |> ignore
             cts.Cancel()
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/MailboxProcessorType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/MailboxProcessorType.fs
@@ -66,18 +66,24 @@ type MailboxProcessorType() =
 
         ()
 
-    [<Fact(Skip="This test fails all the time in CI, likely due to magic sleeps. Need to re-evaluate.")>]
+    [<Fact>]
     member this.``Receive handles cancellation token``() =
-        let result = ref None
-
+        let mutable result = None
+        use mre1 = new ManualResetEventSlim(false)
+        use mre2 = new ManualResetEventSlim(false)
+    
         // https://github.com/Microsoft/visualfsharp/issues/3337
         let cts = new CancellationTokenSource ()
-
+    
         let addMsg msg =
-            match !result with
-            | Some text -> result := Some(text + " " + msg)
-            | None -> result := Some msg
-
+            match result with
+            | Some text ->
+                //printfn "Got some, adding %s" msg
+                result <- Some(text + " " + msg)
+            | None ->
+                //printfn "got none, setting %s" msg
+                result <- Some msg
+    
         let mb =
             MailboxProcessor.Start (
                 fun inbox -> async {
@@ -85,32 +91,41 @@ type MailboxProcessorType() =
                         { new IDisposable with
                             member this.Dispose () =
                                 addMsg "Disposed"
+                                mre2.Set()
                         }
-
+    
                     while true do
-                        let! (msg : int) = inbox.Receive ()
+                        let! (msg : int) = inbox.Receive()
                         addMsg (sprintf "Received %i" msg)
+                        mre1.Set()
                 }, cancellationToken = cts.Token)
+    
+        mb.Post(1)
+        mre1.Wait()
+    
+        cts.Cancel()
+        mre2.Wait()
 
-        mb.Post 1
-        Thread.Sleep 1000
-        cts.Cancel ()
-        Thread.Sleep 4000
+        Assert.AreEqual(Some("Received 1 Disposed"), result)
 
-        Assert.AreEqual(Some("Received 1 Disposed"), !result)
-
-    [<Fact(Skip="This test fails all the time in CI, likely due to magic sleeps. Need to re-evaluate.")>]
+    [<Fact>]
     member this.``Receive with timeout argument handles cancellation token``() =
-        let result = ref None
-
+        let mutable result = None
+        use mre1 = new ManualResetEventSlim(false)
+        use mre2 = new ManualResetEventSlim(false)
+    
         // https://github.com/Microsoft/visualfsharp/issues/3337
         let cts = new CancellationTokenSource ()
-
+    
         let addMsg msg =
-            match !result with
-            | Some text -> result := Some(text + " " + msg)
-            | None -> result := Some msg
-
+            match result with
+            | Some text ->
+                //printfn "Got some, adding %s" msg
+                result <- Some(text + " " + msg)
+            | None ->
+                //printfn "got none, setting %s" msg
+                result <- Some msg
+    
         let mb =
             MailboxProcessor.Start (
                 fun inbox -> async {
@@ -118,31 +133,40 @@ type MailboxProcessorType() =
                         { new IDisposable with
                             member this.Dispose () =
                                 addMsg "Disposed"
+                                mre2.Set()
                         }
-
+    
                     while true do
-                        let! (msg : int) = inbox.Receive (100000)
+                        let! (msg : int) = inbox.Receive(100000)
                         addMsg (sprintf "Received %i" msg)
+                        mre1.Set()
                 }, cancellationToken = cts.Token)
+    
+        mb.Post(1)
+        mre1.Wait()
+    
+        cts.Cancel()
+        mre2.Wait()
 
-        mb.Post 1
-        Thread.Sleep 1000
-        cts.Cancel ()
-        Thread.Sleep 4000
+        Assert.AreEqual(Some("Received 1 Disposed"), result)
 
-        Assert.AreEqual(Some("Received 1 Disposed"),!result)
-
-    [<Fact(Skip="This test fails all the time in CI, likely due to magic sleeps. Need to re-evaluate.")>]
+    [<Fact>]
     member this.``Scan handles cancellation token``() =
-        let result = ref None
+        let mutable result = None
+        use mre1 = new ManualResetEventSlim(false)
+        use mre2 = new ManualResetEventSlim(false)
 
         // https://github.com/Microsoft/visualfsharp/issues/3337
         let cts = new CancellationTokenSource ()
 
         let addMsg msg =
-            match !result with
-            | Some text -> result := Some(text + " " + msg)
-            | None -> result := Some msg
+            match result with
+            | Some text ->
+                //printfn "Got some, adding %s" msg
+                result <- Some(text + " " + msg)
+            | None ->
+                //printfn "got none, setting %s" msg
+                result <- Some msg
 
         let mb =
             MailboxProcessor.Start (
@@ -151,19 +175,22 @@ type MailboxProcessorType() =
                         { new IDisposable with
                             member this.Dispose () =
                                 addMsg "Disposed"
+                                mre2.Set()
                         }
 
                     while true do
                         let! (msg : int) = inbox.Scan (fun msg -> Some(async { return msg }) )
                         addMsg (sprintf "Scanned %i" msg)
+                        mre1.Set()
                 }, cancellationToken = cts.Token)
 
-        mb.Post 1
-        Thread.Sleep 1000
-        cts.Cancel ()
-        Thread.Sleep 4000
+        mb.Post(1)
+        mre1.Wait()
 
-        Assert.AreEqual(Some("Scanned 1 Disposed"), !result)
+        cts.Cancel()
+        mre2.Wait()
+
+        Assert.AreEqual(Some("Scanned 1 Disposed"), result)
 
     [<Fact>]
     member this.``Receive Races with Post``() =


### PR DESCRIPTION
This should address part of https://github.com/dotnet/fsharp/issues/11219