### PR TITLE
Fix tools path for vs developer prompt

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Dependencies/fsharp.bat
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/fsharp.bat
@@ -1,7 +1,7 @@
 if "%VSCMD_TEST%" NEQ "" goto :test
 if "%VSCMD_ARG_CLEAN_ENV%" NEQ "" goto :clean_env
 
-set FSHARPINSTALLDIR=%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\FSharp\
+set FSHARPINSTALLDIR=%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools
 set "PATH=%FSHARPINSTALLDIR%;%PATH%"
 
 goto :end


### PR DESCRIPTION
The FSC and FSI command are no longer on the path in dev16.10 preview ....  clearly this is a bug.

