### PR TITLE
auto-complete vs insertion supports values of 'auto', 'true', or 'false'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -506,3 +506,4 @@ stages:
       insertTargetBranch: rel/d16.9
       insertTeamEmail: fsharpteam@microsoft.com
       insertTeamName: 'F#'
+      completeInsertion: 'auto'

--- a/eng/release/insert-into-vs.yml
+++ b/eng/release/insert-into-vs.yml
@@ -4,6 +4,7 @@ parameters:
   insertTargetBranch: ''
   insertTeamEmail: ''
   insertTeamName: ''
+  completeInsertion: 'false' # 'true', 'false', 'auto'
   dependsOn: [build]
 
 stages:
@@ -49,10 +50,23 @@ stages:
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/release/scripts/GetAssemblyVersions.ps1
         arguments: -assemblyVersionsPath $(Build.ArtifactStagingDirectory)\VSSetup\DevDivPackages\DependentAssemblyVersions.csv
+    - task: PowerShell@2
+      displayName: Calculate autocompletion state
+      inputs:
+        targetType: 'inline'
+        pwsh: true
+        script: |
+          # mark the insertion for auto-completion if:
+          #   `parameters.completeInsertion` == `true`
+          # OR
+          #   `parameters.completeInsertion` == `auto` AND `parameters.insertTargetBranch` does not contain 'rel/'
+          $completeInsertion = '${{ parameters.completeInsertion }}'
+          $autoComplete = ($completeInsertion -Eq 'true') -Or (($completeInsertion -Eq 'auto') -And (-Not ($env:INSERTTARGETBRANCH.Contains('rel/'))))
+          $autoCompleteStr = if ($autoComplete) { 'true' } else { 'false' }
+          Write-Host "Setting AutoCompletePR to '$autoCompleteStr'"
+          Write-Host "##vso[task.setvariable variable=AutoCompletePR]$autoCompleteStr"
     - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@3
       displayName: 'Insert VS Payload'
       inputs:
-        # only auto-complete if the target branch is not `rel/*`
-        AutoCompletePR: ${{ not(contains(parameters.insertTargetBranch, 'rel/')) }}
         LinkWorkItemsToPR: false
       condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], '${{ parameters.componentBranchName }}'), eq(variables['Build.SourceBranch'], 'refs/heads/${{ parameters.componentBranchName }}')))


### PR DESCRIPTION
The current behavior of the VS insertion leg of the build is to always mark it as `AutoCompletePR=true` _unless_ the target branch contains the substring `rel/`, and that's to prevent auto-inserting during ask mode.

This PR adds a new parameter to our auto-insertion story.  The values of `true` and `false` will always be honored, no matter the branch names, but the value `auto` will behave as before: set auto-complete to true unless it's a VS rel branch.

This is to make future insertion testing easier, so we can add a temporary commit to force the insertion, saving us a bunch of manual work.