### PR TITLE
Added binary writer to write to any stream without PDB info

### DIFF
--- a/src/fsharp/absil/ilwrite.fsi
+++ b/src/fsharp/absil/ilwrite.fsi
@@ -4,6 +4,7 @@
 module internal FSharp.Compiler.AbstractIL.ILBinaryWriter
 
 open Internal.Utilities
+open System.IO
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILPdbWriter
 open FSharp.Compiler.AbstractIL.StrongNameSign
@@ -26,3 +27,6 @@ type options =
 
 /// Write a binary to the file system. Extra configuration parameters can also be specified. 
 val WriteILBinary: filename: string * options:  options * inputModule: ILModuleDef * (ILAssemblyRef -> ILAssemblyRef) -> unit
+
+/// Write a binary to the given stream. Extra configuration parameters can also be specified. 
+val WriteILBinaryStreamWithNoPDB: stream: Stream * options: options * inputModule: ILModuleDef * (ILAssemblyRef -> ILAssemblyRef) -> unit


### PR DESCRIPTION
We need the ability to write a binary assembly directly to any kind of stream; without relying on the file system.
This PR adds an API to do that, but without PDB info for now. This is necessary for our reference assembly work.
The API is not public; only internal.