### PR TITLE
[VS] Stop switching to threadpool for `StartAsyncAsTask`

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -110,8 +110,7 @@ module internal RoslynHelpers =
         let task = tcs.Task
         let disposeReg() = barrier.Stop(); if not task.IsCanceled then reg.Dispose()
         Async.StartWithContinuations(
-                  async { do! Async.SwitchToThreadPool()
-                          return! computation }, 
+                  computation, 
                   continuation=(fun result -> 
                       disposeReg()
                       tcs.TrySetResult(result) |> ignore


### PR DESCRIPTION
Stop switching to threadpool when we run an `Async` as a `Task`. This will help with stack traces when debugging.