### PR TITLE
Use RunImmediate for better debug stacks

### DIFF
--- a/src/fsharp/absil/illib.fsi
+++ b/src/fsharp/absil/illib.fsi
@@ -47,6 +47,10 @@ module internal PervasiveAutoOpens =
 
         member inline EndsWithOrdinal: value:string -> bool
 
+    type Async with
+        /// Runs the computation synchronously, always starting on the current thread.
+        static member RunImmediate: computation: Async<'T> * ?cancellationToken: CancellationToken -> 'T
+
     val foldOn: p:('a -> 'b) -> f:('c -> 'b -> 'd) -> z:'c -> x:'a -> 'd
 
     val notFound: unit -> 'a

--- a/tests/FSharp.Compiler.UnitTests/BuildGraphTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/BuildGraphTests.fs
@@ -71,7 +71,7 @@ module BuildGraphTests =
 
         let work = Async.Parallel(Array.init requests (fun _ -> graphNode.GetOrComputeValue() |> Async.AwaitNodeCode))
 
-        Async.RunSynchronously(work)
+        Async.RunImmediate(work)
         |> ignore
 
         Assert.shouldBe 1 computationCount
@@ -84,7 +84,7 @@ module BuildGraphTests =
 
         let work = Async.Parallel(Array.init requests (fun _ -> graphNode.GetOrComputeValue() |> Async.AwaitNodeCode))
 
-        let result = Async.RunSynchronously(work)
+        let result = Async.RunImmediate(work)
 
         Assert.shouldNotBeEmpty result
         Assert.shouldBe requests result.Length
@@ -116,7 +116,7 @@ module BuildGraphTests =
         
         Assert.shouldBeTrue weak.IsAlive
 
-        Async.RunSynchronously(Async.Parallel(Array.init requests (fun _ -> graphNode.GetOrComputeValue() |> Async.AwaitNodeCode)))
+        Async.RunImmediate(Async.Parallel(Array.init requests (fun _ -> graphNode.GetOrComputeValue() |> Async.AwaitNodeCode)))
         |> ignore
 
         GC.Collect(2, GCCollectionMode.Forced, true)

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -132,7 +132,7 @@ type CompilerAssert private () =
             options
             |> Array.append defaultProjectOptions.OtherOptions
             |> Array.append [| "fsc.dll"; inputFilePath; "-o:" + outputFilePath; (if isExe then "--target:exe" else "--target:library"); "--nowin32manifest" |]
-        let errors, _ = checker.Compile args |> Async.RunSynchronously
+        let errors, _ = checker.Compile args |> Async.RunImmediate
         errors, outputFilePath
 
     static let compileAux isExe options source f : unit =
@@ -397,7 +397,7 @@ type CompilerAssert private () =
 
         let parseResults =
             checker.ParseFile("test.fs", SourceText.ofString source, parseOptions)
-            |> Async.RunSynchronously
+            |> Async.RunImmediate
 
         Assert.IsEmpty(parseResults.Diagnostics, sprintf "Parse errors: %A" parseResults.Diagnostics)
 
@@ -410,7 +410,7 @@ type CompilerAssert private () =
 
         let compileErrors, statusCode =
             checker.Compile([parseResults.ParseTree], "test", outputFilePath, dependencies, executable = isExe, noframework = true)
-            |> Async.RunSynchronously
+            |> Async.RunImmediate
 
         Assert.IsEmpty(compileErrors, sprintf "Compile errors: %A" compileErrors)
         Assert.AreEqual(0, statusCode, sprintf "Nonzero status code: %d" statusCode)
@@ -421,7 +421,7 @@ type CompilerAssert private () =
         let parseOptions = { FSharpParsingOptions.Default with SourceFiles = [|"test.fs"|] }
         let parseResults =
             checker.ParseFile("test.fs", SourceText.ofString source, parseOptions)
-            |> Async.RunSynchronously
+            |> Async.RunImmediate
 
         Assert.IsEmpty(parseResults.Diagnostics, sprintf "Parse errors: %A" parseResults.Diagnostics)
 
@@ -434,7 +434,7 @@ type CompilerAssert private () =
 
         let compileErrors, statusCode, assembly =
             checker.CompileToDynamicAssembly([parseResults.ParseTree], assemblyName, dependencies, None, noframework = true)
-            |> Async.RunSynchronously
+            |> Async.RunImmediate
 
         Assert.IsEmpty(compileErrors, sprintf "Compile errors: %A" compileErrors)
         Assert.AreEqual(0, statusCode, sprintf "Nonzero status code: %d" statusCode)
@@ -442,7 +442,7 @@ type CompilerAssert private () =
         Option.get assembly
 
     static member Pass (source: string) =
-        let parseResults, fileAnswer = checker.ParseAndCheckFileInProject("test.fs", 0, SourceText.ofString source, defaultProjectOptions) |> Async.RunSynchronously
+        let parseResults, fileAnswer = checker.ParseAndCheckFileInProject("test.fs", 0, SourceText.ofString source, defaultProjectOptions) |> Async.RunImmediate
 
         Assert.IsEmpty(parseResults.Diagnostics, sprintf "Parse errors: %A" parseResults.Diagnostics)
 
@@ -455,7 +455,7 @@ type CompilerAssert private () =
     static member PassWithOptions options (source: string) =
         let options = { defaultProjectOptions with OtherOptions = Array.append options defaultProjectOptions.OtherOptions}
 
-        let parseResults, fileAnswer = checker.ParseAndCheckFileInProject("test.fs", 0, SourceText.ofString source, options) |> Async.RunSynchronously
+        let parseResults, fileAnswer = checker.ParseAndCheckFileInProject("test.fs", 0, SourceText.ofString source, options) |> Async.RunImmediate
 
         Assert.IsEmpty(parseResults.Diagnostics, sprintf "Parse errors: %A" parseResults.Diagnostics)
 
@@ -473,7 +473,7 @@ type CompilerAssert private () =
                 0,
                 SourceText.ofString (File.ReadAllText absoluteSourceFile),
                 { defaultProjectOptions with OtherOptions = Array.append options defaultProjectOptions.OtherOptions; SourceFiles = [|sourceFile|] })
-            |> Async.RunSynchronously
+            |> Async.RunImmediate
 
         Assert.IsEmpty(parseResults.Diagnostics, sprintf "Parse errors: %A" parseResults.Diagnostics)
 
@@ -503,7 +503,7 @@ type CompilerAssert private () =
                     0,
                     SourceText.ofString source,
                     { defaultProjectOptions with OtherOptions = Array.append options defaultProjectOptions.OtherOptions; SourceFiles = [|name|] })
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
 
             if parseResults.Diagnostics.Length > 0 then
                 parseResults.Diagnostics
@@ -523,7 +523,7 @@ type CompilerAssert private () =
                     0,
                     SourceText.ofString source,
                     { defaultProjectOptions with OtherOptions = Array.append options defaultProjectOptions.OtherOptions})
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
 
             if parseResults.Diagnostics.Length > 0 then
                 parseResults.Diagnostics
@@ -543,7 +543,7 @@ type CompilerAssert private () =
                 0,
                 SourceText.ofString source,
                 { defaultProjectOptions with OtherOptions = Array.append options defaultProjectOptions.OtherOptions})
-            |> Async.RunSynchronously
+            |> Async.RunImmediate
 
         match fileAnswer with
         | FSharpCheckFileAnswer.Aborted _ -> Assert.Fail("Type Checker Aborted"); failwith "Type Checker Aborted"
@@ -565,7 +565,7 @@ type CompilerAssert private () =
                     0,
                     SourceText.ofString source,
                     { defaultProjectOptions with OtherOptions = Array.append options defaultProjectOptions.OtherOptions})
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
 
             if parseResults.Diagnostics.Length > 0 then
                 parseResults.Diagnostics
@@ -669,7 +669,7 @@ type CompilerAssert private () =
     static member Parse (source: string) =
         let sourceFileName = "test.fs"
         let parsingOptions = { FSharpParsingOptions.Default with SourceFiles = [| sourceFileName |] }
-        checker.ParseFile(sourceFileName, SourceText.ofString source, parsingOptions) |> Async.RunSynchronously
+        checker.ParseFile(sourceFileName, SourceText.ofString source, parsingOptions) |> Async.RunImmediate
 
     static member ParseWithErrors (source: string) expectedParseErrors =
         let parseResults = CompilerAssert.Parse source

--- a/tests/benchmarks/CompilerServiceBenchmarks/Program.fs
+++ b/tests/benchmarks/CompilerServiceBenchmarks/Program.fs
@@ -1,6 +1,7 @@
 ﻿open System
 open System.IO
 open System.Text
+open System.Threading.Tasks
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Diagnostics
@@ -87,6 +88,19 @@ type SourceText with
 [<AutoOpen>]
 module Helpers =
 
+    type Async with
+        static member RunImmediate (computation: Async<'T>, ?cancellationToken ) =
+            let cancellationToken = defaultArg cancellationToken Async.DefaultCancellationToken
+            let ts = TaskCompletionSource<'T>()
+            let task = ts.Task
+            Async.StartWithContinuations(
+                computation,
+                (fun k -> ts.SetResult k),
+                (fun exn -> ts.SetException exn),
+                (fun _ -> ts.SetCanceled()),
+                cancellationToken)
+            task.Result
+    
     let createProject name referencedProjects =
         let tmpPath = Path.GetTempPath()
         let file = Path.Combine(tmpPath, Path.ChangeExtension(name, ".fs"))
@@ -178,10 +192,10 @@ type CompilerService() =
         | None ->
             let options, _ =
                 checkerOpt.Value.GetProjectOptionsFromScript("decentlySizedStandAloneFile.fsx", SourceText.ofString decentlySizedStandAloneFile)
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
             let _, checkResult =                                                                
                 checkerOpt.Value.ParseAndCheckFileInProject("decentlySizedStandAloneFile.fsx", 0, SourceText.ofString decentlySizedStandAloneFile, options)
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
             decentlySizedStandAloneFileCheckResultOpt <- Some checkResult
         | _ -> ()
 
@@ -191,7 +205,7 @@ type CompilerService() =
         | None, _ -> failwith "no checker"
         | _, None -> failwith "no source"
         | Some(checker), Some(source) ->
-            let results = checker.ParseFile("CheckExpressions.fs", source.ToFSharpSourceText(), parsingOptions) |> Async.RunSynchronously
+            let results = checker.ParseFile("CheckExpressions.fs", source.ToFSharpSourceText(), parsingOptions) |> Async.RunImmediate
             if results.ParseHadErrors then failwithf "parse had errors: %A" results.Diagnostics
 
     [<IterationCleanup(Target = "ParsingTypeCheckerFs")>]
@@ -201,7 +215,7 @@ type CompilerService() =
         | Some(checker) ->
             checker.InvalidateAll()
             checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-            checker.ParseFile("dummy.fs", SourceText.ofString "dummy", parsingOptions) |> Async.RunSynchronously |> ignore
+            checker.ParseFile("dummy.fs", SourceText.ofString "dummy", parsingOptions) |> Async.RunImmediate |> ignore
             ClearAllILModuleReaderCache()
 
     [<Benchmark>]
@@ -272,7 +286,7 @@ type CompilerService() =
         | Some checker ->
             let parseResult, checkResult =                                                                
                 checker.ParseAndCheckFileInProject(file, 0, SourceText.ofString (File.ReadAllText(file)), options)
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
 
             if parseResult.Diagnostics.Length > 0 then
                 failwithf "%A" parseResult.Diagnostics
@@ -343,7 +357,7 @@ type CompilerService() =
             | FSharpCheckFileAnswer.Aborted -> failwith "checker aborted"
             | FSharpCheckFileAnswer.Succeeded results ->
                 let sourceLines = decentlySizedStandAloneFile.Split ([|"\r\n"; "\n"; "\r"|], StringSplitOptions.None)
-                let ranges = SimplifyNames.getSimplifiableNames(results, fun lineNum -> sourceLines.[Line.toZ lineNum]) |> Async.RunSynchronously
+                let ranges = SimplifyNames.getSimplifiableNames(results, fun lineNum -> sourceLines.[Line.toZ lineNum]) |> Async.RunImmediate
                 ignore ranges                
             ()
         | _ -> failwith "oopsie"
@@ -356,7 +370,7 @@ type CompilerService() =
             | FSharpCheckFileAnswer.Aborted -> failwith "checker aborted"
             | FSharpCheckFileAnswer.Succeeded results ->
                 let sourceLines = decentlySizedStandAloneFile.Split ([|"\r\n"; "\n"; "\r"|], StringSplitOptions.None)
-                let decls = UnusedOpens.getUnusedOpens(results, fun lineNum -> sourceLines.[Line.toZ lineNum]) |> Async.RunSynchronously
+                let decls = UnusedOpens.getUnusedOpens(results, fun lineNum -> sourceLines.[Line.toZ lineNum]) |> Async.RunImmediate
                 ignore decls              
             ()
         | _ -> failwith "oopsie"
@@ -368,7 +382,7 @@ type CompilerService() =
             match checkResult with
             | FSharpCheckFileAnswer.Aborted -> failwith "checker aborted"
             | FSharpCheckFileAnswer.Succeeded results ->
-                let decls = UnusedDeclarations.getUnusedDeclarations(results, true) |> Async.RunSynchronously
+                let decls = UnusedDeclarations.getUnusedDeclarations(results, true) |> Async.RunImmediate
                 ignore decls // should be 16                
             ()
         | _ -> failwith "oopsie"

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -63,7 +63,7 @@ let test() =
             |> SourceText.ofString
         let _, checkAnswer = 
             CompilerAssert.Checker.ParseAndCheckFileInProject("test.fs", 0, fsText, fsOptions)
-            |> Async.RunSynchronously
+            |> Async.RunImmediate
 
 
         match checkAnswer with
@@ -76,7 +76,7 @@ let test() =
         try
             let result, _ =
                 checker.Compile([|"fsc.dll";filePath;$"-o:{ outputFilePath }";"--deterministic+";"--optimize+";"--target:library"|])
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
 
             if result.Length > 0 then
                 failwith "Compilation has errors."
@@ -162,7 +162,7 @@ let x = Script1.x
 
             let checkProjectResults = 
                 checker.ParseAndCheckProject(fsOptions1)
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
 
             Assert.IsEmpty(checkProjectResults.Diagnostics)
 
@@ -176,7 +176,7 @@ let y = Script1.y
 
             let checkProjectResults = 
                 checker.ParseAndCheckProject(fsOptions1)
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
 
             Assert.IsNotEmpty(checkProjectResults.Diagnostics)
 
@@ -190,7 +190,7 @@ let y = 1
 
             let checkProjectResults = 
                 checker.ParseAndCheckProject(fsOptions1)
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
 
             Assert.IsEmpty(checkProjectResults.Diagnostics)
 

--- a/tests/service/AssemblyContentProviderTests.fs
+++ b/tests/service/AssemblyContentProviderTests.fs
@@ -43,7 +43,7 @@ let (=>) (source: string) (expected: string list) =
                // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak
                yield "" |]
 
-    let _, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, 0, FSharp.Compiler.Text.SourceText.ofString source, projectOptions) |> Async.RunSynchronously
+    let _, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, 0, FSharp.Compiler.Text.SourceText.ofString source, projectOptions) |> Async.RunImmediate
     
     let checkFileResults =
         match checkFileAnswer with

--- a/tests/service/AssemblyContentProviderTests.fs
+++ b/tests/service/AssemblyContentProviderTests.fs
@@ -13,6 +13,7 @@ open System.Text
 open NUnit.Framework
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.EditorServices
+open FSharp.Compiler.Service.Tests.Common
 
 let private filePath = "C:\\test.fs"
 

--- a/tests/service/AssemblyReaderShim.fs
+++ b/tests/service/AssemblyReaderShim.fs
@@ -29,5 +29,5 @@ let x = 123
 """
 
     let fileName, options = Common.mkTestFileAndOptions source [| |]
-    Common.checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString source, options) |> Async.RunSynchronously |> ignore
+    Common.checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString source, options) |> Async.RunImmediate |> ignore
     gotRequest |> should be True

--- a/tests/service/CSharpProjectAnalysis.fs
+++ b/tests/service/CSharpProjectAnalysis.fs
@@ -43,7 +43,7 @@ let internal getProjectReferences (content: string, dllFiles, libDirs, otherFlag
                  yield "-I:"+libDir
                yield! otherFlags
                yield fileName1 |])
-    let results = checker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let results = checker.ParseAndCheckProject(options) |> Async.RunImmediate
     if results.HasCriticalErrors then
         let builder = new System.Text.StringBuilder()
         for err in results.Diagnostics do

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -6,6 +6,7 @@ open System.Diagnostics
 open System.IO
 open System.Collections.Generic
 open System.Collections.Immutable
+open System.Threading.Tasks
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.IO
 open FSharp.Compiler.Diagnostics
@@ -13,9 +14,21 @@ open FSharp.Compiler.Symbols
 open FSharp.Compiler.Symbols.FSharpExprPatterns
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open FSharp.Compiler.Text
 open FsUnit
 open NUnit.Framework
+
+type Async with
+    static member RunImmediate (computation: Async<'T>, ?cancellationToken ) =
+        let cancellationToken = defaultArg cancellationToken Async.DefaultCancellationToken
+        let ts = TaskCompletionSource<'T>()
+        let task = ts.Task
+        Async.StartWithContinuations(
+            computation,
+            (fun k -> ts.SetResult k),
+            (fun exn -> ts.SetException exn),
+            (fun _ -> ts.SetCanceled()),
+            cancellationToken)
+        task.Result
 
 #if NETCOREAPP
 let readRefs (folder : string) (projectFile: string) =
@@ -65,14 +78,14 @@ type TempFile(ext, contents: string) =
 
 let getBackgroundParseResultsForScriptText (input: string) =
     use file =  new TempFile("fsx", input)
-    let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file.Name, SourceText.ofString input) |> Async.RunSynchronously
-    checker.GetBackgroundParseResultsForFileInProject(file.Name, checkOptions)  |> Async.RunSynchronously
+    let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file.Name, SourceText.ofString input) |> Async.RunImmediate
+    checker.GetBackgroundParseResultsForFileInProject(file.Name, checkOptions)  |> Async.RunImmediate
 
 
 let getBackgroundCheckResultsForScriptText (input: string) =
     use file =  new TempFile("fsx", input)
-    let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file.Name, SourceText.ofString input) |> Async.RunSynchronously
-    checker.GetBackgroundCheckResultsForFileInProject(file.Name, checkOptions) |> Async.RunSynchronously
+    let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file.Name, SourceText.ofString input) |> Async.RunImmediate
+    checker.GetBackgroundCheckResultsForFileInProject(file.Name, checkOptions) |> Async.RunImmediate
 
 
 let sysLib nm =
@@ -172,7 +185,7 @@ let mkTestFileAndOptions source additionalArgs =
     fileName, options
 
 let parseAndCheckFile fileName source options =
-    match checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString source, options) |> Async.RunSynchronously with
+    match checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString source, options) |> Async.RunImmediate with
     | parseResults, FSharpCheckFileAnswer.Succeeded(checkResults) -> parseResults, checkResults
     | _ -> failwithf "Parsing aborted unexpectedly..."
 
@@ -197,12 +210,12 @@ let parseAndCheckScriptWithOptions (file:string, input, opts) =
                 Directory.Delete(path, true)
 
 #else
-    let projectOptions, _diagnostics = checker.GetProjectOptionsFromScript(file, SourceText.ofString input) |> Async.RunSynchronously
+    let projectOptions, _diagnostics = checker.GetProjectOptionsFromScript(file, SourceText.ofString input) |> Async.RunImmediate
     //printfn "projectOptions = %A" projectOptions
 #endif
 
     let projectOptions = { projectOptions with OtherOptions = Array.append opts projectOptions.OtherOptions }
-    let parseResult, typedRes = checker.ParseAndCheckFileInProject(file, 0, SourceText.ofString input, projectOptions) |> Async.RunSynchronously
+    let parseResult, typedRes = checker.ParseAndCheckFileInProject(file, 0, SourceText.ofString input, projectOptions) |> Async.RunImmediate
 
     // if parseResult.Errors.Length > 0 then
     //     printfn "---> Parse Input = %A" input
@@ -222,7 +235,7 @@ let parseSourceCode (name: string, code: string) =
     let dllPath = Path.Combine(location, name + ".dll")
     let args = mkProjectCommandLineArgs(dllPath, [filePath])
     let options, errors = checker.GetParsingOptionsFromCommandLineArgs(List.ofArray args)
-    let parseResults = checker.ParseFile(filePath, SourceText.ofString code, options) |> Async.RunSynchronously
+    let parseResults = checker.ParseFile(filePath, SourceText.ofString code, options) |> Async.RunImmediate
     parseResults.ParseTree
 
 let matchBraces (name: string, code: string) =
@@ -232,7 +245,7 @@ let matchBraces (name: string, code: string) =
     let dllPath = Path.Combine(location, name + ".dll")
     let args = mkProjectCommandLineArgs(dllPath, [filePath])
     let options, errors = checker.GetParsingOptionsFromCommandLineArgs(List.ofArray args)
-    let braces = checker.MatchBraces(filePath, SourceText.ofString code, options) |> Async.RunSynchronously
+    let braces = checker.MatchBraces(filePath, SourceText.ofString code, options) |> Async.RunImmediate
     braces
 
 

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -68,7 +68,7 @@ let ``Intro test`` () =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input)
     let identToken = FSharpTokenTag.IDENT
-//    let projectOptions = checker.GetProjectOptionsFromScript(file, input) |> Async.RunSynchronously
+//    let projectOptions = checker.GetProjectOptionsFromScript(file, input) |> Async.RunImmediate
 
     // So we check that the messages are the same
     for msg in typeCheckResults.Diagnostics do
@@ -132,7 +132,7 @@ let ``Intro test`` () =
 //        let! checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file, SourceText.ofString input)
 //        let! parseResult, typedRes = checker.ParseAndCheckFileInProject(file, 0, SourceText.ofString input, checkOptions)
 //        return parseResult, typedRes
-//    } |> Async.RunSynchronously
+//    } |> Async.RunImmediate
 //      |> ignore
 //    Assert.Fail("expected a cancellation")
 //   with :? OperationCanceledException -> ()
@@ -1216,7 +1216,7 @@ let _ = RegexTypedStatic.IsMatch<"ABC" >(  (*$*) ) // TEST: no assert on Ctrl-sp
 [<Test>]
 let ``Test TPProject all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(TPProject.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(TPProject.options) |> Async.RunImmediate
     let allSymbolUses = wholeProjectResults.GetAllUsesOfAllSymbols()
     let allSymbolUsesInfo =  [ for s in allSymbolUses -> s.Symbol.DisplayName, tups s.Range, attribsOfSymbol s.Symbol ]
     //printfn "allSymbolUsesInfo = \n----\n%A\n----" allSymbolUsesInfo
@@ -1254,8 +1254,8 @@ let ``Test TPProject all symbols`` () =
 
 [<Test>]
 let ``Test TPProject errors`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(TPProject.options) |> Async.RunSynchronously
-    let parseResult, typeCheckAnswer = checker.ParseAndCheckFileInProject(TPProject.fileName1, 0, TPProject.fileSource1, TPProject.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(TPProject.options) |> Async.RunImmediate
+    let parseResult, typeCheckAnswer = checker.ParseAndCheckFileInProject(TPProject.fileName1, 0, TPProject.fileSource1, TPProject.options) |> Async.RunImmediate
     let typeCheckResults =
         match typeCheckAnswer with
         | FSharpCheckFileAnswer.Succeeded(res) -> res
@@ -1285,8 +1285,8 @@ let internal extractToolTipText (ToolTipText(els)) =
 
 [<Test>]
 let ``Test TPProject quick info`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(TPProject.options) |> Async.RunSynchronously
-    let parseResult, typeCheckAnswer = checker.ParseAndCheckFileInProject(TPProject.fileName1, 0, TPProject.fileSource1, TPProject.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(TPProject.options) |> Async.RunImmediate
+    let parseResult, typeCheckAnswer = checker.ParseAndCheckFileInProject(TPProject.fileName1, 0, TPProject.fileSource1, TPProject.options) |> Async.RunImmediate
     let typeCheckResults =
         match typeCheckAnswer with
         | FSharpCheckFileAnswer.Succeeded(res) -> res
@@ -1319,8 +1319,8 @@ let ``Test TPProject quick info`` () =
 
 [<Test>]
 let ``Test TPProject param info`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(TPProject.options) |> Async.RunSynchronously
-    let parseResult, typeCheckAnswer = checker.ParseAndCheckFileInProject(TPProject.fileName1, 0, TPProject.fileSource1, TPProject.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(TPProject.options) |> Async.RunImmediate
+    let parseResult, typeCheckAnswer = checker.ParseAndCheckFileInProject(TPProject.fileName1, 0, TPProject.fileSource1, TPProject.options) |> Async.RunImmediate
     let typeCheckResults =
         match typeCheckAnswer with
         | FSharpCheckFileAnswer.Succeeded(res) -> res

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -728,7 +728,7 @@ let ``Test Unoptimized Declarations Project1`` () =
     let cleanup, options = Project1.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     for e in wholeProjectResults.Diagnostics do
         printfn "Project1 error: <<<%s>>>" e.Message
@@ -863,7 +863,7 @@ let ``Test Optimized Declarations Project1`` () =
     let cleanup, options = Project1.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     for e in wholeProjectResults.Diagnostics do
         printfn "Project1 error: <<<%s>>>" e.Message
@@ -1014,7 +1014,7 @@ let testOperators dnName fsName excludedTests expectedUnoptimized expectedOptimi
 
         let options =  checker.GetProjectOptionsFromCommandLineArgs (projFilePath, args)
 
-        let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+        let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
         let referencedAssemblies = wholeProjectResults.ProjectContext.GetReferencedAssemblies()
         let currentAssemblyToken =
             let fsCore = referencedAssemblies |> List.tryFind (fun asm -> asm.SimpleName = "FSharp.Core")
@@ -3194,7 +3194,7 @@ let ``Test expressions of declarations stress big expressions`` () =
     let cleanup, options = ProjectStressBigExpressions.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
 
@@ -3210,7 +3210,7 @@ let ``Test expressions of optimized declarations stress big expressions`` () =
     let cleanup, options = ProjectStressBigExpressions.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
 
@@ -3270,7 +3270,7 @@ let ``Test ProjectForWitnesses1`` () =
     let cleanup, options = ProjectForWitnesses1.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     for e in wholeProjectResults.Diagnostics do
         printfn "Project1 error: <<<%s>>>" e.Message
@@ -3314,7 +3314,7 @@ let ``Test ProjectForWitnesses1 GetWitnessPassingInfo`` () =
     let cleanup, options = ProjectForWitnesses1.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     for e in wholeProjectResults.Diagnostics do
         printfn "ProjectForWitnesses1 error: <<<%s>>>" e.Message
@@ -3394,7 +3394,7 @@ let ``Test ProjectForWitnesses2`` () =
     let cleanup, options = ProjectForWitnesses2.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     for e in wholeProjectResults.Diagnostics do
         printfn "ProjectForWitnesses2 error: <<<%s>>>" e.Message
@@ -3449,7 +3449,7 @@ let ``Test ProjectForWitnesses3`` () =
     let cleanup, options = createOptionsAux [ ProjectForWitnesses3.fileSource1 ] ["--langversion:preview"]
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     for e in wholeProjectResults.Diagnostics do
         printfn "ProjectForWitnesses3 error: <<<%s>>>" e.Message
@@ -3480,7 +3480,7 @@ let ``Test ProjectForWitnesses3 GetWitnessPassingInfo`` () =
     let cleanup, options = ProjectForWitnesses3.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     for e in wholeProjectResults.Diagnostics do
         printfn "ProjectForWitnesses3 error: <<<%s>>>" e.Message
@@ -3543,7 +3543,7 @@ let ``Test ProjectForWitnesses4 GetWitnessPassingInfo`` () =
     let cleanup, options = ProjectForWitnesses4.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
 
     for e in wholeProjectResults.Diagnostics do
         printfn "ProjectForWitnesses4 error: <<<%s>>>" e.Message

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -86,7 +86,7 @@ let ``FileSystem compilation test``() =
           OriginalLoadReferences = []
           Stamp = None }
 
-    let results = checker.ParseAndCheckProject(projectOptions) |> Async.RunSynchronously
+    let results = checker.ParseAndCheckProject(projectOptions) |> Async.RunImmediate
 
     results.Diagnostics.Length |> shouldEqual 0
     results.AssemblySignature.Entities.Count |> shouldEqual 2

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -132,7 +132,7 @@ let u = Case1 3
 [<Test>]
 let ``Test multi project 1 basic`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject1.options) |> Async.RunImmediate
 
     [ for x in wholeProjectResults.AssemblySignature.Entities -> x.DisplayName ] |> shouldEqual ["MultiProject1"]
 
@@ -145,9 +145,9 @@ let ``Test multi project 1 basic`` () =
 [<Test>]
 let ``Test multi project 1 all symbols`` () =
 
-    let p1A = checker.ParseAndCheckProject(Project1A.options) |> Async.RunSynchronously
-    let p1B = checker.ParseAndCheckProject(Project1B.options) |> Async.RunSynchronously
-    let mp = checker.ParseAndCheckProject(MultiProject1.options) |> Async.RunSynchronously
+    let p1A = checker.ParseAndCheckProject(Project1A.options) |> Async.RunImmediate
+    let p1B = checker.ParseAndCheckProject(Project1B.options) |> Async.RunImmediate
+    let mp = checker.ParseAndCheckProject(MultiProject1.options) |> Async.RunImmediate
 
     let x1FromProject1A =
         [ for s in p1A.GetAllUsesOfAllSymbols() do
@@ -183,9 +183,9 @@ let ``Test multi project 1 all symbols`` () =
 [<Test>]
 let ``Test multi project 1 xmldoc`` () =
 
-    let p1A = checker.ParseAndCheckProject(Project1A.options) |> Async.RunSynchronously
-    let p1B = checker.ParseAndCheckProject(Project1B.options) |> Async.RunSynchronously
-    let mp = checker.ParseAndCheckProject(MultiProject1.options) |> Async.RunSynchronously
+    let p1A = checker.ParseAndCheckProject(Project1A.options) |> Async.RunImmediate
+    let p1B = checker.ParseAndCheckProject(Project1B.options) |> Async.RunImmediate
+    let mp = checker.ParseAndCheckProject(MultiProject1.options) |> Async.RunImmediate
 
     let symbolFromProject1A sym =
         [ for s in p1A.GetAllUsesOfAllSymbols() do
@@ -327,7 +327,7 @@ let ``Test ManyProjectsStressTest basic`` () =
 
     let checker = ManyProjectsStressTest.makeCheckerForStressTest true
 
-    let wholeProjectResults = checker.ParseAndCheckProject(ManyProjectsStressTest.jointProject.Options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(ManyProjectsStressTest.jointProject.Options) |> Async.RunImmediate
 
     [ for x in wholeProjectResults.AssemblySignature.Entities -> x.DisplayName ] |> shouldEqual ["JointProject"]
 
@@ -341,7 +341,7 @@ let ``Test ManyProjectsStressTest cache too small`` () =
 
     let checker = ManyProjectsStressTest.makeCheckerForStressTest false
 
-    let wholeProjectResults = checker.ParseAndCheckProject(ManyProjectsStressTest.jointProject.Options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(ManyProjectsStressTest.jointProject.Options) |> Async.RunImmediate
 
     [ for x in wholeProjectResults.AssemblySignature.Entities -> x.DisplayName ] |> shouldEqual ["JointProject"]
 
@@ -356,8 +356,8 @@ let ``Test ManyProjectsStressTest all symbols`` () =
   let checker = ManyProjectsStressTest.makeCheckerForStressTest true
   for i in 1 .. 10 do
     printfn "stress test iteration %d (first may be slow, rest fast)" i
-    let projectsResults = [ for p in ManyProjectsStressTest.projects -> p, checker.ParseAndCheckProject(p.Options) |> Async.RunSynchronously ]
-    let jointProjectResults = checker.ParseAndCheckProject(ManyProjectsStressTest.jointProject.Options) |> Async.RunSynchronously
+    let projectsResults = [ for p in ManyProjectsStressTest.projects -> p, checker.ParseAndCheckProject(p.Options) |> Async.RunImmediate ]
+    let jointProjectResults = checker.ParseAndCheckProject(ManyProjectsStressTest.jointProject.Options) |> Async.RunImmediate
 
     let vsFromJointProject =
         [ for s in jointProjectResults.GetAllUsesOfAllSymbols() do
@@ -441,13 +441,13 @@ let ``Test multi project symbols should pick up changes in dependent projects`` 
 
     let proj1options = MultiProjectDirty1.getOptions()
 
-    let wholeProjectResults1 = checker.ParseAndCheckProject(proj1options) |> Async.RunSynchronously
+    let wholeProjectResults1 = checker.ParseAndCheckProject(proj1options) |> Async.RunImmediate
 
     count.Value |> shouldEqual 1
 
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(MultiProjectDirty1.fileName1, proj1options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     count.Value |> shouldEqual 1
 
@@ -461,11 +461,11 @@ let ``Test multi project symbols should pick up changes in dependent projects`` 
 
     let proj2options = MultiProjectDirty2.getOptions()
 
-    let wholeProjectResults2 = checker.ParseAndCheckProject(proj2options) |> Async.RunSynchronously
+    let wholeProjectResults2 = checker.ParseAndCheckProject(proj2options) |> Async.RunImmediate
 
     count.Value |> shouldEqual 2
 
-    let _ = checker.ParseAndCheckProject(proj2options) |> Async.RunSynchronously
+    let _ = checker.ParseAndCheckProject(proj2options) |> Async.RunImmediate
 
     count.Value |> shouldEqual 2 // cached
 
@@ -500,12 +500,12 @@ let ``Test multi project symbols should pick up changes in dependent projects`` 
     printfn "Old write time: '%A', ticks = %d"  wt1 wt1.Ticks
     printfn "New write time: '%A', ticks = %d"  wt2 wt2.Ticks
 
-    let wholeProjectResults1AfterChange1 = checker.ParseAndCheckProject(proj1options) |> Async.RunSynchronously
+    let wholeProjectResults1AfterChange1 = checker.ParseAndCheckProject(proj1options) |> Async.RunImmediate
     count.Value |> shouldEqual 3
 
     let backgroundParseResults1AfterChange1, backgroundTypedParse1AfterChange1 =
         checker.GetBackgroundCheckResultsForFileInProject(MultiProjectDirty1.fileName1, proj1options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let xSymbolUseAfterChange1 = backgroundTypedParse1AfterChange1.GetSymbolUseAtLocation(4, 4, "", ["x"])
     xSymbolUseAfterChange1.IsSome |> shouldEqual true
@@ -514,7 +514,7 @@ let ``Test multi project symbols should pick up changes in dependent projects`` 
 
     printfn "Checking project 2 after first change, options = '%A'" proj2options
 
-    let wholeProjectResults2AfterChange1 = checker.ParseAndCheckProject(proj2options) |> Async.RunSynchronously
+    let wholeProjectResults2AfterChange1 = checker.ParseAndCheckProject(proj2options) |> Async.RunImmediate
 
     count.Value |> shouldEqual 4
 
@@ -549,19 +549,19 @@ let ``Test multi project symbols should pick up changes in dependent projects`` 
     printfn "New write time: '%A', ticks = %d"  wt2b wt2b.Ticks
 
     count.Value |> shouldEqual 4
-    let wholeProjectResults2AfterChange2 = checker.ParseAndCheckProject(proj2options) |> Async.RunSynchronously
+    let wholeProjectResults2AfterChange2 = checker.ParseAndCheckProject(proj2options) |> Async.RunImmediate
 
     System.Threading.Thread.Sleep(1000)
     count.Value |> shouldEqual 6 // note, causes two files to be type checked, one from each project
 
 
-    let wholeProjectResults1AfterChange2 = checker.ParseAndCheckProject(proj1options) |> Async.RunSynchronously
+    let wholeProjectResults1AfterChange2 = checker.ParseAndCheckProject(proj1options) |> Async.RunImmediate
 
     count.Value |> shouldEqual 6 // the project is already checked
 
     let backgroundParseResults1AfterChange2, backgroundTypedParse1AfterChange2 =
         checker.GetBackgroundCheckResultsForFileInProject(MultiProjectDirty1.fileName1, proj1options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let xSymbolUseAfterChange2 = backgroundTypedParse1AfterChange2.GetSymbolUseAtLocation(4, 4, "", ["x"])
     xSymbolUseAfterChange2.IsSome |> shouldEqual true
@@ -668,14 +668,14 @@ let v = Project2A.C().InternalMember // access an internal symbol
 [<Test>]
 let ``Test multi project2 errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project2B.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project2B.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "multi project2 error: <<<%s>>>" e.Message
 
     wholeProjectResults .Diagnostics.Length |> shouldEqual 0
 
 
-    let wholeProjectResultsC = checker.ParseAndCheckProject(Project2C.options) |> Async.RunSynchronously
+    let wholeProjectResultsC = checker.ParseAndCheckProject(Project2C.options) |> Async.RunImmediate
     wholeProjectResultsC.Diagnostics.Length |> shouldEqual 1
 
 
@@ -683,9 +683,9 @@ let ``Test multi project2 errors`` () =
 [<Test>]
 let ``Test multi project 2 all symbols`` () =
 
-    let mpA = checker.ParseAndCheckProject(Project2A.options) |> Async.RunSynchronously
-    let mpB = checker.ParseAndCheckProject(Project2B.options) |> Async.RunSynchronously
-    let mpC = checker.ParseAndCheckProject(Project2C.options) |> Async.RunSynchronously
+    let mpA = checker.ParseAndCheckProject(Project2A.options) |> Async.RunImmediate
+    let mpB = checker.ParseAndCheckProject(Project2B.options) |> Async.RunImmediate
+    let mpC = checker.ParseAndCheckProject(Project2C.options) |> Async.RunImmediate
 
     // These all get the symbol in A, but from three different project compilations/checks
     let symFromA =
@@ -761,7 +761,7 @@ let fizzBuzz = function
 [<Test>]
 let ``Test multi project 3 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "multi project 3 error: <<<%s>>>" e.Message
 
@@ -770,10 +770,10 @@ let ``Test multi project 3 whole project errors`` () =
 [<Test>]
 let ``Test active patterns' XmlDocSig declared in referenced projects`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(MultiProject3.fileName1, MultiProject3.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let divisibleBySymbolUse = backgroundTypedParse1.GetSymbolUseAtLocation(7,7,"",["DivisibleBy"])
     divisibleBySymbolUse.IsSome |> shouldEqual true
@@ -803,12 +803,12 @@ let ``Test max memory gets triggered`` () =
     let checker = FSharpChecker.Create()
     let reached = ref false
     checker.MaxMemoryReached.Add (fun () -> reached := true)
-    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunImmediate
     reached.Value |> shouldEqual false
     checker.MaxMemory <- 0
-    let wholeProjectResults2 = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunSynchronously
+    let wholeProjectResults2 = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunImmediate
     reached.Value |> shouldEqual true
-    let wholeProjectResults3 = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunSynchronously
+    let wholeProjectResults3 = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunImmediate
     reached.Value |> shouldEqual true
 
 
@@ -886,7 +886,7 @@ let ``Type provider project references should not throw exceptions`` () =
     //printfn "options: %A" options
     let fileName = __SOURCE_DIRECTORY__ + @"/data/TypeProviderConsole/Program.fs"
     let fileSource = FileSystem.OpenFileForReadShim(fileName).ReadAllText()
-    let fileParseResults, fileCheckAnswer = checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString fileSource, options) |> Async.RunSynchronously
+    let fileParseResults, fileCheckAnswer = checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString fileSource, options) |> Async.RunImmediate
     let fileCheckResults =
         match fileCheckAnswer with
         | FSharpCheckFileAnswer.Succeeded(res) -> res
@@ -978,7 +978,7 @@ let ``Projects creating generated types should not utilize cross-project-referen
     let fileName = __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/Program.fs"
     let fileSource = FileSystem.OpenFileForReadShim(fileName).ReadAllText()
 
-    let fileParseResults, fileCheckAnswer = checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString fileSource, options) |> Async.RunSynchronously
+    let fileParseResults, fileCheckAnswer = checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString fileSource, options) |> Async.RunImmediate
     let fileCheckResults =
         match fileCheckAnswer with
         | FSharpCheckFileAnswer.Succeeded(res) -> res

--- a/tests/service/PerfTests.fs
+++ b/tests/service/PerfTests.fs
@@ -49,7 +49,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     let pB, tB = FSharpChecker.ActualParseFileCount, FSharpChecker.ActualCheckFileCount
 
     printfn "ParseFile()..."
-    let parseResults1 = checker.ParseFile(Project1.fileNames.[5], Project1.fileSources2.[5], Project1.parsingOptions)  |> Async.RunSynchronously
+    let parseResults1 = checker.ParseFile(Project1.fileNames.[5], Project1.fileSources2.[5], Project1.parsingOptions)  |> Async.RunImmediate
     let pC, tC = FSharpChecker.ActualParseFileCount, FSharpChecker.ActualCheckFileCount
     (pC - pB) |> shouldEqual 1
     (tC - tB) |> shouldEqual 0
@@ -59,7 +59,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     backgroundCheckCount.Value |> shouldEqual 0
 
     printfn "CheckFileInProject()..."
-    let checkResults1 = checker.CheckFileInProject(parseResults1, Project1.fileNames.[5], 0, Project1.fileSources2.[5], Project1.options)  |> Async.RunSynchronously
+    let checkResults1 = checker.CheckFileInProject(parseResults1, Project1.fileNames.[5], 0, Project1.fileSources2.[5], Project1.options)  |> Async.RunImmediate
     let pD, tD = FSharpChecker.ActualParseFileCount, FSharpChecker.ActualCheckFileCount
 
     printfn "checking background parsing happened...., backgroundParseCount.Value = %d" backgroundParseCount.Value
@@ -78,7 +78,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     (tD - tC) |> shouldEqual 1
 
     printfn "CheckFileInProject()..."
-    let checkResults2 = checker.CheckFileInProject(parseResults1, Project1.fileNames.[7], 0, Project1.fileSources2.[7], Project1.options)  |> Async.RunSynchronously
+    let checkResults2 = checker.CheckFileInProject(parseResults1, Project1.fileNames.[7], 0, Project1.fileSources2.[7], Project1.options)  |> Async.RunImmediate
     let pE, tE = FSharpChecker.ActualParseFileCount, FSharpChecker.ActualCheckFileCount
     printfn "checking no extra  foreground parsing...., (pE - pD) = %d" (pE - pD)
     (pE - pD) |> shouldEqual 0
@@ -91,7 +91,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
 
     printfn "ParseAndCheckFileInProject()..."
     // A subsequent ParseAndCheck of identical source code doesn't do any more anything
-    let checkResults2 = checker.ParseAndCheckFileInProject(Project1.fileNames.[7], 0, Project1.fileSources2.[7], Project1.options)  |> Async.RunSynchronously
+    let checkResults2 = checker.ParseAndCheckFileInProject(Project1.fileNames.[7], 0, Project1.fileSources2.[7], Project1.options)  |> Async.RunImmediate
     let pF, tF = FSharpChecker.ActualParseFileCount, FSharpChecker.ActualCheckFileCount
     printfn "checking no extra foreground parsing...."
     (pF - pE) |> shouldEqual 0  // note, no new parse of the file

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -97,7 +97,7 @@ let mmmm2 : M.CAbbrev = new M.CAbbrev() // note, these don't count as uses of C
 [<Test>]
 let ``Test project1 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
     wholeProjectResults .Diagnostics.Length |> shouldEqual 2
     wholeProjectResults.Diagnostics.[1].Message.Contains("Incomplete pattern matches on this expression") |> shouldEqual true // yes it does
     wholeProjectResults.Diagnostics.[1].ErrorNumber |> shouldEqual 25
@@ -111,7 +111,7 @@ let ``Test project1 whole project errors`` () =
 let ``Test project1 and make sure TcImports gets cleaned up`` () =
 
     let test () =
-        let (_, checkFileAnswer) = checker.ParseAndCheckFileInProject(Project1.fileName1, 0, Project1.fileSource1, Project1.options) |> Async.RunSynchronously
+        let (_, checkFileAnswer) = checker.ParseAndCheckFileInProject(Project1.fileName1, 0, Project1.fileSource1, Project1.options) |> Async.RunImmediate
         match checkFileAnswer with
         | FSharpCheckFileAnswer.Aborted -> failwith "should not be aborted"
         | FSharpCheckFileAnswer.Succeeded checkFileResults ->
@@ -130,7 +130,7 @@ let ``Test project1 and make sure TcImports gets cleaned up`` () =
 
 [<Test>]
 let ``Test Project1 should have protected FullName and TryFullName return same results`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
     let rec getFullNameComparisons (entity: FSharpEntity) =
         #if !NO_EXTENSIONTYPING
         seq { if not entity.IsProvided && entity.Accessibility.IsPublic then
@@ -149,7 +149,7 @@ let ``Test Project1 should have protected FullName and TryFullName return same r
 [<Test>]
 [<Ignore("SKIPPED: BaseType shouldn't throw exceptions")>]
 let ``Test project1 should not throw exceptions on entities from referenced assemblies`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
     let rec getAllBaseTypes (entity: FSharpEntity) =
         seq { if not entity.IsProvided && entity.Accessibility.IsPublic then
                 if not entity.IsUnresolved then yield entity.BaseType
@@ -166,7 +166,7 @@ let ``Test project1 should not throw exceptions on entities from referenced asse
 let ``Test project1 basic`` () =
 
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
 
     set [ for x in wholeProjectResults.AssemblySignature.Entities -> x.DisplayName ] |> shouldEqual (set ["N"; "M"])
 
@@ -180,7 +180,7 @@ let ``Test project1 basic`` () =
 [<Test>]
 let ``Test project1 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities true wholeProjectResults.AssemblySignature.Entities
     for s in allSymbols do
         s.DeclarationLocation.IsSome |> shouldEqual true
@@ -306,7 +306,7 @@ let ``Test project1 all symbols`` () =
 [<Test>]
 let ``Test project1 all symbols excluding compiler generated`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
     let allSymbolsNoCompGen = allSymbolsInEntities false wholeProjectResults.AssemblySignature.Entities
     [ for x in allSymbolsNoCompGen -> x.ToString() ]
       |> shouldEqual
@@ -323,10 +323,10 @@ let ``Test project1 all symbols excluding compiler generated`` () =
 let ``Test project1 xxx symbols`` () =
 
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project1.fileName1, Project1.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let xSymbolUseOpt = backgroundTypedParse1.GetSymbolUseAtLocation(9,9,"",["xxx"])
     let xSymbolUse = xSymbolUseOpt.Value
@@ -347,7 +347,7 @@ let ``Test project1 xxx symbols`` () =
 [<Test>]
 let ``Test project1 all uses of all signature symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities true wholeProjectResults.AssemblySignature.Entities
     let allUsesOfAllSymbols =
         [ for s in allSymbols do
@@ -415,7 +415,7 @@ let ``Test project1 all uses of all signature symbols`` () =
 [<Test>]
 let ``Test project1 all uses of all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
     let allUsesOfAllSymbols =
         [ for s in wholeProjectResults.GetAllUsesOfAllSymbols() ->
               s.Symbol.DisplayName, s.Symbol.FullName, Project1.cleanFileName s.FileName, tupsZ s.Range, attribsOfSymbol s.Symbol ]
@@ -554,18 +554,18 @@ let ``Test project1 all uses of all symbols`` () =
 let ``Test file explicit parse symbols`` () =
 
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
-    let parseResults1 = checker.ParseFile(Project1.fileName1, Project1.fileSource1, Project1.parsingOptions)  |> Async.RunSynchronously
-    let parseResults2 = checker.ParseFile(Project1.fileName2, Project1.fileSource2, Project1.parsingOptions)  |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
+    let parseResults1 = checker.ParseFile(Project1.fileName1, Project1.fileSource1, Project1.parsingOptions)  |> Async.RunImmediate
+    let parseResults2 = checker.ParseFile(Project1.fileName2, Project1.fileSource2, Project1.parsingOptions)  |> Async.RunImmediate
 
     let checkResults1 =
         checker.CheckFileInProject(parseResults1, Project1.fileName1, 0, Project1.fileSource1, Project1.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
         |> function FSharpCheckFileAnswer.Succeeded x ->  x | _ -> failwith "unexpected aborted"
 
     let checkResults2 =
         checker.CheckFileInProject(parseResults2, Project1.fileName2, 0, Project1.fileSource2, Project1.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
         |> function FSharpCheckFileAnswer.Succeeded x ->  x | _ -> failwith "unexpected aborted"
 
     let xSymbolUse2Opt = checkResults1.GetSymbolUseAtLocation(9,9,"",["xxx"])
@@ -600,18 +600,18 @@ let ``Test file explicit parse symbols`` () =
 let ``Test file explicit parse all symbols`` () =
 
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously
-    let parseResults1 = checker.ParseFile(Project1.fileName1, Project1.fileSource1, Project1.parsingOptions) |> Async.RunSynchronously
-    let parseResults2 = checker.ParseFile(Project1.fileName2, Project1.fileSource2, Project1.parsingOptions) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
+    let parseResults1 = checker.ParseFile(Project1.fileName1, Project1.fileSource1, Project1.parsingOptions) |> Async.RunImmediate
+    let parseResults2 = checker.ParseFile(Project1.fileName2, Project1.fileSource2, Project1.parsingOptions) |> Async.RunImmediate
 
     let checkResults1 =
         checker.CheckFileInProject(parseResults1, Project1.fileName1, 0, Project1.fileSource1, Project1.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
         |> function FSharpCheckFileAnswer.Succeeded x ->  x | _ -> failwith "unexpected aborted"
 
     let checkResults2 =
         checker.CheckFileInProject(parseResults2, Project1.fileName2, 0, Project1.fileSource2, Project1.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
         |> function FSharpCheckFileAnswer.Succeeded x ->  x | _ -> failwith "unexpected aborted"
 
     let usesOfSymbols = checkResults1.GetAllUsesOfAllSymbolsInFile()
@@ -684,7 +684,7 @@ let _ = GenericFunction(3, 4)
 [<Test>]
 let ``Test project2 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunImmediate
     wholeProjectResults .Diagnostics.Length |> shouldEqual 0
 
 
@@ -692,7 +692,7 @@ let ``Test project2 whole project errors`` () =
 let ``Test project2 basic`` () =
 
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunImmediate
 
     set [ for x in wholeProjectResults.AssemblySignature.Entities -> x.DisplayName ] |> shouldEqual (set ["M"])
 
@@ -704,7 +704,7 @@ let ``Test project2 basic`` () =
 [<Test>]
 let ``Test project2 all symbols in signature`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities true wholeProjectResults.AssemblySignature.Entities
     [ for x in allSymbols -> x.ToString() ]
        |> shouldEqual
@@ -717,7 +717,7 @@ let ``Test project2 all symbols in signature`` () =
 
 [<Test>]
 let ``Test project2 all uses of all signature symbols`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities true wholeProjectResults.AssemblySignature.Entities
     let allUsesOfAllSymbols =
         [ for s in allSymbols do
@@ -757,7 +757,7 @@ let ``Test project2 all uses of all signature symbols`` () =
 [<Test>]
 let ``Test project2 all uses of all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project2.options) |> Async.RunImmediate
     let allUsesOfAllSymbols =
         [ for s in wholeProjectResults.GetAllUsesOfAllSymbols() ->
             s.Symbol.DisplayName, (if s.FileName = Project2.fileName1 then "file1" else "???"), tupsZ s.Range, attribsOfSymbol s.Symbol ]
@@ -926,7 +926,7 @@ let getM (foo: IFoo) = foo.InterfaceMethod("d")
 [<Test>]
 let ``Test project3 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project3.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project3.options) |> Async.RunImmediate
     wholeProjectResults .Diagnostics.Length |> shouldEqual 0
 
 
@@ -934,7 +934,7 @@ let ``Test project3 whole project errors`` () =
 let ``Test project3 basic`` () =
 
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project3.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project3.options) |> Async.RunImmediate
 
     set [ for x in wholeProjectResults.AssemblySignature.Entities -> x.DisplayName ] |> shouldEqual (set ["M"])
 
@@ -947,7 +947,7 @@ let ``Test project3 basic`` () =
 [<Test>]
 let ``Test project3 all symbols in signature`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project3.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project3.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities false wholeProjectResults.AssemblySignature.Entities
     let results = [ for x in allSymbols -> x.ToString(), attribsOfSymbol x ]
     [("M", ["module"]);
@@ -1031,7 +1031,7 @@ let ``Test project3 all symbols in signature`` () =
 [<Test>]
 let ``Test project3 all uses of all signature symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project3.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project3.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities false wholeProjectResults.AssemblySignature.Entities
 
     let allUsesOfAllSymbols =
@@ -1294,13 +1294,13 @@ let inline twice(x : ^U, y : ^U) = x + y
 
 [<Test>]
 let ``Test project4 whole project errors`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunImmediate
     wholeProjectResults .Diagnostics.Length |> shouldEqual 0
 
 
 [<Test>]
 let ``Test project4 basic`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunImmediate
 
     set [ for x in wholeProjectResults.AssemblySignature.Entities -> x.DisplayName ] |> shouldEqual (set ["M"])
 
@@ -1313,7 +1313,7 @@ let ``Test project4 basic`` () =
 [<Test>]
 let ``Test project4 all symbols in signature`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities false wholeProjectResults.AssemblySignature.Entities
     [ for x in allSymbols -> x.ToString() ]
       |> shouldEqual
@@ -1323,7 +1323,7 @@ let ``Test project4 all symbols in signature`` () =
 
 [<Test>]
 let ``Test project4 all uses of all signature symbols`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities false wholeProjectResults.AssemblySignature.Entities
     let allUsesOfAllSymbols =
         [ for s in allSymbols do
@@ -1348,10 +1348,10 @@ let ``Test project4 all uses of all signature symbols`` () =
 [<Test>]
 let ``Test project4 T symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project4.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project4.fileName1, Project4.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let tSymbolUse2 = backgroundTypedParse1.GetSymbolUseAtLocation(4,19,"",["T"])
     tSymbolUse2.IsSome |> shouldEqual true
@@ -1467,7 +1467,7 @@ let parseNumeric str =
 [<Test>]
 let ``Test project5 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project5.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project5.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project5 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -1476,7 +1476,7 @@ let ``Test project5 whole project errors`` () =
 [<Test>]
 let ``Test project 5 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project5.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project5.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -1543,10 +1543,10 @@ let ``Test project 5 all symbols`` () =
 [<Test>]
 let ``Test complete active patterns' exact ranges from uses of symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project5.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project5.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project5.fileName1, Project5.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let oddSymbolUse = backgroundTypedParse1.GetSymbolUseAtLocation(11,8,"",["Odd"])
     oddSymbolUse.IsSome |> shouldEqual true
@@ -1610,10 +1610,10 @@ let ``Test complete active patterns' exact ranges from uses of symbols`` () =
 [<Test>]
 let ``Test partial active patterns' exact ranges from uses of symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project5.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project5.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project5.fileName1, Project5.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let floatSymbolUse = backgroundTypedParse1.GetSymbolUseAtLocation(22,10,"",["Float"])
     floatSymbolUse.IsSome |> shouldEqual true
@@ -1678,7 +1678,7 @@ let f () =
 [<Test>]
 let ``Test project6 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project6.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project6.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project6 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -1687,7 +1687,7 @@ let ``Test project6 whole project errors`` () =
 [<Test>]
 let ``Test project 6 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project6.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project6.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -1734,7 +1734,7 @@ let x2 = C.M(arg1 = 3, arg2 = 4, ?arg3 = Some 5)
 [<Test>]
 let ``Test project7 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project7.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project7.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project7 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -1743,7 +1743,7 @@ let ``Test project7 whole project errors`` () =
 [<Test>]
 let ``Test project 7 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project7.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project7.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -1795,7 +1795,7 @@ let x =
 [<Test>]
 let ``Test project8 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project8.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project8.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project8 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -1804,7 +1804,7 @@ let ``Test project8 whole project errors`` () =
 [<Test>]
 let ``Test project 8 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project8.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project8.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -1875,7 +1875,7 @@ let inline check< ^T when ^T : (static member IsInfinity : ^T -> bool)> (num: ^T
 [<Test>]
 let ``Test project9 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project9.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project9.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project9 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -1884,7 +1884,7 @@ let ``Test project9 whole project errors`` () =
 [<Test>]
 let ``Test project 9 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project9.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project9.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -1954,7 +1954,7 @@ C.M("http://goo", query = 1)
 [<Test>]
 let ``Test Project10 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project10.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project10.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project10 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -1963,7 +1963,7 @@ let ``Test Project10 whole project errors`` () =
 [<Test>]
 let ``Test Project10 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project10.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project10.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -1988,7 +1988,7 @@ let ``Test Project10 all symbols`` () =
 
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project10.fileName1, Project10.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let querySymbolUseOpt =
         backgroundTypedParse1.GetSymbolUseAtLocation(7,23,"",["query"])
@@ -2034,7 +2034,7 @@ let fff (x:System.Collections.Generic.Dictionary<int,int>.Enumerator) = ()
 [<Test>]
 let ``Test Project11 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project11.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project11.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project11 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2043,7 +2043,7 @@ let ``Test Project11 whole project errors`` () =
 [<Test>]
 let ``Test Project11 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project11.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project11.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2103,7 +2103,7 @@ let x2 = query { for i in 0 .. 100 do
 [<Test>]
 let ``Test Project12 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project12.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project12.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project12 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2112,7 +2112,7 @@ let ``Test Project12 whole project errors`` () =
 [<Test>]
 let ``Test Project12 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project12.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project12.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2170,7 +2170,7 @@ let x3 = new System.DateTime()
 [<Test>]
 let ``Test Project13 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project13.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project13.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project13 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2179,7 +2179,7 @@ let ``Test Project13 whole project errors`` () =
 [<Test>]
 let ``Test Project13 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project13.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project13.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2321,7 +2321,7 @@ let x2  = S(3)
 [<Test>]
 let ``Test Project14 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project14.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project14.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project14 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2330,7 +2330,7 @@ let ``Test Project14 whole project errors`` () =
 [<Test>]
 let ``Test Project14 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project14.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project14.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2389,7 +2389,7 @@ let f x =
 [<Test>]
 let ``Test Project15 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project15.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project15.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project15 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2398,7 +2398,7 @@ let ``Test Project15 whole project errors`` () =
 [<Test>]
 let ``Test Project15 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project15.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project15.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2476,7 +2476,7 @@ and G = Case1 | Case2 of int
 [<Test>]
 let ``Test Project16 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project16.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project16.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project16 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2485,7 +2485,7 @@ let ``Test Project16 whole project errors`` () =
 [<Test>]
 let ``Test Project16 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project16.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project16.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2582,13 +2582,13 @@ let ``Test Project16 all symbols`` () =
 let ``Test Project16 sig symbols are equal to impl symbols`` () =
 
     let checkResultsSig =
-        checker.ParseAndCheckFileInProject(Project16.sigFileName1, 0, Project16.sigFileSource1, Project16.options)  |> Async.RunSynchronously
+        checker.ParseAndCheckFileInProject(Project16.sigFileName1, 0, Project16.sigFileSource1, Project16.options)  |> Async.RunImmediate
         |> function
             | _, FSharpCheckFileAnswer.Succeeded(res) -> res
             | _ -> failwithf "Parsing aborted unexpectedly..."
 
     let checkResultsImpl =
-        checker.ParseAndCheckFileInProject(Project16.fileName1, 0, Project16.fileSource1, Project16.options)  |> Async.RunSynchronously
+        checker.ParseAndCheckFileInProject(Project16.fileName1, 0, Project16.fileSource1, Project16.options)  |> Async.RunImmediate
         |> function
             | _, FSharpCheckFileAnswer.Succeeded(res) -> res
             | _ -> failwithf "Parsing aborted unexpectedly..."
@@ -2631,7 +2631,7 @@ let ``Test Project16 sig symbols are equal to impl symbols`` () =
 [<Test>]
 let ``Test Project16 sym locations`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project16.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project16.options) |> Async.RunImmediate
 
     let fmtLoc (mOpt: range option) =
         match mOpt with
@@ -2693,7 +2693,7 @@ let ``Test Project16 sym locations`` () =
 let ``Test project16 DeclaringEntity`` () =
     let wholeProjectResults =
         checker.ParseAndCheckProject(Project16.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
     let allSymbolsUses = wholeProjectResults.GetAllUsesOfAllSymbols()
     for sym in allSymbolsUses do
        match sym.Symbol with
@@ -2746,7 +2746,7 @@ let f3 (x: System.Exception) = x.HelpLink <- "" // check use of .NET setter prop
 [<Test>]
 let ``Test Project17 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project17.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project17.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project17 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2755,7 +2755,7 @@ let ``Test Project17 whole project errors`` () =
 [<Test>]
 let ``Test Project17 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project17.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project17.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2832,7 +2832,7 @@ let _ = list<_>.Empty
 [<Test>]
 let ``Test Project18 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project18.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project18.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project18 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2841,7 +2841,7 @@ let ``Test Project18 whole project errors`` () =
 [<Test>]
 let ``Test Project18 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project18.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project18.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2888,7 +2888,7 @@ let s = System.DayOfWeek.Monday
 [<Test>]
 let ``Test Project19 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project19.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project19.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project19 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2897,7 +2897,7 @@ let ``Test Project19 whole project errors`` () =
 [<Test>]
 let ``Test Project19 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project19.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project19.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -2962,7 +2962,7 @@ type A<'T>() =
 [<Test>]
 let ``Test Project20 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project20.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project20.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project20 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -2971,7 +2971,7 @@ let ``Test Project20 whole project errors`` () =
 [<Test>]
 let ``Test Project20 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project20.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project20.options) |> Async.RunImmediate
 
     let tSymbolUse = wholeProjectResults.GetAllUsesOfAllSymbols() |> Array.find (fun su -> su.Range.StartLine = 5 && su.Symbol.ToString() = "generic parameter T")
     let tSymbol = tSymbolUse.Symbol
@@ -3023,7 +3023,7 @@ let _ = { new IMyInterface<int> with
 [<Test>]
 let ``Test Project21 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project21.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project21.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project21 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 2
@@ -3032,7 +3032,7 @@ let ``Test Project21 whole project errors`` () =
 [<Test>]
 let ``Test Project21 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project21.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project21.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -3098,7 +3098,7 @@ let f5 (x: int[,,]) = () // test a multi-dimensional array
 [<Test>]
 let ``Test Project22 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project22.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project22.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project22 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -3107,7 +3107,7 @@ let ``Test Project22 whole project errors`` () =
 [<Test>]
 let ``Test Project22 IList contents`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project22.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project22.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -3189,7 +3189,7 @@ let ``Test Project22 IList contents`` () =
 [<Test>]
 let ``Test Project22 IList properties`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project22.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project22.options) |> Async.RunImmediate
 
     let ilistTypeUse =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -3243,7 +3243,7 @@ module Setter =
 [<Test>]
 let ``Test Project23 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project23.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project23.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project23 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -3251,7 +3251,7 @@ let ``Test Project23 whole project errors`` () =
 [<Test>]
 let ``Test Project23 property`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project23.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project23.options) |> Async.RunImmediate
     let allSymbolsUses = wholeProjectResults.GetAllUsesOfAllSymbols()
 
     let classTypeUse = allSymbolsUses |> Array.find (fun su -> su.Symbol.DisplayName = "Class")
@@ -3318,7 +3318,7 @@ let ``Test Project23 property`` () =
 [<Test>]
 let ``Test Project23 extension properties' getters/setters should refer to the correct declaring entities`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project23.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project23.options) |> Async.RunImmediate
     let allSymbolsUses = wholeProjectResults.GetAllUsesOfAllSymbols()
 
     let extensionMembers = allSymbolsUses |> Array.rev |> Array.filter (fun su -> su.Symbol.DisplayName = "Value")
@@ -3414,17 +3414,17 @@ TypeWithProperties.StaticAutoPropGetSet  <- 3
 
 [<Test>]
 let ``Test Project24 whole project errors`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project24.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project24.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project24 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
 
 [<Test>]
 let ``Test Project24 all symbols`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project24.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project24.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project24.fileName1, Project24.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let allUses  =
         backgroundTypedParse1.GetAllUsesOfAllSymbolsInFile()
@@ -3528,10 +3528,10 @@ let ``Test Project24 all symbols`` () =
 
 [<Test>]
 let ``Test symbol uses of properties with both getters and setters`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project24.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project24.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project24.fileName1, Project24.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let getAllSymbolUses =
         backgroundTypedParse1.GetAllUsesOfAllSymbolsInFile()
@@ -3666,7 +3666,7 @@ let _ = XmlProvider<"<root><value>1</value><value>3</value></root>">.GetSample()
 [<Ignore "SKIPPED: Disabled until FSharp.Data.dll is build for dotnet core.">]
 #endif
 let ``Test Project25 whole project errors`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project25.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project25.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project25 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -3676,10 +3676,10 @@ let ``Test Project25 whole project errors`` () =
 [<Ignore "SKIPPED: Disabled until FSharp.Data.dll is build for dotnet core.">]
 #endif
 let ``Test Project25 symbol uses of type-provided members`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project25.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project25.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project25.fileName1, Project25.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let allUses  =
         backgroundTypedParse1.GetAllUsesOfAllSymbolsInFile()
@@ -3735,10 +3735,10 @@ let ``Test Project25 symbol uses of type-provided members`` () =
 [<Ignore "SKIPPED: Disabled until FSharp.Data.dll is build for dotnet core.">]
 #endif
 let ``Test symbol uses of type-provided types`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project25.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project25.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project25.fileName1, Project25.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let getSampleSymbolUseOpt =
         backgroundTypedParse1.GetSymbolUseAtLocation(4,26,"",["XmlProvider"])
@@ -3755,10 +3755,10 @@ let ``Test symbol uses of type-provided types`` () =
 
 [<Test>]
 let ``Test symbol uses of fully-qualified records`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project25.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project25.options) |> Async.RunImmediate
     let backgroundParseResults1, backgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project25.fileName1, Project25.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let getSampleSymbolUseOpt =
         backgroundTypedParse1.GetSymbolUseAtLocation(7,11,"",["Record"])
@@ -3802,7 +3802,7 @@ type Class() =
 [<Test>]
 let ``Test Project26 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project26.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project26.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project26 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -3810,7 +3810,7 @@ let ``Test Project26 whole project errors`` () =
 
 [<Test>]
 let ``Test Project26 parameter symbols`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project26.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project26.options) |> Async.RunImmediate
 
     let allUsesOfAllSymbols =
         wholeProjectResults.GetAllUsesOfAllSymbols()
@@ -3891,13 +3891,13 @@ type CFooImpl() =
 [<Test>]
 let ``Test project27 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project27.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project27.options) |> Async.RunImmediate
     wholeProjectResults .Diagnostics.Length |> shouldEqual 0
 
 [<Test>]
 let ``Test project27 all symbols in signature`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project27.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project27.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities true wholeProjectResults.AssemblySignature.Entities
     [ for x in allSymbols -> x.ToString(), attribsOfSymbol x ]
       |> shouldEqual
@@ -3955,7 +3955,7 @@ type Use() =
 #if !NO_EXTENSIONTYPING
 [<Test>]
 let ``Test project28 all symbols in signature`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project28.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project28.options) |> Async.RunImmediate
     let allSymbols = allSymbolsInEntities true wholeProjectResults.AssemblySignature.Entities
     let xmlDocSigs =
         allSymbols
@@ -4035,7 +4035,7 @@ let f (x: INotifyPropertyChanged) = failwith ""
 [<Test>]
 let ``Test project29 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project29.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project29.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project29 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -4043,7 +4043,7 @@ let ``Test project29 whole project errors`` () =
 [<Test>]
 let ``Test project29 event symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project29.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project29.options) |> Async.RunImmediate
 
     let objSymbol = wholeProjectResults.GetAllUsesOfAllSymbols()  |> Array.find (fun su -> su.Symbol.DisplayName = "INotifyPropertyChanged")
     let objEntity = objSymbol.Symbol :?> FSharpEntity
@@ -4092,7 +4092,7 @@ type T() =
 
 let ``Test project30 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project30.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project30.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project30 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -4100,7 +4100,7 @@ let ``Test project30 whole project errors`` () =
 [<Test>]
 let ``Test project30 Format attributes`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project30.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project30.options) |> Async.RunImmediate
 
     let moduleSymbol = wholeProjectResults.GetAllUsesOfAllSymbols()  |> Array.find (fun su -> su.Symbol.DisplayName = "Module")
     let moduleEntity = moduleSymbol.Symbol :?> FSharpEntity
@@ -4152,7 +4152,7 @@ let g = Console.ReadKey()
     let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
 
 let ``Test project31 whole project errors`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project31 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -4163,7 +4163,7 @@ let ``Test project31 whole project errors`` () =
 #endif
 let ``Test project31 C# type attributes`` () =
     if not runningOnMono then
-        let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunSynchronously
+        let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunImmediate
 
         let objSymbol = wholeProjectResults.GetAllUsesOfAllSymbols()  |> Array.find (fun su -> su.Symbol.DisplayName = "List")
         let objEntity = objSymbol.Symbol :?> FSharpEntity
@@ -4185,7 +4185,7 @@ let ``Test project31 C# type attributes`` () =
 [<Test>]
 let ``Test project31 C# method attributes`` () =
     if not runningOnMono then
-        let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunSynchronously
+        let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunImmediate
 
         let objSymbol = wholeProjectResults.GetAllUsesOfAllSymbols()  |> Array.find (fun su -> su.Symbol.DisplayName = "Console")
         let objEntity = objSymbol.Symbol :?> FSharpEntity
@@ -4212,7 +4212,7 @@ let ``Test project31 C# method attributes`` () =
 #endif
 let ``Test project31 Format C# type attributes`` () =
     if not runningOnMono then
-        let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunSynchronously
+        let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunImmediate
 
         let objSymbol = wholeProjectResults.GetAllUsesOfAllSymbols()  |> Array.find (fun su -> su.Symbol.DisplayName = "List")
         let objEntity = objSymbol.Symbol :?> FSharpEntity
@@ -4229,7 +4229,7 @@ let ``Test project31 Format C# type attributes`` () =
 [<Test>]
 let ``Test project31 Format C# method attributes`` () =
     if not runningOnMono then
-        let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunSynchronously
+        let wholeProjectResults = checker.ParseAndCheckProject(Project31.options) |> Async.RunImmediate
 
         let objSymbol = wholeProjectResults.GetAllUsesOfAllSymbols()  |> Array.find (fun su -> su.Symbol.DisplayName = "Console")
         let objEntity = objSymbol.Symbol :?> FSharpEntity
@@ -4276,7 +4276,7 @@ val func : int -> int
 [<Test>]
 let ``Test Project32 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project32.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project32.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project32 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -4284,10 +4284,10 @@ let ``Test Project32 whole project errors`` () =
 [<Test>]
 let ``Test Project32 should be able to find sig symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project32.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project32.options) |> Async.RunImmediate
     let _sigBackgroundParseResults1, sigBackgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project32.sigFileName1, Project32.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let sigSymbolUseOpt = sigBackgroundTypedParse1.GetSymbolUseAtLocation(4,5,"",["func"])
     let sigSymbol = sigSymbolUseOpt.Value.Symbol
@@ -4303,10 +4303,10 @@ let ``Test Project32 should be able to find sig symbols`` () =
 [<Test>]
 let ``Test Project32 should be able to find impl symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project32.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project32.options) |> Async.RunImmediate
     let _implBackgroundParseResults1, implBackgroundTypedParse1 =
         checker.GetBackgroundCheckResultsForFileInProject(Project32.fileName1, Project32.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     let implSymbolUseOpt = implBackgroundTypedParse1.GetSymbolUseAtLocation(3,5,"",["func"])
     let implSymbol = implSymbolUseOpt.Value.Symbol
@@ -4343,7 +4343,7 @@ type System.Int32 with
 [<Test>]
 let ``Test Project33 whole project errors`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project33.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project33.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project33 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -4351,7 +4351,7 @@ let ``Test Project33 whole project errors`` () =
 [<Test>]
 let ``Test Project33 extension methods`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project33.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project33.options) |> Async.RunImmediate
     let allSymbolsUses = wholeProjectResults.GetAllUsesOfAllSymbols()
 
     let implModuleUse = allSymbolsUses |> Array.find (fun su -> su.Symbol.DisplayName = "Impl")
@@ -4388,7 +4388,7 @@ module Dummy
 
 [<Test>]
 let ``Test Project34 whole project errors`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project34.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project34.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "Project34 error: <<<%s>>>" e.Message
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
@@ -4398,7 +4398,7 @@ let ``Test Project34 whole project errors`` () =
 [<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
 #endif
 let ``Test project34 should report correct accessibility for System.Data.Listeners`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project34.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project34.options) |> Async.RunImmediate
     let rec getNestedEntities (entity: FSharpEntity) =
         seq { yield entity
               for e in entity.NestedEntities do
@@ -4451,7 +4451,7 @@ type Test =
 
 [<Test>]
 let ``Test project35 CurriedParameterGroups should be available for nested functions`` () =
-    let wholeProjectResults = checker.ParseAndCheckProject(Project35.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project35.options) |> Async.RunImmediate
     let allSymbolUses = wholeProjectResults.GetAllUsesOfAllSymbols()
     let findByDisplayName name =
         Array.find (fun (su:FSharpSymbolUse) -> su.Symbol.DisplayName = name)
@@ -4524,13 +4524,13 @@ module internal Project35b =
     let args2 = Array.append args [| "-r:notexist.dll" |]
     let options = checker.GetProjectOptionsFromCommandLineArgs (projPath, args2)
 #else
-    let options =  checker.GetProjectOptionsFromScript(fileName1, fileSource1) |> Async.RunSynchronously |> fst
+    let options =  checker.GetProjectOptionsFromScript(fileName1, fileSource1) |> Async.RunImmediate |> fst
 #endif
 
 [<Test>]
 let ``Test project35b Dependency files for ParseAndCheckFileInProject`` () =
     let checkFileResults =
-        checker.ParseAndCheckFileInProject(Project35b.fileName1, 0, Project35b.fileSource1, Project35b.options) |> Async.RunSynchronously
+        checker.ParseAndCheckFileInProject(Project35b.fileName1, 0, Project35b.fileSource1, Project35b.options) |> Async.RunImmediate
         |> function
             | _, FSharpCheckFileAnswer.Succeeded(res) -> res
             | _ -> failwithf "Parsing aborted unexpectedly..."
@@ -4542,7 +4542,7 @@ let ``Test project35b Dependency files for ParseAndCheckFileInProject`` () =
 
 [<Test>]
 let ``Test project35b Dependency files for GetBackgroundCheckResultsForFileInProject`` () =
-    let _,checkFileResults = checker.GetBackgroundCheckResultsForFileInProject(Project35b.fileName1, Project35b.options) |> Async.RunSynchronously
+    let _,checkFileResults = checker.GetBackgroundCheckResultsForFileInProject(Project35b.fileName1, Project35b.options) |> Async.RunImmediate
     for d in checkFileResults.DependencyFiles do
         printfn "GetBackgroundCheckResultsForFileInProject dependency: %s" d
     checkFileResults.DependencyFiles |> Array.exists (fun s -> s.Contains "notexist.dll") |> shouldEqual true
@@ -4551,7 +4551,7 @@ let ``Test project35b Dependency files for GetBackgroundCheckResultsForFileInPro
 
 [<Test>]
 let ``Test project35b Dependency files for check of project`` () =
-    let checkResults = checker.ParseAndCheckProject(Project35b.options) |> Async.RunSynchronously
+    let checkResults = checker.ParseAndCheckProject(Project35b.options) |> Async.RunImmediate
     for d in checkResults.DependencyFiles do
         printfn "ParseAndCheckProject dependency: %s" d
     checkResults.DependencyFiles |> Array.exists (fun s -> s.Contains "notexist.dll") |> shouldEqual true
@@ -4592,7 +4592,7 @@ let ``Test project36 FSharpMemberOrFunctionOrValue.IsBaseValue`` () =
     let options =  keepAssemblyContentsChecker.GetProjectOptionsFromCommandLineArgs (Project36.projFileName, Project36.args)
     let wholeProjectResults =
         keepAssemblyContentsChecker.ParseAndCheckProject(options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
 
     wholeProjectResults.GetAllUsesOfAllSymbols()
     |> Array.pick (fun (su:FSharpSymbolUse) ->
@@ -4605,7 +4605,7 @@ let ``Test project36 FSharpMemberOrFunctionOrValue.IsBaseValue`` () =
 let ``Test project36 FSharpMemberOrFunctionOrValue.IsConstructorThisValue & IsMemberThisValue`` () =
     let keepAssemblyContentsChecker = FSharpChecker.Create(keepAssemblyContents=true)
     let options =  keepAssemblyContentsChecker.GetProjectOptionsFromCommandLineArgs (Project36.projFileName, Project36.args)
-    let wholeProjectResults = keepAssemblyContentsChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = keepAssemblyContentsChecker.ParseAndCheckProject(options) |> Async.RunImmediate
     let declarations =
         let checkedFile = wholeProjectResults.AssemblyContents.ImplementationFiles.[0]
         match checkedFile.Declarations.[0] with
@@ -4642,7 +4642,7 @@ let ``Test project36 FSharpMemberOrFunctionOrValue.IsConstructorThisValue & IsMe
 let ``Test project36 FSharpMemberOrFunctionOrValue.LiteralValue`` () =
     let keepAssemblyContentsChecker = FSharpChecker.Create(keepAssemblyContents=true)
     let options =  keepAssemblyContentsChecker.GetProjectOptionsFromCommandLineArgs (Project36.projFileName, Project36.args)
-    let wholeProjectResults = keepAssemblyContentsChecker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = keepAssemblyContentsChecker.ParseAndCheckProject(options) |> Async.RunImmediate
     let project36Module = wholeProjectResults.AssemblySignature.Entities.[0]
     let lit = project36Module.MembersFunctionsAndValues.[0]
     shouldEqual true (lit.LiteralValue.Value |> unbox |> (=) 1.)
@@ -4710,7 +4710,7 @@ do ()
 let ``Test project37 typeof and arrays in attribute constructor arguments`` () =
     let wholeProjectResults =
         checker.ParseAndCheckProject(Project37.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
     let allSymbolsUses = wholeProjectResults.GetAllUsesOfAllSymbols()
     for su in allSymbolsUses do
         match su.Symbol with
@@ -4764,7 +4764,7 @@ let ``Test project37 typeof and arrays in attribute constructor arguments`` () =
 let ``Test project37 DeclaringEntity`` () =
     let wholeProjectResults =
         checker.ParseAndCheckProject(Project37.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
     let allSymbolsUses = wholeProjectResults.GetAllUsesOfAllSymbols()
     for sym in allSymbolsUses do
        match sym.Symbol with
@@ -4852,7 +4852,7 @@ type A<'XX, 'YY>() =
 let ``Test project38 abstract slot information`` () =
     let wholeProjectResults =
         checker.ParseAndCheckProject(Project38.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
     let printAbstractSignature (s: FSharpAbstractSignature) =
         let printType (t: FSharpType) =
             hash t  |> ignore // smoke test to check hash code doesn't loop
@@ -4938,7 +4938,7 @@ let uses () =
 [<Test>]
 let ``Test project39 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project39.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project39.options) |> Async.RunImmediate
     let allSymbolUses = wholeProjectResults.GetAllUsesOfAllSymbols()
     let typeTextOfAllSymbolUses =
         [ for s in allSymbolUses do
@@ -5013,7 +5013,7 @@ let g (x: C) = x.IsItAnA,x.IsItAnAMethod()
 [<Test>]
 let ``Test Project40 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project40.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project40.options) |> Async.RunImmediate
     let allSymbolUses = wholeProjectResults.GetAllUsesOfAllSymbols()
     let allSymbolUsesInfo =  [ for s in allSymbolUses -> s.Symbol.DisplayName, tups s.Range, attribsOfSymbol s.Symbol ]
     allSymbolUsesInfo |> shouldEqual
@@ -5083,7 +5083,7 @@ module M
 [<Test>]
 let ``Test project41 all symbols`` () =
 
-    let wholeProjectResults = checker.ParseAndCheckProject(Project41.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(Project41.options) |> Async.RunImmediate
     let allSymbolUses = wholeProjectResults.GetAllUsesOfAllSymbols()
     let allSymbolUsesInfo =
         [ for s in allSymbolUses do
@@ -5169,13 +5169,13 @@ let test2() = test()
 [<Test>]
 let ``Test project42 to ensure cached checked results are invalidated`` () =
     let text2 = SourceText.ofString(FileSystem.OpenFileForReadShim(Project42.fileName2).ReadAllText())
-    let checkedFile2 = checker.ParseAndCheckFileInProject(Project42.fileName2, text2.GetHashCode(), text2, Project42.options) |> Async.RunSynchronously
+    let checkedFile2 = checker.ParseAndCheckFileInProject(Project42.fileName2, text2.GetHashCode(), text2, Project42.options) |> Async.RunImmediate
     match checkedFile2 with
     | _, FSharpCheckFileAnswer.Succeeded(checkedFile2Results) ->
         Assert.IsEmpty(checkedFile2Results.Diagnostics)
         FileSystem.OpenFileForWriteShim(Project42.fileName1).Write("""module File1""")
         try
-            let checkedFile2Again = checker.ParseAndCheckFileInProject(Project42.fileName2, text2.GetHashCode(), text2, Project42.options) |> Async.RunSynchronously
+            let checkedFile2Again = checker.ParseAndCheckFileInProject(Project42.fileName2, text2.GetHashCode(), text2, Project42.options) |> Async.RunImmediate
             match checkedFile2Again with
             | _, FSharpCheckFileAnswer.Succeeded(checkedFile2AgainResults) ->
                 Assert.IsNotEmpty(checkedFile2AgainResults.Diagnostics) // this should contain errors as File1 does not contain the function `test()`
@@ -5212,7 +5212,7 @@ let ``add files with same name from different folders`` () =
     let projFileName = __SOURCE_DIRECTORY__ + "/data/samename/tempet.fsproj"
     let args = mkProjectCommandLineArgs ("test.dll", fileNames)
     let options = checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
-    let wholeProjectResults = checker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(options) |> Async.RunImmediate
     let errors =
         wholeProjectResults.Diagnostics
         |> Array.filter (fun x -> x.Severity = FSharpDiagnosticSeverity.Error)
@@ -5251,7 +5251,7 @@ let foo (a: Foo): bool =
 [<Test>]
 let ``Test typed AST for struct unions`` () = // See https://github.com/fsharp/FSharp.Compiler.Service/issues/756
     let keepAssemblyContentsChecker = FSharpChecker.Create(keepAssemblyContents=true)
-    let wholeProjectResults = keepAssemblyContentsChecker.ParseAndCheckProject(ProjectStructUnions.options) |> Async.RunSynchronously
+    let wholeProjectResults = keepAssemblyContentsChecker.ParseAndCheckProject(ProjectStructUnions.options) |> Async.RunImmediate
     let declarations =
         let checkedFile = wholeProjectResults.AssemblyContents.ImplementationFiles.[0]
         match checkedFile.Declarations.[0] with
@@ -5291,7 +5291,7 @@ let x = (1 = 3.0)
 let ``Test line directives in foreground analysis`` () = // see https://github.com/Microsoft/visualfsharp/issues/3317
 
     // In background analysis and normal compiler checking, the errors are reported w.r.t. the line directives
-    let wholeProjectResults = checker.ParseAndCheckProject(ProjectLineDirectives.options) |> Async.RunSynchronously
+    let wholeProjectResults = checker.ParseAndCheckProject(ProjectLineDirectives.options) |> Async.RunImmediate
     for e in wholeProjectResults.Diagnostics do
         printfn "ProjectLineDirectives wholeProjectResults error file: <<<%s>>>" e.Range.FileName
 
@@ -5301,7 +5301,7 @@ let ``Test line directives in foreground analysis`` () = // see https://github.c
     // file, which is assumed to be in the editor, not the other files referred to by line directives.
     let checkResults1 =
         checker.ParseAndCheckFileInProject(ProjectLineDirectives.fileName1, 0, ProjectLineDirectives.fileSource1, ProjectLineDirectives.options)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
         |> function (_,FSharpCheckFileAnswer.Succeeded x) ->  x | _ -> failwith "unexpected aborted"
 
     for e in checkResults1.Diagnostics do
@@ -5331,7 +5331,7 @@ type A(i:int) =
     let options =  keepAssemblyContentsChecker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
 
     let fileCheckResults =
-        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunSynchronously
+        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunImmediate
         |> function
             | _, FSharpCheckFileAnswer.Succeeded(res) -> res
             | _ -> failwithf "Parsing aborted unexpectedly..."
@@ -5422,17 +5422,17 @@ type UseTheThings(i:int) =
     let options =  keepAssemblyContentsChecker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
 
     let fileCheckResults =
-        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunSynchronously
+        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunImmediate
         |> function
             | _, FSharpCheckFileAnswer.Succeeded(res) -> res
             | _ -> failwithf "Parsing aborted unexpectedly..."
-    //let symbolUses = fileCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunSynchronously |> Array.indexed
+    //let symbolUses = fileCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunImmediate |> Array.indexed
     // Fragments used to check hash codes:
     //(snd symbolUses.[42]).Symbol.IsEffectivelySameAs((snd symbolUses.[37]).Symbol)
     //(snd symbolUses.[42]).Symbol.GetEffectivelySameAsHash()
     //(snd symbolUses.[37]).Symbol.GetEffectivelySameAsHash()
     let lines = FileSystem.OpenFileForReadShim(fileName1).ReadAllLines()
-    let unusedOpens = UnusedOpens.getUnusedOpens (fileCheckResults, (fun i -> lines.[i-1])) |> Async.RunSynchronously
+    let unusedOpens = UnusedOpens.getUnusedOpens (fileCheckResults, (fun i -> lines.[i-1])) |> Async.RunImmediate
     let unusedOpensData = [ for uo in unusedOpens -> tups uo, lines.[uo.StartLine-1] ]
     let expected =
           [(((4, 5), (4, 23)), "open System.Collections // unused");
@@ -5495,17 +5495,17 @@ type UseTheThings(i:int) =
     let options =  keepAssemblyContentsChecker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
 
     let fileCheckResults =
-        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunSynchronously
+        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunImmediate
         |> function
             | _, FSharpCheckFileAnswer.Succeeded(res) -> res
             | _ -> failwithf "Parsing aborted unexpectedly..."
-    //let symbolUses = fileCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunSynchronously |> Array.indexed
+    //let symbolUses = fileCheckResults.GetAllUsesOfAllSymbolsInFile() |> Async.RunImmediate |> Array.indexed
     // Fragments used to check hash codes:
     //(snd symbolUses.[42]).Symbol.IsEffectivelySameAs((snd symbolUses.[37]).Symbol)
     //(snd symbolUses.[42]).Symbol.GetEffectivelySameAsHash()
     //(snd symbolUses.[37]).Symbol.GetEffectivelySameAsHash()
     let lines = FileSystem.OpenFileForReadShim(fileName1).ReadAllLines()
-    let unusedOpens = UnusedOpens.getUnusedOpens (fileCheckResults, (fun i -> lines.[i-1])) |> Async.RunSynchronously
+    let unusedOpens = UnusedOpens.getUnusedOpens (fileCheckResults, (fun i -> lines.[i-1])) |> Async.RunImmediate
     let unusedOpensData = [ for uo in unusedOpens -> tups uo, lines.[uo.StartLine-1] ]
     let expected =
           [(((4, 5), (4, 23)), "open System.Collections // unused");
@@ -5576,12 +5576,12 @@ module M2 =
     let options =  keepAssemblyContentsChecker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
 
     let fileCheckResults =
-        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunSynchronously
+        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunImmediate
         |> function
             | _, FSharpCheckFileAnswer.Succeeded(res) -> res
             | _ -> failwithf "Parsing aborted unexpectedly..."
     let lines = FileSystem.OpenFileForReadShim(fileName1).ReadAllLines()
-    let unusedOpens = UnusedOpens.getUnusedOpens (fileCheckResults, (fun i -> lines.[i-1])) |> Async.RunSynchronously
+    let unusedOpens = UnusedOpens.getUnusedOpens (fileCheckResults, (fun i -> lines.[i-1])) |> Async.RunImmediate
     let unusedOpensData = [ for uo in unusedOpens -> tups uo, lines.[uo.StartLine-1] ]
     let expected =
           [(((2, 5), (2, 23)), "open System.Collections // unused");
@@ -5653,10 +5653,10 @@ let checkContentAsScript content =
     let tempDir = Path.GetTempPath()
     let scriptFullPath = Path.Combine(tempDir, scriptName)
     let sourceText = SourceText.ofString content
-    let projectOptions, _ = checker.GetProjectOptionsFromScript(scriptFullPath, sourceText, useSdkRefs = true, assumeDotNetFramework = false) |> Async.RunSynchronously
+    let projectOptions, _ = checker.GetProjectOptionsFromScript(scriptFullPath, sourceText, useSdkRefs = true, assumeDotNetFramework = false) |> Async.RunImmediate
     let parseOptions, _ = checker.GetParsingOptionsFromProjectOptions projectOptions
-    let parseResults = checker.ParseFile(scriptFullPath, sourceText, parseOptions) |> Async.RunSynchronously
-    let checkResults = checker.CheckFileInProject(parseResults, scriptFullPath, 0, sourceText, projectOptions) |> Async.RunSynchronously
+    let parseResults = checker.ParseFile(scriptFullPath, sourceText, parseOptions) |> Async.RunImmediate
+    let checkResults = checker.CheckFileInProject(parseResults, scriptFullPath, 0, sourceText, projectOptions) |> Async.RunImmediate
     match checkResults with
     | FSharpCheckFileAnswer.Aborted -> failwith "no check results"
     | FSharpCheckFileAnswer.Succeeded r -> r

--- a/tests/service/ScriptOptionsTests.fs
+++ b/tests/service/ScriptOptionsTests.fs
@@ -31,7 +31,7 @@ let ``can generate options for different frameworks regardless of execution envi
     let tempFile = Path.Combine(path, file)
     let (_, errors) =
         checker.GetProjectOptionsFromScript(tempFile, SourceText.ofString scriptSource, assumeDotNetFramework = assumeNetFx, useSdkRefs = useSdk, otherFlags = flags)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
     match errors with
     | [] -> ()
     | errors -> failwithf "Error while parsing script with assumeDotNetFramework:%b, useSdkRefs:%b, and otherFlags:%A:\n%A" assumeNetFx useSdk flags errors
@@ -43,7 +43,7 @@ let ``all default assembly references are system assemblies``(assumeNetFx, useSd
     let tempFile = Path.GetTempFileName() + ".fsx"
     let (options, errors) =
         checker.GetProjectOptionsFromScript(tempFile, SourceText.ofString scriptSource, assumeDotNetFramework = assumeNetFx, useSdkRefs = useSdkRefs, otherFlags = flags)
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
     match errors with
     | [] -> ()
     | errors -> failwithf "Error while parsing script with assumeNetFx:%b, useSdkRefs:%b, and otherFlags:%A:\n%A" assumeNetFx useSdkRefs flags errors
@@ -76,7 +76,7 @@ let ``sdk dir with dodgy global json gives warning``() =
     FileSystem.OpenFileForWriteShim(globalJsonPath).Write("""{ "sdk": { "version": "666.666.666" } }""")
     let (options, errors) =
         checker.GetProjectOptionsFromScript(tempFile, SourceText.ofString scriptSource, assumeDotNetFramework = false, useSdkRefs = true, otherFlags = [| |])
-        |> Async.RunSynchronously
+        |> Async.RunImmediate
     FileSystem.FileDeleteShim(globalJsonPath)
     match errors with
     | [] ->

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -6,6 +6,7 @@ module internal Microsoft.VisualStudio.FSharp.Editor.Extensions
 open System
 open System.IO
 open System.Collections.Immutable
+open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Text
@@ -290,3 +291,16 @@ module Exception =
         | _ -> root
         |> flattenInner
         |> String.concat " ---> "
+
+type Async with
+    static member RunImmediate (computation: Async<'T>, ?cancellationToken ) =
+        let cancellationToken = defaultArg cancellationToken Async.DefaultCancellationToken
+        let ts = TaskCompletionSource<'T>()
+        let task = ts.Task
+        Async.StartWithContinuations(
+            computation,
+            (fun k -> ts.SetResult k),
+            (fun exn -> ts.SetException exn),
+            (fun _ -> ts.SetCanceled()),
+            cancellationToken)
+        task.Result

--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -228,3 +228,4 @@ module internal OpenDeclarationHelper =
 module internal TaggedText =
     let toString (tts: TaggedText[]) =
         tts |> Array.map (fun tt -> tt.Text) |> String.concat ""
+

--- a/vsintegration/src/FSharp.Editor/Formatting/IndentationService.fs
+++ b/vsintegration/src/FSharp.Editor/Formatting/IndentationService.fs
@@ -107,4 +107,4 @@ type internal FSharpIndentationService
                     match indent with
                     | None -> Nullable()
                     | Some(indentation) -> Nullable<FSharpIndentationResult>(FSharpIndentationResult(sourceText.Lines.[lineNumber].Start, indentation))
-            } |> (fun c -> Async.RunSynchronously(c,cancellationToken=cancellationToken))
+            } |> (fun c -> Async.RunImmediate(c,cancellationToken=cancellationToken))

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -203,7 +203,7 @@ type Document with
         let workspaceService = this.Project.Solution.GetFSharpWorkspaceService()
         let parsingOptions, _, _ = 
             workspaceService.FSharpProjectOptionsManager.TryGetOptionsForDocumentOrProject(this, CancellationToken.None, nameof(this.SetFSharpProjectOptionsForTesting))
-            |> Async.RunSynchronously
+            |> Async.RunImmediate
             |> Option.get
         ProjectCache.Projects.Add(this.Project, (workspaceService.Checker, workspaceService.FSharpProjectOptionsManager, parsingOptions, projectOptions))
 

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -473,7 +473,7 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                         }
 
                     let span =
-                        match Async.RunSynchronously(goToAsync, cancellationToken = cancellationToken) with
+                        match Async.RunImmediate(goToAsync, cancellationToken = cancellationToken) with
                         | Some span -> span
                         | _ -> TextSpan()
 

--- a/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
+++ b/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
@@ -7,6 +7,7 @@
 namespace Microsoft.VisualStudio.FSharp.LanguageService
 
 open System
+open System.Threading.Tasks
 open Microsoft.VisualStudio.TextManager.Interop 
 open Microsoft.VisualStudio.Text
 open FSharp.Compiler
@@ -17,6 +18,21 @@ open Microsoft.VisualStudio.FSharp.LanguageService.SiteProvider
 open Microsoft.VisualStudio.FSharp.Interactive.Session
 
 #nowarn "44" // use of obsolete CheckFileInProjectAllowingStaleCachedResults
+
+[<AutoOpen>]
+module AsyncExtensions =
+    type Async with
+        static member RunImmediate (computation: Async<'T>, ?cancellationToken ) =
+            let cancellationToken = defaultArg cancellationToken Async.DefaultCancellationToken
+            let ts = TaskCompletionSource<'T>()
+            let task = ts.Task
+            Async.StartWithContinuations(
+                computation,
+                (fun k -> ts.SetResult k),
+                (fun exn -> ts.SetException exn),
+                (fun _ -> ts.SetCanceled()),
+                cancellationToken)
+            task.Result
 
 //
 // Note: DEPRECATED CODE ONLY ACTIVE IN UNIT TESTING VIA "UNROSLYNIZED" UNIT TESTS. 
@@ -98,7 +114,7 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
                         lazy // This portion is executed on the language service thread
                             let timestamp = if source=null then System.DateTime(2000,1,1) else source.OpenedTime // source is null in unit tests
                             let checker = getInteractiveChecker()
-                            let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(fileName,  FSharp.Compiler.Text.SourceText.ofString sourceText, SessionsProperties.fsiPreview, timestamp, [| |]) |> Async.RunSynchronously
+                            let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(fileName,  FSharp.Compiler.Text.SourceText.ofString sourceText, SessionsProperties.fsiPreview, timestamp, [| |]) |> Async.RunImmediate
                             let referencedProjectFileNames = [| |]
                             let projectSite = ProjectSitesAndFiles.CreateProjectSiteForScript(fileName, referencedProjectFileNames, checkOptions)
                             { ProjectSite = projectSite
@@ -141,7 +157,7 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
             // Do brace matching if required
             if req.ResultSink.BraceMatching then  
                 // Record brace-matching
-                let braceMatches = interactiveChecker.MatchBraces(req.FileName,req.Text,checkOptions) |> Async.RunSynchronously
+                let braceMatches = interactiveChecker.MatchBraces(req.FileName,req.Text,checkOptions) |> Async.RunImmediate
                     
                 let mutable pri = 0
                 for (b1,b2) in braceMatches do
@@ -153,14 +169,14 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
             | BackgroundRequestReason.ParseFile ->
 
                 // invoke ParseFile directly - relying on cache inside the interactiveChecker
-                let parseResults = interactiveChecker.ParseFileInProject(req.FileName, req.Text, checkOptions) |> Async.RunSynchronously
+                let parseResults = interactiveChecker.ParseFileInProject(req.FileName, req.Text, checkOptions) |> Async.RunImmediate
 
                 parseFileResults <- Some parseResults
 
             | _ -> 
                 let syncParseInfoOpt = 
                     if FSharpIntellisenseInfo_DEPRECATED.IsReasonRequiringSyncParse(req.Reason) then
-                        let parseResults = interactiveChecker.ParseFileInProject(req.FileName,req.Text,checkOptions) |> Async.RunSynchronously
+                        let parseResults = interactiveChecker.ParseFileInProject(req.FileName,req.Text,checkOptions) |> Async.RunImmediate
                         Some parseResults
                     else None
 
@@ -188,14 +204,14 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
                         let parseResults = 
                             match syncParseInfoOpt with 
                             | Some x -> x
-                            | None -> interactiveChecker.ParseFileInProject(req.FileName,req.Text,checkOptions) |> Async.RunSynchronously
+                            | None -> interactiveChecker.ParseFileInProject(req.FileName,req.Text,checkOptions) |> Async.RunImmediate
                         
                         // Should never matter but don't let anything in FSharp.Compiler extend the lifetime of 'source'
                         let sr = ref (Some source)
 
                         // Type-checking
                         let typedResults,aborted = 
-                            match interactiveChecker.CheckFileInProject(parseResults,req.FileName,req.Timestamp,FSharp.Compiler.Text.SourceText.ofString(req.Text),checkOptions) |> Async.RunSynchronously with 
+                            match interactiveChecker.CheckFileInProject(parseResults,req.FileName,req.Timestamp,FSharp.Compiler.Text.SourceText.ofString(req.Text),checkOptions) |> Async.RunImmediate with 
                             | FSharpCheckFileAnswer.Aborted -> 
                                 // isResultObsolete returned true during the type check.
                                 None,true
@@ -219,7 +235,7 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
                     if outOfDateProjectFileNames.Contains(projectFileName) then
                         interactiveChecker.InvalidateConfiguration(checkOptions)
                         interactiveChecker.ParseAndCheckProject(checkOptions)
-                        |> Async.RunSynchronously
+                        |> Async.RunImmediate
                         |> ignore
                         outOfDateProjectFileNames.Remove(projectFileName) |> ignore
 
@@ -236,7 +252,7 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
                         // On 'FullTypeCheck', send a message to the reactor to start the background compile for this project, just in case
                         if req.Reason = BackgroundRequestReason.FullTypeCheck then    
                             interactiveChecker.ParseAndCheckProject(checkOptions)
-                            |> Async.RunSynchronously
+                            |> Async.RunImmediate
                             |> ignore
 
                     | Some typedResults -> 
@@ -265,7 +281,7 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
                         // On 'FullTypeCheck', send a message to the reactor to start the background compile for this project, just in case
                         if req.Reason = BackgroundRequestReason.FullTypeCheck then    
                             interactiveChecker.ParseAndCheckProject(checkOptions)
-                            |> Async.RunSynchronously
+                            |> Async.RunImmediate
                             |> ignore
                             
                         // On 'QuickInfo', get the text for the quick info while we're off the UI thread, instead of doing it later

--- a/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
+++ b/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
@@ -7,7 +7,6 @@
 namespace Microsoft.VisualStudio.FSharp.LanguageService
 
 open System
-open System.Threading.Tasks
 open Microsoft.VisualStudio.TextManager.Interop 
 open Microsoft.VisualStudio.Text
 open FSharp.Compiler
@@ -18,21 +17,6 @@ open Microsoft.VisualStudio.FSharp.LanguageService.SiteProvider
 open Microsoft.VisualStudio.FSharp.Interactive.Session
 
 #nowarn "44" // use of obsolete CheckFileInProjectAllowingStaleCachedResults
-
-[<AutoOpen>]
-module AsyncExtensions =
-    type Async with
-        static member RunImmediate (computation: Async<'T>, ?cancellationToken ) =
-            let cancellationToken = defaultArg cancellationToken Async.DefaultCancellationToken
-            let ts = TaskCompletionSource<'T>()
-            let task = ts.Task
-            Async.StartWithContinuations(
-                computation,
-                (fun k -> ts.SetResult k),
-                (fun exn -> ts.SetException exn),
-                (fun _ -> ts.SetCanceled()),
-                cancellationToken)
-            task.Result
 
 //
 // Note: DEPRECATED CODE ONLY ACTIVE IN UNIT TESTING VIA "UNROSLYNIZED" UNIT TESTS. 

--- a/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
@@ -373,7 +373,7 @@ type internal FSharpSource_DEPRECATED(service:LanguageService_DEPRECATED, textLi
                   Stamp = None }
                 |> ic.GetParsingOptionsFromProjectOptions
 
-            ic.ParseFile(fileName,  FSharp.Compiler.Text.SourceText.ofString (source.GetText()), co) |> Async.RunSynchronously
+            ic.ParseFile(fileName,  FSharp.Compiler.Text.SourceText.ofString (source.GetText()), co) |> Async.RunImmediate
 
         override source.GetCommentFormat() = 
             let mutable info = new CommentInfo()

--- a/vsintegration/src/FSharp.LanguageService/LanguageServiceConstants.fs
+++ b/vsintegration/src/FSharp.LanguageService/LanguageServiceConstants.fs
@@ -2,6 +2,8 @@
 
 namespace Microsoft.VisualStudio.FSharp.LanguageService
 
+open System.Threading.Tasks
+
 [<RequireQualifiedAccess>]
 module internal LanguageServiceConstants =
     
@@ -12,3 +14,20 @@ module internal LanguageServiceConstants =
     [<Literal>]
     /// "F# Language Service"
     let FSharpLanguageServiceCallbackName = "F# Language Service"
+
+
+[<AutoOpen>]
+module AsyncExtensions =
+    type Async with
+        static member RunImmediate (computation: Async<'T>, ?cancellationToken ) =
+            let cancellationToken = defaultArg cancellationToken Async.DefaultCancellationToken
+            let ts = TaskCompletionSource<'T>()
+            let task = ts.Task
+            Async.StartWithContinuations(
+                computation,
+                (fun k -> ts.SetResult k),
+                (fun exn -> ts.SetException exn),
+                (fun _ -> ts.SetCanceled()),
+                cancellationToken)
+            task.Result
+

--- a/vsintegration/tests/Salsa/FSharpLanguageServiceTestable.fs
+++ b/vsintegration/tests/Salsa/FSharpLanguageServiceTestable.fs
@@ -129,7 +129,7 @@ type internal FSharpLanguageServiceTestable() as this =
     member this.OnProjectCleaned(projectSite:IProjectSite) = 
         let enableInMemoryCrossProjectReferences = true
         let _, checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(enableInMemoryCrossProjectReferences, (fun _ -> None), projectSite, serviceProvider.Value, "" , false)
-        this.FSharpChecker.NotifyProjectCleaned(checkOptions) |> Async.RunSynchronously
+        this.FSharpChecker.NotifyProjectCleaned(checkOptions) |> Async.RunImmediate
 
     member this.OnActiveViewChanged(textView) =
         bgRequests.OnActiveViewChanged(textView)

--- a/vsintegration/tests/Salsa/salsa.fs
+++ b/vsintegration/tests/Salsa/salsa.fs
@@ -1102,7 +1102,7 @@ module internal Salsa =
             member file.GetFileName() = filename
             member file.GetProjectOptionsOfScript() = 
                 project.Solution.Vs.LanguageService.FSharpChecker.GetProjectOptionsFromScript(filename, FSharp.Compiler.Text.SourceText.ofString file.CombinedLines, false, System.DateTime(2000,1,1), [| |]) 
-                |> Async.RunSynchronously
+                |> Async.RunImmediate
                 |> fst // drop diagnostics
                  
             member file.RecolorizeWholeFile() = ()
@@ -1316,7 +1316,7 @@ module internal Salsa =
                 
                 let declarations = 
                     let snapshot = VsActual.createTextBuffer(file.CombinedLines).CurrentSnapshot 
-                    currentAuthoringScope.GetDeclarations(snapshot, cursor.line-1, cursor.col-1, reason) |> Async.RunSynchronously
+                    currentAuthoringScope.GetDeclarations(snapshot, cursor.line-1, cursor.col-1, reason) |> Async.RunImmediate
                 match declarations with 
                 | null -> [||]
                 | declarations ->
@@ -1335,7 +1335,7 @@ module internal Salsa =
                 let currentAuthoringScope = file.DoIntellisenseRequest(BackgroundRequestReason.MemberSelect)
                 let declarations = 
                     let snapshot = VsActual.createTextBuffer(file.CombinedLines).CurrentSnapshot 
-                    currentAuthoringScope.GetDeclarations(snapshot, cursor.line-1,cursor.col-1, BackgroundRequestReason.MemberSelect) |> Async.RunSynchronously
+                    currentAuthoringScope.GetDeclarations(snapshot, cursor.line-1,cursor.col-1, BackgroundRequestReason.MemberSelect) |> Async.RunImmediate
                 match declarations with 
                 | null -> None
                 | declarations -> 

--- a/vsintegration/tests/UnitTests/BraceMatchingServiceTests.fs
+++ b/vsintegration/tests/UnitTests/BraceMatchingServiceTests.fs
@@ -37,7 +37,7 @@ type BraceMatchingServiceTests()  =
         Assert.IsTrue(position >= 0, "Cannot find marker '{0}' in file contents", marker)
 
         let parsingOptions, _ = checker.GetParsingOptionsFromProjectOptions projectOptions
-        match FSharpBraceMatchingService.GetBraceMatchingResult(checker, sourceText, fileName, parsingOptions, position, "UnitTest") |> Async.RunSynchronously with
+        match FSharpBraceMatchingService.GetBraceMatchingResult(checker, sourceText, fileName, parsingOptions, position, "UnitTest") |> Async.RunImmediate with
         | None -> ()
         | Some(left, right) -> Assert.Fail("Found match for brace '{0}'", marker)
         
@@ -50,7 +50,7 @@ type BraceMatchingServiceTests()  =
         Assert.IsTrue(endMarkerPosition >= 0, "Cannot find end marker '{0}' in file contents", endMarkerPosition)
         
         let parsingOptions, _ = checker.GetParsingOptionsFromProjectOptions projectOptions
-        match FSharpBraceMatchingService.GetBraceMatchingResult(checker, sourceText, fileName, parsingOptions, startMarkerPosition, "UnitTest") |> Async.RunSynchronously with
+        match FSharpBraceMatchingService.GetBraceMatchingResult(checker, sourceText, fileName, parsingOptions, startMarkerPosition, "UnitTest") |> Async.RunImmediate with
         | None -> Assert.Fail("Didn't find a match for start brace at position '{0}", startMarkerPosition)
         | Some(left, right) ->
             let endPositionInRange(range) = 


### PR DESCRIPTION
Addresses internal engineering issue https://github.com/dotnet/fsharp/issues/11754

Async.RunSynchronously starts the async on a thread pool thread.  There is a suggestion to add Async.RunImmediate that never does this. https://github.com/fsharp/fslang-suggestions/issues/1042.  This can be defined in terms of `Async.StartWithContinuations` (which should really be called `Async.StartImmediateWithContinuations`)

This defines and uses Async.RunImmediate internally in our compiler/service implementation and testing since it gives much better synchronous stacks.  

