### PR TITLE
Disable two flakey tests

### DIFF
--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -1038,6 +1038,7 @@ let f (tp:ITypeProvider(*$$$*)) = tp.Invalidate
            "Generic.LinkedList" "System.Collections.ICollection.ISynchronized" // Bug 5092: A framework class contained a private method impl
 
     [<Test>]
+    [<Ignore("https://github.com/dotnet/fsharp/issues/11724")>]
     member public this.``Regression.ModulesFromExternalLibrariesBug5785``() =
         use _guard = this.UsingNewVS()
         let solution = this.CreateSolution()

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.TimeStamp.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.TimeStamp.fs
@@ -46,6 +46,7 @@ type UsingMSBuild()  =
     // In this bug, if you clean the dependent project, the dependee started getting errors again about the unresolved assembly.
     // The desired behavior is like C#, which is if the assembly disappears from disk, we use cached results of last time it was there.
     [<Test>]
+    [<Ignore("https://github.com/dotnet/fsharp/issues/11724")>]
     member public this.``Regression.NoError.Timestamps.Bug3368b``() =
         use _guard = this.UsingNewVS()
         let solution = this.CreateSolution()


### PR DESCRIPTION
I'm not sure what change could have caused these two tests to be flakey, but `Regression.NoError.Timestamps.Bug3368b` is failing because it's not including the reference DLLs in the command line options; apparently in order to get the references, it needs an instance of an `IVsSolution` which it cannot get because, the custom implemented `IServiceProvider` can only return two types and `IVsSolution` is not one of them - I don't even know how these tests were passing...

Regardless of that, these tests really do not represent reality; they do not even use Roslyn.

Currently in `main`, we have the ability to test Roslyn workspaces and our Roslyn services - if anything, we should start creating more tests based on those instead of relying on the crusty custom VS test implementation.