### PR TITLE
Fix 11797

### DIFF
--- a/src/fsharp/FSharp.Core/async.fs
+++ b/src/fsharp/FSharp.Core/async.fs
@@ -237,41 +237,41 @@ namespace Microsoft.FSharp.Control
         member ctxt.WithExceptionContinuation econt = AsyncActivation<'T> { contents with aux = { ctxt.aux with econt = econt } }
 
         /// Produce a new execution context for a composite async
-        member _.WithContinuation cont = AsyncActivation<'U> { cont = cont; aux = contents.aux }
+        member ctxt.WithContinuation cont = AsyncActivation<'U> { cont = cont; aux = contents.aux }
 
         /// Produce a new execution context for a composite async
-        member _.WithContinuations(cont, econt) = AsyncActivation<'U> { cont = cont; aux = { contents.aux with econt = econt } }
+        member ctxt.WithContinuations(cont, econt) = AsyncActivation<'U> { cont = cont; aux = { contents.aux with econt = econt } }
 
         /// Produce a new execution context for a composite async
         member ctxt.WithContinuations(cont, econt, ccont) = AsyncActivation<'T> { contents with cont = cont; aux = { ctxt.aux with econt = econt; ccont = ccont } }
 
         /// The extra information relevant to the execution of the async
-        member _.aux = contents.aux
+        member ctxt.aux = contents.aux
 
         /// The success continuation relevant to the execution of the async
-        member _.cont = contents.cont
+        member ctxt.cont = contents.cont
 
         /// The exception continuation relevant to the execution of the async
-        member _.econt = contents.aux.econt
+        member ctxt.econt = contents.aux.econt
 
         /// The cancellation continuation relevant to the execution of the async
-        member _.ccont = contents.aux.ccont
+        member ctxt.ccont = contents.aux.ccont
 
         /// The cancellation token relevant to the execution of the async
-        member _.token = contents.aux.token
+        member ctxt.token = contents.aux.token
 
         /// The trampoline holder being used to protect execution of the async
-        member _.trampolineHolder = contents.aux.trampolineHolder
+        member ctxt.trampolineHolder = contents.aux.trampolineHolder
 
         /// Check if cancellation has been requested
-        member _.IsCancellationRequested = contents.aux.token.IsCancellationRequested
+        member ctxt.IsCancellationRequested = contents.aux.token.IsCancellationRequested
 
         /// Call the cancellation continuation of the active computation
-        member _.OnCancellation () =
+        member ctxt.OnCancellation () =
             contents.aux.ccont (OperationCanceledException (contents.aux.token))
 
         /// Check for trampoline hijacking.
-        member inline _.HijackCheckThenCall cont arg =
+        member inline ctxt.HijackCheckThenCall cont arg =
             contents.aux.trampolineHolder.HijackCheckThenCall cont arg
 
         /// Call the success continuation of the asynchronous execution context after checking for
@@ -283,7 +283,7 @@ namespace Microsoft.FSharp.Control
                 ctxt.HijackCheckThenCall ctxt.cont result
 
         /// Save the exception continuation during propagation of an exception, or prior to raising an exception
-        member _.OnExceptionRaised() =
+        member ctxt.OnExceptionRaised() =
             contents.aux.trampolineHolder.OnExceptionRaised contents.aux.econt
 
         /// Make an initial async activation.
@@ -394,6 +394,24 @@ namespace Microsoft.FSharp.Control
             else
                 fake()
 
+        /// Like `CallThenInvoke` but does not do a hijack check for historical reasons (exact code compat)
+        [<DebuggerHidden>]
+        let CallThenInvokeNoHijackCheck (ctxt: AsyncActivation<_>) userCode result1 =
+            let mutable res = Unchecked.defaultof<_>
+            let mutable ok = false
+
+            try
+                res <- userCode result1
+                ok <- true
+            finally
+                if not ok then
+                    ctxt.OnExceptionRaised()
+
+            if ok then
+                res.Invoke ctxt
+            else
+                fake()
+
         /// Apply 'catchFilter' to 'arg'. If the result is 'Some' invoke the resulting computation. If the result is 'None'
         /// then send 'result1' to the exception continuation.
         [<DebuggerHidden>]
@@ -441,30 +459,31 @@ namespace Microsoft.FSharp.Control
         [<DebuggerHidden>]
         // Note: direct calls to this function end up in user assemblies via inlining
         let Bind (ctxt: AsyncActivation<'T>) (part1: Async<'U>) (part2: 'U -> Async<'T>) : AsyncReturn =
-            // We do a cancellation check before the Bind, but not after. This is because we may be about to enter
-            // a TryFinally
             if ctxt.IsCancellationRequested then
                 ctxt.OnCancellation ()
             else
-                Invoke part1 (ctxt.WithContinuation(fun result1 -> CallThenInvoke ctxt result1 part2))
+                Invoke part1 (ctxt.WithContinuation(fun result1 -> CallThenInvokeNoHijackCheck ctxt part2 result1 ))
 
         [<DebuggerHidden>]
         /// Re-route all continuations to execute the finally function.
         let TryFinally (ctxt: AsyncActivation<'T>) computation finallyFunction =
-            // The new continuation runs the finallyFunction and resumes the old continuation
-            // If an exception is thrown we continue with the previous exception continuation.
-            let cont result     =
-                CallThenContinue finallyFunction () (ctxt.WithContinuation(fun () -> ctxt.cont result))
-            // The new exception continuation runs the finallyFunction and then runs the previous exception continuation.
-            // If an exception is thrown we continue with the previous exception continuation.
-            let econt exn  =
-                CallThenContinue finallyFunction () (ctxt.WithContinuation(fun () -> ctxt.econt exn))
-            // The cancellation continuation runs the finallyFunction and then runs the previous cancellation continuation.
-            // If an exception is thrown we continue with the previous cancellation continuation (the exception is lost)
-            let ccont cexn =
-                CallThenContinue finallyFunction () (ctxt.WithContinuations(cont=(fun () -> ctxt.ccont cexn), econt = (fun _ -> ctxt.ccont cexn)))
-            let newCtxt = ctxt.WithContinuations(cont=cont, econt=econt, ccont=ccont)
-            computation.Invoke newCtxt
+            if ctxt.IsCancellationRequested then
+                ctxt.OnCancellation ()
+            else
+                // The new continuation runs the finallyFunction and resumes the old continuation
+                // If an exception is thrown we continue with the previous exception continuation.
+                let cont result     =
+                    CallThenContinue finallyFunction () (ctxt.WithContinuation(fun () -> ctxt.cont result))
+                // The new exception continuation runs the finallyFunction and then runs the previous exception continuation.
+                // If an exception is thrown we continue with the previous exception continuation.
+                let econt exn  =
+                    CallThenContinue finallyFunction () (ctxt.WithContinuation(fun () -> ctxt.econt exn))
+                // The cancellation continuation runs the finallyFunction and then runs the previous cancellation continuation.
+                // If an exception is thrown we continue with the previous cancellation continuation (the exception is lost)
+                let ccont cexn =
+                    CallThenContinue finallyFunction () (ctxt.WithContinuations(cont=(fun () -> ctxt.ccont cexn), econt = (fun _ -> ctxt.ccont cexn)))
+                let newCtxt = ctxt.WithContinuations(cont=cont, econt=econt, ccont=ccont)
+                computation.Invoke newCtxt
 
         /// Re-route the exception continuation to call to catchFunction. If catchFunction returns None then call the exception continuation.
         /// If it returns Some, invoke the resulting async.
@@ -487,7 +506,7 @@ namespace Microsoft.FSharp.Control
         let CreateProtectedAsync f =
             MakeAsync (fun ctxt -> ProtectedCode ctxt f)
 
-        /// Make an async from an AsyncResult
+        /// Internal way of making an async from result, for exact code compat.
         let CreateAsyncResultAsync res =
             MakeAsync (fun ctxt ->
                 match res with
@@ -606,8 +625,7 @@ namespace Microsoft.FSharp.Control
                                        ccont = (fun x -> ctxt.trampolineHolder.PostWithTrampoline syncCtxt (fun () -> ctxt.ccont x)))
 
         // When run, ensures that each of the continuations of the process are run in the same synchronization context.
-        // Also protects 'f' which should not actually call any of the continuations of 'ctxt'
-        let CreateDelimitedProtectedAsync f =
+        let CreateDelimitedUserCodeAsync f =
             CreateProtectedAsync (fun ctxt ->
                 let ctxtWithSync = DelimitSyncContext ctxt
                 f ctxtWithSync)
@@ -1354,7 +1372,7 @@ namespace Microsoft.FSharp.Control
             AsyncPrimitives.StartWithContinuations cancellationToken computation id (fun edi -> edi.ThrowAny()) ignore
 
         static member Sleep (millisecondsDueTime: int64) : Async<unit> =
-            CreateDelimitedProtectedAsync (fun ctxt ->
+            CreateDelimitedUserCodeAsync (fun ctxt ->
                 let mutable timer = None: Timer option
                 let cont = ctxt.cont
                 let ccont = ctxt.ccont
@@ -1415,7 +1433,7 @@ namespace Microsoft.FSharp.Control
                     let ok = waitHandle.WaitOne(0, exitContext=false)
                     async.Return ok)
             else
-                CreateDelimitedProtectedAsync(fun ctxt ->
+                CreateDelimitedUserCodeAsync(fun ctxt ->
                     let aux = ctxt.aux
                     let rwh = ref (None: RegisteredWaitHandle option)
                     let latch = Latch()
@@ -1464,7 +1482,11 @@ namespace Microsoft.FSharp.Control
 
         /// Bind the result of a result cell, calling the appropriate continuation.
         static member BindResult (result: AsyncResult<'T>) : Async<'T> =
-            CreateAsyncResultAsync result
+            MakeAsync (fun ctxt ->
+                   (match result with
+                    | Ok v -> ctxt.cont v
+                    | Error exn -> ctxt.econt exn
+                    | Canceled exn -> ctxt.ccont exn) )
 
         /// Await and use the result of a result cell. The resulting async doesn't support cancellation
         /// or timeout directly, rather the underlying computation must fill the result if cancellation
@@ -1687,13 +1709,13 @@ namespace Microsoft.FSharp.Control
             if task.IsCompleted then
                 MakeAsync (fun ctxt -> OnTaskCompleted task ctxt)
             else
-                CreateDelimitedProtectedAsync (fun ctxt -> AttachContinuationToTask task ctxt)
+                CreateDelimitedUserCodeAsync (fun ctxt -> AttachContinuationToTask task ctxt)
 
         static member AwaitTask (task:Task) : Async<unit> =
             if task.IsCompleted then
                 MakeAsync (fun ctxt -> OnUnitTaskCompleted task ctxt)
             else
-                CreateDelimitedProtectedAsync (fun ctxt -> AttachContinuationToUnitTask task ctxt)
+                CreateDelimitedUserCodeAsync (fun ctxt -> AttachContinuationToUnitTask task ctxt)
 
     module CommonExtensions =
 

--- a/src/fsharp/FSharp.Core/async.fs
+++ b/src/fsharp/FSharp.Core/async.fs
@@ -933,27 +933,28 @@ namespace Microsoft.FSharp.Control
                 ctxt.cont ()
 
         // Helper to attach continuation to the given task, which is assumed not to be completed.
-        // When the task completes the continuation will be run asynchronously in the thread pool
-        // with trampoline protection.
+        // When the task completes the continuation will be run synchronously on the thread
+        // completing the task. This will install a new trampoline on that thread and continue the
+        // execution of the async there.
         [<DebuggerHidden>]
         let AttachContinuationToTask (task: Task<'T>) (ctxt: AsyncActivation<'T>)  =
             task.ContinueWith(Action<Task<'T>>(fun completedTask -> 
                 ctxt.trampolineHolder.ExecuteWithTrampoline (fun () ->
                     OnTaskCompleted completedTask ctxt)
-                |> unfake))
+                |> unfake), TaskContinuationOptions.ExecuteSynchronously)
             |> ignore
             |> fake
 
         // Helper to attach continuation to the given task, which is assumed not to be completed
-        // When the task completes the continuation will be run asynchronously in the thread pool
-        // with trampoline protection.
+        // When the task completes the continuation will be run synchronously on the thread
+        // completing the task. This will install a new trampoline on that thread and continue the
+        // execution of the async there.
         [<DebuggerHidden>]
         let AttachContinuationToUnitTask (task: Task) (ctxt: AsyncActivation<unit>) =
             task.ContinueWith(Action<Task>(fun completedTask ->
                 ctxt.trampolineHolder.ExecuteWithTrampoline (fun () ->
                     OnUnitTaskCompleted completedTask ctxt)
-                |> unfake
-            ))
+                |> unfake), TaskContinuationOptions.ExecuteSynchronously)
             |> ignore 
             |> fake
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -21,9 +21,12 @@ type AsyncType() =
     let ignoreSynchCtx f =
         f ()
 
+    let waitASec (t:Task) =
+        let result = t.Wait(TimeSpan(hours=0,minutes=0,seconds=1))
+        Assert.True(result, "Task did not finish after waiting for a second.")
 
     [<Fact>]
-    member this.StartWithContinuations() =
+    member _.StartWithContinuations() =
 
         let whatToDo = ref Exit
 
@@ -75,7 +78,7 @@ type AsyncType() =
         ()
 
     [<Fact>]
-    member this.AsyncRunSynchronouslyReusesThreadPoolThread() =
+    member _.AsyncRunSynchronouslyReusesThreadPoolThread() =
         let action = async { async { () } |> Async.RunSynchronously }
         let computation =
             [| for i in 1 .. 1000 -> action |]
@@ -90,7 +93,7 @@ type AsyncType() =
     [<Theory>]
     [<InlineData("int32")>]
     [<InlineData("timespan")>]
-    member this.AsyncSleepCancellation1(sleepType) =
+    member _.AsyncSleepCancellation1(sleepType) =
         ignoreSynchCtx (fun () ->
             let computation =
                 match sleepType with
@@ -112,7 +115,7 @@ type AsyncType() =
     [<Theory>]
     [<InlineData("int32")>]
     [<InlineData("timespan")>]
-    member this.AsyncSleepCancellation2(sleepType) =
+    member _.AsyncSleepCancellation2(sleepType) =
         ignoreSynchCtx (fun () ->
             let computation =
                 match sleepType with
@@ -137,7 +140,7 @@ type AsyncType() =
     [<Theory>]
     [<InlineData("int32")>]
     [<InlineData("timespan")>]
-    member this.AsyncSleepThrowsOnNegativeDueTimes(sleepType) =
+    member _.AsyncSleepThrowsOnNegativeDueTimes(sleepType) =
         async {
             try
                 do! match sleepType with
@@ -150,7 +153,7 @@ type AsyncType() =
         } |> Async.RunSynchronously
 
     [<Fact>]
-    member this.AsyncSleepInfinitely() =
+    member _.AsyncSleepInfinitely() =
         ignoreSynchCtx (fun () ->
             let computation = Async.Sleep(System.Threading.Timeout.Infinite)
             let result = TaskCompletionSource<string>()
@@ -164,27 +167,17 @@ type AsyncType() =
             Assert.AreEqual("Cancel", result)
         )
 
-    member private this.WaitASec (t:Task) =
-        let result = t.Wait(TimeSpan(hours=0,minutes=0,seconds=1))
-        Assert.True(result, "Task did not finish after waiting for a second.")
-
-
     [<Fact>]
-    member this.CreateTask () =
+    member _.CreateTask () =
         let s = "Hello tasks!"
         let a = async { return s }
-#if !NET46
-        let t : Task<string> =
-#else
-        use t : Task<string> =
-#endif
-            Async.StartAsTask a
-        this.WaitASec t
+        use t : Task<string> = Async.StartAsTask a
+        waitASec t
         Assert.True (t.IsCompleted)
         Assert.AreEqual(s, t.Result)
 
     [<Fact>]
-    member this.StartAsTaskCancellation () =
+    member _.StartAsTaskCancellation () =
         let cts = new CancellationTokenSource()
         let mutable spinloop = true
         let doSpinloop () = while spinloop do ()
@@ -192,12 +185,7 @@ type AsyncType() =
             cts.CancelAfter (100)
             doSpinloop()
         }
-#if !NET46
-        let t : Task<unit> =
-#else
-        use t : Task<unit> =
-#endif
-            Async.StartAsTask(a, cancellationToken = cts.Token)
+        use t : Task<unit> = Async.StartAsTask(a, cancellationToken = cts.Token)
 
         // Should not finish, we don't eagerly mark the task done just because it's been signaled to cancel.
         try
@@ -208,7 +196,7 @@ type AsyncType() =
         spinloop <- false
 
         try
-            this.WaitASec t
+            waitASec t
         with :? AggregateException as a ->
             match a.InnerException with
             | :? TaskCanceledException as t -> ()
@@ -216,7 +204,7 @@ type AsyncType() =
         Assert.True (t.IsCompleted, "Task is not completed")
 
     [<Fact>]
-    member this.``AwaitTask ignores Async cancellation`` () =
+    member _.``AwaitTask ignores Async cancellation`` () =
         let cts = new CancellationTokenSource()
         let tcs = new TaskCompletionSource<unit>()
         let innerTcs = new TaskCompletionSource<unit>()
@@ -233,7 +221,7 @@ type AsyncType() =
         innerTcs.SetResult ()
 
         try
-            this.WaitASec tcs.Task
+            waitASec tcs.Task
         with :? AggregateException as a ->
             match a.InnerException with
             | :? TaskCanceledException -> ()
@@ -241,7 +229,7 @@ type AsyncType() =
         Assert.True (tcs.Task.IsCompleted, "Task is not completed")
 
     [<Fact>]
-    member this.RunSynchronouslyCancellationWithDelayedResult () =
+    member _.RunSynchronouslyCancellationWithDelayedResult () =
         let cts = new CancellationTokenSource()
         let tcs = TaskCompletionSource<int>()
         let _ = cts.Token.Register(fun () -> tcs.SetResult 42)
@@ -260,45 +248,35 @@ type AsyncType() =
         Assert.True (cancelled, "Task is not cancelled")
 
     [<Fact>]
-    member this.ExceptionPropagatesToTask () =
+    member _.ExceptionPropagatesToTask () =
         let a = async {
             do raise (Exception ())
          }
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Async.StartAsTask a
+        use t = Async.StartAsTask a
         let mutable exceptionThrown = false
         try
-            this.WaitASec t
+            waitASec t
         with
             e -> exceptionThrown <- true
         Assert.True (t.IsFaulted)
         Assert.True(exceptionThrown)
 
     [<Fact>]
-    member this.CancellationPropagatesToTask () =
+    member _.CancellationPropagatesToTask () =
         let a = async {
                 while true do ()
             }
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Async.StartAsTask a
+        use t = Async.StartAsTask a
         Async.CancelDefaultToken ()
         let mutable exceptionThrown = false
         try
-            this.WaitASec t
+            waitASec t
         with e -> exceptionThrown <- true
         Assert.True (exceptionThrown)
         Assert.True(t.IsCanceled)
 
     [<Fact>]
-    member this.CancellationPropagatesToGroup () =
+    member _.CancellationPropagatesToGroup () =
         let ewh = new ManualResetEvent(false)
         let cancelled = ref false
         let a = async {
@@ -308,67 +286,47 @@ type AsyncType() =
             }
         let cts = new CancellationTokenSource()
         let token = cts.Token
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Async.StartAsTask(a, cancellationToken=token)
+        use t = Async.StartAsTask(a, cancellationToken=token)
 //        printfn "%A" t.Status
         ewh.WaitOne() |> Assert.True
         cts.Cancel()
 //        printfn "%A" t.Status
         let mutable exceptionThrown = false
         try
-            this.WaitASec t
+            waitASec t
         with e -> exceptionThrown <- true
         Assert.True (exceptionThrown)
         Assert.True(t.IsCanceled)
         Assert.True(!cancelled)
 
     [<Fact>]
-    member this.CreateImmediateAsTask () =
+    member _.CreateImmediateAsTask () =
         let s = "Hello tasks!"
         let a = async { return s }
-#if !NET46
-        let t : Task<string> =
-#else
-        use t : Task<string> =
-#endif
-            Async.StartImmediateAsTask a
-        this.WaitASec t
+        use t : Task<string> = Async.StartImmediateAsTask a
+        waitASec t
         Assert.True (t.IsCompleted)
         Assert.AreEqual(s, t.Result)
 
     [<Fact>]
-    member this.StartImmediateAsTask () =
+    member _.StartImmediateAsTask () =
         let s = "Hello tasks!"
         let a = async { return s }
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Async.StartImmediateAsTask a
-        this.WaitASec t
+        use t = Async.StartImmediateAsTask a
+        waitASec t
         Assert.True (t.IsCompleted)
         Assert.AreEqual(s, t.Result)
 
 
     [<Fact>]
-    member this.ExceptionPropagatesToImmediateTask () =
+    member _.ExceptionPropagatesToImmediateTask () =
         let a = async {
             do raise (Exception ())
          }
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Async.StartImmediateAsTask a
+        use t = Async.StartImmediateAsTask a
         let mutable exceptionThrown = false
         try
-            this.WaitASec t
+            waitASec t
         with
             e -> exceptionThrown <- true
         Assert.True (t.IsFaulted)
@@ -377,20 +335,15 @@ type AsyncType() =
 #if IGNORED
     [<Fact>]
     [<Ignore("https://github.com/Microsoft/visualfsharp/issues/4337")>]
-    member this.CancellationPropagatesToImmediateTask () =
+    member _.CancellationPropagatesToImmediateTask () =
         let a = async {
                 while true do ()
             }
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Async.StartImmediateAsTask a
+        use t = Async.StartImmediateAsTask a
         Async.CancelDefaultToken ()
         let mutable exceptionThrown = false
         try
-            this.WaitASec t
+            waitASec t
         with e -> exceptionThrown <- true
         Assert.True (exceptionThrown)
         Assert.True(t.IsCanceled)
@@ -399,7 +352,7 @@ type AsyncType() =
 #if IGNORED
     [<Fact>]
     [<Ignore("https://github.com/Microsoft/visualfsharp/issues/4337")>]
-    member this.CancellationPropagatesToGroupImmediate () =
+    member _.CancellationPropagatesToGroupImmediate () =
         let ewh = new ManualResetEvent(false)
         let cancelled = ref false
         let a = async {
@@ -417,7 +370,7 @@ type AsyncType() =
 //        printfn "%A" t.Status
         let mutable exceptionThrown = false
         try
-            this.WaitASec t
+            waitASec t
         with e -> exceptionThrown <- true
         Assert.True (exceptionThrown)
         Assert.True(t.IsCanceled)
@@ -425,14 +378,9 @@ type AsyncType() =
 #endif
 
     [<Fact>]
-    member this.TaskAsyncValue () =
+    member _.TaskAsyncValue () =
         let s = "Test"
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Task.Factory.StartNew(Func<_>(fun () -> s))
+        use t = Task.Factory.StartNew(Func<_>(fun () -> s))
         let a = async {
                 let! s1 = Async.AwaitTask(t)
                 return s = s1
@@ -440,7 +388,7 @@ type AsyncType() =
         Async.RunSynchronously(a) |> Assert.True
 
     [<Fact>]
-    member this.AwaitTaskCancellation () =
+    member _.AwaitTaskCancellation () =
         let test() = async {
             let tcs = new System.Threading.Tasks.TaskCompletionSource<unit>()
             tcs.SetCanceled()
@@ -453,7 +401,7 @@ type AsyncType() =
         Async.RunSynchronously(test()) |> Assert.True
 
     [<Fact>]
-    member this.AwaitCompletedTask() =
+    member _.AwaitCompletedTask() =
         let test() = async {
             let threadIdBefore = Thread.CurrentThread.ManagedThreadId
             do! Async.AwaitTask Task.CompletedTask
@@ -464,7 +412,7 @@ type AsyncType() =
         Async.RunSynchronously(test()) |> Assert.True
 
     [<Fact>]
-    member this.AwaitTaskCancellationUntyped () =
+    member _.AwaitTaskCancellationUntyped () =
         let test() = async {
             let tcs = new System.Threading.Tasks.TaskCompletionSource<unit>()
             tcs.SetCanceled()
@@ -477,13 +425,8 @@ type AsyncType() =
         Async.RunSynchronously(test()) |> Assert.True
 
     [<Fact>]
-    member this.TaskAsyncValueException () =
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Task.Factory.StartNew(Func<unit>(fun () -> raise <| Exception()))
+    member _.TaskAsyncValueException () =
+        use t = Task.Factory.StartNew(Func<unit>(fun () -> raise <| Exception()))
         let a = async {
                 try
                     let! v = Async.AwaitTask(t)
@@ -494,16 +437,11 @@ type AsyncType() =
 
     // test is flaky: https://github.com/dotnet/fsharp/issues/11586
     //[<Fact>]
-    member this.TaskAsyncValueCancellation () =
+    member _.TaskAsyncValueCancellation () =
         use ewh = new ManualResetEvent(false)
         let cts = new CancellationTokenSource()
         let token = cts.Token
-#if !NET46
-        let t : Task<unit>=
-#else
-        use t : Task<unit>=
-#endif
-          Task.Factory.StartNew(Func<unit>(fun () -> while not token.IsCancellationRequested do ()), token)
+        use t : Task<unit> = Task.Factory.StartNew(Func<unit>(fun () -> while not token.IsCancellationRequested do ()), token)
         let cancelled = ref true
         let a = 
             async {
@@ -521,14 +459,9 @@ type AsyncType() =
         ewh.WaitOne(10000) |> ignore
 
     [<Fact>]
-    member this.NonGenericTaskAsyncValue () =
+    member _.NonGenericTaskAsyncValue () =
         let hasBeenCalled = ref false
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Task.Factory.StartNew(Action(fun () -> hasBeenCalled := true))
+        use t = Task.Factory.StartNew(Action(fun () -> hasBeenCalled := true))
         let a = async {
                 do! Async.AwaitTask(t)
                 return true
@@ -537,13 +470,8 @@ type AsyncType() =
         (!hasBeenCalled && result) |> Assert.True
 
     [<Fact>]
-    member this.NonGenericTaskAsyncValueException () =
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Task.Factory.StartNew(Action(fun () -> raise <| Exception()))
+    member _.NonGenericTaskAsyncValueException () =
+        use t = Task.Factory.StartNew(Action(fun () -> raise <| Exception()))
         let a = async {
                 try
                     let! v = Async.AwaitTask(t)
@@ -553,16 +481,11 @@ type AsyncType() =
         Async.RunSynchronously(a) |> Assert.True
 
     [<Fact>]
-    member this.NonGenericTaskAsyncValueCancellation () =
+    member _.NonGenericTaskAsyncValueCancellation () =
         use ewh = new ManualResetEvent(false)
         let cts = new CancellationTokenSource()
         let token = cts.Token
-#if !NET46
-        let t =
-#else
-        use t =
-#endif
-            Task.Factory.StartNew(Action(fun () -> while not token.IsCancellationRequested do ()), token)
+        use t = Task.Factory.StartNew(Action(fun () -> while not token.IsCancellationRequested do ()), token)
         let a =
             async {
                 try
@@ -579,7 +502,7 @@ type AsyncType() =
         ewh.WaitOne(10000) |> ignore
 
     [<Fact>]
-    member this.CancellationExceptionThrown () =
+    member _.CancellationExceptionThrown () =
         use ewh = new ManualResetEventSlim(false)
         let cts = new CancellationTokenSource()
         let token = cts.Token
@@ -594,3 +517,20 @@ type AsyncType() =
         cts.Cancel()
         ewh.Wait(10000) |> ignore
         Assert.False hasThrown
+
+    [<Fact>]
+    member _.NoStackOverflowOnRecursion() =
+
+        let mutable hasThrown = false
+        let rec loop (x: int) = async {
+            do! Task.CompletedTask |> Async.AwaitTask
+            Console.WriteLine (if x = 10000 then failwith "finish" else x)
+            return! loop(x+1)
+        }
+    
+        try 
+           Async.RunSynchronously (loop 0)
+           hasThrown <- false
+        with Failure "finish" -> 
+            hasThrown <- true
+        Assert.True hasThrown


### PR DESCRIPTION
Fixes the regression #11797

The cause was this PR: https://github.com/dotnet/fsharp/pull/11142. That change installed a new trampoline on each completed task continuation. No new trampoline should be installed when we detect synchronous completion.

