### PR TITLE
[release/dev16.10] ensure compiler and targets can be found in legacy projects

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.Base/Utilities.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Utilities.cs
@@ -740,7 +740,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             {
                 var lclGlobalProperties = (null == globalProperties) ? new Dictionary<string, string>() : new Dictionary<string, string>(globalProperties)
                 {
-                    { "FSharpCompilerPath", Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) }
+                    { "FSharpCompilerPath", Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Tools") }
                 };
                 buildProject = buildEngine.LoadProject(fullProjectPath, lclGlobalProperties, null);
                 buildProject.IsBuildEnabled = true;


### PR DESCRIPTION
PR #11159 moved the compiler and targets down into a `Tools` directory and we missed the in-memory legacy project.

~~Draft until a test insertion can be verified.~~  Manual test was good.