### PR TITLE
Layout names that are keywords with double backticks for external navigation

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1178,7 +1178,7 @@ module InfoMemberPrinting =
             // detect parameter type, if ptyOpt is None - this is .NET style optional argument
             let pty = match ptyOpt with ValueSome x -> x | _ -> pty
             let idText =
-                if Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
+                if denv.escapeKeywordNames && Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
                     "``" + nm.idText + "``"
                 else
                     nm.idText
@@ -1192,7 +1192,7 @@ module InfoMemberPrinting =
         // Layout a named argument 
         | true, Some nm, _, _ -> 
             let idText =
-                if Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
+                if denv.escapeKeywordNames && Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
                     "``" + nm.idText + "``"
                 else
                     nm.idText
@@ -1202,7 +1202,7 @@ module InfoMemberPrinting =
             PrintTypes.layoutType denv pty
         | false, Some nm, _, _ -> 
             let idText =
-                if Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
+                if denv.escapeKeywordNames && Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
                     "``" + nm.idText + "``"
                 else
                     nm.idText

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1177,8 +1177,13 @@ module InfoMemberPrinting =
         | _, Some nm, true, ptyOpt -> 
             // detect parameter type, if ptyOpt is None - this is .NET style optional argument
             let pty = match ptyOpt with ValueSome x -> x | _ -> pty
+            let idText =
+                if Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
+                    "``" + nm.idText + "``"
+                else
+                    nm.idText
             SepL.questionMark ^^
-            wordL (tagParameter nm.idText) ^^
+            wordL (tagParameter idText) ^^
             RightL.colon ^^
             PrintTypes.layoutType denv pty
         // Layout an unnamed argument 
@@ -1186,12 +1191,22 @@ module InfoMemberPrinting =
             PrintTypes.layoutType denv pty
         // Layout a named argument 
         | true, Some nm, _, _ -> 
+            let idText =
+                if Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
+                    "``" + nm.idText + "``"
+                else
+                    nm.idText
             layoutBuiltinAttribute denv denv.g.attrib_ParamArrayAttribute ^^
-            wordL (tagParameter nm.idText) ^^
+            wordL (tagParameter idText) ^^
             RightL.colon ^^
             PrintTypes.layoutType denv pty
         | false, Some nm, _, _ -> 
-            wordL (tagParameter nm.idText) ^^
+            let idText =
+                if Lexhelp.Keywords.keywordNames |> List.contains nm.idText then
+                    "``" + nm.idText + "``"
+                else
+                    nm.idText
+            wordL (tagParameter idText) ^^
             RightL.colon ^^
             PrintTypes.layoutType denv pty
 

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -2759,7 +2759,8 @@ type DisplayEnv =
       showTyparDefaultConstraints: bool
       showDocumentation: bool
       shrinkOverloads: bool
-      printVerboseSignatures : bool
+      printVerboseSignatures: bool
+      escapeKeywordNames: bool
       g: TcGlobals
       contextAccessibility: Accessibility
       generatedValueLayout : (Val -> Layout option)
@@ -2795,6 +2796,7 @@ type DisplayEnv =
         useColonForReturnType = false
         shrinkOverloads = true
         printVerboseSignatures = false
+        escapeKeywordNames = false
         g = tcGlobals
         contextAccessibility = taccessPublic
         generatedValueLayout = (fun _ -> None)
@@ -2823,7 +2825,7 @@ type DisplayEnv =
                suppressInlineKeyword = false
                showDocumentation = true
                shrinkOverloads = false
-               }
+               escapeKeywordNames = true }
         denv.SetOpenPaths
             [ FSharpLib.RootPath
               FSharpLib.CorePath

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -991,6 +991,7 @@ type DisplayEnv =
       showDocumentation: bool
       shrinkOverloads: bool
       printVerboseSignatures: bool
+      escapeKeywordNames: bool
       g: TcGlobals
       contextAccessibility: Accessibility
       generatedValueLayout: (Val -> Layout option)


### PR DESCRIPTION
Prior to this change, the below screenshot would not have full colors and you wouldn't be able to navigate. That's because `function` is a keyword, which is not correct since it's a parameter name.

I think there's probably a better way to handle this, hence being a draft. But this does appear to solve the problem.

![image](https://user-images.githubusercontent.com/6309070/114285400-aba58000-9a0b-11eb-8ea5-2e94b30a6000.png)
