### PR TITLE
Relax validation on warnings as errors passed to compiler

### DIFF
--- a/src/fsharp/CompilerOptions.fs
+++ b/src/fsharp/CompilerOptions.fs
@@ -594,11 +594,9 @@ let inputFileFlagsFsi (tcConfigB: TcConfigBuilder) =
 let errorsAndWarningsFlags (tcConfigB: TcConfigBuilder) = 
     let trimFS (s:string) = if s.StartsWithOrdinal "FS" then s.Substring 2 else s
     let trimFStoInt (s:string) =
-        try
-            Some (int32 (trimFS s))
-        with _ ->
-            errorR(Error(FSComp.SR.buildArgInvalidInt s, rangeCmdArgs))
-            None
+        match Int32.TryParse (trimFS s) with
+        | true, n ->  Some n
+        | false, _ -> None
     [
         CompilerOption("warnaserror", tagNone, OptionSwitch(fun switch ->
             tcConfigB.errorSeverityOptions <-

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/warnaserror/env.lst
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/warnaserror/env.lst
@@ -9,9 +9,11 @@
 	SOURCE=t6.fs SCFLAGS="--warnaserror+ --warnaserror+:25"		# t6.fs enabled, incl list with one warning, list with 1 element
 
 	SOURCE=t7.fs SCFLAGS="--warnaserror- --warnaserror-:25,26,988"	# t7.fs disabled, excl list with all warnings, list with >1 element
-	SOURCE=t8.fs SCFLAGS="--warnaserror- --warnaserror-:25,26"	# t8.fs disabled, excl list with some warning, list with >1 element
-	SOURCE=t9.fs SCFLAGS="--warnaserror- --warnaserror-:25"		# t9.fs disabled, excl list with one warning, list with 1 element
+	SOURCE=t8.fs SCFLAGS="--warnaserror- --warnaserror-:25,26"	    # t8.fs disabled, excl list with some warning, list with >1 element
+	SOURCE=t9.fs SCFLAGS="--warnaserror- --warnaserror-:25"		    # t9.fs disabled, excl list with one warning, list with 1 element
 
 	SOURCE=t10.fs SCFLAGS="--warnaserror- --warnaserror+:25,26,988"	# t10.fs disabled, incl list with all warnings, list with >1 element
-	SOURCE=t11.fs SCFLAGS="--warnaserror- --warnaserror+:25,26"	# t11.fs disabled, incl list with some warning, list with >1 element
+	SOURCE=t11.fs SCFLAGS="--warnaserror- --warnaserror+:25,26"	    # t11.fs disabled, incl list with some warning, list with >1 element
 	SOURCE=t12.fs SCFLAGS="--warnaserror- --warnaserror+:25"        # t12.fs disabled, incl list with one warning, list with 1 element
+	
+	SOURCE=t12.fs SCFLAGS="--warnaserror- --warnaserror+:25,nu0001,fs0001"  # t12a.fs disabled, incl list with one warning, list with 1 element


### PR DESCRIPTION
Fix #11300

The dotnet sdk allows warnings as errors values to contain settings from mixed tools.  Whilst this is a fairly suspect approach, it has been in use for quite a few years by now.  Certainly the C# compiler supports this approach.

The F# compiler inadvertently validated the arguments to --warningaserror so that non numeric values, prefixed with anything other than fs threw an exception.  This PR relaxes that validation.

Adds a test case that ensures prefixes nu are supported.
