### PR TITLE
Eliminate binding when the body is const unit

### DIFF
--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1480,7 +1480,7 @@ let TryEliminateBinding cenv _env (TBind(vspec1, e1, spBind)) e2 _m =
              | None -> None
 
          | Expr.Const (Const.Unit, _, _) ->
-             Some e2
+             Some e1
 
          | _ ->  
             None

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1479,6 +1479,9 @@ let TryEliminateBinding cenv _env (TBind(vspec1, e1, spBind)) e2 _m =
              | Some(largs, rargs) -> Some (Expr.Op (c, tyargs, (largs @ (e1 :: rargs)), m))
              | None -> None
 
+         | Expr.Const (Const.Unit, _, _) ->
+             Some e2
+
          | _ ->  
             None
 


### PR DESCRIPTION
Trying to see what blows up as a result of this half-baked fix for https://github.com/dotnet/fsharp/issues/4884.

```fsharp
let z1 () =
    System.DateTime.Now
    ()
    
let z2 () =
    ignore System.DateTime.Now

let z3 () =
    let discard = System.DateTime.Now
    ()
```

The IL for `z2` and `z3` contains `stloc.0` into a local instead of a `pop` instruction like in `z1`. Because `DateTime` is a value type, JIT generates extra init instructions to zero the local, see https://sharplab.io/#v2:DYLgZgzgNALiCGEC2AfYBTGACAXgRiwAoBKLAXgFgAoLWrAZQE8IZ0kA6AEXlYBUBLJOnYA5APYB3anSLFpdahmw4ATLPLza/AOYA7MQCd0DZqw7c+g4eKlVqizLgDM6yjTpKsAE34QAxvAGXuQmLGxcPOgCQqKSmrJAA===.
With this change all 3 functions produce the same IL as `z1`.