### PR TITLE
Added 'layoutModuleOrNamespace' to NicePrint

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/CodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CodeAnalysisExtensions.fs
@@ -30,6 +30,11 @@ type Project with
 
 type Solution with 
 
+    /// Checks if the file path is associated with a document in the solution.
+    member self.ContainsDocumentWithFilePath filePath =
+        self.GetDocumentIdsWithFilePath(filePath).IsEmpty
+        |> not
+
     /// Try to get a document inside the solution using the document's name
     member self.TryGetDocumentNamed docName =
         self.Projects |> Seq.tryPick (fun proj ->

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -276,8 +276,8 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
                     return (FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences), idRange)
 
             | FindDeclResult.DeclFound targetRange -> 
-                // If the file does not actually exist, it's external considered external.
-                if not (File.Exists targetRange.FileName) then
+                // If the file is not associated with a document, it's considered external.
+                if not (originDocument.Project.Solution.ContainsDocumentWithFilePath(targetRange.FileName)) then
                     let metadataReferences = originDocument.Project.MetadataReferences
                     return (FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences), idRange)
                 else


### PR DESCRIPTION
This adds 'layoutModuleOrNamespace' to the NicePrint module and is used when trying to get metadata on a module.
The PR also has a small tweak to determine if a symbol's declaration actually exists within the solution for VS.