### PR TITLE
Add RequireQualifiedAccess to ParsedHashDirectiveArgument type.

### DIFF
--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1826,7 +1826,7 @@ type SynModuleOrNamespaceSig =
         match this with
         | SynModuleOrNamespaceSig (range=m) -> m
 
-[<NoEquality; NoComparison>]
+[<NoEquality; NoComparison; RequireQualifiedAccess>]
 type ParsedHashDirectiveArgument =
      | String of value: string * stringKind: SynStringKind * range: Range
      | SourceIdentifier of constant: string * value: string * range: Range

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -2015,7 +2015,7 @@ type SynModuleOrNamespaceSig =
     member Range: range
 
 /// Represents a parsed hash directive argument
-[<NoEquality; NoComparison>]
+[<NoEquality; NoComparison; RequireQualifiedAccess>]
 type ParsedHashDirectiveArgument =
     | String of value: string * stringKind: SynStringKind * range: Range
     | SourceIdentifier of constant: string * value: string * range: Range


### PR DESCRIPTION
Otherwise, there is quite the collision with the `String` type.
Good spot by @auduchinok!