### PR TITLE
Allow FSharp.Core support netstandard2.1

### DIFF
--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);FSHARP_CORE</DefineConstants>

--- a/src/fsharp/FSharp.Core/FSharp.Core.nuspec
+++ b/src/fsharp/FSharp.Core/FSharp.Core.nuspec
@@ -5,6 +5,7 @@
         <language>en-US</language>
         <dependencies>
             <group targetFramework=".NETStandard2.0" />
+            <group targetFramework=".NETStandard2.1" />
         </dependencies>
         <contentFiles> <!-- Deploy doc comments as Content -->
             <files include="**/FSharp.Core.xml" buildAction="None" copyToOutput="true" flatten="true" />
@@ -17,7 +18,12 @@
         <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.xml" target="lib\netstandard2.0" />
         <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.xml" target="contentFiles/any/netstandard2.0" />
 
+        <file src="FSharp.Core\$Configuration$\netstandard2.1\FSharp.Core.dll" target="lib\netstandard2.1" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.1\FSharp.Core.xml" target="lib\netstandard2.1" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.1\FSharp.Core.xml" target="contentFiles/any/netstandard2.1" />
+
         <!-- resources -->
         <file src="FSharp.Core\$Configuration$\netstandard2.0\**\FSharp.Core.resources.dll" target="lib\netstandard2.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.1\**\FSharp.Core.resources.dll" target="lib\netstandard2.1" />
     </files>
 </package>

--- a/src/fsharp/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -6,7 +6,7 @@
         <dependencies>
             <group targetFramework=".NET5.0">
                 <dependency id="Microsoft.NETCore.Platforms" version="2.0.0" />
-                <dependency id="NETStandard.Library" version="2.0.0" />
+                <dependency id="NETStandard.Library" version="2.1.0" />
                 <dependency id="System.Collections.Immutable" version="1.5.0" />
                 <dependency id="System.Diagnostics.Process" version="4.3.0" />
                 <dependency id="System.Diagnostics.TraceSource" version="4.3.0" />
@@ -48,8 +48,8 @@
         <!-- assemblies -->
         <file src="fsc\$Configuration$\net5.0\fsc.dll"                                                     target="lib\net5.0" />
         <file src="fsi\$Configuration$\net5.0\fsi.dll"                                                     target="lib\net5.0" />
-        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.dll"                             target="lib\net5.0" />
-        <file src="FSharp.Core\$Configuration$\netstandard2.0\FSharp.Core.xml"                             target="lib\net5.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.1\FSharp.Core.dll"                             target="lib\net5.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.1\FSharp.Core.xml"                             target="lib\net5.0" />
         <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\FSharp.Compiler.Service.dll"     target="lib\net5.0" />
         <file src="FSharp.Build\$Configuration$\netstandard2.0\FSharp.Build.dll"                           target="lib\net5.0" />
         <file src="FSharp.DependencyManager.Nuget\$configuration$\netstandard2.0\FSharp.DependencyManager.Nuget.dll"
@@ -66,7 +66,7 @@
         <file src="FSharp.Build\$Configuration$\netstandard2.0\Microsoft.FSharp.Overrides.NetSdk.targets"  target="contentFiles\any\any" />
 
         <!-- resources -->
-        <file src="FSharp.Core\$Configuration$\netstandard2.0\**\FSharp.Core.resources.dll"                target="lib\net5.0" />
+        <file src="FSharp.Core\$Configuration$\netstandard2.1\**\FSharp.Core.resources.dll"                target="lib\net5.0" />
         <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\**\FSharp.Compiler.Service.resources.dll"
                                                                                                            target="lib\net5.0" />
         <file src="FSharp.Compiler.Interactive.Settings\$Configuration$\netstandard2.0\**\FSharp.Compiler.Interactive.Settings.resources.dll"


### PR DESCRIPTION
The task feature that @dsyme is working requires to use netstandard2.1 within FSharp.Core.  So this change is preparation for that.

/cc @cartermp 
