### PR TITLE
Remove old artificial delays related to built-in document diagnostic analyzers

### DIFF
--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -37,7 +37,6 @@ type internal SimplifyNameDiagnosticAnalyzer
             asyncMaybe {
                 do! Option.guard document.FSharpOptions.CodeFixes.SimplifyName
                 do Trace.TraceInformation("{0:n3} (start) SimplifyName", DateTime.Now.TimeOfDay.TotalSeconds)
-                do! Async.Sleep DefaultTuning.SimplifyNameInitialDelay |> liftAsync 
                 let! _parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document, cancellationToken, userOpName)
                 let! textVersion = document.GetTextVersionAsync(cancellationToken)
                 let textVersionHash = textVersion.GetHashCode()

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
@@ -28,7 +28,6 @@ type internal UnusedDeclarationsAnalyzer
                 do! Option.guard document.FSharpOptions.CodeFixes.UnusedDeclarations
 
                 do Trace.TraceInformation("{0:n3} (start) UnusedDeclarationsAnalyzer", DateTime.Now.TimeOfDay.TotalSeconds)
-                do! Async.Sleep DefaultTuning.UnusedDeclarationsAnalyzerInitialDelay |> liftAsync // be less intrusive, give other work priority most of the time
                 match! projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document, cancellationToken, userOpName) with
                 | (_parsingOptions, projectOptions) ->
                     let! sourceText = document.GetTextAsync()

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
@@ -37,10 +37,9 @@ type internal UnusedOpensDiagnosticAnalyzer
 
     interface IFSharpUnusedOpensDiagnosticAnalyzer with
 
-        member this.AnalyzeSemanticsAsync(descriptor, document: Document, cancellationToken: CancellationToken) =
+        member _.AnalyzeSemanticsAsync(descriptor, document: Document, cancellationToken: CancellationToken) =
             asyncMaybe {
                 do Trace.TraceInformation("{0:n3} (start) UnusedOpensAnalyzer", DateTime.Now.TimeOfDay.TotalSeconds)
-                do! Async.Sleep DefaultTuning.UnusedOpensAnalyzerInitialDelay |> liftAsync // be less intrusive, give other work priority most of the time
                 let! _parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document, cancellationToken, userOpName)
                 let! sourceText = document.GetTextAsync()
                 let checker = checkerProvider.Checker

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -3,17 +3,10 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 open System
 open System.ComponentModel.Composition
 open System.Runtime.InteropServices
-open System.Windows
-open System.Windows.Controls
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.FSharp.UIResources
 
-module DefaultTuning = 
-    let UnusedDeclarationsAnalyzerInitialDelay = 0 (* 1000 *) (* milliseconds *)
-    let UnusedOpensAnalyzerInitialDelay = 0 (* 2000 *) (* milliseconds *)
-    let SimplifyNameInitialDelay = 2000 (* milliseconds *)
-    let SimplifyNameEachItemDelay = 0 (* milliseconds *)
-
+module DefaultTuning =
     /// How long is the per-document data saved before it is eligible for eviction from the cache? 10 seconds.
     /// Re-tokenizing is fast so we don't need to save this data long.
     let PerDocumentSavedDataSlidingWindow = TimeSpan(0,0,10)(* seconds *)


### PR DESCRIPTION
These delays were put into place before we had the ability to set a priority for the built-in F# document diagnostic analyzers. The priority work has long since been in place, but the artificial delays are still in place and in the case of the two that are active ... achieve nothing other than a useless call to `Async.Sleep` for 0 milliseconds. For name simplification, this is also not an issue even if it is turned on, because the priority of that analyzer is low and handled by Roslyn.