### PR TITLE
Rebuild against latest interops

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -470,8 +470,8 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/release/insert-into-vs.yml
     parameters:
-      componentBranchName: refs/heads/release/dev17.0
+      componentBranchName: refs/heads/fix1329729
       insertTargetBranch: main
       insertTeamEmail: fsharpteam@microsoft.com
       insertTeamName: 'F#'
-      completeInsertion: 'auto'
+      completeInsertion: 'false'

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -107,8 +107,8 @@
     <SystemRuntimeCompilerServicesUnsafeVersion>5.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <!-- VisualStudio package versions  -->
-    <VisualStudioImplementationPackagesVersion>17.0.67-g9e37b637e6</VisualStudioImplementationPackagesVersion>
-    <VisualStudioContractPackagesVersion>17.0.0-previews-1-31319-408</VisualStudioContractPackagesVersion>
+    <VisualStudioImplementationPackagesVersion>17.0.154-preview</VisualStudioImplementationPackagesVersion>
+    <VisualStudioContractPackagesVersion>17.0.0-previews-2-31423-289</VisualStudioContractPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>17.0.77-pre-g62a6cb5699</VisualStudioProjectSystemPackagesVersion>
     <MicrosoftVisualStudioInteropVersion>$(VisualStudioContractPackagesVersion)</MicrosoftVisualStudioInteropVersion>
     <MicrosoftInternalVisualStudioInteropVersion>$(VisualStudioContractPackagesVersion)</MicrosoftInternalVisualStudioInteropVersion>
@@ -163,7 +163,7 @@
     <MicrosoftVisualStudioShellFrameworkVersion>$(VisualStudioContractPackagesVersion)</MicrosoftVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioPackageLanguageService150Version>$(VisualStudioContractPackagesVersion)</MicrosoftVisualStudioPackageLanguageService150Version>
     <!-- Misc. Visual Studio packages -->
-    <MicrosoftVisualStudioRpcContractsVersion>17.0.50-preview-0001-0001</MicrosoftVisualStudioRpcContractsVersion>
+    <MicrosoftVisualStudioRpcContractsVersion>17.0.50-preview-0002-0002</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualStudioComponentModelHostVersion>$(VisualStudioImplementationPackagesVersion)</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>$(VisualStudioContractPackagesVersion)</MicrosoftVisualStudioDesignerInterfacesVersion>
@@ -179,7 +179,7 @@
     <MicrosoftVisualStudioShellImmutable150Version>15.0.25123-Dev15Preview</MicrosoftVisualStudioShellImmutable150Version>
     <MicrosoftVisualStudioShellInterop160DesignTimeVersion>16.0.1</MicrosoftVisualStudioShellInterop160DesignTimeVersion>
     <MicrosoftVisualStudioShellInterop16DesignTimeVersion>16.0.28924.11111</MicrosoftVisualStudioShellInterop16DesignTimeVersion>
-    <MicrosoftVisualStudioThreadingVersion>17.0.15-alpha</MicrosoftVisualStudioThreadingVersion>
+    <MicrosoftVisualStudioThreadingVersion>17.0.26-alpha</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioUtilitiesVersion>$(VisualStudioContractPackagesVersion)</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>17.0.1-alpha</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioWCFReferenceInteropVersion>9.0.30729</MicrosoftVisualStudioWCFReferenceInteropVersion>

--- a/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
+++ b/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
@@ -78,7 +78,7 @@ vs.dependencies
                 type=Required
 
 folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools"
-  file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\fsc.exe" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2 vs.file.ngenApplication="[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\fsc.exe"
+  file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\fsc.exe" vs.file.ngen=yes vs.file.ngenArchitecture=x86 vs.file.ngenPriority=2 vs.file.ngenApplication="[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\fsc.exe"
   file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\fsc.exe.config"
   file source="$(BinariesFolder)fsi\$(Configuration)\$(TargetFramework)\fsi.exe" vs.file.ngen=yes vs.file.ngenArchitecture=X86 vs.file.ngenPriority=2 vs.file.ngenApplication="[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools\fsi.exe"
   file source="$(BinariesFolder)fsi\$(Configuration)\$(TargetFramework)\fsi.exe.config"

--- a/vsintegration/src/FSharp.ProjectSystem.Base/ProjectReferenceNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/ProjectReferenceNode.cs
@@ -15,7 +15,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.Build.Utilities;
 using VSConstants = Microsoft.VisualStudio.VSConstants;
-using Task = Microsoft.VisualStudio.Shell.Task;
+using Task = Microsoft.VisualStudio.Shell.TaskListItem;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// Containes either null if project reference is OK or instance of Task with error message if project reference is invalid
         /// i.e. project A references project B when target framework version for B is higher that for A
         /// </summary>
-        private Shell.Task projectRefError;
+        private Task projectRefError;
 
         /// <summary>
         /// The name of the assembly this refernce represents


### PR DESCRIPTION
Allegedly this fixes an ngen build issue with 64 bit VS components.  I need to do a pretend VS insertion to check that it works.

How do I go about that?


Kevin