### PR TITLE
Correct body SynExpr of parsedData of Lambda when wildcards are involved.

### DIFF
--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -174,10 +174,15 @@ let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
                 let id = mkSynId m nm
                 let item = mkSynIdGet m nm
                 true, None, id, item
-        SynSimplePat.Id (id, altNameRefCell, isCompGen, false, false, id.idRange),
-        Some (fun e ->
-                let clause = SynMatchClause(p, None, e, m, DebugPointForTarget.No)
-                SynExpr.Match (DebugPointAtBinding.NoneAtInvisible, item, [clause], clause.Range))
+        let fn =
+            match p with
+            | SynPat.Wild _ -> None
+            | _ ->
+                Some (fun e ->
+                    let clause = SynMatchClause(p, None, e, m, DebugPointForTarget.No)
+                    SynExpr.Match (DebugPointAtBinding.NoneAtInvisible, item, [clause], clause.Range))
+
+        SynSimplePat.Id (id, altNameRefCell, isCompGen, false, false, id.idRange), fn
 
 let appFunOpt funOpt x = match funOpt with None -> x | Some f -> f x
 

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.il.bsl
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:7:0:0
+  .ver 5:0:0:0
 }
 .assembly DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x0000027A
+  // Offset: 0x00000000 Length: 0x0000028D
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000280 Length: 0x000000BA
+  // Offset: 0x00000298 Length: 0x000000BA
 }
 .module DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.exe
-// MVID: {5EAD3E33-1475-D984-A745-0383333EAD5E}
+// MVID: {60E47018-1475-D984-A745-03831870E460}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00B10000
+// Image base: 0x07120000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -58,15 +58,11 @@
     .method assembly static void  Invoke(object x,
                                          int32 _arg1) cil managed
     {
-      // Code size       3 (0x3)
-      .maxstack  5
-      .locals init ([0] int32 V_0)
+      // Code size       1 (0x1)
+      .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.fs'
-      IL_0000:  ldarg.1
-      IL_0001:  stloc.0
-      .line 6,6 : 80,82 ''
-      IL_0002:  ret
+      .line 6,6 : 80,82 'C:\\GitHub\\dsyme\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.fs'
+      IL_0000:  ret
     } // end of method F@6::Invoke
 
   } // end of class F@6

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_Array_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_Array_FSInterface_NoExtMeth.il.bsl
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:7:0:0
+  .ver 5:0:0:0
 }
 .assembly DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x00000261
+  // Offset: 0x00000000 Length: 0x00000273
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000268 Length: 0x000000AC
+  // Offset: 0x00000278 Length: 0x000000AC
 }
 .module DoNotBoxStruct_Array_FSInterface_NoExtMeth.exe
-// MVID: {5EAD3E33-8127-3EE3-A745-0383333EAD5E}
+// MVID: {60E47018-8127-3EE3-A745-03831870E460}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00AF0000
+// Image base: 0x054A0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -58,15 +58,11 @@
     .method assembly static void  Invoke(object x,
                                          int32 _arg1) cil managed
     {
-      // Code size       3 (0x3)
-      .maxstack  5
-      .locals init ([0] int32 V_0)
+      // Code size       1 (0x1)
+      .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_Array_FSInterface_NoExtMeth.fs'
-      IL_0000:  ldarg.1
-      IL_0001:  stloc.0
-      .line 6,6 : 74,76 ''
-      IL_0002:  ret
+      .line 6,6 : 74,76 'C:\\GitHub\\dsyme\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_Array_FSInterface_NoExtMeth.fs'
+      IL_0000:  ret
     } // end of method F@6::Invoke
 
   } // end of class F@6

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.il.bsl
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:7:0:0
+  .ver 5:0:0:0
 }
 .assembly DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x00000268
+  // Offset: 0x00000000 Length: 0x0000027A
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000270 Length: 0x000000B0
+  // Offset: 0x00000280 Length: 0x000000B0
 }
 .module DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.exe
-// MVID: {5EAD3E33-A67D-867A-A745-0383333EAD5E}
+// MVID: {60E47018-A67D-867A-A745-03831870E460}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x06A00000
+// Image base: 0x056F0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -58,15 +58,11 @@
     .method assembly static void  Invoke(object x,
                                          int32 _arg1) cil managed
     {
-      // Code size       3 (0x3)
-      .maxstack  5
-      .locals init ([0] int32 V_0)
+      // Code size       1 (0x1)
+      .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.fs'
-      IL_0000:  ldarg.1
-      IL_0001:  stloc.0
-      .line 6,6 : 77,79 ''
-      IL_0002:  ret
+      .line 6,6 : 77,79 'C:\\GitHub\\dsyme\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.fs'
+      IL_0000:  ret
     } // end of method F@6::Invoke
 
   } // end of class F@6

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.il.bsl
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:7:0:0
+  .ver 5:0:0:0
 }
 .assembly DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x00000258
+  // Offset: 0x00000000 Length: 0x0000026A
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000260 Length: 0x000000B0
+  // Offset: 0x00000270 Length: 0x000000B0
 }
 .module DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.exe
-// MVID: {5EAD3E33-CD0A-F713-A745-0383333EAD5E}
+// MVID: {60E47018-CD0A-F713-A745-03831870E460}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x05780000
+// Image base: 0x06A30000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -58,15 +58,11 @@
     .method assembly static void  Invoke(object x,
                                          int32 _arg1) cil managed
     {
-      // Code size       3 (0x3)
-      .maxstack  5
-      .locals init ([0] int32 V_0)
+      // Code size       1 (0x1)
+      .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\dev\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.fs'
-      IL_0000:  ldarg.1
-      IL_0001:  stloc.0
-      .line 6,6 : 68,70 ''
-      IL_0002:  ret
+      .line 6,6 : 68,70 'C:\\GitHub\\dsyme\\fsharp\\tests\\fsharpqa\\source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.fs'
+      IL_0000:  ret
     } // end of method F@6::Invoke
 
   } // end of class F@6

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -3312,7 +3312,6 @@ let ``Test Project23 property`` () =
          ("Value", ["member"; "prop"; "extmem"]);
          ("set_Value", ["member"; "extmem"; "setter"]);
          ("x", []);
-         ("_arg1", ["compgen"]);
          ("Value", ["member"; "prop"; "extmem"])]
 
 [<Test>]

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1226,3 +1226,64 @@ module ParsedHashDirective =
             Assert.AreEqual("40", v)
             assertRange (1, 8) (1, 16) m
         | _ -> Assert.Fail "Could not get valid AST"
+
+module Lambdas =
+    [<Test>]
+    let ``Lambda with two parameters gives correct body`` () =
+        let parseResults = 
+            getParseResults
+                "fun a b -> x"
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Named _], SynExpr.Ident(ident)))
+            )
+        ]) ])) ->
+            Assert.AreEqual("x", ident.idText)
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``Lambda with wild card parameter gives correct body`` () =
+        let parseResults = 
+            getParseResults
+                "fun a _ b -> x"
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Wild _; SynPat.Named _], SynExpr.Ident(ident)))
+            )
+        ]) ])) ->
+            Assert.AreEqual("x", ident.idText)
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``Lambda with tuple parameter with wild card gives correct body`` () =
+        let parseResults = 
+            getParseResults
+                "fun a (b, _) c -> x"
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Paren(SynPat.Tuple _,_); SynPat.Named _], SynExpr.Ident(ident)))
+            )
+        ]) ])) ->
+            Assert.AreEqual("x", ident.idText)
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``Lambda with wild card that returns a lambda gives correct body`` () =
+        let parseResults = 
+            getParseResults
+                "fun _ -> fun _ -> x"
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Ident(ident)))))
+            )
+        ]) ])) ->
+            Assert.AreEqual("x", ident.idText)
+        | _ -> Assert.Fail "Could not get valid AST"


### PR DESCRIPTION
This is related to https://github.com/fsprojects/fantomas/issues/1806.
In Fantomas, we want to use `parsedData` of SynExpr.Lambda to print out the body expression of the lambda.
This is currently wrapped in match expressions when wildcards are involved.
This PR tries to resolve this.