### PR TITLE
Use logical file name stamps to calculate logical project time stamp

### DIFF
--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1274,7 +1274,7 @@ type IncrementalBuilder(tcGlobals,
         let state = computeStampedFileNames state cache
         let state = computeStampedReferencedAssemblies state cache
         let t1 = MaxTimeStampInDependencies state.stampedReferencedAssemblies
-        let t2 = MaxTimeStampInDependencies state.stampedFileNames
+        let t2 = MaxTimeStampInDependencies state.logicalStampedFileNames
         max t1 t2
 
     member _.TryGetSlotOfFileName(filename: string) =


### PR DESCRIPTION
We should have been using the logical file name stamps to calculate the logical project time stamp. This should fix unnecessary updating when modifying an implementation file that has a backing signature.