### PR TITLE
Remove call to SetLength when copying `ReadOnlyMemory<byte>` to a MemoryMapped file

### DIFF
--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -353,7 +353,6 @@ module MemoryMappedFileExtensions =
             let length = int64 bytes.Length
             trymmf length
                 (fun stream ->
-                    stream.SetLength(stream.Length + length)
                     let span = Span<byte>(stream.PositionPointer |> NativePtr.toVoidPtr, int length)
                     bytes.Span.CopyTo(span)
                     stream.Position <- stream.Position + length


### PR DESCRIPTION
@vzarytovskii correctly pointed out that we can't set the length of a memory mapped file. It's already fixed length so it should be safe to not do it.