### PR TITLE
Parser: recover newExpr member access (atomicExpr rule)

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1563,3 +1563,4 @@ forFormatInvalidForInterpolated4,"Interpolated strings used as type IFormattable
 3391,tcLiteralAttributeCannotUseActivePattern,"A [<Literal>] declaration cannot use an active pattern for its identifier"
 3392,containerDeprecated,"The 'AssemblyKeyNameAttribute' has been deprecated. Use 'AssemblyKeyFileAttribute' instead."
 3393,containerSigningUnsupportedOnThisPlatform,"Key container signing is not supported on this platform."
+3394,parsNewExprMemberAccess,"This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'"

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -331,7 +331,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <SynPat> headBindingPattern
 %type <SynExpr> atomicExprAfterType
 %type <SynExpr> typedSeqExprBlock
-%type <SynExpr * bool> atomicExpr
+%type <SynExpr * bool * bool> atomicExpr
 %type <SynTypeDefnSimpleRepr> tyconDefnOrSpfnSimpleRepr
 %type <(SynEnumCase, SynUnionCase) Choice list> unionTypeRepr
 %type <SynMemberDefns> tyconDefnAugmentation
@@ -4053,15 +4053,6 @@ minusExpr:
   | AMP_AMP  minusExpr   
       { SynExpr.AddressOf (false, $2, rhs parseState 1, unionRanges (rhs parseState 1) $2.Range) } 
 
-  | NEW atomTypeNonAtomicDeprecated  opt_HIGH_PRECEDENCE_APP atomicExprAfterType 
-      { SynExpr.New (false, $2, $4, unionRanges (rhs parseState 1) $4.Range) }
-
-  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP error   
-      { SynExpr.New (false, $2, arbExpr("minusExpr", (rhs parseState 4)), unionRanges (rhs parseState 1) ($2).Range) }
-
-  | NEW error
-      { arbExpr("minusExpr2", (rhs parseState 1)) }
-
   | UPCAST  minusExpr 
       { SynExpr.InferredUpcast ($2, unionRanges (rhs parseState 1) $2.Range) }   
 
@@ -4076,98 +4067,109 @@ appExpr:
       { SynExpr.App (ExprAtomicFlag.NonAtomic, false, $1, $2, unionRanges $1.Range $2.Range)  }
 
   | atomicExpr 
-      { let arg, _ = $1 
+      { let arg, _, _ = $1 
         arg }
 
 argExpr:
   | ADJACENT_PREFIX_OP atomicExpr 
-      { let arg2, hpa2 = $2 
+      { let arg2, hpa2, _ = $2 
         if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt arg2.Range (FSComp.SR.parsInvalidPrefixOperator())
         if hpa2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
         mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) arg2.Range) ("~"^($1)) arg2 }
 
    | atomicExpr 
-      { let arg, hpa = $1 
+      { let arg, hpa, _ = $1 
         if hpa then reportParseErrorAt arg.Range (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
         arg }
     
 atomicExpr:
   | atomicExpr HIGH_PRECEDENCE_BRACK_APP atomicExpr
-      { let arg1, _ = $1 
-        let arg2, _ = $3 
-        SynExpr.App (ExprAtomicFlag.Atomic, false, arg1, arg2, unionRanges arg1.Range arg2.Range), true  }
+      { let arg1, _, _ = $1
+        let arg2, _, _ = $3
+        SynExpr.App (ExprAtomicFlag.Atomic, false, arg1, arg2, unionRanges arg1.Range arg2.Range), true, false }
 
   | atomicExpr HIGH_PRECEDENCE_PAREN_APP atomicExpr
-      { let arg1, _ = $1 
-        let arg2, _ = $3 
-        SynExpr.App (ExprAtomicFlag.Atomic, false, arg1, arg2, unionRanges arg1.Range arg2.Range), true  }
+      { let arg1, _, _ = $1
+        let arg2, _, _ = $3 
+        SynExpr.App (ExprAtomicFlag.Atomic, false, arg1, arg2, unionRanges arg1.Range arg2.Range), true, false }
 
   | atomicExpr HIGH_PRECEDENCE_TYAPP typeArgsActual
-      { let arg1, _ = $1 
+      { let arg1, _, _ = $1 
         let mLessThan, mGreaterThan, _, args, commas, mTypeArgs = $3
         let mWholeExpr = unionRanges arg1.Range mTypeArgs
-        SynExpr.TypeApp (arg1, mLessThan, args, commas, mGreaterThan, mTypeArgs, mWholeExpr), false }
+        SynExpr.TypeApp (arg1, mLessThan, args, commas, mGreaterThan, mTypeArgs, mWholeExpr), false, false }
 
   | PREFIX_OP atomicExpr  
-      { let arg2, hpa2 = $2 
+      { let arg2, hpa2, isNewExpr = $2
+        if isNewExpr then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
         if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt arg2.Range (FSComp.SR.parsInvalidPrefixOperator())
-        mkSynPrefixPrim (rhs parseState 1) (unionRanges (rhs parseState 1) arg2.Range) $1 arg2, hpa2 }
+        mkSynPrefixPrim (rhs parseState 1) (unionRanges (rhs parseState 1) arg2.Range) $1 arg2, hpa2, false }
 
   | atomicExpr DOT atomicExprQualification 
-      { let arg1, hpa1 = $1 
-        $3 arg1 (lhs parseState) (rhs parseState 2), hpa1 }
+      { let arg1, hpa1, _ = $1 
+        $3 arg1 (lhs parseState) (rhs parseState 2), hpa1, false }
 
   | BASE DOT atomicExprQualification 
       { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1))
-        $3 arg1 (lhs parseState) (rhs parseState 2), false }
+        $3 arg1 (lhs parseState) (rhs parseState 2), false, false }
+
+  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType
+      { SynExpr.New (false, $2, $4, unionRanges (rhs parseState 1) $4.Range), true, true }
+
+  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP error
+      { SynExpr.New (false, $2, arbExpr("minusExpr", (rhs parseState 4)), unionRanges (rhs parseState 1) ($2).Range), false, true }
+
+  | NEW error
+      { arbExpr("minusExpr2", (rhs parseState 1)), false, true }
 
   | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType DOT atomicExprQualification 
       { errorR (Error (FSComp.SR.parsNewExprMemberAccess (), rhs parseState 6))
         let newExpr = SynExpr.New (false, $2, $4, unionRanges (rhs parseState 1) $4.Range)
-        $6 newExpr (lhs parseState) (rhs parseState 5), false }
+        $6 newExpr (lhs parseState) (rhs parseState 5), true, true }
 
   | QMARK nameop 
-      { SynExpr.LongIdent (true, LongIdentWithDots([$2], []), None, rhs parseState 2), false }
+      { SynExpr.LongIdent (true, LongIdentWithDots([$2], []), None, rhs parseState 2), false, false }
 
   | atomicExpr QMARK dynamicArg
-      { let arg1, hpa1 = $1
-        mkSynInfix (rhs parseState 2) arg1 "?" $3, hpa1 }
+      { let arg1, hpa1, isNewExpr = $1
+        if isNewExpr then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
+        mkSynInfix (rhs parseState 2) arg1 "?" $3, hpa1, false }
 
   | GLOBAL
-      { SynExpr.Ident (ident(MangledGlobalName, rhs parseState 1)), false }
+      { SynExpr.Ident (ident(MangledGlobalName, rhs parseState 1)), false, false }
 
   | identExpr
-      { $1, false }
+      { $1, false, false }
 
   | LBRACK listExprElements RBRACK 
-      { $2 (lhs parseState) false, false }
+      { $2 (lhs parseState) false, false, false }
 
   | LBRACK listExprElements recover 
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
-        exprFromParseError ($2 (rhs2 parseState 1 2) false), false }
+        exprFromParseError ($2 (rhs2 parseState 1 2) false), false, false }
 
   | LBRACK error RBRACK 
       { // silent recovery 
-        SynExpr.ArrayOrList (false, [ ], lhs parseState), false  } 
+        SynExpr.ArrayOrList (false, [ ], lhs parseState), false, false }
 
   | LBRACK recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
         // silent recovery 
-        exprFromParseError (SynExpr.ArrayOrList (false, [ ], rhs parseState 1)), false  } 
+        exprFromParseError (SynExpr.ArrayOrList (false, [ ], rhs parseState 1)), false, false }
 
   | STRUCT LPAREN tupleExpr rparen
       { let exprs, commas = $3
         let m = rhs2 parseState 1 4
-        SynExpr.Tuple (true, List.rev exprs, List.rev commas, m), false }
+        SynExpr.Tuple (true, List.rev exprs, List.rev commas, m), false, false }
 
   | STRUCT LPAREN tupleExpr recover
       { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedBracket());
         let exprs, commas = $3
         let m = (rhs parseState 1, exprs) ||> unionRangeWithListBy (fun e -> e.Range)
-        SynExpr.Tuple (true, List.rev exprs, List.rev commas, m), false }
+        SynExpr.Tuple (true, List.rev exprs, List.rev commas, m), false, false }
 
   | atomicExprAfterType 
-      { $1, false }
+      { $1, false, false }
 
 atomicExprQualification:
   | identOrOp 
@@ -5125,7 +5127,8 @@ atomType:
        SynType.StaticConstant(SynConst.String (null, SynStringKind.Regular, m), m) }
 
   | CONST atomicExpr
-     {  let e, _ = $2
+      { let e, hpa, _ = $2
+        if hpa then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
         SynType.StaticConstantExpr(e, lhs parseState) }
 
   | FALSE  

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -4121,6 +4121,11 @@ atomicExpr:
       { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1))
         $3 arg1 (lhs parseState) (rhs parseState 2), false }
 
+  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType DOT atomicExprQualification 
+      { errorR (Error (FSComp.SR.parsNewExprMemberAccess (), rhs parseState 6))
+        let newExpr = SynExpr.New (false, $2, $4, unionRanges (rhs parseState 1) $4.Range)
+        $6 newExpr (lhs parseState) (rhs parseState 5), false }
+
   | QMARK nameop 
       { SynExpr.LongIdent (true, LongIdentWithDots([$2], []), None, rhs parseState 2), false }
 

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Neočekávaný token v definici typu. Za typem {0} se očekává =.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Neočekávaný symbol . v definici členu. Očekávalo se with, = nebo jiný token.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Unerwartetes Token in Typdefinition. Nach Typ "{0}" wurde "=" erwartet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Unerwartetes Symbol "." in der Memberdefinition. Erwartet wurde "with", "=" oder ein anderes Token.</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Token inesperado en la definición de tipo. Se esperaba "=" después del tipo "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Símbolo inesperado "." en la definición de miembro. Se esperaba "with", "=" u otro token.</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Jeton inattendu dans la définition de type. Signe '=' attendu après le type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Symbole '.' inattendu dans la définition du membre. 'with','=' ou autre jeton attendu.</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Token imprevisto nella definizione del tipo. Dopo il tipo '{0}' è previsto '='.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Simbolo '.' imprevisto nella definizione di membro. È previsto 'with', '=' o un altro token.</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -327,6 +327,11 @@
         <target state="translated">型定義に予期しないトークンがあります。型 '{0}' の後には '=' が必要です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">メンバー定義に予期しない記号 '.' があります。'with'、'=' またはその他のトークンが必要です。</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -327,6 +327,11 @@
         <target state="translated">형식 정의에 예기치 않은 토큰이 있습니다. '{0}' 형식 뒤에 '='가 필요합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">멤버 정의의 예기치 않은 기호 '.'입니다. 'with', '=' 또는 기타 토큰이 필요합니다.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Nieoczekiwany token w definicji typu. Oczekiwano znaku „=” po typie „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Nieoczekiwany symbol „.” w definicji składowej. Oczekiwano ciągu „with”, znaku „=” lub innego tokenu.</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Token inesperado na definição de tipo. Esperava-se '=' após o tipo '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Símbolo inesperado '.' na definição de membro. Esperado 'com', '=' ou outro token.</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Неожиданный токен в определении типа. После типа "{0}" ожидается "=".</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Неожиданный символ "." в определении члена. Ожидаемые инструкции: "with", "=" или другие токены.</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -327,6 +327,11 @@
         <target state="translated">Tür tanımında beklenmeyen belirteç var. '{0}' türünden sonra '=' bekleniyordu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">Üye tanımında '.' sembolü beklenmiyordu. 'with', '=' veya başka bir belirteç bekleniyordu.</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -327,6 +327,11 @@
         <target state="translated">类型定义中出现意外标记。类型“{0}”后应为 "="。</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">成员定义中有意外的符号 "."。预期 "with"、"+" 或其他标记。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -327,6 +327,11 @@
         <target state="translated">型別定義中出現非預期的權杖。類型 '{0}' 之後應該要有 '='。</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsNewExprMemberAccess">
+        <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
+        <target state="new">This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsUnexpectedSymbolDot">
         <source>Unexpected symbol '.' in member definition. Expected 'with', '=' or other token.</source>
         <target state="translated">成員定義中的非預期符號 '.'。預期為 'with'、'=' 或其他語彙基元。</target>


### PR DESCRIPTION
An alternative approach for https://github.com/dotnet/fsharp/pull/11691, with recovery in more cases.

```fsharp
new String([||]).Length |> ignore

Seq.empty
```

Before:

<img width="609" alt="Screenshot 2021-06-17 at 23 29 17" src="https://user-images.githubusercontent.com/3923587/122468301-36829800-cfc4-11eb-99d2-f0d0fd55a6d5.png">


After:

<img width="813" alt="Screenshot 2021-06-17 at 23 29 08" src="https://user-images.githubusercontent.com/3923587/122468287-31bde400-cfc4-11eb-9c4d-3e488abecb64.png">


<img width="813" alt="122471000-667f6a80-cfc7-11eb-814c-092e53d02bee" src="https://user-images.githubusercontent.com/3923587/122472303-15707600-cfc9-11eb-903f-d3db7a2ccb34.png">
