### PR TITLE
`ByteBuffer` uses `ArrayPool` to prevent LOH allocations

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,6 +75,7 @@
       https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
     </RestoreSources>
     <!-- System.* packages -->
+    <SystemRuntimeCompilerServicesUnsafeVersion>4.7.1</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
     <SystemConsoleVersion>4.3.0</SystemConsoleVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,7 +75,6 @@
       https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
     </RestoreSources>
     <!-- System.* packages -->
-    <SystemRuntimeCompilerServicesUnsafeVersion>4.7.1</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
     <SystemConsoleVersion>4.3.0</SystemConsoleVersion>
@@ -104,6 +103,7 @@
     <SystemThreadingTasksDataflow>4.11.1</SystemThreadingTasksDataflow>
     <SystemThreadingThreadVersion>4.3.0</SystemThreadingThreadVersion>
     <SystemThreadingThreadPoolVersion>4.3.0</SystemThreadingThreadPoolVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>4.7.1</SystemRuntimeCompilerServicesUnsafeVersion>
     <!-- Roslyn packages -->
     <RoslynVersion>3.8.0-5.20570.14</RoslynVersion>
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>

--- a/src/fsharp/CompilerImports.fs
+++ b/src/fsharp/CompilerImports.fs
@@ -90,9 +90,11 @@ let PickleToResource inMem file (g: TcGlobals) scope rName p x =
     let bytes = pickleObjWithDanglingCcus inMem file g scope p x
     let byteStorage =
         if inMem then
-            ByteStorage.FromByteArrayAndCopy(bytes, useBackingMemoryMappedFile = true)
+            ByteStorage.FromMemoryAndCopy(bytes.AsMemory(), useBackingMemoryMappedFile = true)
         else
-            ByteStorage.FromByteArray(bytes)
+            ByteStorage.FromByteArray(bytes.AsMemory().ToArray())
+
+    (bytes :> IDisposable).Dispose()
 
     { Name = rName
       Location = ILResourceLocation.Local(byteStorage)

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -39,6 +39,7 @@
     <NuspecProperty Include="MicrosoftBuildTasksCorePackageVersion=$(MicrosoftBuildTasksCoreVersion)" />
     <NuspecProperty Include="MicrosoftBuildUtilitiesCorePackageVersion=$(MicrosoftBuildUtilitiesCoreVersion)" />
     <NuspecProperty Include="SystemBuffersPackageVersion=$(SystemBuffersVersion)" />
+    <NuspecProperty Include="SystemRuntimeCompilerServicesUnsafePackageVersion=$(SystemRuntimeCompilerServicesUnsafeVersion)" />
     <NuspecProperty Include="SystemCollectionsImmutablePackageVersion=$(SystemCollectionsImmutableVersion)" />
     <NuspecProperty Include="SystemDiagnosticsProcessPackageVersion=$(SystemDiagnosticsProcessVersion)" />
     <NuspecProperty Include="SystemDiagnosticsTraceSourcePackageVersion=$(SystemDiagnosticsTraceSourceVersion)" />
@@ -983,6 +984,7 @@
     <PackageReference Include="System.Threading.Thread" Version="$(SystemThreadingThreadVersion)" />
     <PackageReference Include="System.Threading.ThreadPool" Version="$(SystemThreadingThreadPoolVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -39,7 +39,6 @@
     <NuspecProperty Include="MicrosoftBuildTasksCorePackageVersion=$(MicrosoftBuildTasksCoreVersion)" />
     <NuspecProperty Include="MicrosoftBuildUtilitiesCorePackageVersion=$(MicrosoftBuildUtilitiesCoreVersion)" />
     <NuspecProperty Include="SystemBuffersPackageVersion=$(SystemBuffersVersion)" />
-    <NuspecProperty Include="SystemRuntimeCompilerServicesUnsafePackageVersion=$(SystemRuntimeCompilerServicesUnsafeVersion)" />
     <NuspecProperty Include="SystemCollectionsImmutablePackageVersion=$(SystemCollectionsImmutableVersion)" />
     <NuspecProperty Include="SystemDiagnosticsProcessPackageVersion=$(SystemDiagnosticsProcessVersion)" />
     <NuspecProperty Include="SystemDiagnosticsTraceSourcePackageVersion=$(SystemDiagnosticsTraceSourceVersion)" />
@@ -60,6 +59,7 @@
     <NuspecProperty Include="SystemThreadingTasksParallelPackageVersion=$(SystemThreadingTasksParallelVersion)" />
     <NuspecProperty Include="SystemThreadingThreadPackageVersion=$(SystemThreadingThreadVersion)" />
     <NuspecProperty Include="SystemThreadingThreadPoolPackageVersion=$(SystemThreadingThreadPoolVersion)" />
+    <NuspecProperty Include="SystemRuntimeCompilerServicesUnsafePackageVersion=$(SystemRuntimeCompilerServicesUnsafeVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -984,11 +984,11 @@
     <PackageReference Include="System.Threading.Thread" Version="$(SystemThreadingThreadVersion)" />
     <PackageReference Include="System.Threading.ThreadPool" Version="$(SystemThreadingThreadPoolVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.nuspec
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.nuspec
@@ -10,6 +10,7 @@
             <dependency id="Microsoft.Build.Tasks.Core" version="$MicrosoftBuildTasksCorePackageVersion$" exclude="Build,Analyzers" />
             <dependency id="Microsoft.Build.Utilities.Core" version="$MicrosoftBuildUtilitiesCorePackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Buffers" version="$SystemBuffersPackageVersion$" exclude="Build,Analyzers" />
+            <dependency id="System.Runtime.CompilerServices.Unsafe" version="$SystemRuntimeCompilerServicesUnsafePackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Collections.Immutable" version="$SystemCollectionsImmutablePackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Diagnostics.Process" version="$SystemDiagnosticsProcessPackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Diagnostics.TraceSource" version="$SystemDiagnosticsTraceSourcePackageVersion$" exclude="Build,Analyzers" />

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.nuspec
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.nuspec
@@ -10,7 +10,6 @@
             <dependency id="Microsoft.Build.Tasks.Core" version="$MicrosoftBuildTasksCorePackageVersion$" exclude="Build,Analyzers" />
             <dependency id="Microsoft.Build.Utilities.Core" version="$MicrosoftBuildUtilitiesCorePackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Buffers" version="$SystemBuffersPackageVersion$" exclude="Build,Analyzers" />
-            <dependency id="System.Runtime.CompilerServices.Unsafe" version="$SystemRuntimeCompilerServicesUnsafePackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Collections.Immutable" version="$SystemCollectionsImmutablePackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Diagnostics.Process" version="$SystemDiagnosticsProcessPackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Diagnostics.TraceSource" version="$SystemDiagnosticsTraceSourcePackageVersion$" exclude="Build,Analyzers" />
@@ -31,6 +30,7 @@
             <dependency id="System.Threading.Tasks.Parallel" version="$SystemThreadingTasksParallelPackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Threading.Thread" version="$SystemThreadingThreadPackageVersion$" exclude="Build,Analyzers" />
             <dependency id="System.Threading.ThreadPool" version="$SystemThreadingThreadPoolPackageVersion$" exclude="Build,Analyzers" />
+            <dependency id="System.Runtime.CompilerServices.Unsafe" version="$SystemRuntimeCompilerServicesUnsafePackageVersion$" exclude="Build,Analyzers" />
           </group>
         </dependencies>
     </metadata>

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2029,7 +2029,7 @@ let GenConstArray cenv (cgbuf: CodeGenBuffer) eenv ilElementType (data:'a[]) (wr
     let g = cenv.g
     use buf = ByteBuffer.Create data.Length
     data |> Array.iter (write buf)
-    let bytes = buf.GetMemory().ToArray()
+    let bytes = buf.AsMemory().ToArray()
     let ilArrayType = mkILArr1DTy ilElementType
     if data.Length = 0 then
         CG.EmitInstrs cgbuf (pop 0) (Push [ilArrayType]) [ mkLdcInt32 0; I_newarr (ILArrayShape.SingleDimensional, ilElementType); ]

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2027,9 +2027,9 @@ let GenString cenv cgbuf s =
 
 let GenConstArray cenv (cgbuf: CodeGenBuffer) eenv ilElementType (data:'a[]) (write: ByteBuffer -> 'a -> unit) =
     let g = cenv.g
-    let buf = ByteBuffer.Create data.Length
+    use buf = ByteBuffer.Create data.Length
     data |> Array.iter (write buf)
-    let bytes = buf.Close()
+    let bytes = buf.GetMemory().ToArray()
     let ilArrayType = mkILArr1DTy ilElementType
     if data.Length = 0 then
         CG.EmitInstrs cgbuf (pop 0) (Push [ilArrayType]) [ mkLdcInt32 0; I_newarr (ILArrayShape.SingleDimensional, ilElementType); ]

--- a/src/fsharp/QuotationPickler.fs
+++ b/src/fsharp/QuotationPickler.fs
@@ -374,7 +374,7 @@ module SimplePickle =
               ostrings=Table<_>.Create() }
         let stringTab, phase1bytes =
             p x st1
-            st1.ostrings.AsList, st1.os.GetMemory()
+            st1.ostrings.AsList, st1.os.AsMemory()
 
         let phase2data = (stringTab, phase1bytes)
 
@@ -383,7 +383,7 @@ module SimplePickle =
              ostrings=Table<_>.Create() }
         let phase2bytes =
             p_tup2 (p_list prim_pstring) p_memory phase2data st2
-            st2.os.GetMemory()
+            st2.os.AsMemory()
 
         let finalBytes = phase2bytes.ToArray()
         (st1.os :> IDisposable).Dispose()

--- a/src/fsharp/QuotationPickler.fs
+++ b/src/fsharp/QuotationPickler.fs
@@ -383,9 +383,9 @@ module SimplePickle =
              ostrings=Table<_>.Create() }
         let phase2bytes =
             p_tup2 (p_list prim_pstring) p_memory phase2data st2
-            st2.os
+            st2.os.GetMemory()
 
-        let finalBytes = phase2bytes.GetMemory().ToArray()
+        let finalBytes = phase2bytes.ToArray()
         (st1.os :> IDisposable).Dispose()
         (st2.os :> IDisposable).Dispose()
         finalBytes

--- a/src/fsharp/QuotationPickler.fs
+++ b/src/fsharp/QuotationPickler.fs
@@ -246,6 +246,10 @@ let SerializedReflectedDefinitionsResourceNameBase = "ReflectedDefinitions"
 
 let freshVar (n, ty, mut) = { vText=n; vType=ty; vMutable=mut }
 
+/// Arbitrary value
+[<Literal>]
+let PickleBufferCapacity = 100000
+
 module SimplePickle =
 
     type Table<'T> =

--- a/src/fsharp/QuotationPickler.fs
+++ b/src/fsharp/QuotationPickler.fs
@@ -374,7 +374,7 @@ module SimplePickle =
 
     let pickle_obj p x =
         let st1 =
-            { os = ByteBuffer.Create(100000, useArrayPool = true)
+            { os = ByteBuffer.Create(PickleBufferCapacity, useArrayPool = true)
               ostrings=Table<_>.Create() }
         let stringTab, phase1bytes =
             p x st1
@@ -383,7 +383,7 @@ module SimplePickle =
         let phase2data = (stringTab, phase1bytes)
 
         let st2 =
-           { os = ByteBuffer.Create(100000, useArrayPool = true)
+           { os = ByteBuffer.Create(PickleBufferCapacity, useArrayPool = true)
              ostrings=Table<_>.Create() }
         let phase2bytes =
             p_tup2 (p_list prim_pstring) p_memory phase2data st2

--- a/src/fsharp/QuotationPickler.fs
+++ b/src/fsharp/QuotationPickler.fs
@@ -2,6 +2,7 @@
 
 module internal FSharp.Compiler.QuotationPickler
 
+open System
 open System.Text
 open FSharp.Compiler.IO
 open Internal.Utilities
@@ -311,6 +312,11 @@ module SimplePickle =
         p_int32 (len) st
         st.os.EmitBytes s
 
+    let p_memory (s:ReadOnlyMemory<byte>) st =
+        let len = s.Length
+        p_int32 (len) st
+        st.os.EmitMemory s
+
     let prim_pstring (s:string) st =
         let bytes = Encoding.UTF8.GetBytes s
         let len = bytes.Length
@@ -363,20 +369,26 @@ module SimplePickle =
         | h :: t -> p_byte 1 st; f h st; p_list f t st
 
     let pickle_obj p x =
+        let st1 =
+            { os = ByteBuffer.Create(100000, useArrayPool = true)
+              ostrings=Table<_>.Create() }
         let stringTab, phase1bytes =
-            let st1 =
-                { os = ByteBuffer.Create 100000
-                  ostrings=Table<_>.Create() }
             p x st1
-            st1.ostrings.AsList, st1.os.Close()
+            st1.ostrings.AsList, st1.os.GetMemory()
+
         let phase2data = (stringTab, phase1bytes)
+
+        let st2 =
+           { os = ByteBuffer.Create(100000, useArrayPool = true)
+             ostrings=Table<_>.Create() }
         let phase2bytes =
-            let st2 =
-               { os = ByteBuffer.Create 100000
-                 ostrings=Table<_>.Create() }
-            p_tup2 (p_list prim_pstring) p_bytes phase2data st2
-            st2.os.Close()
-        phase2bytes
+            p_tup2 (p_list prim_pstring) p_memory phase2data st2
+            st2.os
+
+        let finalBytes = phase2bytes.GetMemory().ToArray()
+        (st1.os :> IDisposable).Dispose()
+        (st2.os :> IDisposable).Dispose()
+        finalBytes
 
 open SimplePickle
 

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -26,6 +26,7 @@ open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Xml
+open FSharp.Compiler.IO
 
 #if !NO_EXTENSIONTYPING
 open FSharp.Compiler.ExtensionTyping
@@ -4637,7 +4638,7 @@ type TOp =
     | Array
 
     /// Constant byte arrays (used for parser tables and other embedded data)
-    | Bytes of byte[] 
+    | Bytes of byte[]
 
     /// Constant uint16 arrays (used for parser tables)
     | UInt16s of uint16[] 

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -26,7 +26,6 @@ open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Xml
-open FSharp.Compiler.IO
 
 #if !NO_EXTENSIONTYPING
 open FSharp.Compiler.ExtensionTyping

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -213,6 +213,11 @@ let p_bytes (s: byte[]) st =
     p_int32 len st
     st.os.EmitBytes s
 
+let p_memory (s: System.ReadOnlyMemory<byte>) st =
+    let len = s.Length
+    p_int32 len st
+    st.os.EmitMemory s
+
 let p_prim_string (s: string) st =
     let bytes = Encoding.UTF8.GetBytes s
     let len = bytes.Length
@@ -776,9 +781,8 @@ let p_encoded_anoninfo x st = p_int x st
 let p_simpletyp x st = p_int (encode_simpletyp st.occus st.ostrings st.onlerefs st.osimpletys st.oscope x) st
 
 let pickleObjWithDanglingCcus inMem file g scope p x =
-  let ccuNameTab, (ntycons, ntypars, nvals, nanoninfos), stringTab, pubpathTab, nlerefTab, simpleTyTab, phase1bytes =
-    let st1 =
-      { os = ByteBuffer.Create 100000
+  let st1 =
+      { os = ByteBuffer.Create(100000, useArrayPool = true)
         oscope=scope
         occus= Table<_>.Create "occus"
         oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), (fun osgn -> osgn), "otycons")
@@ -793,31 +797,32 @@ let pickleObjWithDanglingCcus inMem file g scope p x =
         ofile=file
         oInMem=inMem
         isStructThisArgPos = false}
+  let ccuNameTab, (ntycons, ntypars, nvals, nanoninfos), stringTab, pubpathTab, nlerefTab, simpleTyTab, phase1bytes =
     p x st1
     let sizes =
       st1.oentities.Size,
       st1.otypars.Size,
       st1.ovals.Size,
       st1.oanoninfos.Size
-    st1.occus, sizes, st1.ostrings, st1.opubpaths, st1.onlerefs, st1.osimpletys, st1.os.Close()
+    st1.occus, sizes, st1.ostrings, st1.opubpaths, st1.onlerefs, st1.osimpletys, st1.os.GetMemory()
 
+  let st2 =
+   { os = ByteBuffer.Create(100000, useArrayPool = true)
+     oscope=scope
+     occus= Table<_>.Create "occus (fake)"
+     oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), (fun osgn -> osgn), "otycons")
+     otypars=NodeOutTable<_, _>.Create((fun (tp: Typar) -> tp.Stamp), (fun tp -> tp.DisplayName), (fun tp -> tp.Range), (fun osgn -> osgn), "otypars")
+     ovals=NodeOutTable<_, _>.Create((fun (v: Val) -> v.Stamp), (fun v -> v.LogicalName), (fun v -> v.Range), (fun osgn -> osgn), "ovals")
+     oanoninfos=NodeOutTable<_, _>.Create((fun (v: AnonRecdTypeInfo) -> v.Stamp), (fun v -> string v.Stamp), (fun _ -> range0), id, "oanoninfos")
+     ostrings=Table<_>.Create "ostrings (fake)"
+     opubpaths=Table<_>.Create "opubpaths (fake)"
+     onlerefs=Table<_>.Create "onlerefs (fake)"
+     osimpletys=Table<_>.Create "osimpletys (fake)"
+     oglobals=g
+     ofile=file
+     oInMem=inMem
+     isStructThisArgPos = false }
   let phase2bytes =
-    let st2 =
-     { os = ByteBuffer.Create 100000
-       oscope=scope
-       occus= Table<_>.Create "occus (fake)"
-       oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), (fun osgn -> osgn), "otycons")
-       otypars=NodeOutTable<_, _>.Create((fun (tp: Typar) -> tp.Stamp), (fun tp -> tp.DisplayName), (fun tp -> tp.Range), (fun osgn -> osgn), "otypars")
-       ovals=NodeOutTable<_, _>.Create((fun (v: Val) -> v.Stamp), (fun v -> v.LogicalName), (fun v -> v.Range), (fun osgn -> osgn), "ovals")
-       oanoninfos=NodeOutTable<_, _>.Create((fun (v: AnonRecdTypeInfo) -> v.Stamp), (fun v -> string v.Stamp), (fun _ -> range0), id, "oanoninfos")
-       ostrings=Table<_>.Create "ostrings (fake)"
-       opubpaths=Table<_>.Create "opubpaths (fake)"
-       onlerefs=Table<_>.Create "onlerefs (fake)"
-       osimpletys=Table<_>.Create "osimpletys (fake)"
-       oglobals=g
-       ofile=file
-       oInMem=inMem
-       isStructThisArgPos = false }
     p_array p_encoded_ccuref ccuNameTab.AsArray st2
     // Add a 4th integer indicated by a negative 1st integer
     let z1 = if nanoninfos > 0 then  -ntycons-1 else ntycons
@@ -830,11 +835,15 @@ let pickleObjWithDanglingCcus inMem file g scope p x =
         (p_array p_encoded_pubpath)
         (p_array p_encoded_nleref)
         (p_array p_encoded_simpletyp)
-        p_bytes
+        p_memory
         (stringTab.AsArray, pubpathTab.AsArray, nlerefTab.AsArray, simpleTyTab.AsArray, phase1bytes)
         st2
-    st2.os.Close()
-  phase2bytes
+    st2.os.GetMemory()
+
+  let finalBytes = phase2bytes.ToArray()
+  (st1.os :> System.IDisposable).Dispose()
+  (st2.os :> System.IDisposable).Dispose()
+  finalBytes
 
 let check (ilscope: ILScopeRef) (inMap : NodeInTable<_, _>) =
     for i = 0 to inMap.Count - 1 do

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -780,9 +780,13 @@ let p_encoded_simpletyp x st = p_int x st
 let p_encoded_anoninfo x st = p_int x st
 let p_simpletyp x st = p_int (encode_simpletyp st.occus st.ostrings st.onlerefs st.osimpletys st.oscope x) st
 
+/// Arbitrary value
+[<Literal>]
+let PickleBufferCapacity = 100000
+
 let pickleObjWithDanglingCcus inMem file g scope p x =
   let st1 =
-      { os = ByteBuffer.Create(100000, useArrayPool = true)
+      { os = ByteBuffer.Create(PickleBufferCapacity, useArrayPool = true)
         oscope=scope
         occus= Table<_>.Create "occus"
         oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), (fun osgn -> osgn), "otycons")
@@ -807,7 +811,7 @@ let pickleObjWithDanglingCcus inMem file g scope p x =
     st1.occus, sizes, st1.ostrings, st1.opubpaths, st1.onlerefs, st1.osimpletys, st1.os.AsMemory()
 
   let st2 =
-   { os = ByteBuffer.Create(100000, useArrayPool = true)
+   { os = ByteBuffer.Create(PickleBufferCapacity, useArrayPool = true)
      oscope=scope
      occus= Table<_>.Create "occus (fake)"
      oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), (fun osgn -> osgn), "otycons")

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -838,11 +838,10 @@ let pickleObjWithDanglingCcus inMem file g scope p x =
         p_memory
         (stringTab.AsArray, pubpathTab.AsArray, nlerefTab.AsArray, simpleTyTab.AsArray, phase1bytes)
         st2
-    st2.os.AsMemory()
+    st2.os
 
-  let finalBytes = phase2bytes.ToArray()
+  let finalBytes = phase2bytes
   (st1.os :> System.IDisposable).Dispose()
-  (st2.os :> System.IDisposable).Dispose()
   finalBytes
 
 let check (ilscope: ILScopeRef) (inMap : NodeInTable<_, _>) =

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -804,7 +804,7 @@ let pickleObjWithDanglingCcus inMem file g scope p x =
       st1.otypars.Size,
       st1.ovals.Size,
       st1.oanoninfos.Size
-    st1.occus, sizes, st1.ostrings, st1.opubpaths, st1.onlerefs, st1.osimpletys, st1.os.GetMemory()
+    st1.occus, sizes, st1.ostrings, st1.opubpaths, st1.onlerefs, st1.osimpletys, st1.os.AsMemory()
 
   let st2 =
    { os = ByteBuffer.Create(100000, useArrayPool = true)
@@ -838,7 +838,7 @@ let pickleObjWithDanglingCcus inMem file g scope p x =
         p_memory
         (stringTab.AsArray, pubpathTab.AsArray, nlerefTab.AsArray, simpleTyTab.AsArray, phase1bytes)
         st2
-    st2.os.GetMemory()
+    st2.os.AsMemory()
 
   let finalBytes = phase2bytes.ToArray()
   (st1.os :> System.IDisposable).Dispose()

--- a/src/fsharp/TypedTreePickle.fsi
+++ b/src/fsharp/TypedTreePickle.fsi
@@ -84,7 +84,7 @@ val internal p_ty : pickler<TType>
 val internal pickleCcuInfo : pickler<PickledCcuInfo>
 
 /// Serialize an arbitrary object using the given pickler
-val pickleObjWithDanglingCcus : inMem: bool -> file: string -> TcGlobals -> scope:CcuThunk -> pickler<'T> -> 'T -> byte[]
+val pickleObjWithDanglingCcus : inMem: bool -> file: string -> TcGlobals -> scope:CcuThunk -> pickler<'T> -> 'T -> ByteBuffer
 
 /// The type of state unpicklers read from
 type ReaderState

--- a/src/fsharp/absil/ilsupp.fs
+++ b/src/fsharp/absil/ilsupp.fs
@@ -91,7 +91,7 @@ type IMAGE_FILE_HEADER (m: int16, secs: int16, tds: int32, ptst: int32, nos: int
             with get() = 20
 
         member x.toBytes () =
-            let buf = ByteBuffer.Create IMAGE_FILE_HEADER.Width
+            use buf = ByteBuffer.Create IMAGE_FILE_HEADER.Width
             buf.EmitUInt16 (uint16 machine)
             buf.EmitUInt16 (uint16 numberOfSections)
             buf.EmitInt32 timeDateStamp
@@ -99,7 +99,7 @@ type IMAGE_FILE_HEADER (m: int16, secs: int16, tds: int32, ptst: int32, nos: int
             buf.EmitInt32 numberOfSymbols
             buf.EmitUInt16 (uint16 sizeOfOptionalHeader)
             buf.EmitUInt16 (uint16 characteristics)
-            buf.Close()
+            buf.GetMemory().ToArray()
 
 let bytesToIFH (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_FILE_HEADER.Width then
@@ -172,7 +172,7 @@ type IMAGE_SECTION_HEADER(n: int64, ai: int32, va: int32, srd: int32, prd: int32
             with get() = 40
 
         member x.toBytes () =
-            let buf = ByteBuffer.Create IMAGE_SECTION_HEADER.Width
+            use buf = ByteBuffer.Create IMAGE_SECTION_HEADER.Width
             buf.EmitInt64 name
             buf.EmitInt32 addressInfo
             buf.EmitInt32 virtualAddress
@@ -183,7 +183,7 @@ type IMAGE_SECTION_HEADER(n: int64, ai: int32, va: int32, srd: int32, prd: int32
             buf.EmitUInt16 (uint16 numberOfRelocations)
             buf.EmitUInt16 (uint16 numberOfLineNumbers)
             buf.EmitInt32 characteristics
-            buf.Close()
+            buf.GetMemory().ToArray()
 
 
 let bytesToISH (buffer: byte[]) (offset: int) =
@@ -236,14 +236,14 @@ type IMAGE_SYMBOL(n: int64, v: int32, sn: int16, t: int16, sc: byte, nas: byte) 
             with get() = 18
 
         member x.toBytes() =
-            let buf = ByteBuffer.Create IMAGE_SYMBOL.Width
+            use buf = ByteBuffer.Create IMAGE_SYMBOL.Width
             buf.EmitInt64 name
             buf.EmitInt32 value
             buf.EmitUInt16 (uint16 sectionNumber)
             buf.EmitUInt16 (uint16 stype)
             buf.EmitByte storageClass
             buf.EmitByte numberOfAuxSymbols
-            buf.Close()
+            buf.GetMemory().ToArray()
 
 let bytesToIS (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_SYMBOL.Width then
@@ -280,11 +280,11 @@ type IMAGE_RELOCATION(va: int32, sti: int32, t: int16) =
         with get() = 10
 
     member x.toBytes() =
-        let buf = ByteBuffer.Create IMAGE_RELOCATION.Width
+        use buf = ByteBuffer.Create IMAGE_RELOCATION.Width
         buf.EmitInt32 virtualAddress
         buf.EmitInt32 symbolTableIndex
         buf.EmitUInt16 (uint16 ty)
-        buf.Close()
+        buf.GetMemory().ToArray()
 
 let bytesToIR (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_RELOCATION.Width then
@@ -328,14 +328,14 @@ type IMAGE_RESOURCE_DIRECTORY(c: int32, tds: int32, mjv: int16, mnv: int16, nne:
     static member Width = 16
 
     member x.toBytes () =
-        let buf = ByteBuffer.Create IMAGE_RESOURCE_DIRECTORY.Width
+        use buf = ByteBuffer.Create IMAGE_RESOURCE_DIRECTORY.Width
         buf.EmitInt32 characteristics
         buf.EmitInt32 timeDateStamp
         buf.EmitUInt16 (uint16 majorVersion)
         buf.EmitUInt16 (uint16 minorVersion)
         buf.EmitUInt16 (uint16 numberOfNamedEntries)
         buf.EmitUInt16 (uint16 numberOfIdEntries)
-        buf.Close()
+        buf.GetMemory().ToArray()
 
 let bytesToIRD (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_RESOURCE_DIRECTORY.Width then
@@ -368,10 +368,10 @@ type IMAGE_RESOURCE_DIRECTORY_ENTRY(n: int32, o: int32) =
     static member Width = 8
 
     member x.toBytes () =
-        let buf = ByteBuffer.Create IMAGE_RESOURCE_DIRECTORY_ENTRY.Width
+        use buf = ByteBuffer.Create IMAGE_RESOURCE_DIRECTORY_ENTRY.Width
         buf.EmitInt32 name
         buf.EmitInt32 offset
-        buf.Close()
+        buf.GetMemory().ToArray()
 
 let bytesToIRDE (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_RESOURCE_DIRECTORY_ENTRY.Width then
@@ -466,7 +466,7 @@ type ResFormatHeader() =
     static member Width = 32
 
     member x.toBytes() =
-        let buf = ByteBuffer.Create ResFormatHeader.Width
+        use buf = ByteBuffer.Create ResFormatHeader.Width
         buf.EmitInt32 dwDataSize
         buf.EmitInt32 dwHeaderSize
         buf.EmitInt32 dwTypeID
@@ -476,7 +476,7 @@ type ResFormatHeader() =
         buf.EmitUInt16 (uint16 wLangID)
         buf.EmitInt32 dwVersion
         buf.EmitInt32 dwCharacteristics
-        buf.Close()
+        buf.GetMemory().ToArray()
 
 type ResFormatNode(tid: int32, nid: int32, lid: int32, dataOffset: int32, pbLinkedResource: byte[]) =
     let mutable resHdr = ResFormatHeader()

--- a/src/fsharp/absil/ilsupp.fs
+++ b/src/fsharp/absil/ilsupp.fs
@@ -99,7 +99,7 @@ type IMAGE_FILE_HEADER (m: int16, secs: int16, tds: int32, ptst: int32, nos: int
             buf.EmitInt32 numberOfSymbols
             buf.EmitUInt16 (uint16 sizeOfOptionalHeader)
             buf.EmitUInt16 (uint16 characteristics)
-            buf.GetMemory().ToArray()
+            buf.AsMemory().ToArray()
 
 let bytesToIFH (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_FILE_HEADER.Width then
@@ -183,7 +183,7 @@ type IMAGE_SECTION_HEADER(n: int64, ai: int32, va: int32, srd: int32, prd: int32
             buf.EmitUInt16 (uint16 numberOfRelocations)
             buf.EmitUInt16 (uint16 numberOfLineNumbers)
             buf.EmitInt32 characteristics
-            buf.GetMemory().ToArray()
+            buf.AsMemory().ToArray()
 
 
 let bytesToISH (buffer: byte[]) (offset: int) =
@@ -243,7 +243,7 @@ type IMAGE_SYMBOL(n: int64, v: int32, sn: int16, t: int16, sc: byte, nas: byte) 
             buf.EmitUInt16 (uint16 stype)
             buf.EmitByte storageClass
             buf.EmitByte numberOfAuxSymbols
-            buf.GetMemory().ToArray()
+            buf.AsMemory().ToArray()
 
 let bytesToIS (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_SYMBOL.Width then
@@ -284,7 +284,7 @@ type IMAGE_RELOCATION(va: int32, sti: int32, t: int16) =
         buf.EmitInt32 virtualAddress
         buf.EmitInt32 symbolTableIndex
         buf.EmitUInt16 (uint16 ty)
-        buf.GetMemory().ToArray()
+        buf.AsMemory().ToArray()
 
 let bytesToIR (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_RELOCATION.Width then
@@ -335,7 +335,7 @@ type IMAGE_RESOURCE_DIRECTORY(c: int32, tds: int32, mjv: int16, mnv: int16, nne:
         buf.EmitUInt16 (uint16 minorVersion)
         buf.EmitUInt16 (uint16 numberOfNamedEntries)
         buf.EmitUInt16 (uint16 numberOfIdEntries)
-        buf.GetMemory().ToArray()
+        buf.AsMemory().ToArray()
 
 let bytesToIRD (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_RESOURCE_DIRECTORY.Width then
@@ -371,7 +371,7 @@ type IMAGE_RESOURCE_DIRECTORY_ENTRY(n: int32, o: int32) =
         use buf = ByteBuffer.Create IMAGE_RESOURCE_DIRECTORY_ENTRY.Width
         buf.EmitInt32 name
         buf.EmitInt32 offset
-        buf.GetMemory().ToArray()
+        buf.AsMemory().ToArray()
 
 let bytesToIRDE (buffer: byte[]) (offset: int) =
     if (buffer.Length - offset) < IMAGE_RESOURCE_DIRECTORY_ENTRY.Width then
@@ -476,7 +476,7 @@ type ResFormatHeader() =
         buf.EmitUInt16 (uint16 wLangID)
         buf.EmitInt32 dwVersion
         buf.EmitInt32 dwCharacteristics
-        buf.GetMemory().ToArray()
+        buf.AsMemory().ToArray()
 
 type ResFormatNode(tid: int32, nid: int32, lid: int32, dataOffset: int32, pbLinkedResource: byte[]) =
     let mutable resHdr = ResFormatHeader()

--- a/src/fsharp/absil/ilsupp.fs
+++ b/src/fsharp/absil/ilsupp.fs
@@ -401,7 +401,7 @@ type IMAGE_RESOURCE_DATA_ENTRY(o: int32, s: int32, c: int32, r: int32) =
     static member Width = 16
 
     member x.toBytes() =
-        let buf = ByteBuffer.Create IMAGE_RESOURCE_DATA_ENTRY.Width
+        use buf = ByteBuffer.Create IMAGE_RESOURCE_DATA_ENTRY.Width
         buf.EmitInt32 offsetToData
         buf.EmitInt32 size
         buf.EmitInt32 codePage

--- a/src/fsharp/absil/ilwrite.fs
+++ b/src/fsharp/absil/ilwrite.fs
@@ -2,6 +2,7 @@
 
 module internal FSharp.Compiler.AbstractIL.ILBinaryWriter
 
+open System
 open System.Collections.Generic
 open System.IO
 
@@ -543,9 +544,15 @@ type cenv =
         cenv.codeChunks.EmitBytes code
         cenv.nextCodeAddr <- cenv.nextCodeAddr + code.Length
 
-    member cenv.GetCode() = cenv.codeChunks.Close()
+    member cenv.GetCode() = cenv.codeChunks.GetMemory().ToArray()
 
     override x.ToString() = "<cenv>"
+
+    interface IDisposable with
+        member this.Dispose() =
+            (this.codeChunks :> IDisposable).Dispose()
+            (this.data :> IDisposable).Dispose()
+            (this.resources :> IDisposable).Dispose()
 
 let FindOrAddSharedRow (cenv: cenv) tbl x = cenv.GetTable(tbl).FindOrAddSharedEntry x
 
@@ -1465,6 +1472,10 @@ type CodeBuffer =
       mutable seh: ExceptionClauseSpec list
       seqpoints: ResizeArray<PdbSequencePoint> }
 
+    interface IDisposable with
+        member this.Dispose() =
+            (this.code :> IDisposable).Dispose()
+
     static member Create _nm =
         { seh = []
           code= ByteBuffer.Create 200
@@ -1534,7 +1545,7 @@ module Codebuf =
     let applyBrFixups (origCode : byte[]) origExnClauses origReqdStringFixups (origAvailBrFixups: Dictionary<ILCodeLabel, int>) origReqdBrFixups origSeqPoints origScopes =
       let orderedOrigReqdBrFixups = origReqdBrFixups |> List.sortBy (fun (_, fixupLoc, _) -> fixupLoc)
 
-      let newCode = ByteBuffer.Create origCode.Length
+      use newCode = ByteBuffer.Create origCode.Length
 
       // Copy over all the code, working out whether the branches will be short
       // or long and adjusting the branch destinations. Record an adjust function to adjust all the other
@@ -1639,7 +1650,7 @@ module Codebuf =
               let (origStartOfNoBranchBlock, _, newStartOfNoBranchBlock) = arr.[i]
               addr - (origStartOfNoBranchBlock - newStartOfNoBranchBlock)
 
-          newCode.Close(),
+          newCode.GetMemory().ToArray(),
           !newReqdBrFixups,
           adjuster
 
@@ -2138,9 +2149,9 @@ module Codebuf =
         localsTree
 
     let EmitTopCode cenv localSigs env nm code =
-        let codebuf = CodeBuffer.Create nm
+        use codebuf = CodeBuffer.Create nm
         let origScopes = emitCode cenv localSigs codebuf env code
-        let origCode = codebuf.code.Close()
+        let origCode = codebuf.code.GetMemory().ToArray()
         let origExnClauses = List.rev codebuf.seh
         let origReqdStringFixups = codebuf.reqdStringFixupsInMethod
         let origAvailBrFixups = codebuf.availBrFixups
@@ -2179,7 +2190,7 @@ let GenILMethodBody mname cenv env (il: ILMethodBody) =
 
     let requiredStringFixups, seh, code, seqpoints, scopes = Codebuf.EmitTopCode cenv localSigs env mname il.Code
     let codeSize = code.Length
-    let methbuf = ByteBuffer.Create (codeSize * 3)
+    use methbuf = ByteBuffer.Create (codeSize * 3)
     // Do we use the tiny format?
     if isNil il.Locals && il.MaxStack <= 8 && isNil seh && codeSize < 64 then
         // Use Tiny format
@@ -2189,7 +2200,7 @@ let GenILMethodBody mname cenv env (il: ILMethodBody) =
         methbuf.EmitByte (byte codeSize <<< 2 ||| e_CorILMethod_TinyFormat)
         methbuf.EmitBytes code
         methbuf.EmitPadding codePadding
-        0x0, (requiredStringFixups', methbuf.Close()), seqpoints, scopes
+        0x0, (requiredStringFixups', methbuf.GetMemory().ToArray()), seqpoints, scopes
     else
         // Use Fat format
         let flags =
@@ -2263,7 +2274,7 @@ let GenILMethodBody mname cenv env (il: ILMethodBody) =
 
         let requiredStringFixups' = (12, requiredStringFixups)
 
-        localToken, (requiredStringFixups', methbuf.Close()), seqpoints, scopes
+        localToken, (requiredStringFixups', methbuf.GetMemory().ToArray()), seqpoints, scopes
 
 // --------------------------------------------------------------------
 // ILFieldDef --> FieldDef Row
@@ -2862,7 +2873,7 @@ let GenModule (cenv : cenv) (modul: ILModuleDef) =
 let generateIL requiredDataFixups (desiredMetadataVersion, generatePdb, ilg : ILGlobals, emitTailcalls, deterministic, showTimes) (m : ILModuleDef) cilStartAddress normalizeAssemblyRefs =
     let isDll = m.IsDLL
 
-    let cenv =
+    use cenv =
         { emitTailcalls=emitTailcalls
           deterministic = deterministic
           showTimes=showTimes
@@ -2870,7 +2881,7 @@ let generateIL requiredDataFixups (desiredMetadataVersion, generatePdb, ilg : IL
           desiredMetadataVersion=desiredMetadataVersion
           requiredDataFixups= requiredDataFixups
           requiredStringFixups = []
-          codeChunks=ByteBuffer.Create 40000
+          codeChunks=ByteBuffer.Create(40000, useArrayPool = true)
           nextCodeAddr = cilStartAddress
           data = ByteBuffer.Create 200
           resources = ByteBuffer.Create 200
@@ -2959,8 +2970,8 @@ let generateIL requiredDataFixups (desiredMetadataVersion, generatePdb, ilg : IL
         getUncodedToken TableNames.Event (cenv.eventDefs.GetTableEntry (EventKey (tidx, ed.Name)))) }
     reportTime cenv.showTimes "Finalize Module Generation Results"
     // New return the results
-    let data = cenv.data.Close()
-    let resources = cenv.resources.Close()
+    let data = cenv.data.GetMemory().ToArray()
+    let resources = cenv.resources.GetMemory().ToArray()
     (strings, userStrings, blobs, guids, tables, entryPointToken, code, cenv.requiredStringFixups, data, resources, pdbData, mappings)
 
 
@@ -3230,7 +3241,7 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
             codedBigness 2 TableNames.AssemblyRef ||
             codedBigness 2 TableNames.TypeRef
 
-        let tablesBuf = ByteBuffer.Create 20000
+        use tablesBuf = ByteBuffer.Create 20000
 
         // Now the coded tables themselves - first the schemata header
         tablesBuf.EmitIntsAsBytes
@@ -3287,7 +3298,7 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
                     | _ when t <= RowElementTags.ResolutionScopeMax -> tablesBuf.EmitZTaggedIndex (t - RowElementTags.ResolutionScopeMin) 2 rsBigness n
                     | _ -> failwith "invalid tag in row element"
 
-        tablesBuf.Close()
+        tablesBuf.GetMemory().ToArray()
 
     reportTime showTimes "Write Tables to tablebuf"
 
@@ -3309,7 +3320,7 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
     reportTime showTimes "Layout Metadata"
 
     let metadata, guidStart =
-      let mdbuf = ByteBuffer.Create 500000
+      use mdbuf = ByteBuffer.Create 500000
       mdbuf.EmitIntsAsBytes
         [| 0x42; 0x53; 0x4a; 0x42 // Magic signature
            0x01; 0x00 // Major version
@@ -3378,7 +3389,7 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
           mdbuf.EmitIntAsByte 0x00
       reportTime showTimes "Write Blob Stream"
      // Done - close the buffer and return the result.
-      mdbuf.Close(), guidStart
+      mdbuf.GetMemory().ToArray(), guidStart
 
 
    // Now we know the user string tables etc. we can fixup the

--- a/src/fsharp/absil/ilwrite.fs
+++ b/src/fsharp/absil/ilwrite.fs
@@ -48,7 +48,7 @@ let dw0 n = byte (n &&& 0xFFL)
 let bitsOfSingle (x: float32) = System.BitConverter.ToInt32(System.BitConverter.GetBytes x, 0)
 let bitsOfDouble (x: float) = System.BitConverter.DoubleToInt64Bits x
 
-let emitBytesViaBuffer f = use bb = ByteBuffer.Create 10 in f bb; bb.GetMemory().ToArray()
+let emitBytesViaBuffer f = use bb = ByteBuffer.Create 10 in f bb; bb.AsMemory().ToArray()
 
 /// Alignment and padding
 let align alignment n = ((n + alignment - 1) / alignment) * alignment
@@ -544,7 +544,7 @@ type cenv =
         cenv.codeChunks.EmitBytes code
         cenv.nextCodeAddr <- cenv.nextCodeAddr + code.Length
 
-    member cenv.GetCode() = cenv.codeChunks.GetMemory().ToArray()
+    member cenv.GetCode() = cenv.codeChunks.AsMemory().ToArray()
 
     override x.ToString() = "<cenv>"
 
@@ -1650,7 +1650,7 @@ module Codebuf =
               let (origStartOfNoBranchBlock, _, newStartOfNoBranchBlock) = arr.[i]
               addr - (origStartOfNoBranchBlock - newStartOfNoBranchBlock)
 
-          newCode.GetMemory().ToArray(),
+          newCode.AsMemory().ToArray(),
           !newReqdBrFixups,
           adjuster
 
@@ -2151,7 +2151,7 @@ module Codebuf =
     let EmitTopCode cenv localSigs env nm code =
         use codebuf = CodeBuffer.Create nm
         let origScopes = emitCode cenv localSigs codebuf env code
-        let origCode = codebuf.code.GetMemory().ToArray()
+        let origCode = codebuf.code.AsMemory().ToArray()
         let origExnClauses = List.rev codebuf.seh
         let origReqdStringFixups = codebuf.reqdStringFixupsInMethod
         let origAvailBrFixups = codebuf.availBrFixups
@@ -2200,7 +2200,7 @@ let GenILMethodBody mname cenv env (il: ILMethodBody) =
         methbuf.EmitByte (byte codeSize <<< 2 ||| e_CorILMethod_TinyFormat)
         methbuf.EmitBytes code
         methbuf.EmitPadding codePadding
-        0x0, (requiredStringFixups', methbuf.GetMemory().ToArray()), seqpoints, scopes
+        0x0, (requiredStringFixups', methbuf.AsMemory().ToArray()), seqpoints, scopes
     else
         // Use Fat format
         let flags =
@@ -2274,7 +2274,7 @@ let GenILMethodBody mname cenv env (il: ILMethodBody) =
 
         let requiredStringFixups' = (12, requiredStringFixups)
 
-        localToken, (requiredStringFixups', methbuf.GetMemory().ToArray()), seqpoints, scopes
+        localToken, (requiredStringFixups', methbuf.AsMemory().ToArray()), seqpoints, scopes
 
 // --------------------------------------------------------------------
 // ILFieldDef --> FieldDef Row
@@ -2970,8 +2970,8 @@ let generateIL requiredDataFixups (desiredMetadataVersion, generatePdb, ilg : IL
         getUncodedToken TableNames.Event (cenv.eventDefs.GetTableEntry (EventKey (tidx, ed.Name)))) }
     reportTime cenv.showTimes "Finalize Module Generation Results"
     // New return the results
-    let data = cenv.data.GetMemory().ToArray()
-    let resources = cenv.resources.GetMemory().ToArray()
+    let data = cenv.data.AsMemory().ToArray()
+    let resources = cenv.resources.AsMemory().ToArray()
     (strings, userStrings, blobs, guids, tables, entryPointToken, code, cenv.requiredStringFixups, data, resources, pdbData, mappings)
 
 
@@ -3298,7 +3298,7 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
                     | _ when t <= RowElementTags.ResolutionScopeMax -> tablesBuf.EmitZTaggedIndex (t - RowElementTags.ResolutionScopeMin) 2 rsBigness n
                     | _ -> failwith "invalid tag in row element"
 
-        tablesBuf.GetMemory().ToArray()
+        tablesBuf.AsMemory().ToArray()
 
     reportTime showTimes "Write Tables to tablebuf"
 
@@ -3389,7 +3389,7 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
           mdbuf.EmitIntAsByte 0x00
       reportTime showTimes "Write Blob Stream"
      // Done - close the buffer and return the result.
-      mdbuf.GetMemory().ToArray(), guidStart
+      mdbuf.AsMemory().ToArray(), guidStart
 
 
    // Now we know the user string tables etc. we can fixup the

--- a/src/fsharp/absil/ilwrite.fs
+++ b/src/fsharp/absil/ilwrite.fs
@@ -3241,7 +3241,7 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
             codedBigness 2 TableNames.AssemblyRef ||
             codedBigness 2 TableNames.TypeRef
 
-        use tablesBuf = ByteBuffer.Create 20000
+        use tablesBuf = ByteBuffer.Create(20000, useArrayPool = true)
 
         // Now the coded tables themselves - first the schemata header
         tablesBuf.EmitIntsAsBytes
@@ -3320,7 +3320,7 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
     reportTime showTimes "Layout Metadata"
 
     let metadata, guidStart =
-      use mdbuf = ByteBuffer.Create 500000
+      use mdbuf = ByteBuffer.Create(500000, useArrayPool = true)
       mdbuf.EmitIntsAsBytes
         [| 0x42; 0x53; 0x4a; 0x42 // Magic signature
            0x01; 0x00 // Major version

--- a/src/fsharp/absil/ilwrite.fs
+++ b/src/fsharp/absil/ilwrite.fs
@@ -47,7 +47,7 @@ let dw0 n = byte (n &&& 0xFFL)
 let bitsOfSingle (x: float32) = System.BitConverter.ToInt32(System.BitConverter.GetBytes x, 0)
 let bitsOfDouble (x: float) = System.BitConverter.DoubleToInt64Bits x
 
-let emitBytesViaBuffer f = let bb = ByteBuffer.Create 10 in f bb; bb.Close()
+let emitBytesViaBuffer f = use bb = ByteBuffer.Create 10 in f bb; bb.GetMemory().ToArray()
 
 /// Alignment and padding
 let align alignment n = ((n + alignment - 1) / alignment) * alignment

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -130,8 +130,12 @@ let checkExprOp (lexbuf:UnicodeLexing.Lexbuf) =
 let unexpectedChar lexbuf =
     LEX_FAILURE (FSComp.SR.lexUnexpectedChar(lexeme lexbuf))
 
+/// Arbitrary value
+[<Literal>]
+let StringCapacity = 100
+
 let startString args (lexbuf: UnicodeLexing.Lexbuf) =
-    let buf = ByteBuffer.Create 100
+    let buf = ByteBuffer.Create StringCapacity
     let m = lexbuf.LexemeRange
     let startp = lexbuf.StartPos
     let fin =
@@ -1584,7 +1588,7 @@ and tripleQuoteStringInComment n m args skip = parse
 
 and mlOnly m args skip = parse
  | "\""
-     { let buf = ByteBuffer.Create 100
+     { let buf = ByteBuffer.Create StringCapacity
        let m2 = lexbuf.LexemeRange
        let _ = singleQuoteString (buf, LexerStringFinisher.Default, m2, LexerStringKind.String, args) skip lexbuf
        if not skip then COMMENT (LexCont.MLOnly(args.ifdefStack, args.stringNest, m))

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -101,7 +101,7 @@ let usingLexbufForParsing (lexbuf:Lexbuf, filename) f =
 //-----------------------------------------------------------------------
 
 let stringBufferAsString (buf: ByteBuffer) =
-    let buf = buf.GetMemory()
+    let buf = buf.AsMemory()
     if buf.Length % 2 <> 0 then failwith "Expected even number of bytes"
     let chars : char[] = Array.zeroCreate (buf.Length/2)
     for i = 0 to (buf.Length/2) - 1 do
@@ -117,7 +117,7 @@ let stringBufferAsString (buf: ByteBuffer) =
 /// we just take every second byte we stored.  Note all bytes > 127 should have been 
 /// stored using addIntChar 
 let stringBufferAsBytes (buf: ByteBuffer) = 
-    let bytes = buf.GetMemory()
+    let bytes = buf.AsMemory()
     Array.init (bytes.Length / 2) (fun i -> bytes.Span.[i*2]) 
 
 [<Flags>]
@@ -185,7 +185,7 @@ let addByteChar buf (c:char) = addIntChar buf (int32 c % 256)
 
 /// Sanity check that high bytes are zeros. Further check each low byte <= 127 
 let stringBufferIsBytes (buf: ByteBuffer) = 
-    let bytes = buf.GetMemory()
+    let bytes = buf.AsMemory()
     let mutable ok = true 
     for i = 0 to bytes.Length / 2-1 do
         if bytes.Span.[i*2+1] <> 0uy then ok <- false

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -101,12 +101,12 @@ let usingLexbufForParsing (lexbuf:Lexbuf, filename) f =
 //-----------------------------------------------------------------------
 
 let stringBufferAsString (buf: ByteBuffer) =
-    let buf = buf.Close()
+    let buf = buf.GetMemory()
     if buf.Length % 2 <> 0 then failwith "Expected even number of bytes"
     let chars : char[] = Array.zeroCreate (buf.Length/2)
     for i = 0 to (buf.Length/2) - 1 do
-        let hi = buf.[i*2+1]
-        let lo = buf.[i*2]
+        let hi = buf.Span.[i*2+1]
+        let lo = buf.Span.[i*2]
         let c = char (((int hi) * 256) + (int lo))
         chars.[i] <- c
     System.String(chars)
@@ -117,8 +117,8 @@ let stringBufferAsString (buf: ByteBuffer) =
 /// we just take every second byte we stored.  Note all bytes > 127 should have been 
 /// stored using addIntChar 
 let stringBufferAsBytes (buf: ByteBuffer) = 
-    let bytes = buf.Close()
-    Array.init (bytes.Length / 2) (fun i -> bytes.[i*2]) 
+    let bytes = buf.GetMemory()
+    Array.init (bytes.Length / 2) (fun i -> bytes.Span.[i*2]) 
 
 [<Flags>]
 type LexerStringFinisherContext = 
@@ -185,10 +185,10 @@ let addByteChar buf (c:char) = addIntChar buf (int32 c % 256)
 
 /// Sanity check that high bytes are zeros. Further check each low byte <= 127 
 let stringBufferIsBytes (buf: ByteBuffer) = 
-    let bytes = buf.Close()
+    let bytes = buf.GetMemory()
     let mutable ok = true 
     for i = 0 to bytes.Length / 2-1 do
-        if bytes.[i*2+1] <> 0uy then ok <- false
+        if bytes.Span.[i*2+1] <> 0uy then ok <- false
     ok
 
 let newline (lexbuf:LexBuffer<_>) = 

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -706,7 +706,7 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf,
         | LexCont.String (ifdefs, stringNest, style, kind, m) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
-            use buf = ByteBuffer.Create 100
+            use buf = ByteBuffer.Create (Lexer.StringCapacity)
             let args = (buf, LexerStringFinisher.Default, m, kind, lexargs)
             match style with
             | LexerStringStyle.SingleQuote -> Lexer.singleQuoteString args skip lexbuf

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -706,7 +706,7 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf,
         | LexCont.String (ifdefs, stringNest, style, kind, m) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
-            let buf = ByteBuffer.Create 100
+            use buf = ByteBuffer.Create 100
             let args = (buf, LexerStringFinisher.Default, m, kind, lexargs)
             match style with
             | LexerStringStyle.SingleQuote -> Lexer.singleQuoteString args skip lexbuf

--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -857,14 +857,6 @@ type internal ByteBuffer =
         i.Copy(0, buf.bbArray, buf.bbCurrent, n)
         buf.bbCurrent <- newSize
 
-    member buf.EmitByteBuffer (i:ByteBuffer) =
-        buf.CheckDisposed()
-        let n = i.Position
-        let newSize = buf.bbCurrent + n
-        buf.Ensure newSize
-        Bytes.blit i.bbArray 0 buf.bbArray buf.bbCurrent n
-        buf.bbCurrent <- newSize
-
     member buf.EmitInt32AsUInt16 n =
         buf.CheckDisposed()
         let newSize = buf.bbCurrent + 2

--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -788,7 +788,7 @@ type internal ByteBuffer =
                 if buf.useArrayPool then
                     ArrayPool.Shared.Rent (max newSize (oldBufSize * 2))
                 else
-                    Bytes.sub old 0 (max newSize (oldBufSize * 2))
+                    Bytes.zeroCreate (max newSize (oldBufSize * 2))
             Bytes.blit old 0 buf.bbArray 0 buf.bbCurrent
             if buf.useArrayPool then
                 ArrayPool.Shared.Return old

--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -779,7 +779,7 @@ type internal ByteBuffer =
             if buf.useArrayPool then
                 ArrayPool.Shared.Return old
 
-    member buf.GetMemory() = 
+    member buf.AsMemory() = 
         buf.CheckDisposed()
         ReadOnlyMemory(buf.bbArray, 0, buf.bbCurrent)
 

--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -882,11 +882,11 @@ type internal ByteBuffer =
         buf.CheckDisposed()
         buf.bbCurrent
 
-    static member Create(sz, useArrayPool) =
+    static member Create(capacity, useArrayPool) =
         let useArrayPool = defaultArg useArrayPool false
         { useArrayPool = useArrayPool
           isDisposed = false
-          bbArray = if useArrayPool then ArrayPool.Shared.Rent sz else Bytes.zeroCreate sz
+          bbArray = if useArrayPool then ArrayPool.Shared.Rent capacity else Bytes.zeroCreate capacity
           bbCurrent = 0 }
 
     interface IDisposable with

--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -891,9 +891,10 @@ type internal ByteBuffer =
         buf.bbCurrent
 
     static member Create(sz, useArrayPool) =
-        { useArrayPool = defaultArg useArrayPool false
+        let useArrayPool = defaultArg useArrayPool false
+        { useArrayPool = useArrayPool
           isDisposed = false
-          bbArray = ArrayPool.Shared.Rent sz
+          bbArray = if useArrayPool then ArrayPool.Shared.Rent sz else Bytes.zeroCreate sz
           bbCurrent = 0 }
 
     interface IDisposable with

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -364,9 +364,6 @@ type internal ByteBuffer =
     member EmitByteMemory : ReadOnlyByteMemory -> unit
 
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
-    member EmitByteBuffer : ByteBuffer -> unit
-
-    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitInt32 : int32 -> unit
 
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -97,6 +97,7 @@ type internal ReadOnlyByteMemory =
 module internal MemoryMappedFileExtensions =
     type MemoryMappedFile with
         static member TryFromByteMemory : bytes: ReadOnlyByteMemory -> MemoryMappedFile option
+        static member TryFromMemory : bytes: ReadOnlyMemory<byte> -> MemoryMappedFile option
     
 /// Filesystem helpers
 module internal FileSystemUtils =
@@ -399,6 +400,9 @@ type internal ByteStorage =
 
     /// Creates a ByteStorage that has a copy of the given ByteMemory.
     static member FromByteMemoryAndCopy : ReadOnlyByteMemory * useBackingMemoryMappedFile: bool -> ByteStorage
+
+    /// Creates a ByteStorage that has a copy of the given Memory<byte>.
+    static member FromMemoryAndCopy : ReadOnlyMemory<byte> * useBackingMemoryMappedFile: bool -> ByteStorage
 
     /// Creates a ByteStorage that has a copy of the given byte array.
     static member FromByteArrayAndCopy : byte [] * useBackingMemoryMappedFile: bool -> ByteStorage

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -342,7 +342,7 @@ type internal ByteBuffer =
     interface IDisposable
 
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
-    member GetMemory : unit -> ReadOnlyMemory<byte>
+    member AsMemory : unit -> ReadOnlyMemory<byte>
 
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitIntAsByte : int -> unit

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -335,14 +335,19 @@ type internal ByteStream =
 #endif
 
 /// Imperative buffers and streams of byte[]
+/// Not thread safe.
 [<Sealed>]
 type internal ByteBuffer =
-    member Close : unit -> byte[]
+    interface IDisposable
+
+    member GetMemory : unit -> ReadOnlyMemory<byte>
     member EmitIntAsByte : int -> unit
     member EmitIntsAsBytes : int[] -> unit
     member EmitByte : byte -> unit
     member EmitBytes : byte[] -> unit
+    member EmitMemory : ReadOnlyMemory<byte> -> unit
     member EmitByteMemory : ReadOnlyByteMemory -> unit
+    member EmitByteBuffer : ByteBuffer -> unit
     member EmitInt32 : int32 -> unit
     member EmitInt64 : int64 -> unit
     member FixupInt32 : pos: int -> value: int32 -> unit
@@ -350,7 +355,7 @@ type internal ByteBuffer =
     member EmitBoolAsByte : bool -> unit
     member EmitUInt16 : uint16 -> unit
     member Position : int
-    static member Create : int -> ByteBuffer
+    static member Create : int * ?useArrayPool: bool -> ByteBuffer
 
 [<Sealed>]
 type internal ByteStorage =

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -382,7 +382,7 @@ type internal ByteBuffer =
     member EmitUInt16 : uint16 -> unit
 
     member Position : int
-    static member Create : int * ?useArrayPool: bool -> ByteBuffer
+    static member Create : capacity: int * ?useArrayPool: bool -> ByteBuffer
 
 [<Sealed>]
 type internal ByteStorage =

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -8,6 +8,7 @@ open System.IO.MemoryMappedFiles
 open System.Reflection
 open System.Runtime.InteropServices
 open System.Text
+open System.Runtime.CompilerServices
 
 open FSharp.NativeInterop
 
@@ -340,20 +341,48 @@ type internal ByteStream =
 type internal ByteBuffer =
     interface IDisposable
 
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member GetMemory : unit -> ReadOnlyMemory<byte>
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitIntAsByte : int -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitIntsAsBytes : int[] -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitByte : byte -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitBytes : byte[] -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitMemory : ReadOnlyMemory<byte> -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitByteMemory : ReadOnlyByteMemory -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitByteBuffer : ByteBuffer -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitInt32 : int32 -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitInt64 : int64 -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member FixupInt32 : pos: int -> value: int32 -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitInt32AsUInt16 : int32 -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitBoolAsByte : bool -> unit
+
+    [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     member EmitUInt16 : uint16 -> unit
+
     member Position : int
     static member Create : int * ?useArrayPool: bool -> ByteBuffer
 

--- a/vsintegration/Directory.Build.targets
+++ b/vsintegration/Directory.Build.targets
@@ -14,6 +14,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
   </ItemGroup>
  


### PR DESCRIPTION
![loh](https://user-images.githubusercontent.com/1278959/121424825-a2ab2f00-c926-11eb-8a1f-3021c583233b.png)
We allocate a lot on the LOH when serializing FSharp metadata. This PR should help.