### PR TITLE
Extend SynExpr.IfThenElse with keyword information.

### DIFF
--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -95,7 +95,7 @@ let YieldFree (cenv: cenv) expr =
             | SynExpr.Sequential (_, _, e1, e2, _) ->
                 YieldFree e1 && YieldFree e2
 
-            | SynExpr.IfThenElse (_, _, _, e2, _, e3opt, _, _, _, _) ->
+            | SynExpr.IfThenElse (_, _, _, _, e2, _, e3opt, _, _, _, _) ->
                 YieldFree e2 && Option.forall YieldFree e3opt
 
             | SynExpr.TryWith (e1, _, clauses, _, _, _, _) ->
@@ -126,7 +126,7 @@ let YieldFree (cenv: cenv) expr =
             | SynExpr.Sequential (_, _, e1, e2, _) ->
                 YieldFree e1 && YieldFree e2
 
-            | SynExpr.IfThenElse (_, _, _, e2, _, e3opt, _, _, _, _) ->
+            | SynExpr.IfThenElse (_, _, _, _, e2, _, e3opt, _, _, _, _) ->
                 YieldFree e2 && Option.forall YieldFree e3opt
 
             | SynExpr.TryWith (e1, _, clauses, _, _, _, _) ->
@@ -707,7 +707,7 @@ let TcComputationExpression cenv env overallTy tpenv (mWhole, interpExpr: Expr, 
     // NOTE: we should probably suppress these sequence points altogether
     let rangeForCombine innerComp1 = 
         match innerComp1 with 
-        | SynExpr.IfThenElse (_, _, _, _, _, _, _, _, mIfToThen, _m) -> mIfToThen
+        | SynExpr.IfThenElse (_, _, _, _, _, _, _, _, _, mIfToThen, _m) -> mIfToThen
         | SynExpr.Match (DebugPointAtBinding.Yes mMatch, _, _, _) -> mMatch
         | SynExpr.TryWith (_, _, _, _, _, DebugPointAtTry.Yes mTry, _) -> mTry
         | SynExpr.TryFinally (_, _, _, DebugPointAtTry.Yes mTry, _)  -> mTry
@@ -1071,17 +1071,17 @@ let TcComputationExpression cenv env overallTy tpenv (mWhole, interpExpr: Expr, 
                                 SynExpr.Sequential(sp, true, innerComp1, holeFill, m)
                         translatedCtxt fillExpr))
 
-        | SynExpr.IfThenElse (ifKw, guardExpr, thenKw, thenComp, elseKw, elseCompOpt, spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch) ->
+        | SynExpr.IfThenElse (ifKw, isElif, guardExpr, thenKw, thenComp, elseKw, elseCompOpt, spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch) ->
             match elseCompOpt with 
             | Some elseComp -> 
                 if isQuery then error(Error(FSComp.SR.tcIfThenElseMayNotBeUsedWithinQueries(), mIfToThen))
-                Some (translatedCtxt (SynExpr.IfThenElse (ifKw, guardExpr, thenKw, transNoQueryOps thenComp, elseKw, Some(transNoQueryOps elseComp), spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch)))
+                Some (translatedCtxt (SynExpr.IfThenElse (ifKw, isElif, guardExpr, thenKw, transNoQueryOps thenComp, elseKw, Some(transNoQueryOps elseComp), spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch)))
             | None -> 
                 let elseComp = 
                     if isNil (TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env mIfToThen ad "Zero" builderTy) then
                         error(Error(FSComp.SR.tcRequireBuilderMethod("Zero"), mIfToThen))
                     mkSynCall "Zero" mIfToThen []
-                Some (trans CompExprTranslationPass.Initial q varSpace thenComp (fun holeFill -> translatedCtxt (SynExpr.IfThenElse (ifKw, guardExpr, thenKw, holeFill, None, Some elseComp, spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch))))
+                Some (trans CompExprTranslationPass.Initial q varSpace thenComp (fun holeFill -> translatedCtxt (SynExpr.IfThenElse (ifKw, isElif, guardExpr, thenKw, holeFill, None, Some elseComp, spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch))))
 
         // 'let binds in expr'
         | SynExpr.LetOrUse (isRec, false, binds, innerComp, m) ->
@@ -1543,7 +1543,7 @@ let TcComputationExpression cenv env overallTy tpenv (mWhole, interpExpr: Expr, 
             else
                 None
 
-        | SynExpr.IfThenElse (ifKw, guardExpr, thenKw, thenComp, elseKw, elseCompOpt, spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch) ->
+        | SynExpr.IfThenElse (ifKw, isElif, guardExpr, thenKw, thenComp, elseKw, elseCompOpt, spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch) ->
             match convertSimpleReturnToExpr varSpace thenComp with
             | None -> None
             | Some (_, Some _) -> None
@@ -1558,7 +1558,7 @@ let TcComputationExpression cenv env overallTy tpenv (mWhole, interpExpr: Expr, 
                     | Some (elseExpr, None) -> Some (Some elseExpr)
             match elseExprOptOpt with 
             | None -> None
-            | Some elseExprOpt -> Some (SynExpr.IfThenElse (ifKw, guardExpr, thenKw, thenExpr, elseKw, elseExprOpt, spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch), None)
+            | Some elseExprOpt -> Some (SynExpr.IfThenElse (ifKw, isElif, guardExpr, thenKw, thenExpr, elseKw, elseExprOpt, spIfToThen, isRecovery, mIfToThen, mIfToEndOfElseBranch), None)
 
         | SynExpr.LetOrUse (isRec, false, binds, innerComp, m) ->
             match convertSimpleReturnToExpr varSpace innerComp with
@@ -1599,7 +1599,7 @@ let TcComputationExpression cenv env overallTy tpenv (mWhole, interpExpr: Expr, 
         | OptionalSequential (JoinOrGroupJoinOrZipClause _, _) -> false
         | OptionalSequential (CustomOperationClause _, _) -> false
         | SynExpr.Sequential (_, _, innerComp1, innerComp2, _) -> isSimpleExpr innerComp1 && isSimpleExpr innerComp2
-        | SynExpr.IfThenElse (_, _, _, thenComp, _, elseCompOpt, _, _, _, _) -> 
+        | SynExpr.IfThenElse (_, _, _, _, thenComp, _, elseCompOpt, _, _, _, _) -> 
              isSimpleExpr thenComp && (match elseCompOpt with None -> true | Some c -> isSimpleExpr c)
         | SynExpr.LetOrUse (_, _, _, innerComp, _) -> isSimpleExpr innerComp
         | SynExpr.LetOrUseBang _ -> false
@@ -1822,7 +1822,7 @@ let TcSequenceExpression (cenv: cenv) env tpenv comp overallTy m =
                 let innerExpr2, tpenv = tcSequenceExprBody env genOuterTy tpenv innerComp2
                 Some(Expr.Sequential(stmt1, innerExpr2, NormalSeq, sp, m), tpenv)
 
-        | SynExpr.IfThenElse (_, guardExpr, _, thenComp, _, elseCompOpt, spIfToThen, _isRecovery, mIfToThen, mIfToEndOfElseBranch) ->
+        | SynExpr.IfThenElse (_, _, guardExpr, _, thenComp, _, elseCompOpt, spIfToThen, _isRecovery, mIfToThen, mIfToEndOfElseBranch) ->
             let guardExpr', tpenv = TcExpr cenv cenv.g.bool_ty env tpenv guardExpr
             let thenExpr, tpenv = tcSequenceExprBody env genOuterTy tpenv thenComp
             let elseComp = (match elseCompOpt with Some c -> c | None -> SynExpr.ImplicitZero mIfToThen)

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -7946,7 +7946,7 @@ and TcItemThen cenv overallTy env tpenv (tinstEnclosing, item, mItem, rest, afte
             | SynExpr.ArrayOrList (_, synExprs, _) -> synExprs |> List.forall isSimpleArgument
             | SynExpr.Record (_, copyOpt, fields, _) -> copyOpt |> Option.forall (fst >> isSimpleArgument) && fields |> List.forall (p23 >> Option.forall isSimpleArgument)
             | SynExpr.App (_, _, synExpr, synExpr2, _) -> isSimpleArgument synExpr && isSimpleArgument synExpr2
-            | SynExpr.IfThenElse (synExpr, synExpr2, synExprOpt, _, _, _, _) -> isSimpleArgument synExpr && isSimpleArgument synExpr2 && Option.forall isSimpleArgument synExprOpt
+            | SynExpr.IfThenElse (_, synExpr, _, synExpr2, _, synExprOpt, _, _, _, _) -> isSimpleArgument synExpr && isSimpleArgument synExpr2 && Option.forall isSimpleArgument synExprOpt
             | SynExpr.DotIndexedGet (synExpr, _, _, _) -> isSimpleArgument synExpr
             | SynExpr.ObjExpr _
             | SynExpr.AnonRecd _
@@ -9155,7 +9155,7 @@ and TcLinearExprs bodyChecker cenv env overallTy tpenv isCompExpr expr cont =
             TcLinearExprs bodyChecker cenv envinner overallTy tpenv isCompExpr body (fun (x, tpenv) ->
                 cont (fst (mkf (x, overallTy)), tpenv))
 
-    | SynExpr.IfThenElse (synBoolExpr, synThenExpr, synElseExprOpt, spIfToThen, isRecovery, mIfToThen, m) when not isCompExpr ->
+    | SynExpr.IfThenElse (_, synBoolExpr, _, synThenExpr, _, synElseExprOpt, spIfToThen, isRecovery, mIfToThen, m) when not isCompExpr ->
         let boolExpr, tpenv = TcExprThatCantBeCtorBody cenv cenv.g.bool_ty env tpenv synBoolExpr
         let thenExpr, tpenv =
             let env =

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -7946,7 +7946,7 @@ and TcItemThen cenv overallTy env tpenv (tinstEnclosing, item, mItem, rest, afte
             | SynExpr.ArrayOrList (_, synExprs, _) -> synExprs |> List.forall isSimpleArgument
             | SynExpr.Record (_, copyOpt, fields, _) -> copyOpt |> Option.forall (fst >> isSimpleArgument) && fields |> List.forall (p23 >> Option.forall isSimpleArgument)
             | SynExpr.App (_, _, synExpr, synExpr2, _) -> isSimpleArgument synExpr && isSimpleArgument synExpr2
-            | SynExpr.IfThenElse (_, synExpr, _, synExpr2, _, synExprOpt, _, _, _, _) -> isSimpleArgument synExpr && isSimpleArgument synExpr2 && Option.forall isSimpleArgument synExprOpt
+            | SynExpr.IfThenElse (_, _, synExpr, _, synExpr2, _, synExprOpt, _, _, _, _) -> isSimpleArgument synExpr && isSimpleArgument synExpr2 && Option.forall isSimpleArgument synExprOpt
             | SynExpr.DotIndexedGet (synExpr, _, _, _) -> isSimpleArgument synExpr
             | SynExpr.ObjExpr _
             | SynExpr.AnonRecd _
@@ -9155,7 +9155,7 @@ and TcLinearExprs bodyChecker cenv env overallTy tpenv isCompExpr expr cont =
             TcLinearExprs bodyChecker cenv envinner overallTy tpenv isCompExpr body (fun (x, tpenv) ->
                 cont (fst (mkf (x, overallTy)), tpenv))
 
-    | SynExpr.IfThenElse (_, synBoolExpr, _, synThenExpr, _, synElseExprOpt, spIfToThen, isRecovery, mIfToThen, m) when not isCompExpr ->
+    | SynExpr.IfThenElse (_, _, synBoolExpr, _, synThenExpr, _, synElseExprOpt, spIfToThen, isRecovery, mIfToThen, m) when not isCompExpr ->
         let boolExpr, tpenv = TcExprThatCantBeCtorBody cenv cenv.g.bool_ty env tpenv synBoolExpr
         let thenExpr, tpenv =
             let env =

--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -2126,25 +2126,10 @@ type LexFilterImpl (lightStatus: LightSyntaxStatus, compilingFsLib, lexer, lexbu
             returnToken tokenLexbufState OTHEN 
 
         | ELSE, _ -> 
-            let lookaheadTokenTup = peekNextTokenTup()
-            let lookaheadTokenStartPos = startPosOfTokenTup lookaheadTokenTup
-            match peekNextToken() with 
-            | IF when isSameLine() ->
-                // We convert ELSE IF to ELIF since it then opens the block at the right point,
-                // In particular the case
-                //    if e1 then e2
-                //    else if e3 then e4
-                //    else if e5 then e6 
-                popNextTokenTup() |> pool.Return
-                if debug then dprintf "ELSE IF: replacing ELSE IF with ELIF, pushing CtxtIf, CtxtVanilla(%a)\n" outputPos tokenStartPos
-                pushCtxt tokenTup (CtxtIf tokenStartPos)
-                returnToken tokenLexbufState ELIF
-                  
-            | _ -> 
-                if debug then dprintf "ELSE: replacing ELSE with OELSE, pushing CtxtSeqBlock, CtxtElse(%a)\n" outputPos lookaheadTokenStartPos
-                pushCtxt tokenTup (CtxtElse tokenStartPos)
-                pushCtxtSeqBlock(true, AddBlockEnd)
-                returnToken tokenLexbufState OELSE
+            if debug then dprintf "ELSE: replacing ELSE with OELSE, pushing CtxtSeqBlock, CtxtElse(%a)\n" outputPos tokenStartPos
+            pushCtxt tokenTup (CtxtElse tokenStartPos)
+            pushCtxtSeqBlock(true, AddBlockEnd)
+            returnToken tokenLexbufState OELSE
 
         | (ELIF | IF), _ -> 
             if debug then dprintf "IF, pushing CtxtIf(%a)\n" outputPos tokenStartPos

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -622,7 +622,8 @@ type SynExpr =
         range: range
 
     | IfThenElse of
-        ifKeyword: SynIfThenElseStart *
+        ifKeyword: range *
+        isElif: bool *
         ifExpr: SynExpr *
         thenKeyword: range *
         thenExpr: SynExpr *
@@ -920,16 +921,6 @@ type SynExpr =
         match this with
         | SynExpr.ArbitraryAfterError _ -> true
         | _ -> false
-
-[<NoEquality; NoComparison; RequireQualifiedAccess>]
-type SynIfThenElseStart =
-    | If of range: Range
-    | Elif of range: Range
-
-    member this.Range =
-        match this with
-        | If m
-        | Elif m -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynInterpolatedStringPart =

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -622,8 +622,11 @@ type SynExpr =
         range: range
 
     | IfThenElse of
+        ifKeyword: SynIfThenElseStart *
         ifExpr: SynExpr *
+        thenKeyword: range *
         thenExpr: SynExpr *
+        elseKeyword: range option *
         elseExpr: SynExpr option *
         spIfToThen: DebugPointAtBinding *
         isFromErrorRecovery: bool *
@@ -917,6 +920,16 @@ type SynExpr =
         match this with
         | SynExpr.ArbitraryAfterError _ -> true
         | _ -> false
+
+[<NoEquality; NoComparison; RequireQualifiedAccess>]
+type SynIfThenElseStart =
+    | If of range: Range
+    | Elif of range: Range
+
+    member this.Range =
+        match this with
+        | If m
+        | Elif m -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynInterpolatedStringPart =

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -764,7 +764,8 @@ type SynExpr =
     /// F# syntax: if expr then expr
     /// F# syntax: if expr then expr else expr
     | IfThenElse of
-        ifKeyword: SynIfThenElseStart *
+        ifKeyword: range *
+        isElif: bool *
         ifExpr: SynExpr *
         thenKeyword: range *
         thenExpr: SynExpr *
@@ -1025,14 +1026,6 @@ type SynExpr =
 
     /// Indicates if this expression arises from error recovery
     member IsArbExprAndThusAlreadyReportedError: bool
-
-[<NoEquality; NoComparison; RequireQualifiedAccess>]
-type SynIfThenElseStart =
-    | If of range: Range
-    | Elif of range: Range
-    
-    /// Gets the range of the keyword
-    member Range: range
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynInterpolatedStringPart =

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -764,8 +764,11 @@ type SynExpr =
     /// F# syntax: if expr then expr
     /// F# syntax: if expr then expr else expr
     | IfThenElse of
+        ifKeyword: SynIfThenElseStart *
         ifExpr: SynExpr *
+        thenKeyword: range *
         thenExpr: SynExpr *
+        elseKeyword: range option *
         elseExpr: SynExpr option *
         spIfToThen: DebugPointAtBinding *
         isFromErrorRecovery: bool *
@@ -1022,6 +1025,14 @@ type SynExpr =
 
     /// Indicates if this expression arises from error recovery
     member IsArbExprAndThusAlreadyReportedError: bool
+
+[<NoEquality; NoComparison; RequireQualifiedAccess>]
+type SynIfThenElseStart =
+    | If of range: Range
+    | Elif of range: Range
+    
+    /// Gets the range of the keyword
+    member Range: range
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynInterpolatedStringPart =

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -728,7 +728,7 @@ let rec synExprContainsError inpExpr =
           | SynExpr.SequentialOrImplicitYield (_, e1, e2, _, _) ->
               walkExpr e1 || walkExpr e2
 
-          | SynExpr.IfThenElse (e1, e2, e3opt, _, _, _, _) ->
+          | SynExpr.IfThenElse (_, e1, _, e2, _, e3opt, _, _, _, _) ->
               walkExpr e1 || walkExpr e2 || walkExprOpt e3opt
 
           | SynExpr.DotIndexedGet (e1, es, _, _) ->

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -728,7 +728,7 @@ let rec synExprContainsError inpExpr =
           | SynExpr.SequentialOrImplicitYield (_, e1, e2, _, _) ->
               walkExpr e1 || walkExpr e2
 
-          | SynExpr.IfThenElse (_, e1, _, e2, _, e3opt, _, _, _, _) ->
+          | SynExpr.IfThenElse (_, _, e1, _, e2, _, e3opt, _, _, _, _) ->
               walkExpr e1 || walkExpr e2 || walkExprOpt e3opt
 
           | SynExpr.DotIndexedGet (e1, es, _, _) ->

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -270,7 +270,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %token ODO              /* LexFilter #light converts 'DO' tokens to 'ODO' */
 %token ODO_BANG         /* LexFilter #light converts 'DO_BANG' tokens to 'ODO_BANG' */
 %token OTHEN            /* LexFilter #light converts 'THEN' tokens to 'OTHEN' */
-%token OELSE            /* LexFilter #light converts 'ELSE' tokens to 'OELSE' except if immeditely followed by 'if', when they become 'ELIF' */
+%token OELSE            /* LexFilter #light converts 'ELSE' tokens to 'OELSE' */
 %token OWITH            /* LexFilter #light converts SOME (but not all) 'WITH' tokens to 'OWITH' */ 
 %token OFUNCTION        /* LexFilter #light converts 'FUNCTION' tokens to 'OFUNCTION' */ 
 %token OFUN             /* LexFilter #light converts 'FUN' tokens to 'OFUN' */
@@ -3486,7 +3486,7 @@ declExpr:
         SynExpr.TryFinally ($2, $4, mTryToLast, spTry, spFinally) }
 
   | IF declExpr ifExprCases %prec expr_if 
-      { let mIf = (rhs parseState 1)
+      { let mIf = SynIfThenElseStart.If (rhs parseState 1)
         $3 $2 mIf }
 
   | IF declExpr recover %prec expr_if 
@@ -3504,7 +3504,7 @@ declExpr:
         let m = rhs parseState 1
         let mEnd = m.EndRange
         let spIfToThen = DebugPointAtBinding.Yes mEnd
-        exprFromParseError (SynExpr.IfThenElse (arbExpr("ifGuard1", mEnd), arbExpr("thenBody1", mEnd), None, spIfToThen, true, m, m)) }
+        exprFromParseError (SynExpr.IfThenElse ((SynIfThenElseStart.If m), arbExpr("ifGuard1", mEnd), m, arbExpr("thenBody1", mEnd), None, None, spIfToThen, true, m, m)) }
 
   | LAZY declExpr %prec expr_lazy 
       { SynExpr.Lazy ($2, unionRanges (rhs parseState 1) $2.Range) }
@@ -3986,13 +3986,14 @@ patternResult:
 
 ifExprCases: 
   | ifExprThen ifExprElifs 
-      { let exprThen, mThen = $1 
-        (fun exprGuard mIf -> 
-            let mIfToThen = unionRanges mIf mThen
-            let lastBranch : SynExpr = match $2 with None -> exprThen | Some e -> e
-            let mIfToEndOfLastBranch = unionRanges mIf lastBranch.Range
+      { let exprThen, mThen = $1
+        let mElse, elseExpr = $2
+        (fun exprGuard ifStart ->
+            let mIfToThen = unionRanges ifStart.Range mThen
+            let lastBranch : SynExpr = match elseExpr with None -> exprThen | Some e -> e
+            let mIfToEndOfLastBranch = unionRanges ifStart.Range lastBranch.Range
             let spIfToThen = DebugPointAtBinding.Yes(mIfToThen)
-            SynExpr.IfThenElse (exprGuard, exprThen, $2, spIfToThen, false, mIfToThen, mIfToEndOfLastBranch)) }
+            SynExpr.IfThenElse (ifStart, exprGuard, mThen, exprThen, mElse, elseExpr, spIfToThen, false, mIfToThen, mIfToEndOfLastBranch)) }
 
 ifExprThen: 
   | THEN  declExpr %prec prec_then_if 
@@ -4007,24 +4008,27 @@ ifExprThen:
 
 ifExprElifs: 
   | /* EMPTY */
-      { None }
+      { None, None }
 
   | ELSE declExpr 
-      { Some $2 }
+      { let mElse = rhs parseState 1
+        Some mElse, Some $2 }
 
   | OELSE  OBLOCKBEGIN typedSeqExpr oblockend 
-      { Some $3 }
+      { let mElse = rhs parseState 1
+        Some mElse, Some $3 }
 
   | OELSE  OBLOCKBEGIN typedSeqExpr recover 
-      { if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileElse())
-        Some (exprFromParseError $3) }
+      { let mElse = rhs parseState 1
+        if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileElse())
+        Some mElse, Some (exprFromParseError $3) }
 
   | ELIF declExpr ifExprCases 
       { let mElif = rhs parseState 1 
-        Some ($3 $2 mElif) }
+        None, Some ($3 $2 (SynIfThenElseStart.Elif mElif)) }
 
   | ELIF declExpr recover 
-      { Some (exprFromParseError $2) }
+      { None, Some (exprFromParseError $2) }
 
 tupleExpr: 
   | tupleExpr COMMA declExpr   

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -270,7 +270,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %token ODO              /* LexFilter #light converts 'DO' tokens to 'ODO' */
 %token ODO_BANG         /* LexFilter #light converts 'DO_BANG' tokens to 'ODO_BANG' */
 %token OTHEN            /* LexFilter #light converts 'THEN' tokens to 'OTHEN' */
-%token OELSE            /* LexFilter #light converts 'ELSE' tokens to 'OELSE' */
+%token OELSE            /* LexFilter #light converts 'ELSE' tokens to 'OELSE' except if immeditely followed by 'if', when they become 'ELIF' */
 %token OWITH            /* LexFilter #light converts SOME (but not all) 'WITH' tokens to 'OWITH' */ 
 %token OFUNCTION        /* LexFilter #light converts 'FUNCTION' tokens to 'OFUNCTION' */ 
 %token OFUN             /* LexFilter #light converts 'FUN' tokens to 'OFUN' */
@@ -4025,7 +4025,14 @@ ifExprElifs:
 
   | ELIF declExpr ifExprCases 
       { let mElif = rhs parseState 1
-        None, Some ($3 $2 mElif true) }
+        // verify if `ELIF` is not a merged token
+        let length = mElif.EndColumn - mElif.StartColumn
+        if length > 4 then
+            let mElse = mkRange mElif.FileName (mkPos mElif.StartLine mElif.StartColumn) (mkPos mElif.StartLine (mElif.StartColumn + 4))
+            let mIf = mkRange mElif.FileName (mkPos mElif.StartLine (mElif.EndColumn - 2)) (mkPos mElif.StartLine mElif.EndColumn)
+            Some mElse, (Some ($3 $2 mIf false))
+        else
+            None, Some ($3 $2 mElif true) }
 
   | ELIF declExpr recover 
       { None, Some (exprFromParseError $2) }

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -270,7 +270,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %token ODO              /* LexFilter #light converts 'DO' tokens to 'ODO' */
 %token ODO_BANG         /* LexFilter #light converts 'DO_BANG' tokens to 'ODO_BANG' */
 %token OTHEN            /* LexFilter #light converts 'THEN' tokens to 'OTHEN' */
-%token OELSE /* LexFilter #light converts 'ELSE' tokens to 'OELSE' except if immeditely followed by 'if', when they become 'ELIF' */
+%token OELSE            /* LexFilter #light converts 'ELSE' tokens to 'OELSE' */
 %token OWITH            /* LexFilter #light converts SOME (but not all) 'WITH' tokens to 'OWITH' */ 
 %token OFUNCTION        /* LexFilter #light converts 'FUNCTION' tokens to 'OFUNCTION' */ 
 %token OFUN             /* LexFilter #light converts 'FUN' tokens to 'OFUN' */

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -270,7 +270,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %token ODO              /* LexFilter #light converts 'DO' tokens to 'ODO' */
 %token ODO_BANG         /* LexFilter #light converts 'DO_BANG' tokens to 'ODO_BANG' */
 %token OTHEN            /* LexFilter #light converts 'THEN' tokens to 'OTHEN' */
-%token OELSE            /* LexFilter #light converts 'ELSE' tokens to 'OELSE' */
+%token OELSE /* LexFilter #light converts 'ELSE' tokens to 'OELSE' except if immeditely followed by 'if', when they become 'ELIF' */
 %token OWITH            /* LexFilter #light converts SOME (but not all) 'WITH' tokens to 'OWITH' */ 
 %token OFUNCTION        /* LexFilter #light converts 'FUNCTION' tokens to 'OFUNCTION' */ 
 %token OFUN             /* LexFilter #light converts 'FUN' tokens to 'OFUN' */
@@ -4024,7 +4024,7 @@ ifExprElifs:
         Some mElse, Some (exprFromParseError $3) }
 
   | ELIF declExpr ifExprCases 
-      { let mElif = rhs parseState 1 
+      { let mElif = rhs parseState 1
         None, Some ($3 $2 (SynIfThenElseStart.Elif mElif)) }
 
   | ELIF declExpr recover 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -3486,8 +3486,8 @@ declExpr:
         SynExpr.TryFinally ($2, $4, mTryToLast, spTry, spFinally) }
 
   | IF declExpr ifExprCases %prec expr_if 
-      { let mIf = SynIfThenElseStart.If (rhs parseState 1)
-        $3 $2 mIf }
+      { let mIf = rhs parseState 1
+        $3 $2 mIf false }
 
   | IF declExpr recover %prec expr_if 
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsIncompleteIf()) 
@@ -3504,7 +3504,7 @@ declExpr:
         let m = rhs parseState 1
         let mEnd = m.EndRange
         let spIfToThen = DebugPointAtBinding.Yes mEnd
-        exprFromParseError (SynExpr.IfThenElse ((SynIfThenElseStart.If m), arbExpr("ifGuard1", mEnd), m, arbExpr("thenBody1", mEnd), None, None, spIfToThen, true, m, m)) }
+        exprFromParseError (SynExpr.IfThenElse (m, false, arbExpr("ifGuard1", mEnd), m, arbExpr("thenBody1", mEnd), None, None, spIfToThen, true, m, m)) }
 
   | LAZY declExpr %prec expr_lazy 
       { SynExpr.Lazy ($2, unionRanges (rhs parseState 1) $2.Range) }
@@ -3988,12 +3988,12 @@ ifExprCases:
   | ifExprThen ifExprElifs 
       { let exprThen, mThen = $1
         let mElse, elseExpr = $2
-        (fun exprGuard ifStart ->
-            let mIfToThen = unionRanges ifStart.Range mThen
+        (fun exprGuard mIf isElif ->
+            let mIfToThen = unionRanges mIf mThen
             let lastBranch : SynExpr = match elseExpr with None -> exprThen | Some e -> e
-            let mIfToEndOfLastBranch = unionRanges ifStart.Range lastBranch.Range
+            let mIfToEndOfLastBranch = unionRanges mIf lastBranch.Range
             let spIfToThen = DebugPointAtBinding.Yes(mIfToThen)
-            SynExpr.IfThenElse (ifStart, exprGuard, mThen, exprThen, mElse, elseExpr, spIfToThen, false, mIfToThen, mIfToEndOfLastBranch)) }
+            SynExpr.IfThenElse (mIf, isElif, exprGuard, mThen, exprThen, mElse, elseExpr, spIfToThen, false, mIfToThen, mIfToEndOfLastBranch)) }
 
 ifExprThen: 
   | THEN  declExpr %prec prec_then_if 
@@ -4025,7 +4025,7 @@ ifExprElifs:
 
   | ELIF declExpr ifExprCases 
       { let mElif = rhs parseState 1
-        None, Some ($3 $2 (SynIfThenElseStart.Elif mElif)) }
+        None, Some ($3 $2 mElif true) }
 
   | ELIF declExpr recover 
       { None, Some (exprFromParseError $2) }

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -215,7 +215,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                 | None ->
                     getIdentRangeForFuncExprInApp traverseSynExpr body pos
 
-            | SynExpr.IfThenElse (_, ifExpr, _, thenExpr, _, elseExpr, _, _, _, range) when rangeContainsPos range pos ->
+            | SynExpr.IfThenElse (_, _, ifExpr, _, thenExpr, _, elseExpr, _, _, _, range) when rangeContainsPos range pos ->
                 if rangeContainsPos ifExpr.Range pos then
                     getIdentRangeForFuncExprInApp traverseSynExpr ifExpr pos
                 elif rangeContainsPos thenExpr.Range pos then
@@ -619,7 +619,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                       yield! walkExpr (match spSeq with DebugPointAtSequential.SuppressExpr | DebugPointAtSequential.SuppressBoth -> false | _ -> true) e1
                       yield! walkExpr (match spSeq with DebugPointAtSequential.SuppressStmt | DebugPointAtSequential.SuppressBoth -> false | _ -> true) e2
 
-                  | SynExpr.IfThenElse (_, e1, _, e2, _, e3opt, spBind, _, _, _) ->
+                  | SynExpr.IfThenElse (_, _, e1, _, e2, _, e3opt, spBind, _, _, _) ->
                       yield! walkBindSeqPt spBind
                       yield! walkExpr false e1
                       yield! walkExpr true e2

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -215,7 +215,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                 | None ->
                     getIdentRangeForFuncExprInApp traverseSynExpr body pos
 
-            | SynExpr.IfThenElse (ifExpr, thenExpr, elseExpr, _, _, _, range) when rangeContainsPos range pos ->
+            | SynExpr.IfThenElse (_, ifExpr, _, thenExpr, _, elseExpr, _, _, _, range) when rangeContainsPos range pos ->
                 if rangeContainsPos ifExpr.Range pos then
                     getIdentRangeForFuncExprInApp traverseSynExpr ifExpr pos
                 elif rangeContainsPos thenExpr.Range pos then
@@ -619,7 +619,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                       yield! walkExpr (match spSeq with DebugPointAtSequential.SuppressExpr | DebugPointAtSequential.SuppressBoth -> false | _ -> true) e1
                       yield! walkExpr (match spSeq with DebugPointAtSequential.SuppressStmt | DebugPointAtSequential.SuppressBoth -> false | _ -> true) e2
 
-                  | SynExpr.IfThenElse (e1, e2, e3opt, spBind, _, _, _) ->
+                  | SynExpr.IfThenElse (_, e1, _, e2, _, e3opt, spBind, _, _, _) ->
                       yield! walkBindSeqPt spBind
                       yield! walkExpr false e1
                       yield! walkExpr true e2

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -846,7 +846,7 @@ module InterfaceStubGenerator =
                 | Sequentials exprs  -> 
                     List.tryPick walkExpr exprs
 
-                | SynExpr.IfThenElse (synExpr1, synExpr2, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) -> 
+                | SynExpr.IfThenElse (_, synExpr1, _, synExpr2, _, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) -> 
                     match synExprOpt with
                     | Some synExpr3 ->
                         List.tryPick walkExpr [synExpr1; synExpr2; synExpr3]

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -846,7 +846,7 @@ module InterfaceStubGenerator =
                 | Sequentials exprs  -> 
                     List.tryPick walkExpr exprs
 
-                | SynExpr.IfThenElse (_, synExpr1, _, synExpr2, _, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) -> 
+                | SynExpr.IfThenElse (_, _, synExpr1, _, synExpr2, _, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) -> 
                     match synExprOpt with
                     | Some synExpr3 ->
                         List.tryPick walkExpr [synExpr1; synExpr2; synExpr3]

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -488,12 +488,12 @@ module SyntaxTraversal =
                      dive synExpr2 synExpr2.Range traverseSynExpr]
                     |> pick expr
 
-                | SynExpr.IfThenElse (synExpr, synExpr2, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) -> 
+                | SynExpr.IfThenElse (_, synExpr, _, synExpr2, _, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) -> 
                     [yield dive synExpr synExpr.Range traverseSynExpr
                      yield dive synExpr2 synExpr2.Range traverseSynExpr
                      match synExprOpt with 
                      | None -> ()
-                     | Some(x) -> yield dive x x.Range traverseSynExpr]
+                     | Some x -> yield dive x x.Range traverseSynExpr]
                     |> pick expr
 
                 | SynExpr.Ident _ident -> None

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -488,7 +488,7 @@ module SyntaxTraversal =
                      dive synExpr2 synExpr2.Range traverseSynExpr]
                     |> pick expr
 
-                | SynExpr.IfThenElse (_, synExpr, _, synExpr2, _, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) -> 
+                | SynExpr.IfThenElse (_, _, synExpr, _, synExpr2, _, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) -> 
                     [yield dive synExpr synExpr.Range traverseSynExpr
                      yield dive synExpr2 synExpr2.Range traverseSynExpr
                      match synExprOpt with 

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -587,7 +587,7 @@ module ParsedInput =
             | SynExpr.TryFinally (e1, e2, _, _, _) -> List.tryPick (walkExprWithKind parentKind) [e1; e2]
             | SynExpr.Lazy (e, _) -> walkExprWithKind parentKind e
             | Sequentials es -> List.tryPick (walkExprWithKind parentKind) es
-            | SynExpr.IfThenElse (e1, e2, e3, _, _, _, _) -> 
+            | SynExpr.IfThenElse (_, e1, _, e2, _, e3, _, _, _, _) -> 
                 List.tryPick (walkExprWithKind parentKind) [e1; e2] |> Option.orElse (match e3 with None -> None | Some e -> walkExprWithKind parentKind e)
             | SynExpr.Ident ident -> ifPosInRange ident.idRange (fun _ -> Some (EntityKind.FunctionOrValue false))
             | SynExpr.LongIdentSet (_, e, _) -> walkExprWithKind parentKind e
@@ -1319,7 +1319,7 @@ module ParsedInput =
                 List.iter walkBinding bindings; walkExpr e
             | SynExpr.TryWith (e, _, clauses, _, _, _, _) ->
                 List.iter walkClause clauses;  walkExpr e
-            | SynExpr.IfThenElse (e1, e2, e3, _, _, _, _) ->
+            | SynExpr.IfThenElse (_, e1, _, e2, _, e3, _, _, _, _) ->
                 List.iter walkExpr [e1; e2]
                 e3 |> Option.iter walkExpr
             | SynExpr.LongIdentSet (ident, e, _)

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -587,7 +587,7 @@ module ParsedInput =
             | SynExpr.TryFinally (e1, e2, _, _, _) -> List.tryPick (walkExprWithKind parentKind) [e1; e2]
             | SynExpr.Lazy (e, _) -> walkExprWithKind parentKind e
             | Sequentials es -> List.tryPick (walkExprWithKind parentKind) es
-            | SynExpr.IfThenElse (_, e1, _, e2, _, e3, _, _, _, _) -> 
+            | SynExpr.IfThenElse (_, _, e1, _, e2, _, e3, _, _, _, _) -> 
                 List.tryPick (walkExprWithKind parentKind) [e1; e2] |> Option.orElse (match e3 with None -> None | Some e -> walkExprWithKind parentKind e)
             | SynExpr.Ident ident -> ifPosInRange ident.idRange (fun _ -> Some (EntityKind.FunctionOrValue false))
             | SynExpr.LongIdentSet (_, e, _) -> walkExprWithKind parentKind e
@@ -1319,7 +1319,7 @@ module ParsedInput =
                 List.iter walkBinding bindings; walkExpr e
             | SynExpr.TryWith (e, _, clauses, _, _, _, _) ->
                 List.iter walkClause clauses;  walkExpr e
-            | SynExpr.IfThenElse (_, e1, _, e2, _, e3, _, _, _, _) ->
+            | SynExpr.IfThenElse (_, _, e1, _, e2, _, e3, _, _, _, _) ->
                 List.iter walkExpr [e1; e2]
                 e3 |> Option.iter walkExpr
             | SynExpr.LongIdentSet (ident, e, _)

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -348,7 +348,7 @@ module Structure =
                 | _ -> ()
                 parseExpr tryExpr
                 parseExpr finallyExpr
-            | SynExpr.IfThenElse (_, ifExpr, _, thenExpr, _, elseExprOpt, spIfToThen, _, ifToThenRange, r) ->
+            | SynExpr.IfThenElse (_, _, ifExpr, _, thenExpr, _, elseExprOpt, spIfToThen, _, ifToThenRange, r) ->
                 match spIfToThen with
                 | DebugPointAtBinding.Yes rt ->
                     // Outline the entire IfThenElse

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -348,7 +348,7 @@ module Structure =
                 | _ -> ()
                 parseExpr tryExpr
                 parseExpr finallyExpr
-            | SynExpr.IfThenElse (ifExpr, thenExpr, elseExprOpt, spIfToThen, _, ifToThenRange, r) ->
+            | SynExpr.IfThenElse (_, ifExpr, _, thenExpr, _, elseExprOpt, spIfToThen, _, ifToThenRange, r) ->
                 match spIfToThen with
                 | DebugPointAtBinding.Yes rt ->
                     // Outline the entire IfThenElse

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -6249,7 +6249,9 @@ FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Text.Range get_ra
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+Ident: FSharp.Compiler.Syntax.Ident get_ident()
 FSharp.Compiler.Syntax.SynExpr+Ident: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean get_isElif()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean get_isFromErrorRecovery()
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean isElif
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean isFromErrorRecovery
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.DebugPointAtBinding get_spIfToThen()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.DebugPointAtBinding spIfToThen
@@ -6257,11 +6259,11 @@ FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynExpr get_if
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynExpr get_thenExpr()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynExpr ifExpr
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynExpr thenExpr
-FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynIfThenElseStart get_ifKeyword()
-FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynIfThenElseStart ifKeyword
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range get_ifKeyword()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range get_ifToThenRange()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range get_thenKeyword()
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range ifKeyword
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range ifToThenRange
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range thenKeyword
@@ -6799,7 +6801,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFor(FSharp.Com
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewForEach(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.SeqExprOnly, Boolean, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFromParseError(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIdent(FSharp.Compiler.Syntax.Ident)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIfThenElse(FSharp.Compiler.Syntax.SynIfThenElseStart, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Syntax.DebugPointAtBinding, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIfThenElse(FSharp.Compiler.Text.Range, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Syntax.DebugPointAtBinding, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewImplicitZero(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewInferredDowncast(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewInferredUpcast(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
@@ -6933,27 +6935,6 @@ FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Com
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
 FSharp.Compiler.Syntax.SynField: System.String ToString()
-FSharp.Compiler.Syntax.SynIfThenElseStart
-FSharp.Compiler.Syntax.SynIfThenElseStart+Elif: FSharp.Compiler.Text.Range get_range()
-FSharp.Compiler.Syntax.SynIfThenElseStart+Elif: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynIfThenElseStart+If: FSharp.Compiler.Text.Range get_range()
-FSharp.Compiler.Syntax.SynIfThenElseStart+If: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynIfThenElseStart+Tags: Int32 Elif
-FSharp.Compiler.Syntax.SynIfThenElseStart+Tags: Int32 If
-FSharp.Compiler.Syntax.SynIfThenElseStart: Boolean IsElif
-FSharp.Compiler.Syntax.SynIfThenElseStart: Boolean IsIf
-FSharp.Compiler.Syntax.SynIfThenElseStart: Boolean get_IsElif()
-FSharp.Compiler.Syntax.SynIfThenElseStart: Boolean get_IsIf()
-FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart NewElif(FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart NewIf(FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart+Elif
-FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart+If
-FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart+Tags
-FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Text.Range Range
-FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Text.Range get_Range()
-FSharp.Compiler.Syntax.SynIfThenElseStart: Int32 Tag
-FSharp.Compiler.Syntax.SynIfThenElseStart: Int32 get_Tag()
-FSharp.Compiler.Syntax.SynIfThenElseStart: System.String ToString()
 FSharp.Compiler.Syntax.SynIndexerArg
 FSharp.Compiler.Syntax.SynIndexerArg+One: Boolean fromEnd
 FSharp.Compiler.Syntax.SynIndexerArg+One: Boolean get_fromEnd()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -6257,12 +6257,18 @@ FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynExpr get_if
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynExpr get_thenExpr()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynExpr ifExpr
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynExpr thenExpr
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynIfThenElseStart get_ifKeyword()
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.SynIfThenElseStart ifKeyword
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range get_ifToThenRange()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range get_thenKeyword()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range ifToThenRange
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Text.Range thenKeyword
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr] elseExpr
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr] get_elseExpr()
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] elseKeyword
+FSharp.Compiler.Syntax.SynExpr+IfThenElse: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_elseKeyword()
 FSharp.Compiler.Syntax.SynExpr+ImplicitZero: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+ImplicitZero: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+InferredDowncast: FSharp.Compiler.Syntax.SynExpr expr
@@ -6793,7 +6799,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFor(FSharp.Com
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewForEach(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.SeqExprOnly, Boolean, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFromParseError(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIdent(FSharp.Compiler.Syntax.Ident)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIfThenElse(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Syntax.DebugPointAtBinding, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIfThenElse(FSharp.Compiler.Syntax.SynIfThenElseStart, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Syntax.DebugPointAtBinding, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewImplicitZero(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewInferredDowncast(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewInferredUpcast(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
@@ -6927,6 +6933,27 @@ FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Com
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
 FSharp.Compiler.Syntax.SynField: System.String ToString()
+FSharp.Compiler.Syntax.SynIfThenElseStart
+FSharp.Compiler.Syntax.SynIfThenElseStart+Elif: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynIfThenElseStart+Elif: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynIfThenElseStart+If: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynIfThenElseStart+If: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynIfThenElseStart+Tags: Int32 Elif
+FSharp.Compiler.Syntax.SynIfThenElseStart+Tags: Int32 If
+FSharp.Compiler.Syntax.SynIfThenElseStart: Boolean IsElif
+FSharp.Compiler.Syntax.SynIfThenElseStart: Boolean IsIf
+FSharp.Compiler.Syntax.SynIfThenElseStart: Boolean get_IsElif()
+FSharp.Compiler.Syntax.SynIfThenElseStart: Boolean get_IsIf()
+FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart NewElif(FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart NewIf(FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart+Elif
+FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart+If
+FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Syntax.SynIfThenElseStart+Tags
+FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynIfThenElseStart: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.Syntax.SynIfThenElseStart: Int32 Tag
+FSharp.Compiler.Syntax.SynIfThenElseStart: Int32 get_Tag()
+FSharp.Compiler.Syntax.SynIfThenElseStart: System.String ToString()
 FSharp.Compiler.Syntax.SynIndexerArg
 FSharp.Compiler.Syntax.SynIndexerArg+One: Boolean fromEnd
 FSharp.Compiler.Syntax.SynIndexerArg+One: Boolean get_fromEnd()

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1442,3 +1442,26 @@ else
             assertRange (9, 8) (9, 12) mElse2
 
         | _ -> Assert.Fail "Could not get valid AST"
+        
+    [<Test>]
+    let ``Comment between else and if`` () =
+        let parseResults = 
+            getParseResults
+                """
+if a then
+    b
+else (* some long comment here *) if c then
+    d"""
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIf1
+                                          elseKeyword = Some mElse
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIf2))))
+        ]) ])) ->
+            assertRange (2, 0) (2, 2) mIf1
+            assertRange (4, 0) (4, 4) mElse
+            assertRange (4, 34) (4, 36) mIf2
+
+        | _ -> Assert.Fail "Could not get valid AST"

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1293,7 +1293,7 @@ module IfThenElse =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.DoExpr(
-                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw ; thenKeyword = mThenKw ; elseKeyword = None)
+                expr = SynExpr.IfThenElse(ifKeyword = mIfKw; isElif = false; thenKeyword = mThenKw; elseKeyword = None)
             )
         ]) ])) ->
             assertRange (1, 0) (1, 2) mIfKw
@@ -1309,7 +1309,7 @@ module IfThenElse =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.DoExpr(
-                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw ; thenKeyword = mThenKw ; elseKeyword = Some mElse)
+                expr = SynExpr.IfThenElse(ifKeyword = mIfKw; isElif = false; thenKeyword = mThenKw; elseKeyword = Some mElse)
             )
         ]) ])) ->
             assertRange (1, 0) (1, 2) mIfKw
@@ -1329,7 +1329,7 @@ else c"""
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.DoExpr(
-                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw ; thenKeyword = mThenKw ; elseKeyword = Some mElse)
+                expr = SynExpr.IfThenElse(ifKeyword = mIfKw; isElif = false; thenKeyword = mThenKw; elseKeyword = Some mElse)
             )
         ]) ])) ->
             assertRange (2, 0) (2, 2) mIfKw
@@ -1349,10 +1349,11 @@ elif c then d"""
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.DoExpr(
-                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw
+                expr = SynExpr.IfThenElse(ifKeyword = mIfKw
+                                          isElif = false
                                           thenKeyword = mThenKw
                                           elseKeyword = None
-                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.Elif mElif)))
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = mElif; isElif = true)))
             )
         ]) ])) ->
             assertRange (2, 0) (2, 2) mIfKw
@@ -1373,10 +1374,11 @@ else
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.DoExpr(
-                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw
+                expr = SynExpr.IfThenElse(ifKeyword = mIfKw
+                                          isElif = false
                                           thenKeyword = mThenKw
                                           elseKeyword = Some mElse
-                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mElseIf)))
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = mElseIf; isElif = false)))
             )
         ]) ])) ->
             assertRange (2, 0) (2, 2) mIfKw
@@ -1398,10 +1400,11 @@ else if c then
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.DoExpr(
-                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw
+                expr = SynExpr.IfThenElse(ifKeyword = mIfKw
+                                          isElif = false
                                           thenKeyword = mThenKw
                                           elseKeyword = Some mElse
-                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mElseIf)))
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = mElseIf; isElif = false)))
             )
         ]) ])) ->
             assertRange (2, 0) (2, 2) mIfKw
@@ -1428,11 +1431,14 @@ else
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.DoExpr(
-                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIf1
+                expr = SynExpr.IfThenElse(ifKeyword = mIf1
+                                          isElif = false
                                           elseKeyword = None
-                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.Elif mElif
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = mElif
+                                                                              isElif = true
                                                                               elseKeyword = Some mElse1
-                                                                              elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIf2
+                                                                              elseExpr = Some (SynExpr.IfThenElse(ifKeyword = mIf2
+                                                                                                                  isElif = false
                                                                                                                   elseKeyword = Some mElse2))))))
         ]) ])) ->
             assertRange (2, 0) (2, 2) mIf1
@@ -1456,9 +1462,10 @@ else (* some long comment here *) if c then
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.DoExpr(
-                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIf1
+                expr = SynExpr.IfThenElse(ifKeyword = mIf1
+                                          isElif = false
                                           elseKeyword = Some mElse
-                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIf2))))
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = mIf2; isElif = false))))
         ]) ])) ->
             assertRange (2, 0) (2, 2) mIf1
             assertRange (4, 0) (4, 4) mElse

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -57,7 +57,6 @@ match "foo" with
         getCaseUsages completePatternInput 7 |> Array.head |> getGroupName |> shouldEqual "|True|False|"
         getCaseUsages partialPatternInput 7 |> Array.head |> getGroupName |> shouldEqual "|String|_|"
 
-
 module ExternDeclarations =
     [<Test>]
     let ``Access modifier`` () =
@@ -146,7 +145,6 @@ module Mod2 =
          mod2.XmlDocSig |> shouldEqual "T:Mod1.Mod2"
          mod1val1.XmlDocSig |> shouldEqual "P:Mod1.val1"
          mod2func2.XmlDocSig |> shouldEqual "M:Mod1.Mod2.func2"
-
 
 module Attributes =
     [<Test>]
@@ -1283,4 +1281,164 @@ module Lambdas =
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
+        | _ -> Assert.Fail "Could not get valid AST"
+
+module IfThenElse =
+    [<Test>]
+    let ``If keyword in IfThenElse`` () =
+        let parseResults = 
+            getParseResults
+                "if a then b"
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw ; thenKeyword = mThenKw ; elseKeyword = None)
+            )
+        ]) ])) ->
+            assertRange (1, 0) (1, 2) mIfKw
+            assertRange (1, 5) (1, 9) mThenKw
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``Else keyword in simple IfThenElse`` () =
+        let parseResults = 
+            getParseResults
+                "if a then b else c"
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw ; thenKeyword = mThenKw ; elseKeyword = Some mElse)
+            )
+        ]) ])) ->
+            assertRange (1, 0) (1, 2) mIfKw
+            assertRange (1, 5) (1, 9) mThenKw
+            assertRange (1, 12) (1, 16) mElse
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``If, Then and Else keyword on separate lines`` () =
+        let parseResults = 
+            getParseResults
+                """
+if a
+then b
+else c"""
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw ; thenKeyword = mThenKw ; elseKeyword = Some mElse)
+            )
+        ]) ])) ->
+            assertRange (2, 0) (2, 2) mIfKw
+            assertRange (3, 0) (3, 4) mThenKw
+            assertRange (4, 0) (4, 4) mElse
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``Nested elif in IfThenElse`` () =
+        let parseResults = 
+            getParseResults
+                """
+if a then
+    b
+elif c then d"""
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw
+                                          thenKeyword = mThenKw
+                                          elseKeyword = None
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.Elif mElif)))
+            )
+        ]) ])) ->
+            assertRange (2, 0) (2, 2) mIfKw
+            assertRange (2, 5) (2, 9) mThenKw
+            assertRange (4, 0) (4, 4) mElif
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``Nested else if in IfThenElse`` () =
+        let parseResults = 
+            getParseResults
+                """
+if a then
+    b
+else
+    if c then d"""
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw
+                                          thenKeyword = mThenKw
+                                          elseKeyword = Some mElse
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mElseIf)))
+            )
+        ]) ])) ->
+            assertRange (2, 0) (2, 2) mIfKw
+            assertRange (2, 5) (2, 9) mThenKw
+            assertRange (4, 0) (4, 4) mElse
+            assertRange (5, 4) (5, 6) mElseIf
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``Nested else if on the same line in IfThenElse`` () =
+        let parseResults = 
+            getParseResults
+                """
+if a then
+    b
+else if c then
+    d"""
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIfKw
+                                          thenKeyword = mThenKw
+                                          elseKeyword = Some mElse
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mElseIf)))
+            )
+        ]) ])) ->
+            assertRange (2, 0) (2, 2) mIfKw
+            assertRange (2, 5) (2, 9) mThenKw
+            assertRange (4, 0) (4, 4) mElse
+            assertRange (4, 5) (4, 7) mElseIf
+        | _ -> Assert.Fail "Could not get valid AST"
+    
+    [<Test>]
+    let ``Deeply nested IfThenElse`` () =
+        let parseResults = 
+            getParseResults
+                """
+if a then
+    b
+elif c then
+    d
+else
+        if e then
+            f
+        else
+            g"""
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.DoExpr(
+                expr = SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIf1
+                                          elseKeyword = None
+                                          elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.Elif mElif
+                                                                              elseKeyword = Some mElse1
+                                                                              elseExpr = Some (SynExpr.IfThenElse(ifKeyword = SynIfThenElseStart.If mIf2
+                                                                                                                  elseKeyword = Some mElse2))))))
+        ]) ])) ->
+            assertRange (2, 0) (2, 2) mIf1
+            assertRange (4, 0) (4, 4) mElif
+            assertRange (6, 0) (6, 4) mElse1
+            assertRange (7, 8) (7, 10) mIf2
+            assertRange (9, 8) (9, 12) mElse2
+
         | _ -> Assert.Fail "Could not get valid AST"


### PR DESCRIPTION
Fixes #11833.