### PR TITLE
Implement RFC FS-1079 - Make .Is* discriminated union properties visible from F#

### DIFF
--- a/src/fsharp/AugmentWithHashCompare.fs
+++ b/src/fsharp/AugmentWithHashCompare.fs
@@ -1112,7 +1112,9 @@ let MakeValsForUnionAugmentation g (tcref: TyconRef) =
 
     tcref.UnionCasesAsList
     |> List.map (fun uc ->
-        mkValSpec g tcref tmty vis None ("get_Is" + uc.CompiledName) (tps +-> (mkIsCaseTy g tmty)) unitArg
+        let v = mkValSpec g tcref tmty vis None ("get_Is" + uc.CompiledName) (tps +-> (mkIsCaseTy g tmty)) unitArg
+        g.AddValGeneratedAttributes v m
+        v
     )
 
 let MakeBindingsForUnionAugmentation g (tycon: Tycon) (vals: ValRef list) =

--- a/src/fsharp/AugmentWithHashCompare.fsi
+++ b/src/fsharp/AugmentWithHashCompare.fsi
@@ -35,3 +35,6 @@ val MakeBindingsForEqualityWithComparerAugmentation: TcGlobals -> Tycon -> Bindi
 /// that doesn't assert any new constraints
 val TypeDefinitelyHasEquality: TcGlobals -> TType -> bool
 
+val MakeValsForUnionAugmentation: TcGlobals -> TyconRef -> Val list
+
+val MakeBindingsForUnionAugmentation: TcGlobals -> Tycon -> ValRef list -> Binding list

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -1473,6 +1473,137 @@ module IncrClassChecking =
         
         ctorBody, cctorBodyOpt, methodBinds, reps
 
+//-------------------------------------------------------------------------
+// Build augmentation declarations
+//------------------------------------------------------------------------- 
+
+module AddAugmentationDeclarations = 
+    let tcaugHasNominalInterface g (tcaug: TyconAugmentation) tcref =
+        tcaug.tcaug_interfaces |> List.exists (fun (x, _, _) -> 
+            match tryTcrefOfAppTy g x with
+            | ValueSome tcref2 when tyconRefEq g tcref2 tcref -> true
+            | _ -> false)
+
+    let AddGenericCompareDeclarations (cenv: cenv) (env: TcEnv) (scSet: Set<Stamp>) (tycon: Tycon) =
+        let g = cenv.g
+        if AugmentWithHashCompare.TyconIsCandidateForAugmentationWithCompare g tycon && scSet.Contains tycon.Stamp then 
+            let tcref = mkLocalTyconRef tycon
+            let tcaug = tycon.TypeContents
+            let _, ty = if tcref.Deref.IsExceptionDecl then [], g.exn_ty else generalizeTyconRef tcref
+            let m = tycon.Range
+            let genericIComparableTy = mkAppTy g.system_GenericIComparable_tcref [ty]
+
+
+            let hasExplicitIComparable = tycon.HasInterface g g.mk_IComparable_ty 
+            let hasExplicitGenericIComparable = tcaugHasNominalInterface g tcaug g.system_GenericIComparable_tcref    
+            let hasExplicitIStructuralComparable = tycon.HasInterface g g.mk_IStructuralComparable_ty
+
+            if hasExplicitIComparable then 
+                errorR(Error(FSComp.SR.tcImplementsIComparableExplicitly(tycon.DisplayName), m)) 
+      
+            elif hasExplicitGenericIComparable then 
+                errorR(Error(FSComp.SR.tcImplementsGenericIComparableExplicitly(tycon.DisplayName), m)) 
+            elif hasExplicitIStructuralComparable then
+                errorR(Error(FSComp.SR.tcImplementsIStructuralComparableExplicitly(tycon.DisplayName), m)) 
+            else
+                let hasExplicitGenericIComparable = tycon.HasInterface g genericIComparableTy
+                let cvspec1, cvspec2 = AugmentWithHashCompare.MakeValsForCompareAugmentation g tcref
+                let cvspec3 = AugmentWithHashCompare.MakeValsForCompareWithComparerAugmentation g tcref
+
+                PublishInterface cenv env.DisplayEnv tcref m true g.mk_IStructuralComparable_ty
+                PublishInterface cenv env.DisplayEnv tcref m true g.mk_IComparable_ty
+                if not tycon.IsExceptionDecl && not hasExplicitGenericIComparable then 
+                    PublishInterface cenv env.DisplayEnv tcref m true genericIComparableTy
+                tcaug.SetCompare (mkLocalValRef cvspec1, mkLocalValRef cvspec2)
+                tcaug.SetCompareWith (mkLocalValRef cvspec3)
+                PublishValueDefn cenv env ModuleOrMemberBinding cvspec1
+                PublishValueDefn cenv env ModuleOrMemberBinding cvspec2
+                PublishValueDefn cenv env ModuleOrMemberBinding cvspec3
+
+    let AddGenericEqualityWithComparerDeclarations (cenv: cenv) (env: TcEnv) (seSet: Set<Stamp>) (tycon: Tycon) =
+        let g = cenv.g
+        if AugmentWithHashCompare.TyconIsCandidateForAugmentationWithEquals g tycon && seSet.Contains tycon.Stamp then 
+            let tcref = mkLocalTyconRef tycon
+            let tcaug = tycon.TypeContents
+            let m = tycon.Range
+
+            let hasExplicitIStructuralEquatable = tycon.HasInterface g g.mk_IStructuralEquatable_ty
+
+            if hasExplicitIStructuralEquatable then
+                errorR(Error(FSComp.SR.tcImplementsIStructuralEquatableExplicitly(tycon.DisplayName), m)) 
+            else
+                let evspec1, evspec2, evspec3 = AugmentWithHashCompare.MakeValsForEqualityWithComparerAugmentation g tcref
+                PublishInterface cenv env.DisplayEnv tcref m true g.mk_IStructuralEquatable_ty                
+                tcaug.SetHashAndEqualsWith (mkLocalValRef evspec1, mkLocalValRef evspec2, mkLocalValRef evspec3)
+                PublishValueDefn cenv env ModuleOrMemberBinding evspec1
+                PublishValueDefn cenv env ModuleOrMemberBinding evspec2
+                PublishValueDefn cenv env ModuleOrMemberBinding evspec3
+
+    let AddGenericCompareBindings (cenv: cenv) (tycon: Tycon) =
+        if (* AugmentWithHashCompare.TyconIsCandidateForAugmentationWithCompare cenv.g tycon && *) Option.isSome tycon.GeneratedCompareToValues then 
+            AugmentWithHashCompare.MakeBindingsForCompareAugmentation cenv.g tycon
+        else
+            []
+            
+    let AddGenericCompareWithComparerBindings (cenv: cenv) (tycon: Tycon) =
+        if (* AugmentWithHashCompare.TyconIsCandidateForAugmentationWithCompare cenv.g tycon && *) Option.isSome tycon.GeneratedCompareToWithComparerValues then
+             (AugmentWithHashCompare.MakeBindingsForCompareWithComparerAugmentation cenv.g tycon)
+         else
+            []
+             
+    let AddGenericEqualityWithComparerBindings (cenv: cenv) (tycon: Tycon) =
+        if AugmentWithHashCompare.TyconIsCandidateForAugmentationWithEquals cenv.g tycon && Option.isSome tycon.GeneratedHashAndEqualsWithComparerValues then
+            (AugmentWithHashCompare.MakeBindingsForEqualityWithComparerAugmentation cenv.g tycon)
+        else
+            []
+
+    let AddGenericHashAndComparisonDeclarations (cenv: cenv) (env: TcEnv) scSet seSet tycon =
+        AddGenericCompareDeclarations cenv env scSet tycon
+        AddGenericEqualityWithComparerDeclarations cenv env seSet tycon
+
+    let AddGenericHashAndComparisonBindings cenv tycon =
+        AddGenericCompareBindings cenv tycon @ AddGenericCompareWithComparerBindings cenv tycon @ AddGenericEqualityWithComparerBindings cenv tycon
+
+    // We can only add the Equals override after we've done the augmentation because we have to wait until 
+    // tycon.HasOverride can give correct results 
+    let AddGenericEqualityBindings (cenv: cenv) (env: TcEnv) tycon =
+        let g = cenv.g
+        if AugmentWithHashCompare.TyconIsCandidateForAugmentationWithEquals g tycon then 
+            let tcref = mkLocalTyconRef tycon
+            let tcaug = tycon.TypeContents
+            let _, ty = if tcref.Deref.IsExceptionDecl then [], g.exn_ty else generalizeTyconRef tcref
+            let m = tycon.Range
+            
+            // Note: tycon.HasOverride only gives correct results after we've done the type augmentation 
+            let hasExplicitObjectEqualsOverride = tycon.HasOverride g "Equals" [g.obj_ty]
+            let hasExplicitGenericIEquatable = tcaugHasNominalInterface g tcaug g.system_GenericIEquatable_tcref
+            
+            if hasExplicitGenericIEquatable then 
+                errorR(Error(FSComp.SR.tcImplementsIEquatableExplicitly(tycon.DisplayName), m)) 
+
+            // Note: only provide the equals method if Equals is not implemented explicitly, and
+            // we're actually generating Hash/Equals for this type
+            if not hasExplicitObjectEqualsOverride &&
+                Option.isSome tycon.GeneratedHashAndEqualsWithComparerValues then
+
+                 let vspec1, vspec2 = AugmentWithHashCompare.MakeValsForEqualsAugmentation g tcref
+                 tcaug.SetEquals (mkLocalValRef vspec1, mkLocalValRef vspec2)
+                 if not tycon.IsExceptionDecl then 
+                    PublishInterface cenv env.DisplayEnv tcref m true (mkAppTy g.system_GenericIEquatable_tcref [ty])
+                 PublishValueDefn cenv env ModuleOrMemberBinding vspec1
+                 PublishValueDefn cenv env ModuleOrMemberBinding vspec2
+                 AugmentWithHashCompare.MakeBindingsForEqualsAugmentation g tycon
+            else []
+        else []
+
+    let AddUnionAugmentationBindings (cenv: cenv) (env: TcEnv) tycon =
+        let g = cenv.g
+        let tcref = mkLocalTyconRef tycon
+        let vals = AugmentWithHashCompare.MakeValsForUnionAugmentation g tcref
+        for v in vals do
+            PublishValueDefnMaybeInclCompilerGenerated cenv env true ModuleOrMemberBinding v
+        AugmentWithHashCompare.MakeBindingsForUnionAugmentation g tycon (List.map mkLocalValRef vals)
+
 // Checking of mutually recursive types, members and 'let' bindings in classes
 //
 // Technique: multiple passes.
@@ -2442,7 +2573,7 @@ let TcMutRecDefns_Phase2 (cenv: cenv) envInitial bindsm scopem mutRecNSInfo (env
                     // The rest should have been removed by splitting, they belong to "core" (they are "shape" of type, not implementation) 
                     | _ -> error(Error(FSComp.SR.tcDeclarationElementNotPermittedInAugmentation(), mem.Range))))
 
-
+      let extraBindings = Dictionary(HashIdentity.Reference)
       let binds: MutRecDefnsPhase2Info = 
           (envMutRec, mutRecDefns) ||> MutRecShapes.mapTyconsWithEnv (fun envForDecls tyconData -> 
               let (MutRecDefnsPhase2DataForTycon(tyconOpt, _, declKind, tcref, _, _, declaredTyconTypars, _, _, _, fixupFinalAttrs)) = tyconData
@@ -2451,8 +2582,11 @@ let TcMutRecDefns_Phase2 (cenv: cenv) envInitial bindsm scopem mutRecNSInfo (env
                 // Does not need to be hidden behind a lang version as it needs to be possible to
                 //     implement protected interface methods in lower F# versions regardless if it's a DIM or not.
                 match tyconOpt with
-                | Some _ when declKind = DeclKind.ModuleOrMemberBinding ->
-                    MakeInnerEnvForTyconRef envForDecls tcref false
+                | Some tycon when declKind = DeclKind.ModuleOrMemberBinding ->
+                    let envForDecls = MakeInnerEnvForTyconRef envForDecls tcref false
+                    if tycon.IsUnionTycon then
+                        extraBindings.Add(tycon, AddAugmentationDeclarations.AddUnionAugmentationBindings cenv envForDecls tycon)
+                    envForDecls
                 | _ -> 
                     envForDecls
               let obinds = tyconBindingsOfTypeDefn tyconData
@@ -2462,141 +2596,15 @@ let TcMutRecDefns_Phase2 (cenv: cenv) envInitial bindsm scopem mutRecNSInfo (env
                       (intfTypes, slotImplSets) ||> List.map2 (interfaceMembersFromTypeDefn tyconData) |> List.concat
               MutRecDefnsPhase2InfoForTycon(tyconOpt, tcref, declaredTyconTypars, declKind, obinds @ ibinds, fixupFinalAttrs))
       
-      MutRecBindingChecking.TcMutRecDefns_Phase2_Bindings cenv envInitial tpenv bindsm scopem mutRecNSInfo envMutRec binds
+      let withBindings, env = MutRecBindingChecking.TcMutRecDefns_Phase2_Bindings cenv envInitial tpenv bindsm scopem mutRecNSInfo envMutRec binds
+      (env, withBindings) ||> MutRecShapes.expandTyconsWithEnv (fun _ (tyconOpt, _) ->
+          let mutable binds = Unchecked.defaultof<_>
+          match tyconOpt with 
+          | Some tycon when extraBindings.TryGetValue(tycon, &binds) -> binds, []
+          | _ -> [], [] 
+      ), env
 
     with e -> errorRecovery e scopem; [], envMutRec
-
-//-------------------------------------------------------------------------
-// Build augmentation declarations
-//------------------------------------------------------------------------- 
-
-module AddAugmentationDeclarations = 
-    let tcaugHasNominalInterface g (tcaug: TyconAugmentation) tcref =
-        tcaug.tcaug_interfaces |> List.exists (fun (x, _, _) -> 
-            match tryTcrefOfAppTy g x with
-            | ValueSome tcref2 when tyconRefEq g tcref2 tcref -> true
-            | _ -> false)
-
-    let AddGenericCompareDeclarations (cenv: cenv) (env: TcEnv) (scSet: Set<Stamp>) (tycon: Tycon) =
-        let g = cenv.g
-        if AugmentWithHashCompare.TyconIsCandidateForAugmentationWithCompare g tycon && scSet.Contains tycon.Stamp then 
-            let tcref = mkLocalTyconRef tycon
-            let tcaug = tycon.TypeContents
-            let _, ty = if tcref.Deref.IsExceptionDecl then [], g.exn_ty else generalizeTyconRef tcref
-            let m = tycon.Range
-            let genericIComparableTy = mkAppTy g.system_GenericIComparable_tcref [ty]
-
-
-            let hasExplicitIComparable = tycon.HasInterface g g.mk_IComparable_ty 
-            let hasExplicitGenericIComparable = tcaugHasNominalInterface g tcaug g.system_GenericIComparable_tcref    
-            let hasExplicitIStructuralComparable = tycon.HasInterface g g.mk_IStructuralComparable_ty
-
-            if hasExplicitIComparable then 
-                errorR(Error(FSComp.SR.tcImplementsIComparableExplicitly(tycon.DisplayName), m)) 
-      
-            elif hasExplicitGenericIComparable then 
-                errorR(Error(FSComp.SR.tcImplementsGenericIComparableExplicitly(tycon.DisplayName), m)) 
-            elif hasExplicitIStructuralComparable then
-                errorR(Error(FSComp.SR.tcImplementsIStructuralComparableExplicitly(tycon.DisplayName), m)) 
-            else
-                let hasExplicitGenericIComparable = tycon.HasInterface g genericIComparableTy
-                let cvspec1, cvspec2 = AugmentWithHashCompare.MakeValsForCompareAugmentation g tcref
-                let cvspec3 = AugmentWithHashCompare.MakeValsForCompareWithComparerAugmentation g tcref
-
-                PublishInterface cenv env.DisplayEnv tcref m true g.mk_IStructuralComparable_ty
-                PublishInterface cenv env.DisplayEnv tcref m true g.mk_IComparable_ty
-                if not tycon.IsExceptionDecl && not hasExplicitGenericIComparable then 
-                    PublishInterface cenv env.DisplayEnv tcref m true genericIComparableTy
-                tcaug.SetCompare (mkLocalValRef cvspec1, mkLocalValRef cvspec2)
-                tcaug.SetCompareWith (mkLocalValRef cvspec3)
-                PublishValueDefn cenv env ModuleOrMemberBinding cvspec1
-                PublishValueDefn cenv env ModuleOrMemberBinding cvspec2
-                PublishValueDefn cenv env ModuleOrMemberBinding cvspec3
-
-    let AddGenericEqualityWithComparerDeclarations (cenv: cenv) (env: TcEnv) (seSet: Set<Stamp>) (tycon: Tycon) =
-        let g = cenv.g
-        if AugmentWithHashCompare.TyconIsCandidateForAugmentationWithEquals g tycon && seSet.Contains tycon.Stamp then 
-            let tcref = mkLocalTyconRef tycon
-            let tcaug = tycon.TypeContents
-            let m = tycon.Range
-
-            let hasExplicitIStructuralEquatable = tycon.HasInterface g g.mk_IStructuralEquatable_ty
-
-            if hasExplicitIStructuralEquatable then
-                errorR(Error(FSComp.SR.tcImplementsIStructuralEquatableExplicitly(tycon.DisplayName), m)) 
-            else
-                let evspec1, evspec2, evspec3 = AugmentWithHashCompare.MakeValsForEqualityWithComparerAugmentation g tcref
-                PublishInterface cenv env.DisplayEnv tcref m true g.mk_IStructuralEquatable_ty                
-                tcaug.SetHashAndEqualsWith (mkLocalValRef evspec1, mkLocalValRef evspec2, mkLocalValRef evspec3)
-                PublishValueDefn cenv env ModuleOrMemberBinding evspec1
-                PublishValueDefn cenv env ModuleOrMemberBinding evspec2
-                PublishValueDefn cenv env ModuleOrMemberBinding evspec3
-
-    let AddGenericCompareBindings (cenv: cenv) (tycon: Tycon) =
-        if (* AugmentWithHashCompare.TyconIsCandidateForAugmentationWithCompare cenv.g tycon && *) Option.isSome tycon.GeneratedCompareToValues then 
-            AugmentWithHashCompare.MakeBindingsForCompareAugmentation cenv.g tycon
-        else
-            []
-            
-    let AddGenericCompareWithComparerBindings (cenv: cenv) (tycon: Tycon) =
-        if (* AugmentWithHashCompare.TyconIsCandidateForAugmentationWithCompare cenv.g tycon && *) Option.isSome tycon.GeneratedCompareToWithComparerValues then
-             (AugmentWithHashCompare.MakeBindingsForCompareWithComparerAugmentation cenv.g tycon)
-         else
-            []
-             
-    let AddGenericEqualityWithComparerBindings (cenv: cenv) (tycon: Tycon) =
-        if AugmentWithHashCompare.TyconIsCandidateForAugmentationWithEquals cenv.g tycon && Option.isSome tycon.GeneratedHashAndEqualsWithComparerValues then
-            (AugmentWithHashCompare.MakeBindingsForEqualityWithComparerAugmentation cenv.g tycon)
-        else
-            []
-
-    let AddGenericHashAndComparisonDeclarations (cenv: cenv) (env: TcEnv) scSet seSet tycon =
-        AddGenericCompareDeclarations cenv env scSet tycon
-        AddGenericEqualityWithComparerDeclarations cenv env seSet tycon
-
-    let AddGenericHashAndComparisonBindings cenv tycon =
-        AddGenericCompareBindings cenv tycon @ AddGenericCompareWithComparerBindings cenv tycon @ AddGenericEqualityWithComparerBindings cenv tycon
-
-    // We can only add the Equals override after we've done the augmentation because we have to wait until 
-    // tycon.HasOverride can give correct results 
-    let AddGenericEqualityBindings (cenv: cenv) (env: TcEnv) tycon =
-        let g = cenv.g
-        if AugmentWithHashCompare.TyconIsCandidateForAugmentationWithEquals g tycon then 
-            let tcref = mkLocalTyconRef tycon
-            let tcaug = tycon.TypeContents
-            let _, ty = if tcref.Deref.IsExceptionDecl then [], g.exn_ty else generalizeTyconRef tcref
-            let m = tycon.Range
-            
-            // Note: tycon.HasOverride only gives correct results after we've done the type augmentation 
-            let hasExplicitObjectEqualsOverride = tycon.HasOverride g "Equals" [g.obj_ty]
-            let hasExplicitGenericIEquatable = tcaugHasNominalInterface g tcaug g.system_GenericIEquatable_tcref
-            
-            if hasExplicitGenericIEquatable then 
-                errorR(Error(FSComp.SR.tcImplementsIEquatableExplicitly(tycon.DisplayName), m)) 
-
-            // Note: only provide the equals method if Equals is not implemented explicitly, and
-            // we're actually generating Hash/Equals for this type
-            if not hasExplicitObjectEqualsOverride &&
-                Option.isSome tycon.GeneratedHashAndEqualsWithComparerValues then
-
-                 let vspec1, vspec2 = AugmentWithHashCompare.MakeValsForEqualsAugmentation g tcref
-                 tcaug.SetEquals (mkLocalValRef vspec1, mkLocalValRef vspec2)
-                 if not tycon.IsExceptionDecl then 
-                    PublishInterface cenv env.DisplayEnv tcref m true (mkAppTy g.system_GenericIEquatable_tcref [ty])
-                 PublishValueDefn cenv env ModuleOrMemberBinding vspec1
-                 PublishValueDefn cenv env ModuleOrMemberBinding vspec2
-                 AugmentWithHashCompare.MakeBindingsForEqualsAugmentation g tycon
-            else []
-        else []
-
-    let AddUnionAugmentationBindings (cenv: cenv) (env: TcEnv) tycon =
-        let g = cenv.g
-        let tcref = mkLocalTyconRef tycon
-        let vals = AugmentWithHashCompare.MakeValsForUnionAugmentation g tcref
-        for v in vals do
-            PublishValueDefnMaybeInclCompilerGenerated cenv env true ModuleOrMemberBinding v
-        AugmentWithHashCompare.MakeBindingsForUnionAugmentation g tycon (List.map mkLocalValRef vals)
-
 
 /// Infer 'comparison' and 'equality' constraints from type definitions
 module TyconConstraintInference = 
@@ -4879,11 +4887,7 @@ module TcDeclarations =
                     // in, and there are code generation tests to check that.
                     let binds = AddAugmentationDeclarations.AddGenericHashAndComparisonBindings cenv tycon 
                     let binds3 = AddAugmentationDeclarations.AddGenericEqualityBindings cenv envForDecls tycon
-                    let unionBinds =
-                        if tycon.IsUnionTycon then
-                            AddAugmentationDeclarations.AddUnionAugmentationBindings cenv envForDecls tycon
-                        else []
-                    binds, binds3 @ unionBinds)
+                    binds, binds3)
 
         // Check for cyclic structs and inheritance all over again, since we may have added some fields to the struct when generating the implicit construction syntax 
         EstablishTypeDefinitionCores.TcTyconDefnCore_CheckForCyclicStructsAndInheritance cenv tycons

--- a/src/fsharp/CheckExpressions.fsi
+++ b/src/fsharp/CheckExpressions.fsi
@@ -628,6 +628,9 @@ val PublishTypeDefn: cenv: TcFileState -> env: TcEnv -> mspec: Tycon -> unit
 /// Publish a value definition to the module/namespace type accumulator.
 val PublishValueDefn: cenv: TcFileState -> env: TcEnv -> declKind: DeclKind -> vspec: Val -> unit
 
+/// Publish a value definition to the module/namespace type accumulator.
+val PublishValueDefnMaybeInclCompilerGenerated: cenv: TcFileState -> env: TcEnv -> inclCompilerGenerated: bool -> declKind: DeclKind -> vspec: Val -> unit
+
 /// Mark a typar as no longer being an inference type variable
 val SetTyparRigid: DisplayEnv -> range -> Typar -> unit
 

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2416,6 +2416,8 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv sp expr sequel =
             GenGetUnionCaseFieldAddr cenv cgbuf eenv (e, ucref, tyargs, n, m) sequel
         | TOp.UnionCaseTagGet ucref, [e], _ -> 
             GenGetUnionCaseTag cenv cgbuf eenv (e, ucref, tyargs, m) sequel
+        | TOp.UnionCaseTest ucref, [e], _ -> 
+            GenUnionCaseTest cenv cgbuf eenv (e, ucref, tyargs, m) sequel
         | TOp.UnionCaseProof ucref, [e], _ -> 
             GenUnionCaseProof cenv cgbuf eenv (e, ucref, tyargs, m) sequel
         | TOp.ExnFieldSet (ecref, n), [e;e2], _ -> 
@@ -3062,6 +3064,14 @@ and GenGetUnionCaseTag cenv cgbuf eenv (e, tcref, tyargs, m) sequel =
     let avoidHelpers = entityRefInThisAssembly g.compilingFslib tcref
     EraseUnions.emitLdDataTag g.ilg (UnionCodeGen cgbuf) (avoidHelpers, cuspec)
     CG.EmitInstrs cgbuf (pop 1) (Push [g.ilg.typ_Int32]) [ ] // push/pop to match the line above
+    GenSequel cenv eenv.cloc cgbuf sequel
+
+and GenUnionCaseTest cenv cgbuf eenv (e, ucref, tyargs, m) sequel =
+    let g = cenv.g
+    GenExpr cenv cgbuf eenv SPSuppress e Continue
+    let cuspec, idx = GenUnionCaseSpec cenv.amap m eenv.tyenv ucref tyargs
+    let avoidHelpers = entityRefInThisAssembly g.compilingFslib ucref.TyconRef
+    CG.EmitInstrs cgbuf (pop 1) (Push [g.ilg.typ_Bool]) (EraseUnions.mkIsData g.ilg (avoidHelpers, cuspec, idx))
     GenSequel cenv eenv.cloc cgbuf sequel
 
 and GenSetUnionCaseField cenv cgbuf eenv (e, ucref, tyargs, n, e2, m) sequel =

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1361,6 +1361,7 @@ and OpHasEffect g m op =
     | TOp.ExnConstr ecref -> isExnDefinitelyMutable ecref
     | TOp.Bytes _ | TOp.UInt16s _ | TOp.Array -> true // mutable
     | TOp.UnionCaseTagGet _ -> false
+    | TOp.UnionCaseTest _ -> false
     | TOp.UnionCaseProof _ -> false
     | TOp.UnionCaseFieldGet (ucref, n) -> isUnionCaseFieldMutable g ucref n 
     | TOp.ILAsm (instrs, _) -> IlAssemblyCodeHasEffect instrs
@@ -2149,7 +2150,8 @@ and OptimizeExprOpFallback cenv env (op, tyargs, argsR, m) arginfos valu =
       | TOp.TupleFieldGet _    
       | TOp.UnionCaseFieldGet _   
       | TOp.ExnFieldGet _
-      | TOp.UnionCaseTagGet _ -> 
+      | TOp.UnionCaseTagGet _
+      | TOp.UnionCaseTest _ -> 
           // REVIEW: reduction possible here, and may be very effective
           1, valu 
       | TOp.UnionCaseProof _ -> 

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -1397,6 +1397,7 @@ and CheckExprOp cenv env (op, tyargs, args, m) context expr =
         CheckTypeInstNoByrefs cenv env m tyargs
         CheckExprPermitByRefLike cenv env arg1
 
+    | TOp.UnionCaseTest _, _, [arg1]
     | TOp.UnionCaseTagGet _, _, [arg1] -> 
         CheckTypeInstNoByrefs cenv env m tyargs
         CheckExprPermitByRefLike cenv env arg1  // allow byref - it may be address-of-struct

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -2075,10 +2075,14 @@ let CheckEntityDefn cenv env (tycon: Entity) =
                 x.IsDispatchSlot && y.IsDefiniteFSharpOverride
             let IsAbstractDefaultPair2 (minfo: MethInfo) (minfo2: MethInfo) = 
                 IsAbstractDefaultPair minfo minfo2 || IsAbstractDefaultPair minfo2 minfo
+            let IsCompilerGenerated (minfo: MethInfo) =
+                match minfo.ArbitraryValRef with None -> false | Some vref -> vref.IsCompilerGenerated
             let checkForDup erasureFlag (minfo2: MethInfo) =
                 not (IsAbstractDefaultPair2 minfo minfo2)
                 && (minfo.IsInstance = minfo2.IsInstance)
                 && MethInfosEquivWrtUniqueness erasureFlag m minfo minfo2
+                // Don't consider any compiler-generated methods for now; those are handled separately
+                && not (IsCompilerGenerated minfo || IsCompilerGenerated minfo2)
 
             if others |> List.exists (checkForDup EraseAll) then 
                 if others |> List.exists (checkForDup EraseNone) then 

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -4664,7 +4664,10 @@ type TOp =
     | ValFieldGetAddr of RecdFieldRef * readonly: bool      
 
     /// An operation representing getting an integer tag for a union value representing the union case number
-    | UnionCaseTagGet of TyconRef 
+    | UnionCaseTagGet of TyconRef
+
+    /// An operation representing a test that a union value is of a particular union case.
+    | UnionCaseTest of UnionCaseRef
 
     /// An operation representing a coercion that proves a union value is of a particular union case. This is not a test, its
     /// simply added proof to enable us to generate verifiable code for field access on union types
@@ -4756,6 +4759,7 @@ type TOp =
         | ValFieldGet rfref -> "ValFieldGet(" + rfref.FieldName + ")"
         | ValFieldGetAddr (rfref, _) -> "ValFieldGetAddr(" + rfref.FieldName + ",..)"
         | UnionCaseTagGet tcref -> "UnionCaseTagGet(" + tcref.LogicalName + ")"
+        | UnionCaseTest ucref -> "UnionCaseTest(" + ucref.CaseName + ")"
         | UnionCaseProof ucref -> "UnionCaseProof(" + ucref.CaseName + ")"
         | UnionCaseFieldGet (ucref, _) -> "UnionCaseFieldGet(" + ucref.CaseName + ",..)"
         | UnionCaseFieldGetAddr (ucref, _, _) -> "UnionCaseFieldGetAddr(" + ucref.CaseName + ",..)"

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -1366,6 +1366,9 @@ let mkRecdFieldSetViaExprAddr (e1, fref, tinst, e2, m) = Expr.Op (TOp.ValFieldSe
 
 let mkUnionCaseTagGetViaExprAddr (e1, cref, tinst, m) = Expr.Op (TOp.UnionCaseTagGet cref, tinst, [e1], m)
 
+/// Make a 'TOp.UnionCaseTest' expression, which tests that a union value is of a particular union case.
+let mkUnionCaseTest (e1, cref: UnionCaseRef, tinst, m) = Expr.Op (TOp.UnionCaseTest cref, tinst, [e1], m)
+
 /// Make a 'TOp.UnionCaseProof' expression, which proves a union value is over a particular case (used only for ref-unions, not struct-unions)
 let mkUnionCaseProof (e1, cref: UnionCaseRef, tinst, m) = if cref.Tycon.IsStructOrEnumTycon then e1 else Expr.Op (TOp.UnionCaseProof cref, tinst, [e1], m)
 
@@ -4791,7 +4794,8 @@ and accFreeInOp opts op acc =
     
     // Things containing just a union case reference
     | TOp.UnionCaseProof ucref 
-    | TOp.UnionCase ucref 
+    | TOp.UnionCase ucref
+    | TOp.UnionCaseTest ucref
     | TOp.UnionCaseFieldGetAddr (ucref, _, _) 
     | TOp.UnionCaseFieldGet (ucref, _) 
     | TOp.UnionCaseFieldSet (ucref, _) -> 
@@ -5929,6 +5933,7 @@ let rec tyOfExpr g e =
         | TOp.ValFieldGet fref -> actualTyOfRecdFieldRef fref tinst
         | (TOp.ValFieldSet _ | TOp.UnionCaseFieldSet _ | TOp.ExnFieldSet _ | TOp.LValueOp ((LSet | LByrefSet), _)) ->g.unit_ty
         | TOp.UnionCaseTagGet _ -> g.int_ty
+        | TOp.UnionCaseTest _ -> g.bool_ty
         | TOp.UnionCaseFieldGetAddr (cref, j, readonly) -> mkByrefTyWithFlag g readonly (actualTyOfRecdField (mkTyconRefInst cref.TyconRef tinst) (cref.FieldByIndex j))
         | TOp.UnionCaseFieldGet (cref, j) -> actualTyOfRecdField (mkTyconRefInst cref.TyconRef tinst) (cref.FieldByIndex j)
         | TOp.ExnFieldGet (ecref, j) -> recdFieldTyOfExnDefRefByIdx ecref j

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -291,6 +291,9 @@ val mkRecdFieldSetViaExprAddr: Expr * RecdFieldRef * TypeInst * Expr * range -> 
 /// Make an expression that gets the tag of a union value (via the address of the value if it is a struct)
 val mkUnionCaseTagGetViaExprAddr: Expr * TyconRef * TypeInst * range -> Expr
 
+/// Make a 'TOp.UnionCaseTest' expression, which tests that a union value is of a particular union case.
+val mkUnionCaseTest: Expr * UnionCaseRef  * TypeInst * range -> Expr
+
 /// Make a 'TOp.UnionCaseProof' expression, which proves a union value is over a particular case (used only for ref-unions, not struct-unions)
 val mkUnionCaseProof: Expr * UnionCaseRef  * TypeInst * range -> Expr
 

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -2498,6 +2498,7 @@ and p_op x st =
     (* 30: TOp.TupleFieldGet  when evalTupInfoIsStruct tupInfo = true *)
     | TOp.AnonRecd info   -> p_byte 31 st; p_anonInfo info st
     | TOp.AnonRecdGet (info, n)   -> p_byte 32 st; p_anonInfo info st; p_int n st
+    | TOp.UnionCaseTest a         -> p_byte 33 st; p_ucref a st
     | TOp.Goto _ | TOp.Label _ | TOp.Return -> failwith "unexpected backend construct in pickled TAST"
 
 and u_op st =
@@ -2569,6 +2570,8 @@ and u_op st =
     | 32 -> let info = u_anonInfo st
             let n = u_int st
             TOp.AnonRecdGet (info, n)
+    | 33 -> let a = u_ucref st
+            TOp.UnionCaseTest a
     | _ -> ufailwith st "u_op"
 
 and p_expr expr st =

--- a/src/fsharp/absil/il.fsi
+++ b/src/fsharp/absil/il.fsi
@@ -1726,6 +1726,7 @@ val internal mkILNonGenericStaticMethSpecInTy: ILType * string * ILType list * I
 
 /// Construct references to constructors.
 val internal mkILCtorMethSpecForTy: ILType * ILType list -> ILMethodSpec
+val internal mkILNonGenericCtorMethSpec: ILTypeRef * ILType list -> ILMethodSpec
 
 /// Construct references to fields.
 val internal mkILFieldRef: ILTypeRef * string * ILType -> ILFieldRef

--- a/src/fsharp/ilx/EraseUnions.fs
+++ b/src/fsharp/ilx/EraseUnions.fs
@@ -683,31 +683,6 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
         | SpecialFSharpOptionHelpers  
         | SpecialFSharpListHelpers  -> 
 
-            let baseTesterMeths, baseTesterProps = 
-                if cud.cudAlternatives.Length <= 1 then [], []
-                elif repr.RepresentOneAlternativeAsNull info then [], []
-                else
-                    [ mkILNonGenericInstanceMethod
-                         ("get_" + mkTesterName altName,
-                          cud.cudHelpersAccess,[],
-                          mkILReturn ilg.typ_Bool,
-                          mkMethodBody(true,[],2,nonBranchingInstrsToCode 
-                                    ([ mkLdarg0 ] @ mkIsData ilg (true, cuspec, num)), attr))
-                      |> addMethodGeneratedAttrs ],
-                    [ ILPropertyDef(name = mkTesterName altName,
-                                    attributes = PropertyAttributes.None,
-                                    setMethod = None,
-                                    getMethod = Some (mkILMethRef (baseTy.TypeRef, ILCallingConv.Instance, "get_" + mkTesterName altName, 0, [], ilg.typ_Bool)),
-                                    callingConv = ILThisConvention.Instance,
-                                    propertyType = ilg.typ_Bool,
-                                    init = None,
-                                    args = [],
-                                    customAttrs = emptyILCustomAttrs)
-                      |> addPropertyGeneratedAttrs
-                      |> addPropertyNeverAttrs ]
-
-          
-
             let baseMakerMeths, baseMakerProps = 
 
                 if alt.IsNullary then 
@@ -752,7 +727,7 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
 
                     [mdef],[]
 
-            (baseMakerMeths@baseTesterMeths), (baseMakerProps@baseTesterProps)
+            baseMakerMeths, baseMakerProps
 
         | NoHelpers ->
             [], []

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="Language\CodeQuotationTests.fs" />
     <Compile Include="Language\ComputationExpressionTests.fs" />
     <Compile Include="Language\CastingTests.fs" />
+    <Compile Include="Language\DiscriminatedUnionTests.fs" />
     <Compile Include="ConstraintSolver\PrimitiveConstraints.fs" />
     <Compile Include="ConstraintSolver\MemberConstraints.fs" />
     <Compile Include="Interop\SimpleInteropTests.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Language/DiscriminatedUnionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/DiscriminatedUnionTests.fs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.Language
+
+open Xunit
+open FSharp.Test.Utilities.Compiler
+open FSharp.Quotations.Patterns
+
+module DiscriminatedUnionTests =
+
+    [<Fact>]
+    let ``Is* discriminated union properties are visible`` () =
+        FSharp """
+namespace rec Hello
+
+[<Struct>]
+type Foo =
+    private
+    | Foo of string
+    | Bar
+
+module Main =
+    [<EntryPoint>]
+    let main _ =
+        let foo = Foo.Foo "hi"
+        printfn "IsFoo: %b / IsBar: %b" foo.IsFoo foo.IsBar
+        0
+        """
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> withStdOutContains "IsFoo: true / IsBar: false"


### PR DESCRIPTION
This implements [RFC FS-1079 - Make .Is* discriminated union properties visible from F#](https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1079-union-properties-visible.md).

I'd love feedback on a couple details:

1. I added the union augmentation stuff into `AugmentWithHashCompare` so I could re-use the helper functions, and because the code is similar to what was already there. Is that a good place, and if so, should we rename that module because it no longer deals just with HashCompare?

2. I'm not super proud of the fix to make the properties visible in a `namespace rec` context (penultimate commit). It works, but maybe there is a nicer way to do it

Thanks!