### PR TITLE
minor fix of duplicate definition in ServiceLexing.fsi

### DIFF
--- a/src/fsharp/service/ServiceLexing.fsi
+++ b/src/fsharp/service/ServiceLexing.fsi
@@ -340,16 +340,14 @@ module FSharpKeywords =
     val DoesIdentifierNeedQuotation : string -> bool
 
     /// Add backticks if the identifier is a keyword.
+    /// A utility to help determine if an identifier needs to be quoted, this doesn't quote F# keywords.
     val QuoteIdentifierIfNeeded : string -> string
 
     /// Remove backticks if present.
     val NormalizeIdentifierBackticks : string -> string
 
     /// Keywords paired with their descriptions. Used in completion and quick info.
-    val KeywordsWithDescription : (string * string) list
-
-    /// A utility to help determine if an identifier needs to be quoted, this doesn't quote F# keywords.
-    val QuoteIdentifierIfNeeded: string -> string
+    val KeywordsWithDescription : (string * string) list      
 
     /// All the keywords in the F# language
     val KeywordNames: string list

--- a/src/fsharp/service/ServiceLexing.fsi
+++ b/src/fsharp/service/ServiceLexing.fsi
@@ -347,7 +347,7 @@ module FSharpKeywords =
     val NormalizeIdentifierBackticks : string -> string
 
     /// Keywords paired with their descriptions. Used in completion and quick info.
-    val KeywordsWithDescription : (string * string) list      
+    val KeywordsWithDescription : (string * string) list
 
     /// All the keywords in the F# language
     val KeywordNames: string list
@@ -579,4 +579,3 @@ type public FSharpLexer =
         
     [<Experimental("This FCS API is experimental and subject to change.")>]
     static member Tokenize: text: ISourceText * tokenCallback: (FSharpToken -> unit) * ?langVersion: string * ?filePath: string * ?conditionalCompilationDefines: string list * ?flags: FSharpLexerFlags * ?pathMap: Map<string, string> * ?ct: CancellationToken -> unit
-


### PR DESCRIPTION
`val QuoteIdentifierIfNeeded` apeared twice