### PR TITLE
Optimize interpolated string with no holes

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -6739,27 +6739,35 @@ and TcInterpolatedStringExpr cenv overallTy env m tpenv (parts: SynInterpolatedS
 
         UnifyTypes cenv env m printerTupleTy printerTupleTyRequired
 
-        // Type check the expressions filling the holes
-        let flexes = argTys |> List.map (fun _ -> false)
-        let fillExprs, tpenv = TcExprs cenv env m tpenv flexes argTys synFillExprs
+        if List.isEmpty synFillExprs then
+            let str = mkString g m printfFormatString
 
-        let fillExprsBoxed = (argTys, fillExprs) ||> List.map2 (mkCallBox g m)
-
-        let argsExpr = mkArray (g.obj_ty, fillExprsBoxed, m)
-        let percentATysExpr =
-            if percentATys.Length = 0 then
-                mkNull m (mkArrayType g g.system_Type_ty)
+            if isString then
+                str, tpenv
             else
-                let tyExprs = percentATys |> Array.map (mkCallTypeOf g m) |> Array.toList
-                mkArray (g.system_Type_ty, tyExprs, m)
-
-        let fmtExpr = MakeMethInfoCall cenv.amap m newFormatMethod [] [mkString g m printfFormatString; argsExpr; percentATysExpr]
-
-        if isString then
-            // Make the call to sprintf
-            mkCall_sprintf g m printerTy fmtExpr [], tpenv
+                mkCallNewFormat cenv.g m printerTy printerArgTy printerResidueTy printerResultTy printerTupleTy str, tpenv
         else
-            fmtExpr, tpenv
+            // Type check the expressions filling the holes
+            let flexes = argTys |> List.map (fun _ -> false)
+            let fillExprs, tpenv = TcExprs cenv env m tpenv flexes argTys synFillExprs
+
+            let fillExprsBoxed = (argTys, fillExprs) ||> List.map2 (mkCallBox g m)
+
+            let argsExpr = mkArray (g.obj_ty, fillExprsBoxed, m)
+            let percentATysExpr =
+                if percentATys.Length = 0 then
+                    mkNull m (mkArrayType g g.system_Type_ty)
+                else
+                    let tyExprs = percentATys |> Array.map (mkCallTypeOf g m) |> Array.toList
+                    mkArray (g.system_Type_ty, tyExprs, m)
+
+            let fmtExpr = MakeMethInfoCall cenv.amap m newFormatMethod [] [mkString g m printfFormatString; argsExpr; percentATysExpr]
+
+            if isString then
+                // Make the call to sprintf
+                mkCall_sprintf g m printerTy fmtExpr [], tpenv
+            else
+                fmtExpr, tpenv
 
     // The case for $"..." used as type FormattableString or IFormattable
     | Choice2Of2 createFormattableStringMethod ->

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.EmittedIL
+
+open Xunit
+open FSharp.Test.Utilities.Compiler
+
+module ``StringFormatAndInterpolation`` =
+    [<Fact>]
+    let ``Interpolated string with no holes is reduced to a string or simple format when used in printf``() =
+        FSharp """
+module StringFormatAndInterpolation
+
+let stringOnly () = $"no hole" 
+
+let printed () = printf $"printed no hole"
+         """
+         |> compile
+         |> shouldSucceed
+         |> verifyIL ["""
+IL_0000:  ldstr      "no hole"
+IL_0005:  ret"""
+                      """
+IL_0000:  ldstr      "printed no hole"
+IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormat<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+IL_000f:  pop
+IL_0010:  ret"""]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -18,6 +18,9 @@ let printed () = printf $"printed no hole"
          |> compile
          |> shouldSucceed
          |> verifyIL ["""
+IL_0000:  ldstr      "no hole"
+IL_0005:  ret"""
+                      """
 IL_0000:  ldstr      "printed no hole"
 IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
 IL_000a:  stloc.0

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -18,11 +18,12 @@ let printed () = printf $"printed no hole"
          |> compile
          |> shouldSucceed
          |> verifyIL ["""
-IL_0000:  ldstr      "no hole"
-IL_0005:  ret"""
-                      """
 IL_0000:  ldstr      "printed no hole"
 IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormat<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-IL_000f:  pop
-IL_0010:  ret"""]
+IL_000a:  stloc.0
+IL_000b:  call       class [netstandard]System.IO.TextWriter [netstandard]System.Console::get_Out()
+IL_0010:  ldloc.0
+IL_0011:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.PrintfModule::PrintFormatToTextWriter<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [runtime]System.IO.TextWriter,
+                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+IL_0016:  pop
+IL_0017:  ret"""]

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="EmittedIL\Literals.fs" />
     <Compile Include="EmittedIL\Misc.fs" />
     <Compile Include="EmittedIL\SkipLocalsInit.fs" />
+    <Compile Include="EmittedIL\StringFormatAndInterpolation.fs" />
     <Compile Include="EmittedIL\TailCalls.fs" />
     <Compile Include="EmittedIL\TupleElimination.fs" />
     <Compile Include="ErrorMessages\TypeEqualsMissingTests.fs" />

--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -4119,6 +4119,19 @@ module CheckEliminatedConstructs =
        """IfThenElse (Call (None, op_Equality, [ValueWithName ([||], ts), Value (<null>)]),
             Value (true), Value (false))"""
         
+module Interpolation =
+    let interpolatedNoHoleQuoted = <@ $"abc" @>
+    let actual1 = interpolatedNoHoleQuoted.ToString()
+    checkStrings "brewbreebrwhat1" actual1 """Value ("abc")"""
+
+    let interpolatedWithLiteralQuoted = <@ $"abc {1} def" @>
+    let actual2 = interpolatedWithLiteralQuoted.ToString()
+    checkStrings "brewbreebrwhat2" actual2
+        """Call (None, PrintFormatToString,
+                 [NewObject (PrintfFormat`5, Value ("abc %P() def"),
+                             NewArray (Object, Call (None, Box, [Value (1)])),
+                             Value (<null>))])"""
+
 module TestAssemblyAttributes = 
     let attributes = System.Reflection.Assembly.GetExecutingAssembly().GetCustomAttributes(false)
 


### PR DESCRIPTION
```fsharp
let stringOnly () = $"no hole" 
let printed () = printf $"printed no hole"
```

becomes

```csharp
public static string stringOnly()
{
    return "no hole";
}

public static void printed()
{
    PrintfFormat<Unit, TextWriter, Unit, Unit> format = new PrintfFormat<Unit, TextWriter, Unit, Unit, Unit>("printed no hole");
    PrintfModule.PrintFormatToTextWriter(Console.Out, format);
}
```

instead of

```csharp
public static string stringOnly()
{
    return PrintfModule.PrintFormatToStringThen(new PrintfFormat<string, Unit, string, string, Unit>("no hole", new object[0], null));
}

public static void printed()
{
    PrintfFormat<Unit, TextWriter, Unit, Unit> format = new PrintfFormat<Unit, TextWriter, Unit, Unit, Unit>("printed no hole", new object[0], null);
    PrintfModule.PrintFormatToTextWriter(Console.Out, format);
}
```