### PR TITLE
Fix for #11610 + bump SDK to 5.0.300

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ variables:
   - name: VisualStudioDropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
   - name: DotNetSdkVersion
-    value: '5.0.100'
+    value: '5.0.300'
   - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - name: RunningAsPullRequest
       value: true

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "5.0.300",
     "rollForward": "minor"
   },
   "tools": {
-    "dotnet": "5.0.100",
+    "dotnet": "5.0.300",
     "vs": {
       "version": "16.8",
       "components": [

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -4422,7 +4422,8 @@ and TcStaticConstantParameter cenv (env: TcEnv) tpenv kind (StripParenTypes v) i
             | SynConst.Single n when typeEquiv g g.float32_ty kind -> record(g.float32_ty); box (n: single)
             | SynConst.Double n when typeEquiv g g.float_ty kind -> record(g.float_ty); box (n: double)
             | SynConst.Char n when typeEquiv g g.char_ty kind -> record(g.char_ty); box (n: char)
-            | SynConst.String (s, _, _) when s <> null && typeEquiv g g.string_ty kind -> record(g.string_ty); box (s: string)
+            | SynConst.String (s, _, _)
+            | SynConst.SourceIdentifier (_, s, _) when s <> null && typeEquiv g g.string_ty kind -> record(g.string_ty); box (s: string)
             | SynConst.Bool b when typeEquiv g g.bool_ty kind -> record(g.bool_ty); box (b: bool)
             | _ -> fail()
         v, tpenv

--- a/tests/fsharp/typeProviders/helloWorld/test.fsx
+++ b/tests/fsharp/typeProviders/helloWorld/test.fsx
@@ -760,6 +760,9 @@ module String =
     check "vlkrrevpojvr1"
         FSharp.HelloWorld.HelloWorldTypeWithStaticStringParameter<"10000">.StaticProperty1
         "You got a static property"
+    check "vlkrrevpojvr1c"
+        FSharp.HelloWorld.HelloWorldTypeWithStaticStringParameter<__SOURCE_DIRECTORY__>.StaticProperty1
+        "You got a static property"
 
 module Bool = 
     check "vlkrrevpojvr1"


### PR DESCRIPTION
Bump SDK to 5.0.300 (+corresponding runtime), fixes #11610, adds test to check that `SynConst.SourceIdentifier` is recognized as valid static argument to a provided type.