### PR TITLE
Delaying the creation of a PE Stream for a FSharpReferencedProject

### DIFF
--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -48,18 +48,65 @@ open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.AbstractIL
 open System.Reflection.PortableExecutable
 
 open Internal.Utilities
 open Internal.Utilities.Collections
+open Internal.Utilities.Library
 open FSharp.Compiler.AbstractIL.ILBinaryReader
 
 type FSharpUnresolvedReferencesSet = FSharpUnresolvedReferencesSet of UnresolvedAssemblyReference list
 
-[<RequireQualifiedAccess;NoComparison>]
+[<Sealed>]
+type internal DelayedILModuleReader =
+
+    val private name : string
+    val private gate : obj
+    val mutable private getStream : (CancellationToken -> Stream option)
+    val mutable private result : ILModuleReader
+
+    new (name, getStream) = { name = name; gate = obj(); getStream = getStream; result = Unchecked.defaultof<_> }
+
+    member this.TryGetILModuleReader() =
+        // fast path
+        match box this.result with
+        | null ->
+            cancellable {
+                let! ct = Cancellable.token()
+                return
+                    lock this.gate (fun () ->
+                        // see if we have a result or not after the lock so we do not evaluate the stream more than once
+                        match box this.result with
+                        | null ->
+                            let streamOpt = this.getStream ct
+                            match streamOpt with
+                            | Some stream ->
+                                let ilReaderOptions: ILReaderOptions = 
+                                    {
+                                        pdbDirPath = None
+                                        reduceMemoryUsage = ReduceMemoryFlag.Yes
+                                        metadataOnly = MetadataOnlyFlag.Yes
+                                        tryGetMetadataSnapshot = fun _ -> None                        
+                                    }
+                                let ilReader = ILBinaryReader.OpenILModuleReaderFromStream this.name stream ilReaderOptions
+                                this.result <- ilReader
+                                this.getStream <- Unchecked.defaultof<_> // clear out the function so we do not hold onto anything
+                                Some ilReader
+                            | _ ->
+                                None
+                        | _ ->
+                            Some this.result
+                    )
+            }
+        | _ ->
+            Cancellable.ret (Some this.result)
+
+
+[<RequireQualifiedAccess;NoComparison;CustomEquality>]
 type FSharpReferencedProject =
     | FSharpReference of projectFileName: string * options: FSharpProjectOptions
-    | PEReference of projectFileName: string * stamp: DateTime * reader: ILModuleReader
+    | PEReference of projectFileName: string * stamp: DateTime * delayedReader: DelayedILModuleReader
 
     member this.FileName =
         match this with
@@ -69,16 +116,23 @@ type FSharpReferencedProject =
     static member CreateFSharp(projectFileName, options) =
         FSharpReference(projectFileName, options)
 
-    static member CreatePortableExecutable(projectFileName, stamp, stream) =
-        let ilReaderOptions: ILReaderOptions = 
-            {
-                pdbDirPath = None
-                reduceMemoryUsage = ReduceMemoryFlag.Yes
-                metadataOnly = MetadataOnlyFlag.Yes
-                tryGetMetadataSnapshot = fun _ -> None                        
-            }
-        let ilReader = ILBinaryReader.OpenILModuleReaderFromStream projectFileName stream ilReaderOptions
-        PEReference(projectFileName, stamp, ilReader)
+    static member CreatePortableExecutable(projectFileName, stamp, getStream) =
+        PEReference(projectFileName, stamp, DelayedILModuleReader(projectFileName, getStream))
+
+    override this.Equals(o) =
+        match o with
+        | :? FSharpReferencedProject as o ->
+            match this, o with
+            | FSharpReference(projectFileName1, options1), FSharpReference(projectFileName2, options2) ->
+                projectFileName1 = projectFileName2 && options1 = options2
+            | PEReference(projectFileName1, stamp1, _), PEReference(projectFileName2, stamp2, _) ->
+                projectFileName1 = projectFileName2 && stamp1 = stamp2
+            | _ ->
+                false
+        | _ ->
+            false
+
+    override this.GetHashCode() = this.FileName.GetHashCode()
 
 // NOTE: may be better just to move to optional arguments here
 and FSharpProjectOptions =

--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -107,6 +107,7 @@ and [<NoComparison;CustomEquality>] public FSharpReferencedProject =
     /// Creates a reference for any portable executable, including F#. The stream is owned by this reference.
     /// The stream will be automatically disposed when there are no references to FSharpReferencedProject and is GC collected.
     /// Once the stream is evaluated, the function that constructs the stream will no longer be referenced by anything.
+    /// If the stream evaluation throws an exception, it will be automatically handled.
     static member CreatePortableExecutable : projectFileName: string * stamp: DateTime * getStream: (CancellationToken -> Stream option) -> FSharpReferencedProject
 
 /// Represents the use of an F# symbol from F# source code

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -2124,13 +2124,10 @@ FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: System.String[] get_OtherOpti
 FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: System.String[] get_SourceFiles()
 FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: Void .ctor(System.String, Microsoft.FSharp.Core.FSharpOption`1[System.String], System.String[], System.String[], FSharp.Compiler.CodeAnalysis.FSharpReferencedProject[], Boolean, Boolean, System.DateTime, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.CodeAnalysis.FSharpUnresolvedReferencesSet], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Text.Range,System.String,System.String]], Microsoft.FSharp.Core.FSharpOption`1[System.Int64])
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean Equals(FSharp.Compiler.CodeAnalysis.FSharpReferencedProject)
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean Equals(System.Object)
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreateFSharp(System.String, FSharp.Compiler.CodeAnalysis.FSharpProjectOptions)
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreatePortableExecutable(System.String, System.DateTime, System.IO.Stream)
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreatePortableExecutable(System.String, System.DateTime, Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 GetHashCode()
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 GetHashCode(System.Collections.IEqualityComparer)
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String FileName
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String ToString()
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String get_FileName()

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -211,7 +211,7 @@ type private FSharpProjectOptionsReactor (workspace: Workspace, settings: Editor
                             match! tryComputeOptions referencedProject ct with
                             | None -> canBail <- true
                             | Some(_, projectOptions) -> referencedProjects.Add(FSharpReferencedProject.CreateFSharp(referencedProject.OutputFilePath, projectOptions))
-                        else
+                        elif referencedProject.SupportsCompilation then
                             let! comp = referencedProject.GetCompilationAsync(ct) |> Async.AwaitTask
                             let peRef = createPEReference referencedProject comp
                             referencedProjects.Add(peRef)


### PR DESCRIPTION
This is an optimization that is needed so we do not spend a lot of time emitting a C#/VB/etc. reference assembly DLL stream while trying to get project options from VS. Instead, we delay getting the stream at a later point in FCS and is still cancellable.