### PR TITLE
Support navigating to generic F# function values for external symbols

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1833,7 +1833,9 @@ module private TastDefinitionPrinting =
 
         let path, mspec = fullPath mspec [mspec.DemangledModuleOrNamespaceName]
 
-        let denv = denv.AddOpenPath path
+        let denv =
+            let outerPath = outerPath |> List.map fst
+            denv.AddOpenPath (outerPath @ path)
 
         let headerL =
             if mspec.IsNamespace then

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -108,6 +108,20 @@ type private FSharpProjectOptionsReactor (workspace: Workspace, settings: Editor
                         assumeDotNetFramework=not SessionsProperties.fsiUseNetCore,
                         userOpName=userOpName)
 
+                let project = document.Project
+
+                let otherOptions =
+                    if project.IsFSharpMetadata then
+                        project.ProjectReferences
+                        |> Seq.map (fun x -> "-r:" + project.Solution.GetProject(x.ProjectId).OutputFilePath)
+                        |> Array.ofSeq
+                        |> Array.append (
+                                project.MetadataReferences.OfType<PortableExecutableReference>()
+                                |> Seq.map (fun x -> "-r:" + x.FilePath)
+                                |> Array.ofSeq)
+                    else
+                        [||]
+
                 let projectOptions =
                     if isScriptFile document.FilePath then
                         scriptProjectOptions
@@ -116,7 +130,7 @@ type private FSharpProjectOptionsReactor (workspace: Workspace, settings: Editor
                             ProjectFileName = document.FilePath
                             ProjectId = None
                             SourceFiles = [|document.FilePath|]
-                            OtherOptions = [||]
+                            OtherOptions = otherOptions
                             ReferencedProjects = [||]
                             IsIncompleteTypeCheckEnvironment = false
                             UseScriptResolutionRules = CompilerEnvironment.MustBeSingleFileProject (Path.GetFileName(document.FilePath))

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
@@ -101,13 +101,20 @@ type internal FSharpGoToDefinitionService
                                             let rec areTypesEqual (ty1: FSharpType) (ty2: FSharpType) =
                                                 let ty1 = ty1.StripAbbreviations()
                                                 let ty2 = ty2.StripAbbreviations()
-                                                ty1.TypeDefinition.DisplayName = ty2.TypeDefinition.DisplayName &&
-                                                ty1.TypeDefinition.AccessPath = ty2.TypeDefinition.AccessPath &&
-                                                ty1.GenericArguments.Count = ty2.GenericArguments.Count &&
-                                                (
-                                                    (ty1.GenericArguments, ty2.GenericArguments)
-                                                    ||> Seq.forall2 areTypesEqual
-                                                )
+                                                let generic =
+                                                    ty1.IsGenericParameter && ty2.IsGenericParameter ||
+                                                    (
+                                                        ty1.GenericArguments.Count = ty2.GenericArguments.Count &&
+                                                        (ty1.GenericArguments, ty2.GenericArguments)
+                                                        ||> Seq.forall2 areTypesEqual
+                                                    )                                                    
+                                                if generic then
+                                                    true
+                                                else
+                                                    let namesEqual = ty1.TypeDefinition.DisplayName = ty2.TypeDefinition.DisplayName
+                                                    let accessPathsEqual = ty1.TypeDefinition.AccessPath = ty2.TypeDefinition.AccessPath
+                                                    namesEqual && accessPathsEqual
+
 
                                             // This tries to find the best possible location of the target symbol's location in the metadata source.
                                             // We really should rely on symbol equality within FCS instead of doing it here, 
@@ -118,6 +125,8 @@ type internal FSharpGoToDefinitionService
                                                 | (:? FSharpEntity as symbol1), (:? FSharpEntity as symbol2) when x.IsFromDefinition ->
                                                     symbol1.DisplayName = symbol2.DisplayName
                                                 | (:? FSharpMemberOrFunctionOrValue as symbol1), (:? FSharpMemberOrFunctionOrValue as symbol2) ->
+                                                    let symbol1 = symbol1
+                                                    let symbol2 = symbol2
                                                     symbol1.DisplayName = symbol2.DisplayName &&
                                                     symbol1.GenericParameters.Count = symbol2.GenericParameters.Count &&
                                                     symbol1.CurriedParameterGroups.Count = symbol2.CurriedParameterGroups.Count &&

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
@@ -115,7 +115,6 @@ type internal FSharpGoToDefinitionService
                                                     let accessPathsEqual = ty1.TypeDefinition.AccessPath = ty2.TypeDefinition.AccessPath
                                                     namesEqual && accessPathsEqual
 
-
                                             // This tries to find the best possible location of the target symbol's location in the metadata source.
                                             // We really should rely on symbol equality within FCS instead of doing it here, 
                                             //     but the generated metadata as source isn't perfect for symbol equality.
@@ -125,8 +124,6 @@ type internal FSharpGoToDefinitionService
                                                 | (:? FSharpEntity as symbol1), (:? FSharpEntity as symbol2) when x.IsFromDefinition ->
                                                     symbol1.DisplayName = symbol2.DisplayName
                                                 | (:? FSharpMemberOrFunctionOrValue as symbol1), (:? FSharpMemberOrFunctionOrValue as symbol2) ->
-                                                    let symbol1 = symbol1
-                                                    let symbol2 = symbol2
                                                     symbol1.DisplayName = symbol2.DisplayName &&
                                                     symbol1.GenericParameters.Count = symbol2.GenericParameters.Count &&
                                                     symbol1.CurriedParameterGroups.Count = symbol2.CurriedParameterGroups.Count &&


### PR DESCRIPTION
Prior to this change, values like `id` and `List.map` would not get navigated to. This fixes it.

![nav2](https://user-images.githubusercontent.com/6309070/114234864-35821a00-9934-11eb-95e8-76cba55cc033.gif)

There are some more cases where navigation doesn't work, for example `defaultConfig` in the Suave library. Will investigate, but this can be merged before any fix for that.