### PR TITLE
Type checker: recover missing 'this' error

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -2399,7 +2399,14 @@ module BindingNormalization =
                     match longId with
                     // x.Member in member binding patterns.
                     | [thisId;memberId] -> NormalizeInstanceMemberBinding cenv memberFlags valSynData thisId memberId toolId vis typars args m rhsExpr
-                    | [memberId] -> NormalizeStaticMemberBinding cenv memberFlags valSynData memberId vis typars args m rhsExpr
+                    | [memberId] ->
+                        if memberFlags.IsInstance then
+                            // instance method without adhoc "this" argument
+                            errorR(Error(FSComp.SR.tcInstanceMemberRequiresTarget(), m))
+                            let thisId = ident ("_", m)
+                            NormalizeInstanceMemberBinding cenv memberFlags valSynData thisId memberId toolId vis typars args m rhsExpr
+                        else
+                            NormalizeStaticMemberBinding cenv memberFlags valSynData memberId vis typars args m rhsExpr
                     | _ -> NormalizedBindingPat(pat, rhsExpr, valSynData, typars)
 
             // Object constructors are normalized in TcLetrec

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -2402,7 +2402,7 @@ module BindingNormalization =
                     | [memberId] ->
                         if memberFlags.IsInstance then
                             // instance method without adhoc "this" argument
-                            errorR(Error(FSComp.SR.tcInstanceMemberRequiresTarget(), m))
+                            errorR(Error(FSComp.SR.tcInstanceMemberRequiresTarget(), memberId.idRange))
                             let thisId = ident ("_", m)
                             NormalizeInstanceMemberBinding cenv memberFlags valSynData thisId memberId toolId vis typars args m rhsExpr
                         else

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -1436,6 +1436,15 @@ let ``Inherit ctor arg recovery`` () =
     assertHasSymbolUsages ["x"] checkResults
 
 [<Test>]
+let ``Missing this recovery`` () =
+    let _, checkResults = getParseAndCheckResults """
+    type T() =
+        member M() =
+            let x = 1 in ()
+    """
+    assertHasSymbolUsages ["x"] checkResults
+
+[<Test>]
 let ``Brace matching smoke test`` () =
     let input =
       """


### PR DESCRIPTION
Before the change:
<img width="371" alt="Screenshot 2021-06-02 at 15 16 07" src="https://user-images.githubusercontent.com/3923587/120463748-a7676480-c3b5-11eb-88aa-e856eebd46a4.png">

After the change:
<img width="389" alt="Screenshot 2021-06-02 at 15 15 58" src="https://user-images.githubusercontent.com/3923587/120463764-ab938200-c3b5-11eb-8f2c-186f1f1fafe9.png">

The change adds another check for missing `this` parameter and uses the instance member checking logic instead of static one.

The current error-producing logic left intact here:
https://github.com/dotnet/fsharp/blob/6034e99b1e939c46963650d22ded174bc85de112/src/fsharp/CheckExpressions.fs#L2333-L2335
I'm not sure if this logic can trigger it:
https://github.com/dotnet/fsharp/blob/6034e99b1e939c46963650d22ded174bc85de112/src/fsharp/CheckExpressions.fs#L2405-L2408
If not, I'm happy to remove the old check since it doesn't seem to be used in cases I've checked anymore.