### PR TITLE
fix test, simplify unused code, add docs

### DIFF
--- a/src/fsharp/FSharp.Core/async.fs
+++ b/src/fsharp/FSharp.Core/async.fs
@@ -923,16 +923,13 @@ namespace Microsoft.FSharp.Control
 
         // Helper to attach continuation to the given task.
         [<DebuggerHidden>]
-        let taskContinueWith (task: Task<'T>) (ctxt: AsyncActivation<'T>) useCcontForTaskCancellation =
+        let taskContinueWith (task: Task<'T>) (ctxt: AsyncActivation<'T>)  =
 
             let continuation (completedTask: Task<_>) : unit =
                 ctxt.trampolineHolder.ExecuteWithTrampoline (fun () ->
                     if completedTask.IsCanceled then
-                        if useCcontForTaskCancellation then
-                            ctxt.OnCancellation ()
-                        else
-                            let edi = ExceptionDispatchInfo.Capture(TaskCanceledException completedTask)
-                            ctxt.econt edi
+                        let edi = ExceptionDispatchInfo.Capture(TaskCanceledException completedTask)
+                        ctxt.econt edi
                     elif completedTask.IsFaulted then
                         let edi = ExceptionDispatchInfo.RestoreOrCapture completedTask.Exception
                         ctxt.econt edi
@@ -946,16 +943,13 @@ namespace Microsoft.FSharp.Control
                 |> ignore |> fake
 
         [<DebuggerHidden>]
-        let taskContinueWithUnit (task: Task) (ctxt: AsyncActivation<unit>) useCcontForTaskCancellation =
+        let taskContinueWithUnit (task: Task) (ctxt: AsyncActivation<unit>) =
 
             let continuation (completedTask: Task) : unit =
                 ctxt.trampolineHolder.ExecuteWithTrampoline (fun () ->
                     if completedTask.IsCanceled then
-                        if useCcontForTaskCancellation then
-                            ctxt.OnCancellation ()
-                        else
-                            let edi = ExceptionDispatchInfo.Capture(TaskCanceledException(completedTask))
-                            ctxt.econt edi
+                        let edi = ExceptionDispatchInfo.Capture(TaskCanceledException(completedTask))
+                        ctxt.econt edi
                     elif completedTask.IsFaulted then
                         let edi = ExceptionDispatchInfo.RestoreOrCapture completedTask.Exception
                         ctxt.econt edi
@@ -1699,15 +1693,15 @@ namespace Microsoft.FSharp.Control
 
         static member AwaitTask (task:Task<'T>) : Async<'T> =
             if task.IsCompleted then
-                CreateProtectedAsync (fun ctxt -> taskContinueWith task ctxt false)
+                CreateProtectedAsync (fun ctxt -> taskContinueWith task ctxt)
             else
-                CreateDelimitedUserCodeAsync (fun ctxt -> taskContinueWith task ctxt false)
+                CreateDelimitedUserCodeAsync (fun ctxt -> taskContinueWith task ctxt)
 
         static member AwaitTask (task:Task) : Async<unit> =
             if task.IsCompleted then
-                CreateProtectedAsync (fun ctxt -> taskContinueWithUnit task ctxt false)
+                CreateProtectedAsync (fun ctxt -> taskContinueWithUnit task ctxt)
             else
-                CreateDelimitedUserCodeAsync (fun ctxt -> taskContinueWithUnit task ctxt false)
+                CreateDelimitedUserCodeAsync (fun ctxt -> taskContinueWithUnit task ctxt)
 
     module CommonExtensions =
 

--- a/src/fsharp/FSharp.Core/async.fsi
+++ b/src/fsharp/FSharp.Core/async.fsi
@@ -365,6 +365,17 @@ namespace Microsoft.FSharp.Control
         ///
         /// <param name="task">The task to await.</param>
         ///
+        /// <remarks>If an exception occurs in the asynchronous computation then an exception is re-raised by this
+        /// function.
+        ///        
+        /// If the task is cancelled then <see cref="F:System.Threading.Tasks.TaskCanceledException"/> is raised. Note
+        /// that the task may be governed by a different cancellation token to the overall async computation
+        /// where the AwaitTask occurs. In practice you should normally start the task with the
+        /// cancellation token returned by <c>let! ct = Async.CancellationToken</c>, and catch
+        /// any <see cref="F:System.Threading.Tasks.TaskCanceledException"/> at the point where the
+        /// overall async is started.
+        /// </remarks>
+        ///
         /// <category index="2">Awaiting Results</category>
         static member AwaitTask: task: Task<'T> -> Async<'T>
 
@@ -372,6 +383,17 @@ namespace Microsoft.FSharp.Control
         /// its result.</summary>
         ///
         /// <param name="task">The task to await.</param>
+        ///
+        /// <remarks>If an exception occurs in the asynchronous computation then an exception is re-raised by this
+        /// function.
+        ///        
+        /// If the task is cancelled then <see cref="F:System.Threading.Tasks.TaskCanceledException"/> is raised. Note
+        /// that the task may be governed by a different cancellation token to the overall async computation
+        /// where the AwaitTask occurs. In practice you should normally start the task with the
+        /// cancellation token returned by <c>let! ct = Async.CancellationToken</c>, and catch
+        /// any <see cref="F:System.Threading.Tasks.TaskCanceledException"/> at the point where the
+        /// overall async is started.
+        /// </remarks>
         ///
         /// <category index="2">Awaiting Results</category>
         static member AwaitTask: task: Task -> Async<unit>

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -505,10 +505,16 @@ type AsyncType() =
 #endif
           Task.Factory.StartNew(Func<unit>(fun () -> while not token.IsCancellationRequested do ()), token)
         let cancelled = ref true
-        let a = async {
+        let a = 
+            async {
+                try
                     use! _holder = Async.OnCancel(fun _ -> ewh.Set() |> ignore)
                     let! v = Async.AwaitTask(t)
                     return v
+                // AwaitTask raises TaskCanceledException when it is canceled
+                with
+                   :? TaskCanceledException -> 
+                      return ()
             }
         Async.Start a
         cts.Cancel()
@@ -557,10 +563,16 @@ type AsyncType() =
         use t =
 #endif
             Task.Factory.StartNew(Action(fun () -> while not token.IsCancellationRequested do ()), token)
-        let a = async {
+        let a =
+            async {
+                try
                     use! _holder = Async.OnCancel(fun _ -> ewh.Set() |> ignore)
                     let! v = Async.AwaitTask(t)
                     return v
+                // AwaitTask raises TaskCanceledException when it is canceled
+                with
+                   :? TaskCanceledException -> 
+                      return ()
             }
         Async.Start a
         cts.Cancel()

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -511,10 +511,10 @@ type AsyncType() =
                     use! _holder = Async.OnCancel(fun _ -> ewh.Set() |> ignore)
                     let! v = Async.AwaitTask(t)
                     return v
-                // AwaitTask raises TaskCanceledException when it is canceled
+                // AwaitTask raises TaskCanceledException when it is canceled, it is a valid result of this test
                 with
                    :? TaskCanceledException -> 
-                      return ()
+                      ewh.Set() |> ignore // this is ok
             }
         Async.Start a
         cts.Cancel()
@@ -569,10 +569,10 @@ type AsyncType() =
                     use! _holder = Async.OnCancel(fun _ -> ewh.Set() |> ignore)
                     let! v = Async.AwaitTask(t)
                     return v
-                // AwaitTask raises TaskCanceledException when it is canceled
+                // AwaitTask raises TaskCanceledException when it is canceled, it is a valid result of this test
                 with
                    :? TaskCanceledException -> 
-                      return ()
+                      ewh.Set() |> ignore // this is ok
             }
         Async.Start a
         cts.Cancel()


### PR DESCRIPTION
This should fix the dodgy tests we've seen recently

The test doesn't account for the fact that AwaitTask can raise TaskCanceledException if the task gets started before the Cancel gets into effect

`useCcontForTaskCancellation` is always false so we can simplify that code