### PR TITLE
(do not merge) experiment around method binding, to understand shape of SynValInfo

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -8618,7 +8618,7 @@ and TcMethodApplication
 
         let callerArgCounts = (List.sumBy List.length unnamedCurriedCallerArgs, List.sumBy List.length namedCurriedCallerArgs)
 
-        let callerArgs = { Unnamed = unnamedCurriedCallerArgs; Named = namedCurriedCallerArgs }
+        let callerArgs = CallerArgs(unnamedCurriedCallerArgs, namedCurriedCallerArgs)
 
         let makeOneCalledMeth (minfo, pinfoOpt, usesParamArrayConversion) =
             let minst = FreshenMethInfo mItem minfo
@@ -8717,7 +8717,7 @@ and TcMethodApplication
     /// Select the called method that's the result of overload resolution
     let finalCalledMeth =
 
-        let callerArgs = { Unnamed = unnamedCurriedCallerArgs ; Named = namedCurriedCallerArgs }
+        let callerArgs = CallerArgs(unnamedCurriedCallerArgs, namedCurriedCallerArgs)
 
         let postArgumentTypeCheckingCalledMethGroup =
             preArgumentTypeCheckingCalledMethGroup |> List.map (fun (minfo: MethInfo, minst, pinfoOpt, usesParamArrayConversion) ->

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1555,8 +1555,7 @@ and SolveMemberConstraint (csenv: ConstraintSolverEnv) ignoreUnresolvedOverload 
                     |> List.choose (fun minfo ->
                           if minfo.IsCurried then None else
                           let callerArgs = 
-                            { Unnamed = [ (argtys |> List.map (fun argty -> CallerArg(argty, m, false, dummyExpr))) ]
-                              Named = [ [ ] ] }
+                            CallerArgs( ([ (argtys |> List.map (fun argty -> CallerArg(argty, m, false, dummyExpr))) ]),                              ([ [ ] ] ))
                           let minst = FreshenMethInfo m minfo
                           let objtys = minfo.GetObjArgTypes(amap, m, minst)
                           Some(CalledMeth<Expr>(csenv.InfoReader, None, false, FreshenMethInfo, m, AccessibleFromEverywhere, minfo, minst, minst, None, objtys, callerArgs, false, false, None)))
@@ -1564,7 +1563,7 @@ and SolveMemberConstraint (csenv: ConstraintSolverEnv) ignoreUnresolvedOverload 
               let methOverloadResult, errors = 
                   trace.CollectThenUndoOrCommit
                       (fun (a, _) -> Option.isSome a)
-                      (fun trace -> ResolveOverloading csenv (WithTrace trace) nm ndeep (Some traitInfo) CallerArgs.Empty AccessibleFromEverywhere calledMethGroup false (Some rty))
+                      (fun trace -> ResolveOverloading csenv (WithTrace trace) nm ndeep (Some traitInfo) (CallerArgs([],[])) AccessibleFromEverywhere calledMethGroup false (Some rty))
 
               match anonRecdPropSearch, recdPropSearch, methOverloadResult with 
               | Some (anonInfo, tinst, i), None, None -> 

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -121,13 +121,20 @@ type CallerNamedArg<'T> =
 /// Represents the list of unnamed / named arguments at method call site
 /// remark: The usage of list list is due to tupling and currying of arguments,
 /// stemming from SynValInfo in the AST.
-[<Struct>]
-type CallerArgs<'T> = 
-    { 
-        Unnamed: CallerArg<'T> list list
-        Named: CallerNamedArg<'T> list list 
-    }
-    static member Empty : CallerArgs<'T> = { Unnamed = []; Named = [] }
+//[<Struct>]
+type CallerArgs<'T>= 
+    //{ 
+    //    Unnamed: CallerArg<'T> list list
+    //    Named: CallerNamedArg<'T> list list 
+    //}
+    val Unnamed : CallerArg<'T> list list
+    val Named : CallerNamedArg<'T> list list
+    new (unnamed, named) = 
+      match unnamed, named with
+      | [_],[_] | [], [_]| [_], [] ->()
+      | _ -> raise (new System.Exception("odd shape in caller args"))
+      {Unnamed = unnamed; Named = named}
+    //static member Empty : CallerArgs<'T> = CallerArgs<'T>(unnamed = [], named = [])
     member x.CallerArgCounts = List.length x.Unnamed, List.length x.Named
     member x.CurriedCallerArgs = List.zip x.Unnamed x.Named
     member x.ArgumentNamesAndTypes =

--- a/src/fsharp/MethodCalls.fsi
+++ b/src/fsharp/MethodCalls.fsi
@@ -88,15 +88,16 @@ type CallerNamedArg<'T> =
 /// Represents the list of unnamed / named arguments at method call site
 /// remark: The usage of list list is due to tupling and currying of arguments,
 /// stemming from SynValInfo in the AST.
-[<StructAttribute>]
-type CallerArgs<'T> =
-    { Unnamed: CallerArg<'T> list list
-      Named: CallerNamedArg<'T> list list }
+//[<Struct>]
+type CallerArgs<'T> = 
+    val Unnamed: CallerArg<'T> list list
+    val Named: CallerNamedArg<'T> list list
+    new : (CallerArg<'T> list list) * (CallerNamedArg<'T> list list) -> CallerArgs<'T>
     member ArgumentNamesAndTypes: (string option * TType) list
     member CallerArgCounts: int * int
     member CurriedCallerArgs: (CallerArg<'T> list * CallerNamedArg<'T> list) list
-    static member Empty: CallerArgs<'T>
-  
+    //static member Empty: CallerArgs<'T>
+
 /// F# supports some adhoc conversions at method callsites
 val AdjustCalledArgType: infoReader:InfoReader -> isConstraint:bool -> enforceNullableOptionalsKnownTypes:bool -> calledArg:CalledArg -> callerArg:CallerArg<'a> -> TType
 


### PR DESCRIPTION
I'm having hard time groking `CallerArgs` in `MethodCalls` module, and other types where we get binding of method arguments into `obj list list`, stemming from the AST `SynValInfo`.

Trying to figure out if there are invariants that could be encoded for method bindings that would prevent the need for `list list`.