### PR TITLE
Fix the left arrow guard for F# Interactive window in VS.

### DIFF
--- a/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -375,8 +375,7 @@ type internal FsiToolWindow() as this =
         textView.SetSelection(line, endColumn, line, startColumn) |> throwOnFailure0
 
     /// Hanlde no-op, used to overwrite some standard command with an empty action.
-    let onNoAction (sender:obj) (e:EventArgs) = 
-        ()
+    let onNoAction (sender:obj) (e:EventArgs) = ()
     
     
     /// Handle "Clear Pane". Clear input and all but the last ReadOnly line (probably the prompt).    

--- a/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -339,7 +339,7 @@ type internal FsiToolWindow() as this =
     let supportWhenAtStartOfInputArea (sender:obj) (e:EventArgs) =
         let command = sender :?> MenuCommand       
         if command <> null then
-            command.Supported <- not source.IsCompletorActive && isCurrentPositionInInputArea()
+            command.Supported <- not source.IsCompletorActive && isCurrentPositionAtStartOfInputArea()
 
     /// Support when at the start of the input area AND no-selection (e.g. to enable NoAction on BACKSPACE).
     let supportWhenAtStartOfInputAreaAndNoSelection (sender:obj) (e:EventArgs) =
@@ -375,7 +375,8 @@ type internal FsiToolWindow() as this =
         textView.SetSelection(line, endColumn, line, startColumn) |> throwOnFailure0
 
     /// Hanlde no-op, used to overwrite some standard command with an empty action.
-    let onNoAction (sender:obj) (e:EventArgs) = ()
+    let onNoAction (sender:obj) (e:EventArgs) = 
+        ()
     
     
     /// Handle "Clear Pane". Clear input and all but the last ReadOnly line (probably the prompt).    
@@ -675,7 +676,7 @@ type internal FsiToolWindow() as this =
                     else
                         new OleMenuCommandService(this, originalFilter)
 
-            let addCommand guid cmdId handler guard=
+            let addCommand guid cmdId handler guard =
                 let id  = new CommandID(guid,cmdId)
                 let cmd = new OleMenuCommand(new EventHandler(handler),id)
                 match guard with


### PR DESCRIPTION
Fixes #11251, was introduced in #10163.