### PR TITLE
Adding last successful compilations for VS - C# -> F#

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -433,6 +433,13 @@ type private FSharpProjectOptionsReactor (workspace: Workspace, settings: Editor
         | true, result -> Some(result)
         | _ -> None
 
+    member _.ClearAllCaches() =
+        cpsCommandLineOptions.Clear()
+        legacyProjectSites.Clear()
+        cache.Clear()
+        singleFileCache.Clear()
+        lastSuccessfulCompilations.Clear()
+
     interface IDisposable with
         member _.Dispose() = 
             cancellationTokenSource.Cancel()
@@ -521,6 +528,9 @@ type internal FSharpProjectOptionsManager
         match reactor.TryGetCachedOptionsByProjectId(document.Project.Id) with
         | Some (_, parsingOptions, _) -> parsingOptions
         | _ -> { FSharpParsingOptions.Default with IsInteractive = CompilerEnvironment.IsScriptFile document.Name }
+
+    member this.ClearAllCaches() =
+        reactor.ClearAllCaches()
 
     [<Export>]
     /// This handles commandline change notifications from the Dotnet Project-system

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -62,6 +62,7 @@ type private FSharpSolutionEvents(projectManager: FSharpProjectOptionsManager) =
         member _.OnAfterCloseSolution(_) =
             projectManager.Checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
             projectManager.MetadataAsSource.ClearGeneratedFiles()
+            projectManager.ClearAllCaches()
             VSConstants.S_OK
 
         member _.OnAfterLoadProject(_, _) = VSConstants.E_NOTIMPL


### PR DESCRIPTION
When we were emitting C#/VB metadataOnly compilations, if it failed, we would attempt to read from disk. This PR makes a change where we will not read from disk if that compilation failed. Instead, if the compilation failed, we will try to get the last successful compilation that was associated with that project.