### PR TITLE
Enable external symbol navigation for ctrl+click navigation

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeLens/CodeLensProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeLens/CodeLensProvider.fs
@@ -50,7 +50,7 @@ type internal CodeLensProvider
                 )
 
             let tagger = CodeLensGeneralTagger(wpfView, buffer)
-            let service = FSharpCodeLensService(serviceProvider, workspace, documentId, buffer, checkerProvider.Checker, projectInfoManager, componentModel.GetService(), typeMap, tagger, settings)
+            let service = FSharpCodeLensService(serviceProvider, workspace, documentId, buffer, checkerProvider, projectInfoManager, componentModel.GetService(), typeMap, tagger, settings)
             let provider = (wpfView, (tagger, service))
             wpfView.Closed.Add (fun _ -> taggers.Remove provider |> ignore)
             taggers.Add((wpfView, (tagger, service)))
@@ -69,7 +69,7 @@ type internal CodeLensProvider
                     | _ -> None
                     |> Option.get
                 )
-            let service = FSharpCodeLensService(serviceProvider, workspace, documentId, buffer, checkerProvider.Checker, projectInfoManager, componentModel.GetService(), typeMap, LineLensDisplayService(wpfView, buffer), settings)
+            let service = FSharpCodeLensService(serviceProvider, workspace, documentId, buffer, checkerProvider, projectInfoManager, componentModel.GetService(), typeMap, LineLensDisplayService(wpfView, buffer), settings)
             let provider = (wpfView, service)
             wpfView.Closed.Add (fun _ -> lineLensProvider.Remove provider |> ignore)
             lineLensProvider.Add(provider)

--- a/vsintegration/src/FSharp.Editor/CodeLens/FSharpCodeLensService.fs
+++ b/vsintegration/src/FSharp.Editor/CodeLens/FSharpCodeLensService.fs
@@ -44,7 +44,7 @@ type internal FSharpCodeLensService
         workspace: Workspace, 
         documentId: Lazy<DocumentId>,
         buffer: ITextBuffer, 
-        checker: FSharpChecker,
+        checkerProvider: FSharpCheckerProvider,
         projectInfoManager: FSharpProjectOptionsManager,
         classificationFormatMapService: IClassificationFormatMapService,
         typeMap: Lazy<FSharpClassificationTypeMap>,
@@ -54,6 +54,7 @@ type internal FSharpCodeLensService
 
     let lineLens = codeLens
     let userOpName = "FSharpCodeLensService"
+    let checker = checkerProvider.Checker
 
     let visit pos parseTree = 
         SyntaxTraversal.Traverse(pos, parseTree, { new SyntaxVisitorBase<_>() with 
@@ -193,7 +194,7 @@ type internal FSharpCodeLensService
                                 let taggedText = ResizeArray()        
                                 typeLayout |> Seq.iter taggedText.Add
                                 let statusBar = StatusBar(serviceProvider.GetService<SVsStatusbar, IVsStatusbar>()) 
-                                let navigation = QuickInfoNavigation(statusBar, checker, projectInfoManager, document, realPosition)
+                                let navigation = QuickInfoNavigation(statusBar, checkerProvider, projectInfoManager, document, realPosition)
                                 // Because the data is available notify that this line should be updated, displaying the results
                                 return Some (taggedText, navigation)
                             | None -> 

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
@@ -4,24 +4,14 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
 open System.Composition
-open System.IO
 open System.Threading
 open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis
-open Microsoft.CodeAnalysis.Text
-open Microsoft.CodeAnalysis.Editor
-open Microsoft.CodeAnalysis.Host.Mef
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
-open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
 
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
-open Microsoft.VisualStudio.LanguageServices
-
-open FSharp.Compiler.CodeAnalysis
-open FSharp.Compiler.EditorServices
-open FSharp.Compiler.Symbols
 
 [<Export(typeof<IFSharpGoToDefinitionService>)>]
 [<Export(typeof<FSharpGoToDefinitionService>)>]
@@ -32,9 +22,8 @@ type internal FSharpGoToDefinitionService
         projectInfoManager: FSharpProjectOptionsManager
     ) =
 
-    let gtd = GoToDefinition(checkerProvider.Checker, projectInfoManager)
+    let gtd = GoToDefinition(checkerProvider, projectInfoManager)
     let statusBar = StatusBar(ServiceProvider.GlobalProvider.GetService<SVsStatusbar,IVsStatusbar>())
-    let metadataAsSourceService = checkerProvider.MetadataAsSource
    
     interface IFSharpGoToDefinitionService with
         /// Invoked with Peek Definition.
@@ -71,102 +60,9 @@ type internal FSharpGoToDefinitionService
                         // 'true' means do it, like Sheev Palpatine would want us to.
                         true
                     | FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences) ->
-                        let textOpt =
-                            match targetSymbolUse.Symbol with
-                            | :? FSharpEntity as symbol ->
-                                symbol.TryGetMetadataText()
-                                |> Option.map (fun text -> text, symbol.DisplayName)
-                            | :? FSharpMemberOrFunctionOrValue as symbol ->
-                                symbol.ApparentEnclosingEntity.TryGetMetadataText()
-                                |> Option.map (fun text -> text, symbol.ApparentEnclosingEntity.DisplayName)
-                            | _ ->
-                                None
-
-                        match textOpt with
-                        | Some (text, fileName) ->
-                            let tmpProjInfo, tmpDocInfo = 
-                                MetadataAsSource.generateTemporaryDocument(
-                                    AssemblyIdentity(targetSymbolUse.Symbol.Assembly.QualifiedName), 
-                                    fileName, 
-                                    metadataReferences)
-                            let tmpShownDocOpt = metadataAsSourceService.ShowDocument(tmpProjInfo, tmpDocInfo.FilePath, SourceText.From(text.ToString()))
-                            match tmpShownDocOpt with
-                            | Some tmpShownDoc ->
-                                let goToAsync =
-                                    asyncMaybe {
-                                        let userOpName = "TryGoToDefinition"
-                                        let! _, _, projectOptions = projectInfoManager.TryGetOptionsForDocumentOrProject (tmpShownDoc, cancellationToken, userOpName)
-                                        let! _, _, checkResults = checkerProvider.Checker.ParseAndCheckDocument(tmpShownDoc, projectOptions, userOpName)
-                                        let! r =
-                                            let rec areTypesEqual (ty1: FSharpType) (ty2: FSharpType) =
-                                                let ty1 = ty1.StripAbbreviations()
-                                                let ty2 = ty2.StripAbbreviations()
-                                                let generic =
-                                                    ty1.IsGenericParameter && ty2.IsGenericParameter ||
-                                                    (
-                                                        ty1.GenericArguments.Count = ty2.GenericArguments.Count &&
-                                                        (ty1.GenericArguments, ty2.GenericArguments)
-                                                        ||> Seq.forall2 areTypesEqual
-                                                    )                                                    
-                                                if generic then
-                                                    true
-                                                else
-                                                    let namesEqual = ty1.TypeDefinition.DisplayName = ty2.TypeDefinition.DisplayName
-                                                    let accessPathsEqual = ty1.TypeDefinition.AccessPath = ty2.TypeDefinition.AccessPath
-                                                    namesEqual && accessPathsEqual
-
-                                            // This tries to find the best possible location of the target symbol's location in the metadata source.
-                                            // We really should rely on symbol equality within FCS instead of doing it here, 
-                                            //     but the generated metadata as source isn't perfect for symbol equality.
-                                            checkResults.GetAllUsesOfAllSymbolsInFile(cancellationToken)
-                                            |> Seq.tryFind (fun x ->
-                                                match x.Symbol, targetSymbolUse.Symbol with
-                                                | (:? FSharpEntity as symbol1), (:? FSharpEntity as symbol2) when x.IsFromDefinition ->
-                                                    symbol1.DisplayName = symbol2.DisplayName
-                                                | (:? FSharpMemberOrFunctionOrValue as symbol1), (:? FSharpMemberOrFunctionOrValue as symbol2) ->
-                                                    symbol1.DisplayName = symbol2.DisplayName &&
-                                                    symbol1.GenericParameters.Count = symbol2.GenericParameters.Count &&
-                                                    symbol1.CurriedParameterGroups.Count = symbol2.CurriedParameterGroups.Count &&
-                                                    (
-                                                        (symbol1.CurriedParameterGroups, symbol2.CurriedParameterGroups)
-                                                        ||> Seq.forall2 (fun pg1 pg2 ->
-                                                            pg1.Count = pg2.Count &&
-                                                            (
-                                                                (pg1, pg2)
-                                                                ||> Seq.forall2 (fun p1 p2 ->
-                                                                    areTypesEqual p1.Type p2.Type
-                                                                )
-                                                            )
-                                                        )
-                                                    ) &&
-                                                    areTypesEqual symbol1.ReturnParameter.Type symbol2.ReturnParameter.Type
-                                                | _ ->
-                                                    false
-                                            )
-                                            |> Option.map (fun x -> x.Range)
-
-                                        let span =
-                                            match RoslynHelpers.TryFSharpRangeToTextSpan(tmpShownDoc.GetTextAsync(cancellationToken).Result, r) with
-                                            | Some span -> span
-                                            | _ -> TextSpan()
-
-                                        return span                             
-                                    }
-
-                                let span =
-                                    match Async.RunSynchronously(goToAsync, cancellationToken = cancellationToken) with
-                                    | Some span -> span
-                                    | _ -> TextSpan()
-
-                                let navItem = FSharpGoToDefinitionNavigableItem(tmpShownDoc, span)                               
-                                gtd.NavigateToItem(navItem, statusBar)
-                                true
-                            | _ ->
-                                statusBar.TempMessage (SR.CannotDetermineSymbol())
-                                false
-                        | _ ->
-                            statusBar.TempMessage (SR.CannotDetermineSymbol())
-                            false
+                        gtd.NavigateToExternalDeclaration(targetSymbolUse, metadataReferences, cancellationToken, statusBar)
+                        // 'true' means do it, like Sheev Palpatine would want us to.
+                        true
                 else 
                     statusBar.TempMessage (SR.CannotDetermineSymbol())
                     false

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Navigation.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Navigation.fs
@@ -14,7 +14,7 @@ open Microsoft.VisualStudio.Shell.Interop
 type internal QuickInfoNavigation
     (
         statusBar: StatusBar,
-        checker: FSharpChecker,
+        checkerProvider: FSharpCheckerProvider,
         projectInfoManager: FSharpProjectOptionsManager,
         initialDoc: Document,
         thisSymbolUseRange: range
@@ -43,7 +43,7 @@ type internal QuickInfoNavigation
             let! targetDoc = solution.TryGetDocumentFromFSharpRange (range, initialDoc.Project.Id)
             let! targetSource = targetDoc.GetTextAsync()
             let! targetTextSpan = RoslynHelpers.TryFSharpRangeToTextSpan (targetSource, range)
-            let gtd = GoToDefinition(checker, projectInfoManager)
+            let gtd = GoToDefinition(checkerProvider, projectInfoManager)
 
             // To ensure proper navigation decsions, we need to check the type of document the navigation call
             // is originating from and the target we're provided by default:

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -230,7 +230,7 @@ type internal FSharpAsyncQuickInfoSource
                     | None, Some quickInfo ->
                         let mainDescription, docs = FSharpAsyncQuickInfoSource.BuildSingleQuickInfoItem documentationBuilder quickInfo
                         let imageId = Tokenizer.GetImageIdForSymbol(quickInfo.Symbol, quickInfo.SymbolKind)
-                        let navigation = QuickInfoNavigation(statusBar, checkerProvider.Checker, projectInfoManager, document, symbolUseRange)
+                        let navigation = QuickInfoNavigation(statusBar, checkerProvider, projectInfoManager, document, symbolUseRange)
                         let content = QuickInfoViewProvider.provideContent(imageId, mainDescription, docs, navigation)
                         let span = getTrackingSpan quickInfo.Span
                         return QuickInfoItem(span, content)
@@ -260,7 +260,7 @@ type internal FSharpAsyncQuickInfoSource
                             ] |> ResizeArray
                         let docs = RoslynHelpers.joinWithLineBreaks [documentation; typeParameterMap; usage; exceptions]
                         let imageId = Tokenizer.GetImageIdForSymbol(targetQuickInfo.Symbol, targetQuickInfo.SymbolKind)
-                        let navigation = QuickInfoNavigation(statusBar, checkerProvider.Checker, projectInfoManager, document, symbolUseRange)
+                        let navigation = QuickInfoNavigation(statusBar, checkerProvider, projectInfoManager, document, symbolUseRange)
                         let content = QuickInfoViewProvider.provideContent(imageId, mainDescription, docs, navigation)
                         let span = getTrackingSpan targetQuickInfo.Span
                         return QuickInfoItem(span, content)


### PR DESCRIPTION
This is almost entirely refactoring, since I had to move the external symbol logic into the core of `GoToDefinition`. From there it's just fixing up some call sites and implementing the Navigable Symbols interface.
![nav3](https://user-images.githubusercontent.com/6309070/114284300-c5db6000-9a03-11eb-8712-817e2cbfd58a.gif)
