### PR TITLE
Hook up createMemoryMapFile to use the IFileSystem mock

### DIFF
--- a/src/fsharp/absil/ilread.fs
+++ b/src/fsharp/absil/ilread.fs
@@ -3868,7 +3868,7 @@ let createByteFileChunk opts fileName chunk =
 
 let createMemoryMapFile fileName = 
     let mmf, accessor, length = 
-        let fileStream = FileSystem.OpenReadShim(fileName)
+        let fileStream = FileSystem.FileStreamReadLockShim(fileName)
         let length = fileStream.Length
         let mmf = MemoryMappedFile.CreateFromFile(fileStream, null, length, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen=false)
         mmf, mmf.CreateViewAccessor(0L, fileStream.Length, MemoryMappedFileAccess.Read), length

--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -14,6 +14,9 @@ type IFileSystem =
     /// A shim over FileStream with FileMode.Open, FileAccess.Read, FileShare.ReadWrite
     abstract FileStreamReadShim: fileName: string -> Stream
 
+    /// A shim over FileStream with FileMode.Open, FileAccess.Read, FileShare.Read
+    abstract FileStreamReadLockShim: fileName: string -> Stream
+
     /// A shim over FileStream with FileMode.Create, FileAccess.Write, FileShare.Read
     abstract FileStreamCreateShim: fileName: string -> Stream
 
@@ -63,6 +66,8 @@ type DefaultFileSystem() =
             Assembly.Load assemblyName
 
         member _.ReadAllBytesShim (fileName: string) = File.ReadAllBytes fileName
+
+        member _.FileStreamReadLockShim (fileName: string) = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read)  :> Stream
 
         member _.FileStreamReadShim (fileName: string) = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)  :> Stream
 

--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -15,7 +15,7 @@ type IFileSystem =
     abstract FileStreamReadShim: fileName: string -> Stream
 
     /// A shim over FileStream with FileMode.Open, FileAccess.Read, FileShare.Read
-    abstract FileStreamReadLockShim: fileName: string -> Stream
+    abstract FileStreamReadLockShim: fileName: string -> FileStream
 
     /// A shim over FileStream with FileMode.Create, FileAccess.Write, FileShare.Read
     abstract FileStreamCreateShim: fileName: string -> Stream
@@ -67,7 +67,7 @@ type DefaultFileSystem() =
 
         member _.ReadAllBytesShim (fileName: string) = File.ReadAllBytes fileName
 
-        member _.FileStreamReadLockShim (fileName: string) = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read)  :> Stream
+        member _.FileStreamReadLockShim (fileName: string) = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read)
 
         member _.FileStreamReadShim (fileName: string) = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)  :> Stream
 

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -22,8 +22,8 @@ type public IFileSystem =
     /// A shim over FileStream with FileMode.Open, FileAccess.Read, FileShare.ReadWrite
     abstract member FileStreamReadShim: fileName:string -> Stream
 
-    /// A shim over FileStream with FileMode.Open, FileAccess.Read, FileShare.Read
-    abstract FileStreamReadLockShim: fileName: string -> Stream
+    /// A shim over File.Open with FileMode.Open, FileAccess.Read, FileShare.Read
+    abstract FileStreamReadLockShim: fileName: string -> FileStream
 
     /// A shim over FileStream with FileMode.Open, FileAccess.Write, FileShare.Read
     abstract member FileStreamWriteExistingShim: fileName:string -> Stream

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -22,6 +22,9 @@ type public IFileSystem =
     /// A shim over FileStream with FileMode.Open, FileAccess.Read, FileShare.ReadWrite
     abstract member FileStreamReadShim: fileName:string -> Stream
 
+    /// A shim over FileStream with FileMode.Open, FileAccess.Read, FileShare.Read
+    abstract FileStreamReadLockShim: fileName: string -> Stream
+
     /// A shim over FileStream with FileMode.Open, FileAccess.Write, FileShare.Read
     abstract member FileStreamWriteExistingShim: fileName:string -> Stream
 

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -36,7 +36,12 @@ let B = File1.A + File1.A"""
             match files.TryGetValue fileName with
             | true, text -> new MemoryStream(Encoding.UTF8.GetBytes(text)) :> Stream
             | _ -> defaultFileSystem.FileStreamReadShim(fileName)
-            
+
+        member _.FileStreamReadLockShim(fileName) =
+            match files.TryGetValue fileName with
+            | true, text -> new MemoryStream(Encoding.UTF8.GetBytes(text)) :> Stream
+            | _ -> defaultFileSystem.FileStreamReadLockShim(fileName)
+
         member _.FileStreamCreateShim(fileName) = 
             defaultFileSystem.FileStreamCreateShim(fileName)
 


### PR DESCRIPTION
This creates a new method on IFileSystem to correspond to the specific options that were used previously (FileShare.Read).
Hopefully this bugfix will allow us to run FSC against a completely virtual filesystem (e.g. System.IO.Abstractions.TestingHelpers's MockFileSystem).

I have verified the claim I made in the new comment on `_.FileName`: the property is unused. (I deleted it locally and rebuilt the compiler to check this.)

I'm not 100% certain right now that `FileStream(blah)` is identical to `File.Open(blah)`, because it's late at night. But they should be the same in a sane world.