### PR TITLE
Fix packaging on preview sdks

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -54,7 +54,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </PropertyGroup>
 
   <PropertyGroup>
-    <RestoreAdditionalProjectSources Condition="'$(_NETCoreSdkIsPreview)' != 'false'">$(RestoreAdditionalProjectSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSources Condition="'$(_NETCoreSdkIsPreview)' != 'false' and '$(DisableFSharpCorePreviewCheck)' != 'true'">$(RestoreAdditionalProjectSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <Target Name="CollectFSharpDesignTimeTools" BeforeTargets="BeforeCompile" DependsOnTargets="_GetFrameworkAssemblyReferences">

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
@@ -136,6 +136,8 @@ $(POUND_R)
     <TargetFramework>$(TARGETFRAMEWORK)</TargetFramework>
     <RuntimeIdentifier>$(RUNTIMEIDENTIFIER)</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
+    <_NETCoreSdkIsPreview>false</_NETCoreSdkIsPreview>                      <!-- Disable preview FSharp.Core for legacy DotNet Sdks -->
+    <DisableFSharpCorePreviewCheck>true</DisableFSharpCorePreviewCheck>     <!-- Disable preview FSharp.Core current DotNet Sdks    -->
 
     <!-- Disable automagic FSharp.Core resolution when not using with FSharp scripts -->
     <DisableImplicitFSharpCoreReference Condition="'$(SCRIPTEXTENSION)' != '.fsx'">true</DisableImplicitFSharpCoreReference>


### PR DESCRIPTION
When FSharp is run on a preview SDK we want users to have access to the preview FSharp.Core so that preview language features will work.

So we have some machinery to do that here https://github.com/dotnet/fsharp/blob/main/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props#L83

In order to locate the preview FSharp.Core we have to add  a package source to an azure feed here
https://github.com/dotnet/fsharp/blob/main/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets#L56

There is a bug, when we add the feed we don't take into account the build variable: DisableFSharpCorePreviewCheck which was implemented to disable access to preview FSharp.Cores.

Mostly that doesn't matter, which is why no one has noticed, however, notebooks use the same feed for internal and preview builds, and when breaking changes happens, we can inadvertently break scripts that use packages built on the dotnet interactive assemblies, when a preview dotnet sdk is installed on the machine.

This change fixes the bug mentioned above by ensuring that setting DisableFSharpCorePreviewCheck turns off using the preview FSharp.Core.  It also updates the package manager so that it sets DisableFSharpCorePreviewCheck  to true.

However, if a developer has a global json that pins dotnet to use a specific release of the dotnet sdk, then that older sdk will still have the bug, so this change also disables _NETCoreSdkIsPreview when doing #r "nuget" this is perfectly benign since #r nuget does not and should not rely on _NETCoreSdkIsPreview.

/cc @jonsequitur  






