### PR TITLE
Add ApplicationIcon/Win32Icon Support

### DIFF
--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -398,6 +398,7 @@ type TcConfigBuilder =
       mutable internConstantStrings: bool
       mutable extraOptimizationIterations: int
 
+      mutable win32icon: string
       mutable win32res: string 
       mutable win32manifest: string
       mutable includewin32manifest: bool
@@ -603,6 +604,7 @@ type TcConfigBuilder =
           internConstantStrings = true
           extraOptimizationIterations = 0
 
+          win32icon = ""
           win32res = ""
           win32manifest = ""
           includewin32manifest = true
@@ -981,6 +983,7 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
     member x.ignoreSymbolStoreSequencePoints = data.ignoreSymbolStoreSequencePoints
     member x.internConstantStrings = data.internConstantStrings
     member x.extraOptimizationIterations = data.extraOptimizationIterations
+    member x.win32icon = data.win32icon
     member x.win32res = data.win32res
     member x.win32manifest = data.win32manifest
     member x.includewin32manifest = data.includewin32manifest

--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -207,6 +207,7 @@ type TcConfigBuilder =
       mutable ignoreSymbolStoreSequencePoints: bool
       mutable internConstantStrings: bool
       mutable extraOptimizationIterations: int
+      mutable win32icon: string 
       mutable win32res: string 
       mutable win32manifest: string
       mutable includewin32manifest: bool
@@ -395,6 +396,7 @@ type TcConfig =
     member ignoreSymbolStoreSequencePoints: bool
     member internConstantStrings: bool
     member extraOptimizationIterations: int
+    member win32icon: string
     member win32res: string 
     member win32manifest: string
     member includewin32manifest: bool

--- a/src/fsharp/CompilerOptions.fs
+++ b/src/fsharp/CompilerOptions.fs
@@ -733,6 +733,10 @@ let resourcesFlagsFsi (_tcConfigB: TcConfigBuilder) = []
 let resourcesFlagsFsc (tcConfigB: TcConfigBuilder) =
     [
         CompilerOption
+            ("win32icon", tagFile,
+             OptionString (fun s -> tcConfigB.win32icon <- s), None,
+             Some (FSComp.SR.optsWin32icon()))
+        CompilerOption
            ("win32res", tagFile,
             OptionString (fun s -> tcConfigB.win32res <- s), None,
             Some (FSComp.SR.optsWin32res()))

--- a/src/fsharp/CreateILModule.fs
+++ b/src/fsharp/CreateILModule.fs
@@ -467,7 +467,7 @@ module MainModuleBuilder =
                   yield  ILNativeResource.Out [| yield! ResFileFormat.ResFileHeader() 
                                                  yield! (ManifestResourceFormat.VS_MANIFEST_RESOURCE((FileSystem.ReadAllBytesShim win32Manifest), tcConfig.target = CompilerTarget.Dll)) |]
               if tcConfig.win32res = "" && tcConfig.win32icon <> "" && tcConfig.target <> CompilerTarget.Dll then
-                  let ms = new MemoryStream()
+                  use ms = new MemoryStream()
                   Win32ResourceConversions.AppendIconToResourceStream(ms, FileSystem.FileStreamReadShim tcConfig.win32icon)
                   yield ILNativeResource.Out [| yield! ResFileFormat.ResFileHeader()
                                                 yield! ms.ToArray() |] ]
@@ -492,4 +492,3 @@ module MainModuleBuilder =
                         yield! codegenResults.ilNetModuleAttrs ])
               NativeResources=nativeResources
               Manifest = manifest }
-

--- a/src/fsharp/CreateILModule.fs
+++ b/src/fsharp/CreateILModule.fs
@@ -11,6 +11,7 @@ open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
 open FSharp.Compiler
 open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.NativeRes
 open FSharp.Compiler.AbstractIL.StrongNameSign
 open FSharp.Compiler.BinaryResourceFormats
 open FSharp.Compiler.CheckDeclarations
@@ -464,7 +465,12 @@ module MainModuleBuilder =
                   yield ILNativeResource.Out (FileSystem.ReadAllBytesShim tcConfig.win32res) 
               if tcConfig.includewin32manifest && not(win32Manifest = "") && not runningOnMono then
                   yield  ILNativeResource.Out [| yield! ResFileFormat.ResFileHeader() 
-                                                 yield! (ManifestResourceFormat.VS_MANIFEST_RESOURCE((FileSystem.ReadAllBytesShim win32Manifest), tcConfig.target = CompilerTarget.Dll)) |]]
+                                                 yield! (ManifestResourceFormat.VS_MANIFEST_RESOURCE((FileSystem.ReadAllBytesShim win32Manifest), tcConfig.target = CompilerTarget.Dll)) |]
+              if tcConfig.win32res = "" && tcConfig.win32icon <> "" && tcConfig.target <> CompilerTarget.Dll then
+                  let ms = new MemoryStream()
+                  Win32ResourceConversions.AppendIconToResourceStream(ms, FileSystem.FileStreamReadShim tcConfig.win32icon)
+                  yield ILNativeResource.Out [| yield! ResFileFormat.ResFileHeader()
+                                                yield! ms.ToArray() |] ]
 
         // Add attributes, version number, resources etc. 
         {mainModule with 

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -853,6 +853,7 @@ optsNoInterface,"Don't add a resource to the generated assembly containing F#-sp
 optsSig,"Print the inferred interface of the assembly to a file"
 optsReference,"Reference an assembly (Short form: -r)"
 optsCompilerTool,"Reference an assembly or directory containing a design time tool (Short form: -t)"
+optsWin32icon,"Specify a Win32 icon file (.ico)"
 optsWin32res,"Specify a Win32 resource file (.res)"
 optsWin32manifest,"Specify a Win32 manifest file"
 optsNowin32manifest,"Do not include the default Win32 manifest"

--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -78,6 +78,7 @@ type public Fsc () as this =
     let mutable versionFile : string = null
     let mutable warningLevel : string = null
     let mutable warnOn : string = null
+    let mutable win32icon: string = null
     let mutable win32res : string = null
     let mutable win32manifest : string = null
     let mutable vserrors : bool = false
@@ -224,6 +225,9 @@ type public Fsc () as this =
         match warningsNotAsErrors with
         | null -> ()
         | _ -> builder.AppendSwitchIfNotNull("--warnaserror-:", warningsNotAsErrors |> splitAndWsTrim, ",")
+
+        // Win32IconFile
+        builder.AppendSwitchIfNotNull("--win32icon:", win32icon)
 
         // Win32ResourceFile
         builder.AppendSwitchIfNotNull("--win32res:", win32res)
@@ -489,6 +493,11 @@ type public Fsc () as this =
     member fsc.VersionFile
         with get() = versionFile
         and set(s) = versionFile <- s
+
+    // For specifying a win32 icon file (.ico)
+    member fsc.Win32IconFile
+        with get() = win32icon
+        and set(s) = win32icon <- s
 
     // For specifying a win32 native resource file (.res)
     member fsc.Win32ResourceFile

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -329,6 +329,7 @@ this file.
               WarningLevel="$(WarningLevel)"
               WarningsAsErrors="$(WarningsAsErrors)"
               WarnOn="$(WarnOn)"
+              Win32IconFile ="$(ApplicationIcon)"
               Win32ManifestFile="$(Win32Manifest)"
               Win32ResourceFile="$(Win32Resource)">
           <Output TaskParameter="CommandLineArgs" ItemName="FscCommandLineArgs" />

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Zobrazit banner verze kompilátoru a ukončit</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">Funkce správy balíčků vyžaduje jazykovou verzi 5.0, použijte /langversion:preview.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Banner zur Compilerversion anzeigen und beenden</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">Für das Paketverwaltungsfeature ist Sprachversion 5.0 erforderlich. Verwenden Sie /langversion:preview.</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Mostrar el banner de versión del compilador y salir</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">La característica de administración de paquetes requiere la versión de lenguaje 5.0; use /langversion:preview</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Afficher la bannière de la version du compilateur et quitter</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="translated">Spécifier un fichier icône Win32 (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">La fonctionnalité de gestion des packages nécessite la version 5.0 du langage. Utilisez /langversion:preview</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Visualizza il banner della versione del compilatore ed esce</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">Con la funzionalità di gestione pacchetti è richiesta la versione 5.0 del linguaggio. Usare /langversion:preview</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -267,6 +267,11 @@
         <target state="translated">コンパイラ バージョンのバナーを表示して終了する</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">パッケージ管理機能では、言語バージョン 5.0 で /langversion:preview を使用する必要があります</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -267,6 +267,11 @@
         <target state="translated">컴파일러 버전 배너를 표시하고 종료</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">패키지 관리 기능을 사용하려면 언어 버전 5.0이 필요합니다. /langversion:preview를 사용하세요.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Wyświetl baner wersji kompilatora i zakończ</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">Funkcja zarządzania pakietami wymaga języka w wersji 5.0, użyj parametru /langversion:preview</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Exibir a faixa de versão do compilador e sair</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">O recurso de gerenciamento de pacotes requer a versão de idioma 5.0. Use /langversion:preview</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Отобразить окно с версией компилятора и выйти</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">Для функции управления пакетами требуется версия языка 5.0, используйте параметр /langversion:preview</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Derleyici sürümü başlığını görüntüle ve çık</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">Paket yönetimi özelliği dil sürümü 5.0 gerektiriyor, /langversion:preview kullanın</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -267,6 +267,11 @@
         <target state="translated">显示编译器版本横幅并退出</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">包管理功能需要语言版本 5.0，请使用 /langversion:preview</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -267,6 +267,11 @@
         <target state="translated">顯示編譯器版本橫幅並結束</target>
         <note />
       </trans-unit>
+      <trans-unit id="optsWin32icon">
+        <source>Specify a Win32 icon file (.ico)</source>
+        <target state="new">Specify a Win32 icon file (.ico)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="packageManagementRequiresVFive">
         <source>The package management feature requires language version 5.0 use /langversion:preview</source>
         <target state="translated">套件管理功能需要語言版本 5.0，請使用 /langversion:preview</target>

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/help/help40.437.1033.bsl
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/help/help40.437.1033.bsl
@@ -47,6 +47,7 @@ Copyright (c) Microsoft Corporation. All Rights Reserved.
 
 
 		- RESOURCES -
+--win32icon:<file>                       Specify a Win32 icon file (.ico)
 --win32res:<file>                        Specify a Win32 resource file (.res)
 --win32manifest:<file>                   Specify a Win32 manifest file
 --nowin32manifest                        Do not include the default Win32


### PR DESCRIPTION
fix for #10065
Currently the `<ApplicationIcon>` property group and `win32icon` compiler option aren't working for f# but are for c#/vb. _`<ApplicationIcon>` is already defined as a property group but doesn't do anything_. `win32icon` is added in the tooltask and compiler options. The icon's attached as a native resource in `\src\fsharp\CreateILModule.fs` using the same logic as Roslyn, ignoring if it doesn't exist, a win32res file is specified, or the output type is set to a dll. Actually conversion of the icon file to resource bytes is handled by existing code in `\src\fsharp\absil\ilnativeres.fs`

* adds compiler flag `--win32icon`
* fixes property group `<ApplicationIcon>`
* adds "win32icon" compiler option, a path to an `.ico` file 
    * included as a native resource
    * ignored when output type is set to dll
    * ignored when win32res is included