### PR TITLE
Optimize PreComputeTupleReader

### DIFF
--- a/src/fsharp/FSharp.Core/reflect.fs
+++ b/src/fsharp/FSharp.Core/reflect.fs
@@ -187,6 +187,56 @@ module internal Impl =
 
         expr.Compile ()
 
+    let compileTupleReader tupleEncField getTupleElementAccessors typ =
+        let rec assignments (typ: Type) (tuple: Expression) outputArray startIndex = seq {
+            let elements =
+                match getTupleElementAccessors typ with
+                | Choice1Of2 (fi: FieldInfo[]) -> fi |> Array.map (fun fi -> Expression.Field (tuple, fi), fi.FieldType)
+                | Choice2Of2 (pi: PropertyInfo[]) -> pi |> Array.map (fun pi -> Expression.Property (tuple, pi), pi.PropertyType)
+
+            for index, (element, elementType) in elements |> Array.indexed do
+                if index = tupleEncField then
+                    let innerTupleParam = Expression.Parameter (elementType, "innerTuple" + index.ToString ())
+                    Expression.Block (
+                        [ innerTupleParam ],
+                        [
+                            yield Expression.Assign (innerTupleParam, element) :> Expression
+                            yield! assignments elementType innerTupleParam outputArray (startIndex + index)
+                        ]
+                    ) :> Expression
+                else
+                    Expression.Assign (
+                        Expression.ArrayAccess (outputArray, Expression.Constant (index + startIndex)),
+                        Expression.Convert (element, typeof<obj>)
+                    ) :> Expression }
+
+        let param = Expression.Parameter (typeof<obj>, "outerTuple")
+        let outputArray = Expression.Variable (typeof<obj[]>, "output")
+        let rec outputLength tupleEncField (typ: Type) =
+            let genericArgs = typ.GetGenericArguments ()
+
+            if genericArgs.Length > tupleEncField then
+                tupleEncField + outputLength tupleEncField genericArgs.[genericArgs.Length - 1]
+            else
+                genericArgs.Length
+
+        let expr =
+            Expression.Lambda<Func<obj, obj[]>> (
+                Expression.Block (
+                    [ outputArray ],
+                    [|
+                        yield Expression.Assign (
+                            outputArray,
+                            Expression.NewArrayBounds (typeof<obj>, Expression.Constant (outputLength tupleEncField typ))
+                        ) :> Expression
+                        yield! assignments typ (Expression.Convert (param, typ)) outputArray 0
+                        yield outputArray :> Expression
+                    |]
+                ),
+                param)
+
+        expr.Compile ()
+
     //-----------------------------------------------------------------
     // ATTRIBUTE DECOMPILATION
 
@@ -634,16 +684,19 @@ module internal Impl =
           (fun (args: obj[]) ->
               ctor.Invoke(BindingFlags.InvokeMethod ||| BindingFlags.Instance ||| BindingFlags.Public, null, args, null))
 
+    let getTupleElementAccessors (typ: Type) =
+        if typ.IsValueType then
+            Choice1Of2 (typ.GetFields (instanceFieldFlags ||| BindingFlags.Public) |> orderTupleFields)
+        else
+            Choice2Of2 (typ.GetProperties (instancePropertyFlags ||| BindingFlags.Public) |> orderTupleProperties)
+
     let rec getTupleReader (typ: Type) =
         let etys = typ.GetGenericArguments()
         // Get the reader for the outer tuple record
         let reader =
-            if typ.IsValueType then
-                let fields = (typ.GetFields (instanceFieldFlags ||| BindingFlags.Public) |> orderTupleFields)
-                ((fun (obj: obj) -> fields |> Array.map (fun field -> field.GetValue obj)))
-            else
-                let props = (typ.GetProperties (instancePropertyFlags ||| BindingFlags.Public) |> orderTupleProperties)
-                ((fun (obj: obj) -> props |> Array.map (fun prop -> prop.GetValue (obj, null))))
+            match getTupleElementAccessors typ with
+            | Choice1Of2 fi -> fun obj -> fi |> Array.map (fun f -> f.GetValue obj)
+            | Choice2Of2 pi -> fun obj -> pi |> Array.map (fun p -> p.GetValue (obj, null))
         if etys.Length < maxTuple
         then reader
         else
@@ -1009,7 +1062,7 @@ type FSharpValue =
 
     static member PreComputeTupleReader(tupleType: Type) : (obj -> obj[])  =
         checkTupleType("tupleType", tupleType)
-        getTupleReader tupleType
+        (compileTupleReader tupleEncField getTupleElementAccessors tupleType).Invoke
 
     static member PreComputeTuplePropertyInfo(tupleType: Type, index: int) =
         checkTupleType("tupleType", tupleType)

--- a/src/fsharp/FSharp.Core/reflect.fs
+++ b/src/fsharp/FSharp.Core/reflect.fs
@@ -191,7 +191,9 @@ module internal Impl =
         let rec writeTupleIntoArray (typ: Type) (tuple: Expression) outputArray startIndex = seq {
             let elements =
                 match getTupleElementAccessors typ with
+                // typ is a struct tuple and its elements are accessed via fields 
                 | Choice1Of2 (fi: FieldInfo[]) -> fi |> Array.map (fun fi -> Expression.Field (tuple, fi), fi.FieldType)
+                // typ is a class tuple and its elements are accessed via properties 
                 | Choice2Of2 (pi: PropertyInfo[]) -> pi |> Array.map (fun pi -> Expression.Property (tuple, pi), pi.PropertyType)
 
             for index, (element, elementType) in elements |> Array.indexed do
@@ -224,14 +226,14 @@ module internal Impl =
             Expression.Lambda<Func<obj, obj[]>> (
                 Expression.Block (
                     [ outputArray ],
-                    [|
+                    [
                         yield Expression.Assign (
                             outputArray,
                             Expression.NewArrayBounds (typeof<obj>, Expression.Constant (outputLength tupleEncField typ))
                         ) :> Expression
                         yield! writeTupleIntoArray typ (Expression.Convert (param, typ)) outputArray 0
                         yield outputArray :> Expression
-                    |]
+                    ]
                 ),
                 param)
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Reflection/FSharpReflection.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Reflection/FSharpReflection.fs
@@ -665,6 +665,9 @@ type FSharpValueTests() =
         // Nested 
         let nestedtuplereader = FSharpValue.PreComputeTupleReader(typeof<Tuple<int, Tuple<int, string>>>)    
         Assert.AreEqual(nestedtuplereader(tuple3).[1], box(2, "tuple"))
+
+        let longTupleReader = FSharpValue.PreComputeTupleReader (longTuple.GetType ())
+        Assert.AreEqual (longTupleReader longTuple, [| box ("yup", 1s); box 2; box 3; box 4; box 5; box 6; box 7; box 8; box 9; box 10; box 11; box (Some 12); box 13; box "nope"; box (struct (15, 16)); box 17; box 18; box (ValueSome 19) |])
         
         // null value
         CheckThrowsArgumentException(fun () ->FSharpValue.PreComputeTupleReader(null)|> ignore)
@@ -683,6 +686,9 @@ type FSharpValueTests() =
         let nestedtuplereader = FSharpValue.PreComputeTupleReader(typeof<struct (int * struct (int * string))>)    
         Assert.AreEqual(nestedtuplereader(structTuple3).[1], box (struct (2, "tuple")))
         
+        let longTupleReader = FSharpValue.PreComputeTupleReader (longStructTuple.GetType ())
+        Assert.AreEqual (longTupleReader longStructTuple, [| box ("yup", 1s); box 2; box 3; box 4; box 5; box 6; box 7; box 8; box 9; box 10; box 11; box (Some 12); box 13; box "nope"; box (struct (15, 16)); box 17; box 18; box (ValueSome 19) |])
+
         // invalid value
         CheckThrowsArgumentException(fun () -> FSharpValue.PreComputeTupleReader(typeof<StructRecordType>) |> ignore)        
         


### PR DESCRIPTION
``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=6.0.100-preview.3.21173.9
  [Host]     : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT DEBUG
  DefaultJob : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
```
|   Method |         Mean |      Error |     StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |-------------:|-----------:|-----------:|-------:|------:|------:|----------:|
| New3Part |    78.389 ns |  3.2447 ns |  9.5672 ns | 0.0592 |     - |     - |     496 B |
| Old3Part | 1,998.145 ns | 16.6370 ns | 14.7483 ns | 0.1144 |     - |     - |     984 B |
| New1Part |     9.285 ns |  0.1842 ns |  0.1538 ns | 0.0076 |     - |     - |      64 B |
| Old1Part |   180.918 ns |  3.5238 ns |  3.2961 ns | 0.0076 |     - |     - |      64 B |

Tested against
```fsharp
let threePart = (("yup", 1s), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, Some 12, 13, "nope",  17, 18, ValueSome 19)
let onePart = ("yup", 1s)
```

And I think that's the conclusion to optimizing the PreCompute family of methods 🥳 (as far as big gains like this go anyway).