### PR TITLE
Add internal `block` type for use in the compiler. `IncrementalBuilder` only maintains two states

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -190,6 +190,12 @@
     <Compile Include="..\lib.fs">
       <Link>Utilities\lib.fs</Link>
     </Compile>
+    <Compile Include="..\block.fsi">
+      <Link>Utilities\block.fsi</Link>
+    </Compile>
+    <Compile Include="..\block.fs">
+      <Link>Utilities\block.fs</Link>
+    </Compile>
     <Compile Include="..\rational.fsi">
       <Link>Utilities\rational.fsi</Link>
     </Compile>

--- a/src/fsharp/block.fs
+++ b/src/fsharp/block.fs
@@ -177,7 +177,7 @@ module Block =
         builder.Capacity <- builder.Count
         builder.MoveToImmutable()
 
-    let isEmpty (arr: block<_>) = arr.Length = 0
+    let isEmpty (arr: block<_>) = arr.IsEmpty
 
     let fold folder state (arr: block<_>) =
         let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(folder)

--- a/src/fsharp/block.fs
+++ b/src/fsharp/block.fs
@@ -1,0 +1,222 @@
+module Internal.Utilities.Library.Block
+
+open System.Collections.Immutable
+
+type block<'T> = ImmutableArray<'T>
+type blockbuilder<'T> = ImmutableArray<'T>.Builder
+
+[<RequireQualifiedAccess>]
+module BlockBuilder =
+
+    let create size : blockbuilder<'T> =
+        if size = 0 then
+            ImmutableArray.CreateBuilder()
+        else
+            ImmutableArray.CreateBuilder(size)
+
+[<RequireQualifiedAccess>]
+module Block =
+
+    let empty<'T> = ImmutableArray<'T>.Empty
+
+    let init n (f: int -> 'T) : block<_> =
+        match n with
+        | 0 -> ImmutableArray.Empty
+        | 1 -> ImmutableArray.Create(f 0)
+        | n ->
+            if n < 0 then
+                invalidArg "n" "Below zero."
+
+            let builder = ImmutableArray.CreateBuilder(n)
+            for i = 0 to n - 1 do
+                builder.Add(f i)
+            builder.ToImmutable()
+
+    let iter f (arr: block<'T>) =
+        for i = 0 to arr.Length - 1 do
+            f arr.[i]
+
+    let iteri f (arr: block<'T>) =
+        for i = 0 to arr.Length - 1 do
+            f i arr.[i]
+
+    let iter2 f (arr1: block<'T1>) (arr2: block<'T2>) =
+        if arr1.Length <> arr2.Length then
+            invalidOp "Block lengths do not match."
+
+        for i = 0 to arr1.Length - 1 do
+            f arr1.[i] arr2.[i]
+
+    let iteri2 f (arr1: block<'T1>) (arr2: block<'T2>) =
+        if arr1.Length <> arr2.Length then
+            invalidOp "Block lengths do not match."
+
+        for i = 0 to arr1.Length - 1 do
+            f i arr1.[i] arr2.[i]
+
+    let map (mapper: 'T -> 'U) (arr: block<'T>) : block<_> =
+        match arr.Length with
+        | 0 -> block.Empty
+        | 1 -> ImmutableArray.Create(mapper arr.[0])
+        | _ ->
+            let builder = ImmutableArray.CreateBuilder(arr.Length)
+            for i = 0 to arr.Length - 1 do
+                builder.Add(mapper arr.[i])
+            builder.ToImmutable()
+
+    let mapi (mapper: int -> 'T -> 'U) (arr: block<'T>) : block<_> =
+        match arr.Length with
+        | 0 -> block.Empty
+        | 1 -> ImmutableArray.Create(mapper 0 arr.[0])
+        | _ ->
+            let builder = ImmutableArray.CreateBuilder(arr.Length)
+            for i = 0 to arr.Length - 1 do
+                builder.Add(mapper i arr.[i])
+            builder.ToImmutable()
+
+    let map2 (mapper: 'T1 -> 'T2 -> 'T) (arr1: block<'T1>) (arr2: block<'T2>) : block<_> =
+        if arr1.Length <> arr2.Length then
+            invalidOp "Block lengths do not match."
+      
+        match arr1.Length with
+        | 0 -> ImmutableArray.Empty
+        | 1 -> ImmutableArray.Create(mapper arr1.[0] arr2.[0])
+        | n ->
+            let builder = ImmutableArray.CreateBuilder(n)
+            for i = 0 to n - 1 do
+                builder.Add(mapper arr1.[i] arr2.[i])
+            builder.ToImmutable()
+
+    let mapi2 (mapper: int -> 'T1 -> 'T2 -> 'T) (arr1: block<'T1>) (arr2: block<'T2>) : block<_> =
+        if arr1.Length <> arr2.Length then
+            invalidOp "Block lengths do not match."
+      
+        match arr1.Length with
+        | 0 -> ImmutableArray.Empty
+        | 1 -> ImmutableArray.Create(mapper 0 arr1.[0] arr2.[0])
+        | n ->
+            let builder = ImmutableArray.CreateBuilder(n)
+            for i = 0 to n - 1 do
+                builder.Add(mapper i arr1.[i] arr2.[i])
+            builder.ToImmutable()
+
+    let concat (arr: block<block<'T>>) : block<'T> =
+        if arr.IsEmpty then
+            empty
+        elif arr.Length = 1 then
+            arr.[0]
+        elif arr.Length = 2 then
+            arr.[0].AddRange(arr.[1])
+        else
+            let mutable arr2 = arr.[0]
+            for i = 1 to arr.Length - 1 do
+                arr2 <- arr2.AddRange(arr.[i])
+            arr2
+
+    let forall predicate (arr: block<'T>) =
+        match arr.Length with
+        | 0 -> true
+        | 1 -> predicate arr.[0]
+        | n ->
+            let mutable result = true
+            let mutable i = 0
+            while result && i < n do
+                result <- predicate arr.[i]
+                i <- i + 1
+            result
+
+    let forall2 predicate (arr1: block<'T1>) (arr2: block<'T2>) =
+        if arr1.Length <> arr2.Length then
+            invalidOp "Block lengths do not match."
+
+        match arr1.Length with
+        | 0 -> true
+        | 1 -> predicate arr1.[0] arr2.[0]
+        | n ->
+            let mutable result = true
+            let mutable i = 0
+            while result && i < n do
+                result <- predicate arr1.[i] arr2.[i]
+                i <- i + 1
+            result
+
+    let tryFind predicate (arr: block<'T>) =
+        match arr.Length with
+        | 0 -> None
+        | 1 -> if predicate arr.[0] then Some arr.[0] else None
+        | n ->
+            let mutable result = None
+            let mutable i = 0
+            while result.IsNone && i < n do
+                if predicate arr.[i] then
+                    result <- Some arr.[i]
+                i <- i + 1
+            result
+
+    let tryFindIndex predicate (arr: block<'T>) =
+        match arr.Length with
+        | 0 -> None
+        | 1 -> if predicate arr.[0] then Some 0 else None
+        | n ->
+            let mutable result = None
+            let mutable i = 0
+            while result.IsNone && i < n do
+                if predicate arr.[i] then
+                    result <- Some i
+                i <- i + 1
+            result
+
+    let tryPick chooser (arr: block<'T>) =
+        match arr.Length with
+        | 0 -> None
+        | 1 -> chooser arr.[0]
+        | n ->
+            let mutable result = None
+            let mutable i = 0
+            while result.IsNone && i < n do
+                result <- chooser arr.[i]
+                i <- i + 1
+            result
+
+    let ofSeq (xs: 'T seq) =
+        ImmutableArray.CreateRange(xs)
+
+    let append (arr1: block<'T1>) (arr2: block<'T1>) : block<_> =
+        arr1.AddRange(arr2)
+
+    let createOne (item: 'T) : block<_> =
+        ImmutableArray.Create(item)
+
+    let filter predicate (arr: block<'T>) : block<'T> =
+        let builder = ImmutableArray.CreateBuilder(arr.Length)
+        for i = 0 to arr.Length - 1 do
+            if predicate arr.[i] then
+                builder.Add(arr.[i])
+        builder.ToImmutable()
+
+    let exists predicate (arr: block<'T>) =
+        let n = arr.Length
+        let mutable result = false
+        let mutable i = 0
+        while not result && i < n do
+            if predicate arr.[i] then
+                result <- true
+            i <- i + 1
+        result
+
+    let choose (chooser: 'T -> 'U option) (arr: block<'T>) : block<'U> =
+        let builder = ImmutableArray.CreateBuilder(arr.Length)
+        for i = 0 to arr.Length - 1 do
+            let result = chooser arr.[i]
+            if result.IsSome then
+                builder.Add(result.Value)
+        builder.ToImmutable()
+
+    let isEmpty (arr: block<_>) = arr.Length = 0
+
+    let fold folder state (arr: block<_>) =
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(folder)
+        let mutable state = state
+        for i = 0 to arr.Length - 1 do 
+            state <- f.Invoke(state, arr.[i])
+        state

--- a/src/fsharp/block.fs
+++ b/src/fsharp/block.fs
@@ -9,14 +9,12 @@ type blockbuilder<'T> = ImmutableArray<'T>.Builder
 module BlockBuilder =
 
     let create size : blockbuilder<'T> =
-        if size = 0 then
-            ImmutableArray.CreateBuilder()
-        else
-            ImmutableArray.CreateBuilder(size)
+        ImmutableArray.CreateBuilder(size)
 
 [<RequireQualifiedAccess>]
 module Block =
 
+    [<GeneralizableValue>]
     let empty<'T> = ImmutableArray<'T>.Empty
 
     let init n (f: int -> 'T) : block<_> =
@@ -30,7 +28,7 @@ module Block =
             let builder = ImmutableArray.CreateBuilder(n)
             for i = 0 to n - 1 do
                 builder.Add(f i)
-            builder.ToImmutable()
+            builder.MoveToImmutable()
 
     let iter f (arr: block<'T>) =
         for i = 0 to arr.Length - 1 do
@@ -56,23 +54,23 @@ module Block =
 
     let map (mapper: 'T -> 'U) (arr: block<'T>) : block<_> =
         match arr.Length with
-        | 0 -> block.Empty
+        | 0 -> ImmutableArray.Empty
         | 1 -> ImmutableArray.Create(mapper arr.[0])
         | _ ->
             let builder = ImmutableArray.CreateBuilder(arr.Length)
             for i = 0 to arr.Length - 1 do
                 builder.Add(mapper arr.[i])
-            builder.ToImmutable()
+            builder.MoveToImmutable()
 
     let mapi (mapper: int -> 'T -> 'U) (arr: block<'T>) : block<_> =
         match arr.Length with
-        | 0 -> block.Empty
+        | 0 -> ImmutableArray.Empty
         | 1 -> ImmutableArray.Create(mapper 0 arr.[0])
         | _ ->
             let builder = ImmutableArray.CreateBuilder(arr.Length)
             for i = 0 to arr.Length - 1 do
                 builder.Add(mapper i arr.[i])
-            builder.ToImmutable()
+            builder.MoveToImmutable()
 
     let map2 (mapper: 'T1 -> 'T2 -> 'T) (arr1: block<'T1>) (arr2: block<'T2>) : block<_> =
         if arr1.Length <> arr2.Length then
@@ -85,7 +83,7 @@ module Block =
             let builder = ImmutableArray.CreateBuilder(n)
             for i = 0 to n - 1 do
                 builder.Add(mapper arr1.[i] arr2.[i])
-            builder.ToImmutable()
+            builder.MoveToImmutable()
 
     let mapi2 (mapper: int -> 'T1 -> 'T2 -> 'T) (arr1: block<'T1>) (arr2: block<'T2>) : block<_> =
         if arr1.Length <> arr2.Length then
@@ -98,85 +96,55 @@ module Block =
             let builder = ImmutableArray.CreateBuilder(n)
             for i = 0 to n - 1 do
                 builder.Add(mapper i arr1.[i] arr2.[i])
-            builder.ToImmutable()
+            builder.MoveToImmutable()
 
-    let concat (arr: block<block<'T>>) : block<'T> =
-        if arr.IsEmpty then
-            empty
-        elif arr.Length = 1 then
-            arr.[0]
-        elif arr.Length = 2 then
-            arr.[0].AddRange(arr.[1])
-        else
-            let mutable arr2 = arr.[0]
-            for i = 1 to arr.Length - 1 do
-                arr2 <- arr2.AddRange(arr.[i])
-            arr2
+    let concat (arrs: block<block<'T>>) : block<'T> =
+        match arrs.Length with
+        | 0 -> ImmutableArray.Empty
+        | 1 -> arrs.[0]
+        | 2 -> arrs.[0].AddRange(arrs.[1])
+        | _ ->
+            let mutable acc = 0    
+            for h in arrs do
+                acc <- acc + h.Length
+
+            let builder = ImmutableArray.CreateBuilder(acc)
+            for i = 0 to arrs.Length - 1 do
+                builder.AddRange(arrs.[i])
+            builder.MoveToImmutable()
 
     let forall predicate (arr: block<'T>) =
-        match arr.Length with
-        | 0 -> true
-        | 1 -> predicate arr.[0]
-        | n ->
-            let mutable result = true
-            let mutable i = 0
-            while result && i < n do
-                result <- predicate arr.[i]
-                i <- i + 1
-            result
+        let len = arr.Length
+        let rec loop i = i >= len || (predicate arr.[i] && loop (i+1))
+        loop 0
 
     let forall2 predicate (arr1: block<'T1>) (arr2: block<'T2>) =
         if arr1.Length <> arr2.Length then
             invalidOp "Block lengths do not match."
 
-        match arr1.Length with
-        | 0 -> true
-        | 1 -> predicate arr1.[0] arr2.[0]
-        | n ->
-            let mutable result = true
-            let mutable i = 0
-            while result && i < n do
-                result <- predicate arr1.[i] arr2.[i]
-                i <- i + 1
-            result
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(predicate)
+        let len1 = arr1.Length
+        let rec loop i = i >= len1 || (f.Invoke(arr1.[i], arr2.[i]) && loop (i+1))
+        loop 0
 
     let tryFind predicate (arr: block<'T>) =
-        match arr.Length with
-        | 0 -> None
-        | 1 -> if predicate arr.[0] then Some arr.[0] else None
-        | n ->
-            let mutable result = None
-            let mutable i = 0
-            while result.IsNone && i < n do
-                if predicate arr.[i] then
-                    result <- Some arr.[i]
-                i <- i + 1
-            result
+        let rec loop i = 
+            if i >= arr.Length then None else 
+            if predicate arr.[i] then Some arr.[i]  else loop (i+1)
+        loop 0 
 
     let tryFindIndex predicate (arr: block<'T>) =
-        match arr.Length with
-        | 0 -> None
-        | 1 -> if predicate arr.[0] then Some 0 else None
-        | n ->
-            let mutable result = None
-            let mutable i = 0
-            while result.IsNone && i < n do
-                if predicate arr.[i] then
-                    result <- Some i
-                i <- i + 1
-            result
+        let len = arr.Length 
+        let rec go n = if n >= len then None elif predicate arr.[n] then Some n else go (n+1)
+        go 0 
 
     let tryPick chooser (arr: block<'T>) =
-        match arr.Length with
-        | 0 -> None
-        | 1 -> chooser arr.[0]
-        | n ->
-            let mutable result = None
-            let mutable i = 0
-            while result.IsNone && i < n do
-                result <- chooser arr.[i]
-                i <- i + 1
-            result
+        let rec loop i = 
+            if i >= arr.Length then None else 
+            match chooser arr.[i] with 
+            | None -> loop(i+1)
+            | res -> res
+        loop 0 
 
     let ofSeq (xs: 'T seq) =
         ImmutableArray.CreateRange(xs)
@@ -192,17 +160,13 @@ module Block =
         for i = 0 to arr.Length - 1 do
             if predicate arr.[i] then
                 builder.Add(arr.[i])
-        builder.ToImmutable()
+        builder.Capacity <- builder.Count
+        builder.MoveToImmutable()
 
     let exists predicate (arr: block<'T>) =
-        let n = arr.Length
-        let mutable result = false
-        let mutable i = 0
-        while not result && i < n do
-            if predicate arr.[i] then
-                result <- true
-            i <- i + 1
-        result
+        let len = arr.Length
+        let rec loop i = i < len && (predicate arr.[i] || loop (i+1))
+        len > 0 && loop 0
 
     let choose (chooser: 'T -> 'U option) (arr: block<'T>) : block<'U> =
         let builder = ImmutableArray.CreateBuilder(arr.Length)
@@ -210,7 +174,8 @@ module Block =
             let result = chooser arr.[i]
             if result.IsSome then
                 builder.Add(result.Value)
-        builder.ToImmutable()
+        builder.Capacity <- builder.Count
+        builder.MoveToImmutable()
 
     let isEmpty (arr: block<_>) = arr.Length = 0
 

--- a/src/fsharp/block.fsi
+++ b/src/fsharp/block.fsi
@@ -1,0 +1,62 @@
+[<AutoOpen>]
+module internal Internal.Utilities.Library.Block
+
+open System.Collections.Immutable
+
+/// Type alias for System.Collections.Immutable.ImmutableArray<'T>
+type block<'T> = ImmutableArray<'T>
+
+/// Type alias for System.Collections.Immutable.ImmutableArray<'T>.Builder
+type blockbuilder<'T> = ImmutableArray<'T>.Builder
+
+[<RequireQualifiedAccess>]
+module BlockBuilder =
+
+    val create : size: int -> blockbuilder<'T>
+
+[<RequireQualifiedAccess>]
+module Block =
+
+    val empty<'T> : block<'T>
+
+    val init : n: int -> f: (int -> 'T) -> block<'T>
+
+    val iter : f: ('T -> unit) -> block<'T> -> unit
+
+    val iteri : f: (int -> 'T -> unit) -> block<'T> -> unit
+
+    val iter2 : f: ('T1 -> 'T2 -> unit) -> block<'T1> -> block<'T2> -> unit
+
+    val iteri2 : f: (int -> 'T1 -> 'T2 -> unit) -> block<'T1> -> block<'T2> -> unit
+
+    val map : mapper: ('T1 -> 'T2) -> block<'T1> -> block<'T2>
+
+    val mapi : mapper: (int -> 'T1 -> 'T2) -> block<'T1> -> block<'T2>
+
+    val concat : block<block<'T>> -> block<'T>
+
+    val forall : predicate: ('T -> bool) -> block<'T> -> bool
+
+    val forall2 : predicate: ('T1 -> 'T2 -> bool) -> block<'T1> -> block<'T2> -> bool
+
+    val tryFind : predicate: ('T -> bool) -> block<'T> -> 'T option
+
+    val tryFindIndex : predicate: ('T -> bool) -> block<'T> -> int option
+
+    val tryPick : chooser: ('T1 -> 'T2 option) -> block<'T1> -> 'T2 option
+
+    val ofSeq : seq<'T> -> block<'T>
+
+    val append : block<'T> -> block<'T> -> block<'T>
+
+    val createOne : 'T -> block<'T>
+
+    val filter : predicate: ('T -> bool) -> block<'T> -> block<'T>
+
+    val exists : predicate: ('T -> bool) -> block<'T> -> bool
+
+    val choose : chooser: ('T -> 'U option) -> block<'T> -> block<'U>
+
+    val isEmpty : block<'T> -> bool
+
+    val fold : folder: ('State -> 'T -> 'State) -> 'State -> block<'T> -> 'State

--- a/src/fsharp/block.fsi
+++ b/src/fsharp/block.fsi
@@ -17,6 +17,7 @@ module BlockBuilder =
 [<RequireQualifiedAccess>]
 module Block =
 
+    [<GeneralizableValue>]
     val empty<'T> : block<'T>
 
     val init : n: int -> f: (int -> 'T) -> block<'T>

--- a/src/fsharp/lib.fs
+++ b/src/fsharp/lib.fs
@@ -604,3 +604,4 @@ module ArrayParallel =
 
     let inline map f (arr: 'T []) =
         arr |> mapi (fun _ item -> f item)
+   

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -832,7 +832,7 @@ module IncrementalBuilderHelpers =
 
         let! results =
             boundModels 
-            |> Seq.map (fun boundModel -> node { 
+            |> Block.map (fun boundModel -> node { 
                 if enablePartialTypeChecking then
                     let! tcInfo = boundModel.GetOrComputeTcInfo()
                     return tcInfo, None
@@ -840,7 +840,7 @@ module IncrementalBuilderHelpers =
                     let! tcInfo, tcInfoExtras = boundModel.GetOrComputeTcInfoWithExtras()
                     return tcInfo, tcInfoExtras.latestImplFile
             })
-            |> Seq.map (fun work ->
+            |> Block.map (fun work ->
                 node {
                     let! tcInfo, latestImplFile = work
                     return (tcInfo.tcEnvAtEndOfFile, defaultArg tcInfo.topAttribs EmptyTopAttrs, latestImplFile, tcInfo.latestCcuSigForFile)
@@ -1339,7 +1339,7 @@ type IncrementalBuilder(initialState: IncrementalBuilderInitialState, state: Inc
                    String.Compare(filename, f2, StringComparison.CurrentCultureIgnoreCase)=0
                 || String.Compare(FileSystem.GetFullPathShim filename, FileSystem.GetFullPathShim f2, StringComparison.CurrentCultureIgnoreCase)=0
             result
-        match fileNames |> Seq.tryFindIndex CompareFileNames with
+        match fileNames |> Block.tryFindIndex CompareFileNames with
         | Some slot -> Some slot
         | None -> None
 
@@ -1399,7 +1399,7 @@ type IncrementalBuilder(initialState: IncrementalBuilderInitialState, state: Inc
             let tcConfigB, sourceFiles =
 
                 let getSwitchValue switchString =
-                    match commandLineArgs |> Seq.tryFindIndex(fun s -> s.StartsWithOrdinal switchString) with
+                    match commandLineArgs |> List.tryFindIndex(fun s -> s.StartsWithOrdinal switchString) with
                     | Some idx -> Some(commandLineArgs.[idx].Substring(switchString.Length))
                     | _ -> None
 

--- a/tests/FSharp.Compiler.UnitTests/BlockTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/BlockTests.fs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+namespace FSharp.Compiler.UnitTests
+
+open Xunit
+open FSharp.Test.Utilities
+open Internal.Utilities.Library
+
+module BlockTests =
+
+    [<Fact>]
+    let ``Iter should work correctly``() =
+        let b = Block.init 5 id
+
+        let results = ResizeArray()
+        b
+        |> Block.iter (fun x ->
+            results.Add(x)
+        )
+
+        Assert.Equal(
+            [
+                0
+                1
+                2
+                3
+                4
+            ],
+            results
+        )
+
+    [<Fact>]
+    let ``Map should work correctly``() =
+        let b = Block.init 5 id
+
+        let b2 = b |> Block.map (fun x -> x + 1)
+
+        Assert.Equal(
+            [
+                1
+                2
+                3
+                4
+                5
+            ],
+            b2
+        )
+
+    [<Fact>]
+    let ``Fold should work correctly``() =
+        let b = Block.init 5 id
+
+        let result =
+            (0, b)
+            ||> Block.fold (fun state n ->
+                state + n
+            )
+
+        Assert.Equal(10, result)

--- a/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.UnitTests.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="EditDistance.fs" />
     <Compile Include="SuggestionBuffer.fs" />
     <Compile Include="ByteMemoryTests.fs" />
+    <Compile Include="BlockTests.fs" />
     <Compile Include="BuildGraphTests.fs" />
     <Compile Include="FsiTests.fs" />
     <Compile Include="AssemblySigningAttributes.fs" />


### PR DESCRIPTION
This is mostly a refactoring PR. It does add the `block` type for internal compiler use; it is basically `ImmutableArray<'T>` but with F# idiomatic collection functions.

Incremental Builder changes:
- Added `IncrementalBuilderInitialState` to group the initial state when creating an `IncrementalBuilder` internally.
- Lifted a lot of local functions in `IncrementalBuilder` to be top-level.
- `IncrementalBuilder` now manages only two states: `IncrementalBuilderInitialState` and `IncrementalBuilderState`.