### PR TITLE
Optimize PreComputeTupleConstructor

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Reflection/FSharpReflection.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Reflection/FSharpReflection.fs
@@ -118,10 +118,12 @@ type FSharpValueTests() =
     let tuple1 = ( 1, "tuple1")
     let tuple2 = ( 2, "tuple2", (fun x -> x + 1))
     let tuple3 = ( 1, ( 2, "tuple"))
+    let longTuple = (("yup", 1s), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, Some 12, 13, "nope", struct (15, 16), 17, 18, ValueSome 19)
     
     let structTuple1 = struct ( 1, "tuple1")
     let structTuple2 = struct ( 2, "tuple2", (fun x -> x + 1))
     let structTuple3 = struct ( 1, struct ( 2, "tuple"))
+    let longStructTuple = struct (("yup", 1s), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, Some 12, 13, "nope", struct (15, 16), 17, 18, ValueSome 19)
     
     let func1  param  = param + 1
     let func2  param  = param + ""
@@ -550,6 +552,9 @@ type FSharpValueTests() =
         // Tuple
         let tupleCtor = FSharpValue.PreComputeTupleConstructor(tuple1.GetType())    
         Assert.AreEqual( tupleCtor([| box 1; box "tuple1" |]) , box(tuple1))
+
+        let tupleCtor = FSharpValue.PreComputeTupleConstructor(longTuple.GetType())    
+        Assert.AreEqual( tupleCtor([| box ("yup", 1s); box 2; box 3; box 4; box 5; box 6; box 7; box 8; box 9; box 10; box 11; box (Some 12); box 13; box "nope"; box (struct (15, 16)); box 17; box 18; box (ValueSome 19) |]) , box(longTuple))
         
         // Tuple with function member
         let tuplewithFuncCtor = FSharpValue.PreComputeTupleConstructor(tuple2.GetType())  
@@ -573,6 +578,9 @@ type FSharpValueTests() =
         let tupleCtor = FSharpValue.PreComputeTupleConstructor(structTuple1.GetType())    
         Assert.AreEqual( tupleCtor([| box 1; box "tuple1" |]) , box(structTuple1))
         
+        let tupleCtor = FSharpValue.PreComputeTupleConstructor(longStructTuple.GetType())    
+        Assert.AreEqual( tupleCtor([| box ("yup", 1s); box 2; box 3; box 4; box 5; box 6; box 7; box 8; box 9; box 10; box 11; box (Some 12); box 13; box "nope"; box (struct (15, 16)); box 17; box 18; box (ValueSome 19) |]) , box(longStructTuple))
+ 
         // Tuple with function member
         let tuplewithFuncCtor = FSharpValue.PreComputeTupleConstructor(structTuple2.GetType())  
         let resultTuplewithFunc = tuplewithFuncCtor([| box 2; box "tuple2"; box (fun x -> x + 1) |])

--- a/tests/fsharp/Compiler/Libraries/Core/Reflection/PreComputedTupleConstructorTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Reflection/PreComputedTupleConstructorTests.fs
@@ -25,4 +25,4 @@ module ``PreComputedTupleConstructor Tests`` =
         let testDelegate = TestDelegate (fun () -> 
             Reflection.FSharpValue.PreComputeTupleConstructor(typeof<int * string>) [| box "text"; box 12; |] |> ignore)
 
-        Assert.Throws<System.ArgumentException> testDelegate |> ignore
+        Assert.Throws<System.InvalidCastException> testDelegate |> ignore


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.200-preview.21077.7
  [Host]     : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT DEBUG
  DefaultJob : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT


```
|   Method |        Mean |     Error |    StdDev |      Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |------------:|----------:|----------:|------------:|-------:|------:|------:|----------:|
| New3Part |   134.50 ns |  3.313 ns |  9.768 ns |   129.21 ns | 0.0842 |     - |     - |     704 B |
| Old3Part | 1,758.37 ns | 19.991 ns | 18.699 ns | 1,757.57 ns | 0.1755 |     - |     - |    1480 B |
| New1Part |    14.62 ns |  0.330 ns |  0.309 ns |    14.68 ns | 0.0115 |     - |     - |      96 B |
| Old1Part |   283.67 ns |  2.794 ns |  2.614 ns |   282.73 ns | 0.0162 |     - |     - |     136 B |

Tested against
```fsharp
let threePart = (("yup", 1s), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, Some 12, 13, "nope",  17, 18, ValueSome 19)
let onePart = ("yup", 1s)
```

There's one little problem though. When values of the wrong type are passed to the precomputed constructor, `InvalidCastException` is now thrown instead of `ArgumentException` (`MakeTuple` still throws this as well). I'm not sure if this matters that much (I suspect a similar change sneaked into #9784), but if it does, I could theoretically emit a runtime check throwing the old exception [here](https://github.com/dotnet/fsharp/compare/main...kerams:tuple-ctor?expand=1#diff-f194035d2135be4dc6464a2cccecbf2356719511e3b6a4189bf722e4bfab8ae4R174) at the cost of a small performance hit.