### PR TITLE
Fixed interface method implementation for non-newslot

### DIFF
--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -478,7 +478,7 @@ module DispatchSlotChecking =
             // specific method is "optionally" implemented.
             let isInterfaceOptional = ListSet.contains (typeEquiv g) interfaceTy availImpliedInterfaces
             [ for minfo in GetImmediateIntrinsicMethInfosOfType (None, ad) g amap m interfaceTy do
-                if minfo.IsNewSlot then
+                if minfo.IsNewSlot || minfo.IsAbstract then
                       // If the interface itself is considered optional, then we are finished and do not need anymore context.
                       //     Even if the method is actually not abstract.
                       if isInterfaceOptional then

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -478,7 +478,7 @@ module DispatchSlotChecking =
             // specific method is "optionally" implemented.
             let isInterfaceOptional = ListSet.contains (typeEquiv g) interfaceTy availImpliedInterfaces
             [ for minfo in GetImmediateIntrinsicMethInfosOfType (None, ad) g amap m interfaceTy do
-                if minfo.IsNewSlot || minfo.IsAbstract then
+                if minfo.IsNewSlot then
                       // If the interface itself is considered optional, then we are finished and do not need anymore context.
                       //     Even if the method is actually not abstract.
                       if isInterfaceOptional then

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1172,10 +1172,9 @@ type MethInfo =
 #endif
 
     member x.IsNewSlot =
-        isInterfaceTy x.TcGlobals x.ApparentEnclosingType ||
         (x.IsVirtual &&
           (match x with
-           | ILMeth(_, x, _) -> x.IsNewSlot
+           | ILMeth(_, x, _) -> x.IsNewSlot || (isInterfaceTy x.TcGlobals x.ApparentEnclosingType && not x.IsFinal)
            | FSMeth(_, _, vref, _) -> vref.IsDispatchSlotMember
 #if !NO_EXTENSIONTYPING
            | ProvidedMeth(_, mi, _, m) -> mi.PUntaint((fun mi -> mi.IsHideBySig), m) // REVIEW: Check this is correct

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1172,6 +1172,7 @@ type MethInfo =
 #endif
 
     member x.IsNewSlot =
+        isInterfaceTy x.TcGlobals x.ApparentEnclosingType ||
         (x.IsVirtual &&
           (match x with
            | ILMeth(_, x, _) -> x.IsNewSlot


### PR DESCRIPTION
Fixes this: https://github.com/dotnet/fsharp/issues/11015

This bug occurred when we merged DIMs, but it is quite subtle. Before, we assumed that a method is a `newslot` if the enclosing type was an interface. I removed that check as it's not quite correct because you technically can have an interface method that does not have the `newslot` attribute; as the issue shows. 

Most externally-defined interface methods outside of F# have `newslot` attribute as part of the method definition, which is probably why the bug didn't show up earlier. F#-defined interface methods do not actually emit a `newslot` attribute but the compiler still knows that it is a `newslot` due to F# metadata.