### PR TITLE
[WIP] Use explicit disposables when working with RawByteMemory/RawMemoryFile

### DIFF
--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -416,7 +416,7 @@ type DefaultFileSystem() as this =
         if runningOnMono || (not useMemoryMappedFile) then
             fileStream :> Stream
         else
-            use mmf =
+            let mmf =
                 if shouldShadowCopy then
                     let mmf =
                         MemoryMappedFile.CreateNew(
@@ -425,7 +425,7 @@ type DefaultFileSystem() as this =
                             MemoryMappedFileAccess.Read,
                             MemoryMappedFileOptions.None,
                             HandleInheritability.None)
-                    use stream = mmf.CreateViewStream(0L, length, MemoryMappedFileAccess.Read)
+                    let stream = mmf.CreateViewStream(0L, length, MemoryMappedFileAccess.Read)
                     fileStream.CopyTo(stream)
                     fileStream.Dispose()
                     mmf
@@ -437,9 +437,12 @@ type DefaultFileSystem() as this =
                         MemoryMappedFileAccess.Read,
                         HandleInheritability.None,
                         leaveOpen=false)
+
             let stream = mmf.CreateViewStream(0L, length, MemoryMappedFileAccess.Read)
+
             if not stream.CanRead then
                 invalidOp "Cannot read file"
+
             stream :> Stream
 
     abstract OpenFileForWriteShim: filePath: string * ?fileMode: FileMode * ?fileAccess: FileAccess * ?fileShare: FileShare -> Stream

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -313,7 +313,7 @@ type internal ByteMemory with
 
     /// Creates a ByteMemory object that is backed by a raw pointer.
     /// Use with care.
-    static member FromUnsafePointer: addr: nativeint * length: int * holder: obj -> ByteMemory
+    static member FromUnsafePointer: addr: nativeint * length: int * holder: IDisposable -> ByteMemory
 
     /// Creates a ByteMemory object that is backed by a byte array with the specified offset and length.
     static member FromArray: bytes: byte[] * offset: int * length: int -> ByteMemory


### PR DESCRIPTION
Use SafeUnmanagedMemoryStream, and explicit disposables for MMF and Accessors, when using memory mapped files, raw byte memory and raw memory files.