### PR TITLE
Fixed duplication of CombineCcuContentFragments

### DIFF
--- a/src/fsharp/ParseAndCheckInputs.fs
+++ b/src/fsharp/ParseAndCheckInputs.fs
@@ -858,8 +858,6 @@ let TypeCheckOneInputEventually (checkForErrors, tcConfig: TcConfig, tcImports: 
                   | Some prefixPath when not hadSig -> TcOpenModuleOrNamespaceDecl tcSink tcGlobals amap m tcSigEnv (prefixPath, m)
                   | _ -> tcSigEnv 
 
-              let ccuSig = CombineCcuContentFragments m [implFileSigType; tcState.tcsCcuSig ]
-
               let ccuSigForFile = CombineCcuContentFragments m [implFileSigType; tcState.tcsCcuSig]
 
               let tcState = 
@@ -867,7 +865,7 @@ let TypeCheckOneInputEventually (checkForErrors, tcConfig: TcConfig, tcImports: 
                         tcsTcSigEnv=tcSigEnv
                         tcsTcImplEnv=tcImplEnv
                         tcsRootImpls=rootImpls
-                        tcsCcuSig=ccuSig
+                        tcsCcuSig=ccuSigForFile
                         tcsCreatesGeneratedProvidedTypes=tcState.tcsCreatesGeneratedProvidedTypes || createsGeneratedProvidedTypes }
               return (tcEnvAtEnd, topAttrs, Some implFile, ccuSigForFile), tcState
      


### PR DESCRIPTION
Was looking around and found that we were calling `CombineCcuContentFragments m [implFileSigType; tcState.tcsCcuSig]` twice in `TypeCheckOneInputEventually`. Now it will only do it once.