### PR TITLE
Added script reference test and clearing check file caches on re-created incremental build

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -334,6 +334,25 @@ type BackgroundCompiler(
         return (builderOpt, diagnostics)
       }
 
+    let parseCacheLock = Lock<ParseCacheLockToken>()
+    
+    // STATIC ROOT: FSharpLanguageServiceTestable.FSharpChecker.parseFileInProjectCache. Most recently used cache for parsing files.
+    let parseFileCache = MruCache<ParseCacheLockToken,(_ * SourceTextHash * _),_>(parseFileCacheSize, areSimilar = AreSimilarForParsing, areSame = AreSameForParsing)
+
+    // STATIC ROOT: FSharpLanguageServiceTestable.FSharpChecker.checkFileInProjectCache
+    //
+    /// Cache which holds recently seen type-checks.
+    /// This cache may hold out-of-date entries, in two senses
+    ///    - there may be a more recent antecedent state available because the background build has made it available
+    ///    - the source for the file may have changed
+
+    // Also keyed on source. This can only be out of date if the antecedent is out of date
+    let checkFileInProjectCache =
+        MruCache<ParseCacheLockToken, CheckFileCacheKey, GraphNode<CheckFileCacheValue>>
+            (keepStrongly=checkFileInProjectCacheSize,
+             areSame=AreSameForChecking3,
+             areSimilar=AreSubsumable3)
+
     // STATIC ROOT: FSharpLanguageServiceTestable.FSharpChecker.backgroundCompiler.incrementalBuildersCache. This root typically holds more 
     // live information than anything else in the F# Language Service, since it holds up to 3 (projectCacheStrongSize) background project builds
     // strongly.
@@ -388,6 +407,17 @@ type BackgroundCompiler(
                     Logger.Log LogCompilerFunctionId.Service_IncrementalBuildersCache_GettingCache
                     return builderOpt,creationDiags
                 | _ ->
+                    // The builder could be re-created,
+                    //    clear the check file caches that are associated with it.
+                    //    We must do this in order to not return stale results when a reference
+                    //    in the project changes/added/removed.
+                    parseCacheLock.AcquireLock(fun ltok -> 
+                        options.SourceFiles
+                        |> Array.iter (fun sourceFile ->
+                            let key = (sourceFile, 0L, options)
+                            checkFileInProjectCache.RemoveAnySimilar(ltok, key)
+                        )
+                    )
                     return! createAndGetBuilder (options, userOpName)
             }
         | _ -> 
@@ -412,25 +442,6 @@ type BackgroundCompiler(
             getBuilder
         | _ ->
             getOrCreateBuilder (options, userOpName)
-
-    let parseCacheLock = Lock<ParseCacheLockToken>()
-    
-    // STATIC ROOT: FSharpLanguageServiceTestable.FSharpChecker.parseFileInProjectCache. Most recently used cache for parsing files.
-    let parseFileCache = MruCache<ParseCacheLockToken,(_ * SourceTextHash * _),_>(parseFileCacheSize, areSimilar = AreSimilarForParsing, areSame = AreSameForParsing)
-
-    // STATIC ROOT: FSharpLanguageServiceTestable.FSharpChecker.checkFileInProjectCache
-    //
-    /// Cache which holds recently seen type-checks.
-    /// This cache may hold out-of-date entries, in two senses
-    ///    - there may be a more recent antecedent state available because the background build has made it available
-    ///    - the source for the file may have changed
-
-    // Also keyed on source. This can only be out of date if the antecedent is out of date
-    let checkFileInProjectCache =
-        MruCache<ParseCacheLockToken, CheckFileCacheKey, GraphNode<CheckFileCacheValue>>
-            (keepStrongly=checkFileInProjectCacheSize,
-             areSame=AreSameForChecking3,
-             areSimilar=AreSubsumable3)
 
     /// Should be a fast operation. Ensures that we have only one async lazy object per file and its hash.
     let getCheckFileNode (parseResults,

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -409,7 +409,7 @@ type BackgroundCompiler(
                 | _ ->
                     // The builder could be re-created,
                     //    clear the check file caches that are associated with it.
-                    //    We must do this in order to not return stale results when a references
+                    //    We must do this in order to not return stale results when references
                     //    in the project get changed/added/removed.
                     parseCacheLock.AcquireLock(fun ltok -> 
                         options.SourceFiles

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -409,8 +409,8 @@ type BackgroundCompiler(
                 | _ ->
                     // The builder could be re-created,
                     //    clear the check file caches that are associated with it.
-                    //    We must do this in order to not return stale results when a reference
-                    //    in the project changes/added/removed.
+                    //    We must do this in order to not return stale results when a references
+                    //    in the project get changed/added/removed.
                     parseCacheLock.AcquireLock(fun ltok -> 
                         options.SourceFiles
                         |> Array.iter (fun sourceFile ->

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -72,6 +72,54 @@ let test() =
             Assert.shouldBeEmpty(checkResults.Diagnostics)
             WeakReference(ms)
 
+    let compileFileAsDll (checker: FSharpChecker) filePath outputFilePath =
+        try
+            let result, _ =
+                checker.Compile([|"fsc.dll";filePath;$"-o:{ outputFilePath }";"--deterministic+";"--optimize+";"--target:library"|])
+                |> Async.RunSynchronously
+
+            if result.Length > 0 then
+                failwith "Compilation has errors."
+        with
+        | _ ->
+            try File.Delete(outputFilePath) with | _ -> ()
+            reraise()
+
+    let createOnDisk src =
+        let tmpFilePath = Path.GetTempFileName()
+        let tmpRealFilePath = Path.ChangeExtension(tmpFilePath, ".fs")
+        try File.Delete(tmpFilePath) with | _ -> ()
+        File.WriteAllText(tmpRealFilePath, src)
+        tmpRealFilePath
+
+    let createOnDiskCompiledAsDll checker src =
+        let tmpFilePath = Path.GetTempFileName()
+        let tmpRealFilePath = Path.ChangeExtension(tmpFilePath, ".fs")
+        try File.Delete(tmpFilePath) with | _ -> ()
+        File.WriteAllText(tmpRealFilePath, src)
+
+        let outputFilePath = Path.ChangeExtension(tmpRealFilePath, ".dll")
+
+        try
+            compileFileAsDll checker tmpRealFilePath outputFilePath
+            outputFilePath
+        finally
+            try File.Delete(tmpRealFilePath) with | _ -> ()
+
+    let updateFileOnDisk filePath src =
+        File.WriteAllText(filePath, src)
+
+    let updateCompiledDllOnDisk checker (dllPath: string) src =
+        if not (File.Exists dllPath) then
+            failwith $"File {dllPath} does not exist."
+
+        let filePath = createOnDisk src
+
+        try
+            compileFileAsDll checker filePath dllPath
+        finally
+            try File.Delete(filePath) with | _ -> ()
+
     [<Test>]
     let ``Using a CSharp reference project in-memory``() =
         AssertInMemoryCSharpReferenceIsValid() |> ignore
@@ -82,6 +130,74 @@ let test() =
         CompilerAssert.Checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
         GC.Collect(2, GCCollectionMode.Forced, true)
         Assert.shouldBeFalse(weakRef.IsAlive)
+
+    [<Test>]
+    let ``Using compiler service, file referencing a DLL will correctly update when the referenced DLL file changes``() =
+        let checker = CompilerAssert.Checker
+
+        let dllPath1 = 
+            createOnDiskCompiledAsDll checker
+                """
+module Script1
+
+let x = 1
+                """
+
+        let filePath1 = 
+            createOnDisk 
+                """
+module Script2
+
+let x = Script1.x
+                """
+        
+        try
+            let fsOptions1 = CompilerAssert.DefaultProjectOptions
+            let fsOptions1 =
+                { fsOptions1 with 
+                    ProjectId = Some(Guid.NewGuid().ToString())
+                    OtherOptions = [|"-r:" + dllPath1|]
+                    ReferencedProjects = [||]
+                    SourceFiles = [|filePath1|] }              
+
+            let checkProjectResults = 
+                checker.ParseAndCheckProject(fsOptions1)
+                |> Async.RunSynchronously
+
+            Assert.IsEmpty(checkProjectResults.Diagnostics)
+
+            updateFileOnDisk filePath1
+                $"""
+module Script2
+
+let x = Script1.x
+let y = Script1.y
+                """
+
+            let checkProjectResults = 
+                checker.ParseAndCheckProject(fsOptions1)
+                |> Async.RunSynchronously
+
+            Assert.IsNotEmpty(checkProjectResults.Diagnostics)
+
+            updateCompiledDllOnDisk checker dllPath1
+                $"""
+module Script1
+
+let x = 1
+let y = 1
+                """
+
+            let checkProjectResults = 
+                checker.ParseAndCheckProject(fsOptions1)
+                |> Async.RunSynchronously
+
+            Assert.IsEmpty(checkProjectResults.Diagnostics)
+
+        finally
+            try File.Delete(dllPath1) with | _ -> ()
+            try File.Delete(filePath1) with | _ -> ()
+
 
 
         

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -167,7 +167,7 @@ let x = Script1.x
             Assert.IsEmpty(checkProjectResults.Diagnostics)
 
             updateFileOnDisk filePath1
-                $"""
+                """
 module Script2
 
 let x = Script1.x
@@ -181,7 +181,7 @@ let y = Script1.y
             Assert.IsNotEmpty(checkProjectResults.Diagnostics)
 
             updateCompiledDllOnDisk checker dllPath1
-                $"""
+                """
 module Script1
 
 let x = 1

--- a/vsintegration/tests/UnitTests/Workspace/WorkspaceTests.fs
+++ b/vsintegration/tests/UnitTests/Workspace/WorkspaceTests.fs
@@ -392,7 +392,6 @@ module Script1
 
 let x = 1
                 """
-            |> ignore
 
             assertEmptyDocumentDiagnostics workspace filePath2
 
@@ -442,7 +441,6 @@ module Script1
 
 let x = 1
                 """
-            |> ignore
 
             assertEmptyDocumentDiagnostics workspace filePath2
 

--- a/vsintegration/tests/UnitTests/Workspace/WorkspaceTests.fs
+++ b/vsintegration/tests/UnitTests/Workspace/WorkspaceTests.fs
@@ -2,6 +2,7 @@
 
 open System
 open System.IO
+open System.Text
 open System.Reflection
 open System.Linq
 open System.Composition.Hosting
@@ -22,22 +23,19 @@ open NUnit.Framework
 [<TestFixture>]
 module WorkspaceTests =
 
-    let compileFileAsDll (workspace: Workspace) filePath =
+    let compileFileAsDll (workspace: Workspace) filePath outputFilePath =
         let workspaceService = workspace.Services.GetRequiredService<IFSharpWorkspaceService>()
-        let tmpRealDllPath = Path.ChangeExtension(filePath, ".dll")
 
         try
             let result, _ =
-                workspaceService.Checker.Compile([|"fsc.dll";filePath;$"-o:{ tmpRealDllPath }";"--deterministic+";"--optimize+";"--target:library"|])
+                workspaceService.Checker.Compile([|"fsc.dll";filePath;$"-o:{ outputFilePath }";"--deterministic+";"--optimize+";"--target:library"|])
                 |> Async.RunSynchronously
 
             if result.Length > 0 then
                 failwith "Compilation has errors."
-
-            tmpRealDllPath
         with
         | _ ->
-            try File.Delete(tmpRealDllPath) with | _ -> ()
+            try File.Delete(outputFilePath) with | _ -> ()
             reraise()
 
     let createOnDiskScript src =
@@ -53,8 +51,11 @@ module WorkspaceTests =
         try File.Delete(tmpFilePath) with | _ -> ()
         File.WriteAllText(tmpRealFilePath, src)
 
+        let outputFilePath = Path.ChangeExtension(tmpRealFilePath, ".dll")
+
         try
-            compileFileAsDll workspace tmpRealFilePath
+            compileFileAsDll workspace tmpRealFilePath outputFilePath
+            outputFilePath
         finally
             try File.Delete(tmpRealFilePath) with | _ -> ()
 
@@ -64,7 +65,24 @@ module WorkspaceTests =
     let createMiscFileWorkspace() =
         createWorkspace()
 
-    let openDocument (workspace: Workspace) (docId: DocumentId) =
+    let createProjectInfoWithFileOnDisk filePath =
+        RoslynTestHelpers.CreateProjectInfoWithSingleDocument(filePath, filePath)
+
+    let getDocumentId (workspace: Workspace) filePath =
+        let solution = workspace.CurrentSolution
+        solution.GetDocumentIdsWithFilePath(filePath) 
+        |> Seq.exactlyOne
+
+    let getDocument (workspace: Workspace) filePath =
+        let solution = workspace.CurrentSolution
+        solution.GetDocumentIdsWithFilePath(filePath) 
+        |> Seq.exactlyOne
+        |> solution.GetDocument
+
+    let openDocument (workspace: Workspace) (filePath: string) =
+        let docId =
+            workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath) 
+            |> Seq.exactlyOne
         use waitHandle = new ManualResetEventSlim(false)
         use _sub = workspace.DocumentOpened.Subscribe(fun _ ->
             waitHandle.Set()
@@ -72,11 +90,71 @@ module WorkspaceTests =
         workspace.OpenDocument(docId)
         waitHandle.Wait()
 
-    let getDocument (workspace: Workspace) filePath =
-        let solution = workspace.CurrentSolution
-        solution.GetDocumentIdsWithFilePath(filePath) 
-        |> Seq.exactlyOne
-        |> solution.GetDocument
+    let updateDocumentOnDisk (workspace: Workspace) filePath src =
+        File.WriteAllText(filePath, src)
+
+        let doc = getDocument workspace filePath
+        // The adhoc workspaces do not listen for files changing on disk,
+        // so we simulate the update here.
+        let newSolution = 
+            doc.Project.Solution.WithDocumentTextLoader(
+                doc.Id, 
+                new FileTextLoader(doc.FilePath, Encoding.Default),
+                PreservationMode.PreserveIdentity)
+        workspace.TryApplyChanges(newSolution) |> ignore
+
+    let updateCompiledDllOnDisk workspace (dllPath: string) src =
+        if not (File.Exists dllPath) then
+            failwith $"File {dllPath} does not exist."
+
+        let filePath = createOnDiskScript src
+
+        try
+            compileFileAsDll workspace filePath dllPath
+
+            let newMetadataReference = 
+                PortableExecutableReference.CreateFromFile(
+                    dllPath, 
+                    MetadataReferenceProperties.Assembly
+                )
+            // The adhoc workspaces do not listen for files changing on disk,
+            // so we simulate the update here.
+            let solution = workspace.CurrentSolution
+            let projects = solution.Projects
+            let newSolution =
+                (solution, projects)
+                ||> Seq.fold (fun solution proj ->
+                    let mutable mustUpdate = false
+                    let metadataReferences =
+                        proj.MetadataReferences
+                        |> Array.ofSeq
+                        |> Array.map (fun x ->
+                            match x with
+                            | :? PortableExecutableReference as x ->
+                                if String.Equals(x.FilePath, newMetadataReference.FilePath, StringComparison.OrdinalIgnoreCase) then
+                                    mustUpdate <- true
+                                    newMetadataReference :> MetadataReference
+                                else
+                                    x :> MetadataReference
+                            | _ ->
+                                x
+                        )
+
+                    if mustUpdate then
+                        solution.WithProjectMetadataReferences(proj.Id, metadataReferences)
+                    else
+                        solution
+                )
+            workspace.TryApplyChanges(newSolution) |> ignore
+        finally
+            try File.Delete(filePath) with | _ -> ()
+
+    let isDocumentOpen (workspace: Workspace) filePath =
+        let docId = getDocumentId workspace filePath
+        workspace.IsDocumentOpen(docId)
+
+    let hasDocument (workspace: Workspace) filePath =
+        workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Length > 0
 
     let addProject (workspace: Workspace) projInfo =
         if not (workspace.TryApplyChanges(workspace.CurrentSolution.AddProject(projInfo))) then
@@ -86,13 +164,15 @@ module WorkspaceTests =
         if not (workspace.TryApplyChanges(workspace.CurrentSolution.RemoveProject(projId))) then
             failwith "Unable to apply workspace changes."
 
-    let assertEmptyDocumentDiagnostics (doc: Document) =
+    let assertEmptyDocumentDiagnostics (workspace: Workspace) (filePath: string) =
+        let doc = getDocument workspace filePath
         let parseResults, checkResults = doc.GetFSharpParseAndCheckResultsAsync("assertEmptyDocumentDiagnostics") |> Async.RunSynchronously
         
         Assert.IsEmpty(parseResults.Diagnostics)
         Assert.IsEmpty(checkResults.Diagnostics)
 
-    let assertHasDocumentDiagnostics (doc: Document) =
+    let assertHasDocumentDiagnostics (workspace: Workspace) (filePath: string) =
+        let doc = getDocument workspace filePath
         let parseResults, checkResults = doc.GetFSharpParseAndCheckResultsAsync("assertHasDocumentDiagnostics") |> Async.RunSynchronously
         
         Assert.IsEmpty(parseResults.Diagnostics)
@@ -126,7 +206,7 @@ module WorkspaceTests =
                 let currentProj = mainProj
                 let mutable solution = currentProj.Solution
 
-                mainProj.ProjectReferences
+                currentProj.ProjectReferences
                 |> Seq.iter (fun projRef ->
                     solution <- solution.RemoveProjectReference(currentProj.Id, projRef)
                 )
@@ -137,6 +217,42 @@ module WorkspaceTests =
                         solution.AddProjectReference(
                             currentProj.Id, 
                             ProjectReference(projRef.Id)
+                        )
+                )
+
+                not (solution.Workspace.TryApplyChanges(solution)) |> ignore
+
+                mainProj <- solution.GetProject(currentProj.Id)
+
+            member this.MetadataReferenceCount: int = mainProj.MetadataReferences.Count
+
+            member this.HasMetadataReference(referencePath: string): bool =
+                mainProj.MetadataReferences
+                |> Seq.exists (fun x -> 
+                    match x with
+                    | :? PortableExecutableReference as r ->
+                        String.Equals(r.FilePath, referencePath, StringComparison.OrdinalIgnoreCase)
+                    | _ ->
+                        false)
+
+            member this.SetMetadataReferences(referencePaths: string seq): unit =
+                let currentProj = mainProj
+                let mutable solution = currentProj.Solution
+
+                currentProj.MetadataReferences
+                |> Seq.iter (fun r ->
+                    solution <- solution.RemoveMetadataReference(currentProj.Id, r)
+                )
+
+                referencePaths
+                |> Seq.iter (fun referencePath ->
+                    solution <- 
+                        solution.AddMetadataReference(
+                            currentProj.Id, 
+                            PortableExecutableReference.CreateFromFile(
+                                referencePath,
+                                MetadataReferenceProperties.Assembly
+                            )
                         )
                 )
 
@@ -178,26 +294,23 @@ let x = 1
                 """
         
         try
-            let projInfo = RoslynTestHelpers.CreateProjectInfoWithSingleDocument(filePath, filePath)
+            let projInfo = createProjectInfoWithFileOnDisk filePath
             addProject miscFilesWorkspace projInfo
-            
-            let doc = getDocument miscFilesWorkspace filePath
 
-            Assert.IsFalse(miscFilesWorkspace.IsDocumentOpen(doc.Id))
-            Assert.AreEqual(0, workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Length)
+            Assert.IsTrue(hasDocument miscFilesWorkspace filePath)
+            Assert.IsFalse(hasDocument workspace filePath)
 
-            openDocument miscFilesWorkspace doc.Id
-            // Although we opened the document, this is false as it has been transferred to the other workspace.
-            Assert.IsFalse(miscFilesWorkspace.IsDocumentOpen(doc.Id))
+            Assert.IsFalse(isDocumentOpen miscFilesWorkspace filePath)
+            openDocument miscFilesWorkspace filePath
 
-            Assert.AreEqual(0, miscFilesWorkspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Length)
-            Assert.AreEqual(1, workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Length)
+            // Although we opened the document, it has been transferred to the other workspace.
+            Assert.IsFalse(hasDocument miscFilesWorkspace filePath)
+            Assert.IsTrue(hasDocument workspace filePath)
 
-            let doc = getDocument workspace filePath
+            // Should not be automatically opened when transferred.
+            Assert.IsFalse(isDocumentOpen workspace filePath)
 
-            Assert.IsFalse(workspace.IsDocumentOpen(doc.Id))
-
-            assertEmptyDocumentDiagnostics doc
+            assertEmptyDocumentDiagnostics workspace filePath
 
         finally
             try File.Delete(filePath) with | _ -> ()
@@ -228,14 +341,10 @@ let x = Script1.x
                 """
         
         try
-            let projInfo2 = RoslynTestHelpers.CreateProjectInfoWithSingleDocument(filePath2, filePath2)
-
+            let projInfo2 = createProjectInfoWithFileOnDisk filePath2
             addProject miscFilesWorkspace projInfo2
-
-            openDocument miscFilesWorkspace (getDocument miscFilesWorkspace filePath2).Id            
-
-            let doc2 = getDocument workspace filePath2
-            assertEmptyDocumentDiagnostics doc2
+            openDocument miscFilesWorkspace filePath2       
+            assertEmptyDocumentDiagnostics workspace filePath2
 
         finally
             try File.Delete(filePath1) with | _ -> ()
@@ -265,29 +374,27 @@ let x = Script1.x
                 """
         
         try
-            let projInfo1 = RoslynTestHelpers.CreateProjectInfoWithSingleDocument(filePath1, filePath1)
-            let projInfo2 = RoslynTestHelpers.CreateProjectInfoWithSingleDocument(filePath2, filePath2)
+            let projInfo1 = createProjectInfoWithFileOnDisk filePath1
+            let projInfo2 = createProjectInfoWithFileOnDisk filePath2
 
             addProject miscFilesWorkspace projInfo1
             addProject miscFilesWorkspace projInfo2
 
-            openDocument miscFilesWorkspace (getDocument miscFilesWorkspace filePath1).Id
-            openDocument miscFilesWorkspace (getDocument miscFilesWorkspace filePath2).Id            
+            openDocument miscFilesWorkspace filePath1
+            openDocument miscFilesWorkspace filePath2           
             
-            let doc1 = getDocument workspace filePath1
-            assertEmptyDocumentDiagnostics doc1
+            assertEmptyDocumentDiagnostics workspace filePath1
+            assertHasDocumentDiagnostics workspace filePath2
 
-            let doc2 = getDocument workspace filePath2
-            assertHasDocumentDiagnostics doc2
-
-            File.WriteAllText(filePath1,
+            updateDocumentOnDisk workspace filePath1
                 """
 module Script1
 
 let x = 1
-                """)
+                """
+            |> ignore
 
-            assertEmptyDocumentDiagnostics doc2
+            assertEmptyDocumentDiagnostics workspace filePath2
 
         finally
             try File.Delete(filePath1) with | _ -> ()
@@ -317,29 +424,27 @@ let x = Script1.x
                 """
         
         try
-            let projInfo1 = RoslynTestHelpers.CreateProjectInfoWithSingleDocument(filePath1, filePath1)
-            let projInfo2 = RoslynTestHelpers.CreateProjectInfoWithSingleDocument(filePath2, filePath2)
+            let projInfo1 = createProjectInfoWithFileOnDisk filePath1
+            let projInfo2 = createProjectInfoWithFileOnDisk filePath2
 
             addProject miscFilesWorkspace projInfo1
             addProject miscFilesWorkspace projInfo2
 
-            openDocument miscFilesWorkspace (getDocument miscFilesWorkspace filePath2).Id
-            openDocument miscFilesWorkspace (getDocument miscFilesWorkspace filePath1).Id          
+            openDocument miscFilesWorkspace filePath2
+            openDocument miscFilesWorkspace filePath1         
             
-            let doc2 = getDocument workspace filePath2
-            assertHasDocumentDiagnostics doc2
+            assertHasDocumentDiagnostics workspace filePath2 
+            assertEmptyDocumentDiagnostics workspace filePath1
 
-            let doc1 = getDocument workspace filePath1
-            assertEmptyDocumentDiagnostics doc1
-
-            File.WriteAllText(filePath1,
+            updateDocumentOnDisk workspace filePath1
                 """
 module Script1
 
 let x = 1
-                """)
+                """
+            |> ignore
 
-            assertEmptyDocumentDiagnostics doc2
+            assertEmptyDocumentDiagnostics workspace filePath2
 
         finally
             try File.Delete(filePath1) with | _ -> ()
@@ -371,14 +476,34 @@ let x = Script1.x
                 """
         
         try
-            let projInfo1 = RoslynTestHelpers.CreateProjectInfoWithSingleDocument(filePath1, filePath1)
+            let projInfo1 = createProjectInfoWithFileOnDisk filePath1
 
             addProject miscFilesWorkspace projInfo1
 
-            openDocument miscFilesWorkspace (getDocument miscFilesWorkspace filePath1).Id          
+            openDocument miscFilesWorkspace filePath1         
 
-            let doc1 = getDocument workspace filePath1
-            assertEmptyDocumentDiagnostics doc1
+            assertEmptyDocumentDiagnostics workspace filePath1
+
+            updateDocumentOnDisk workspace filePath1
+                $"""
+module Script2
+#r "{ Path.GetFileName(dllPath1) }"
+
+let x = Script1.x
+let y = Script1.y
+                """
+
+            assertHasDocumentDiagnostics workspace filePath1
+
+            updateCompiledDllOnDisk workspace dllPath1
+                $"""
+module Script1
+
+let x = 1
+let y = 1
+                """
+
+            assertEmptyDocumentDiagnostics workspace filePath1
 
         finally
             try File.Delete(filePath1) with | _ -> ()

--- a/vsintegration/tests/UnitTests/Workspace/WorkspaceTests.fs
+++ b/vsintegration/tests/UnitTests/Workspace/WorkspaceTests.fs
@@ -494,7 +494,7 @@ let y = Script1.y
             assertHasDocumentDiagnostics workspace filePath1
 
             updateCompiledDllOnDisk workspace dllPath1
-                $"""
+                """
 module Script1
 
 let x = 1

--- a/vsintegration/tests/UnitTests/Workspace/WorkspaceTests.fs
+++ b/vsintegration/tests/UnitTests/Workspace/WorkspaceTests.fs
@@ -506,4 +506,5 @@ let y = 1
             assertEmptyDocumentDiagnostics workspace filePath1
 
         finally
+            try File.Delete(dllPath1) with | _ -> ()
             try File.Delete(filePath1) with | _ -> ()


### PR DESCRIPTION
This adds a single test to `WorkspaceTests` that tests whether or not the script will update properly when a DLL file that it is referencing changes.

When first writing the test, it was failing because FCS was returning back cached/stale check file results even after the incremental build was re-created when one of its references changed. Clearing the items associated with the project in the cache fixed this issue. 

What caused the issue in the first place, wasn't necessarily due to not clearing any caches, but because I made a change where the first file was returning `DateTime.MinValue` instead of the `defaultTimeStamp` which gets set to `DateTime.UtcNow` when an incremental build gets created. I made an additional change to return the `defaultTimeStamp`.