### PR TITLE
Fix two issues in signature help

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -390,7 +390,6 @@ type internal FSharpSignatureHelpProvider
                             let info =
                                 { ParameterName = name
                                   IsOptional = false
-                                  // No need to do anything different here, as this field is only relevant for overloaded parameter names in methods.
                                   CanonicalTypeTextForSorting = name
                                   Documentation = ResizeArray()
                                   DisplayParts = display }
@@ -444,9 +443,8 @@ type internal FSharpSignatureHelpProvider
                             display.Add(RoslynTaggedText(TextTags.Punctuation, ")"))
                             
                             let info =
-                                { ParameterName = "" // No name here, since it's a tuple of arguments
+                                { ParameterName = "" // No name here, since it's a tuple of arguments has no name in the F# symbol info
                                   IsOptional = false
-                                  // No need to do anything here as this field is only relevant for overloaded parameter names in methods.
                                   CanonicalTypeTextForSorting = ""
                                   Documentation = ResizeArray()
                                   DisplayParts = display }

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -169,7 +169,7 @@ type internal FSharpSignatureHelpProvider
                     | n -> n
 
                 // Compute the current argument name if it is named.
-                let argumentName = 
+                let namedArgumentName = 
                     if argumentIndex < paramLocations.NamedParamNames.Length then 
                         paramLocations.NamedParamNames.[argumentIndex] 
                     else 
@@ -222,7 +222,7 @@ type internal FSharpSignatureHelpProvider
                       ApplicableSpan = applicableSpan
                       ArgumentIndex = argumentIndex
                       ArgumentCount = argumentCount
-                      ArgumentName = argumentName
+                      ArgumentName = namedArgumentName
                       CurrentSignatureHelpSessionKind = MethodCall }
 
                 return! Some data
@@ -569,7 +569,7 @@ type internal FSharpSignatureHelpProvider
                         checkFileResults,
                         documentationBuilder,
                         sourceText,
-                        adjustedColumnInSource,
+                        caretPosition,
                         triggerTypedChar)
         }
 

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -18,7 +18,6 @@ open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
-open FSharp.Compiler.Text
 open FSharp.Compiler.Tokenization
 
 type SignatureHelpParameterInfo =
@@ -280,7 +279,7 @@ type internal FSharpSignatureHelpProvider
                         | None -> 0
                         | Some (_, numArgsApplied) -> numArgsApplied
 
-                    let definedArgs = mfv.CurriedParameterGroups |> Seq.concat |> Array.ofSeq
+                    let definedArgs = mfv.CurriedParameterGroups |> Array.ofSeq
                         
                     let numDefinedArgs = definedArgs.Length
 
@@ -360,40 +359,100 @@ type internal FSharpSignatureHelpProvider
                     // Offset by 1 here until we support reverse indexes in this codebase
                     definedArgs.[.. definedArgs.Length - 1 - numArgsAlreadyApplied] |> Array.iteri (fun index argument ->
                         let tt = ResizeArray()
-                        let taggedText = argument.Type.FormatLayout symbolUse.DisplayContext
-                        taggedText |> Seq.iter (RoslynHelpers.CollectTaggedText tt)
+
+                        if argument.Count = 1 then
+                            let argument = argument.[0]
+                            let taggedText = argument.Type.FormatLayout symbolUse.DisplayContext
+                            taggedText |> Seq.iter (RoslynHelpers.CollectTaggedText tt)
                             
-                        let name =
-                            if String.IsNullOrWhiteSpace(argument.DisplayName) then
-                                "arg" + string index
-                            else
-                                argument.DisplayName
+                            let name =
+                                if String.IsNullOrWhiteSpace(argument.DisplayName) then
+                                    "arg" + string index
+                                else
+                                    argument.DisplayName
 
-                        let display =
-                            [|
-                                RoslynTaggedText(TextTags.Local, name)
-                                RoslynTaggedText(TextTags.Punctuation, ":")
-                                RoslynTaggedText(TextTags.Space, " ")
-                            |]
-                            |> ResizeArray
+                            let display =
+                                [|
+                                    RoslynTaggedText(TextTags.Local, name)
+                                    RoslynTaggedText(TextTags.Punctuation, ":")
+                                    RoslynTaggedText(TextTags.Space, " ")
+                                |]
+                                |> ResizeArray
 
-                        if argument.Type.IsFunctionType then
+                            if argument.Type.IsFunctionType then
+                                display.Add(RoslynTaggedText(TextTags.Punctuation, "("))
+
+                            display.AddRange(tt)
+
+                            if argument.Type.IsFunctionType then
+                                display.Add(RoslynTaggedText(TextTags.Punctuation, ")"))
+
+                            let info =
+                                { ParameterName = name
+                                  IsOptional = false
+                                  // No need to do anything different here, as this field is only relevant for overloaded parameter names in methods.
+                                  CanonicalTypeTextForSorting = name
+                                  Documentation = ResizeArray()
+                                  DisplayParts = display }
+
+                            displayArgs.Add(info)
+
+                        else
+                            let display = ResizeArray()
                             display.Add(RoslynTaggedText(TextTags.Punctuation, "("))
 
-                        display.AddRange(tt)
+                            let separatorParts =
+                                [|
+                                    RoslynTaggedText(TextTags.Space, " ")
+                                    RoslynTaggedText(TextTags.Operator, "*")
+                                    RoslynTaggedText(TextTags.Space, " ")
+                                |]
 
-                        if argument.Type.IsFunctionType then
+                            let mutable first = true
+                            argument |> Seq.iteri (fun index arg ->
+                                if first then
+                                    first <- false
+                                else
+                                    display.AddRange(separatorParts)
+                                let tt = ResizeArray()
+
+                                let taggedText = arg.Type.FormatLayout symbolUse.DisplayContext
+                                taggedText |> Seq.iter (RoslynHelpers.CollectTaggedText tt)
+                                
+                                let name =
+                                    if String.IsNullOrWhiteSpace(arg.DisplayName) then
+                                        "arg" + string index
+                                    else
+                                        arg.DisplayName   
+                                        
+                                let namePart =
+                                    [|
+                                        RoslynTaggedText(TextTags.Local, name)
+                                        RoslynTaggedText(TextTags.Punctuation, ":")
+                                        RoslynTaggedText(TextTags.Space, " ")
+                                    |]
+
+                                display.AddRange(namePart)
+                                    
+                                if arg.Type.IsFunctionType then
+                                    display.Add(RoslynTaggedText(TextTags.Punctuation, "("))
+                                    
+                                display.AddRange(tt)
+                                    
+                                if arg.Type.IsFunctionType then
+                                    display.Add(RoslynTaggedText(TextTags.Punctuation, ")")))
+                            
                             display.Add(RoslynTaggedText(TextTags.Punctuation, ")"))
+                            
+                            let info =
+                                { ParameterName = "" // No name here, since it's a tuple of arguments
+                                  IsOptional = false
+                                  // No need to do anything here as this field is only relevant for overloaded parameter names in methods.
+                                  CanonicalTypeTextForSorting = ""
+                                  Documentation = ResizeArray()
+                                  DisplayParts = display }
 
-                        let info =
-                            { ParameterName = name
-                              IsOptional = false
-                              // No need to do anything different here, as this field is only relevant for overloaded parameter names in methods.
-                              CanonicalTypeTextForSorting = name
-                              Documentation = ResizeArray()
-                              DisplayParts = display }
-
-                        displayArgs.Add(info))
+                            displayArgs.Add(info))
 
                     do! Option.guard (displayArgs.Count > 0)
 

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -396,7 +396,6 @@ type internal FSharpSignatureHelpProvider
                                   DisplayParts = display }
 
                             displayArgs.Add(info)
-
                         else
                             let display = ResizeArray()
                             display.Add(RoslynTaggedText(TextTags.Punctuation, "("))


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/11256 and a recent regression that was introduced in https://github.com/dotnet/fsharp/pull/10886

First issue:

Current signature help displays tupled arguments as function arguments if you hit space before hitting `(`, which is **100% wrong** and if you follow what the tooltip shows, it will result in a compile error.

This fixes the issue by looping through the tupled arguments and rendering them like a tuple in the tooltip:

![image](https://user-images.githubusercontent.com/6309070/111533718-5768f200-8724-11eb-93a9-a0e2d0c3c176.png)

So now if you pressed a space after `C.M` instead of immediately pressing `(`, it will give a tooltip indicating that you need to press `(`.

Second issue:

If you pressed `,` after the first argument in method signature help, it wouldn't actually show you the argument you're "on" until you started typing out that argument. This was a regression introduced in a small perf fix where the wrong parameter was being passed to the method. It now correctly triggers with the right parameter highlighted:

![image](https://user-images.githubusercontent.com/6309070/111533930-9bf48d80-8724-11eb-965f-9cd92b41ace2.png)
