### PR TITLE
Fix signature type range

### DIFF
--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1360,6 +1360,10 @@ type SynTypeDefnSig =
         members: SynMemberSig list *
         range: range
 
+    member this.Range =
+        match this with
+        | SynTypeDefnSig(range=m) -> m
+
 [<NoEquality; NoComparison>]
 type SynField =
     | SynField of

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -1558,6 +1558,9 @@ type SynTypeDefnSig =
         members: SynMemberSig list *
         range: range
 
+    /// Gets the syntax range of this construct
+    member Range: range
+
 /// Represents the syntax tree for a field declaration in a record or class
 [<NoEquality; NoComparison>]
 type SynField =

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -809,8 +809,10 @@ moduleSpfn:
            match $3 with
            | [] -> raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEmptyModuleDefn()) 
            | h :: t -> h, t 
-        let tc = (SynTypeDefnSig(SynComponentInfo($1@cas, a, cs, b, c, d, d2, d3), e, f, g))in 
-        SynModuleSigDecl.Types (tc :: rest, rhs parseState 3) } 
+        let tc = (SynTypeDefnSig(SynComponentInfo($1@cas, a, cs, b, c, d, d2, d3), e, f, g))
+        let lastType = List.tryLast rest |> Option.defaultValue tc |> fun t -> t.Range
+        let m = mkRange lastType.FileName (lhs parseState).Start lastType.End
+        SynModuleSigDecl.Types (tc :: rest, m) } 
 
   | opt_attributes opt_declVisibility exconSpfn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -8379,6 +8379,8 @@ FSharp.Compiler.Syntax.SynTypeDefnSig: FSharp.Compiler.Syntax.SynComponentInfo t
 FSharp.Compiler.Syntax.SynTypeDefnSig: FSharp.Compiler.Syntax.SynTypeDefnSig NewSynTypeDefnSig(FSharp.Compiler.Syntax.SynComponentInfo, FSharp.Compiler.Syntax.SynTypeDefnSigRepr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberSig], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeDefnSig: FSharp.Compiler.Syntax.SynTypeDefnSigRepr get_typeRepr()
 FSharp.Compiler.Syntax.SynTypeDefnSig: FSharp.Compiler.Syntax.SynTypeDefnSigRepr typeRepr
+FSharp.Compiler.Syntax.SynTypeDefnSig: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynTypeDefnSig: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynTypeDefnSig: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynTypeDefnSig: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynTypeDefnSig: Int32 Tag

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -506,7 +506,8 @@ module SynModuleOrNamespaceSig =
                 """
 namespace Foobar
 
-type Bar = | Bar of string * int"""
+type Bar = | Bar of string * int
+"""
 
         match parseResults with
         | ParsedInput.SigFile(ParsedSigFileInput(modules = [
@@ -523,10 +524,31 @@ type Bar = | Bar of string * int"""
 // bar
 namespace  global
 
-type Bar = | Bar of string * int"""
+type Bar = | Bar of string * int
+"""
 
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
             SynModuleOrNamespaceSig(kind = SynModuleOrNamespaceKind.GlobalNamespace; range = r) ])) ->
             assertRange (3, 0) (5, 32) r
+        | _ -> Assert.Fail "Could not get valid AST"
+
+module SignatureTypes =
+    [<Test>]
+    let ``Range of Type should end at end keyword`` () =
+        let parseResults = 
+            getParseResultsOfSignatureFile
+                """namespace GreatProjectThing
+
+type Meh =
+        class
+        end
+
+
+// foo"""
+
+        match parseResults with
+        | ParsedInput.SigFile (ParsedSigFileInput (modules = [
+            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(range = r)]) ])) ->
+            assertRange (3, 0) (5,11) r
         | _ -> Assert.Fail "Could not get valid AST"


### PR DESCRIPTION
Depends on #11364, will rebase afterwards.
Take the end position of the last type to end `SynModuleSigDecl.Types`.
Fixes #11312.