### PR TITLE
Minor test namespace refactor

### DIFF
--- a/src/scripts/scriptlib.fsx
+++ b/src/scripts/scriptlib.fsx
@@ -77,7 +77,6 @@ module Scripting =
         if Directory.Exists output then 
             Directory.Delete(output, true) 
 
-
     let log format = printfn format
 
     type FilePath = string

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/noframework.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/noframework.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.CompilerOptions.fsc
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module noframework =
 

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/platform.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/platform.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.CompilerOptions.fsc
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module platform =
 

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/times.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/times.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.CompilerOptions.fsc
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module times =
 

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warn.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warn.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.CompilerOptions.fsc
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module warn =
 

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warnon.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warnon.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.CompilerOptions.fsc
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module warnon =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/RecordTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/RecordTypes.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.BasicTypeAndModuleDefinitions
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module RecordTypes =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/UnionTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/UnionTypes.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.BasicTypeAndModuleDefinitions
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module UnionTypes =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/DeclarationElements/LetBindings/TypeFunctions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/DeclarationElements/LetBindings/TypeFunctions.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.DeclarationElements.LetBindings
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module TypeFunctions =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/DeclarationElements/LetBindings/UseBindings.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/DeclarationElements/LetBindings/UseBindings.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.DeclarationElements.LetBindings
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module UseBindings =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ApplicationExpressions/BasicApplication.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ApplicationExpressions/BasicApplication.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.Expressions.ApplicationExpressions
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module BasicApplication =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ControlFlowExpressions/PatternMatching.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ControlFlowExpressions/PatternMatching.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.Expressions.ControlFlowExpressions
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module PatternMatching =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ControlFlowExpressions/SequenceIteration.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ControlFlowExpressions/SequenceIteration.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.Expressions.ControlFlowExpressions
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module SequenceIteration =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/Type-relatedExpressions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/Type-relatedExpressions.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.Expressions
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module TyperelatedExpressions =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/InferenceProcedures/RecursiveSafetyAnalysis.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/InferenceProcedures/RecursiveSafetyAnalysis.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.InferenceProcedures
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module RecursiveSafetyAnalysis =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/Comments.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/Comments.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.LexicalAnalysis
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module Comments =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/NumericLiterals.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/NumericLiterals.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.LexicalAnalysis
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module NumericLiterals =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/Shift/Generics.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/Shift/Generics.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.LexicalAnalysis.Shift
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module Generics =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/SymbolicKeywords.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/SymbolicKeywords.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.LexicalAnalysis
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module SymbolicKeywords =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/SymbolicOperators.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalAnalysis/SymbolicOperators.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.LexicalAnalysis
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module SymbolicOperators =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/Basic/OffsideExceptions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/Basic/OffsideExceptions.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.LexicalFiltering.Basic
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module OffsideExceptions =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/HashLight.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/HashLight.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.LexicalFiltering
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module HashLight =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/HighPrecedenceApplication.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/HighPrecedenceApplication.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.LexicalFiltering
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module HighPrecedenceApplication =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/ObjectOrientedTypeDefinitions/ClassTypes/ExplicitObjectConstructors.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/ObjectOrientedTypeDefinitions/ClassTypes/ExplicitObjectConstructors.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.ObjectOrientedTypeDefinitions.ClassTypes
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module ExplicitObjectConstructors =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/ObjectOrientedTypeDefinitions/ClassTypes/ImplicitObjectConstructors.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/ObjectOrientedTypeDefinitions/ClassTypes/ImplicitObjectConstructors.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.ObjectOrientedTypeDefinitions.ClassTypes
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module ImplicitObjectConstructors =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/ObjectOrientedTypeDefinitions/ClassTypes/ValueRestriction.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/ObjectOrientedTypeDefinitions/ClassTypes/ValueRestriction.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.ObjectOrientedTypeDefinitions.ClassTypes
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module ValueRestriction =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/ObjectOrientedTypeDefinitions/StructTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/ObjectOrientedTypeDefinitions/StructTypes.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.ObjectOrientedTypeDefinitions
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module StructTypes =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.PatternMatching
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module Simple =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/CheckingSyntacticTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/CheckingSyntacticTypes.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.TypesAndTypeConstraints
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module CheckingSyntacticTypes =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/LogicalPropertiesOfTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/LogicalPropertiesOfTypes.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.TypesAndTypeConstraints
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module LogicalPropertiesOfTypes =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/UnitsOfMeasure/Basic.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/UnitsOfMeasure/Basic.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.UnitsOfMeasure
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module Basic =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/UnitsOfMeasure/Diagnostics.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/UnitsOfMeasure/Diagnostics.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.UnitsOfMeasure
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module Diagnostics =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/UnitsOfMeasure/Parsing.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/UnitsOfMeasure/Parsing.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.UnitsOfMeasure
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module Parsing =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/UnitsOfMeasure/TypeChecker.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/UnitsOfMeasure/TypeChecker.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Conformance.UnitsOfMeasure
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module TypeChecker =
 

--- a/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/MemberConstraints.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/MemberConstraints.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ConstraintSolver
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module MemberConstraints =
 

--- a/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/PrimitiveConstraints.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/PrimitiveConstraints.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.ConstraintSolver
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module PrimitiveConstraints =
 

--- a/tests/FSharp.Compiler.ComponentTests/Diagnostics/General.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Diagnostics/General.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Diagnostics
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module General =
 

--- a/tests/FSharp.Compiler.ComponentTests/Diagnostics/async.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Diagnostics/async.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.Diagnostics
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module async =
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Literals.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Literals.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.EmittedIL
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Literals`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.EmittedIL
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Misc`` =
     [<Fact>]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Operators.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Operators.fs
@@ -2,8 +2,8 @@
 namespace FSharp.Compiler.ComponentTests.EmittedIL
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module Operators =
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SkipLocalsInit.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SkipLocalsInit.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.EmittedIL
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 #if NETCOREAPP
 module ``SkipLocalsInit`` =

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.EmittedIL
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``StringFormatAndInterpolation`` =
     [<Fact>]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TailCalls.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TailCalls.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.EmittedIL
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Tail Calls`` =
     // Regression test for DevDiv:72571

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TupleElimination.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TupleElimination.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.EmittedIL
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``TupleElimination`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/AccessOfTypeAbbreviationTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/AccessOfTypeAbbreviationTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 open FSharp.Compiler.Diagnostics
 
 module ``Access Of Type Abbreviation`` =

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/AssignmentErrorTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/AssignmentErrorTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Errors assigning to mutable objects`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Classes`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ConfusingTypeName.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ConfusingTypeName.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Confusing Type Name`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ConstructorTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ConstructorTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Constructor`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/DontSuggestTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/DontSuggestTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Don't Suggest`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ElseBranchHasWrongTypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ElseBranchHasWrongTypeTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Else branch has wrong type`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/InvalidLiteralTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/InvalidLiteralTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Invalid literals`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/InvalidNumericLiteralTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/InvalidNumericLiteralTests.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test
+open FSharp.Test.Compiler
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.AbstractIL
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/MissingElseBranch.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/MissingElseBranch.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Else branch is missing`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/MissingExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/MissingExpressionTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 
 module ``Missing Expression`` =

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ModuleTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ModuleTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 
 module Modules =

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/NameResolutionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/NameResolutionTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module NameResolutionTests =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/SuggestionsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/SuggestionsTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module Suggestions =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeEqualsMissingTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeMismatchTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeMismatchTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Type Mismatch`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnitGenericAbstactType.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnitGenericAbstactType.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 
 module ``Unit generic abstract Type`` =

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnsupportedAttributes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnsupportedAttributes.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 #if NETCOREAPP
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Unsupported Attributes`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UpcastDowncastTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UpcastDowncastTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Upcast and Downcast`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WarnExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WarnExpressionTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 
 module ``Warn Expression`` =

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WrongSyntaxInForLoop.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WrongSyntaxInForLoop.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.ErrorMessages
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 
 module ``Wrong syntax in for loop`` =

--- a/tests/FSharp.Compiler.ComponentTests/Interop/SimpleInteropTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Interop/SimpleInteropTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.Interop
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Simple interop verification`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/Interop/VisibilityTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Interop/VisibilityTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharp.Compiler.ComponentTests.Interop
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Verify visibility of properties`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/Language/AttributeCheckingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/AttributeCheckingTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.AttributeChecking
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module AttributeCheckingTests =
 

--- a/tests/FSharp.Compiler.ComponentTests/Language/CastingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CastingTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module CastingTests =
 

--- a/tests/FSharp.Compiler.ComponentTests/Language/CodeQuotationTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CodeQuotationTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.Language
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 open FSharp.Quotations.Patterns
 
 module CodeQuotationsTests =

--- a/tests/FSharp.Compiler.ComponentTests/Language/CompilerDirectiveTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CompilerDirectiveTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.Language
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Test Compiler Directives`` =
 

--- a/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.Language
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ComputationExpressionTests =
     [<Fact>]

--- a/tests/FSharp.Compiler.ComponentTests/Language/RegressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/RegressionTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.Language
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module RegressionTests =
 

--- a/tests/FSharp.Compiler.ComponentTests/Language/XmlComments.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/XmlComments.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.XmlComments
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module XmlCommentChecking =
 

--- a/tests/FSharp.Compiler.ComponentTests/OCamlCompat/OCamlCompat.fs
+++ b/tests/FSharp.Compiler.ComponentTests/OCamlCompat/OCamlCompat.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.OCamlCompat
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module OCamlCompat =
 

--- a/tests/FSharp.Compiler.ComponentTests/Scripting/Interactive.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Scripting/Interactive.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.ComponentTests.Scripting
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 module ``Interactive tests`` =
     [<Fact>]

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckDeclarationsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckDeclarationsTests.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.ComponentTests.CheckDeclarationsTests
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module CheckDeclarationsTests =
 

--- a/tests/FSharp.Compiler.UnitTests/AssemblySigningAttributes.fs
+++ b/tests/FSharp.Compiler.UnitTests/AssemblySigningAttributes.fs
@@ -3,9 +3,9 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
-open FSharp.Test.Utilities.Compiler
-open FSharp.Test.Utilities.Xunit.Attributes
-open FSharp.Test.Utilities
+open FSharp.Test
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
 
 module AssemblySigning =
 

--- a/tests/FSharp.Compiler.UnitTests/BlockTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/BlockTests.fs
@@ -2,7 +2,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
-open FSharp.Test.Utilities
+open FSharp.Test
 open Internal.Utilities.Library
 
 module BlockTests =

--- a/tests/FSharp.Compiler.UnitTests/BuildGraphTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/BuildGraphTests.fs
@@ -5,7 +5,8 @@ open System
 open System.Threading
 open System.Runtime.CompilerServices
 open Xunit
-open FSharp.Test.Utilities
+open FSharp.Test
+open FSharp.Test.Compiler
 open FSharp.Compiler.BuildGraph
 open Internal.Utilities.Library
 

--- a/tests/FSharp.Compiler.UnitTests/ByteMemoryTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/ByteMemoryTests.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 open System
 open System.Globalization
 open Xunit
-open FSharp.Test.Utilities
+open FSharp.Test
 
 module ByteMemoryTests =
     open FSharp.Compiler.IO

--- a/tests/FSharp.Compiler.UnitTests/EditDistance.fs
+++ b/tests/FSharp.Compiler.UnitTests/EditDistance.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 open System
 open System.Globalization
 open Xunit
-open FSharp.Test.Utilities
+open FSharp.Test
 
 module EditDistance =
     open Internal.Utilities.EditDistance

--- a/tests/FSharp.Compiler.UnitTests/FsiTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/FsiTests.fs
@@ -3,7 +3,7 @@ open System
 open System.IO
 open FSharp.Compiler.Interactive.Shell
 open Xunit
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<Collection("SingleThreaded")>]
 module FsiTests =

--- a/tests/FSharp.Compiler.UnitTests/HashIfExpression.fs
+++ b/tests/FSharp.Compiler.UnitTests/HashIfExpression.fs
@@ -6,7 +6,7 @@ open System
 open System.Text
 
 open Xunit
-open FSharp.Test.Utilities
+open FSharp.Test
 
 open Internal.Utilities
 open Internal.Utilities.Text.Lexing

--- a/tests/FSharp.Compiler.UnitTests/ManglingNameOfProvidedTypes.fs
+++ b/tests/FSharp.Compiler.UnitTests/ManglingNameOfProvidedTypes.fs
@@ -4,6 +4,7 @@ namespace FSharp.Compiler.UnitTests
 open System
 open System.Text
 open Xunit
+open FSharp.Test
 open FSharp.Test.Utilities
 open FSharp.Compiler.Syntax
 

--- a/tests/FSharp.Compiler.UnitTests/ProductVersion.fs
+++ b/tests/FSharp.Compiler.UnitTests/ProductVersion.fs
@@ -4,7 +4,7 @@ open System
 open System.IO
 open System.Text
 open Xunit
-open FSharp.Test.Utilities
+open FSharp.Test
 
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.CreateILModule.MainModuleBuilder

--- a/tests/FSharp.Compiler.UnitTests/SuggestionBuffer.fs
+++ b/tests/FSharp.Compiler.UnitTests/SuggestionBuffer.fs
@@ -2,8 +2,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
-open FSharp.Test.Utilities
-
+open FSharp.Test
 
 module SuggestionBuffer =
     open FSharp.Compiler.ErrorResolutionHints

--- a/tests/FSharp.Test.Utilities/Assert.fs
+++ b/tests/FSharp.Test.Utilities/Assert.fs
@@ -1,4 +1,4 @@
-namespace FSharp.Test.Utilities
+namespace FSharp.Test
 
 module Assert =
     open FluentAssertions

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Test.Utilities
+namespace FSharp.Test
 
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.IO
 open FSharp.Compiler.Diagnostics
+open FSharp.Test.Assert
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Assert
-open FSharp.Test.Utilities.Utilities
 open FSharp.Test.ScriptHelpers
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.CSharp

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Test.Utilities
+namespace FSharp.Test
 
 open System
 open System.IO
@@ -15,7 +15,7 @@ open FSharp.Compiler.Text
 open System.Runtime.Loader
 #endif
 open NUnit.Framework
-open FSharp.Test.Utilities.Utilities
+open FSharp.Test.Utilities
 open TestFramework
 
 [<Sealed>]

--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Test.Utilities
+namespace FSharp.Test
 
 open System
 open System.IO

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -183,7 +183,6 @@ module Commands =
         Directory.CreateDirectory path |> ignore
         path
 
-
 type TestConfig =
     { EnvironmentVariables : Map<string, string>
       CSC : string

--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Test.Utilities
+namespace FSharp.Test
 
 open System
 open System.IO
@@ -10,7 +10,6 @@ open System.Diagnostics
 open System.Threading.Tasks
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.CSharp
-open FSharp.Test.Utilities
 open TestFramework
 open NUnit.Framework
 
@@ -52,6 +51,8 @@ module Utilities =
         use memoryStream = new MemoryStream (bytes)
         stream.CopyTo(memoryStream)
         bytes
+
+    let inline getTestsDirectory dir = __SOURCE_DIRECTORY__ ++ dir
 
     let private getOrCreateResource (resource: byref<byte[]>) (name: string) =
         match resource with

--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -52,7 +52,7 @@ module Utilities =
         stream.CopyTo(memoryStream)
         bytes
 
-    let inline getTestsDirectory dir = __SOURCE_DIRECTORY__ ++ dir
+    let inline getTestsDirectory src dir = src ++ dir
 
     let private getOrCreateResource (resource: byref<byte[]>) (name: string) =
         match resource with

--- a/tests/FSharp.Test.Utilities/Xunit/Attributes/DirectoryAttribute.fs
+++ b/tests/FSharp.Test.Utilities/Xunit/Attributes/DirectoryAttribute.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharp.Test.Utilities.Xunit.Attributes
+﻿namespace FSharp.Test.Xunit.Attributes
 
 open System
 open System.IO
@@ -7,8 +7,8 @@ open Xunit.Sdk
 
 open FSharp.Compiler.IO
 
-open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test
+open FSharp.Test.Compiler
 
 /// Attribute to use with Xunit's TheoryAttribute.
 /// Takes a directory, relative to current test suite's root.

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/BooleanLogic.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/BooleanLogic.fs
@@ -2,7 +2,7 @@
 
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
-open FSharp.Test.Utilities
+open FSharp.Test
 open NUnit.Framework
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/CeEdiThrow.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/CeEdiThrow.fs
@@ -3,7 +3,7 @@ namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Compiler.UnitTests
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module CeEdiThrow =

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ComputedListExpressions.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ComputedListExpressions.fs
@@ -2,7 +2,7 @@
 
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
-open FSharp.Test.Utilities
+open FSharp.Test
 open NUnit.Framework
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/Mutation.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/Mutation.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Compiler.UnitTests
-open FSharp.Test.Utilities
+open FSharp.Test
 open NUnit.Framework
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticLinkTests.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticLinkTests.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open System.IO
 open System.Reflection
-open FSharp.Test.Utilities
+open FSharp.Test
 open NUnit.Framework
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
@@ -2,7 +2,7 @@
 
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
-open FSharp.Test.Utilities
+open FSharp.Test
 open NUnit.Framework
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/BasicConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/BasicConstants.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Conformance/DataExpressions/ComputationExpressions.fs
+++ b/tests/fsharp/Compiler/Conformance/DataExpressions/ComputationExpressions.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Infrastructure/AstCompiler.fs
+++ b/tests/fsharp/Compiler/Infrastructure/AstCompiler.fs
@@ -2,7 +2,7 @@
 
 namespace FSharp.Compiler.UnitTests.AstCompiler
 
-open FSharp.Test.Utilities
+open FSharp.Test
 open NUnit.Framework
 open System.Reflection
 

--- a/tests/fsharp/Compiler/Language/AnonRecordTests.fs
+++ b/tests/fsharp/Compiler/Language/AnonRecordTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/ByrefTests.fs
+++ b/tests/fsharp/Compiler/Language/ByrefTests.fs
@@ -3,12 +3,10 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Utilities
 open FSharp.Compiler.Diagnostics
+open FSharp.Test
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Compiler
-open FSharp.Tests
+open FSharp.Test.Compiler
 
 [<TestFixture>]
 module ByrefTests =

--- a/tests/fsharp/Compiler/Language/CompilerDirectiveTests.fs
+++ b/tests/fsharp/Compiler/Language/CompilerDirectiveTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/ComputationExpressionTests.fs
+++ b/tests/fsharp/Compiler/Language/ComputationExpressionTests.fs
@@ -1,7 +1,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/CustomCollectionTests.fs
+++ b/tests/fsharp/Compiler/Language/CustomCollectionTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/DefaultInterfaceMemberTests.fs
+++ b/tests/fsharp/Compiler/Language/DefaultInterfaceMemberTests.fs
@@ -3,8 +3,8 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
+open FSharp.Test
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Utilities
 open FSharp.Compiler.Diagnostics
 
 #if NETCOREAPP

--- a/tests/fsharp/Compiler/Language/FixedIndexSliceTests.fs
+++ b/tests/fsharp/Compiler/Language/FixedIndexSliceTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/HatDesugaringTests.fs
+++ b/tests/fsharp/Compiler/Language/HatDesugaringTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/InitOnlyPropertyConsumptionTests.fs
+++ b/tests/fsharp/Compiler/Language/InitOnlyPropertyConsumptionTests.fs
@@ -3,10 +3,9 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test
+open FSharp.Test.Compiler
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Utilities
-open FSharp.Tests
 
 #if NETCOREAPP
 

--- a/tests/fsharp/Compiler/Language/InterfaceTests.fs
+++ b/tests/fsharp/Compiler/Language/InterfaceTests.fs
@@ -6,7 +6,6 @@ open FSharp.Compiler.Diagnostics
 open NUnit.Framework
 open FSharp.Test
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Utilities
 
 [<TestFixture>]
 module InterfaceTests =

--- a/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
+++ b/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
@@ -4,10 +4,9 @@ namespace FSharp.Compiler.UnitTests
 
 open FSharp.Compiler.Diagnostics
 open NUnit.Framework
+open FSharp.Test
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Utilities
-open FSharp.Test.Utilities.Compiler
-open FSharp.Tests
+open FSharp.Test.Compiler
 
 [<TestFixture>]
 module OpenTypeDeclarationTests =
@@ -2257,7 +2256,7 @@ let main _ =
 
     [<Test>]
     let ``Opening type providers with abbreviation result in unqualified access to types and members`` () =
-        let dir = Core.getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory "typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """
@@ -2299,7 +2298,7 @@ if StaticProperty1 <> "You got a static property" then
 
     [<Test>]
     let ``Opening type providers result in unqualified access to types and members`` () =
-        let dir = Core.getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory "typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """
@@ -2339,7 +2338,7 @@ if StaticProperty1 <> "You got a static property" then
 
     [<Test>]
     let ``Opening type providers with nested result in unqualified access to types and members`` () =
-        let dir = Core.getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory "typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """
@@ -2376,7 +2375,7 @@ if StaticProperty1 <> "You got a static property" then
 
     [<Test>]
     let ``Opening generative type providers in unqualified access to types and members`` () =
-        let dir = Core.getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory "typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """
@@ -2414,7 +2413,7 @@ let _ : TheNestedGeneratedType = Unchecked.defaultof<_>
 
     [<Test>]
     let ``Opening generative type providers directly in unqualified access to types and members - Errors`` () =
-        let dir = Core.getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory "typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """

--- a/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
+++ b/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
@@ -2256,7 +2256,7 @@ let main _ =
 
     [<Test>]
     let ``Opening type providers with abbreviation result in unqualified access to types and members`` () =
-        let dir = getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """
@@ -2298,7 +2298,7 @@ if StaticProperty1 <> "You got a static property" then
 
     [<Test>]
     let ``Opening type providers result in unqualified access to types and members`` () =
-        let dir = getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """
@@ -2338,7 +2338,7 @@ if StaticProperty1 <> "You got a static property" then
 
     [<Test>]
     let ``Opening type providers with nested result in unqualified access to types and members`` () =
-        let dir = getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """
@@ -2375,7 +2375,7 @@ if StaticProperty1 <> "You got a static property" then
 
     [<Test>]
     let ``Opening generative type providers in unqualified access to types and members`` () =
-        let dir = getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """
@@ -2413,7 +2413,7 @@ let _ : TheNestedGeneratedType = Unchecked.defaultof<_>
 
     [<Test>]
     let ``Opening generative type providers directly in unqualified access to types and members - Errors`` () =
-        let dir = getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
         let provider =
             Fsx (sprintf """

--- a/tests/fsharp/Compiler/Language/OptionalInteropTests.fs
+++ b/tests/fsharp/Compiler/Language/OptionalInteropTests.fs
@@ -4,9 +4,9 @@ namespace FSharp.Compiler.UnitTests
 
 open System.Collections.Immutable
 open NUnit.Framework
+open FSharp.Test
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Utilities
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 open FSharp.Compiler.Diagnostics
 open Microsoft.CodeAnalysis
 

--- a/tests/fsharp/Compiler/Language/SlicingQuotationTests.fs
+++ b/tests/fsharp/Compiler/Language/SlicingQuotationTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/SpanOptimizationTests.fs
+++ b/tests/fsharp/Compiler/Language/SpanOptimizationTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 #if NETCOREAPP
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/SpanTests.fs
+++ b/tests/fsharp/Compiler/Language/SpanTests.fs
@@ -5,7 +5,7 @@ namespace FSharp.Compiler.UnitTests
 open System
 open FSharp.Compiler.Diagnostics
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 #if NETCOREAPP
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/StringConcatOptimizationTests.fs
+++ b/tests/fsharp/Compiler/Language/StringConcatOptimizationTests.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open System
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 #if !NETCOREAPP
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/StringInterpolation.fs
+++ b/tests/fsharp/Compiler/Language/StringInterpolation.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
 open FSharp.Compiler.Diagnostics
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module StringInterpolationTests =

--- a/tests/fsharp/Compiler/Language/StructActivePatternTests.fs
+++ b/tests/fsharp/Compiler/Language/StructActivePatternTests.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
 open FSharp.Compiler.Diagnostics
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module StructActivePatternTests =

--- a/tests/fsharp/Compiler/Language/TypeAttributeTests.fs
+++ b/tests/fsharp/Compiler/Language/TypeAttributeTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Language/UIntTests.fs
+++ b/tests/fsharp/Compiler/Language/UIntTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module UIntTests =

--- a/tests/fsharp/Compiler/Language/WitnessTests.fs
+++ b/tests/fsharp/Compiler/Language/WitnessTests.fs
@@ -14,7 +14,7 @@ module WitnessTests =
 
     [<Test>]
     let ``Witness expressions are created as a result of compiling the type provider tests`` () =
-        let dir = getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
         Fsx (sprintf """
 #load @"%s"
         """ (dir ++ "provider.fsx"))

--- a/tests/fsharp/Compiler/Language/WitnessTests.fs
+++ b/tests/fsharp/Compiler/Language/WitnessTests.fs
@@ -3,8 +3,9 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities.Compiler
-open FSharp.Tests
+open FSharp.Test
+open FSharp.Test.Utilities
+open FSharp.Test.Compiler
 
 #if !NETCOREAPP
 
@@ -13,7 +14,7 @@ module WitnessTests =
 
     [<Test>]
     let ``Witness expressions are created as a result of compiling the type provider tests`` () =
-        let dir = Core.getTestsDirectory "typeProviders/helloWorld"
+        let dir = getTestsDirectory "typeProviders/helloWorld"
         Fsx (sprintf """
 #load @"%s"
         """ (dir ++ "provider.fsx"))

--- a/tests/fsharp/Compiler/Libraries/Core/Collections/ListTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Collections/ListTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Libraries/Core/ExtraTopLevelOperators/DictionaryTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/ExtraTopLevelOperators/DictionaryTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 module ``Dictionary Tests`` =
 

--- a/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/CastToUnitsTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/CastToUnitsTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module ``Cast to Units Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/ComparisonTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/ComparisonTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module ``Comparison Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/StringFormatTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/StringFormatTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module ``String Format Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/NativeInterop/StackallocTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/NativeInterop/StackallocTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 #nowarn "9"

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/AbsTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/AbsTests.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
 open FSharp.Compiler.Diagnostics
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module ``Abs Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/CastTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/CastTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open System
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/HashTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/HashTests.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
 open FSharp.Compiler.Diagnostics
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module ``Hash Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/SignTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/SignTests.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
 open FSharp.Compiler.Diagnostics
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module ``Sign Tests`` =

--- a/tests/fsharp/Compiler/Regressions/ForInDoMutableRegressionTest.fs
+++ b/tests/fsharp/Compiler/Regressions/ForInDoMutableRegressionTest.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open System
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture()>]
 module ForInDoMutableRegressionTest =

--- a/tests/fsharp/Compiler/Regressions/IndexerRegressionTests.fs
+++ b/tests/fsharp/Compiler/Regressions/IndexerRegressionTests.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open System
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture()>]
 module IndexerRegressionTests =

--- a/tests/fsharp/Compiler/Regressions/NullableOptionalRegressionTests.fs
+++ b/tests/fsharp/Compiler/Regressions/NullableOptionalRegressionTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities.Compiler
+open FSharp.Test.Compiler
 
 [<TestFixture()>]
 module NullableOptionalRegressionTests =

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -6,10 +6,9 @@ open System
 open System.IO
 open FSharp.Compiler.Diagnostics
 open NUnit.Framework
+open FSharp.Test
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Utilities
-open FSharp.Test.Utilities.Compiler
-open FSharp.Tests
+open FSharp.Test.Compiler
 open FSharp.Compiler.CodeAnalysis
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.CSharp

--- a/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
+++ b/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
@@ -4,10 +4,9 @@ namespace FSharp.Compiler.UnitTests
 
 open FSharp.Compiler.Diagnostics
 open NUnit.Framework
+open FSharp.Test
 open FSharp.Test.Utilities
-open FSharp.Test.Utilities.Utilities
-open FSharp.Test.Utilities.Compiler
-open FSharp.Tests
+open FSharp.Test.Compiler
 
 [<TestFixture>]
 module SignatureGenerationTests =

--- a/tests/fsharp/Compiler/Stress/LargeExprTests.fs
+++ b/tests/fsharp/Compiler/Stress/LargeExprTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 
 [<TestFixture>]
 module LargeExprTests =

--- a/tests/fsharp/Compiler/Warnings/AssignmentWarningTests.fs
+++ b/tests/fsharp/Compiler/Warnings/AssignmentWarningTests.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Warnings/ExperimentalAttributeTests.fs
+++ b/tests/fsharp/Compiler/Warnings/ExperimentalAttributeTests.fs
@@ -2,7 +2,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/Compiler/Warnings/PatternMatchingWarningTests.fs
+++ b/tests/fsharp/Compiler/Warnings/PatternMatchingWarningTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
 open NUnit.Framework
-open FSharp.Test.Utilities
+open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 [<TestFixture>]

--- a/tests/fsharp/TypeProviderTests.fs
+++ b/tests/fsharp/TypeProviderTests.fs
@@ -20,7 +20,6 @@ open Scripting
 open SingleTest
 
 open FSharp.Compiler.IO
-open FSharp.Test.Utilities
 
 #if !NETCOREAPP
 // All tests which do a manual invoke of the F# compiler are disabled
@@ -34,6 +33,7 @@ let FSC_BASIC = FSC_OPT_PLUS_DEBUG
 let FSI_BASIC = FSI_FILE
 #endif
 
+let inline getTestsDirectory dir = FSharp.Test.Utilities.getTestsDirectory __SOURCE_DIRECTORY__ dir
 let testConfig = getTestsDirectory >> testConfig
 
 [<Test>]

--- a/tests/fsharp/TypeProviderTests.fs
+++ b/tests/fsharp/TypeProviderTests.fs
@@ -20,6 +20,7 @@ open Scripting
 open SingleTest
 
 open FSharp.Compiler.IO
+open FSharp.Test.Utilities
 
 #if !NETCOREAPP
 // All tests which do a manual invoke of the F# compiler are disabled
@@ -33,7 +34,6 @@ let FSC_BASIC = FSC_OPT_PLUS_DEBUG
 let FSI_BASIC = FSI_FILE
 #endif
 
-let inline getTestsDirectory dir = __SOURCE_DIRECTORY__ ++ dir
 let testConfig = getTestsDirectory >> testConfig
 
 [<Test>]

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -18,7 +18,6 @@ open Scripting
 open SingleTest
 open HandleExpects
 open FSharp.Test
-open FSharp.Test.Utilities
 
 #if NETCOREAPP
 // Use these lines if you want to test CoreCLR
@@ -33,6 +32,7 @@ let FSI_BASIC = FSI_FILE
 #endif
 // ^^^^^^^^^^^^ To run these tests in F# Interactive , 'build net40', then send this chunk, then evaluate body of a test ^^^^^^^^^^^^
 
+let inline getTestsDirectory dir = FSharp.Test.Utilities.getTestsDirectory __SOURCE_DIRECTORY__ dir
 let singleTestBuildAndRun = getTestsDirectory >> singleTestBuildAndRun
 let singleTestBuildAndRunVersion = getTestsDirectory >> singleTestBuildAndRunVersion
 let testConfig = getTestsDirectory >> testConfig

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -17,6 +17,8 @@ open TestFramework
 open Scripting
 open SingleTest
 open HandleExpects
+open FSharp.Test
+open FSharp.Test.Utilities
 
 #if NETCOREAPP
 // Use these lines if you want to test CoreCLR
@@ -31,7 +33,6 @@ let FSI_BASIC = FSI_FILE
 #endif
 // ^^^^^^^^^^^^ To run these tests in F# Interactive , 'build net40', then send this chunk, then evaluate body of a test ^^^^^^^^^^^^
 
-let inline getTestsDirectory dir = __SOURCE_DIRECTORY__ ++ dir
 let singleTestBuildAndRun = getTestsDirectory >> singleTestBuildAndRun
 let singleTestBuildAndRunVersion = getTestsDirectory >> singleTestBuildAndRunVersion
 let testConfig = getTestsDirectory >> testConfig


### PR DESCRIPTION
Whilst investigating a CI issue, I noticed that we use getTestDirectory from tests.fs in a bunch of the new test framework tests cases.

This refactor breaks that dependence.

- moves the FSharp.Tests.Utilities namespace up to FSharp.Tests
- adds to FSharp.Tests.Utilities.Utilities the getTestDirectory function