### PR TITLE
fix #10151 - Compiler doesn't build using dotnet on windows

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <!-- directory locations -->
-  <PropertyGroup>
-    <DisableAutoSetFscCompilerPath Condition="'$(DisableAutoSetFscCompilerPath)' == '' and '$(Configuration)' != 'Proto'">true</DisableAutoSetFscCompilerPath>
+
+  <PropertyGroup Condition="'$(OS)' != 'Unix' and '$(DisableAutoSetFscCompilerPath)' != 'true' and '$(Configuration)' != 'Proto' and '$(DOTNET_HOST_PATH)' != ''">
+    <DisableAutoSetFscCompilerPath>true</DisableAutoSetFscCompilerPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -9,6 +9,10 @@
 
   <!-- directory locations -->
   <PropertyGroup>
+    <DisableAutoSetFscCompilerPath Condition="'$(DisableAutoSetFscCompilerPath)' == '' and '$(Configuration)' != 'Proto'">true</DisableAutoSetFscCompilerPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <FSharpSourcesRoot>$(RepoRoot)src</FSharpSourcesRoot>
     <FSharpTestsRoot>$(RepoRoot)tests</FSharpTestsRoot>
     <SymStoreDirectory>$(ArtifactsDir)\SymStore</SymStoreDirectory>
@@ -16,7 +20,7 @@
     <ValueTupleImplicitPackageVersion>4.4.0</ValueTupleImplicitPackageVersion>
     <WarningsAsErrors>1182;0025;$(WarningsAsErrors)</WarningsAsErrors>
     <OtherFlags>$(OtherFlags) --nowarn:3384</OtherFlags>
-</PropertyGroup>
+  </PropertyGroup>
 
   <!-- nuget -->
   <PropertyGroup>


### PR DESCRIPTION
This was caused because on windows we build the protocompiler to target windows, on linux/macos, we target coreclr.  The FSharp build targets know where to look by detecting the platform.

This detection interfered with our builds need to build product assemblies using the proto-compiler made at the start of the build.

This change, ensures that when we are building the product F# does not  try to pick a different compiler.