### PR TITLE
Cleanup: attributes

### DIFF
--- a/src/fsharp/CompilerImports.fs
+++ b/src/fsharp/CompilerImports.fs
@@ -210,7 +210,7 @@ type ResolvedExtensionReference = ResolvedExtensionReference of string * Assembl
 #endif
 
 #if DEBUG
-[<DebuggerDisplayAttribute("AssemblyResolution({resolvedPath})")>]
+[<DebuggerDisplay("AssemblyResolution({resolvedPath})")>]
 #endif
 type AssemblyResolution =
     {  /// The original reference to the assembly.

--- a/src/fsharp/DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/DependencyManager/DependencyProvider.fs
@@ -117,7 +117,7 @@ type IResolveDependenciesResult =
     abstract Roots: seq<string>
 
 
-[<AllowNullLiteralAttribute>]
+[<AllowNullLiteral>]
 type IDependencyManagerProvider =
     abstract Name: string
     abstract Key: string

--- a/src/fsharp/DependencyManager/DependencyProvider.fsi
+++ b/src/fsharp/DependencyManager/DependencyProvider.fsi
@@ -37,7 +37,7 @@ type IResolveDependenciesResult =
     abstract Roots: seq<string>
 
 /// Wraps access to a DependencyManager implementation
-[<AllowNullLiteralAttribute >]
+[<AllowNullLiteral>]
 type IDependencyManagerProvider =
 
     /// Name of the dependency manager

--- a/src/fsharp/ErrorLogger.fsi
+++ b/src/fsharp/ErrorLogger.fsi
@@ -8,7 +8,7 @@ open FSharp.Compiler.Features
 open FSharp.Compiler.Text
 
 /// Represents the style being used to format errors
-[<RequireQualifiedAccessAttribute>]
+[<RequireQualifiedAccess>]
 type ErrorStyle =
     | DefaultErrors
     | EmacsErrors
@@ -79,7 +79,7 @@ type Exiter =
 val QuitProcessExiter: Exiter
 
 /// Closed enumeration of build phases.
-[<RequireQualifiedAccessAttribute>]
+[<RequireQualifiedAccess>]
 type BuildPhase =
     | DefaultPhase
     | Compile
@@ -95,18 +95,18 @@ type BuildPhase =
 
 /// Literal build phase subcategory strings.
 module BuildPhaseSubcategory =
-    [<LiteralAttribute>] val DefaultPhase: string = ""
-    [<LiteralAttribute>] val Compile: string = "compile"
-    [<LiteralAttribute>] val Parameter: string = "parameter"
-    [<LiteralAttribute>] val Parse: string = "parse"
-    [<LiteralAttribute>] val TypeCheck: string = "typecheck"
-    [<LiteralAttribute>] val CodeGen: string = "codegen"
-    [<LiteralAttribute>] val Optimize: string = "optimize"
-    [<LiteralAttribute>] val IlxGen: string = "ilxgen"
-    [<LiteralAttribute>] val IlGen: string = "ilgen"
-    [<LiteralAttribute>] val Output: string = "output"
-    [<LiteralAttribute>] val Interactive: string = "interactive"
-    [<LiteralAttribute>] val Internal: string = "internal"
+    [<Literal>] val DefaultPhase: string = ""
+    [<Literal>] val Compile: string = "compile"
+    [<Literal>] val Parameter: string = "parameter"
+    [<Literal>] val Parse: string = "parse"
+    [<Literal>] val TypeCheck: string = "typecheck"
+    [<Literal>] val CodeGen: string = "codegen"
+    [<Literal>] val Optimize: string = "optimize"
+    [<Literal>] val IlxGen: string = "ilxgen"
+    [<Literal>] val IlGen: string = "ilgen"
+    [<Literal>] val Output: string = "output"
+    [<Literal>] val Interactive: string = "interactive"
+    [<Literal>] val Internal: string = "internal"
 
 type PhasedDiagnostic =
     { Exception: exn
@@ -131,7 +131,7 @@ type PhasedDiagnostic =
     ///
     member Subcategory: unit -> string
   
-[<AbstractClass()>]
+[<AbstractClass>]
 type ErrorLogger =
 
     new: nameForDebugging:string -> ErrorLogger
@@ -235,7 +235,7 @@ val suppressErrorReporting: f:(unit -> 'a) -> 'a
 val conditionallySuppressErrorReporting: cond:bool -> f:(unit -> 'a) -> 'a
 
 /// The result type of a computational modality to colelct warnings and possibly fail
-[<NoEqualityAttribute (); NoComparisonAttribute>]
+[<NoEquality; NoComparison>]
 type OperationResult<'T> =
     | OkResult of warnings: exn list * 'T
     | ErrorResult of warnings: exn list * exn

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -13,7 +13,7 @@ open FSDependencyManager
 
 module FSharpDependencyManager =
     
-    [<assembly: DependencyManagerAttribute()>]
+    [<assembly: DependencyManager>]
     do ()
 
     let private concat (s:string) (v:string) : string =
@@ -171,7 +171,7 @@ type ResolveDependenciesResult (success: bool, stdOut: string array, stdError: s
     ///     #I @"c:\somepath\to\packages\ResolvedPackage\1.1.1\"
     member _.Roots = roots
 
-[<DependencyManagerAttribute>] 
+[<DependencyManager>] 
 type FSharpDependencyManager (outputDirectory:string option) =
 
     let key = "nuget"

--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fsi
@@ -39,7 +39,7 @@ type ResolveDependenciesResult =
     ///     #I @"c:\somepath\to\packages\ResolvedPackage\1.1.1\"
     member Roots: seq<string>
 
-[<DependencyManagerAttribute>]
+[<DependencyManager>]
 type FSharpDependencyManager =
     new: outputDirectory:string option -> FSharpDependencyManager
 

--- a/src/fsharp/MethodCalls.fsi
+++ b/src/fsharp/MethodCalls.fsi
@@ -88,7 +88,7 @@ type CallerNamedArg<'T> =
 /// Represents the list of unnamed / named arguments at method call site
 /// remark: The usage of list list is due to tupling and currying of arguments,
 /// stemming from SynValInfo in the AST.
-[<StructAttribute>]
+[<Struct>]
 type CallerArgs<'T> =
     { Unnamed: CallerArg<'T> list list
       Named: CallerNamedArg<'T> list list }

--- a/src/fsharp/ParseHelpers.fsi
+++ b/src/fsharp/ParseHelpers.fsi
@@ -72,7 +72,7 @@ type LexerStringStyle =
     | TripleQuote
     | SingleQuote
 
-[<RequireQualifiedAccess; StructAttribute>]
+[<RequireQualifiedAccess; Struct>]
 type LexerStringKind =
     { IsByteString: bool
       IsInterpolated: bool

--- a/src/fsharp/PrettyNaming.fsi
+++ b/src/fsharp/PrettyNaming.fsi
@@ -7,20 +7,20 @@ module public FSharp.Compiler.Syntax.PrettyNaming
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text
 
-[<LiteralAttribute>]
+[<Literal>]
 val internal parenGet: string = ".()"
 
-[<LiteralAttribute>]
+[<Literal>]
 val internal parenSet: string = ".()<-"
 
-[<LiteralAttribute>]
+[<Literal>]
 val internal qmark: string = "?"
 
-[<LiteralAttribute>]
+[<Literal>]
 val internal qmarkSet: string = "?<-"
 
 /// Prefix for compiled (mangled) operator names.
-[<LiteralAttribute>]
+[<Literal>]
 val internal opNamePrefix: string = "op_"
 
 /// Returns `true` if given string is an operator or double backticked name, e.g. ( |>> ) or ( long identifier ).
@@ -113,10 +113,10 @@ val internal ChopPropertyName: s:string -> string
 
 val internal SplitNamesForILPath: s:string -> string list
 
-[<LiteralAttribute>]
+[<Literal>]
 val internal FSharpModuleSuffix: string = "Module"
 
-[<LiteralAttribute>]
+[<Literal>]
 val internal MangledGlobalName: string = "`global`"
 
 val internal IllegalCharactersInTypeAndNamespaceNames: char []
@@ -163,7 +163,7 @@ module internal FSharpLib =
     val CorePath: string list
 
 module internal CustomOperations =
-    [<LiteralAttribute>]
+    [<Literal>]
     val Into: string = "into"
 
 val internal unassignedTyparName: string

--- a/src/fsharp/ReferenceResolver.fs
+++ b/src/fsharp/ReferenceResolver.fs
@@ -57,7 +57,7 @@ type internal ILegacyReferenceResolver =
         logDiagnostic:(bool -> string -> string -> unit)
             -> LegacyResolvedFile[]
 
-[<AllowNullLiteralAttribute>]
+[<AllowNullLiteral>]
 type LegacyReferenceResolver(impl:ILegacyReferenceResolver)  = 
     member internal _.Impl = impl
 

--- a/src/fsharp/ReferenceResolver.fsi
+++ b/src/fsharp/ReferenceResolver.fsi
@@ -26,7 +26,7 @@ type internal LegacyResolvedFile =
         baggage:string
     }
   
-[<AllowNullLiteralAttribute>]
+[<AllowNullLiteral>]
 type internal ILegacyReferenceResolver =
     /// Get the "v4.5.1"-style moniker for the highest installed .NET Framework version.
     /// This is the value passed back to Resolve if no explicit "mscorlib" has been given.
@@ -57,7 +57,7 @@ type internal ILegacyReferenceResolver =
   
 // Note, two implementations of this are provided, and no further implementations can be added from
 // outside FSharp.Compiler.Service
-[<Class; AllowNullLiteralAttribute; Obsolete("This API is obsolete and not for external use")>]
+[<Class; AllowNullLiteral; Obsolete("This API is obsolete and not for external use")>]
 type LegacyReferenceResolver =
     internal new: impl: ILegacyReferenceResolver -> LegacyReferenceResolver
     member internal Impl: ILegacyReferenceResolver

--- a/src/fsharp/absil/illib.fsi
+++ b/src/fsharp/absil/illib.fsi
@@ -55,7 +55,7 @@ module internal PervasiveAutoOpens =
 
     val notFound: unit -> 'a
 
-[<StructAttribute>]
+[<Struct>]
 type internal InlineDelayInit<'T when 'T: not struct> =
 
     new: f:(unit -> 'T) -> InlineDelayInit<'T>
@@ -345,7 +345,7 @@ module internal ResultOrException =
 
     val otherwise : f:(unit -> ResultOrException<'a>) -> x:ResultOrException<'a> -> ResultOrException<'a>
 
-[<RequireQualifiedAccessAttribute; Struct>]
+[<RequireQualifiedAccess; Struct>]
 type internal ValueOrCancelled<'TResult> =
     | Value of result: 'TResult
     | Cancelled of ``exception``: OperationCanceledException
@@ -608,7 +608,7 @@ module internal MapAutoOpens =
         member MarkAsCollapsible: unit -> Map<'Key,'Value> when 'Key: comparison
 
 /// Immutable map collection, with explicit flattening to a backing dictionary 
-[<SealedAttribute>]
+[<Sealed>]
 type internal LayeredMultiMap<'Key,'Value when 'Key: comparison> =
 
     new: contents:LayeredMap<'Key,'Value list> -> LayeredMultiMap<'Key,'Value>

--- a/src/fsharp/import.fsi
+++ b/src/fsharp/import.fsi
@@ -39,7 +39,7 @@ type AssemblyLoader =
 /// There is normally only one ImportMap for any assembly compilation, though additional instances can be created
 /// using tcImports.GetImportMap() if needed, and it is not harmful if multiple instances are used. The object 
 /// serves as an interface through to the tables stored in the primary TcImports structures defined in CompileOps.fs. 
-[<SealedAttribute>]
+[<Sealed>]
 type ImportMap =
     new : g:TcGlobals * assemblyLoader:AssemblyLoader -> ImportMap
     

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -900,7 +900,7 @@ type ILMethInfo =
 
 
 /// Describes an F# use of a method
-[<System.Diagnostics.DebuggerDisplayAttribute("{DebuggerDisplayName}")>]
+[<System.Diagnostics.DebuggerDisplay("{DebuggerDisplayName}")>]
 [<NoComparison; NoEquality>]
 type MethInfo =
     /// Describes a use of a method declared in F# code and backed by F# metadata.

--- a/src/fsharp/lib.fsi
+++ b/src/fsharp/lib.fsi
@@ -260,7 +260,7 @@ val inline tryGetCacheValue: cache:cache<'a> -> NonNullSlot<'a> voption
 module AsyncUtil =
 
     /// Represents the reified result of an asynchronous computation.
-    [<NoEqualityAttribute; NoComparisonAttribute>]
+    [<NoEquality; NoComparison>]
     type AsyncResult<'T> =
         | AsyncOk of 'T
         | AsyncException of exn
@@ -268,7 +268,7 @@ module AsyncUtil =
         static member Commit: res:AsyncResult<'T> -> Async<'T>
 
     /// When using .NET 4.0 you can replace this type by <see cref="Task{T}"/>
-    [<SealedAttribute>]
+    [<Sealed>]
     type AsyncResultCell<'T> =
 
         new: unit -> AsyncResultCell<'T>
@@ -281,7 +281,7 @@ module UnmanagedProcessExecutionOptions =
 module StackGuard =
     val EnsureSufficientExecutionStack: recursionDepth:int -> unit
 
-[<RequireQualifiedAccessAttribute>]
+[<RequireQualifiedAccess>]
 type MaybeLazy<'T> =
     | Strict of 'T
     | Lazy of System.Lazy<'T>

--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -606,7 +606,7 @@ type FSharpStaticParameter =
     /// Indicates if the static parameter is optional
     member IsOptional: bool
 
-    [<System.ObsoleteAttribute("This member is no longer used, use IsOptional instead")>]
+    [<System.Obsolete("This member is no longer used, use IsOptional instead")>]
     member HasDefaultValue: bool
 #endif
 


### PR DESCRIPTION
Removes redundant `()` and `Attribute` in attribute references.