### PR TITLE
Integrated XML documentation reading in FCS

### DIFF
--- a/src/fsharp/AugmentWithHashCompare.fs
+++ b/src/fsharp/AugmentWithHashCompare.fs
@@ -9,6 +9,7 @@ open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Infos
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -5718,7 +5718,7 @@ let ApplyDefaults (cenv: cenv) g denvAtEnd m mexpr extraAttribs =
                     ConstraintSolver.ChooseTyparSolutionAndSolve cenv.css denvAtEnd tp)
     with e -> errorRecovery e m
 
-let CheckValueRestriction denvAtEnd rootSigOpt implFileTypePriorToSig m = 
+let CheckValueRestriction denvAtEnd infoReader rootSigOpt implFileTypePriorToSig m = 
     if Option.isNone rootSigOpt then
       let rec check (mty: ModuleOrNamespaceType) =
           for v in mty.AllValsAndMembers do
@@ -5732,7 +5732,7 @@ let CheckValueRestriction denvAtEnd rootSigOpt implFileTypePriorToSig m =
                   // for example FSharp 1.0 3661.
                   (match v.ValReprInfo with None -> true | Some tvi -> tvi.HasNoArgs)) then 
                 match ftyvs with 
-                | tp :: _ -> errorR (ValueRestriction(denvAtEnd, false, v, tp, v.Range))
+                | tp :: _ -> errorR (ValueRestriction(denvAtEnd, infoReader, false, v, tp, v.Range))
                 | _ -> ()
           mty.ModuleAndNamespaceDefinitions |> List.iter (fun v -> check v.ModuleOrNamespaceType) 
       try check implFileTypePriorToSig with e -> errorRecovery e m
@@ -5763,7 +5763,7 @@ let CheckModuleSignature g (cenv: cenv) m denvAtEnd rootSigOpt implFileTypePrior
                 // As typechecked the signature and implementation use different tycons etc. 
                 // Here we (a) check there are enough names, (b) match them up to build a renaming and   
                 // (c) check signature conformance up to this renaming. 
-                if not (SignatureConformance.CheckNamesOfModuleOrNamespace denv (mkLocalTyconRef implFileSpecPriorToSig) sigFileType) then 
+                if not (SignatureConformance.CheckNamesOfModuleOrNamespace denv cenv.infoReader (mkLocalTyconRef implFileSpecPriorToSig) sigFileType) then 
                     raise (ReportedError None)
 
                 // Compute the remapping from implementation to signature
@@ -5771,7 +5771,7 @@ let CheckModuleSignature g (cenv: cenv) m denvAtEnd rootSigOpt implFileTypePrior
                      
                 let aenv = { TypeEquivEnv.Empty with EquivTycons = TyconRefMap.OfList remapInfo.RepackagedEntities }
                     
-                if not (SignatureConformance.Checker(cenv.g, cenv.amap, denv, remapInfo, true).CheckSignature aenv (mkLocalModRef implFileSpecPriorToSig) sigFileType) then (
+                if not (SignatureConformance.Checker(cenv.g, cenv.amap, denv, remapInfo, true).CheckSignature aenv cenv.infoReader (mkLocalModRef implFileSpecPriorToSig) sigFileType) then (
                     // We can just raise 'ReportedError' since CheckModuleOrNamespace raises its own error 
                     raise (ReportedError None)
                 )
@@ -5795,6 +5795,8 @@ let TypeCheckOneImplFile
        env 
        (rootSigOpt: ModuleOrNamespaceType option)
        (ParsedImplFileInput (_, isScript, qualNameOfFile, scopedPragmas, _, implFileFrags, isLastCompiland)) =
+
+ let infoReader = InfoReader(g, amap)
 
  eventually {
     let cenv = 
@@ -5839,7 +5841,7 @@ let TypeCheckOneImplFile
 
     // Check the value restriction. Only checked if there is no signature.
     conditionallySuppressErrorReporting (checkForErrors()) (fun () ->
-      CheckValueRestriction denvAtEnd rootSigOpt implFileTypePriorToSig m)
+      CheckValueRestriction denvAtEnd infoReader rootSigOpt implFileTypePriorToSig m)
 
     // Solve unsolved internal type variables 
     conditionallySuppressErrorReporting (checkForErrors()) (fun () ->

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -30,6 +30,7 @@ open FSharp.Compiler.Syntax.PrettyNaming
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -2574,7 +2574,7 @@ let TcValEarlyGeneralizationConsistencyCheck cenv (env: TcEnv) (v: Val, vrec, ti
               let tau3 = instType (mkTyparInst tpsorig tinst) tau2
               //printfn "tau3 = '%s'" (DebugPrint.showType tau3)
               if not (AddCxTypeEqualsTypeUndoIfFailed env.DisplayEnv cenv.css m tau tau3) then
-                  let txt = bufs (fun buf -> NicePrint.outputQualifiedValSpec env.DisplayEnv cenv.infoReader buf v)
+                  let txt = bufs (fun buf -> NicePrint.outputQualifiedValSpec env.DisplayEnv cenv.infoReader buf (mkLocalValRef v))
                   error(Error(FSComp.SR.tcInferredGenericTypeGivesRiseToInconsistency(v.DisplayName, txt), m)))
     | _ -> ()
 

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -79,7 +79,7 @@ exception UnitTypeExpectedWithPossibleAssignment of DisplayEnv * TType * bool * 
 exception UnitTypeExpectedWithPossiblePropertySetter of DisplayEnv * TType * string * string * range
 exception UnionPatternsBindDifferentNames of range
 exception VarBoundTwice of Ident
-exception ValueRestriction of DisplayEnv * bool * Val * Typar * range
+exception ValueRestriction of DisplayEnv * InfoReader * bool * Val * Typar * range
 exception ValNotMutable of DisplayEnv * ValRef * range
 exception ValNotLocal of DisplayEnv * ValRef * range
 exception InvalidRuntimeCoercion of DisplayEnv * TType * TType * range
@@ -2574,7 +2574,7 @@ let TcValEarlyGeneralizationConsistencyCheck cenv (env: TcEnv) (v: Val, vrec, ti
               let tau3 = instType (mkTyparInst tpsorig tinst) tau2
               //printfn "tau3 = '%s'" (DebugPrint.showType tau3)
               if not (AddCxTypeEqualsTypeUndoIfFailed env.DisplayEnv cenv.css m tau tau3) then
-                  let txt = bufs (fun buf -> NicePrint.outputQualifiedValSpec env.DisplayEnv buf v)
+                  let txt = bufs (fun buf -> NicePrint.outputQualifiedValSpec env.DisplayEnv cenv.infoReader buf v)
                   error(Error(FSComp.SR.tcInferredGenericTypeGivesRiseToInconsistency(v.DisplayName, txt), m)))
     | _ -> ()
 
@@ -6231,7 +6231,7 @@ and FreshenObjExprAbstractSlot cenv (env: TcEnv) (implty: TType) virtNameAndArit
     match absSlots with 
     | [] when not (CompileAsEvent cenv.g bindAttribs) -> 
         let absSlotsByName = List.filter (fst >> fst >> (=) bindName) virtNameAndArityPairs
-        let getSignature absSlot = (NicePrint.stringOfMethInfo cenv.amap mBinding env.DisplayEnv absSlot).Replace("abstract ", "")
+        let getSignature absSlot = (NicePrint.stringOfMethInfo cenv.infoReader mBinding env.DisplayEnv absSlot).Replace("abstract ", "")
         let getDetails (absSlot: MethInfo) = 
             if absSlot.GetParamTypes(cenv.amap, mBinding, []) |> List.existsSquared (isAnyTupleTy cenv.g) then
                 FSComp.SR.tupleRequiredInAbstractMethod()
@@ -6507,7 +6507,7 @@ and TcObjectExpr cenv overallTy env tpenv (synObjTy, argopt, binds, extraImpls, 
         overridesAndVirts |> List.iter (fun (m, implty, dispatchSlots, dispatchSlotsKeyed, availPriorOverrides, overrides) -> 
             let overrideSpecs = overrides |> List.map fst
 
-            DispatchSlotChecking.CheckOverridesAreAllUsedOnce (env.DisplayEnv, cenv.g, cenv.amap, true, implty, dispatchSlotsKeyed, availPriorOverrides, overrideSpecs)
+            DispatchSlotChecking.CheckOverridesAreAllUsedOnce (env.DisplayEnv, cenv.g, cenv.infoReader, true, implty, dispatchSlotsKeyed, availPriorOverrides, overrideSpecs)
 
             DispatchSlotChecking.CheckDispatchSlotsAreImplemented (env.DisplayEnv, cenv.infoReader, m, env.NameEnv, cenv.tcSink, false, implty, dispatchSlots, availPriorOverrides, overrideSpecs) |> ignore)
         
@@ -9909,7 +9909,7 @@ and ApplyAbstractSlotInference (cenv: cenv) (envinner: TcEnv) (bindingTy, m, syn
                      | [] -> 
                          let details =
                              slots
-                             |> Seq.map (NicePrint.stringOfMethInfo cenv.amap m envinner.DisplayEnv)
+                             |> Seq.map (NicePrint.stringOfMethInfo cenv.infoReader m envinner.DisplayEnv)
                              |> Seq.map (sprintf "%s   %s" System.Environment.NewLine)
                              |> String.concat ""
 

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -35,6 +35,7 @@ open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/CheckExpressions.fsi
+++ b/src/fsharp/CheckExpressions.fsi
@@ -20,6 +20,7 @@ open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
 

--- a/src/fsharp/CheckExpressions.fsi
+++ b/src/fsharp/CheckExpressions.fsi
@@ -131,7 +131,7 @@ exception UnitTypeExpectedWithPossibleAssignment of DisplayEnv * TType * bool * 
 exception FunctionValueUnexpected of DisplayEnv * TType * range
 exception UnionPatternsBindDifferentNames of range
 exception VarBoundTwice of Ident
-exception ValueRestriction of DisplayEnv * bool * Val * Typar * range
+exception ValueRestriction of DisplayEnv * InfoReader * bool * Val * Typar * range
 exception ValNotMutable of DisplayEnv * ValRef * range
 exception ValNotLocal of DisplayEnv * ValRef * range
 exception InvalidRuntimeCoercion of DisplayEnv * TType * TType * range

--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -25,6 +25,7 @@ open FSharp.Compiler.IO
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 
 #if !NO_EXTENSIONTYPING
@@ -487,6 +488,8 @@ type TcConfigBuilder =
       mutable pathMap: PathMap
 
       mutable langVersion: LanguageVersion
+
+      mutable xmlDocInfoLoader: IXmlDocumentationInfoLoader option
       }
 
 
@@ -662,6 +665,7 @@ type TcConfigBuilder =
           useFsiAuxLib = isInteractive
           rangeForErrors = rangeForErrors
           sdkDirOverride = sdkDirOverride
+          xmlDocInfoLoader = None
         }
         
     member tcConfigB.FxResolver =
@@ -1033,6 +1037,7 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
     member x.tryGetMetadataSnapshot = data.tryGetMetadataSnapshot
     member x.internalTestSpanStackReferring = data.internalTestSpanStackReferring
     member x.noConditionalErasure = data.noConditionalErasure
+    member x.xmlDocInfoLoader = data.xmlDocInfoLoader
 
     static member Create(builder, validate) = 
         use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parameter

--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -7,6 +7,7 @@ open System
 open Internal.Utilities
 open Internal.Utilities.Library
 open FSharp.Compiler
+open FSharp.Compiler.Xml
 open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILBinaryReader
@@ -273,6 +274,8 @@ type TcConfigBuilder =
       mutable pathMap : PathMap
 
       mutable langVersion : LanguageVersion
+
+      mutable xmlDocInfoLoader : IXmlDocumentationInfoLoader option
     }
 
     static member CreateNew:
@@ -439,6 +442,8 @@ type TcConfig =
     /// If true, indicates all type checking and code generation is in the context of fsi.exe
     member isInteractive: bool
     member isInvalidationSupported: bool 
+
+    member xmlDocInfoLoader: IXmlDocumentationInfoLoader option
 
     member FxResolver: FxResolver
 

--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -1349,7 +1349,7 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
           os.Append(UnionPatternsBindDifferentNamesE().Format) |> ignore
 
       | ValueNotContained (denv, infoReader, mref, implVal, sigVal, f) ->
-          let text1, text2 = NicePrint.minimalStringsOfTwoValues denv infoReader implVal sigVal
+          let text1, text2 = NicePrint.minimalStringsOfTwoValues denv infoReader (mkLocalValRef implVal) (mkLocalValRef sigVal)
           os.Append(f((fullDisplayTextOfModRef mref), text1, text2)) |> ignore
 
       | ConstrNotContained (denv, infoReader, enclosingTycon, v1, v2, f) ->
@@ -1519,12 +1519,12 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
               if isFunTy denv.g tau && (arityOfVal v).HasNoArgs then 
                 os.Append(ValueRestriction1E().Format
                   v.DisplayName 
-                  (NicePrint.stringOfQualifiedValOrMember denv infoReader v)
+                  (NicePrint.stringOfQualifiedValOrMember denv infoReader (mkLocalValRef v))
                   v.DisplayName) |> ignore
               else
                 os.Append(ValueRestriction2E().Format
                   v.DisplayName 
-                  (NicePrint.stringOfQualifiedValOrMember denv infoReader v)
+                  (NicePrint.stringOfQualifiedValOrMember denv infoReader (mkLocalValRef v))
                   v.DisplayName) |> ignore
           else
               match v.MemberInfo with 
@@ -1535,17 +1535,17 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
                   | SynMemberKind.Constructor -> true (* can't infer extra polymorphism *)
                   | _ -> false (* can infer extra polymorphism *)
                   end -> 
-                      os.Append(ValueRestriction3E().Format (NicePrint.stringOfQualifiedValOrMember denv infoReader v)) |> ignore
+                      os.Append(ValueRestriction3E().Format (NicePrint.stringOfQualifiedValOrMember denv infoReader (mkLocalValRef v))) |> ignore
               | _ -> 
                 if isFunTy denv.g tau && (arityOfVal v).HasNoArgs then 
                     os.Append(ValueRestriction4E().Format
                       v.DisplayName
-                      (NicePrint.stringOfQualifiedValOrMember denv infoReader v)
+                      (NicePrint.stringOfQualifiedValOrMember denv infoReader (mkLocalValRef v))
                       v.DisplayName) |> ignore
                 else
                     os.Append(ValueRestriction5E().Format
                       v.DisplayName
-                      (NicePrint.stringOfQualifiedValOrMember denv infoReader v)
+                      (NicePrint.stringOfQualifiedValOrMember denv infoReader (mkLocalValRef v))
                       v.DisplayName) |> ignore
                 
 

--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -142,7 +142,7 @@ let GetRangeOfDiagnostic(err: PhasedDiagnostic) =
       | IntfImplInIntrinsicAugmentation m 
       | OverrideInExtrinsicAugmentation m
       | IntfImplInExtrinsicAugmentation m 
-      | ValueRestriction(_, _, _, _, m) 
+      | ValueRestriction(_, _, _, _, _, m) 
       | LetRecUnsound (_, _, m) 
       | ObsoleteError (_, m) 
       | ObsoleteWarning (_, m) 
@@ -156,10 +156,10 @@ let GetRangeOfDiagnostic(err: PhasedDiagnostic) =
       | TyconBadArgs(_, _, _, m) -> 
           Some m
 
-      | FieldNotContained(_, arf, _, _) -> Some arf.Range
-      | ValueNotContained(_, _, aval, _, _) -> Some aval.Range
-      | ConstrNotContained(_, aval, _, _) -> Some aval.Id.idRange
-      | ExnconstrNotContained(_, aexnc, _, _) -> Some aexnc.Range
+      | FieldNotContained(_, _, _, arf, _, _) -> Some arf.Range
+      | ValueNotContained(_, _, _, aval, _, _) -> Some aval.Range
+      | ConstrNotContained(_, _, _, aval, _, _) -> Some aval.Id.idRange
+      | ExnconstrNotContained(_, _, aexnc, _, _) -> Some aexnc.Range
 
       | VarBoundTwice id 
       | UndefinedName(_, _, id, _) -> 
@@ -803,7 +803,7 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
                       sprintf " // %s" nameOrOneBasedIndexMessage
                   | _ -> ""
                   
-              (NicePrint.stringOfMethInfo x.amap m displayEnv x.methodSlot.Method) + paramInfo
+              (NicePrint.stringOfMethInfo x.infoReader m displayEnv x.methodSlot.Method) + paramInfo
               
           let nl = System.Environment.NewLine
           let formatOverloads (overloads: OverloadInformation list) =
@@ -1348,18 +1348,20 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
       | UnionPatternsBindDifferentNames _ -> 
           os.Append(UnionPatternsBindDifferentNamesE().Format) |> ignore
 
-      | ValueNotContained (denv, mref, implVal, sigVal, f) ->
-          let text1, text2 = NicePrint.minimalStringsOfTwoValues denv implVal sigVal
+      | ValueNotContained (denv, infoReader, mref, implVal, sigVal, f) ->
+          let text1, text2 = NicePrint.minimalStringsOfTwoValues denv infoReader implVal sigVal
           os.Append(f((fullDisplayTextOfModRef mref), text1, text2)) |> ignore
 
-      | ConstrNotContained (denv, v1, v2, f) ->
-          os.Append(f((NicePrint.stringOfUnionCase denv v1), (NicePrint.stringOfUnionCase denv v2))) |> ignore
+      | ConstrNotContained (denv, infoReader, enclosingTycon, v1, v2, f) ->
+          let enclosingTcref = mkLocalEntityRef enclosingTycon
+          os.Append(f((NicePrint.stringOfUnionCase denv infoReader enclosingTcref v1), (NicePrint.stringOfUnionCase denv infoReader enclosingTcref v2))) |> ignore
 
-      | ExnconstrNotContained (denv, v1, v2, f) ->
-          os.Append(f((NicePrint.stringOfExnDef denv v1), (NicePrint.stringOfExnDef denv v2))) |> ignore
+      | ExnconstrNotContained (denv, infoReader, v1, v2, f) ->
+          os.Append(f((NicePrint.stringOfExnDef denv infoReader (mkLocalEntityRef v1)), (NicePrint.stringOfExnDef denv infoReader (mkLocalEntityRef v2)))) |> ignore
 
-      | FieldNotContained (denv, v1, v2, f) ->
-          os.Append(f((NicePrint.stringOfRecdField denv v1), (NicePrint.stringOfRecdField denv v2))) |> ignore
+      | FieldNotContained (denv, infoReader, enclosingTycon, v1, v2, f) ->
+          let enclosingTcref = mkLocalEntityRef enclosingTycon
+          os.Append(f((NicePrint.stringOfRecdField denv infoReader enclosingTcref v1), (NicePrint.stringOfRecdField denv infoReader enclosingTcref v2))) |> ignore
 
       | RequiredButNotSpecified (_, mref, k, name, _) ->
           let nsb = new System.Text.StringBuilder()
@@ -1510,19 +1512,19 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
 
       | MissingFields(sl, _) -> os.Append(MissingFieldsE().Format (String.concat "," sl + ".")) |> ignore
 
-      | ValueRestriction(denv, hassig, v, _, _) -> 
+      | ValueRestriction(denv, infoReader, hassig, v, _, _) -> 
           let denv = { denv with showImperativeTyparAnnotations=true }
           let tau = v.TauType
           if hassig then 
               if isFunTy denv.g tau && (arityOfVal v).HasNoArgs then 
                 os.Append(ValueRestriction1E().Format
                   v.DisplayName 
-                  (NicePrint.stringOfQualifiedValOrMember denv v)
+                  (NicePrint.stringOfQualifiedValOrMember denv infoReader v)
                   v.DisplayName) |> ignore
               else
                 os.Append(ValueRestriction2E().Format
                   v.DisplayName 
-                  (NicePrint.stringOfQualifiedValOrMember denv v)
+                  (NicePrint.stringOfQualifiedValOrMember denv infoReader v)
                   v.DisplayName) |> ignore
           else
               match v.MemberInfo with 
@@ -1533,17 +1535,17 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
                   | SynMemberKind.Constructor -> true (* can't infer extra polymorphism *)
                   | _ -> false (* can infer extra polymorphism *)
                   end -> 
-                      os.Append(ValueRestriction3E().Format (NicePrint.stringOfQualifiedValOrMember denv v)) |> ignore
+                      os.Append(ValueRestriction3E().Format (NicePrint.stringOfQualifiedValOrMember denv infoReader v)) |> ignore
               | _ -> 
                 if isFunTy denv.g tau && (arityOfVal v).HasNoArgs then 
                     os.Append(ValueRestriction4E().Format
                       v.DisplayName
-                      (NicePrint.stringOfQualifiedValOrMember denv v)
+                      (NicePrint.stringOfQualifiedValOrMember denv infoReader v)
                       v.DisplayName) |> ignore
                 else
                     os.Append(ValueRestriction5E().Format
                       v.DisplayName
-                      (NicePrint.stringOfQualifiedValOrMember denv v)
+                      (NicePrint.stringOfQualifiedValOrMember denv infoReader v)
                       v.DisplayName) |> ignore
                 
 

--- a/src/fsharp/CompilerImports.fs
+++ b/src/fsharp/CompilerImports.fs
@@ -1076,7 +1076,7 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
                 TypeForwarders = Map.empty
                 XmlDocumentationInfo =
                     match tcConfig.xmlDocInfoLoader with
-                    | Some xmlDocInfoLoader -> xmlDocInfoLoader.TryLoad(fileName)
+                    | Some xmlDocInfoLoader -> xmlDocInfoLoader.TryLoad(fileName, ilModule)
                     | _ -> None
               }
                     
@@ -1506,8 +1506,8 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
                       MemberSignatureEquality= (fun ty1 ty2 -> typeEquivAux EraseAll (tcImports.GetTcGlobals()) ty1 ty2)
                       TypeForwarders = ImportILAssemblyTypeForwarders(tcImports.GetImportMap, m, ilModule.GetRawTypeForwarders())
                       XmlDocumentationInfo =
-                        match tcConfig.xmlDocInfoLoader with
-                        | Some xmlDocInfoLoader -> xmlDocInfoLoader.TryLoad(filename)
+                        match tcConfig.xmlDocInfoLoader, ilModule.TryGetILModuleDef() with
+                        | Some xmlDocInfoLoader, Some ilModuleDef -> xmlDocInfoLoader.TryLoad(filename, ilModuleDef)
                         | _ -> None
                     }
 

--- a/src/fsharp/ConstraintSolver.fsi
+++ b/src/fsharp/ConstraintSolver.fsi
@@ -94,7 +94,7 @@ type ContextInfo =
 type OverloadInformation = 
     {
         methodSlot: CalledMeth<Expr>
-        amap : ImportMap
+        infoReader: InfoReader
         error: exn
     }
 

--- a/src/fsharp/DetupleArgs.fs
+++ b/src/fsharp/DetupleArgs.fs
@@ -8,6 +8,7 @@ open Internal.Utilities.Library.Extras
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -32,6 +32,7 @@ open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.LayoutRender
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/InfoReader.fs
+++ b/src/fsharp/InfoReader.fs
@@ -980,12 +980,12 @@ let GetXmlDocSigOfScopedValRef g (tcref: TyconRef) (vref: ValRef) =
         v.XmlDocSig <- XmlDocSigOfVal g false path v
     Some (ccuFileName, v.XmlDocSig)                
 
-let GetXmlDocSigOfRecdFieldInfo (rfinfo: RecdFieldInfo) = 
-    let tcref = rfinfo.TyconRef
+let GetXmlDocSigOfRecdFieldRef (rfref: RecdFieldRef) = 
+    let tcref = rfref.TyconRef
     let ccuFileName = libFileOfEntityRef tcref 
-    if rfinfo.RecdField.XmlDocSig = "" then
-        rfinfo.RecdField.XmlDocSig <- XmlDocSigOfProperty [tcref.CompiledRepresentationForNamedType.FullName; rfinfo.Name]
-    Some (ccuFileName, rfinfo.RecdField.XmlDocSig)            
+    if rfref.RecdField.XmlDocSig = "" then
+        rfref.RecdField.XmlDocSig <- XmlDocSigOfProperty [tcref.CompiledRepresentationForNamedType.FullName; rfref.RecdField.Name]
+    Some (ccuFileName, rfref.RecdField.XmlDocSig)
 
 let GetXmlDocSigOfUnionCaseInfo (ucinfo: UnionCaseInfo) = 
     let tcref =  ucinfo.TyconRef

--- a/src/fsharp/InfoReader.fs
+++ b/src/fsharp/InfoReader.fs
@@ -19,6 +19,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypeRelations
 
 /// Use the given function to select some of the member values from the members of an F# type
@@ -926,8 +927,142 @@ let PropTypOfEventInfo (infoReader: InfoReader) m ad (einfo: EventInfo) =
     let argsTy = ArgsTypOfEventInfo infoReader m ad einfo 
     mkIEventType g delTy argsTy
 
-let TryFindXmlDocByAssemblyNameAndMetadataKey (infoReader: InfoReader) assemblyName metadataKey =
+/// Try to find the name of the metadata file for this external definition 
+let TryFindMetadataInfoOfExternalEntityRef (infoReader: InfoReader) m eref = 
+    let g = infoReader.g
+    match eref with 
+    | ERefLocal _ -> None
+    | ERefNonLocal nlref -> 
+        // Generalize to get a formal signature 
+        let formalTypars = eref.Typars m
+        let formalTypeInst = generalizeTypars formalTypars
+        let ty = TType_app(eref, formalTypeInst)
+        if isILAppTy g ty then
+            let formalTypeInfo = ILTypeInfo.FromType g ty
+            Some(nlref.Ccu.FileName, formalTypars, formalTypeInfo)
+        else None
+
+/// Try to find the xml doc associated with the assembly name and xml doc signature
+let TryFindXmlDocByAssemblyNameAndSig (infoReader: InfoReader) assemblyName xmlDocSig =
     infoReader.amap.assemblyLoader.TryFindXmlDocumentationInfo(assemblyName)
     |> Option.bind (fun xmlDocInfo ->
-        xmlDocInfo.TryGetXmlDocByMetadataKey(metadataKey)
+        xmlDocInfo.TryGetXmlDocBySig(xmlDocSig)
     )
+
+let private libFileOfEntityRef x =
+    match x with
+    | ERefLocal _ -> None
+    | ERefNonLocal nlref -> nlref.Ccu.FileName 
+
+let GetXmlDocSigOfEntityRef infoReader m (eref: EntityRef) = 
+    if eref.IsILTycon then 
+        match TryFindMetadataInfoOfExternalEntityRef infoReader m eref  with
+        | None -> None
+        | Some (ccuFileName, _, formalTypeInfo) -> Some(ccuFileName, "T:"+formalTypeInfo.ILTypeRef.FullName)
+    else
+        let ccuFileName = libFileOfEntityRef eref
+        let m = eref.Deref
+        if m.XmlDocSig = "" then
+            m.XmlDocSig <- XmlDocSigOfEntity eref
+        Some (ccuFileName, m.XmlDocSig)
+
+let GetXmlDocSigOfScopedValRef g (tcref: TyconRef) (vref: ValRef) = 
+    let ccuFileName = libFileOfEntityRef tcref
+    let v = vref.Deref
+    if v.XmlDocSig = "" && v.HasDeclaringEntity then
+        let ap = buildAccessPath vref.TopValDeclaringEntity.CompilationPathOpt
+        let path =
+            if vref.TopValDeclaringEntity.IsModule then
+                let sep = if ap.Length > 0 then "." else ""
+                ap + sep + vref.TopValDeclaringEntity.CompiledName
+            else
+                ap
+        v.XmlDocSig <- XmlDocSigOfVal g false path v
+    Some (ccuFileName, v.XmlDocSig)                
+
+let GetXmlDocSigOfRecdFieldInfo (rfinfo: RecdFieldInfo) = 
+    let tcref = rfinfo.TyconRef
+    let ccuFileName = libFileOfEntityRef tcref 
+    if rfinfo.RecdField.XmlDocSig = "" then
+        rfinfo.RecdField.XmlDocSig <- XmlDocSigOfProperty [tcref.CompiledRepresentationForNamedType.FullName; rfinfo.Name]
+    Some (ccuFileName, rfinfo.RecdField.XmlDocSig)            
+
+let GetXmlDocSigOfUnionCaseInfo (ucinfo: UnionCaseInfo) = 
+    let tcref =  ucinfo.TyconRef
+    let ccuFileName = libFileOfEntityRef tcref
+    if  ucinfo.UnionCase.XmlDocSig = "" then
+        ucinfo.UnionCase.XmlDocSig <- XmlDocSigOfUnionCase [tcref.CompiledRepresentationForNamedType.FullName; ucinfo.Name]
+    Some (ccuFileName, ucinfo.UnionCase.XmlDocSig)
+
+let GetXmlDocSigOfMethInfo (infoReader: InfoReader)  m (minfo: MethInfo) = 
+    let amap = infoReader.amap
+    match minfo with
+    | FSMeth (g, _, vref, _) ->
+        GetXmlDocSigOfScopedValRef g minfo.DeclaringTyconRef vref
+    | ILMeth (g, ilminfo, _) ->            
+        let actualTypeName = ilminfo.DeclaringTyconRef.CompiledRepresentationForNamedType.FullName
+        let fmtps = ilminfo.FormalMethodTypars            
+        let genArity = if fmtps.Length=0 then "" else sprintf "``%d" fmtps.Length
+
+        match TryFindMetadataInfoOfExternalEntityRef infoReader m ilminfo.DeclaringTyconRef  with 
+        | None -> None
+        | Some (ccuFileName, formalTypars, formalTypeInfo) ->
+            let filminfo = ILMethInfo(g, formalTypeInfo.ToType, None, ilminfo.RawMetadata, fmtps) 
+            let args = 
+                match ilminfo.IsILExtensionMethod with
+                | true -> filminfo.GetRawArgTypes(amap, m, minfo.FormalMethodInst)
+                | false -> filminfo.GetParamTypes(amap, m, minfo.FormalMethodInst)
+
+            // http://msdn.microsoft.com/en-us/library/fsbx0t7x.aspx
+            // If the name of the item itself has periods, they are replaced by the hash-sign ('#'). 
+            // It is assumed that no item has a hash-sign directly in its name. For example, the fully 
+            // qualified name of the String constructor would be "System.String.#ctor".
+            let normalizedName = ilminfo.ILName.Replace(".", "#")
+
+            Some (ccuFileName, "M:"+actualTypeName+"."+normalizedName+genArity+XmlDocArgsEnc g (formalTypars, fmtps) args)
+    | DefaultStructCtor _ -> None
+#if !NO_EXTENSIONTYPING
+    | ProvidedMeth _ -> None
+#endif
+
+let GetXmlDocSigOfValRef g (vref: ValRef) =
+    if not vref.IsLocalRef then
+        let ccuFileName = vref.nlr.Ccu.FileName
+        let v = vref.Deref
+        if v.XmlDocSig = "" && v.HasDeclaringEntity then
+            v.XmlDocSig <- XmlDocSigOfVal g false vref.TopValDeclaringEntity.CompiledRepresentationForNamedType.Name v
+        Some (ccuFileName, v.XmlDocSig)
+    else 
+        None
+
+let GetXmlDocSigOfProp infoReader m (pinfo: PropInfo) =
+    let g = pinfo.TcGlobals
+    match pinfo with 
+#if !NO_EXTENSIONTYPING
+    | ProvidedProp _ -> None // No signature is possible. If an xml comment existed it would have been returned by PropInfo.XmlDoc in infos.fs
+#endif
+    | FSProp _ as fspinfo -> 
+        match fspinfo.ArbitraryValRef with 
+        | None -> None
+        | Some vref -> GetXmlDocSigOfScopedValRef g pinfo.DeclaringTyconRef vref
+    | ILProp(ILPropInfo(_, pdef)) -> 
+        match TryFindMetadataInfoOfExternalEntityRef infoReader m pinfo.DeclaringTyconRef with
+        | Some (ccuFileName, formalTypars, formalTypeInfo) ->
+            let filpinfo = ILPropInfo(formalTypeInfo, pdef)
+            Some (ccuFileName, "P:"+formalTypeInfo.ILTypeRef.FullName+"."+pdef.Name+XmlDocArgsEnc g (formalTypars, []) (filpinfo.GetParamTypes(infoReader.amap, m)))
+        | _ -> None
+
+let GetXmlDocSigOfEvent infoReader m (einfo: EventInfo) =
+    match einfo with
+    | ILEvent _ ->
+        match TryFindMetadataInfoOfExternalEntityRef infoReader m einfo.DeclaringTyconRef with 
+        | Some (ccuFileName, _, formalTypeInfo) -> 
+            Some(ccuFileName, "E:"+formalTypeInfo.ILTypeRef.FullName+"."+einfo.EventName)
+        | _ -> None
+    | _ -> None
+
+let GetXmlDocSigOfILFieldInfo infoReader m (finfo: ILFieldInfo) =
+    match TryFindMetadataInfoOfExternalEntityRef infoReader m finfo.DeclaringTyconRef with
+    | Some (ccuFileName, _, formalTypeInfo) ->
+        Some(ccuFileName, "F:"+formalTypeInfo.ILTypeRef.FullName+"."+finfo.FieldName)
+    | _ -> None

--- a/src/fsharp/InfoReader.fs
+++ b/src/fsharp/InfoReader.fs
@@ -987,12 +987,12 @@ let GetXmlDocSigOfRecdFieldRef (rfref: RecdFieldRef) =
         rfref.RecdField.XmlDocSig <- XmlDocSigOfProperty [tcref.CompiledRepresentationForNamedType.FullName; rfref.RecdField.Name]
     Some (ccuFileName, rfref.RecdField.XmlDocSig)
 
-let GetXmlDocSigOfUnionCaseInfo (ucinfo: UnionCaseInfo) = 
-    let tcref =  ucinfo.TyconRef
+let GetXmlDocSigOfUnionCaseRef (ucref: UnionCaseRef) = 
+    let tcref =  ucref.TyconRef
     let ccuFileName = libFileOfEntityRef tcref
-    if  ucinfo.UnionCase.XmlDocSig = "" then
-        ucinfo.UnionCase.XmlDocSig <- XmlDocSigOfUnionCase [tcref.CompiledRepresentationForNamedType.FullName; ucinfo.Name]
-    Some (ccuFileName, ucinfo.UnionCase.XmlDocSig)
+    if  ucref.UnionCase.XmlDocSig = "" then
+        ucref.UnionCase.XmlDocSig <- XmlDocSigOfUnionCase [tcref.CompiledRepresentationForNamedType.FullName; ucref.CaseName]
+    Some (ccuFileName, ucref.UnionCase.XmlDocSig)
 
 let GetXmlDocSigOfMethInfo (infoReader: InfoReader)  m (minfo: MethInfo) = 
     let amap = infoReader.amap

--- a/src/fsharp/InfoReader.fs
+++ b/src/fsharp/InfoReader.fs
@@ -925,3 +925,9 @@ let PropTypOfEventInfo (infoReader: InfoReader) m ad (einfo: EventInfo) =
     let delTy = einfo.GetDelegateType(amap, m)
     let argsTy = ArgsTypOfEventInfo infoReader m ad einfo 
     mkIEventType g delTy argsTy
+
+let TryFindXmlDocByAssemblyNameAndMetadataKey (infoReader: InfoReader) assemblyName metadataKey =
+    infoReader.amap.assemblyLoader.TryFindXmlDocumentationInfo(assemblyName)
+    |> Option.bind (fun xmlDocInfo ->
+        xmlDocInfo.TryGetXmlDocByMetadataKey(metadataKey)
+    )

--- a/src/fsharp/InfoReader.fs
+++ b/src/fsharp/InfoReader.fs
@@ -1033,7 +1033,11 @@ let GetXmlDocSigOfValRef g (vref: ValRef) =
             v.XmlDocSig <- XmlDocSigOfVal g false vref.TopValDeclaringEntity.CompiledRepresentationForNamedType.Name v
         Some (ccuFileName, v.XmlDocSig)
     else 
-        None
+        match vref.ApparentEnclosingEntity with
+        | Parent tcref ->
+            GetXmlDocSigOfScopedValRef g tcref vref
+        | _ ->
+            None
 
 let GetXmlDocSigOfProp infoReader m (pinfo: PropInfo) =
     let g = pinfo.TcGlobals

--- a/src/fsharp/InfoReader.fsi
+++ b/src/fsharp/InfoReader.fsi
@@ -161,20 +161,20 @@ val TryFindMetadataInfoOfExternalEntityRef: infoReader:InfoReader -> m:range -> 
 /// Try to find the xml doc associated with the assembly name and metadata key
 val TryFindXmlDocByAssemblyNameAndSig: infoReader:InfoReader -> assemblyName: string -> xmlDocSig: string -> XmlDoc option
 
-val GetXmlDocSigOfEntityRef: infoReader:InfoReader -> m:range -> eref: EntityRef -> (string option * string) option
+val GetXmlDocSigOfEntityRef: infoReader:InfoReader -> m:range -> eref:EntityRef -> (string option * string) option
 
-val GetXmlDocSigOfScopedValRef: TcGlobals -> tcref: TyconRef -> vref: ValRef -> (string option * string) option
+val GetXmlDocSigOfScopedValRef: TcGlobals -> tcref:TyconRef -> vref:ValRef -> (string option * string) option
 
 val GetXmlDocSigOfRecdFieldRef: rfref:RecdFieldRef -> (string option * string) option
 
-val GetXmlDocSigOfUnionCaseInfo: ucinfo:UnionCaseInfo -> (string option * string) option
+val GetXmlDocSigOfUnionCaseRef: ucref:UnionCaseRef -> (string option * string) option
 
 val GetXmlDocSigOfMethInfo: infoReader: InfoReader -> m:range -> minfo:MethInfo -> (string option * string) option
 
 val GetXmlDocSigOfValRef: TcGlobals -> vref: ValRef -> (string option * string) option
 
-val GetXmlDocSigOfProp: infoReader: InfoReader -> m:range -> pinfo:PropInfo -> (string option * string) option
+val GetXmlDocSigOfProp: infoReader:InfoReader -> m:range -> pinfo:PropInfo -> (string option * string) option
 
-val GetXmlDocSigOfEvent: infoReader: InfoReader -> m:range -> einfo:EventInfo -> (string option * string) option
+val GetXmlDocSigOfEvent: infoReader:InfoReader -> m:range -> einfo:EventInfo -> (string option * string) option
 
-val GetXmlDocSigOfILFieldInfo: infoReader: InfoReader -> m:range -> finfo:ILFieldInfo -> (string option * string) option
+val GetXmlDocSigOfILFieldInfo: infoReader:InfoReader -> m:range -> finfo:ILFieldInfo -> (string option * string) option

--- a/src/fsharp/InfoReader.fsi
+++ b/src/fsharp/InfoReader.fsi
@@ -11,6 +11,7 @@ open FSharp.Compiler.Import
 open FSharp.Compiler.Infos
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 
 /// Try to select an F# value when querying members, and if so return a MethInfo that wraps the F# value.
@@ -153,3 +154,5 @@ val IsStandardEventInfo: infoReader:InfoReader -> m:range -> ad:AccessorDomain -
 val ArgsTypOfEventInfo: infoReader:InfoReader -> m:range -> ad:AccessorDomain -> einfo:EventInfo -> TType
 
 val PropTypOfEventInfo: infoReader:InfoReader -> m:range -> ad:AccessorDomain -> einfo:EventInfo -> TType
+
+val TryFindXmlDocByAssemblyNameAndMetadataKey: infoReader:InfoReader -> assemblyName: string -> metadataKey: string -> XmlDoc option

--- a/src/fsharp/InfoReader.fsi
+++ b/src/fsharp/InfoReader.fsi
@@ -155,4 +155,26 @@ val ArgsTypOfEventInfo: infoReader:InfoReader -> m:range -> ad:AccessorDomain ->
 
 val PropTypOfEventInfo: infoReader:InfoReader -> m:range -> ad:AccessorDomain -> einfo:EventInfo -> TType
 
-val TryFindXmlDocByAssemblyNameAndMetadataKey: infoReader:InfoReader -> assemblyName: string -> metadataKey: string -> XmlDoc option
+/// Try to find the name of the metadata file for this external definition 
+val TryFindMetadataInfoOfExternalEntityRef: infoReader:InfoReader -> m:range -> eref:EntityRef -> (string option * Typars * ILTypeInfo) option
+
+/// Try to find the xml doc associated with the assembly name and metadata key
+val TryFindXmlDocByAssemblyNameAndSig: infoReader:InfoReader -> assemblyName: string -> xmlDocSig: string -> XmlDoc option
+
+val GetXmlDocSigOfEntityRef: infoReader:InfoReader -> m:range -> eref: EntityRef -> (string option * string) option
+
+val GetXmlDocSigOfScopedValRef: TcGlobals -> tcref: TyconRef -> vref: ValRef -> (string option * string) option
+
+val GetXmlDocSigOfRecdFieldInfo: rfinfo:RecdFieldInfo -> (string option * string) option
+
+val GetXmlDocSigOfUnionCaseInfo: ucinfo:UnionCaseInfo -> (string option * string) option
+
+val GetXmlDocSigOfMethInfo: infoReader: InfoReader -> m:range -> minfo:MethInfo -> (string option * string) option
+
+val GetXmlDocSigOfValRef: TcGlobals -> vref: ValRef -> (string option * string) option
+
+val GetXmlDocSigOfProp: infoReader: InfoReader -> m:range -> pinfo:PropInfo -> (string option * string) option
+
+val GetXmlDocSigOfEvent: infoReader: InfoReader -> m:range -> einfo:EventInfo -> (string option * string) option
+
+val GetXmlDocSigOfILFieldInfo: infoReader: InfoReader -> m:range -> finfo:ILFieldInfo -> (string option * string) option

--- a/src/fsharp/InfoReader.fsi
+++ b/src/fsharp/InfoReader.fsi
@@ -165,7 +165,7 @@ val GetXmlDocSigOfEntityRef: infoReader:InfoReader -> m:range -> eref: EntityRef
 
 val GetXmlDocSigOfScopedValRef: TcGlobals -> tcref: TyconRef -> vref: ValRef -> (string option * string) option
 
-val GetXmlDocSigOfRecdFieldInfo: rfinfo:RecdFieldInfo -> (string option * string) option
+val GetXmlDocSigOfRecdFieldRef: rfref:RecdFieldRef -> (string option * string) option
 
 val GetXmlDocSigOfUnionCaseInfo: ucinfo:UnionCaseInfo -> (string option * string) option
 

--- a/src/fsharp/InnerLambdasToTopLevelFuncs.fs
+++ b/src/fsharp/InnerLambdasToTopLevelFuncs.fs
@@ -13,6 +13,7 @@ open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Layout
 open FSharp.Compiler.Text.LayoutRender
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/MethodOverrides.fsi
+++ b/src/fsharp/MethodOverrides.fsi
@@ -81,7 +81,7 @@ module DispatchSlotChecking =
     val CheckDispatchSlotsAreImplemented: denv:DisplayEnv * infoReader:InfoReader * m:range * nenv:NameResolutionEnv * sink:TcResultsSink * isOverallTyAbstract:bool * reqdTy:TType * dispatchSlots:RequiredSlot list * availPriorOverrides:OverrideInfo list * overrides:OverrideInfo list -> bool
 
     /// Check all implementations implement some dispatch slot.
-    val CheckOverridesAreAllUsedOnce: denv:DisplayEnv * g:TcGlobals * amap:ImportMap * isObjExpr:bool * reqdTy:TType * dispatchSlotsKeyed:NameMultiMap<RequiredSlot> * availPriorOverrides:OverrideInfo list * overrides:OverrideInfo list -> unit
+    val CheckOverridesAreAllUsedOnce: denv:DisplayEnv * g:TcGlobals * infoReader:InfoReader * isObjExpr:bool * reqdTy:TType * dispatchSlotsKeyed:NameMultiMap<RequiredSlot> * availPriorOverrides:OverrideInfo list * overrides:OverrideInfo list -> unit
 
     /// Get the slots of a type that can or must be implemented. 
     val GetSlotImplSets: infoReader:InfoReader -> denv:DisplayEnv -> ad:AccessorDomain -> isObjExpr:bool -> allReqdTys:(TType * range) list -> SlotImplSet list

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1464,7 +1464,7 @@ module private TastDefinitionPrinting =
     let layoutExtensionMembers denv infoReader vs =
         aboveListL (List.map (layoutExtensionMember denv infoReader) vs) 
 
-    let layoutRecdField addAccess denv infoReader enclosingTcref (fld: RecdField) =
+    let layoutRecdField addAccess denv infoReader (enclosingTcref: TyconRef) (fld: RecdField) =
         let lhs =
             tagRecordField fld.Name
             |> mkNav fld.DefinitionRange
@@ -1472,7 +1472,12 @@ module private TastDefinitionPrinting =
         let lhs = (if addAccess then layoutAccessibility denv fld.Accessibility lhs else lhs)
         let lhs = if fld.IsMutable then wordL (tagKeyword "mutable") --- lhs else lhs
         let fieldL = (lhs ^^ RightL.colon) --- layoutType denv fld.FormalType
-        layoutXmlDocOfRecdFieldRef denv infoReader (RecdFieldRef(enclosingTcref, fld.Id.idText)) fieldL
+
+        // The enclosing TyconRef might be a union and we can only get fields from union cases, so we need ignore unions here.
+        if not enclosingTcref.IsUnionTycon then
+            layoutXmlDocOfRecdFieldRef denv infoReader (RecdFieldRef(enclosingTcref, fld.Id.idText)) fieldL
+        else
+            fieldL
 
     let layoutUnionOrExceptionField denv infoReader isGenerated enclosingTcref i (fld: RecdField) =
         if isGenerated i fld then layoutTypeWithInfoAndPrec denv SimplifyTypes.typeSimplificationInfo0 2 fld.FormalType

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -173,10 +173,31 @@ module internal PrintUtilities =
         else
             restL
 
+    let layoutXmlDocOfPropInfo (denv: DisplayEnv) (infoReader: InfoReader) (pinfo: PropInfo) restL =
+        if denv.showDocumentation then
+            GetXmlDocSigOfProp infoReader Range.range0 pinfo
+            |> layoutXmlDocFromSig denv infoReader pinfo.XmlDoc restL             
+        else
+            restL
+
     let layoutXmlDocOfRecdFieldRef (denv: DisplayEnv) (infoReader: InfoReader) (rfref: RecdFieldRef) restL =
         if denv.showDocumentation then
             GetXmlDocSigOfRecdFieldRef rfref
             |> layoutXmlDocFromSig denv infoReader rfref.RecdField.XmlDoc restL             
+        else
+            restL
+
+    let layoutXmlDocOfUnionCaseRef (denv: DisplayEnv) (infoReader: InfoReader) (ucref: UnionCaseRef) restL =
+        if denv.showDocumentation then
+            GetXmlDocSigOfUnionCaseRef ucref
+            |> layoutXmlDocFromSig denv infoReader ucref.UnionCase.XmlDoc restL             
+        else
+            restL
+
+    let layoutXmlDocOfEntityRef (denv: DisplayEnv) (infoReader: InfoReader) (eref: EntityRef) restL =
+        if denv.showDocumentation then
+            GetXmlDocSigOfEntityRef infoReader Range.range0 eref
+            |> layoutXmlDocFromSig denv infoReader eref.XmlDoc restL             
         else
             restL
 

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -2186,7 +2186,7 @@ let stringOfTyparConstraints denv x = x |> PrintTypes.layoutConstraintsWithInfo 
 
 let layoutTycon denv infoReader ad m (* width *) x = TastDefinitionPrinting.layoutTyconRef denv infoReader ad m true WordL.keywordType (mkLocalEntityRef x) (* |> Display.squashTo width *)
 
-let layoutEntity denv infoReader ad m x = TastDefinitionPrinting.layoutEntityRef denv infoReader ad m (mkLocalEntityRef x)
+let layoutEntityRef denv infoReader ad m x = TastDefinitionPrinting.layoutEntityRef denv infoReader ad m x
 
 let layoutUnionCases denv infoReader enclosingTcref x = x |> TastDefinitionPrinting.layoutUnionCaseFields denv infoReader true enclosingTcref
 

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -131,11 +131,15 @@ module internal PrintUtilities =
                     emptyL
                 else
                     xml.UnprocessedLines
-                    |> List.ofArray
+                    |> Array.map (fun x ->
+                        x.Split('\n') // These lines may have new-lines in them and we need to split them so we can format it
+                    )
+                    |> Array.concat
                     /// note here that we don't add a space after the triple-slash, because
                     /// the implicit spacing hasn't been trimmed here.
-                    |> List.map (fun line -> ("///" + line) |> tagText |> wordL)
-                    |> spaceListL
+                    |> Array.map (fun line -> ("///" + line) |> tagText |> wordL)
+                    |> List.ofArray
+                    |> aboveListL
             xmlDocL @@ restL
         else restL
 

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -21,6 +21,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Layout
 open FSharp.Compiler.Text.LayoutRender
 open FSharp.Compiler.Text.TaggedText
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/NicePrint.fsi
+++ b/src/fsharp/NicePrint.fsi
@@ -40,17 +40,17 @@ val prettyLayoutsOfUnresolvedOverloading: denv:DisplayEnv -> argInfos:(TType * A
 
 val dataExprL: denv:DisplayEnv -> expr:Expr -> Layout
 
-val outputValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> x:Val -> unit
+val outputValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> x:ValRef -> unit
 
-val stringValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> x:Val -> string
+val stringValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> x:ValRef -> string
 
-val layoutQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> typarInst:TyparInst -> v:Val -> TyparInst * Layout
+val layoutQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> typarInst:TyparInst -> v:ValRef -> TyparInst * Layout
 
-val outputQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> v:Val -> unit
+val outputQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> v:ValRef -> unit
 
-val outputQualifiedValSpec: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> v:Val -> unit
+val outputQualifiedValSpec: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> v:ValRef -> unit
 
-val stringOfQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> v:Val -> string
+val stringOfQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> v:ValRef -> string
 
 val formatMethInfoToBufferFreeStyle: infoReader:InfoReader -> m:range -> denv:DisplayEnv -> buf:StringBuilder -> d:MethInfo -> unit
 
@@ -102,9 +102,9 @@ val stringOfILAttrib: denv:DisplayEnv -> ILType * ILAttribElem list -> string
 
 val layoutInferredSigOfModuleExpr: showHeader:bool -> denv:DisplayEnv -> infoReader:InfoReader -> ad:AccessorDomain -> m:range -> expr:ModuleOrNamespaceExprWithSig -> Layout
 
-val prettyLayoutOfValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> typarInst:TyparInst -> v:Val -> TyparInst * Layout
+val prettyLayoutOfValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> typarInst:TyparInst -> v:ValRef -> TyparInst * Layout
 
-val prettyLayoutOfValOrMemberNoInst: denv:DisplayEnv -> infoReader:InfoReader -> v:Val -> Layout
+val prettyLayoutOfValOrMemberNoInst: denv:DisplayEnv -> infoReader:InfoReader -> v:ValRef -> Layout
 
 val prettyLayoutOfMemberNoInstShort: denv:DisplayEnv -> infoReader:InfoReader -> v:Val -> Layout
 
@@ -112,6 +112,6 @@ val prettyLayoutOfInstAndSig: denv:DisplayEnv -> TyparInst * TTypes * TType -> T
 
 val minimalStringsOfTwoTypes: denv:DisplayEnv -> t1:TType -> t2:TType -> string * string * string
 
-val minimalStringsOfTwoValues: denv:DisplayEnv -> infoReader:InfoReader -> v1:Val -> v2:Val -> string * string
+val minimalStringsOfTwoValues: denv:DisplayEnv -> infoReader:InfoReader -> v1:ValRef -> v2:ValRef -> string * string
 
 val minimalStringOfType: denv:DisplayEnv -> ty:TType -> string

--- a/src/fsharp/NicePrint.fsi
+++ b/src/fsharp/NicePrint.fsi
@@ -106,7 +106,7 @@ val prettyLayoutOfValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> typar
 
 val prettyLayoutOfValOrMemberNoInst: denv:DisplayEnv -> infoReader:InfoReader -> v:ValRef -> Layout
 
-val prettyLayoutOfMemberNoInstShort: denv:DisplayEnv -> infoReader:InfoReader -> v:Val -> Layout
+val prettyLayoutOfMemberNoInstShort: denv:DisplayEnv -> v:Val -> Layout
 
 val prettyLayoutOfInstAndSig: denv:DisplayEnv -> TyparInst * TTypes * TType -> TyparInst * (TTypes * TType) * (Layout list * Layout) * Layout
 

--- a/src/fsharp/NicePrint.fsi
+++ b/src/fsharp/NicePrint.fsi
@@ -70,7 +70,7 @@ val stringOfTyparConstraints: denv:DisplayEnv -> x:(Typar * TyparConstraint) lis
 
 val layoutTycon: denv:DisplayEnv -> infoReader:InfoReader -> ad:AccessorDomain -> m:range -> x:Tycon -> Layout
 
-val layoutEntity: denv:DisplayEnv -> infoReader:InfoReader -> ad:AccessorDomain -> m:range -> x:Entity -> Layout
+val layoutEntityRef: denv:DisplayEnv -> infoReader:InfoReader -> ad:AccessorDomain -> m:range -> x:EntityRef -> Layout
 
 val layoutUnionCases: denv:DisplayEnv -> infoReader:InfoReader -> enclosingTcref:TyconRef -> x:RecdField list -> Layout
 

--- a/src/fsharp/NicePrint.fsi
+++ b/src/fsharp/NicePrint.fsi
@@ -40,31 +40,31 @@ val prettyLayoutsOfUnresolvedOverloading: denv:DisplayEnv -> argInfos:(TType * A
 
 val dataExprL: denv:DisplayEnv -> expr:Expr -> Layout
 
-val outputValOrMember: denv:DisplayEnv -> os:StringBuilder -> x:Val -> unit
+val outputValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> x:Val -> unit
 
-val stringValOrMember: denv:DisplayEnv -> x:Val -> string
+val stringValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> x:Val -> string
 
-val layoutQualifiedValOrMember: denv:DisplayEnv -> typarInst:TyparInst -> v:Val -> TyparInst * Layout
+val layoutQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> typarInst:TyparInst -> v:Val -> TyparInst * Layout
 
-val outputQualifiedValOrMember: denv:DisplayEnv -> os:StringBuilder -> v:Val -> unit
+val outputQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> v:Val -> unit
 
-val outputQualifiedValSpec: denv:DisplayEnv -> os:StringBuilder -> v:Val -> unit
+val outputQualifiedValSpec: denv:DisplayEnv -> infoReader:InfoReader -> os:StringBuilder -> v:Val -> unit
 
-val stringOfQualifiedValOrMember: denv:DisplayEnv -> v:Val -> string
+val stringOfQualifiedValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> v:Val -> string
 
-val formatMethInfoToBufferFreeStyle: amap:ImportMap -> m:range -> denv:DisplayEnv -> buf:StringBuilder -> d:MethInfo -> unit
+val formatMethInfoToBufferFreeStyle: infoReader:InfoReader -> m:range -> denv:DisplayEnv -> buf:StringBuilder -> d:MethInfo -> unit
 
-val prettyLayoutOfMethInfoFreeStyle: amap:ImportMap -> m:range -> denv:DisplayEnv -> typarInst:TyparInst -> minfo:MethInfo -> TyparInst * Layout
+val prettyLayoutOfMethInfoFreeStyle: infoReader:InfoReader -> m:range -> denv:DisplayEnv -> typarInst:TyparInst -> minfo:MethInfo -> TyparInst * Layout
 
 val prettyLayoutOfPropInfoFreeStyle: g:TcGlobals -> amap:ImportMap -> m:range -> denv:DisplayEnv -> d:PropInfo -> Layout
 
-val stringOfMethInfo: amap:ImportMap -> m:range -> denv:DisplayEnv -> d:MethInfo -> string
+val stringOfMethInfo: infoReader:InfoReader -> m:range -> denv:DisplayEnv -> d:MethInfo -> string
 
 val stringOfParamData: denv:DisplayEnv -> paramData:ParamData -> string
 
 val layoutOfParamData: denv:DisplayEnv -> paramData:ParamData -> Layout
 
-val layoutExnDef: denv:DisplayEnv -> x:Entity -> Layout
+val layoutExnDef: denv:DisplayEnv -> infoReader:InfoReader -> x:EntityRef -> Layout
 
 val stringOfTyparConstraints: denv:DisplayEnv -> x:(Typar * TyparConstraint) list -> string
 
@@ -72,7 +72,7 @@ val layoutTycon: denv:DisplayEnv -> infoReader:InfoReader -> ad:AccessorDomain -
 
 val layoutEntity: denv:DisplayEnv -> infoReader:InfoReader -> ad:AccessorDomain -> m:range -> x:Entity -> Layout
 
-val layoutUnionCases: denv:DisplayEnv -> x:RecdField list -> Layout
+val layoutUnionCases: denv:DisplayEnv -> infoReader:InfoReader -> enclosingTcref:TyconRef -> x:RecdField list -> Layout
 
 val isGeneratedUnionCaseField: pos:int -> f:RecdField -> bool
 
@@ -90,11 +90,11 @@ val prettyStringOfTy: denv:DisplayEnv -> x:TType -> string
 
 val prettyStringOfTyNoCx: denv:DisplayEnv -> x:TType -> string
 
-val stringOfRecdField: denv:DisplayEnv -> x:RecdField -> string
+val stringOfRecdField: denv:DisplayEnv -> infoReader:InfoReader -> enclosingTcref:TyconRef -> x:RecdField -> string
 
-val stringOfUnionCase: denv:DisplayEnv -> x:UnionCase -> string
+val stringOfUnionCase: denv:DisplayEnv -> infoReader:InfoReader -> enclosingTcref:TyconRef -> x:UnionCase -> string
 
-val stringOfExnDef: denv:DisplayEnv -> x:Entity -> string
+val stringOfExnDef: denv:DisplayEnv -> infoReader:InfoReader -> x:EntityRef -> string
 
 val stringOfFSAttrib: denv:DisplayEnv -> x:Attrib -> string
 
@@ -102,16 +102,16 @@ val stringOfILAttrib: denv:DisplayEnv -> ILType * ILAttribElem list -> string
 
 val layoutInferredSigOfModuleExpr: showHeader:bool -> denv:DisplayEnv -> infoReader:InfoReader -> ad:AccessorDomain -> m:range -> expr:ModuleOrNamespaceExprWithSig -> Layout
 
-val prettyLayoutOfValOrMember: denv:DisplayEnv -> typarInst:TyparInst -> v:Val -> TyparInst * Layout
+val prettyLayoutOfValOrMember: denv:DisplayEnv -> infoReader:InfoReader -> typarInst:TyparInst -> v:Val -> TyparInst * Layout
 
-val prettyLayoutOfValOrMemberNoInst: denv:DisplayEnv -> v:Val -> Layout
+val prettyLayoutOfValOrMemberNoInst: denv:DisplayEnv -> infoReader:InfoReader -> v:Val -> Layout
 
-val prettyLayoutOfMemberNoInstShort: denv:DisplayEnv -> v:Val -> Layout
+val prettyLayoutOfMemberNoInstShort: denv:DisplayEnv -> infoReader:InfoReader -> v:Val -> Layout
 
 val prettyLayoutOfInstAndSig: denv:DisplayEnv -> TyparInst * TTypes * TType -> TyparInst * (TTypes * TType) * (Layout list * Layout) * Layout
 
 val minimalStringsOfTwoTypes: denv:DisplayEnv -> t1:TType -> t2:TType -> string * string * string
 
-val minimalStringsOfTwoValues: denv:DisplayEnv -> v1:Val -> v2:Val -> string * string
+val minimalStringsOfTwoValues: denv:DisplayEnv -> infoReader:InfoReader -> v1:Val -> v2:Val -> string * string
 
 val minimalStringOfType: denv:DisplayEnv -> ty:TType -> string

--- a/src/fsharp/ParseAndCheckInputs.fs
+++ b/src/fsharp/ParseAndCheckInputs.fs
@@ -34,6 +34,7 @@ open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
 open FSharp.Compiler.TcGlobals
@@ -735,7 +736,8 @@ let GetInitialTcState(m, ccuName, tcConfig: TcConfig, tcGlobals, tcImports: TcIm
           ILScopeRef=ILScopeRef.Local
           Contents=ccuContents
           MemberSignatureEquality= typeEquivAux EraseAll tcGlobals
-          TypeForwarders=Map.empty }
+          TypeForwarders=Map.empty
+          XmlDocumentationInfo = None }
 
     let ccu = CcuThunk.Create(ccuName, ccuData)
 

--- a/src/fsharp/ParseHelpers.fs
+++ b/src/fsharp/ParseHelpers.fs
@@ -5,12 +5,12 @@ module FSharp.Compiler.ParseHelpers
 open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Features
-open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.UnicodeLexing
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 open Internal.Utilities.Text.Lexing
 open Internal.Utilities.Text.Parsing
 

--- a/src/fsharp/ParseHelpers.fsi
+++ b/src/fsharp/ParseHelpers.fsi
@@ -3,8 +3,8 @@
 module internal FSharp.Compiler.ParseHelpers
 
 open FSharp.Compiler.AbstractIL.IL
-open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open Internal.Utilities.Text.Lexing
 open Internal.Utilities.Text.Parsing
 

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -1741,6 +1741,7 @@ and AdjustAccess isHidden (cpath: unit -> CompilationPath) access =
         access
 
 and CheckBinding cenv env alwaysCheckNoReraise context (TBind(v, bindRhs, _) as bind) : Limit =
+    let vref = mkLocalValRef v
     let g = cenv.g
     let isTop = Option.isSome bind.Var.ValReprInfo
     //printfn "visiting %s..." v.DisplayName
@@ -1748,9 +1749,9 @@ and CheckBinding cenv env alwaysCheckNoReraise context (TBind(v, bindRhs, _) as 
     let env = { env with external = env.external || g.attrib_DllImportAttribute |> Option.exists (fun attr -> HasFSharpAttribute g attr v.Attribs) }
 
     // Check that active patterns don't have free type variables in their result
-    match TryGetActivePatternInfo (mkLocalValRef v) with 
+    match TryGetActivePatternInfo vref with 
     | Some _apinfo when _apinfo.ActiveTags.Length > 1 -> 
-        if doesActivePatternHaveFreeTypars g (mkLocalValRef v) then
+        if doesActivePatternHaveFreeTypars g vref then
            errorR(Error(FSComp.SR.activePatternChoiceHasFreeTypars(v.LogicalName), v.Range))
     | _ -> ()
     
@@ -1767,7 +1768,7 @@ and CheckBinding cenv env alwaysCheckNoReraise context (TBind(v, bindRhs, _) as 
     // Check accessibility
     if (v.IsMemberOrModuleBinding || v.IsMember) && not v.IsIncrClassGeneratedMember then 
         let access =  AdjustAccess (IsHiddenVal env.sigToImplRemapInfo v) (fun () -> v.TopValDeclaringEntity.CompilationPath) v.Accessibility
-        CheckTypeForAccess cenv env (fun () -> NicePrint.stringOfQualifiedValOrMember cenv.denv cenv.infoReader v) access v.Range v.Type
+        CheckTypeForAccess cenv env (fun () -> NicePrint.stringOfQualifiedValOrMember cenv.denv cenv.infoReader vref) access v.Range v.Type
     
     let env = if v.IsConstructor && not v.IsIncrClassConstructor then { env with ctorLimitedZone=true } else env
 

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -1767,7 +1767,7 @@ and CheckBinding cenv env alwaysCheckNoReraise context (TBind(v, bindRhs, _) as 
     // Check accessibility
     if (v.IsMemberOrModuleBinding || v.IsMember) && not v.IsIncrClassGeneratedMember then 
         let access =  AdjustAccess (IsHiddenVal env.sigToImplRemapInfo v) (fun () -> v.TopValDeclaringEntity.CompilationPath) v.Accessibility
-        CheckTypeForAccess cenv env (fun () -> NicePrint.stringOfQualifiedValOrMember cenv.denv v) access v.Range v.Type
+        CheckTypeForAccess cenv env (fun () -> NicePrint.stringOfQualifiedValOrMember cenv.denv cenv.infoReader v) access v.Range v.Type
     
     let env = if v.IsConstructor && not v.IsIncrClassConstructor then { env with ctorLimitedZone=true } else env
 
@@ -2189,7 +2189,7 @@ let CheckEntityDefn cenv env (tycon: Entity) =
                     match parentMethsOfSameName |> List.tryFind (checkForDup EraseAll) with
                     | None -> ()
                     | Some minfo ->
-                        let mtext = NicePrint.stringOfMethInfo cenv.amap m cenv.denv minfo
+                        let mtext = NicePrint.stringOfMethInfo cenv.infoReader m cenv.denv minfo
                         if parentMethsOfSameName |> List.exists (checkForDup EraseNone) then 
                             warning(Error(FSComp.SR.tcNewMemberHidesAbstractMember mtext, m))
                         else

--- a/src/fsharp/SignatureConformance.fs
+++ b/src/fsharp/SignatureConformance.fs
@@ -445,12 +445,12 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
             let m2 = NameMap.ofKeyedList (fun (v: ValRef) -> v.DisplayName) sigAbstractSlots
             (m1, m2) ||> NameMap.suball2 (fun _s vref -> 
                 let kindText = implTycon.TypeOrMeasureKind.ToString()
-                let valText = NicePrint.stringValOrMember denv infoReader vref.Deref
+                let valText = NicePrint.stringValOrMember denv infoReader vref
                 errorR(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleAbstractMemberMissingInImpl(kindText, implTycon.DisplayName, valText), m)); false) (fun _x _y -> true)  &&
 
             (m2, m1) ||> NameMap.suball2 (fun _s vref -> 
                 let kindText = implTycon.TypeOrMeasureKind.ToString()
-                let valText = NicePrint.stringValOrMember denv infoReader vref.Deref
+                let valText = NicePrint.stringValOrMember denv infoReader vref
                 errorR(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleAbstractMemberMissingInSig(kindText, implTycon.DisplayName, valText), m)); false) (fun _x _y -> true)  
 
         and checkClassFields isStruct m aenv infoReader (implTycon: Tycon) (implFields: TyconRecdFields) (sigFields: TyconRecdFields) =
@@ -583,7 +583,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                 errorR(RequiredButNotSpecified(denv, implModRef, "value", (fun os -> 
                    (* In the case of missing members show the full required enclosing type and signature *)
                    if fx.IsMember then 
-                       NicePrint.outputQualifiedValOrMember denv infoReader os fx
+                       NicePrint.outputQualifiedValOrMember denv infoReader os (mkLocalValRef fx)
                    else
                        Printf.bprintf os "%s" fx.DisplayName), m))
             
@@ -667,7 +667,7 @@ let rec CheckNamesOfModuleOrNamespaceContents denv infoReader (implModRef: Modul
                     errorR(RequiredButNotSpecified(denv, implModRef, "value", (fun os -> 
                        // In the case of missing members show the full required enclosing type and signature 
                        if Option.isSome fx.MemberInfo then 
-                           NicePrint.outputQualifiedValOrMember denv infoReader os fx
+                           NicePrint.outputQualifiedValOrMember denv infoReader os (mkLocalValRef fx)
                        else
                            Printf.bprintf os "%s" fx.DisplayName), m)); false)
                 (fun _ _ -> true) 

--- a/src/fsharp/SignatureConformance.fs
+++ b/src/fsharp/SignatureConformance.fs
@@ -21,6 +21,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.InfoReader
 
 #if !NO_EXTENSIONTYPING
 open FSharp.Compiler.ExtensionTyping
@@ -28,13 +29,13 @@ open FSharp.Compiler.ExtensionTyping
 
 exception RequiredButNotSpecified of DisplayEnv * ModuleOrNamespaceRef * string * (StringBuilder -> unit) * range
 
-exception ValueNotContained of DisplayEnv * ModuleOrNamespaceRef * Val * Val * (string * string * string -> string)
+exception ValueNotContained of DisplayEnv * InfoReader * ModuleOrNamespaceRef * Val * Val * (string * string * string -> string)
 
-exception ConstrNotContained of DisplayEnv * UnionCase * UnionCase * (string * string -> string)
+exception ConstrNotContained of DisplayEnv * InfoReader * Tycon * UnionCase * UnionCase * (string * string -> string)
 
-exception ExnconstrNotContained of DisplayEnv * Tycon * Tycon * (string * string -> string)
+exception ExnconstrNotContained of DisplayEnv * InfoReader * Tycon * Tycon * (string * string -> string)
 
-exception FieldNotContained of DisplayEnv * RecdField * RecdField * (string * string -> string)
+exception FieldNotContained of DisplayEnv * InfoReader * Tycon * RecdField * RecdField * (string * string -> string)
 
 exception InterfaceNotRevealed of DisplayEnv * TType * range
 
@@ -157,7 +158,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                               true) &&
                   (not checkingSig || checkAttribs aenv implTypar.Attribs sigTypar.Attribs (fun attribs -> implTypar.SetAttribs attribs)))
 
-        and checkTypeDef (aenv: TypeEquivEnv) (implTycon: Tycon) (sigTycon: Tycon) =
+        and checkTypeDef (aenv: TypeEquivEnv) (infoReader: InfoReader) (implTycon: Tycon) (sigTycon: Tycon) =
             let m = implTycon.Range
             
             // Propagate defn location information from implementation to signature . 
@@ -174,7 +175,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                 false 
             else
             
-            checkExnInfo  (fun f -> ExnconstrNotContained(denv, implTycon, sigTycon, f)) aenv implTycon.ExceptionInfo sigTycon.ExceptionInfo &&
+            checkExnInfo  (fun f -> ExnconstrNotContained(denv, infoReader, implTycon, sigTycon, f)) aenv infoReader implTycon implTycon.ExceptionInfo sigTycon.ExceptionInfo &&
             
             let implTypars = implTycon.Typars m
             let sigTypars = sigTycon.Typars m
@@ -255,10 +256,10 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                 else
 
                 checkTypars m aenv implTypars sigTypars &&
-                checkTypeRepr m aenv implTycon sigTycon.TypeReprInfo &&
+                checkTypeRepr m aenv infoReader implTycon sigTycon.TypeReprInfo &&
                 checkTypeAbbrev m aenv implTycon sigTycon &&
                 checkAttribs aenv implTycon.Attribs sigTycon.Attribs (fun attribs -> implTycon.entity_attribs <- attribs) &&
-                checkModuleOrNamespaceContents implTycon.Range aenv (mkLocalEntityRef implTycon) sigTycon.ModuleOrNamespaceType 
+                checkModuleOrNamespaceContents implTycon.Range aenv infoReader (mkLocalEntityRef implTycon) sigTycon.ModuleOrNamespaceType 
             
         and checkValInfo aenv err (implVal : Val) (sigVal : Val) = 
             let id = implVal.Id
@@ -302,13 +303,13 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                   implVal.SetValReprInfo (Some (ValReprInfo (sigTyparNames, implArgInfos, implRetInfo)))
                   res
 
-        and checkVal implModRef (aenv: TypeEquivEnv) (implVal: Val) (sigVal: Val) =
+        and checkVal implModRef (aenv: TypeEquivEnv) (infoReader: InfoReader) (implVal: Val) (sigVal: Val) =
 
             // Propagate defn location information from implementation to signature . 
             sigVal.SetOtherRange (implVal.Range, true)
             implVal.SetOtherRange (sigVal.Range, false)
 
-            let mk_err denv f = ValueNotContained(denv, implModRef, implVal, sigVal, f)
+            let mk_err denv f = ValueNotContained(denv, infoReader, implModRef, implVal, sigVal, f)
             let err denv f = errorR(mk_err denv f); false
             let m = implVal.Range
             if implVal.IsMutable <> sigVal.IsMutable then (err denv FSComp.SR.ValueNotContainedMutabilityAttributesDiffer)
@@ -332,7 +333,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                 else checkAttribs aenv implVal.Attribs sigVal.Attribs (fun attribs -> implVal.SetAttribs attribs)              
 
 
-        and checkExnInfo err aenv implTypeRepr sigTypeRepr =
+        and checkExnInfo err aenv (infoReader: InfoReader) (enclosingTycon: Tycon) implTypeRepr sigTypeRepr =
             match implTypeRepr, sigTypeRepr with 
             | TExnAsmRepr _, TExnFresh _ -> 
                 (errorR (err FSComp.SR.ExceptionDefsNotCompatibleHiddenBySignature); false)
@@ -344,23 +345,23 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                 if not (tcrefAEquiv g aenv ecr1 ecr2) then 
                   (errorR (err FSComp.SR.ExceptionDefsNotCompatibleSignaturesDiffer); false)
                 else true
-            | TExnFresh r1, TExnFresh  r2-> checkRecordFieldsForExn g denv err aenv r1 r2
+            | TExnFresh r1, TExnFresh  r2-> checkRecordFieldsForExn g denv err aenv infoReader enclosingTycon r1 r2
             | TExnNone, TExnNone -> true
             | _ -> 
                 (errorR (err FSComp.SR.ExceptionDefsNotCompatibleExceptionDeclarationsDiffer); false)
 
-        and checkUnionCase aenv implUnionCase sigUnionCase =
-            let err f = errorR(ConstrNotContained(denv, implUnionCase, sigUnionCase, f));false
+        and checkUnionCase aenv infoReader (enclosingTycon: Tycon) implUnionCase sigUnionCase =
+            let err f = errorR(ConstrNotContained(denv, infoReader, enclosingTycon, implUnionCase, sigUnionCase, f));false
             sigUnionCase.OtherRangeOpt <- Some (implUnionCase.Range, true)
             implUnionCase.OtherRangeOpt <- Some (sigUnionCase.Range, false)
             if implUnionCase.Id.idText <> sigUnionCase.Id.idText then  err FSComp.SR.ModuleContainsConstructorButNamesDiffer
             elif implUnionCase.RecdFieldsArray.Length <> sigUnionCase.RecdFieldsArray.Length then err FSComp.SR.ModuleContainsConstructorButDataFieldsDiffer
-            elif not (Array.forall2 (checkField aenv) implUnionCase.RecdFieldsArray sigUnionCase.RecdFieldsArray) then err FSComp.SR.ModuleContainsConstructorButTypesOfFieldsDiffer
+            elif not (Array.forall2 (checkField aenv infoReader enclosingTycon) implUnionCase.RecdFieldsArray sigUnionCase.RecdFieldsArray) then err FSComp.SR.ModuleContainsConstructorButTypesOfFieldsDiffer
             elif isLessAccessible implUnionCase.Accessibility sigUnionCase.Accessibility then err FSComp.SR.ModuleContainsConstructorButAccessibilityDiffers
             else checkAttribs aenv implUnionCase.Attribs sigUnionCase.Attribs (fun attribs -> implUnionCase.Attribs <- attribs)
 
-        and checkField aenv implField sigField =
-            let err f = errorR(FieldNotContained(denv, implField, sigField, f)); false
+        and checkField aenv infoReader (enclosingTycon: Tycon) implField sigField =
+            let err f = errorR(FieldNotContained(denv, infoReader, enclosingTycon, implField, sigField, f)); false
             sigField.rfield_other_range <- Some (implField.Range, true)
             implField.rfield_other_range <- Some (sigField.Range, false)
             if implField.rfield_id.idText <> sigField.rfield_id.idText then err FSComp.SR.FieldNotContainedNamesDiffer
@@ -408,67 +409,67 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
 
             | _ -> false
 
-        and checkRecordFields m aenv (implTycon: Tycon) (implFields: TyconRecdFields) (sigFields: TyconRecdFields) =
+        and checkRecordFields m aenv infoReader (implTycon: Tycon) (implFields: TyconRecdFields) (sigFields: TyconRecdFields) =
             let implFields = implFields.TrueFieldsAsList
             let sigFields = sigFields.TrueFieldsAsList
             let m1 = implFields |> NameMap.ofKeyedList (fun rfld -> rfld.Name)
             let m2 = sigFields |> NameMap.ofKeyedList (fun rfld -> rfld.Name)
             NameMap.suball2 
                 (fun fieldName _ -> errorR(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleFieldRequiredButNotSpecified(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName, fieldName), m)); false) 
-                (checkField aenv) m1 m2 &&
+                (checkField aenv infoReader implTycon) m1 m2 &&
             NameMap.suball2 
                 (fun fieldName _ -> errorR(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleFieldWasPresent(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName, fieldName), m)); false) 
-                (fun x y -> checkField aenv y x) m2 m1 &&
+                (fun x y -> checkField aenv infoReader implTycon y x) m2 m1 &&
 
             // This check is required because constructors etc. are externally visible 
             // and thus compiled representations do pick up dependencies on the field order  
-            (if List.forall2 (checkField aenv)  implFields sigFields
+            (if List.forall2 (checkField aenv infoReader implTycon)  implFields sigFields
              then true
              else (errorR(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleFieldOrderDiffer(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName), m)); false))
 
-        and checkRecordFieldsForExn _g _denv err aenv (implFields: TyconRecdFields) (sigFields: TyconRecdFields) =
+        and checkRecordFieldsForExn _g _denv err aenv (infoReader: InfoReader) (enclosingTycon: Tycon) (implFields: TyconRecdFields) (sigFields: TyconRecdFields) =
             let implFields = implFields.TrueFieldsAsList
             let sigFields = sigFields.TrueFieldsAsList
             let m1 = implFields |> NameMap.ofKeyedList (fun rfld -> rfld.Name)
             let m2 = sigFields |> NameMap.ofKeyedList (fun rfld -> rfld.Name)
-            NameMap.suball2 (fun s _ -> errorR(err (fun (x, y) -> FSComp.SR.ExceptionDefsNotCompatibleFieldInSigButNotImpl(s, x, y))); false) (checkField aenv)  m1 m2 &&
-            NameMap.suball2 (fun s _ -> errorR(err (fun (x, y) -> FSComp.SR.ExceptionDefsNotCompatibleFieldInImplButNotSig(s, x, y))); false) (fun x y -> checkField aenv y x)  m2 m1 &&
+            NameMap.suball2 (fun s _ -> errorR(err (fun (x, y) -> FSComp.SR.ExceptionDefsNotCompatibleFieldInSigButNotImpl(s, x, y))); false) (checkField aenv infoReader enclosingTycon)  m1 m2 &&
+            NameMap.suball2 (fun s _ -> errorR(err (fun (x, y) -> FSComp.SR.ExceptionDefsNotCompatibleFieldInImplButNotSig(s, x, y))); false) (fun x y -> checkField aenv infoReader enclosingTycon y x)  m2 m1 &&
             // This check is required because constructors etc. are externally visible 
             // and thus compiled representations do pick up dependencies on the field order  
-            (if List.forall2 (checkField aenv)  implFields sigFields
+            (if List.forall2 (checkField aenv infoReader enclosingTycon)  implFields sigFields
              then true
              else (errorR(err (FSComp.SR.ExceptionDefsNotCompatibleFieldOrderDiffers)); false))
 
-        and checkVirtualSlots denv m (implTycon: Tycon) implAbstractSlots sigAbstractSlots =
+        and checkVirtualSlots denv infoReader m (implTycon: Tycon) implAbstractSlots sigAbstractSlots =
             let m1 = NameMap.ofKeyedList (fun (v: ValRef) -> v.DisplayName) implAbstractSlots
             let m2 = NameMap.ofKeyedList (fun (v: ValRef) -> v.DisplayName) sigAbstractSlots
             (m1, m2) ||> NameMap.suball2 (fun _s vref -> 
                 let kindText = implTycon.TypeOrMeasureKind.ToString()
-                let valText = NicePrint.stringValOrMember denv vref.Deref
+                let valText = NicePrint.stringValOrMember denv infoReader vref.Deref
                 errorR(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleAbstractMemberMissingInImpl(kindText, implTycon.DisplayName, valText), m)); false) (fun _x _y -> true)  &&
 
             (m2, m1) ||> NameMap.suball2 (fun _s vref -> 
                 let kindText = implTycon.TypeOrMeasureKind.ToString()
-                let valText = NicePrint.stringValOrMember denv vref.Deref
+                let valText = NicePrint.stringValOrMember denv infoReader vref.Deref
                 errorR(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleAbstractMemberMissingInSig(kindText, implTycon.DisplayName, valText), m)); false) (fun _x _y -> true)  
 
-        and checkClassFields isStruct m aenv (implTycon: Tycon) (implFields: TyconRecdFields) (sigFields: TyconRecdFields) =
+        and checkClassFields isStruct m aenv infoReader (implTycon: Tycon) (implFields: TyconRecdFields) (sigFields: TyconRecdFields) =
             let implFields = implFields.TrueFieldsAsList
             let sigFields = sigFields.TrueFieldsAsList
             let m1 = implFields |> NameMap.ofKeyedList (fun rfld -> rfld.Name) 
             let m2 = sigFields |> NameMap.ofKeyedList (fun rfld -> rfld.Name) 
             NameMap.suball2 
                 (fun fieldName _ -> errorR(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleFieldRequiredButNotSpecified(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName, fieldName), m)); false) 
-                (checkField aenv) m1 m2 &&
+                (checkField aenv infoReader implTycon) m1 m2 &&
             (if isStruct then 
                 NameMap.suball2 
                     (fun fieldName _ -> warning(Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleFieldIsInImplButNotSig(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName, fieldName), m)); true) 
-                    (fun x y -> checkField aenv y x) m2 m1 
+                    (fun x y -> checkField aenv infoReader implTycon y x) m2 m1 
              else
                 true)
             
 
-        and checkTypeRepr m aenv (implTycon: Tycon) sigTypeRepr =
+        and checkTypeRepr m aenv (infoReader: InfoReader) (implTycon: Tycon) sigTypeRepr =
             let reportNiceError k s1 s2 = 
               let aset = NameSet.ofList s1
               let fset = NameSet.ofList s2
@@ -504,9 +505,9 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                 if ucases1.Length <> ucases2.Length then
                   let names (l: UnionCase list) = l |> List.map (fun c -> c.Id.idText)
                   reportNiceError "union case" (names ucases1) (names ucases2) 
-                else List.forall2 (checkUnionCase aenv) ucases1 ucases2
+                else List.forall2 (checkUnionCase aenv infoReader implTycon) ucases1 ucases2
             | (TRecdRepr implFields), (TRecdRepr sigFields) -> 
-                checkRecordFields m aenv implTycon implFields sigFields
+                checkRecordFields m aenv infoReader implTycon implFields sigFields
             | (TFSharpObjectRepr r1), (TFSharpObjectRepr r2) -> 
                 if not (match r1.fsobjmodel_kind, r2.fsobjmodel_kind with 
                          | TTyconClass, TTyconClass -> true
@@ -528,8 +529,8 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                   (errorR (Error(FSComp.SR.DefinitionsInSigAndImplNotCompatibleTypeIsDifferentKind(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName), m)); false)
                 else 
                   let isStruct = (match r1.fsobjmodel_kind with TTyconStruct -> true | _ -> false)
-                  checkClassFields isStruct m aenv implTycon r1.fsobjmodel_rfields r2.fsobjmodel_rfields &&
-                  checkVirtualSlots denv m implTycon r1.fsobjmodel_vslots r2.fsobjmodel_vslots
+                  checkClassFields isStruct m aenv infoReader implTycon r1.fsobjmodel_rfields r2.fsobjmodel_rfields &&
+                  checkVirtualSlots denv infoReader m implTycon r1.fsobjmodel_vslots r2.fsobjmodel_vslots
             | (TAsmRepr tcr1),  (TAsmRepr tcr2) -> 
                 if tcr1 <> tcr2 then  (errorR (Error(FSComp.SR.DefinitionsInSigAndImplNotCompatibleILDiffer(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName), m)); false) else true
             | (TMeasureableRepr ty1),  (TMeasureableRepr ty2) -> 
@@ -562,7 +563,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
               | Some _, None -> (errorR (Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleAbbreviationHiddenBySig(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName), m)); false)
               | None, Some _ -> (errorR (Error (FSComp.SR.DefinitionsInSigAndImplNotCompatibleSigHasAbbreviation(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName), m)); false)
 
-        and checkModuleOrNamespaceContents m aenv (implModRef: ModuleOrNamespaceRef) (signModType: ModuleOrNamespaceType) = 
+        and checkModuleOrNamespaceContents m aenv (infoReader: InfoReader) (implModRef: ModuleOrNamespaceRef) (signModType: ModuleOrNamespaceType) = 
             let implModType = implModRef.ModuleOrNamespaceType
             (if implModType.ModuleOrNamespaceKind <> signModType.ModuleOrNamespaceKind then errorR(Error(FSComp.SR.typrelModuleNamespaceAttributesDifferInSigAndImpl(), m)))
 
@@ -570,19 +571,19 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
             (implModType.TypesByMangledName, signModType.TypesByMangledName)
              ||> NameMap.suball2 
                 (fun s _fx -> errorR(RequiredButNotSpecified(denv, implModRef, "type", (fun os -> Printf.bprintf os "%s" s), m)); false) 
-                (checkTypeDef aenv)  &&
+                (checkTypeDef aenv infoReader)  &&
 
 
             (implModType.ModulesAndNamespacesByDemangledName, signModType.ModulesAndNamespacesByDemangledName ) 
               ||> NameMap.suball2 
                    (fun s fx -> errorR(RequiredButNotSpecified(denv, implModRef, (if fx.IsModule then "module" else "namespace"), (fun os -> Printf.bprintf os "%s" s), m)); false) 
-                   (fun x1 x2 -> checkModuleOrNamespace aenv (mkLocalModRef x1) x2)  &&
+                   (fun x1 x2 -> checkModuleOrNamespace aenv infoReader (mkLocalModRef x1) x2)  &&
 
             let sigValHadNoMatchingImplementation (fx: Val) (_closeActualVal: Val option) = 
                 errorR(RequiredButNotSpecified(denv, implModRef, "value", (fun os -> 
                    (* In the case of missing members show the full required enclosing type and signature *)
                    if fx.IsMember then 
-                       NicePrint.outputQualifiedValOrMember denv os fx
+                       NicePrint.outputQualifiedValOrMember denv infoReader os fx
                    else
                        Printf.bprintf os "%s" fx.DisplayName), m))
             
@@ -601,7 +602,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                         | [], _ | _, [] -> failwith "unreachable"
                         | [av], [fv] -> 
                             if valuesPartiallyMatch av fv then
-                                checkVal implModRef aenv av fv
+                                checkVal implModRef aenv infoReader av fv
                             else
                                 sigValHadNoMatchingImplementation fv None
                                 false    
@@ -614,7 +615,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                                       | Some av -> Some(fv, av))
                              
                              // Check the ones with matching linkage
-                             let allPairsOk = matchingPairs |> List.map (fun (fv, av) -> checkVal implModRef aenv av fv) |> List.forall id
+                             let allPairsOk = matchingPairs |> List.map (fun (fv, av) -> checkVal implModRef aenv infoReader av fv) |> List.forall id
                              let someNotOk = matchingPairs.Length < fvs.Length
                              // Report an error for those that don't. Try pairing up by enclosing-type/name
                              if someNotOk then 
@@ -624,28 +625,28 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                                           | None -> Choice1Of2 fv
                                           | Some av -> Choice2Of2(fv, av))
                                  for (fv, av) in partialMatchingPairs do
-                                     checkVal implModRef aenv av fv |> ignore
+                                     checkVal implModRef aenv infoReader av fv |> ignore
                                  for fv in noMatches do 
                                      sigValHadNoMatchingImplementation fv None
                              allPairsOk && not someNotOk)
 
 
-        and checkModuleOrNamespace aenv implModRef sigModRef = 
+        and checkModuleOrNamespace aenv (infoReader: InfoReader) implModRef sigModRef = 
             // Propagate defn location information from implementation to signature . 
             sigModRef.SetOtherRange (implModRef.Range, true)
             implModRef.Deref.SetOtherRange (sigModRef.Range, false)
-            checkModuleOrNamespaceContents implModRef.Range aenv implModRef sigModRef.ModuleOrNamespaceType &&
+            checkModuleOrNamespaceContents implModRef.Range aenv infoReader implModRef sigModRef.ModuleOrNamespaceType &&
             checkAttribs aenv implModRef.Attribs sigModRef.Attribs implModRef.Deref.SetAttribs
 
-        member _.CheckSignature aenv (implModRef: ModuleOrNamespaceRef) (signModType: ModuleOrNamespaceType) = 
-            checkModuleOrNamespaceContents implModRef.Range aenv implModRef signModType
+        member _.CheckSignature aenv (infoReader: InfoReader) (implModRef: ModuleOrNamespaceRef) (signModType: ModuleOrNamespaceType) = 
+            checkModuleOrNamespaceContents implModRef.Range aenv infoReader implModRef signModType
 
         member _.CheckTypars m aenv (implTypars: Typars) (signTypars: Typars) = 
             checkTypars m aenv implTypars signTypars
 
 
 /// Check the names add up between a signature and its implementation. We check this first.
-let rec CheckNamesOfModuleOrNamespaceContents denv (implModRef: ModuleOrNamespaceRef) (signModType: ModuleOrNamespaceType) = 
+let rec CheckNamesOfModuleOrNamespaceContents denv infoReader (implModRef: ModuleOrNamespaceRef) (signModType: ModuleOrNamespaceType) = 
         let m = implModRef.Range 
         let implModType = implModRef.ModuleOrNamespaceType
         NameMap.suball2 
@@ -657,7 +658,7 @@ let rec CheckNamesOfModuleOrNamespaceContents denv (implModRef: ModuleOrNamespac
         (implModType.ModulesAndNamespacesByDemangledName, signModType.ModulesAndNamespacesByDemangledName ) 
           ||> NameMap.suball2 
                 (fun s fx -> errorR(RequiredButNotSpecified(denv, implModRef, (if fx.IsModule then "module" else "namespace"), (fun os -> Printf.bprintf os "%s" s), m)); false) 
-                (fun x1 (x2: ModuleOrNamespace) -> CheckNamesOfModuleOrNamespace denv (mkLocalModRef x1) x2.ModuleOrNamespaceType)  &&
+                (fun x1 (x2: ModuleOrNamespace) -> CheckNamesOfModuleOrNamespace denv infoReader (mkLocalModRef x1) x2.ModuleOrNamespaceType)  &&
 
         (implModType.AllValsAndMembersByLogicalNameUncached, signModType.AllValsAndMembersByLogicalNameUncached) 
           ||> NameMap.suball2 
@@ -666,12 +667,12 @@ let rec CheckNamesOfModuleOrNamespaceContents denv (implModRef: ModuleOrNamespac
                     errorR(RequiredButNotSpecified(denv, implModRef, "value", (fun os -> 
                        // In the case of missing members show the full required enclosing type and signature 
                        if Option.isSome fx.MemberInfo then 
-                           NicePrint.outputQualifiedValOrMember denv os fx
+                           NicePrint.outputQualifiedValOrMember denv infoReader os fx
                        else
                            Printf.bprintf os "%s" fx.DisplayName), m)); false)
                 (fun _ _ -> true) 
 
 
-and CheckNamesOfModuleOrNamespace denv (implModRef: ModuleOrNamespaceRef) signModType = 
-        CheckNamesOfModuleOrNamespaceContents denv implModRef signModType
+and CheckNamesOfModuleOrNamespace denv (infoReader: InfoReader) (implModRef: ModuleOrNamespaceRef) signModType = 
+        CheckNamesOfModuleOrNamespaceContents denv infoReader implModRef signModType
 

--- a/src/fsharp/SignatureConformance.fsi
+++ b/src/fsharp/SignatureConformance.fsi
@@ -10,16 +10,17 @@ open FSharp.Compiler
 open FSharp.Compiler.Text
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.InfoReader
 
 exception RequiredButNotSpecified of DisplayEnv * ModuleOrNamespaceRef * string * (StringBuilder -> unit) * range
 
-exception ValueNotContained of DisplayEnv * ModuleOrNamespaceRef * Val * Val * (string * string * string -> string)
+exception ValueNotContained of DisplayEnv * InfoReader * ModuleOrNamespaceRef * Val * Val * (string * string * string -> string)
 
-exception ConstrNotContained of DisplayEnv * UnionCase * UnionCase * (string * string -> string)
+exception ConstrNotContained of DisplayEnv * InfoReader * Tycon * UnionCase * UnionCase * (string * string -> string)
 
-exception ExnconstrNotContained of DisplayEnv * Tycon * Tycon * (string * string -> string)
+exception ExnconstrNotContained of DisplayEnv * InfoReader * Tycon * Tycon * (string * string -> string)
 
-exception FieldNotContained of DisplayEnv * RecdField * RecdField * (string * string -> string)
+exception FieldNotContained of DisplayEnv * InfoReader * Tycon * RecdField * RecdField * (string * string -> string)
 
 exception InterfaceNotRevealed of DisplayEnv * TType * range
 
@@ -27,11 +28,11 @@ type Checker =
 
       new: g:TcGlobals.TcGlobals * amap:Import.ImportMap * denv:DisplayEnv * remapInfo:SignatureRepackageInfo * checkingSig:bool -> Checker
 
-      member CheckSignature: aenv:TypeEquivEnv -> implModRef:ModuleOrNamespaceRef -> signModType:ModuleOrNamespaceType -> bool
+      member CheckSignature: aenv:TypeEquivEnv -> infoReader:InfoReader -> implModRef:ModuleOrNamespaceRef -> signModType:ModuleOrNamespaceType -> bool
 
       member CheckTypars: m:range -> aenv:TypeEquivEnv -> implTypars:Typars -> signTypars:Typars -> bool
   
 /// Check the names add up between a signature and its implementation. We check this first.
-val CheckNamesOfModuleOrNamespaceContents: denv:DisplayEnv -> implModRef:ModuleOrNamespaceRef -> signModType:ModuleOrNamespaceType -> bool
+val CheckNamesOfModuleOrNamespaceContents: denv:DisplayEnv -> infoReader:InfoReader -> implModRef:ModuleOrNamespaceRef -> signModType:ModuleOrNamespaceType -> bool
 
-val CheckNamesOfModuleOrNamespace: denv:DisplayEnv -> implModRef:ModuleOrNamespaceRef -> signModType:ModuleOrNamespaceType -> bool
+val CheckNamesOfModuleOrNamespace: denv:DisplayEnv -> infoReader:InfoReader -> implModRef:ModuleOrNamespaceRef -> signModType:ModuleOrNamespaceType -> bool

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -7,6 +7,7 @@ open Internal.Utilities.Library
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 
 [<Struct; NoEquality; NoComparison; DebuggerDisplay("{idText}")>]
 type Ident (text: string, range: range) =

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -4,6 +4,7 @@ namespace rec FSharp.Compiler.Syntax
 
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 
 /// Represents an identifier in F# code
 [<Struct; NoEquality; NoComparison>]

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -8,6 +8,7 @@ open FSharp.Compiler.Syntax
 open FSharp.Compiler.Syntax.PrettyNaming
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 
 /// Generate implicit argument names in parsing
 type SynArgNameGenerator() =

--- a/src/fsharp/SyntaxTreeOps.fsi
+++ b/src/fsharp/SyntaxTreeOps.fsi
@@ -3,6 +3,7 @@
 module internal FSharp.Compiler.SyntaxTreeOps
 
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.Syntax
 
 [<Class>]

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -25,6 +25,7 @@ open FSharp.Compiler.QuotationPickler
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 
 #if !NO_EXTENSIONTYPING
 open FSharp.Compiler.ExtensionTyping
@@ -5084,7 +5085,9 @@ type CcuData =
       MemberSignatureEquality: (TType -> TType -> bool) 
       
       /// The table of .NET CLI type forwarders for this assembly
-      TypeForwarders: CcuTypeForwarderTable }
+      TypeForwarders: CcuTypeForwarderTable
+      
+      XmlDocumentationInfo: XmlDocumentationInfo option }
 
     [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
     member x.DebugText = x.ToString()

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -27,6 +27,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Layout
 open FSharp.Compiler.Text.LayoutRender
 open FSharp.Compiler.Text.TaggedText
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 #if !NO_EXTENSIONTYPING

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -11,7 +11,7 @@ open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL 
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TcGlobals
 

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -22,6 +22,7 @@ open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/XmlDoc.fs
+++ b/src/fsharp/XmlDoc.fs
@@ -7,6 +7,7 @@ open System.IO
 open System.Xml
 open System.Xml.Linq
 open Internal.Utilities.Library
+open Internal.Utilities.Collections
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
@@ -218,10 +219,21 @@ type PreXmlDoc =
     static member Merge a b = PreXmlMerge (a, b)
 
 [<Sealed>]
-type XmlDocumentationInfo private (lazyXmlDocument: Lazy<XmlDocument option>) =
+type XmlDocumentationInfo private (tryGetXmlDocument: unit -> XmlDocument option) =
+
+    // 2 and 4 are arbitrary but should be reasonable enough
+    [<Literal>]
+    static let cacheStrongSize = 2
+    [<Literal>]
+    static let cacheMaxSize = 4
+    static let cacheAreSimilar =
+        fun ((str1: string, dt1: DateTime), (str2: string, dt2: DateTime)) ->
+            str1.Equals(str2, StringComparison.OrdinalIgnoreCase) &&
+            dt1 = dt2
+    static let cache = AgedLookup<unit, string * DateTime, XmlDocument>(keepStrongly=cacheStrongSize, areSimilar=cacheAreSimilar, keepMax=cacheMaxSize)
 
     let tryGetSummaryNode xmlDocSig =
-        lazyXmlDocument.Value
+        tryGetXmlDocument()
         |> Option.bind (fun doc ->
             match doc.SelectSingleNode(sprintf "doc/members/member[@name='%s']" xmlDocSig) with
             | null -> None
@@ -243,17 +255,23 @@ type XmlDocumentationInfo private (lazyXmlDocument: Lazy<XmlDocument option>) =
         if not (File.Exists(xmlFileName)) || not (String.Equals(Path.GetExtension(xmlFileName), ".xml", StringComparison.OrdinalIgnoreCase)) then
             None
         else
-            try
-                let doc = XmlDocument()
-                use xmlStream = File.OpenRead(xmlFileName)
-                doc.Load(xmlStream)
-                Some(XmlDocumentationInfo(lazy(Some doc)))
-            with
-            | _ ->
-                None
-
-    static member Create(lazyXmlDocument: Lazy<XmlDocument option>) =
-        XmlDocumentationInfo(lazyXmlDocument)
+            let tryGetXmlDocument =
+                fun () ->
+                    try
+                        let lastWriteTime = File.GetLastWriteTimeUtc(xmlFileName)
+                        let cacheKey = (xmlFileName, lastWriteTime)
+                        match cache.TryGet((), cacheKey) with
+                        | Some doc -> Some doc
+                        | _ ->
+                            let doc = XmlDocument()
+                            use xmlStream = File.OpenRead(xmlFileName)
+                            doc.Load(xmlStream)
+                            cache.Put((), cacheKey, doc)
+                            Some doc
+                    with
+                    | _ ->
+                        None
+            Some(XmlDocumentationInfo(tryGetXmlDocument))
 
 type IXmlDocumentationInfoLoader =
 

--- a/src/fsharp/XmlDoc.fs
+++ b/src/fsharp/XmlDoc.fs
@@ -220,16 +220,16 @@ type PreXmlDoc =
 [<Sealed>]
 type XmlDocumentationInfo private (lazyXmlDocument: Lazy<XmlDocument option>) =
 
-    let tryGetSummaryNode metadataKey =
+    let tryGetSummaryNode xmlDocSig =
         lazyXmlDocument.Value
         |> Option.bind (fun doc ->
-            match doc.SelectSingleNode(sprintf "doc/members/member[@name='%s']" metadataKey) with
+            match doc.SelectSingleNode(sprintf "doc/members/member[@name='%s']" xmlDocSig) with
             | null -> None
             | node when node.HasChildNodes -> Some node
             | _ -> None)
 
-    member _.TryGetXmlDocByMetadataKey(metadataKey: string) =
-        tryGetSummaryNode metadataKey
+    member _.TryGetXmlDocBySig(xmlDocSig: string) =
+        tryGetSummaryNode xmlDocSig
         |> Option.map (fun node ->
             let childNodes = node.ChildNodes
             let lines = Array.zeroCreate childNodes.Count

--- a/src/fsharp/XmlDoc.fs
+++ b/src/fsharp/XmlDoc.fs
@@ -231,9 +231,10 @@ type XmlDocumentationInfo private (lazyXmlDocument: Lazy<XmlDocument option>) =
     member _.TryGetXmlDocByMetadataKey(metadataKey: string) =
         tryGetSummaryNode metadataKey
         |> Option.map (fun node ->
-            let lines = Array.zeroCreate node.ChildNodes.Count
-            for i = 0 to node.ChildNodes.Count - 1 do
-                let childNode = node.ChildNodes.[i]
+            let childNodes = node.ChildNodes
+            let lines = Array.zeroCreate childNodes.Count
+            for i = 0 to childNodes.Count - 1 do
+                let childNode = childNodes.[i]
                 lines.[i] <- childNode.OuterXml
             XmlDoc(lines, range0)
         )      

--- a/src/fsharp/XmlDoc.fsi
+++ b/src/fsharp/XmlDoc.fsi
@@ -4,6 +4,7 @@ namespace FSharp.Compiler.Xml
 
 open System.Xml
 open FSharp.Compiler.Text
+open FSharp.Compiler.AbstractIL.IL
 
 /// Represents collected XmlDoc lines
 [<Class>]
@@ -62,14 +63,12 @@ type public PreXmlDoc =
 [<Sealed>]
 type internal XmlDocumentationInfo =
 
-    member FileName : string
-
     member TryGetXmlDocByMetadataKey : metadataKey: string -> XmlDoc option
 
-    static member TryCreateFromFile : fileName: string -> XmlDocumentationInfo option
+    static member TryCreateFromFile : xmlFileName: string -> XmlDocumentationInfo option
 
-    static member Create : fileName: string * lazyXmlDocument: Lazy<XmlDocument option> -> XmlDocumentationInfo
+    static member Create : lazyXmlDocument: Lazy<XmlDocument option> -> XmlDocumentationInfo
 
 type internal IXmlDocumentationInfoLoader =
 
-    abstract TryLoad : assemblyFileName: string -> XmlDocumentationInfo option
+    abstract TryLoad : assemblyFileName: string * ILModuleDef -> XmlDocumentationInfo option

--- a/src/fsharp/XmlDoc.fsi
+++ b/src/fsharp/XmlDoc.fsi
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Compiler.Syntax
+namespace FSharp.Compiler.Xml
 
+open System.Xml
 open FSharp.Compiler.Text
 
 /// Represents collected XmlDoc lines
@@ -57,3 +58,18 @@ type public PreXmlDoc =
     member ToXmlDoc: check:bool * paramNamesOpt:string list option -> XmlDoc
 
     static member Empty: PreXmlDoc
+
+[<Sealed>]
+type internal XmlDocumentationInfo =
+
+    member FileName : string
+
+    member TryGetXmlDocByMetadataKey : metadataKey: string -> XmlDoc option
+
+    static member TryCreateFromFile : fileName: string -> XmlDocumentationInfo option
+
+    static member Create : fileName: string * lazyXmlDocument: Lazy<XmlDocument option> -> XmlDocumentationInfo
+
+type internal IXmlDocumentationInfoLoader =
+
+    abstract TryLoad : assemblyFileName: string -> XmlDocumentationInfo option

--- a/src/fsharp/XmlDoc.fsi
+++ b/src/fsharp/XmlDoc.fsi
@@ -67,8 +67,6 @@ type internal XmlDocumentationInfo =
 
     static member TryCreateFromFile : xmlFileName: string -> XmlDocumentationInfo option
 
-    static member Create : lazyXmlDocument: Lazy<XmlDocument option> -> XmlDocumentationInfo
-
 type internal IXmlDocumentationInfoLoader =
 
     abstract TryLoad : assemblyFileName: string * ILModuleDef -> XmlDocumentationInfo option

--- a/src/fsharp/XmlDoc.fsi
+++ b/src/fsharp/XmlDoc.fsi
@@ -63,7 +63,7 @@ type public PreXmlDoc =
 [<Sealed>]
 type internal XmlDocumentationInfo =
 
-    member TryGetXmlDocByMetadataKey : metadataKey: string -> XmlDoc option
+    member TryGetXmlDocBySig : xmlDocSig: string -> XmlDoc option
 
     static member TryCreateFromFile : xmlFileName: string -> XmlDocumentationInfo option
 

--- a/src/fsharp/XmlDocFileWriter.fs
+++ b/src/fsharp/XmlDocFileWriter.fs
@@ -10,6 +10,7 @@ open Internal.Utilities.Library.Extras
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -471,9 +471,9 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, tcConfigB: Tc
         Display.layout_to_string opts lay
     
     /// Fetch the saved value of an expression out of the 'it' register and show it.
-    member valuePrinter.InvokeExprPrinter (denv, infoReader, emEnv, ilxGenerator: IlxAssemblyGenerator, vref) = 
+    member valuePrinter.InvokeExprPrinter (denv, infoReader, emEnv, ilxGenerator: IlxAssemblyGenerator, vref: ValRef) = 
         let opts        = valuePrinter.GetFsiPrintOptions()
-        let res    = ilxGenerator.LookupGeneratedValue (valuePrinter.GetEvaluationContext emEnv, vref)
+        let res    = ilxGenerator.LookupGeneratedValue (valuePrinter.GetEvaluationContext emEnv, vref.Deref)
         let rhsL = 
             match res with
                 | None             -> None
@@ -1409,7 +1409,7 @@ type internal FsiDynamicCompiler
         | NameResolution.Item.Value vref -> 
              if not tcConfig.noFeedback then 
                  let infoReader = InfoReader(istate.tcGlobals, istate.tcImports.GetImportMap())
-                 valuePrinter.InvokeExprPrinter (istate.tcState.TcEnvFromImpls.DisplayEnv, infoReader, istate.emEnv, istate.ilxGenerator, vref.Deref)
+                 valuePrinter.InvokeExprPrinter (istate.tcState.TcEnvFromImpls.DisplayEnv, infoReader, istate.emEnv, istate.ilxGenerator, vref)
 
              /// Clear the value held in the previous "it" binding, if any, as long as it has never been referenced.
              match prevIt with

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -471,7 +471,7 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, tcConfigB: Tc
         Display.layout_to_string opts lay
     
     /// Fetch the saved value of an expression out of the 'it' register and show it.
-    member valuePrinter.InvokeExprPrinter (denv, emEnv, ilxGenerator: IlxAssemblyGenerator, vref) = 
+    member valuePrinter.InvokeExprPrinter (denv, infoReader, emEnv, ilxGenerator: IlxAssemblyGenerator, vref) = 
         let opts        = valuePrinter.GetFsiPrintOptions()
         let res    = ilxGenerator.LookupGeneratedValue (valuePrinter.GetEvaluationContext emEnv, vref)
         let rhsL = 
@@ -484,9 +484,9 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, tcConfigB: Tc
         let denv = { denv with suppressInlineKeyword = false } // dont' suppress 'inline' in 'val inline f = ...'
         let fullL = 
             if Option.isNone rhsL || isEmptyL rhsL.Value then
-                NicePrint.prettyLayoutOfValOrMemberNoInst denv vref (* the rhs was suppressed by the printer, so no value to print *)
+                NicePrint.prettyLayoutOfValOrMemberNoInst denv infoReader vref (* the rhs was suppressed by the printer, so no value to print *)
             else
-                (NicePrint.prettyLayoutOfValOrMemberNoInst denv vref ++ wordL (TaggedText.tagText "=")) --- rhsL.Value
+                (NicePrint.prettyLayoutOfValOrMemberNoInst denv infoReader vref ++ wordL (TaggedText.tagText "=")) --- rhsL.Value
 
         Utilities.colorPrintL outWriter opts fullL
 
@@ -1408,7 +1408,8 @@ type internal FsiDynamicCompiler
         match istate.tcState.TcEnvFromImpls.NameEnv.FindUnqualifiedItem itName with 
         | NameResolution.Item.Value vref -> 
              if not tcConfig.noFeedback then 
-                 valuePrinter.InvokeExprPrinter (istate.tcState.TcEnvFromImpls.DisplayEnv, istate.emEnv, istate.ilxGenerator, vref.Deref)
+                 let infoReader = InfoReader(istate.tcGlobals, istate.tcImports.GetImportMap())
+                 valuePrinter.InvokeExprPrinter (istate.tcState.TcEnvFromImpls.DisplayEnv, infoReader, istate.emEnv, istate.ilxGenerator, vref.Deref)
 
              /// Clear the value held in the previous "it" binding, if any, as long as it has never been referenced.
              match prevIt with

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -63,6 +63,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Layout
+open FSharp.Compiler.Xml
 open FSharp.Compiler.Tokenization
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/import.fs
+++ b/src/fsharp/import.fs
@@ -612,7 +612,7 @@ let ImportILAssembly(amap: (unit -> ImportMap), m, auxModuleLoader, xmlDocInfoLo
           TypeForwarders = forwarders
           XmlDocumentationInfo = 
             match xmlDocInfoLoader, filename with
-            | Some xmlDocInfoLoader, Some filename -> xmlDocInfoLoader.TryLoad(filename)
+            | Some xmlDocInfoLoader, Some filename -> xmlDocInfoLoader.TryLoad(filename, ilModule)
             | _ -> None
         }
                 

--- a/src/fsharp/import.fs
+++ b/src/fsharp/import.fs
@@ -14,6 +14,7 @@ open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps
@@ -579,7 +580,7 @@ let ImportILAssemblyTypeForwarders (amap, m, exportedTypes: ILExportedTypesAndFo
     ] |> Map.ofList
 
 /// Import an IL assembly as a new TAST CCU
-let ImportILAssembly(amap: (unit -> ImportMap), m, auxModuleLoader, ilScopeRef, sourceDir, filename, ilModule: ILModuleDef, invalidateCcu: IEvent<string>) = 
+let ImportILAssembly(amap: (unit -> ImportMap), m, auxModuleLoader, xmlDocInfoLoader: IXmlDocumentationInfoLoader option, ilScopeRef, sourceDir, filename, ilModule: ILModuleDef, invalidateCcu: IEvent<string>) = 
     invalidateCcu |> ignore
     let aref =   
         match ilScopeRef with 
@@ -608,6 +609,11 @@ let ImportILAssembly(amap: (unit -> ImportMap), m, auxModuleLoader, ilScopeRef, 
           FileName = filename
           MemberSignatureEquality= (fun ty1 ty2 -> typeEquivAux EraseAll (amap()).g ty1 ty2)
           TryGetILModuleDef = (fun () -> Some ilModule)
-          TypeForwarders = forwarders }
+          TypeForwarders = forwarders
+          XmlDocumentationInfo = 
+            match xmlDocInfoLoader, filename with
+            | Some xmlDocInfoLoader, Some filename -> xmlDocInfoLoader.TryLoad(filename)
+            | _ -> None
+        }
                 
     CcuThunk.Create(nm, ccuData)

--- a/src/fsharp/import.fs
+++ b/src/fsharp/import.fs
@@ -30,6 +30,9 @@ type AssemblyLoader =
 
     /// Resolve an Abstract IL assembly reference to a Ccu
     abstract FindCcuFromAssemblyRef : CompilationThreadToken * range * ILAssemblyRef -> CcuResolutionResult
+
+    abstract TryFindXmlDocumentationInfo : assemblyName: string -> XmlDocumentationInfo option
+
 #if !NO_EXTENSIONTYPING
 
     /// Get a flag indicating if an assembly is a provided assembly, plus the

--- a/src/fsharp/import.fsi
+++ b/src/fsharp/import.fsi
@@ -21,6 +21,8 @@ type AssemblyLoader =
     /// Resolve an Abstract IL assembly reference to a Ccu
     abstract FindCcuFromAssemblyRef : CompilationThreadToken * range * ILAssemblyRef -> CcuResolutionResult
 
+    abstract TryFindXmlDocumentationInfo : assemblyName: string -> XmlDocumentationInfo option
+
 #if !NO_EXTENSIONTYPING
     /// Get a flag indicating if an assembly is a provided assembly, plus the
     /// table of information recording remappings from type names in the provided assembly to type

--- a/src/fsharp/import.fsi
+++ b/src/fsharp/import.fsi
@@ -7,6 +7,7 @@ open Internal.Utilities.Library
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 
 #if !NO_EXTENSIONTYPING
@@ -76,7 +77,7 @@ val internal ImportProvidedMethodBaseAsILMethodRef : ImportMap -> range -> Taint
 val internal ImportILGenericParameters : (unit -> ImportMap) -> range -> ILScopeRef -> TType list -> ILGenericParameterDef list -> Typar list
 
 /// Import an IL assembly as a new TAST CCU
-val internal ImportILAssembly : (unit -> ImportMap) * range * (ILScopeRef -> ILModuleDef) * ILScopeRef * sourceDir:string * filename: string option * ILModuleDef * IEvent<string> -> CcuThunk
+val internal ImportILAssembly : (unit -> ImportMap) * range * (ILScopeRef -> ILModuleDef) * IXmlDocumentationInfoLoader option * ILScopeRef * sourceDir:string * filename: string option * ILModuleDef * IEvent<string> -> CcuThunk
 
 /// Import the type forwarder table for an IL assembly
 val internal ImportILAssemblyTypeForwarders : (unit -> ImportMap) * range * ILExportedTypesAndForwarders -> Map<(string array * string), Lazy<EntityRef>>

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -13,6 +13,7 @@ open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/infos.fsi
+++ b/src/fsharp/infos.fsi
@@ -8,6 +8,7 @@ open FSharp.Compiler.Syntax
 open FSharp.Compiler.Import
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -24,6 +24,7 @@ open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 
 #if DEBUG
 let debugPrint s =

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1395,33 +1395,11 @@ type IncrementalBuilder(tcGlobals,
                 tcConfigB.xmlDocInfoLoader <-
                     { new IXmlDocumentationInfoLoader with
                         /// Try to load xml documentation associated with an assembly by the same file path with the extension ".xml".
-                        /// If that fails, look to see if it exists in ILModuleDef's resources.
                         member _.TryLoad(assemblyFileName, ilModule) =
                             let xmlFileName = Path.ChangeExtension(assemblyFileName, ".xml")
 
                             // REVIEW: File IO - Will eventually need to change this to use a file system interface of some sort.
                             XmlDocumentationInfo.TryCreateFromFile(xmlFileName)
-                            |> Option.orElseWith (fun () ->
-                                let name = Path.GetFileName(xmlFileName)
-                                ilModule.Resources.AsList
-                                |> List.tryFind (fun x -> x.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
-                                |> Option.map (fun ilRes ->
-                                    let ilRes = WeakReference<_>(ilRes)
-                                    let lazyXmlDocument =
-                                        lazy
-                                            match ilRes.TryGetTarget() with
-                                            | false, _ -> None
-                                            | true, ilRes ->
-                                                try
-                                                    let xmlDocument = XmlDocument()
-                                                    xmlDocument.Load(ilRes.GetBytes().AsStream())
-                                                    Some xmlDocument
-                                                with
-                                                | _ ->
-                                                    None
-                                    XmlDocumentationInfo.Create(lazyXmlDocument)                                               
-                                )
-                            )
                     }
                     |> Some
 

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1395,7 +1395,7 @@ type IncrementalBuilder(tcGlobals,
                 tcConfigB.xmlDocInfoLoader <-
                     { new IXmlDocumentationInfoLoader with
                         /// Try to load xml documentation associated with an assembly by the same file path with the extension ".xml".
-                        member _.TryLoad(assemblyFileName, ilModule) =
+                        member _.TryLoad(assemblyFileName, _ilModule) =
                             let xmlFileName = Path.ChangeExtension(assemblyFileName, ".xml")
 
                             // REVIEW: File IO - Will eventually need to change this to use a file system interface of some sort.

--- a/src/fsharp/service/ServiceDeclarationLists.fs
+++ b/src/fsharp/service/ServiceDeclarationLists.fs
@@ -159,7 +159,7 @@ module DeclarationListHelpers =
             FormatItemDescriptionToToolTipElement isListItem infoReader m denv { item with Item = Item.Value vref }
 
         | Item.Value vref | Item.CustomBuilder (_, vref) ->            
-            let prettyTyparInst, resL = NicePrint.layoutQualifiedValOrMember denv infoReader item.TyparInst vref.Deref
+            let prettyTyparInst, resL = NicePrint.layoutQualifiedValOrMember denv infoReader item.TyparInst vref
             let remarks = OutputFullName isListItem pubpathOfValRef fullDisplayTextOfValRefAsLayout vref
             let tpsL = FormatTyparMapping denv prettyTyparInst
             let tpsL = List.map LayoutRender.toArray tpsL

--- a/src/fsharp/service/ServiceDeclarationLists.fs
+++ b/src/fsharp/service/ServiceDeclarationLists.fs
@@ -101,7 +101,7 @@ module DeclarationListHelpers =
         
         let layouts = 
             [ for minfo in minfos -> 
-                let prettyTyparInst, layout = NicePrint.prettyLayoutOfMethInfoFreeStyle infoReader.amap m denv item.TyparInst minfo
+                let prettyTyparInst, layout = NicePrint.prettyLayoutOfMethInfoFreeStyle infoReader m denv item.TyparInst minfo
                 let xml = GetXmlCommentForMethInfoItem infoReader m item.Item minfo
                 let tpsL = FormatTyparMapping denv prettyTyparInst
                 let layout = LayoutRender.toArray layout
@@ -159,7 +159,7 @@ module DeclarationListHelpers =
             FormatItemDescriptionToToolTipElement isListItem infoReader m denv { item with Item = Item.Value vref }
 
         | Item.Value vref | Item.CustomBuilder (_, vref) ->            
-            let prettyTyparInst, resL = NicePrint.layoutQualifiedValOrMember denv item.TyparInst vref.Deref
+            let prettyTyparInst, resL = NicePrint.layoutQualifiedValOrMember denv infoReader item.TyparInst vref.Deref
             let remarks = OutputFullName isListItem pubpathOfValRef fullDisplayTextOfValRefAsLayout vref
             let tpsL = FormatTyparMapping denv prettyTyparInst
             let tpsL = List.map LayoutRender.toArray tpsL
@@ -178,7 +178,7 @@ module DeclarationListHelpers =
                 sepL (tagPunctuation ".") ^^
                 wordL (tagUnionCase (DecompileOpName uc.Id.idText) |> mkNav uc.DefinitionRange) ^^
                 RightL.colon ^^
-                (if List.isEmpty recd then emptyL else NicePrint.layoutUnionCases denv recd ^^ WordL.arrow) ^^
+                (if List.isEmpty recd then emptyL else NicePrint.layoutUnionCases denv infoReader ucinfo.TyconRef recd ^^ WordL.arrow) ^^
                 NicePrint.layoutType denv rty
             let layout = LayoutRender.toArray layout
             ToolTipElement.Single (layout, xml)
@@ -217,7 +217,7 @@ module DeclarationListHelpers =
 
         // F# exception names
         | Item.ExnCase ecref -> 
-            let layout = NicePrint.layoutExnDef denv ecref.Deref
+            let layout = NicePrint.layoutExnDef denv infoReader ecref
             let remarks = OutputFullName isListItem pubpathOfTyconRef fullDisplayTextOfExnRefAsLayout ecref
             let layout = LayoutRender.toArray layout
             let remarks = LayoutRender.toArray remarks

--- a/src/fsharp/service/ServiceXmlDocParser.fs
+++ b/src/fsharp/service/ServiceXmlDocParser.fs
@@ -6,6 +6,7 @@ open Internal.Utilities.Library
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
 
 /// Represent an Xml documentation block in source code
 type XmlDocable =

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -17,7 +17,7 @@ open FSharp.Compiler
 open FSharp.Compiler.CompilerDiagnostics
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.ErrorLogger
-open FSharp.Compiler.Syntax
+open FSharp.Compiler.Xml
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
@@ -233,13 +233,12 @@ open FSharp.Compiler.InfoReader
 open FSharp.Compiler.Infos
 open FSharp.Compiler.IO 
 open FSharp.Compiler.NameResolution
-open FSharp.Compiler.Syntax
 open FSharp.Compiler.Syntax.PrettyNaming
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
-open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Layout
 open FSharp.Compiler.Text.TaggedText
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -442,7 +442,7 @@ module internal SymbolHelpers =
             mkXmlComment (GetXmlDocSigOfValRef g vref)
         | Item.UnionCase  (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseInfo ucinfo)
         | Item.ExnCase tcref -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
-        | Item.RecdField rfinfo -> mkXmlComment (GetXmlDocSigOfRecdFieldInfo rfinfo)
+        | Item.RecdField rfinfo -> mkXmlComment (GetXmlDocSigOfRecdFieldRef rfinfo.RecdFieldRef)
         | Item.NewDef _ -> FSharpXmlDoc.None
         | Item.ILField finfo -> mkXmlComment (GetXmlDocSigOfILFieldInfo infoReader m finfo)
         | Item.Types(_, ((TType_app(tcref, _)) :: _)) ->  mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -419,145 +419,17 @@ module internal SymbolHelpers =
                   yield ParamNameAndType(argInfo.Name, ty) ]
         | _ -> []
 
-    // Find the name of the metadata file for this external definition 
-    let metaInfoOfEntityRef (infoReader: InfoReader) m tcref = 
-        let g = infoReader.g
-        match tcref with 
-        | ERefLocal _ -> None
-        | ERefNonLocal nlref -> 
-            // Generalize to get a formal signature 
-            let formalTypars = tcref.Typars m
-            let formalTypeInst = generalizeTypars formalTypars
-            let ty = TType_app(tcref, formalTypeInst)
-            if isILAppTy g ty then
-                let formalTypeInfo = ILTypeInfo.FromType g ty
-                Some(nlref.Ccu.FileName, formalTypars, formalTypeInfo)
-            else None
-
     let mkXmlComment thing =
         match thing with
         | Some (Some fileName, xmlDocSig) -> FSharpXmlDoc.FromXmlFile(fileName, xmlDocSig)
         | _ -> FSharpXmlDoc.None
-
-    let GetXmlDocSigOfEntityRef infoReader m (eref: EntityRef) = 
-        if eref.IsILTycon then 
-            match metaInfoOfEntityRef infoReader m eref  with
-            | None -> None
-            | Some (ccuFileName, _, formalTypeInfo) -> Some(ccuFileName, "T:"+formalTypeInfo.ILTypeRef.FullName)
-        else
-            let ccuFileName = libFileOfEntityRef eref
-            let m = eref.Deref
-            if m.XmlDocSig = "" then
-                m.XmlDocSig <- XmlDocSigOfEntity eref
-            Some (ccuFileName, m.XmlDocSig)
-
-    let GetXmlDocSigOfScopedValRef g (tcref: TyconRef) (vref: ValRef) = 
-        let ccuFileName = libFileOfEntityRef tcref
-        let v = vref.Deref
-        if v.XmlDocSig = "" && v.HasDeclaringEntity then
-            let ap = buildAccessPath vref.TopValDeclaringEntity.CompilationPathOpt
-            let path =
-                if vref.TopValDeclaringEntity.IsModule then
-                    let sep = if ap.Length > 0 then "." else ""
-                    ap + sep + vref.TopValDeclaringEntity.CompiledName
-                else
-                    ap
-            v.XmlDocSig <- XmlDocSigOfVal g false path v
-        Some (ccuFileName, v.XmlDocSig)                
-
-    let GetXmlDocSigOfRecdFieldInfo (rfinfo: RecdFieldInfo) = 
-        let tcref = rfinfo.TyconRef
-        let ccuFileName = libFileOfEntityRef tcref 
-        if rfinfo.RecdField.XmlDocSig = "" then
-            rfinfo.RecdField.XmlDocSig <- XmlDocSigOfProperty [tcref.CompiledRepresentationForNamedType.FullName; rfinfo.Name]
-        Some (ccuFileName, rfinfo.RecdField.XmlDocSig)            
-
-    let GetXmlDocSigOfUnionCaseInfo (ucinfo: UnionCaseInfo) = 
-        let tcref =  ucinfo.TyconRef
-        let ccuFileName = libFileOfEntityRef tcref
-        if  ucinfo.UnionCase.XmlDocSig = "" then
-            ucinfo.UnionCase.XmlDocSig <- XmlDocSigOfUnionCase [tcref.CompiledRepresentationForNamedType.FullName; ucinfo.Name]
-        Some (ccuFileName, ucinfo.UnionCase.XmlDocSig)
-
-    let GetXmlDocSigOfMethInfo (infoReader: InfoReader)  m (minfo: MethInfo) = 
-        let amap = infoReader.amap
-        match minfo with
-        | FSMeth (g, _, vref, _) ->
-            GetXmlDocSigOfScopedValRef g minfo.DeclaringTyconRef vref
-        | ILMeth (g, ilminfo, _) ->            
-            let actualTypeName = ilminfo.DeclaringTyconRef.CompiledRepresentationForNamedType.FullName
-            let fmtps = ilminfo.FormalMethodTypars            
-            let genArity = if fmtps.Length=0 then "" else sprintf "``%d" fmtps.Length
-
-            match metaInfoOfEntityRef infoReader m ilminfo.DeclaringTyconRef  with 
-            | None -> None
-            | Some (ccuFileName, formalTypars, formalTypeInfo) ->
-                let filminfo = ILMethInfo(g, formalTypeInfo.ToType, None, ilminfo.RawMetadata, fmtps) 
-                let args = 
-                    match ilminfo.IsILExtensionMethod with
-                    | true -> filminfo.GetRawArgTypes(amap, m, minfo.FormalMethodInst)
-                    | false -> filminfo.GetParamTypes(amap, m, minfo.FormalMethodInst)
-
-                // http://msdn.microsoft.com/en-us/library/fsbx0t7x.aspx
-                // If the name of the item itself has periods, they are replaced by the hash-sign ('#'). 
-                // It is assumed that no item has a hash-sign directly in its name. For example, the fully 
-                // qualified name of the String constructor would be "System.String.#ctor".
-                let normalizedName = ilminfo.ILName.Replace(".", "#")
-
-                Some (ccuFileName, "M:"+actualTypeName+"."+normalizedName+genArity+XmlDocArgsEnc g (formalTypars, fmtps) args)
-        | DefaultStructCtor _ -> None
-#if !NO_EXTENSIONTYPING
-        | ProvidedMeth _ -> None
-#endif
-
-    let GetXmlDocSigOfValRef g (vref: ValRef) =
-        if not vref.IsLocalRef then
-            let ccuFileName = vref.nlr.Ccu.FileName
-            let v = vref.Deref
-            if v.XmlDocSig = "" && v.HasDeclaringEntity then
-                v.XmlDocSig <- XmlDocSigOfVal g false vref.TopValDeclaringEntity.CompiledRepresentationForNamedType.Name v
-            Some (ccuFileName, v.XmlDocSig)
-        else 
-            None
-
-    let GetXmlDocSigOfProp infoReader m (pinfo: PropInfo) =
-        let g = pinfo.TcGlobals
-        match pinfo with 
-#if !NO_EXTENSIONTYPING
-        | ProvidedProp _ -> None // No signature is possible. If an xml comment existed it would have been returned by PropInfo.XmlDoc in infos.fs
-#endif
-        | FSProp _ as fspinfo -> 
-            match fspinfo.ArbitraryValRef with 
-            | None -> None
-            | Some vref -> GetXmlDocSigOfScopedValRef g pinfo.DeclaringTyconRef vref
-        | ILProp(ILPropInfo(_, pdef)) -> 
-            match metaInfoOfEntityRef infoReader m pinfo.DeclaringTyconRef with
-            | Some (ccuFileName, formalTypars, formalTypeInfo) ->
-                let filpinfo = ILPropInfo(formalTypeInfo, pdef)
-                Some (ccuFileName, "P:"+formalTypeInfo.ILTypeRef.FullName+"."+pdef.Name+XmlDocArgsEnc g (formalTypars, []) (filpinfo.GetParamTypes(infoReader.amap, m)))
-            | _ -> None
-
-    let GetXmlDocSigOfEvent infoReader m (einfo: EventInfo) =
-        match einfo with
-        | ILEvent _ ->
-            match metaInfoOfEntityRef infoReader m einfo.DeclaringTyconRef with 
-            | Some (ccuFileName, _, formalTypeInfo) -> 
-                Some(ccuFileName, "E:"+formalTypeInfo.ILTypeRef.FullName+"."+einfo.EventName)
-            | _ -> None
-        | _ -> None
-
-    let GetXmlDocSigOfILFieldInfo infoReader m (finfo: ILFieldInfo) =
-        match metaInfoOfEntityRef infoReader m finfo.DeclaringTyconRef with
-        | Some (ccuFileName, _, formalTypeInfo) ->
-            Some(ccuFileName, "F:"+formalTypeInfo.ILTypeRef.FullName+"."+finfo.FieldName)
-        | _ -> None
 
     let GetXmlDocFromLoader (infoReader: InfoReader) xmlDoc =
         match xmlDoc with
         | FSharpXmlDoc.None
         | FSharpXmlDoc.FromXmlText _ -> xmlDoc
         | FSharpXmlDoc.FromXmlFile(dllName, xmlSig) ->
-            TryFindXmlDocByAssemblyNameAndMetadataKey infoReader (Path.GetFileNameWithoutExtension dllName) xmlSig
+            TryFindXmlDocByAssemblyNameAndSig infoReader (Path.GetFileNameWithoutExtension dllName) xmlSig
             |> Option.map FSharpXmlDoc.FromXmlText
             |> Option.defaultValue xmlDoc
 

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -557,11 +557,8 @@ module internal SymbolHelpers =
         | FSharpXmlDoc.None
         | FSharpXmlDoc.FromXmlText _ -> xmlDoc
         | FSharpXmlDoc.FromXmlFile(dllName, xmlSig) ->
-            infoReader.amap.assemblyLoader.TryFindXmlDocumentationInfo(Path.GetFileNameWithoutExtension dllName)
-            |> Option.bind (fun xmlDocInfo ->
-                xmlDocInfo.TryGetXmlDocByMetadataKey(xmlSig)
-                |> Option.map FSharpXmlDoc.FromXmlText
-            )
+            TryFindXmlDocByAssemblyNameAndMetadataKey infoReader (Path.GetFileNameWithoutExtension dllName) xmlSig
+            |> Option.map FSharpXmlDoc.FromXmlText
             |> Option.defaultValue xmlDoc
 
     /// This function gets the signature to pass to Visual Studio to use its lookup functions for .NET stuff. 

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -556,31 +556,43 @@ module internal SymbolHelpers =
     let GetXmlDocHelpSigOfItemForLookup (infoReader: InfoReader) m d = 
         let g = infoReader.g
                 
-        match d with
-        | Item.ActivePatternCase (APElemRef(_, vref, _))        
-        | Item.Value vref | Item.CustomBuilder (_, vref) -> 
-            mkXmlComment (GetXmlDocSigOfValRef g vref)
-        | Item.UnionCase  (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseInfo ucinfo)
-        | Item.ExnCase tcref -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
-        | Item.RecdField rfinfo -> mkXmlComment (GetXmlDocSigOfRecdFieldInfo rfinfo)
-        | Item.NewDef _ -> FSharpXmlDoc.None
-        | Item.ILField finfo -> mkXmlComment (GetXmlDocSigOfILFieldInfo infoReader m finfo)
-        | Item.Types(_, ((TType_app(tcref, _)) :: _)) ->  mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
-        | Item.CustomOperation (_, _, Some minfo) -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader  m minfo)
-        | Item.TypeVar _  -> FSharpXmlDoc.None
-        | Item.ModuleOrNamespaces(modref :: _) -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m modref)
+        let xmlDoc =
+            match d with
+            | Item.ActivePatternCase (APElemRef(_, vref, _))        
+            | Item.Value vref | Item.CustomBuilder (_, vref) -> 
+                mkXmlComment (GetXmlDocSigOfValRef g vref)
+            | Item.UnionCase  (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseInfo ucinfo)
+            | Item.ExnCase tcref -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
+            | Item.RecdField rfinfo -> mkXmlComment (GetXmlDocSigOfRecdFieldInfo rfinfo)
+            | Item.NewDef _ -> FSharpXmlDoc.None
+            | Item.ILField finfo -> mkXmlComment (GetXmlDocSigOfILFieldInfo infoReader m finfo)
+            | Item.Types(_, ((TType_app(tcref, _)) :: _)) ->  mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
+            | Item.CustomOperation (_, _, Some minfo) -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader  m minfo)
+            | Item.TypeVar _  -> FSharpXmlDoc.None
+            | Item.ModuleOrNamespaces(modref :: _) -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m modref)
 
-        | Item.Property(_, (pinfo :: _)) -> mkXmlComment (GetXmlDocSigOfProp infoReader m pinfo)
-        | Item.Event einfo -> mkXmlComment (GetXmlDocSigOfEvent infoReader m einfo)
+            | Item.Property(_, (pinfo :: _)) -> mkXmlComment (GetXmlDocSigOfProp infoReader m pinfo)
+            | Item.Event einfo -> mkXmlComment (GetXmlDocSigOfEvent infoReader m einfo)
 
-        | Item.MethodGroup(_, minfo :: _, _) -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader  m minfo)
-        | Item.CtorGroup(_, minfo :: _) -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader  m minfo)
-        | Item.ArgName(_, _, Some argContainer) -> 
-            match argContainer with 
-            | ArgumentContainer.Method minfo -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader m minfo)
-            | ArgumentContainer.Type tcref -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
-        | Item.UnionCaseField (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseInfo ucinfo)
-        |  _ -> FSharpXmlDoc.None
+            | Item.MethodGroup(_, minfo :: _, _) -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader  m minfo)
+            | Item.CtorGroup(_, minfo :: _) -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader  m minfo)
+            | Item.ArgName(_, _, Some argContainer) -> 
+                match argContainer with 
+                | ArgumentContainer.Method minfo -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader m minfo)
+                | ArgumentContainer.Type tcref -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
+            | Item.UnionCaseField (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseInfo ucinfo)
+            |  _ -> FSharpXmlDoc.None
+
+        match xmlDoc with
+        | FSharpXmlDoc.None
+        | FSharpXmlDoc.FromXmlText _ -> xmlDoc
+        | FSharpXmlDoc.FromXmlFile(dllName, xmlSig) ->
+            infoReader.amap.assemblyLoader.TryFindXmlDocumentationInfo(dllName)
+            |> Option.bind (fun xmlDocInfo ->
+                xmlDocInfo.TryGetXmlDocByMetadataKey(xmlSig)
+                |> Option.map FSharpXmlDoc.FromXmlText
+            )
+            |> Option.defaultValue xmlDoc
 
     /// Produce an XmlComment with a signature or raw text, given the F# comment and the item
     let GetXmlCommentForItemAux (xmlDoc: XmlDoc option) (infoReader: InfoReader) m d = 

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -440,7 +440,7 @@ module internal SymbolHelpers =
         | Item.ActivePatternCase (APElemRef(_, vref, _))        
         | Item.Value vref | Item.CustomBuilder (_, vref) -> 
             mkXmlComment (GetXmlDocSigOfValRef g vref)
-        | Item.UnionCase  (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseInfo ucinfo)
+        | Item.UnionCase  (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseRef ucinfo.UnionCaseRef)
         | Item.ExnCase tcref -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
         | Item.RecdField rfinfo -> mkXmlComment (GetXmlDocSigOfRecdFieldRef rfinfo.RecdFieldRef)
         | Item.NewDef _ -> FSharpXmlDoc.None
@@ -459,7 +459,7 @@ module internal SymbolHelpers =
             match argContainer with 
             | ArgumentContainer.Method minfo -> mkXmlComment (GetXmlDocSigOfMethInfo infoReader m minfo)
             | ArgumentContainer.Type tcref -> mkXmlComment (GetXmlDocSigOfEntityRef infoReader m tcref)
-        | Item.UnionCaseField (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseInfo ucinfo)
+        | Item.UnionCaseField (ucinfo, _) -> mkXmlComment (GetXmlDocSigOfUnionCaseRef ucinfo.UnionCaseRef)
         |  _ -> FSharpXmlDoc.None
 
         |> GetXmlDocFromLoader infoReader

--- a/src/fsharp/symbols/SymbolHelpers.fsi
+++ b/src/fsharp/symbols/SymbolHelpers.fsi
@@ -137,24 +137,6 @@ namespace FSharp.Compiler.Symbols
     module internal SymbolHelpers =
         val ParamNameAndTypesOfUnaryCustomOperation : TcGlobals -> MethInfo -> ParamNameAndType list
 
-        val GetXmlDocSigOfEntityRef : InfoReader -> range -> EntityRef -> (string option * string) option
-
-        val GetXmlDocSigOfScopedValRef : TcGlobals -> TyconRef -> ValRef -> (string option * string) option
-
-        val GetXmlDocSigOfILFieldInfo : InfoReader -> range -> ILFieldInfo -> (string option * string) option
-
-        val GetXmlDocSigOfRecdFieldInfo : RecdFieldInfo -> (string option * string) option
-
-        val GetXmlDocSigOfUnionCaseInfo : UnionCaseInfo -> (string option * string) option
-
-        val GetXmlDocSigOfMethInfo : InfoReader -> range -> MethInfo -> (string option * string) option
-
-        val GetXmlDocSigOfValRef : TcGlobals -> ValRef -> (string option * string) option
-
-        val GetXmlDocSigOfProp : InfoReader -> range -> PropInfo -> (string option * string) option
-
-        val GetXmlDocSigOfEvent : InfoReader -> range -> EventInfo -> (string option * string) option
-
         val GetXmlCommentForItem : InfoReader -> range -> Item -> FSharpXmlDoc
 
         val RemoveDuplicateItems : TcGlobals -> ItemWithInst list -> ItemWithInst list

--- a/src/fsharp/symbols/SymbolHelpers.fsi
+++ b/src/fsharp/symbols/SymbolHelpers.fsi
@@ -114,7 +114,7 @@ namespace FSharp.Compiler.Symbols
     open FSharp.Compiler.InfoReader
     open FSharp.Compiler.Syntax
     open FSharp.Compiler.Text
-    open FSharp.Compiler.Text
+    open FSharp.Compiler.Xml
     open FSharp.Compiler.TypedTree
     open FSharp.Compiler.TypedTreeOps
 

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -955,7 +955,7 @@ type FSharpUnionCase(cenv, v: UnionCaseRef) =
     member _.XmlDocSig = 
         checkIsResolved()
         let unionCase = UnionCaseInfo(generalizeTypars v.TyconRef.TyparsNoRange, v)
-        match GetXmlDocSigOfUnionCaseInfo unionCase with
+        match GetXmlDocSigOfUnionCaseRef unionCase.UnionCaseRef with
         | Some (_, docsig) -> docsig
         | _ -> ""
 
@@ -1133,7 +1133,7 @@ type FSharpField(cenv: SymbolEnv, d: FSharpFieldData)  =
                 GetXmlDocSigOfRecdFieldRef recd.RecdFieldRef
             | Union (v, _) -> 
                 let unionCase = UnionCaseInfo(generalizeTypars v.TyconRef.TyparsNoRange, v)
-                GetXmlDocSigOfUnionCaseInfo unionCase
+                GetXmlDocSigOfUnionCaseRef unionCase.UnionCaseRef
             | ILField f -> 
                 GetXmlDocSigOfILFieldInfo cenv.infoReader range0 f
             | AnonField _ -> None

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2217,7 +2217,7 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
     member x.FormatLayout (context:FSharpDisplayContext) =
         match x.IsMember, d with
         | true, V v ->
-            NicePrint.prettyLayoutOfMemberNoInstShort { (context.Contents cenv.g) with showMemberContainers=true } cenv.infoReader v.Deref
+            NicePrint.prettyLayoutOfMemberNoInstShort { (context.Contents cenv.g) with showMemberContainers=true } v.Deref
             |> LayoutRender.toArray
         | _,_ ->
             checkIsResolved()

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -197,7 +197,7 @@ module Impl =
             
 
     let getXmlDocSigForEntity (cenv: SymbolEnv) (ent:EntityRef)=
-        match SymbolHelpers.GetXmlDocSigOfEntityRef cenv.infoReader ent.Range ent with
+        match GetXmlDocSigOfEntityRef cenv.infoReader ent.Range ent with
         | Some (_, docsig) -> docsig
         | _ -> ""
 
@@ -955,7 +955,7 @@ type FSharpUnionCase(cenv, v: UnionCaseRef) =
     member _.XmlDocSig = 
         checkIsResolved()
         let unionCase = UnionCaseInfo(generalizeTypars v.TyconRef.TyparsNoRange, v)
-        match SymbolHelpers.GetXmlDocSigOfUnionCaseInfo unionCase with
+        match GetXmlDocSigOfUnionCaseInfo unionCase with
         | Some (_, docsig) -> docsig
         | _ -> ""
 
@@ -1130,12 +1130,12 @@ type FSharpField(cenv: SymbolEnv, d: FSharpFieldData)  =
             match d with 
             | RecdOrClass v -> 
                 let recd = RecdFieldInfo(generalizeTypars v.TyconRef.TyparsNoRange, v)
-                SymbolHelpers.GetXmlDocSigOfRecdFieldInfo recd
+                GetXmlDocSigOfRecdFieldInfo recd
             | Union (v, _) -> 
                 let unionCase = UnionCaseInfo(generalizeTypars v.TyconRef.TyparsNoRange, v)
-                SymbolHelpers.GetXmlDocSigOfUnionCaseInfo unionCase
+                GetXmlDocSigOfUnionCaseInfo unionCase
             | ILField f -> 
-                SymbolHelpers.GetXmlDocSigOfILFieldInfo cenv.infoReader range0 f
+                GetXmlDocSigOfILFieldInfo cenv.infoReader range0 f
             | AnonField _ -> None
         match xmlsig with
         | Some (_, docsig) -> docsig
@@ -1272,7 +1272,7 @@ type FSharpActivePatternCase(cenv, apinfo: PrettyNaming.ActivePatternInfo, ty, n
     member _.XmlDocSig = 
         let xmlsig = 
             match valOpt with
-            | Some valref -> SymbolHelpers.GetXmlDocSigOfValRef cenv.g valref
+            | Some valref -> GetXmlDocSigOfValRef cenv.g valref
             | None -> None
         match xmlsig with
         | Some (_, docsig) -> docsig
@@ -1961,23 +1961,23 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         match d with 
         | E e ->
             let range = defaultArg sym.DeclarationLocationOpt range0
-            match SymbolHelpers.GetXmlDocSigOfEvent cenv.infoReader range e with
+            match GetXmlDocSigOfEvent cenv.infoReader range e with
             | Some (_, docsig) -> docsig
             | _ -> ""
         | P p ->
             let range = defaultArg sym.DeclarationLocationOpt range0
-            match SymbolHelpers.GetXmlDocSigOfProp cenv.infoReader range p with
+            match GetXmlDocSigOfProp cenv.infoReader range p with
             | Some (_, docsig) -> docsig
             | _ -> ""
         | M m | C m -> 
             let range = defaultArg sym.DeclarationLocationOpt range0
-            match SymbolHelpers.GetXmlDocSigOfMethInfo cenv.infoReader range m with
+            match GetXmlDocSigOfMethInfo cenv.infoReader range m with
             | Some (_, docsig) -> docsig
             | _ -> ""
         | V v ->
             match v.DeclaringEntity with 
             | Parent entityRef -> 
-                match SymbolHelpers.GetXmlDocSigOfScopedValRef cenv.g entityRef v with
+                match GetXmlDocSigOfScopedValRef cenv.g entityRef v with
                 | Some (_, docsig) -> docsig
                 | _ -> ""
             | ParentNone -> "" 

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -810,7 +810,7 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
 
     member this.TryGetMetadataText() =
         match entity.TryDeref with
-        | ValueSome entity ->
+        | ValueSome _ ->
             if entity.IsNamespace then None
             else
 
@@ -886,7 +886,7 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
                 [
                     (Layout.(^^) headerL (Layout.sepL TaggedText.lineBreak))
                     (Layout.(^^) openL (Layout.sepL TaggedText.lineBreak))
-                    (NicePrint.layoutEntity denv infoReader AccessibleFromSomewhere range0 entity)
+                    (NicePrint.layoutEntityRef denv infoReader AccessibleFromSomewhere range0 entity)
                 ]
             |> LayoutRender.showL
             |> SourceText.ofString

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -1130,7 +1130,7 @@ type FSharpField(cenv: SymbolEnv, d: FSharpFieldData)  =
             match d with 
             | RecdOrClass v -> 
                 let recd = RecdFieldInfo(generalizeTypars v.TyconRef.TyparsNoRange, v)
-                GetXmlDocSigOfRecdFieldInfo recd
+                GetXmlDocSigOfRecdFieldRef recd.RecdFieldRef
             | Union (v, _) -> 
                 let unionCase = UnionCaseInfo(generalizeTypars v.TyconRef.TyparsNoRange, v)
                 GetXmlDocSigOfUnionCaseInfo unionCase
@@ -2217,7 +2217,7 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
     member x.FormatLayout (context:FSharpDisplayContext) =
         match x.IsMember, d with
         | true, V v ->
-            NicePrint.prettyLayoutOfMemberNoInstShort { (context.Contents cenv.g) with showMemberContainers=true } v.Deref
+            NicePrint.prettyLayoutOfMemberNoInstShort { (context.Contents cenv.g) with showMemberContainers=true } cenv.infoReader v.Deref
             |> LayoutRender.toArray
         | _,_ ->
             checkIsResolved()

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -19,7 +19,7 @@ open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
-open FSharp.Compiler.Text
+open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TcGlobals

--- a/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SurfaceArea.netstandard.fs
@@ -5018,8 +5018,8 @@ FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlFile: System.String dllName
 FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlFile: System.String get_dllName()
 FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlFile: System.String get_xmlSig()
 FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlFile: System.String xmlSig
-FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlText: FSharp.Compiler.Syntax.XmlDoc Item
-FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlText: FSharp.Compiler.Syntax.XmlDoc get_Item()
+FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlText: FSharp.Compiler.Xml.XmlDoc Item
+FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlText: FSharp.Compiler.Xml.XmlDoc get_Item()
 FSharp.Compiler.Symbols.FSharpXmlDoc+Tags: Int32 FromXmlFile
 FSharp.Compiler.Symbols.FSharpXmlDoc+Tags: Int32 FromXmlText
 FSharp.Compiler.Symbols.FSharpXmlDoc+Tags: Int32 None
@@ -5033,7 +5033,7 @@ FSharp.Compiler.Symbols.FSharpXmlDoc: Boolean get_IsFromXmlFile()
 FSharp.Compiler.Symbols.FSharpXmlDoc: Boolean get_IsFromXmlText()
 FSharp.Compiler.Symbols.FSharpXmlDoc: Boolean get_IsNone()
 FSharp.Compiler.Symbols.FSharpXmlDoc: FSharp.Compiler.Symbols.FSharpXmlDoc NewFromXmlFile(System.String, System.String)
-FSharp.Compiler.Symbols.FSharpXmlDoc: FSharp.Compiler.Symbols.FSharpXmlDoc NewFromXmlText(FSharp.Compiler.Syntax.XmlDoc)
+FSharp.Compiler.Symbols.FSharpXmlDoc: FSharp.Compiler.Symbols.FSharpXmlDoc NewFromXmlText(FSharp.Compiler.Xml.XmlDoc)
 FSharp.Compiler.Symbols.FSharpXmlDoc: FSharp.Compiler.Symbols.FSharpXmlDoc None
 FSharp.Compiler.Symbols.FSharpXmlDoc: FSharp.Compiler.Symbols.FSharpXmlDoc get_None()
 FSharp.Compiler.Symbols.FSharpXmlDoc: FSharp.Compiler.Symbols.FSharpXmlDoc+FromXmlFile
@@ -5305,12 +5305,12 @@ FSharp.Compiler.Syntax.ParsedImplFileFragment+NamedModule: FSharp.Compiler.Synta
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamedModule: FSharp.Compiler.Syntax.SynModuleOrNamespace namedModule
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Boolean get_isRecursive()
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Boolean isRecursive
-FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind get_kind()
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind kind
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
@@ -5328,7 +5328,7 @@ FSharp.Compiler.Syntax.ParsedImplFileFragment: Boolean get_IsNamedModule()
 FSharp.Compiler.Syntax.ParsedImplFileFragment: Boolean get_IsNamespaceFragment()
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment NewAnonModule(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment NewNamedModule(FSharp.Compiler.Syntax.SynModuleOrNamespace)
-FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment NewNamespaceFragment(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment NewNamespaceFragment(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment+AnonModule
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment+NamedModule
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment
@@ -5419,12 +5419,12 @@ FSharp.Compiler.Syntax.ParsedSigFileFragment+NamedModule: FSharp.Compiler.Syntax
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamedModule: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig namedModule
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Boolean get_isRecursive()
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Boolean isRecursive
-FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind get_kind()
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind kind
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
@@ -5442,7 +5442,7 @@ FSharp.Compiler.Syntax.ParsedSigFileFragment: Boolean get_IsNamedModule()
 FSharp.Compiler.Syntax.ParsedSigFileFragment: Boolean get_IsNamespaceFragment()
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment NewAnonModule(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment NewNamedModule(FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
-FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment NewNamespaceFragment(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment NewNamespaceFragment(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment+AnonModule
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment+NamedModule
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment
@@ -5488,18 +5488,6 @@ FSharp.Compiler.Syntax.ParserDetail: Int32 GetHashCode(System.Collections.IEqual
 FSharp.Compiler.Syntax.ParserDetail: Int32 Tag
 FSharp.Compiler.Syntax.ParserDetail: Int32 get_Tag()
 FSharp.Compiler.Syntax.ParserDetail: System.String ToString()
-FSharp.Compiler.Syntax.PreXmlDoc
-FSharp.Compiler.Syntax.PreXmlDoc: Boolean Equals(FSharp.Compiler.Syntax.PreXmlDoc)
-FSharp.Compiler.Syntax.PreXmlDoc: Boolean Equals(System.Object)
-FSharp.Compiler.Syntax.PreXmlDoc: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
-FSharp.Compiler.Syntax.PreXmlDoc: FSharp.Compiler.Syntax.PreXmlDoc Create(System.String[], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.PreXmlDoc: FSharp.Compiler.Syntax.PreXmlDoc Empty
-FSharp.Compiler.Syntax.PreXmlDoc: FSharp.Compiler.Syntax.PreXmlDoc Merge(FSharp.Compiler.Syntax.PreXmlDoc, FSharp.Compiler.Syntax.PreXmlDoc)
-FSharp.Compiler.Syntax.PreXmlDoc: FSharp.Compiler.Syntax.PreXmlDoc get_Empty()
-FSharp.Compiler.Syntax.PreXmlDoc: FSharp.Compiler.Syntax.XmlDoc ToXmlDoc(Boolean, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[System.String]])
-FSharp.Compiler.Syntax.PreXmlDoc: Int32 GetHashCode()
-FSharp.Compiler.Syntax.PreXmlDoc: Int32 GetHashCode(System.Collections.IEqualityComparer)
-FSharp.Compiler.Syntax.PreXmlDoc: System.String ToString()
 FSharp.Compiler.Syntax.PrettyNaming
 FSharp.Compiler.Syntax.PrettyNaming: Boolean IsActivePatternName(System.String)
 FSharp.Compiler.Syntax.PrettyNaming: Boolean IsCompilerGeneratedName(System.String)
@@ -5652,9 +5640,7 @@ FSharp.Compiler.Syntax.SynBinding: Boolean isMutable
 FSharp.Compiler.Syntax.SynBinding: Boolean mustInline
 FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.DebugPointAtBinding get_seqPoint()
 FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.DebugPointAtBinding seqPoint
-FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
-FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.SynBinding NewSynBinding(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Syntax.SynBindingKind, Boolean, Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.PreXmlDoc, FSharp.Compiler.Syntax.SynValData, FSharp.Compiler.Syntax.SynPat, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynBindingReturnInfo], FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.DebugPointAtBinding)
+FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.SynBinding NewSynBinding(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Syntax.SynBindingKind, Boolean, Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Syntax.SynValData, FSharp.Compiler.Syntax.SynPat, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynBindingReturnInfo], FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.DebugPointAtBinding)
 FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.SynBindingKind get_kind()
 FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.SynBindingKind kind
 FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Syntax.SynExpr expr
@@ -5671,6 +5657,8 @@ FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Text.Range get_RangeOfBinding
 FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Text.Range get_RangeOfHeadPattern()
 FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynBinding: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynBinding: Int32 Tag
 FSharp.Compiler.Syntax.SynBinding: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynBinding: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
@@ -5745,13 +5733,13 @@ FSharp.Compiler.Syntax.SynByteStringKind: System.String ToString()
 FSharp.Compiler.Syntax.SynComponentInfo
 FSharp.Compiler.Syntax.SynComponentInfo: Boolean get_preferPostfix()
 FSharp.Compiler.Syntax.SynComponentInfo: Boolean preferPostfix
-FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
-FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Syntax.SynComponentInfo NewSynComponentInfo(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Syntax.PreXmlDoc, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Syntax.SynComponentInfo NewSynComponentInfo(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTyparDecl], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Xml.PreXmlDoc, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynComponentInfo: Int32 Tag
 FSharp.Compiler.Syntax.SynComponentInfo: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
@@ -5933,17 +5921,17 @@ FSharp.Compiler.Syntax.SynConst: System.String ToString()
 FSharp.Compiler.Syntax.SynEnumCase
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.Ident get_ident()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.Ident ident
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynConst get_value()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynConst value
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynEnumCase NewSynEnumCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.PreXmlDoc, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynEnumCase NewSynEnumCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range, FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range get_valueRange()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range valueRange
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynEnumCase: Int32 Tag
 FSharp.Compiler.Syntax.SynEnumCase: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynEnumCase: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
@@ -5963,15 +5951,15 @@ FSharp.Compiler.Syntax.SynExceptionDefn: Microsoft.FSharp.Collections.FSharpList
 FSharp.Compiler.Syntax.SynExceptionDefn: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn] members
 FSharp.Compiler.Syntax.SynExceptionDefn: System.String ToString()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr
-FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
-FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynExceptionDefnRepr NewSynExceptionDefnRepr(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynUnionCase, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident]], FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynExceptionDefnRepr NewSynExceptionDefnRepr(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynUnionCase, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident]], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynUnionCase caseName
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynUnionCase get_caseName()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: Int32 Tag
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
@@ -6815,13 +6803,13 @@ FSharp.Compiler.Syntax.SynField: Boolean get_isMutable()
 FSharp.Compiler.Syntax.SynField: Boolean get_isStatic()
 FSharp.Compiler.Syntax.SynField: Boolean isMutable
 FSharp.Compiler.Syntax.SynField: Boolean isStatic
-FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
-FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynField NewSynField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Syntax.SynType, Boolean, FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynField NewSynField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Syntax.SynType, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynType fieldType
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynType get_fieldType()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynField: Int32 Tag
 FSharp.Compiler.Syntax.SynField: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
@@ -7009,14 +6997,14 @@ FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Boolean get_isStatic()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Boolean isStatic
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.Ident get_ident()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.Ident ident
-FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynExpr get_synExpr()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynExpr synExpr
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynMemberKind get_propKind()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynMemberKind propKind
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynMemberKind,FSharp.Compiler.Syntax.SynMemberFlags] get_memberFlags()
@@ -7027,12 +7015,12 @@ FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Microsoft.FSharp.Core.FSharpO
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynType] typeOpt
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] getSetRange
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_getSetRange()
-FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Syntax.SynSimplePats ctorArgs
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Syntax.SynSimplePats get_ctorArgs()
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_selfIdentifier()
@@ -7119,8 +7107,8 @@ FSharp.Compiler.Syntax.SynMemberDefn: Boolean get_IsNestedType()
 FSharp.Compiler.Syntax.SynMemberDefn: Boolean get_IsOpen()
 FSharp.Compiler.Syntax.SynMemberDefn: Boolean get_IsValField()
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewAbstractSlot(FSharp.Compiler.Syntax.SynValSig, FSharp.Compiler.Syntax.SynMemberFlags, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewAutoProperty(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynType], FSharp.Compiler.Syntax.SynMemberKind, Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynMemberKind,FSharp.Compiler.Syntax.SynMemberFlags], FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitCtor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynSimplePats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Syntax.PreXmlDoc, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewAutoProperty(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynType], FSharp.Compiler.Syntax.SynMemberKind, Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynMemberKind,FSharp.Compiler.Syntax.SynMemberFlags], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitCtor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynSimplePats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitInherit(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInherit(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInterface(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn]], FSharp.Compiler.Text.Range)
@@ -7366,15 +7354,15 @@ FSharp.Compiler.Syntax.SynModuleDecl: System.String ToString()
 FSharp.Compiler.Syntax.SynModuleOrNamespace
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Boolean get_isRecursive()
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Boolean isRecursive
-FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
-FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace NewSynModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace NewSynModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind get_kind()
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind kind
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Int32 Tag
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
@@ -7424,15 +7412,15 @@ FSharp.Compiler.Syntax.SynModuleOrNamespaceKind: System.String ToString()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Boolean get_isRecursive()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Boolean isRecursive
-FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind get_kind()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind kind
-FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig NewSynModuleOrNamespaceSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig NewSynModuleOrNamespaceSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Int32 Tag
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
@@ -8526,15 +8514,15 @@ FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: System.String ToString()
 FSharp.Compiler.Syntax.SynUnionCase
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.Ident get_ident()
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.Ident ident
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCase NewSynUnionCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynUnionCaseKind, FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCase NewSynUnionCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynUnionCaseKind, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCaseKind caseType
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCaseKind get_caseType()
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynUnionCase: Int32 Tag
 FSharp.Compiler.Syntax.SynUnionCase: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynUnionCase: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
@@ -8596,8 +8584,6 @@ FSharp.Compiler.Syntax.SynValSig: Boolean isInline
 FSharp.Compiler.Syntax.SynValSig: Boolean isMutable
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.Ident get_ident()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.Ident ident
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.PreXmlDoc get_xmlDoc()
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType SynType
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType get_SynType()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType get_synType()
@@ -8606,13 +8592,15 @@ FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo SynInfo
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo arity
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_SynInfo()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_arity()
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Syntax.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls explicitValDecls
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls get_explicitValDecls()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Text.Range RangeOfId
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Text.Range get_RangeOfId()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynValSig: Int32 Tag
 FSharp.Compiler.Syntax.SynValSig: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
@@ -8744,21 +8732,6 @@ FSharp.Compiler.Syntax.TyparStaticReq: Int32 GetHashCode(System.Collections.IEqu
 FSharp.Compiler.Syntax.TyparStaticReq: Int32 Tag
 FSharp.Compiler.Syntax.TyparStaticReq: Int32 get_Tag()
 FSharp.Compiler.Syntax.TyparStaticReq: System.String ToString()
-FSharp.Compiler.Syntax.XmlDoc
-FSharp.Compiler.Syntax.XmlDoc: Boolean IsEmpty
-FSharp.Compiler.Syntax.XmlDoc: Boolean NonEmpty
-FSharp.Compiler.Syntax.XmlDoc: Boolean get_IsEmpty()
-FSharp.Compiler.Syntax.XmlDoc: Boolean get_NonEmpty()
-FSharp.Compiler.Syntax.XmlDoc: FSharp.Compiler.Syntax.XmlDoc Empty
-FSharp.Compiler.Syntax.XmlDoc: FSharp.Compiler.Syntax.XmlDoc Merge(FSharp.Compiler.Syntax.XmlDoc, FSharp.Compiler.Syntax.XmlDoc)
-FSharp.Compiler.Syntax.XmlDoc: FSharp.Compiler.Syntax.XmlDoc get_Empty()
-FSharp.Compiler.Syntax.XmlDoc: FSharp.Compiler.Text.Range Range
-FSharp.Compiler.Syntax.XmlDoc: FSharp.Compiler.Text.Range get_Range()
-FSharp.Compiler.Syntax.XmlDoc: System.String GetXmlText()
-FSharp.Compiler.Syntax.XmlDoc: System.String[] GetElaboratedXmlLines()
-FSharp.Compiler.Syntax.XmlDoc: System.String[] UnprocessedLines
-FSharp.Compiler.Syntax.XmlDoc: System.String[] get_UnprocessedLines()
-FSharp.Compiler.Syntax.XmlDoc: Void .ctor(System.String[], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Text.ISourceText
 FSharp.Compiler.Text.ISourceText: Boolean ContentEquals(FSharp.Compiler.Text.ISourceText)
 FSharp.Compiler.Text.ISourceText: Boolean SubTextEquals(System.String, Int32)
@@ -10281,5 +10254,32 @@ FSharp.Compiler.Tokenization.FSharpTokenizerLexState: Int64 PosBits
 FSharp.Compiler.Tokenization.FSharpTokenizerLexState: Int64 get_OtherBits()
 FSharp.Compiler.Tokenization.FSharpTokenizerLexState: Int64 get_PosBits()
 FSharp.Compiler.Tokenization.FSharpTokenizerLexState: System.String ToString()
-FSharp.Compiler.Tokenization.FSharpTokenizerLexState: Void .ctor(Int64, Int64)"
+FSharp.Compiler.Tokenization.FSharpTokenizerLexState: Void .ctor(Int64, Int64)
+FSharp.Compiler.Xml.PreXmlDoc
+FSharp.Compiler.Xml.PreXmlDoc: Boolean Equals(FSharp.Compiler.Xml.PreXmlDoc)
+FSharp.Compiler.Xml.PreXmlDoc: Boolean Equals(System.Object)
+FSharp.Compiler.Xml.PreXmlDoc: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
+FSharp.Compiler.Xml.PreXmlDoc: FSharp.Compiler.Xml.PreXmlDoc Create(System.String[], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Xml.PreXmlDoc: FSharp.Compiler.Xml.PreXmlDoc Empty
+FSharp.Compiler.Xml.PreXmlDoc: FSharp.Compiler.Xml.PreXmlDoc Merge(FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Xml.PreXmlDoc)
+FSharp.Compiler.Xml.PreXmlDoc: FSharp.Compiler.Xml.PreXmlDoc get_Empty()
+FSharp.Compiler.Xml.PreXmlDoc: FSharp.Compiler.Xml.XmlDoc ToXmlDoc(Boolean, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[System.String]])
+FSharp.Compiler.Xml.PreXmlDoc: Int32 GetHashCode()
+FSharp.Compiler.Xml.PreXmlDoc: Int32 GetHashCode(System.Collections.IEqualityComparer)
+FSharp.Compiler.Xml.PreXmlDoc: System.String ToString()
+FSharp.Compiler.Xml.XmlDoc
+FSharp.Compiler.Xml.XmlDoc: Boolean IsEmpty
+FSharp.Compiler.Xml.XmlDoc: Boolean NonEmpty
+FSharp.Compiler.Xml.XmlDoc: Boolean get_IsEmpty()
+FSharp.Compiler.Xml.XmlDoc: Boolean get_NonEmpty()
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc Empty
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc Merge(FSharp.Compiler.Xml.XmlDoc, FSharp.Compiler.Xml.XmlDoc)
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc get_Empty()
+FSharp.Compiler.Xml.XmlDoc: System.String GetXmlText()
+FSharp.Compiler.Xml.XmlDoc: System.String[] GetElaboratedXmlLines()
+FSharp.Compiler.Xml.XmlDoc: System.String[] UnprocessedLines
+FSharp.Compiler.Xml.XmlDoc: System.String[] get_UnprocessedLines()
+FSharp.Compiler.Xml.XmlDoc: Void .ctor(System.String[], FSharp.Compiler.Text.Range)"
         SurfaceArea.verify expected "netstandard" (System.IO.Path.Combine(__SOURCE_DIRECTORY__,__SOURCE_FILE__))

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -1559,7 +1559,7 @@ let ``Test complete active patterns' exact ranges from uses of symbols`` () =
     match oddActivePatternCase.XmlDoc with 
     | FSharpXmlDoc.FromXmlText t -> t.GetElaboratedXmlLines() |> shouldEqual [|"<summary>"; "Total active pattern for even/odd integers"; "</summary>" |]
     | _ -> failwith "wrong kind"
-    oddActivePatternCase.XmlDocSig |> shouldEqual ""
+    oddActivePatternCase.XmlDocSig |> shouldEqual "M:ActivePatterns.|Even|Odd|(System.Int32)"
     let oddGroup = oddActivePatternCase.Group
     oddGroup.IsTotal |> shouldEqual true
     oddGroup.Names |> Seq.toList |> shouldEqual ["Even"; "Odd"]
@@ -1577,7 +1577,7 @@ let ``Test complete active patterns' exact ranges from uses of symbols`` () =
         t.UnprocessedLines |> shouldEqual [| "Total active pattern for even/odd integers" |]
         t.GetElaboratedXmlLines() |> shouldEqual [| "<summary>"; "Total active pattern for even/odd integers"; "</summary>" |]
     | _ -> failwith "wrong kind"
-    evenActivePatternCase.XmlDocSig |> shouldEqual ""
+    evenActivePatternCase.XmlDocSig |> shouldEqual "M:ActivePatterns.|Even|Odd|(System.Int32)"
     let evenGroup = evenActivePatternCase.Group
     evenGroup.IsTotal |> shouldEqual true
     evenGroup.Names |> Seq.toList |> shouldEqual ["Even"; "Odd"]
@@ -1625,7 +1625,7 @@ let ``Test partial active patterns' exact ranges from uses of symbols`` () =
         t.UnprocessedLines |> shouldEqual [| "Partial active pattern for floats" |]
         t.GetElaboratedXmlLines() |> shouldEqual [| "<summary>"; "Partial active pattern for floats"; "</summary>" |]
     | _ -> failwith "wrong kind"
-    floatActivePatternCase.XmlDocSig |> shouldEqual ""
+    floatActivePatternCase.XmlDocSig |> shouldEqual "M:ActivePatterns.|Float|_|(System.String)"
     let floatGroup = floatActivePatternCase.Group
     floatGroup.IsTotal |> shouldEqual false
     floatGroup.Names |> Seq.toList |> shouldEqual ["Float"]

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -1948,8 +1948,7 @@ let f (tp:ITypeProvider(*$$$*)) = tp.Invalidate
              [
               "type KeyCollection<";
               "member CopyTo"; 
-              "[Filename:"; "mscorlib.dll]";
-              "[Signature:T:System.Collections.Generic.Dictionary`2.KeyCollection]"
+              """<summary>Represents the collection of keys in a <see cref="T:System.Collections.Generic.Dictionary`2" />. This class cannot be inherited.</summary>"""
              ]
             )   
 
@@ -2051,8 +2050,7 @@ query."
              "AcceptButton", 
              (* expect to see in order... *)
              [
-              "[Filename:"; "System.Windows.Forms.dll]"
-              "[Signature:P:System.Windows.Forms.Form.AcceptButton]"
+              "<summary>Gets or sets the button on the form that is clicked when the user presses the ENTER key.</summary>"
              ]
             )
 
@@ -2883,7 +2881,7 @@ query."
 
         this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker0*)", "Test for members")
         this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker1*)", "x1 param!")
-        this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker2*)", "[ParamName: arg1]")
+        this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker2*)", "<summary>Concatenates the string representations of two specified objects.</summary>")
         this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker3*)", "str of case1")
         this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker4*)", "str of case1")
         this.AssertQuickInfoContainsAtStartOfMarker (fileContent, "(*Marker5*)", "value param")

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -1967,8 +1967,7 @@ let f (tp:ITypeProvider(*$$$*)) = tp.Invalidate
              [
               "type ArgumentException";
               "member Message"; 
-              "[Filename"; "mscorlib.dll]";
-              "[Signature:T:System.ArgumentException]"
+              "<summary>The exception that is thrown when one of the arguments provided to a method is not valid.</summary"
              ]
             )    
 
@@ -1986,8 +1985,7 @@ let f (tp:ITypeProvider(*$$$*)) = tp.Invalidate
              (* expect to see in order... *)
              [
               "property System.AppDomain.CurrentDomain: System.AppDomain";
-              "[Filename"; "mscorlib.dll]";
-              "[Signature:P:System.AppDomain.CurrentDomain]"
+              """<summary>Gets the current application domain for the current <see cref="T:System.Threading.Thread" />.</summary>"""
              ]
             ) 
 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Script.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Script.fs
@@ -907,9 +907,7 @@ type UsingMSBuild() as this =
         let (project, file) = createSingleFileFsxFromLines code
         MoveCursorToEndOfMarker(file, "System.ConsoleModifiers.Sh")
         let tooltip = GetQuickInfoAtCursor file
-        AssertContains(tooltip, @"[Signature:F:System.ConsoleModifiers.Shift]") // A message from the mock IDocumentationBuilder
-        AssertContains(tooltip, @"[Filename:") 
-        AssertContains(tooltip, @"mscorlib.dll]") // The assembly we expect the documentation to get taken from     
+        AssertContains(tooltip, @"<summary>The left or right SHIFT modifier key.</summary>")    
         
         MoveCursorToEndOfMarker(file, "(3).ToString().Len")
         let tooltip = GetQuickInfoAtCursor file


### PR DESCRIPTION
This adds the ability for FCS to read XML documentation without having to rely on a third-party; it's just integrated in.
Not only will this allow other editors to leverage reading XML documentation easily from FCS, it will also allow metadata-as-source features to print out the XML documentation.

This is a pretty big change mainly due to having to plumb `InfoReader` around.

- [x] Cleanup layout calls to ensure they take a `*Ref` version of properties/meths/fields/etc.
- [x] Weak cache for XMLDocument
- [x] Tests