### PR TITLE
bump FCS version to 40.0.0 for nightly prereleases

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
     <FSCoreVersionPrefix>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSCoreVersionPrefix>
     <FSCoreVersion>$(FSMajorVersion).$(FSMinorVersion).0.0</FSCoreVersion>
     <!-- FSharp.Compiler.Service version -->
-    <FCSMajorVersion>39</FCSMajorVersion>
+    <FCSMajorVersion>40</FCSMajorVersion>
     <FCSMinorVersion>0</FCSMinorVersion>
     <FCSBuildVersion>0</FCSBuildVersion>
     <FCSRevisionVersion>$(FSRevisionVersion)</FCSRevisionVersion>


### PR DESCRIPTION
This closes #11285 by bumping the version number in the `main` branch for FCS builds to 40.0.0. This merely reflects the reality of things now (as changes intended for 40.x are already included in `main` and the matching changelogs are in place), and makes it easier on devs consuming the prerelease nightly feeds to have a version that semantically meaningful.

Right now nightly build versions are using the version base of 39.0.0, which means that current users of 39.0.3 stable cannot upgrade meaningfully/simply in their tool of choice.

After this change, `40.0.0-<Versionsuffix>` packages are made for FCS:
<img width="1464" alt="image" src="https://user-images.githubusercontent.com/573979/113528815-660a3280-9587-11eb-8096-3d2f37cc8cba.png">
