### PR TITLE
Update base directory probing

### DIFF
--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -431,7 +431,7 @@ let main1(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted,
 
     let tryGetMetadataSnapshot = (fun _ -> None)
 
-    let defaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()).Value
+    let defaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(None).Value
 
     let tcConfigB =
        TcConfigBuilder.CreateNew(legacyReferenceResolver,
@@ -606,7 +606,7 @@ let main1OfAst
 
     let directoryBuildingFrom = Directory.GetCurrentDirectory()
 
-    let defaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()).Value
+    let defaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(None).Value
 
     let tcConfigB =
         TcConfigBuilder.CreateNew(legacyReferenceResolver, defaultFSharpBinariesDir,

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2766,16 +2766,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     let currentDirectory = Directory.GetCurrentDirectory()
     let tryGetMetadataSnapshot = (fun _ -> None)
 
-    let defaultFSharpBinariesDir = 
-        let fallback() =
-            let d = Assembly.GetExecutingAssembly()
-            Path.GetDirectoryName d.Location
-        match FSharpEnvironment.tryCurrentDomain() with
-        | None -> fallback()
-        | probPoint -> 
-            match FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(probPoint) with
-            | None -> fallback()
-            | Some dir -> dir
+    let defaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(None).Value
 
     let legacyReferenceResolver =
         match legacyReferenceResolver with

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2766,7 +2766,14 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     let currentDirectory = Directory.GetCurrentDirectory()
     let tryGetMetadataSnapshot = (fun _ -> None)
 
-    let defaultFSharpBinariesDir = FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()).Value
+    let defaultFSharpBinariesDir = 
+        try
+            FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()).Value
+        with
+        | _ ->
+            let d = System.Reflection.Assembly.GetExecutingAssembly() //IO.Directory.GetCurrentDirectory()        
+            let fi = IO.FileInfo(d.Location)
+            fi.DirectoryName
 
     let legacyReferenceResolver =
         match legacyReferenceResolver with

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2772,8 +2772,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         with
         | _ ->
             let d = System.Reflection.Assembly.GetExecutingAssembly() //IO.Directory.GetCurrentDirectory()        
-            let fi = IO.FileInfo(d.Location)
-            fi.DirectoryName
+            System.IO.Path.GetDirectoryName d.Location
 
     let legacyReferenceResolver =
         match legacyReferenceResolver with

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2771,9 +2771,9 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
             let d = Assembly.GetExecutingAssembly()
             Path.GetDirectoryName d.Location
         match FSharpEnvironment.tryCurrentDomain() with
-        | null -> fallback()
-        | dom -> 
-            match FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(dom) with
+        | None -> fallback()
+        | probPoint -> 
+            match FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(probPoint) with
             | None -> fallback()
             | Some dir -> dir
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2767,12 +2767,15 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     let tryGetMetadataSnapshot = (fun _ -> None)
 
     let defaultFSharpBinariesDir = 
-        try
-            FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()).Value
-        with
-        | _ ->
-            let d = System.Reflection.Assembly.GetExecutingAssembly() //IO.Directory.GetCurrentDirectory()        
-            System.IO.Path.GetDirectoryName d.Location
+        let fallback() =
+            let d = Assembly.GetExecutingAssembly()
+            Path.GetDirectoryName d.Location
+        match FSharpEnvironment.tryCurrentDomain() with
+        | null -> fallback()
+        | dom -> 
+            match FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(dom) with
+            | None -> fallback()
+            | Some dir -> dir
 
     let legacyReferenceResolver =
         match legacyReferenceResolver with

--- a/src/fsharp/utils/CompilerLocationUtils.fs
+++ b/src/fsharp/utils/CompilerLocationUtils.fs
@@ -199,8 +199,12 @@ module internal FSharpEnvironment =
             match probePoint with
             | Some p when safeExists (Path.Combine(p,"FSharp.Core.dll")) -> Some p
             | _ ->
-                    // For the prototype compiler, we can just use the current domain
-                    tryCurrentDomain()
+                let fallback() =
+                    let d = Assembly.GetExecutingAssembly()
+                    Some (Path.GetDirectoryName d.Location)
+                match tryCurrentDomain() with
+                | None -> fallback()
+                | Some path -> Some path
         with e -> None
 
 #if !FX_NO_WIN_REGISTRY


### PR DESCRIPTION
@ingted 's original PR and comments are here:  https://github.com/dotnet/fsharp/pull/11309

This update does makes a few changes to clean up the code somewhat
1. Rebased on latest main
2. BinFolderOfDefaultFSharpCompiler falls back to tryCurrentDomain .. here: https://github.com/dotnet/fsharp/blob/main/src/fsharp/utils/CompilerLocationUtils.fs#L203
    so FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(FSharpEnvironment.tryCurrentDomain()) just means doing it twice
3. Handle fall back in BinFolderOfDefaultFSharpCompiler
