### PR TITLE
Fix printf test case

### DIFF
--- a/tests/fsharp/core/printf/test.fsx
+++ b/tests/fsharp/core/printf/test.fsx
@@ -137,7 +137,7 @@ let _ = test "cewoui2B" (lazy(sprintf "%X" 0xffffffff)) "FFFFFFFF"
 let _ = test "cewoui2N" (lazy(sprintf "%X" (System.Int32.MinValue+1))) "80000001"
 let _ = test "cewoui2M" (lazy(sprintf "%X" System.Int32.MaxValue)) "7FFFFFFF"
 let _ = test "cewoui2," (lazy(sprintf "%X" System.UInt64.MaxValue)) "FFFFFFFFFFFFFFFF"
-let _ = test "cewoui2." (lazy(sprintf "%X" System.Int64.MinValue)) "FFFFFFFFFFFFFFFF"
+let _ = test "cewoui2." (lazy(sprintf "%X" System.Int64.MinValue)) "8000000000000000"
 
 let _ = test "cewou44a" (lazy(sprintf "%u" 0)) "0"
 let _ = test "cewou44b" (lazy(sprintf "%u" 5)) "5"


### PR DESCRIPTION

One of the printf test cases was testing for the wrong output value

Only a subset of the test cases are run on each run, so this was causing the test to fail 1 time out of 10 or so.

```
2021-06-03T13:07:35.7351726Z  NO: test cewoui2.: expected 
2021-06-03T13:07:35.7352320Z 	'FFFFFFFFFFFFFFFF' but produced 
2021-06-03T13:07:35.7352858Z 	'8000000000000000'
```
