### PR TITLE
Improved VS callback debugging for FSharp.Editor

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -106,6 +106,7 @@ module internal RoslynHelpers =
                 | :? OperationCanceledException ->
                     ts.TrySetCanceled() |> ignore
                 | _ ->
+                    System.Diagnostics.Trace.WriteLine("FSharp.Editor: exception swallowed and not passed to Roslyn: {0}", exn.Message)
                     ts.TrySetResult Unchecked.defaultof<_> |> ignore
             ),
             (fun _ -> ts.TrySetCanceled() |> ignore),

--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -100,15 +100,15 @@ module internal RoslynHelpers =
         let task = ts.Task
         Async.StartWithContinuations(
             computation,
-            (fun k -> ts.SetResult k),
+            (fun k -> ts.TrySetResult k |> ignore),
             (fun exn -> 
                 match exn with
                 | :? OperationCanceledException ->
-                    ts.SetCanceled()
+                    ts.TrySetCanceled() |> ignore
                 | _ ->
-                    ts.SetResult(Unchecked.defaultof<_>)
+                    ts.TrySetResult Unchecked.defaultof<_> |> ignore
             ),
-            (fun _ -> ts.SetCanceled()),
+            (fun _ -> ts.TrySetCanceled() |> ignore),
             cancellationToken)
         task
 

--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -93,12 +93,6 @@ module internal RoslynHelpers =
 
     let CollectTaggedText (list: List<_>) (t:TaggedText) = list.Add(RoslynTaggedText(roslynTag t.Tag, t.Text))
 
-    type VolatileBarrier() =
-        [<VolatileField>]
-        let mutable isStopped = false
-        member _.Proceed = not isStopped
-        member _.Stop() = isStopped <- true
-
     // If exception occurs then return the result as Unchecked.defaultof<_>, i.e. swallow exceptions
     // and hope that Roslyn copes with the null.
     let StartAsyncAsTask (cancellationToken: CancellationToken) computation =

--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -101,8 +101,6 @@ module internal RoslynHelpers =
                 try
                     return! computation
                 with
-                | :? OperationCanceledException as ex ->
-                    return raise ex
                 | _ ->
                     return Unchecked.defaultof<_>
             }


### PR DESCRIPTION
This is what the call stack looks like when debugging FSharp.Editor:
![worse](https://user-images.githubusercontent.com/1278959/119915490-7c919200-bf17-11eb-842e-55817477af3a.png)

This PR improves the call stack by using locks instead of the mailbox processor in Debug mode for `FSharpProjectOptionsManager` and stopping our `RoslynHelpers.StartAsyncAsTask` from switching to a different thread.

The result:
![better](https://user-images.githubusercontent.com/1278959/119915604-b9f61f80-bf17-11eb-9970-f3b922894d94.png)
