### PR TITLE
Fix shims

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -144,7 +144,7 @@
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildOverallPackagesVersion)</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildOverallPackagesVersion)</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildOverallPackagesVersion)</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftVSSDKBuildToolsVersion>17.0.63-dev17-g3f11f5ab</MicrosoftVSSDKBuildToolsVersion>
+    <MicrosoftVSSDKBuildToolsVersion>17.0.2136-preview2</MicrosoftVSSDKBuildToolsVersion>
     <!-- Visual Studio editor packages -->
     <MicrosoftVisualStudioCoreUtilityVersion>$(VisualStudioImplementationPackagesVersion)</MicrosoftVisualStudioCoreUtilityVersion>
     <MicrosoftVisualStudioEditorVersion>$(VisualStudioImplementationPackagesVersion)</MicrosoftVisualStudioEditorVersion>

--- a/setup/shims/Microsoft.FSharp.NetSdk.Shim.props
+++ b/setup/shims/Microsoft.FSharp.NetSdk.Shim.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(MicrosoftFSharpShimHelpersPropsIncluded)'!='true'" Project="$(MSBuildThisFileDirectory)Microsoft.FSharp.ShimHelpers.props" />
 
   <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.NetSdk.props" />
   <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\Microsoft.FSharp.NetSdk.props" />
-
 </Project>

--- a/setup/shims/Microsoft.FSharp.NetSdk.Shim.targets
+++ b/setup/shims/Microsoft.FSharp.NetSdk.Shim.targets
@@ -1,6 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Condition="'$(MicrosoftFSharpShimHelpersPropsIncluded)'!='true'" Project="$(MSBuildThisFileDirectory)Microsoft.FSharp.ShimHelpers.props" />
-
   <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.NetSdk.targets" />
   <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\Microsoft.FSharp.NetSdk.targets" />
 </Project>

--- a/setup/shims/Microsoft.FSharp.NetSdk.Shim.targets
+++ b/setup/shims/Microsoft.FSharp.NetSdk.Shim.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(MicrosoftFSharpShimHelpersPropsIncluded)'!='true'" Project="$(MSBuildThisFileDirectory)Microsoft.FSharp.ShimHelpers.props" />
 
   <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.NetSdk.targets" />
   <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\Microsoft.FSharp.NetSdk.targets" />
-
 </Project>

--- a/setup/shims/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
+++ b/setup/shims/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(MicrosoftFSharpShimHelpersPropsIncluded)'!='true'" Project="$(MSBuildThisFileDirectory)Microsoft.FSharp.ShimHelpers.props" />
 
   <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.Overrides.NetSdk.targets" />
   <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\Microsoft.FSharp.Overrides.NetSdk.targets" />
-
 </Project>

--- a/setup/shims/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
+++ b/setup/shims/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
@@ -1,6 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Condition="'$(MicrosoftFSharpShimHelpersPropsIncluded)'!='true'" Project="$(MSBuildThisFileDirectory)Microsoft.FSharp.ShimHelpers.props" />
-
   <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.Overrides.NetSdk.targets" />
   <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\Microsoft.FSharp.Overrides.NetSdk.targets" />
 </Project>

--- a/setup/shims/Microsoft.FSharp.Shim.targets
+++ b/setup/shims/Microsoft.FSharp.Shim.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(MicrosoftFSharpShimHelpersPropsIncluded)'!='true'" Project="$(MSBuildThisFileDirectory)Microsoft.FSharp.ShimHelpers.props" />
 
   <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.targets" />
   <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\Microsoft.FSharp.targets" />
-
 </Project>

--- a/setup/shims/Microsoft.FSharp.ShimHelpers.props
+++ b/setup/shims/Microsoft.FSharp.ShimHelpers.props
@@ -1,0 +1,22 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MicrosoftFSharpShimHelpersPropsIncluded>true</MicrosoftFSharpShimHelpersPropsIncluded>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(FSharpTryUseLegacyCompiler)' != 'true'">
+
+    <!-- We are in the msbuild/VS build path only, we want to forward to the installed net sdk always -->
+    <FSharpCompilerPath Condition="'$(FSharpCompilerPath)' == ''">$(NetCoreRoot)sdk/$(NETCoreSdkVersion)/FSharp/</FSharpCompilerPath>
+
+    <FscToolPath>$(NetCoreRoot)</FscToolPath>
+    <FscToolExe>$(NetCoreRoot)dotnet.exe</FscToolExe>
+    <DotnetFscCompilerPath>"$(FSharpCompilerPath)fsc.dll"</DotnetFscCompilerPath>
+
+    <FsiToolPath>$(NetCoreRoot)</FsiToolPath>
+    <FsiToolExe>$(NetCoreRoot)dotnet.exe</FsiToolExe>
+    <DotnetFsiCompilerPath>"$(FSharpCompilerPath)fsi.dll"</DotnetFsiCompilerPath>
+
+  </PropertyGroup>
+
+</Project>

--- a/setup/shims/Microsoft.Portable.FSharp.Shim.targets
+++ b/setup/shims/Microsoft.Portable.FSharp.Shim.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(MicrosoftFSharpShimHelpersPropsIncluded)'!='true'" Project="$(MSBuildThisFileDirectory)Microsoft.FSharp.ShimHelpers.props" />
 
   <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.Portable.FSharp.targets" />
   <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\Microsoft.Portable.FSharp.targets" />
-
 </Project>

--- a/src/fsharp/utils/CompilerLocationUtils.fs
+++ b/src/fsharp/utils/CompilerLocationUtils.fs
@@ -362,9 +362,6 @@ module internal FSharpEnvironment =
     let getDefaultFSharpCoreLocation() = Path.Combine(getFSharpCompilerLocation(), getFSharpCoreLibraryName + ".dll")
     let getDefaultFsiLibraryLocation() = Path.Combine(getFSharpCompilerLocation(), fsiLibraryName + ".dll")
 
-    // Path to the directory containing the fsharp compilers
-    let fsharpCompilerPath = Path.Combine(Path.GetDirectoryName(typeof<TypeInThisAssembly>.GetTypeInfo().Assembly.Location), "Tools")
-
     let isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 
     let dotnet = if isWindows then "dotnet.exe" else "dotnet"

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpDebug.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpDebug.csproj
@@ -8,6 +8,7 @@
     <PackageTargetFallback>netcoreapp1.0</PackageTargetFallback>
     <IsShipping>true</IsShipping>
     <DependencyTargetFramework>net472</DependencyTargetFramework>
+    <DeployExtension>true</DeployExtension>
   </PropertyGroup>
 
   <Import Project="VisualFSharp.Core.targets" />

--- a/vsintegration/src/FSharp.Editor/Build/SetGlobalPropertiesForSdkProjects.fs
+++ b/vsintegration/src/FSharp.Editor/Build/SetGlobalPropertiesForSdkProjects.fs
@@ -23,5 +23,4 @@ type internal SetGlobalPropertiesForSdkProjects
     inherit StaticGlobalPropertiesProviderBase(projectService.Services)
 
     override _.GetGlobalPropertiesAsync(_cancellationToken: CancellationToken): Task<IImmutableDictionary<string, string>> =
-        let properties = Empty.PropertiesMap.Add("FSharpCompilerPath", Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Tools"))
-        Task.FromResult<IImmutableDictionary<string, string>>(properties)
+        Task.FromResult<IImmutableDictionary<string, string>>(Empty.PropertiesMap)

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -170,8 +170,6 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="$(MicrosoftVisualStudioProjectSystemManagedVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="$(MicrosoftVisualStudioShellImmutable100Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" Version="$(MicrosoftVisualStudioShellImmutable110Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />


### PR DESCRIPTION
This enables for Dev17 by default build with dotnet sdk version of the F# compiler, from within VS and using msbuild from the command line.

To use the legacy F# compiler add a file called Directory.Build.props
````
<Project>
  <PropertyGroup>
    <FSharpTryUseLegacyCompiler>true</FSharpTryUseLegacyCompiler>
  </PropertyGroup>
</Project>
````

The property has to be set in the Directory.Build.props rather than the project file, because the props files are all loaded by the time the project file is processed and the value is needed in the props files.
