### PR TITLE
Don't deploy Full extension after build

### DIFF
--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -8,6 +8,8 @@
     <PackageTargetFallback>netcoreapp1.0</PackageTargetFallback>
     <IsShipping>true</IsShipping>
     <DependencyTargetFramework>net472</DependencyTargetFramework>
+    <!-- locally you should deploy VisualFSharpDebug.vsix instead -->
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
 
   <Import Project="VisualFSharp.Core.targets" />


### PR DESCRIPTION

Running 

    .\build -c Release -deployExtensions

randomly deployed either the VisualFSharpDebug.vsix or VisualFSharpFull.vsix depending which got built first/last

We only want to deply the VisualFSharpDebug.vsix.

