### PR TITLE
[WIP] - Fixes demangling of `op_Multiply` in `nameof(*)`

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -5328,8 +5328,13 @@ opName:
   | LPAREN error rparen  
      {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName()); ident(CompileOpName "****", rhs parseState 2) }
 
+  /* (*) is a special case, since we need to distinguish it from the comments, so we compensate the position of operator itself, since parens are getting captured here as well, we do it so things like nameof(*) are demangled properly to '*' instead of op_Multiply */
   | LPAREN_STAR_RPAREN
-     {  ident(CompileOpName "*", rhs parseState 1) }
+     {  let m = rhs parseState 1
+        let p1 = mkPos m.StartLine (m.StartColumn + 1)
+        let p2 = mkPos m.EndLine (m.EndColumn - 1)
+        let r = mkFileIndexRange m.FileIndex p1 p2
+        ident(CompileOpName "*", r) }
 
   /* active pattern name */
   | LPAREN activePatternCaseNames BAR rparen 

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="ErrorMessages\WarnExpressionTests.fs" />
     <Compile Include="ErrorMessages\WrongSyntaxInForLoop.fs" />
     <Compile Include="ErrorMessages\ConfusingTypeName.fs" />
+    <Compile Include="Language\NameofTests.fs" />
     <Compile Include="Language\RegressionTests.fs" />
     <Compile Include="Language\AttributeCheckingTests.fs" />
     <Compile Include="Language\XmlComments.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Language/NameofTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/NameofTests.fs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.Language
+
+open Xunit
+open FSharp.Test.Utilities.Compiler
+
+module NameofTests =
+
+    [<Theory>]
+    [<InlineData("+")>]
+    [<InlineData("-")>]
+    [<InlineData("/")>]
+    [<InlineData("*")>]
+    let ``nameof() with operator should return demangled name`` operator =
+        let source = $"""
+let expected = "{operator}"
+let actual = nameof({operator})
+if actual <> expected then failwith $"Expected nameof({{expected}}) to be '{{expected}}', but got '{{actual}}'"
+        """
+        Fsx source
+        |> asExe
+        |> withLangVersion50
+        |> compileAndRun
+        |> shouldSucceed

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -637,7 +637,7 @@ module rec Compiler =
             match result with
             | Success _ -> result
             | Failure r ->
-                let message = sprintf "Operation failed (expected to succeed).\n All errors:\n%A" (r.Diagnostics)
+                let message = sprintf "Operation failed (expected to succeed).\n All errors:\n%A.\n Output:\n%A\n" (r.Diagnostics) (r.Output)
                 failwith message
 
         let shouldFail (result: TestResult) : TestResult =


### PR DESCRIPTION
Fixes op_Multiply demangling in nameof(*):
`(*)` (`LPAREN_STAR_RPARENT`) is a special case in parser, we capture `(` and `)` in range, and don't properly demangle op name. This PR fixes it - we compensate position (start and end column) when we parse it and then create ident.
