### PR TITLE
[VS][WIP] Generate signature of an Entity symbol for viewing metadata

### DIFF
--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -359,6 +359,9 @@ type FSharpEntity =
     /// Safe version of `GetMembersFunctionsAndValues`.
     member TryGetMembersFunctionsAndValues: unit -> IList<FSharpMemberOrFunctionOrValue>
 
+    /// Generates the signature of the symbol as source text.
+    member TryGenerateSignatureText: unit -> ISourceText option
+
 /// Represents a delegate signature in an F# symbol
 [<Class>] 
 type FSharpDelegateSignature =

--- a/vsintegration/src/FSharp.Editor/LanguageService/MetadataAsSource.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/MetadataAsSource.fs
@@ -26,41 +26,15 @@ open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.TextManager.Interop
 
-open FSharp.Compiler.Text
-
 module internal MetadataAsSource =
 
-    open Microsoft.CodeAnalysis.CSharp
-    open ICSharpCode.Decompiler
-    open ICSharpCode.Decompiler.CSharp
-    open ICSharpCode.Decompiler.Metadata
-    open ICSharpCode.Decompiler.CSharp.Transforms
-    open ICSharpCode.Decompiler.TypeSystem
-
-    let generateTemporaryCSharpDocument (asmIdentity: AssemblyIdentity, name: string, metadataReferences) =
+    let generateTemporaryDocument (asmIdentity: AssemblyIdentity, name: string, metadataReferences) =
         let rootPath = Path.Combine(Path.GetTempPath(), "MetadataAsSource")
-        let extension = ".cs"
+        let extension = ".fsi"
         let directoryName = Guid.NewGuid().ToString("N")
         let temporaryFilePath = Path.Combine(rootPath, directoryName, name + extension)
 
         let projectId = ProjectId.CreateNewId()
-
-        let parseOptions = CSharpParseOptions.Default.WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview)
-        // Just say it's always a DLL since we probably won't have a Main method
-        let compilationOptions = Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-
-        // We need to include the version information of the assembly so InternalsVisibleTo and stuff works
-        let assemblyInfoDocumentId = DocumentId.CreateNewId(projectId)
-        let assemblyInfoFileName = "AssemblyInfo" + extension
-        let assemblyInfoString = String.Format(@"[assembly: System.Reflection.AssemblyVersion(""{0}"")]", asmIdentity.Version)
-
-        let assemblyInfoSourceTextContainer = SourceText.From(assemblyInfoString, Encoding.UTF8).Container
-
-        let assemblyInfoDocument = 
-            DocumentInfo.Create(
-                assemblyInfoDocumentId,
-                assemblyInfoFileName,
-                loader = TextLoader.From(assemblyInfoSourceTextContainer, VersionStamp.Default))
 
         let generatedDocumentId = DocumentId.CreateNewId(projectId)
         let documentInfo = 
@@ -76,33 +50,11 @@ module internal MetadataAsSource =
                 VersionStamp.Default,
                 name = asmIdentity.Name,
                 assemblyName = asmIdentity.Name,
-                language = LanguageNames.CSharp,
-                compilationOptions = compilationOptions,
-                parseOptions = parseOptions,
-                documents = [|assemblyInfoDocument;documentInfo|],
+                language = LanguageNames.FSharp,
+                documents = [|documentInfo|],
                 metadataReferences = metadataReferences)
 
         (projectInfo, documentInfo)
-
-    let decompileCSharp (symbolFullTypeName: string, assemblyLocation: string) =
-        let logger = new StringBuilder()
-
-        // Initialize a decompiler with default settings.
-        let decompiler = CSharpDecompiler(assemblyLocation, DecompilerSettings())
-        // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
-        // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
-        decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers())
-
-        let fullTypeName = FullTypeName(symbolFullTypeName)
-
-        // Try to decompile; if an exception is thrown the caller will handle it
-        let text = decompiler.DecompileTypeAsString(fullTypeName)
-
-        let text = text + "#if false // " + Environment.NewLine
-        let text = text + logger.ToString()
-        let text = text + "#endif" + Environment.NewLine
-
-        SourceText.From(text)
 
     let showDocument (filePath, name, serviceProvider: IServiceProvider) =
         let vsRunningDocumentTable4 = serviceProvider.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable4>()
@@ -139,9 +91,9 @@ module internal MetadataAsSource =
 [<Sealed>]
 type internal FSharpMetadataAsSourceService() =
 
-    member val CSharpFiles = System.Collections.Concurrent.ConcurrentDictionary(StringComparer.OrdinalIgnoreCase)
+    member val Files = System.Collections.Concurrent.ConcurrentDictionary(StringComparer.OrdinalIgnoreCase)
 
-    member this.ShowCSharpDocument(projInfo: ProjectInfo, docInfo: DocumentInfo, text: Text.SourceText) =
+    member this.ShowDocument(projInfo: ProjectInfo, docInfo: DocumentInfo, text: Text.SourceText) =
         let _ =
             let directoryName = Path.GetDirectoryName(docInfo.FilePath)
             if Directory.Exists(directoryName) |> not then
@@ -150,6 +102,6 @@ type internal FSharpMetadataAsSourceService() =
             use writer = new StreamWriter(fileStream)
             text.Write(writer)
 
-        this.CSharpFiles.[docInfo.FilePath] <- (projInfo, docInfo)
+        this.Files.[docInfo.FilePath] <- (projInfo, docInfo)
 
         MetadataAsSource.showDocument(docInfo.FilePath, docInfo.Name, ServiceProvider.GlobalProvider)

--- a/vsintegration/src/FSharp.Editor/LanguageService/SingleFileWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SingleFileWorkspaceMap.fs
@@ -33,8 +33,8 @@ type internal SingleFileWorkspaceMap(workspace: VisualStudioWorkspace,
         projectContext.AddSourceFile(filePath, sourceCodeKind = createSourceCodeKind filePath)
         projectContext
 
-    let createCSharpMetadataProjectContext (projInfo: ProjectInfo) (docInfo: DocumentInfo) =
-        let projectContext = projectContextFactory.CreateProjectContext(LanguageNames.CSharp, projInfo.Id.ToString(), projInfo.FilePath, Guid.NewGuid(), null, null)
+    let createMetadataProjectContext (projInfo: ProjectInfo) (docInfo: DocumentInfo) =
+        let projectContext = projectContextFactory.CreateProjectContext(LanguageNames.FSharp, projInfo.Id.ToString(), projInfo.FilePath, Guid.NewGuid(), null, null)
         projectContext.DisplayName <- projInfo.Name
         projectContext.AddSourceFile(docInfo.FilePath, sourceCodeKind = SourceCodeKind.Regular)
         
@@ -54,10 +54,10 @@ type internal SingleFileWorkspaceMap(workspace: VisualStudioWorkspace,
             if document.Project.Language = FSharpConstants.FSharpLanguageName && workspace.CurrentSolution.GetDocumentIdsWithFilePath(document.FilePath).Length = 0 then
                 files.[document.FilePath] <- createProjectContext document.FilePath
 
-            if optionsManager.MetadataAsSource.CSharpFiles.ContainsKey(document.FilePath) && workspace.CurrentSolution.GetDocumentIdsWithFilePath(document.FilePath).Length = 0 then
-                match optionsManager.MetadataAsSource.CSharpFiles.TryGetValue(document.FilePath) with
+            if optionsManager.MetadataAsSource.Files.ContainsKey(document.FilePath) && workspace.CurrentSolution.GetDocumentIdsWithFilePath(document.FilePath).Length = 0 then
+                match optionsManager.MetadataAsSource.Files.TryGetValue(document.FilePath) with
                 | true, (projInfo, docInfo) ->
-                    files.[document.FilePath] <- createCSharpMetadataProjectContext projInfo docInfo
+                    files.[document.FilePath] <- createMetadataProjectContext projInfo docInfo
                 | _ ->
                     ()
         )
@@ -80,7 +80,7 @@ type internal SingleFileWorkspaceMap(workspace: VisualStudioWorkspace,
                 projectContext.Dispose()
             | _ -> ()
 
-            optionsManager.MetadataAsSource.CSharpFiles.TryRemove(document.FilePath) |> ignore
+            optionsManager.MetadataAsSource.Files.TryRemove(document.FilePath) |> ignore
         )
 
         do

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -272,7 +272,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
                     let! location = symbol.Locations |> Seq.tryHead
                     return (FSharpGoToDefinitionResult.NavigableItem(FSharpGoToDefinitionNavigableItem(project.GetDocument(location.SourceTree), location.SourceSpan)), idRange)
                 | _ ->
-                    let tmpProjInfo, tmpDocId = MetadataAsSource.generateTemporaryCSharpDocument(AssemblyIdentity(targetSymbolUse.Symbol.Assembly.QualifiedName), targetSymbolUse.Symbol.DisplayName, originDocument.Project.MetadataReferences)
+                    let tmpProjInfo, tmpDocId = MetadataAsSource.generateTemporaryDocument(AssemblyIdentity(targetSymbolUse.Symbol.Assembly.QualifiedName), targetSymbolUse.Symbol.DisplayName, originDocument.Project.MetadataReferences)
                     return (FSharpGoToDefinitionResult.ExternalAssembly(tmpProjInfo, tmpDocId, targetSymbolUse, targetExternalSym), idRange)
 
             | FindDeclResult.DeclFound targetRange -> 


### PR DESCRIPTION
Related to this: https://github.com/dotnet/fsharp/pull/11303

The PR from @baronfel : https://github.com/dotnet/fsharp/pull/11201 will probably be useful too.

At the moment, when trying to navigate to an external symbol, we decompile the DLL as C# code that the symbol exists in. This isn't particularly useful when you have a decompiled C# view of F# metadata; it isn't as helpful compared to what a F# signature view looks like. 

What we really want to do is to generate a signature (.fsi) file to be used as metadata viewing in VS for *any* symbol, C# or F#, as long as it was navigated from a F# document.