### PR TITLE
Correct SynStringKind for verbatim interpolated string.

### DIFF
--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -158,6 +158,8 @@ let startString args (lexbuf: UnicodeLexing.Lexbuf) =
                     let synStringKind =
                         if isTripleQuote then
                             SynStringKind.TripleQuote
+                        elif isVerbatim then
+                            SynStringKind.Verbatim
                         else
                             SynStringKind.Regular
                     if isPart then 

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -145,6 +145,8 @@ type LexerStringFinisher =
                     let synStringKind =
                         if isTripleQuote then
                             SynStringKind.TripleQuote
+                        elif isVerbatim then
+                            SynStringKind.Verbatim
                         else
                             SynStringKind.Regular
                     if isPart then 

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -424,6 +424,18 @@ let bytes = @"yo"B
         | Some (SynExpr.InterpolatedString(_,  kind, _)) -> kind |> should equal SynStringKind.Regular
         | _ -> Assert.Fail "Couldn't find const"
 
+    [<Test>]
+    let ``SynExpr.InterpolatedString with SynStringKind.Verbatim`` () =
+        let parseResults =
+            getParseResults
+                """
+ let s = $@"Migrate notes of file ""{oldId}"" to new file ""{newId}""."
+ """
+
+        match getBindingExpressionValue parseResults with
+        | Some (SynExpr.InterpolatedString(_,  kind, _)) -> kind |> should equal SynStringKind.Verbatim
+        | _ -> Assert.Fail "Couldn't find const"
+
 module SynModuleOrNamespace =
     [<Test>]
     let ``DeclaredNamespace range should start at namespace keyword`` () =


### PR DESCRIPTION
Fixes #11475.