### PR TITLE
Fix a few async tests

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -250,10 +250,14 @@ type AsyncType() =
             let! result = tcs.Task |> Async.AwaitTask
             return result }
 
-        try
-            Async.RunSynchronously(a, cancellationToken = cts.Token)
-                |> ignore
-        with :? OperationCanceledException as o -> ()
+        let cancelled =
+            try
+                Async.RunSynchronously(a, cancellationToken = cts.Token) |> ignore
+                false
+            with :? OperationCanceledException as o -> true
+                 | _ -> false
+
+        Assert.True (cancelled, "Task is not cancelled")
 
     [<Fact>]
     member this.ExceptionPropagatesToTask () =
@@ -433,7 +437,7 @@ type AsyncType() =
                 let! s1 = Async.AwaitTask(t)
                 return s = s1
             }
-        Async.RunSynchronously(a, 1000) |> Assert.True
+        Async.RunSynchronously(a) |> Assert.True
 
     [<Fact>]
     member this.AwaitTaskCancellation () =
@@ -486,7 +490,7 @@ type AsyncType() =
                     return false
                 with e -> return true
               }
-        Async.RunSynchronously(a, 1000) |> Assert.True
+        Async.RunSynchronously(a) |> Assert.True
 
     [<Fact>]
     member this.TaskAsyncValueCancellation () =
@@ -522,7 +526,7 @@ type AsyncType() =
                 do! Async.AwaitTask(t)
                 return true
             }
-        let result =Async.RunSynchronously(a, 1000)
+        let result =Async.RunSynchronously(a)
         (!hasBeenCalled && result) |> Assert.True
 
     [<Fact>]
@@ -539,7 +543,7 @@ type AsyncType() =
                     return false
                 with e -> return true
               }
-        Async.RunSynchronously(a, 3000) |> Assert.True
+        Async.RunSynchronously(a) |> Assert.True
 
     [<Fact>]
     member this.NonGenericTaskAsyncValueCancellation () =


### PR DESCRIPTION
A couple of async tests, have timeouts specified, and yet do not account for the timeout.  The original intent I suppose was that the specified timeout was big enough to handle the asynchronous code.

Given the current VM limitations of the CI, these tests have been failing intermittently with time outs.

This addresses that by not setting timeout.  If the CI hangs then there is a real bug, and the failure should be addressed.