### PR TITLE
Recognize IsByRefLikeAttribute from user code.

### DIFF
--- a/src/fsharp/AugmentWithHashCompare.fs
+++ b/src/fsharp/AugmentWithHashCompare.fs
@@ -823,7 +823,7 @@ let TyconIsCandidateForAugmentationWithCompare (g: TcGlobals) (tycon: Tycon) =
     // This type gets defined in prim-types, before we can add attributes to F# type definitions
     let isUnit = g.compilingFslib && tycon.DisplayName = "Unit"
     not isUnit && 
-    not (TyconRefHasAttribute g tycon.Range g.attrib_IsByRefLikeAttribute (mkLocalTyconRef tycon)) &&
+    not (isByrefLikeTyconRef g tycon.Range (mkLocalTyconRef tycon)) &&
     match getAugmentationAttribs g tycon with 
     // [< >] 
     | true, true, None, None, None, None, None, None, None
@@ -838,7 +838,7 @@ let TyconIsCandidateForAugmentationWithEquals (g: TcGlobals) (tycon: Tycon) =
     // This type gets defined in prim-types, before we can add attributes to F# type definitions
     let isUnit = g.compilingFslib && tycon.DisplayName = "Unit"
     not isUnit && 
-    not (TyconRefHasAttribute g tycon.Range g.attrib_IsByRefLikeAttribute (mkLocalTyconRef tycon)) &&
+    not (isByrefLikeTyconRef g tycon.Range (mkLocalTyconRef tycon)) &&
 
     match getAugmentationAttribs g tycon with 
     // [< >] 

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -2218,7 +2218,7 @@ let CheckRecdField isUnion cenv env (tycon: Tycon) (rfield: RecdField) =
     let access = AdjustAccess isHidden (fun () -> tycon.CompilationPath) rfield.Accessibility
     CheckTypeForAccess cenv env (fun () -> rfield.LogicalName) access m fieldTy
 
-    if TyconRefHasAttribute g m g.attrib_IsByRefLikeAttribute tcref then 
+    if isByrefLikeTyconRef g m tcref then 
         // Permit Span fields in IsByRefLike types
         CheckTypePermitSpanLike cenv env m fieldTy
         if cenv.reportErrors then
@@ -2441,8 +2441,10 @@ let CheckEntityDefn cenv env (tycon: Entity) =
                         else
                             errorR(Error(FSComp.SR.chkDuplicateMethodInheritedTypeWithSuffix nm, m))
 
-    if TyconRefHasAttribute g m g.attrib_IsByRefLikeAttribute tcref && not tycon.IsStructOrEnumTycon then 
-        errorR(Error(FSComp.SR.tcByRefLikeNotStruct(), tycon.Range))
+    // A check that IsByRefLikeAttribute is applied on a struct used to be here
+    // but was moved to isByrefLikeTyconRef. We call it to ensure it is performed.
+    // If it had been called in the past, the result is cached anyway.
+    isByrefLikeTyconRef g m tcref |> ignore
 
     if TyconRefHasAttribute g m g.attrib_IsReadOnlyAttribute tcref && not tycon.IsStructOrEnumTycon then 
         errorR(Error(FSComp.SR.tcIsReadOnlyNotStruct(), tycon.Range))

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -2441,10 +2441,9 @@ let CheckEntityDefn cenv env (tycon: Entity) =
                         else
                             errorR(Error(FSComp.SR.chkDuplicateMethodInheritedTypeWithSuffix nm, m))
 
-    // A check that IsByRefLikeAttribute is applied on a struct used to be here
-    // but was moved to isByrefLikeTyconRef. We call it to ensure it is performed.
-    // If it had been called in the past, the result is cached anyway.
-    isByrefLikeTyconRef g m tcref |> ignore
+
+    if TyconRefHasAttributeByName m tname_IsByRefLikeAttribute tcref && not tycon.IsStructOrEnumTycon then 
+        errorR(Error(FSComp.SR.tcByRefLikeNotStruct(), tycon.Range))
 
     if TyconRefHasAttribute g m g.attrib_IsReadOnlyAttribute tcref && not tycon.IsStructOrEnumTycon then 
         errorR(Error(FSComp.SR.tcIsReadOnlyNotStruct(), tycon.Range))

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -170,6 +170,8 @@ let tname_DebuggableAttribute = "System.Diagnostics.DebuggableAttribute"
 let tname_AsyncCallback = "System.AsyncCallback"
 [<Literal>]
 let tname_IAsyncResult = "System.IAsyncResult"
+[<Literal>]
+let tname_IsByRefLikeAttribute = "System.Runtime.CompilerServices.IsByRefLikeAttribute"
 
 //-------------------------------------------------------------------------
 // Table of all these "globals"
@@ -1199,7 +1201,6 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
 
   // We use 'findSysAttrib' here because lookup on attribute is done by name comparison, and can proceed
   // even if the type is not found in a system assembly.
-  member val attrib_IsByRefLikeAttribute  = findSysAttrib "System.Runtime.CompilerServices.IsByRefLikeAttribute"
   member val attrib_IsReadOnlyAttribute  = findSysAttrib "System.Runtime.CompilerServices.IsReadOnlyAttribute"
 
   member val attrib_SystemObsolete          = findSysAttrib "System.ObsoleteAttribute"

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -3240,12 +3240,7 @@ let isByrefLikeTyconRef (g: TcGlobals) m (tcref: TyconRef) =
     | _ -> 
        let res = 
            isByrefTyconRef g tcref ||
-           (match isStructTyconRef tcref, TyconRefHasAttributeByName m tname_IsByRefLikeAttribute tcref with
-            | true, hasAttr -> hasAttr
-            | false, hasAttr ->
-                if hasAttr then
-                    errorR(Error(FSComp.SR.tcByRefLikeNotStruct(), tcref.Deref.Range))
-                false)
+           (isStructTyconRef tcref && TyconRefHasAttributeByName m tname_IsByRefLikeAttribute tcref)
        tcref.SetIsByRefLike res
        res
 

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -3201,6 +3201,29 @@ let TyconRefHasAttribute g m attribSpec tcref =
                     (fun _ -> Some ())
         |> Option.isSome
 
+/// Check if a type definition has an attribute with a specific full name
+let TyconRefHasAttributeByName (m: range) attrFullName (tcref: TyconRef) = 
+    ignore m
+    let (attrEnclosing, attrName) as attrNameSplitted = IL.splitILTypeName attrFullName
+    match metadataOfTycon tcref.Deref with 
+#if !NO_EXTENSIONTYPING
+    | ProvidedTypeMetadata info -> 
+        let provAttribs = info.ProvidedType.PApply((fun a -> (a :> IProvidedCustomAttributeProvider)), m)
+        provAttribs.PUntaint((fun a ->
+            a.GetAttributeConstructorArgs(provAttribs.TypeProvider.PUntaintNoFailure id, attrFullName)), m).IsSome
+#endif
+    | ILTypeMetadata (TILObjectReprData(_, _, tdef)) ->
+        tdef.CustomAttrs.AsArray
+        |> Array.exists (fun attr -> isILAttribByName attrNameSplitted attr)
+    | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata ->
+        tcref.Attribs
+        |> List.exists (fun attr ->
+            match attr.TyconRef.CompiledRepresentation with
+            | CompiledTypeRepr.ILAsmNamed(typeRef, _, _) ->
+                typeRef.Enclosing = attrEnclosing
+                && typeRef.Name = attrName
+            | CompiledTypeRepr.ILAsmOpen _ -> false)
+
 let isByrefTyconRef (g: TcGlobals) (tcref: TyconRef) = 
     (g.byref_tcr.CanDeref && tyconRefEq g g.byref_tcr tcref) ||
     (g.byref2_tcr.CanDeref && tyconRefEq g g.byref2_tcr tcref) ||
@@ -3218,7 +3241,14 @@ let isByrefLikeTyconRef (g: TcGlobals) m (tcref: TyconRef) =
     | _ -> 
        let res = 
            isByrefTyconRef g tcref ||
-           (isStructTyconRef tcref && TyconRefHasAttribute g m g.attrib_IsByRefLikeAttribute tcref)
+           (match isStructTyconRef tcref, TyconRefHasAttributeByName m TcGlobals.tname_IsByRefLikeAttribute tcref with
+            | true, hasAttr -> hasAttr
+            | false, hasAttr ->
+                if hasAttr then
+                    errorR(Error(FSComp.SR.tcByRefLikeNotStruct(), tcref.Deref.Range))
+                false)
+           (isStructTyconRef tcref
+            && TyconRefHasAttributeByName m TcGlobals.tname_IsByRefLikeAttribute tcref)
        tcref.SetIsByRefLike res
        res
 

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -3241,14 +3241,12 @@ let isByrefLikeTyconRef (g: TcGlobals) m (tcref: TyconRef) =
     | _ -> 
        let res = 
            isByrefTyconRef g tcref ||
-           (match isStructTyconRef tcref, TyconRefHasAttributeByName m TcGlobals.tname_IsByRefLikeAttribute tcref with
+           (match isStructTyconRef tcref, TyconRefHasAttributeByName m tname_IsByRefLikeAttribute tcref with
             | true, hasAttr -> hasAttr
             | false, hasAttr ->
                 if hasAttr then
                     errorR(Error(FSComp.SR.tcByRefLikeNotStruct(), tcref.Deref.Range))
                 false)
-           (isStructTyconRef tcref
-            && TyconRefHasAttributeByName m TcGlobals.tname_IsByRefLikeAttribute tcref)
        tcref.SetIsByRefLike res
        res
 

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -3204,7 +3204,6 @@ let TyconRefHasAttribute g m attribSpec tcref =
 /// Check if a type definition has an attribute with a specific full name
 let TyconRefHasAttributeByName (m: range) attrFullName (tcref: TyconRef) = 
     ignore m
-    let (attrEnclosing, attrName) as attrNameSplitted = IL.splitILTypeName attrFullName
     match metadataOfTycon tcref.Deref with 
 #if !NO_EXTENSIONTYPING
     | ProvidedTypeMetadata info -> 
@@ -3214,14 +3213,14 @@ let TyconRefHasAttributeByName (m: range) attrFullName (tcref: TyconRef) =
 #endif
     | ILTypeMetadata (TILObjectReprData(_, _, tdef)) ->
         tdef.CustomAttrs.AsArray
-        |> Array.exists (fun attr -> isILAttribByName attrNameSplitted attr)
+        |> Array.exists (fun attr -> isILAttribByName ([], attrFullName) attr)
     | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata ->
         tcref.Attribs
         |> List.exists (fun attr ->
             match attr.TyconRef.CompiledRepresentation with
             | CompiledTypeRepr.ILAsmNamed(typeRef, _, _) ->
-                typeRef.Enclosing = attrEnclosing
-                && typeRef.Name = attrName
+                typeRef.Enclosing.IsEmpty
+                && typeRef.Name = attrFullName
             | CompiledTypeRepr.ILAsmOpen _ -> false)
 
 let isByrefTyconRef (g: TcGlobals) (tcref: TyconRef) = 

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -2155,6 +2155,9 @@ val TryFindTyconRefBoolAttribute: TcGlobals -> range -> BuiltinAttribInfo -> Tyc
 /// Try to find a specific attribute on a type definition
 val TyconRefHasAttribute: TcGlobals -> range -> BuiltinAttribInfo -> TyconRef -> bool
 
+/// Try to find an attribute with a specific full name on a type definition
+val TyconRefHasAttributeByName: range -> string -> TyconRef -> bool
+
 /// Try to find the AttributeUsage attribute, looking for the value of the AllowMultiple named parameter
 val TryFindAttributeUsageAttribute: TcGlobals -> range -> TyconRef -> bool option
 

--- a/src/fsharp/fscmain.fs
+++ b/src/fsharp/fscmain.fs
@@ -48,8 +48,8 @@ let main(argv) =
 
         // The F# compiler expects 'argv' to include the executable name, though it makes no use of it.
         let argv = Array.append [| compilerName |] argv
-
-        // Check for --pause as the very first step so that a compiler can be attached here.
+        
+        // Check for --pause as the very first step so that a debugger can be attached here.
         let pauseFlag = argv |> Array.exists  (fun x -> x = "/pause" || x = "--pause")
         if pauseFlag then 
             System.Console.WriteLine("Press return to continue...")

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="FSharp.Core\ComparersRegression.fs" />
     <Compile Include="FSharp.Core\DiscriminatedUnionType.fs" />
     <Compile Include="FSharp.Core\RecordTypes.fs" />
+    <Compile Include="FSharp.Core\RefStructs.fs" />
     <Compile Include="FSharp.Core\OperatorsModule1.fs" />
     <Compile Include="FSharp.Core\OperatorsModule2.fs" />
     <Compile Include="FSharp.Core\OperatorsModuleChecked.fs" />

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/RefStructs.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/RefStructs.fs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace System.Runtime.CompilerServices
+
+#if NETCOREAPP
+open System
+
+[<AttributeUsage(AttributeTargets.Struct)>]
+type IsByRefLikeAttribute() = inherit Attribute()
+#endif
+
+namespace FSharp.Core.UnitTests
+
+#if NETCOREAPP
+open System
+open System.Runtime.CompilerServices
+open Xunit
+
+[<Struct; IsByRefLike>]
+type SpanWrapper(span: Span<int>) =
+    member _.Span = span
+
+type CustomIsByRefLikeAttributeTests() =
+    [<Fact>]
+    member _.TestSpanWrapper() =
+        let array = Array.init 5 id
+        let span = array.AsSpan()
+        let spanWrapper = SpanWrapper(span)
+        Assert.True(span.SequenceEqual(Span<_>.op_Implicit spanWrapper.Span))
+        Assert.Equal<int>(array, spanWrapper.Span.ToArray())
+        ()
+#endif

--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -48,7 +48,7 @@ module ILChecker =
 
             let unifyRuntimeAssemblyName ilCode =
                 System.Text.RegularExpressions.Regex.Replace(ilCode,
-                    "\[System.Runtime\]|\[System.Console\]|\[System.Runtime.Extensions\]|\[mscorlib\]","[runtime]",
+                    "\[System\.Runtime\]|\[System\.Console\]|\[System\.Runtime\.Extensions\]|\[mscorlib\]|\[System\.Memory\]","[runtime]",
                     System.Text.RegularExpressions.RegexOptions.Singleline)
 
             let raw = File.ReadAllText(ilFilePath)

--- a/tests/fsharp/Compiler/Language/SpanOptimizationTests.fs
+++ b/tests/fsharp/Compiler/Language/SpanOptimizationTests.fs
@@ -11,7 +11,7 @@ module SpanOptimizationTests =
 
     [<Test>]
     let SpanForInDo() =
-        let source = 
+        let source =
             """
 module Test
 
@@ -40,7 +40,7 @@ let test () =
     IL_0006:  ldc.i4.0
     IL_0007:  stloc.1
     IL_0008:  br.s       IL_0022
-        
+
     IL_000a:  ldloca.s   V_0
     IL_000c:  ldloc.1
     IL_000d:  call       instance !0& valuetype [runtime]System.Span`1<object>::get_Item(int32)
@@ -56,14 +56,14 @@ let test () =
     IL_0023:  ldloca.s   V_0
     IL_0025:  call       instance int32 valuetype [runtime]System.Span`1<object>::get_Length()
     IL_002a:  blt.s      IL_000a
-        
+
     IL_002c:  ret
   }"""
                                 ])
 
     [<Test>]
     let ReadOnlySpanForInDo() =
-        let source = 
+        let source =
             """
 module Test
 
@@ -115,7 +115,7 @@ let test () =
     [<Test>]
     let ExplicitSpanTypeForInDo() =
 
-        let source = 
+        let source =
             """
 namespace System.Runtime.CompilerServices
 
@@ -141,9 +141,7 @@ type Span<'T>(arr: 'T []) =
 
     static member Empty = Span<'T>([||])
 
-    interface IEnumerable with
-
-        member _.GetEnumerator() = null
+    member _.GetEnumerator() = arr.AsSpan().GetEnumerator()
 
 module Test =
 
@@ -161,50 +159,45 @@ module Test =
                             """
       .method public static void  test() cil managed
       {
-        
+
         .maxstack  3
         .locals init (valuetype System.Span`1<object> V_0,
-                 class [runtime]System.Collections.IEnumerator V_1,
-                 class [runtime]System.IDisposable V_2)
+                 valuetype [runtime]System.Span`1/Enumerator<object> V_1,
+                 valuetype [runtime]System.Span`1<object> V_2,
+                 object& V_3)
         IL_0000:  call       !!0[] [runtime]System.Array::Empty<object>()
         IL_0005:  newobj     instance void valuetype System.Span`1<object>::.ctor(!0[])
         IL_000a:  stloc.0
-        IL_000b:  ldloc.0
-        IL_000c:  box        valuetype System.Span`1<object>
-        IL_0011:  unbox.any  [runtime]System.Collections.IEnumerable
-        IL_0016:  callvirt   instance class [runtime]System.Collections.IEnumerator [runtime]System.Collections.IEnumerable::GetEnumerator()
-        IL_001b:  stloc.1
+        IL_000b:  ldloca.s   V_0
+        IL_000d:  ldfld      !0[] valuetype System.Span`1<object>::arr
+        IL_0012:  call       valuetype [runtime]System.Span`1<!!0> [runtime]System.MemoryExtensions::AsSpan<object>(!!0[])
+        IL_0017:  stloc.2
+        IL_0018:  ldloca.s   V_2
+        IL_001a:  call       instance valuetype [runtime]System.Span`1/Enumerator<!0> valuetype [runtime]System.Span`1<object>::GetEnumerator()
+        IL_001f:  stloc.1
         .try
         {
-          IL_001c:  ldloc.1
-          IL_001d:  callvirt   instance bool [runtime]System.Collections.IEnumerator::MoveNext()
-          IL_0022:  brfalse.s  IL_0031
-    
-          IL_0024:  ldloc.1
-          IL_0025:  callvirt   instance object [runtime]System.Collections.IEnumerator::get_Current()
-          IL_002a:  call       void [runtime]System.Console::WriteLine(object)
-          IL_002f:  br.s       IL_001c
-    
-          IL_0031:  leave.s    IL_0045
-    
-        }  
+          IL_0020:  ldloca.s   V_1
+          IL_0022:  call       instance bool valuetype [runtime]System.Span`1/Enumerator<object>::MoveNext()
+          IL_0027:  brfalse.s  IL_003e
+
+          IL_0029:  ldloca.s   V_1
+          IL_002b:  call       instance !0& valuetype [runtime]System.Span`1/Enumerator<object>::get_Current()
+          IL_0030:  stloc.3
+          IL_0031:  ldloc.3
+          IL_0032:  ldobj      [runtime]System.Object
+          IL_0037:  call       void [runtime]System.Console::WriteLine(object)
+          IL_003c:  br.s       IL_0020
+
+          IL_003e:  leave.s    IL_0041
+
+        }
         finally
         {
-          IL_0033:  ldloc.1
-          IL_0034:  isinst     [runtime]System.IDisposable
-          IL_0039:  stloc.2
-          IL_003a:  ldloc.2
-          IL_003b:  brfalse.s  IL_0044
-    
-          IL_003d:  ldloc.2
-          IL_003e:  callvirt   instance void [runtime]System.IDisposable::Dispose()
-          IL_0043:  endfinally
-          IL_0044:  endfinally
-        }  
-        IL_0045:  ret
-      } 
-    
-    }
+          IL_0040:  endfinally
+        }
+        IL_0041:  ret
+      }
 """
                         ])
 
@@ -238,7 +231,7 @@ for i in 0 .. span.Length-1 do
     IL_0006:  ldc.i4.0
     IL_0007:  stloc.1
     IL_0008:  br.s       IL_0022
-        
+
     IL_000a:  ldloca.s   V_0
     IL_000c:  ldloc.1
     IL_000d:  call       instance !0& valuetype [runtime]System.Span`1<object>::get_Item(int32)
@@ -254,7 +247,7 @@ for i in 0 .. span.Length-1 do
     IL_0023:  ldloca.s   V_0
     IL_0025:  call       instance int32 valuetype [runtime]System.Span`1<object>::get_Length()
     IL_002a:  blt.s      IL_000a
-        
+
     IL_002c:  ret
   }"""
                             ])

--- a/tests/fsharp/Compiler/Language/SpanTests.fs
+++ b/tests/fsharp/Compiler/Language/SpanTests.fs
@@ -160,4 +160,19 @@ let f (x: TA) = ()
             [|
                 FSharpDiagnosticSeverity.Error, 3300, (6, 8, 6, 9), "The parameter 'x' has an invalid type 'TA'. This is not permitted by the rules of Common IL."
             |]
+
+    [<Test>]
+    let ``A custom IsByRefLikeAttribute can define a ref struct``() =
+        CompilerAssert.TypeCheckWithErrors """
+namespace System.Runtime.CompilerServices
+
+open System
+
+[<AttributeUsage(AttributeTargets.Struct)>]
+type IsByRefLikeAttribute() = inherit Attribute()
+
+[<IsByRefLike>]
+type T(span: Span<byte>) = struct end
+             """
+             [| |]
 #endif

--- a/tests/fsharp/typecheck/sigs/neg107.bsl
+++ b/tests/fsharp/typecheck/sigs/neg107.bsl
@@ -100,9 +100,3 @@ neg107.fsx(66,34,66,38): typecheck error FS3232: Struct members cannot return th
 neg107.fsx(70,19,70,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
 
 neg107.fsx(70,14,70,18): typecheck error FS0437: A type would store a byref typed value. This is not permitted by Common IL.
-
-neg107.fsx(70,19,70,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
-
-neg107.fsx(70,19,70,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
-
-neg107.fsx(70,19,70,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

--- a/tests/fsharp/typecheck/sigs/neg107.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg107.vsbsl
@@ -100,9 +100,3 @@ neg107.fsx(66,34,66,38): typecheck error FS3232: Struct members cannot return th
 neg107.fsx(70,19,70,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
 
 neg107.fsx(70,14,70,18): typecheck error FS0437: A type would store a byref typed value. This is not permitted by Common IL.
-
-neg107.fsx(70,19,70,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
-
-neg107.fsx(70,19,70,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
-
-neg107.fsx(70,19,70,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.


### PR DESCRIPTION
Fixes #8564.

This PR adds support to define ref structs on assemblies targeting frameworks that do not have the `System.Runtime.CompilerServices.IsByRefLikeAttribute` defined, namely .NET Standard 2.0 and .NET Framework versions earlier than 4.7.1, by recognizing the attribute defined by the users themselves.

The logic of `isByrefLikeTyconRef` is updated to find the attribute _by name_, instead of finding a specific attribute type on a system assembly. Consequently, the `TcGlobals.attrib_IsByRefLikeAttribute` property was removed and replaced by a `tname_IsByRefLikeAttribute` constant containing the attribute's full name, and code trying to find that specific attribute was updated to call `isByrefLikeTyconRef`, benefiting from caching the result of the lookup.

~~A check that the attribute is applied on non-struct types was moved from the post-inference checks to the `isByrefLikeTyconRef` function to consolidate the attribute's existence check.~~ Reverted

---

I was going to do the same with the `IsReadOnlyAttribute` but it was more complicated since it might get emitted (not just checked), and such deficiency has almost zero impact.

---

I will also need some help on testing this change.