### PR TITLE
Syntax tree: fix type is not included in SynModuleSigDecl.Types range, inline tyconSpfns rule

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -321,7 +321,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <ParsedScriptInteraction> interaction
 %type <Ident> ident
 %type <SynType> typ typEOF
-%type <SynTypeDefnSig list> tyconSpfns
+%type <SynTypeDefnSig list> tyconSpfnList
 %type <SynExpr> patternResult
 %type <SynExpr> declExpr
 %type <SynExpr> minusExpr
@@ -810,18 +810,19 @@ moduleSpfn:
         let m = (rhs2 parseState 1 4, $5) ||> unionRangeWithListBy (fun (d: SynModuleSigDecl) -> d.Range)
         SynModuleSigDecl.NestedModule(info, isRec, $5, m) }
 
-  | opt_attributes opt_declVisibility  tyconSpfns 
-      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let (SynTypeDefnSig(SynComponentInfo(cas, a, cs, b, c, d, d2, d3), e, f, g)), rest = 
-           match $3 with
-           | [] -> raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEmptyModuleDefn()) 
-           | h :: t -> h, t 
-        let attrs = $1@cas
-        let mTc = (g, attrs)  ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
-        let tc = (SynTypeDefnSig(SynComponentInfo(attrs, a, cs, b, c, d, d2, d3), e, f, mTc))
-        let lastType = List.tryLast rest |> Option.defaultValue tc |> fun t -> t.Range
-        let m = mkRange lastType.FileName mTc.Start lastType.End
-        SynModuleSigDecl.Types (tc :: rest, m) } 
+  | opt_attributes opt_declVisibility typeKeyword tyconSpfnList
+      { if Option.isSome $2 then
+            errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+
+        let typeSigs = $4
+        match typeSigs with
+        | [] -> raiseParseErrorAt (rhs2 parseState 3 4) (FSComp.SR.parsUnexpectedEmptyModuleDefn ())
+        | SynTypeDefnSig (SynComponentInfo (cas, _, _, _, _, _, _, _), _, _, _) :: _ ->
+            let attrs = $1 @ cas
+            let mTc = (rhs parseState 3, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
+            let m = (mTc, typeSigs) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range)
+
+            SynModuleSigDecl.Types (typeSigs, m) }
 
   | opt_attributes opt_declVisibility exconSpfn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
@@ -868,12 +869,6 @@ moduleSpecBlock:
   /* non-#light-syntax, with sig/end or begin/end */
   |             sigOrBegin moduleSpfnsPossiblyEmpty END 
       { $2 }
-
-
-/* A group of type definitions in a signature */
-tyconSpfns:      
-  | typeKeyword tyconSpfnList 
-     { $2 }
 
 
 tyconSpfnList:  

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -814,15 +814,17 @@ moduleSpfn:
       { if Option.isSome $2 then
             errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
 
-        let typeSigs = $4
-        match typeSigs with
+        match $4 with
         | [] -> raiseParseErrorAt (rhs2 parseState 3 4) (FSComp.SR.parsUnexpectedEmptyModuleDefn ())
-        | SynTypeDefnSig (SynComponentInfo (cas, _, _, _, _, _, _, _), _, _, _) :: _ ->
+        | SynTypeDefnSig (SynComponentInfo (cas, a, cs, b, c, d, d2, d3), e, f, g) :: tail ->
             let attrs = $1 @ cas
-            let mTc = (rhs parseState 3, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
-            let m = (mTc, typeSigs) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range)
+            let mTc =
+                let keywordM = rhs parseState 3
+                (keywordM, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range) |> unionRanges g
+            let tc = (SynTypeDefnSig(SynComponentInfo(attrs, a, cs, b, c, d, d2, d3), e, f, mTc))
+            let m = (mTc, tail) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range)
 
-            SynModuleSigDecl.Types (typeSigs, m) }
+            SynModuleSigDecl.Types (tc :: tail, m) }
 
   | opt_attributes opt_declVisibility exconSpfn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -747,7 +747,7 @@ and [<CustomEquality>] Bang =
             ]) as t]) ])) ->
             assertRange (4, 0) (5, 9) r1
             assertRange (7, 4) (12, 42) r2
-            assertRange (4, 5) (12, 42) t.Range
+            assertRange (4, 0) (12, 42) t.Range
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -638,7 +638,7 @@ type Meh =
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
             SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(range = r)]) ])) ->
-            assertRange (3, 5) (5,11) r
+            assertRange (3, 0) (5,11) r
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -653,7 +653,7 @@ type MyRecord =
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
             SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [SynTypeDefnSig.SynTypeDefnSig(range = r)])]) ])) ->
-            assertRange (2, 5) (4, 30) r
+            assertRange (2, 0) (4, 30) r
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -669,7 +669,7 @@ type MyRecord =
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
             SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [SynTypeDefnSig.SynTypeDefnSig(range = r)])]) ])) ->
-            assertRange (2, 5) (5, 30) r
+            assertRange (2, 0) (5, 30) r
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -683,7 +683,7 @@ type MyFunction =
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
             SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [SynTypeDefnSig.SynTypeDefnSig(range = r)])]) ])) ->
-            assertRange (2, 5) (3, 29) r
+            assertRange (2, 0) (3, 29) r
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -698,7 +698,7 @@ type SomeCollection with
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
             SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [SynTypeDefnSig.SynTypeDefnSig(range = r)])]) ])) ->
-            assertRange (2, 5) (4, 37) r
+            assertRange (2, 0) (4, 37) r
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -745,7 +745,7 @@ and [<CustomEquality>] Bang =
                 SynTypeDefnSig.SynTypeDefnSig(range = r1)
                 SynTypeDefnSig.SynTypeDefnSig(range = r2)
             ]) as t]) ])) ->
-            assertRange (4, 5) (5, 9) r1
+            assertRange (4, 0) (5, 9) r1
             assertRange (7, 4) (12, 42) r2
             assertRange (4, 5) (12, 42) t.Range
         | _ -> Assert.Fail "Could not get valid AST"


### PR DESCRIPTION
Fixes `type` is no longer in the module member signature, see https://github.com/dotnet/fsharp/pull/11503#issuecomment-843081063.

Also simplifies the grammar rule and inlines a simple rule (for easier getting the keyword range).