### PR TITLE
More cleanup

### DIFF
--- a/src/fsharp/AugmentWithHashCompare.fs
+++ b/src/fsharp/AugmentWithHashCompare.fs
@@ -4,7 +4,6 @@
 module internal FSharp.Compiler.AugmentWithHashCompare
  
 open Internal.Utilities.Library
-open FSharp.Compiler.AbstractIL 
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Infos

--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -1615,7 +1615,7 @@ let TcComputationExpression cenv env overallTy tpenv (mWhole, interpExpr: Expr, 
         | _ -> true
 
     let basicSynExpr = 
-        trans CompExprTranslationPass.Initial (hasCustomOperations ()) (LazyWithContext.NotLazy ([], env)) comp (fun holeFill -> holeFill)
+        trans CompExprTranslationPass.Initial (hasCustomOperations ()) (LazyWithContext.NotLazy ([], env)) comp id
 
     let delayedExpr = 
         match TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env mBuilderVal ad "Delay" builderTy with 
@@ -1837,7 +1837,7 @@ let TcSequenceExpression (cenv: cenv) env tpenv comp overallTy m =
                 tpenv 
                 true
                 comp 
-                (fun x -> x) |> Some
+                id |> Some
 
         // 'use x = expr in expr'
         | SynExpr.LetOrUse (_isRec, true, [SynBinding (_vis, SynBindingKind.Normal, _, _, _, _, _, pat, _, rhsExpr, _, spBind)], innerComp, wholeExprMark) ->

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -10,7 +10,6 @@ open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
 open Internal.Utilities.Library.ResultOrException
 open FSharp.Compiler 
-open FSharp.Compiler.AbstractIL 
 open FSharp.Compiler.AbstractIL.IL 
 open FSharp.Compiler.AbstractIL.Diagnostics 
 open FSharp.Compiler.AccessibilityLogic

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -1267,7 +1267,7 @@ module IncrClassChecking =
                 // Replace the type parameters that used to be on the rhs with 
                 // the full set of type parameters including the type parameters of the enclosing class
                 let rhsExpr = mkTypeLambda m methodVal.Typars (mkTypeChoose m chooseTps tauExpr, tauTy)
-                (isPriorToSuperInit, (fun e -> e)), [TBind (methodVal, rhsExpr, spBind)]
+                (isPriorToSuperInit, id), [TBind (methodVal, rhsExpr, spBind)]
             
             // If it's represented as a non-escaping local variable then just bind it to its value
             // If it's represented as a non-escaping local arg then no binding necessary (ctor args are already bound)
@@ -1409,7 +1409,7 @@ module IncrClassChecking =
             //     <super init>
             //     <let/do bindings>
             //     return ()
-            let ctorInitActionsPre, ctorInitActionsPost = ctorInitActions |> List.partition (fun (isPriorToSuperInit, _) -> isPriorToSuperInit)
+            let ctorInitActionsPre, ctorInitActionsPost = ctorInitActions |> List.partition fst
 
             // This is the return result
             let ctorBody = mkUnit g m
@@ -3446,7 +3446,7 @@ module EstablishTypeDefinitionCores =
             // Build up a mapping from System.Type --> TyconRef/ILTypeRef, to allow reverse-mapping
             // of types
 
-            let previousContext = (theRootType.PApply ((fun x -> x.Context), m)).PUntaint ((fun x -> x), m)
+            let previousContext = (theRootType.PApply ((fun x -> x.Context), m)).PUntaint (id, m)
             let lookupILTypeRef, lookupTyconRef = previousContext.GetDictionaries()
                     
             let ctxt = ProvidedTypeContext.Create(lookupILTypeRef, lookupTyconRef)
@@ -5299,7 +5299,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
 
       | SynModuleDecl.ModuleAbbrev (id, p, m) -> 
           let env = MutRecBindingChecking.TcModuleAbbrevDecl cenv scopem env (id, p, m)
-          return ((fun e -> e), []), env, env
+          return (Operators.id, []), env, env
 
       | SynModuleDecl.Exception (edef, m) -> 
           let binds, decl, env = TcExceptionDeclarations.TcExnDefn cenv env parent (edef, scopem)
@@ -5319,7 +5319,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
       | SynModuleDecl.Open (target, m) -> 
           let scopem = unionRanges m.EndRange scopem
           let env = TcOpenDecl cenv m scopem env target
-          return ((fun e -> e), []), env, env
+          return (id, []), env, env
 
       | SynModuleDecl.Let (letrec, binds, m) -> 
 
@@ -5346,7 +5346,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
           return ((fun e -> e), attrs), env, env
 
       | SynModuleDecl.HashDirective _ -> 
-          return ((fun e -> e), []), env, env
+          return (id, []), env, env
 
       | SynModuleDecl.NestedModule(compInfo, isRec, mdefs, isContinuingModule, m) ->
 
@@ -5465,7 +5465,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
 
     with exn -> 
         errorRecovery exn synDecl.Range 
-        return ((fun e -> e), []), env, env
+        return (id, []), env, env
  }
  
 /// The non-mutually recursive case for a sequence of declarations

--- a/src/fsharp/CheckDeclarations.fsi
+++ b/src/fsharp/CheckDeclarations.fsi
@@ -2,7 +2,6 @@
 
 module internal FSharp.Compiler.CheckDeclarations
 
-open FSharp.Compiler 
 open Internal.Utilities.Library
 open FSharp.Compiler.CheckExpressions
 open FSharp.Compiler.CompilerGlobalState

--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -11,7 +11,6 @@ open Internal.Utilities.FSharpEnvironment
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
 open FSharp.Compiler
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILBinaryReader
 open FSharp.Compiler.AbstractIL.ILPdbWriter

--- a/src/fsharp/CompilerImports.fs
+++ b/src/fsharp/CompilerImports.fs
@@ -1100,7 +1100,7 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
             let ccuData: CcuData =
               { IsFSharp=false
                 UsesFSharp20PlusQuotations=false
-                InvalidateEvent=(new Event<_>()).Publish
+                InvalidateEvent=(Event<_>()).Publish
                 IsProviderGenerated = true
                 QualifiedName= Some (assembly.PUntaint((fun a -> a.FullName), m))
                 Contents = ccuContents
@@ -1482,7 +1482,7 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
         let nm = aref.Name
         if verbose then dprintn ("Converting IL assembly to F# data structures "+nm)
         let auxModuleLoader = tcImports.MkLoaderForMultiModuleILAssemblies ctok m
-        let invalidateCcu = new Event<_>()
+        let invalidateCcu = Event<_>()
         let ccu = ImportILAssembly(tcImports.GetImportMap, m, auxModuleLoader, tcConfig.xmlDocInfoLoader, ilScopeRef, tcConfig.implicitIncludeDir, Some filename, ilModule, invalidateCcu.Publish)
 
         let ccuinfo =
@@ -1527,7 +1527,7 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
                 let mspec = minfo.mspec
 
 #if !NO_EXTENSIONTYPING
-                let invalidateCcu = new Event<_>()
+                let invalidateCcu = Event<_>()
 #endif
 
                 let codeDir = minfo.compileTimeWorkingDir

--- a/src/fsharp/CompilerImports.fs
+++ b/src/fsharp/CompilerImports.fs
@@ -1571,7 +1571,7 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
                                 RequireTcImportsLock(tcitok, ccuThunks)
                                 for ccuThunk in data.FixupThunks do
                                     if ccuThunk.IsUnresolvedReference then
-                                        ccuThunks.Add(ccuThunk, fun () -> fixupThunk () |> ignore) |> ignore
+                                        ccuThunks.Add(ccuThunk, fun () -> fixupThunk () |> ignore)
                             )
 
                             if verbose then dprintf "found optimization data for CCU %s\n" ccuName
@@ -1613,7 +1613,7 @@ and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAsse
                     if ccuThunk.IsUnresolvedReference then
                       tciLock.AcquireLock <| fun tcitok ->
                         RequireTcImportsLock(tcitok, ccuThunks)
-                        ccuThunks.Add(ccuThunk, fixupThunk) |> ignore
+                        ccuThunks.Add(ccuThunk, fixupThunk)
                 )
 #if !NO_EXTENSIONTYPING
             ccuRawDataAndInfos |> List.iter (fun (_, _, phase2) -> phase2())

--- a/src/fsharp/ConstraintSolver.fsi
+++ b/src/fsharp/ConstraintSolver.fsi
@@ -3,7 +3,6 @@
 /// Solves constraints using a mutable constraint-solver state
 module internal FSharp.Compiler.ConstraintSolver
 
-open FSharp.Compiler 
 open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Import

--- a/src/fsharp/DependencyManager/DependencyProvider.fs
+++ b/src/fsharp/DependencyManager/DependencyProvider.fs
@@ -256,7 +256,7 @@ type ReflectionDependencyManagerProvider(theType: Type,
                                     box scriptName
                                     box (packageManagerTextLines
                                          |> Seq.filter(fun (dv, _) -> dv = "r") 
-                                         |> Seq.map(fun (_, line) -> line))
+                                         |> Seq.map snd)
                                     box tfm |]
                 else
                     None, [||]

--- a/src/fsharp/ErrorResolutionHints.fs
+++ b/src/fsharp/ErrorResolutionHints.fs
@@ -88,7 +88,7 @@ type SuggestionBuffer(idText: string) =
                     suggestion.EndsWithOrdinal dotIdText ||
                     (similarity >= minThresholdForSuggestions && IsInEditDistanceProximity uppercaseText suggestedText)
                 then
-                    insert(similarity, suggestion) |> ignore
+                    insert(similarity, suggestion)
     
     member _.Disabled with get () = disableSuggestions
 

--- a/src/fsharp/FxResolver.fs
+++ b/src/fsharp/FxResolver.fs
@@ -277,7 +277,7 @@ type internal FxResolver(assumeDotNetFramework: bool, projectDir: string, useSdk
             |> Array.map (fun di -> computeVersion di.Name, di)
             |> Array.filter(fun (v, _) -> (compareVersion v targetVersion) <= 0)
             |> Array.sortWith (fun (v1,_) (v2,_) -> compareVersion v1 v2)
-            |> Array.map (fun (_, di) -> di)
+            |> Array.map snd
             |> Array.tryLast
         else
             None

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -14,7 +14,6 @@ open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
 
 open FSharp.Compiler
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.BinaryConstants
 open FSharp.Compiler.AbstractIL.ILX
@@ -25,7 +24,6 @@ open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Features
 open FSharp.Compiler.Infos
 open FSharp.Compiler.Import
-open FSharp.Compiler.Infos
 open FSharp.Compiler.LowerCallsAndSeqs
 open FSharp.Compiler.LowerStateMachines
 open FSharp.Compiler.Syntax

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -4743,7 +4743,7 @@ and GenStructStateMachine cenv cgbuf eenvouter (res: LoweredStateMachine) sequel
           ([mkLocalValRef setDataThisVar], [setDataValueVar], g.mk_IResumableStateMachine_ty dataTy, "set_Data", setDataBody); ]
 
     let mdefs =
-        [ for (thisVals, argVals, interfaceTy, imethName, bodyR) in methods do
+        [ for thisVals, argVals, interfaceTy, imethName, bodyR in methods do
             let eenvinner = eenvinner |> AddStorageForLocalVals g [(moveNextThisVar, Arg 0) ] 
             let m = bodyR.Range
             let implementedMeth = 
@@ -4764,7 +4764,7 @@ and GenStructStateMachine cenv cgbuf eenvouter (res: LoweredStateMachine) sequel
             mkILNonGenericVirtualMethod(imethName, ILMemberAccess.Public, ilParams, mkILReturn ilRetTy, MethodBody.IL (notlazy ilCode)) ]
 
     let mimpls =
-        [ for ((_thisVals, _argVals, interfaceTy, imethName, bodyR), mdef) in (List.zip methods mdefs) do
+        [ for (_thisVals, _argVals, interfaceTy, imethName, bodyR), mdef in (List.zip methods mdefs) do
             let m = bodyR.Range
             let implementedMeth = 
                 match InfoReader.TryFindIntrinsicMethInfo infoReader m AccessibilityLogic.AccessorDomain.AccessibleFromSomewhere imethName interfaceTy with
@@ -4844,7 +4844,7 @@ and GenStructStateMachine cenv cgbuf eenvouter (res: LoweredStateMachine) sequel
         let eenvinner = eenvinner |> AddStorageForLocalVals g [(afterCodeThisVar, Local (locIdx2, realloc, None)) ] 
 
         // Initialize the closure variables
-        for (fv, ilv) in Seq.zip cloFreeVars cloinfo.ilCloAllFreeVars do
+        for fv, ilv in Seq.zip cloFreeVars cloinfo.ilCloAllFreeVars do
             if stateVarsSet.Contains fv then
                 // zero-initialize the state var
                 if realloc then 
@@ -5674,7 +5674,7 @@ and GenDecisionTreeSuccess cenv cgbuf inplabOpt stackAtTargets eenv es targetIdx
         targetInfos, genTargetInfoOpt
 
 and GenDecisionTreeTarget cenv cgbuf stackAtTargets targetInfo sequel =
-    let (targetMarkBeforeBinds, targetMarkAfterBinds, eenvAtTarget, successExpr, spTarget, repeatSP, vs, es, flags, startScope, endScope) = targetInfo
+    let targetMarkBeforeBinds, targetMarkAfterBinds, eenvAtTarget, successExpr, spTarget, repeatSP, vs, es, flags, startScope, endScope = targetInfo
     CG.SetMarkToHere cgbuf targetMarkBeforeBinds
     let spExpr = (match spTarget with DebugPointForTarget.Yes -> SPAlways | DebugPointForTarget.No _ -> SPSuppress)
 

--- a/src/fsharp/LegacyMSBuildReferenceResolver.fs
+++ b/src/fsharp/LegacyMSBuildReferenceResolver.fs
@@ -129,7 +129,7 @@ module FSharp.Compiler.CodeAnalysis.LegacyMSBuildReferenceResolver
                     let v = if dotNetVersion.StartsWith("v") then dotNetVersion.Substring(1) else dotNetVersion
                     let frameworkName = System.Runtime.Versioning.FrameworkName(".NETFramework", Version(v))
                     match ToolLocationHelper.GetPathToReferenceAssemblies(frameworkName) |> Seq.tryHead with
-                    | Some p -> if FileSystem.DirectoryExistsShim(p) then true else false
+                    | Some p -> FileSystem.DirectoryExistsShim(p)
                     | None -> false
                 with _ -> false
             else false

--- a/src/fsharp/LowerCallsAndSeqs.fs
+++ b/src/fsharp/LowerCallsAndSeqs.fs
@@ -5,7 +5,6 @@ module internal FSharp.Compiler.LowerCallsAndSeqs
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.ErrorLogger

--- a/src/fsharp/LowerStateMachines.fs
+++ b/src/fsharp/LowerStateMachines.fs
@@ -274,8 +274,8 @@ type LowerStateMachine(g: TcGlobals) =
                     // type in the IL
                     let targetExpr2Opt = 
                         match targetExpr, newTyOpt with 
-                        | Expr.Op (TOp.ILAsm ([ AbstractIL.IL.I_throw ], [_oldTy]), a, b, c), Some newTy -> 
-                            let targetExpr2 = Expr.Op (TOp.ILAsm ([ AbstractIL.IL.I_throw ], [newTy]), a, b, c) 
+                        | Expr.Op (TOp.ILAsm ([ I_throw ], [_oldTy]), a, b, c), Some newTy -> 
+                            let targetExpr2 = Expr.Op (TOp.ILAsm ([ I_throw ], [newTy]), a, b, c) 
                             Some targetExpr2
                         | Expr.Sequential (Expr.Op (TOp.ILCall ( _, _, _, _, _, _, _, ilMethodRef, _, _, _), _, _, _) as e1, Expr.Const (Const.Zero, m, _oldTy), a, b, c), Some newTy  when ilMethodRef.Name = "Throw" -> 
                             let targetExpr2 = Expr.Sequential (e1, Expr.Const (Const.Zero, m, newTy), a, b, c)
@@ -411,7 +411,7 @@ type LowerStateMachine(g: TcGlobals) =
         if pcs.IsEmpty then 
             expr
         else
-            let initLabel = IL.generateCodeLabel()
+            let initLabel = generateCodeLabel()
             let mbuilder = MatchBuilder(DebugPointAtBinding.NoneAtInvisible, m )
             let mkGotoLabelTarget lab = mbuilder.AddResultTarget(Expr.Op (TOp.Goto lab, [], [], m), DebugPointForTarget.No)
             let dtree =
@@ -536,7 +536,7 @@ type LowerStateMachine(g: TcGlobals) =
             let resumableVars = unionFreeVars (freeInExpr CollectLocals resNone.phase1) resSome.resumableVars 
             let m = someBranchExpr.Range
             let recreate reenterLabOpt e1 e2 = 
-                let lab = (match reenterLabOpt with Some l -> l | _ -> IL.generateCodeLabel())
+                let lab = (match reenterLabOpt with Some l -> l | _ -> generateCodeLabel())
                 mkCond DebugPointAtBinding.NoneAtSticky DebugPointForTarget.No  m (tyOfExpr g noneBranchExpr) (mkFalse g m) (mkLabelled m lab e1) e2
             { phase1 = recreate None resNone.phase1 resSome.phase1
               phase2 = (fun ctxt ->
@@ -558,7 +558,7 @@ type LowerStateMachine(g: TcGlobals) =
         match pcExprVal with
         | Int32Expr contIdPC ->
             let recreate contLabOpt =
-                Expr.Op (TOp.Goto (match contLabOpt with Some l -> l | _ -> IL.generateCodeLabel()), [], [], m)
+                Expr.Op (TOp.Goto (match contLabOpt with Some l -> l | _ -> generateCodeLabel()), [], [], m)
 
             { phase1 = recreate None 
               phase2 = (fun ctxt ->
@@ -713,7 +713,7 @@ type LowerStateMachine(g: TcGlobals) =
                     let innerPcSet = innerPcs |> Set.ofList
                     let outerLabsForInnerPcs = pcsAndLabs |> List.filter (fun (pc, _outerLab) -> innerPcSet.Contains pc) |> List.map snd
                     // generate the inner labels
-                    let pcsAndInnerLabs = pcsAndLabs |> List.map (fun (pc, l) -> (pc, if innerPcSet.Contains pc then IL.generateCodeLabel() else l))
+                    let pcsAndInnerLabs = pcsAndLabs |> List.map (fun (pc, l) -> (pc, if innerPcSet.Contains pc then generateCodeLabel() else l))
                     let innerPc2Lab = Map.ofList pcsAndInnerLabs
 
                     let vBodyR = resBody.phase2 innerPc2Lab
@@ -866,7 +866,7 @@ type LowerStateMachine(g: TcGlobals) =
 
                 // Work out the initial mapping of pcs to labels
                 let pcs = [ 1 .. pcCount ]
-                let labs = pcs |> List.map (fun _ -> IL.generateCodeLabel())
+                let labs = pcs |> List.map (fun _ -> generateCodeLabel())
                 let pc2lab  = Map.ofList (List.zip pcs labs)
 
                 // Execute phase2, building the core of the method

--- a/src/fsharp/LowerStateMachines.fs
+++ b/src/fsharp/LowerStateMachines.fs
@@ -5,9 +5,7 @@ module internal FSharp.Compiler.LowerStateMachines
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
-open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Syntax.PrettyNaming

--- a/src/fsharp/LowerStateMachines.fs
+++ b/src/fsharp/LowerStateMachines.fs
@@ -22,7 +22,7 @@ type StateMachineConversionFirstPhaseResult =
 
      /// The second phase of the transformation.  It is run after all code labels and their mapping to program counters have been determined
      /// after the first phase. 
-     phase2: (Map<int, ILCodeLabel> -> Expr)
+     phase2: Map<int, ILCodeLabel> -> Expr
 
      /// The labels allocated for this portion of the computation
      entryPoints: int list
@@ -277,7 +277,7 @@ type LowerStateMachine(g: TcGlobals) =
                         | Expr.Op (TOp.ILAsm ([ AbstractIL.IL.I_throw ], [_oldTy]), a, b, c), Some newTy -> 
                             let targetExpr2 = Expr.Op (TOp.ILAsm ([ AbstractIL.IL.I_throw ], [newTy]), a, b, c) 
                             Some targetExpr2
-                        | Expr.Sequential ((Expr.Op (TOp.ILCall ( _, _, _, _, _, _, _, ilMethodRef, _, _, _), _, _, _) as e1), Expr.Const (Const.Zero, m, _oldTy), a, b, c), Some newTy  when ilMethodRef.Name = "Throw" -> 
+                        | Expr.Sequential (Expr.Op (TOp.ILCall ( _, _, _, _, _, _, _, ilMethodRef, _, _, _), _, _, _) as e1, Expr.Const (Const.Zero, m, _oldTy), a, b, c), Some newTy  when ilMethodRef.Name = "Throw" -> 
                             let targetExpr2 = Expr.Sequential (e1, Expr.Const (Const.Zero, m, newTy), a, b, c)
                             Some targetExpr2
                         | _ ->
@@ -751,7 +751,7 @@ type LowerStateMachine(g: TcGlobals) =
             let entryPoints = tgl |> List.collect (fun res -> res.entryPoints)
             let resumableVars =
                 (emptyFreeVars, Array.zip targets tglArray)
-                ||> Array.fold (fun fvs ((TTarget(_vs, _, _spTarget, _)), res) ->
+                ||> Array.fold (fun fvs (TTarget(_vs, _, _spTarget, _), res) ->
                     if res.entryPoints.IsEmpty then fvs else unionFreeVars fvs res.resumableVars)
             let stateVars = 
                 (targets, tglArray) ||> Array.zip |> Array.toList |> List.collect (fun (TTarget(vs, _, _, _), res) -> 

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -2744,7 +2744,7 @@ let ChooseTyconRefInExpr (ncenv: NameResolver, m, ad, nenv, id: Ident, typeNameR
     | ResolveTypeNamesToCtors ->
         tys
         |> CollectAtMostOneResult (fun (resInfo, ty) -> ResolveObjectConstructorPrim ncenv nenv.eDisplayEnv resInfo id.idRange ad ty)
-        |> MapResults (fun (resInfo, item) -> (resInfo, item))
+        |> MapResults Operators.id
     | ResolveTypeNamesToTypeRefs ->
         success (tys |> List.map (fun (resInfo, ty) -> (resInfo, Item.Types(id.idText, [ty]))))
 

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1888,7 +1888,7 @@ type TcSymbolUses(g, capturedNameResolutions: ResizeArray<CapturedNameResolution
         |> ResizeArray.mapToSmallArrayChunks (fun cnr -> { Item=cnr.Item; ItemOccurence=cnr.ItemOccurence; DisplayEnv=cnr.DisplayEnv; Range=cnr.Range })
 
     let capturedNameResolutions = ()
-    do ignore capturedNameResolutions // don't capture this!
+    do capturedNameResolutions // don't capture this!
 
     member this.GetUsesOfSymbol item =
         // This member returns what is potentially a very large array, which may approach the size constraints of the Large Object Heap.

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -3,7 +3,6 @@
 module internal FSharp.Compiler.NameResolution
 
 open Internal.Utilities.Library
-open FSharp.Compiler
 open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.Infos
 open FSharp.Compiler.Import

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -8,7 +8,6 @@ open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
 open Internal.Utilities.Rational
 open FSharp.Compiler 
-open FSharp.Compiler.AbstractIL 
 open FSharp.Compiler.AbstractIL.IL 
 open FSharp.Compiler.AttributeChecking
 open FSharp.Compiler.ErrorLogger

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -21,7 +21,6 @@ open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
-open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Text.Layout
 open FSharp.Compiler.Text.LayoutRender
 open FSharp.Compiler.Text.TaggedText

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -162,7 +162,7 @@ type ValInfos(entries) =
                 let vkey = (vref, vref.Deref.GetLinkageFullKey())
                 if dict.ContainsKey vkey then 
                     failwithf "dictionary already contains key %A" vkey
-                dict.Add(vkey, p) |> ignore
+                dict.Add(vkey, p)
             ReadOnlyDictionary dict), id)
 
     member x.Entries = valInfoTable.Force().Values

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1277,7 +1277,7 @@ let IsMutableStructuralBindingForTupleElement (vref: ValRef) =
 
 let IsMutableForOutArg (vref: ValRef) =
     vref.IsCompilerGenerated &&
-    vref.LogicalName.StartsWith(PrettyNaming.outArgCompilerGeneratedName)
+    vref.LogicalName.StartsWith(outArgCompilerGeneratedName)
 
 let IsKnownOnlyMutableBeforeUse (vref: ValRef) =
     IsMutableStructuralBindingForTupleElement vref || 

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1982,7 +1982,7 @@ let rec OptimizeExpr cenv (env: IncrementalOptimizationEnv) expr =
     | LinearMatchExpr _
     | Expr.Sequential _ 
     | Expr.Let _ ->  
-        OptimizeLinearExpr cenv env expr (fun x -> x)
+        OptimizeLinearExpr cenv env expr id
 
     | Expr.Const (c, m, ty) -> 
         OptimizeConst cenv env expr (c, m, ty)

--- a/src/fsharp/ParseAndCheckInputs.fs
+++ b/src/fsharp/ParseAndCheckInputs.fs
@@ -732,7 +732,7 @@ let GetInitialTcState(m, ccuName, tcConfig: TcConfig, tcGlobals, tcImports: TcIm
         { IsFSharp=true
           UsesFSharp20PlusQuotations=false
 #if !NO_EXTENSIONTYPING
-          InvalidateEvent=(new Event<_>()).Publish
+          InvalidateEvent=(Event<_>()).Publish
           IsProviderGenerated = false
           ImportProvidedType = (fun ty -> Import.ImportProvidedType (tcImports.GetImportMap()) m ty)
 #endif

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -138,7 +138,7 @@ let IsOperatorName (name: string) =
             else
                 isOperatorName name (idx + 1) endIndex
 
-    let skipParens = if name.StartsWithOrdinal("( ") && name.EndsWithOrdinal(" )") then true else false
+    let skipParens = name.StartsWithOrdinal("( ") && name.EndsWithOrdinal(" )")
     let startIndex = if skipParens then 2 else 0
     let endIndex = if skipParens then name.Length - 2 else name.Length
 

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -10,7 +10,6 @@ open System.Collections.Concurrent
 open System.Globalization
 open System.Text
 
-open FSharp.Compiler
 open FSharp.Compiler.AbstractIL
 open Internal.Utilities.Library
 open FSharp.Compiler.Text

--- a/src/fsharp/StaticLinking.fs
+++ b/src/fsharp/StaticLinking.fs
@@ -93,7 +93,7 @@ let debugStaticLinking = condition "FSHARP_DEBUG_STATIC_LINKING"
 
 let StaticLinkILModules (tcConfig:TcConfig, ilGlobals, tcImports, ilxMainModule, dependentILModules: (CcuThunk option * ILModuleDef) list) =
     if isNil dependentILModules then
-        ilxMainModule, (fun x -> x)
+        ilxMainModule, id
     else
         let typeForwarding = TypeForwarding(tcImports)
 
@@ -351,7 +351,7 @@ let StaticLink (ctok, tcConfig: TcConfig, tcImports: TcImports, ilGlobals: ILGlo
             && providerGeneratedAssemblies.IsEmpty
 #endif
             then
-        (fun ilxMainModule -> ilxMainModule)
+        id
     else
         (fun ilxMainModule  ->
             ReportTime tcConfig "Find assembly references"

--- a/src/fsharp/StaticLinking.fs
+++ b/src/fsharp/StaticLinking.fs
@@ -16,7 +16,6 @@ open FSharp.Compiler.CompilerOptions
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.IO
 open FSharp.Compiler.OptimizeInputs
-open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -232,7 +232,6 @@ type BlockSeparator = range * pos option
 
 type RecordFieldName = LongIdentWithDots * bool
 
-[<RequireQualifiedAccess>]
 type ExprAtomicFlag =
     | Atomic = 0
     | NonAtomic = 1

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -321,7 +321,6 @@ type RecordFieldName = LongIdentWithDots * bool
 /// 1, "3", ident, ident.[expr] and (expr). If an atomic expression has type T,
 /// then the largest expression ending at the same range as the atomic expression
 /// also has type T.
-[<RequireQualifiedAccess>]
 type ExprAtomicFlag =
     | Atomic = 0
     | NonAtomic = 1

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -12,7 +12,6 @@ open System.Collections.Concurrent
 open System.Diagnostics
 
 open Internal.Utilities.Library
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILX
 open FSharp.Compiler.CompilerGlobalState

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -14,7 +14,6 @@ open Internal.Utilities.Library.Extras
 open Internal.Utilities.Rational
 
 open FSharp.Compiler 
-open FSharp.Compiler.AbstractIL 
 open FSharp.Compiler.AbstractIL.IL 
 open FSharp.Compiler.AbstractIL.ILX.Types
 open FSharp.Compiler.CompilerGlobalState

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -1201,7 +1201,7 @@ type Entity =
                         match isType with 
                         | FSharpModuleWithSuffix | ModuleOrType -> 
                             let outerTypeName = (textOfPath (List.rev (h :: racc)))
-                            ILTypeRef.Create(sref, (outerTypeName :: List.map (fun (nm, _) -> nm) t), item)
+                            ILTypeRef.Create(sref, (outerTypeName :: List.map fst t), item)
                         | _ -> 
                           top (h :: racc) t
                 top [] p 
@@ -5468,7 +5468,7 @@ type Construct() =
                 st.PApplyWithProvider((fun (st, provider) ->
                     ignore provider
                     st.IsMeasure), m)
-                  .PUntaintNoFailure(fun x -> x)
+                  .PUntaintNoFailure(Operators.id)
             if isMeasure then TyparKind.Measure else TyparKind.Type
 
         let access = 
@@ -5704,11 +5704,11 @@ type Construct() =
 
     /// Create a new module or namespace node by cloning an existing one
     static member NewClonedModuleOrNamespace orig =
-        Construct.NewModifiedModuleOrNamespace (fun mty -> mty) orig
+        Construct.NewModifiedModuleOrNamespace id orig
 
     /// Create a new type definition node by cloning an existing one
     static member NewClonedTycon orig =
-        Construct.NewModifiedTycon (fun d -> d) orig
+        Construct.NewModifiedTycon id orig
 
 #if !NO_EXTENSIONTYPING
     /// Compute the definition location of a provided item

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -789,9 +789,9 @@ let pickleObjWithDanglingCcus inMem file g scope p x =
       { os = ByteBuffer.Create(PickleBufferCapacity, useArrayPool = true)
         oscope=scope
         occus= Table<_>.Create "occus"
-        oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), (fun osgn -> osgn), "otycons")
-        otypars=NodeOutTable<_, _>.Create((fun (tp: Typar) -> tp.Stamp), (fun tp -> tp.DisplayName), (fun tp -> tp.Range), (fun osgn -> osgn), "otypars")
-        ovals=NodeOutTable<_, _>.Create((fun (v: Val) -> v.Stamp), (fun v -> v.LogicalName), (fun v -> v.Range), (fun osgn -> osgn), "ovals")
+        oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), id , "otycons")
+        otypars=NodeOutTable<_, _>.Create((fun (tp: Typar) -> tp.Stamp), (fun tp -> tp.DisplayName), (fun tp -> tp.Range), id , "otypars")
+        ovals=NodeOutTable<_, _>.Create((fun (v: Val) -> v.Stamp), (fun v -> v.LogicalName), (fun v -> v.Range), id , "ovals")
         oanoninfos=NodeOutTable<_, _>.Create((fun (v: AnonRecdTypeInfo) -> v.Stamp), (fun v -> string v.Stamp), (fun _ -> range0), id, "oanoninfos")
         ostrings=Table<_>.Create "ostrings"
         onlerefs=Table<_>.Create "onlerefs"
@@ -814,8 +814,8 @@ let pickleObjWithDanglingCcus inMem file g scope p x =
    { os = ByteBuffer.Create(PickleBufferCapacity, useArrayPool = true)
      oscope=scope
      occus= Table<_>.Create "occus (fake)"
-     oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), (fun osgn -> osgn), "otycons")
-     otypars=NodeOutTable<_, _>.Create((fun (tp: Typar) -> tp.Stamp), (fun tp -> tp.DisplayName), (fun tp -> tp.Range), (fun osgn -> osgn), "otypars")
+     oentities=NodeOutTable<_, _>.Create((fun (tc: Tycon) -> tc.Stamp), (fun tc -> tc.LogicalName), (fun tc -> tc.Range), id , "otycons")
+     otypars=NodeOutTable<_, _>.Create((fun (tp: Typar) -> tp.Stamp), (fun tp -> tp.DisplayName), (fun tp -> tp.Range), id , "otypars")
      ovals=NodeOutTable<_, _>.Create((fun (v: Val) -> v.Stamp), (fun v -> v.LogicalName), (fun v -> v.Range), (fun osgn -> osgn), "ovals")
      oanoninfos=NodeOutTable<_, _>.Create((fun (v: AnonRecdTypeInfo) -> v.Stamp), (fun v -> string v.Stamp), (fun _ -> range0), id, "oanoninfos")
      ostrings=Table<_>.Create "ostrings (fake)"

--- a/src/fsharp/absil/ilmorph.fs
+++ b/src/fsharp/absil/ilmorph.fs
@@ -3,7 +3,6 @@
 module internal FSharp.Compiler.AbstractIL.Morphs 
 
 open System.Collections.Generic
-open FSharp.Compiler.AbstractIL 
 open Internal.Utilities.Library 
 open FSharp.Compiler.AbstractIL.IL 
 

--- a/src/fsharp/absil/ilreflect.fs
+++ b/src/fsharp/absil/ilreflect.fs
@@ -11,7 +11,6 @@ open System.Collections.Generic
 
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.Diagnostics
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.ErrorLogger

--- a/src/fsharp/absil/ilsign.fs
+++ b/src/fsharp/absil/ilsign.fs
@@ -123,7 +123,7 @@ module internal FSharp.Compiler.AbstractIL.StrongNameSign
 
         member x.ReadBigInteger (length:int):byte[] =
             let arr:byte[] = Array.zeroCreate<byte> length
-            Array.Copy(x._blob, x._offset, arr, 0, length) |> ignore
+            Array.Copy(x._blob, x._offset, arr, 0, length)
             x._offset <- x._offset  + length
             arr |> Array.rev
 

--- a/src/fsharp/absil/ilwritepdb.fs
+++ b/src/fsharp/absil/ilwritepdb.fs
@@ -13,6 +13,7 @@ open System.Reflection.Metadata.Ecma335
 open System.Text
 open Internal.Utilities
 open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.Support
 open Internal.Utilities.Library
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.IO
@@ -569,7 +570,6 @@ let embedPortablePdbInfo (uncompressedLength: int64)  (contentId: BlobContentId)
 #if !FX_NO_PDB_WRITER
 
 open Microsoft.Win32
-open FSharp.Compiler.AbstractIL.Support
 
 //---------------------------------------------------------------------
 // PDB Writer.  The function [WritePdbInfo] abstracts the

--- a/src/fsharp/absil/ilwritepdb.fs
+++ b/src/fsharp/absil/ilwritepdb.fs
@@ -569,6 +569,7 @@ let embedPortablePdbInfo (uncompressedLength: int64)  (contentId: BlobContentId)
 #if !FX_NO_PDB_WRITER
 
 open Microsoft.Win32
+open FSharp.Compiler.AbstractIL.Support
 
 //---------------------------------------------------------------------
 // PDB Writer.  The function [WritePdbInfo] abstracts the

--- a/src/fsharp/absil/ilwritepdb.fs
+++ b/src/fsharp/absil/ilwritepdb.fs
@@ -273,7 +273,7 @@ let generatePortablePdb (embedAllSource: bool) (embedSourceList: string list) (s
     let metadata = MetadataBuilder()
     let serializeDocumentName (name: string) =
         let name = PathMap.apply pathMap name
-        let count s c = s |> Seq.filter(fun ch -> if c = ch then true else false) |> Seq.length
+        let count s c = s |> Seq.filter(fun ch -> c = ch) |> Seq.length
 
         let s1, s2 = '/', '\\'
         let separator = if (count name s1) >= (count name s2) then s1 else s2

--- a/src/fsharp/absil/ilwritepdb.fs
+++ b/src/fsharp/absil/ilwritepdb.fs
@@ -13,7 +13,6 @@ open System.Reflection.Metadata.Ecma335
 open System.Text
 open Internal.Utilities
 open FSharp.Compiler.AbstractIL.IL
-open FSharp.Compiler.AbstractIL.Support
 open Internal.Utilities.Library
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.IO

--- a/src/fsharp/absil/ilwritepdb.fs
+++ b/src/fsharp/absil/ilwritepdb.fs
@@ -320,9 +320,9 @@ let generatePortablePdb (embedAllSource: bool) (embedSourceList: string list) (s
                     builder.WriteInt32 0
                     builder.TryWriteBytes(stream, length) |> ignore
                 else
-                    builder.WriteInt32 length |>ignore
+                    builder.WriteInt32 length
                     use deflater = new DeflateStream(builder, CompressionMode.Compress, true)
-                    stream.CopyTo deflater |> ignore
+                    stream.CopyTo deflater
                 Some (builder.ToImmutableArray())
 
         let mutable index = Dictionary<string, DocumentHandle>(docs.Length)

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1210,7 +1210,7 @@ type internal FsiDynamicCompiler
                 let responseL = NicePrint.layoutInferredSigOfModuleExpr false denv infoReader AccessibleFromSomewhere rangeStdin mexpr
                 if not (isEmptyL responseL) then
                     let opts = valuePrinter.GetFsiPrintOptions()
-                    colorPrintL outWriter opts responseL |> ignore
+                    colorPrintL outWriter opts responseL
 
         // Build the new incremental state.
         let istate = {istate with  optEnv    = optEnv;

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -734,13 +734,12 @@ type internal FsiCommandLineOptions(fsi: FsiEvaluationSessionHostConfig,
         ]);
        PublicOptions(FSComp.SR.optsHelpBannerMisc(),
         [   CompilerOption("help", tagNone,
-                                 OptionHelp (fun blocks -> displayHelpFsi tcConfigB blocks),None,
-                                 Some (FSIstrings.SR.fsiHelp()))
+                                 OptionHelp (displayHelpFsi tcConfigB), None, Some (FSIstrings.SR.fsiHelp()))
         ]);
        PrivateOptions(
-        [   CompilerOption("?", tagNone, OptionHelp (fun blocks -> displayHelpFsi tcConfigB blocks), None, None); // "Short form of --help");
-            CompilerOption("help", tagNone, OptionHelp (fun blocks -> displayHelpFsi tcConfigB blocks), None, None); // "Short form of --help");
-            CompilerOption("full-help", tagNone, OptionHelp (fun blocks -> displayHelpFsi tcConfigB blocks), None, None); // "Short form of --help");
+        [   CompilerOption("?", tagNone, OptionHelp (displayHelpFsi tcConfigB), None, None); // "Short form of --help");
+            CompilerOption("help", tagNone, OptionHelp (displayHelpFsi tcConfigB), None, None); // "Short form of --help");
+            CompilerOption("full-help", tagNone, OptionHelp (displayHelpFsi tcConfigB), None, None); // "Short form of --help");
         ]);
        PublicOptions(FSComp.SR.optsHelpBannerAdvanced(),
         [CompilerOption("exec",                 "", OptionUnit (fun () -> interact <- false), None, Some (FSIstrings.SR.fsiExec()));

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -238,7 +238,7 @@ type EvaluationEventArgs(fsivalue : FsiValue option, symbolUse : FSharpSymbolUse
 /// User-configurable information that changes how F# Interactive operates, stored in the 'fsi' object
 /// and accessible via the programming model
 type FsiEvaluationSessionHostConfig () =
-    let evaluationEvent = new Event<EvaluationEventArgs> ()
+    let evaluationEvent = Event<EvaluationEventArgs>()
     /// Called by the evaluation session to ask the host for parameters to format text for output
     abstract FormatProvider: IFormatProvider
     /// Called by the evaluation session to ask the host for parameters to format text for output

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -6,7 +6,6 @@ open System
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
 open FSharp.Compiler
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Syntax

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -9,7 +9,6 @@ open Internal.Utilities
 open Internal.Utilities.Library
 open Internal.Utilities.Text.Lexing
 
-open FSharp.Compiler
 open FSharp.Compiler.IO
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.ParseHelpers

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -15,7 +15,6 @@ open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
 open FSharp.Core.Printf
 open FSharp.Compiler
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.CheckExpressions

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -269,7 +269,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
 
             | expr ->
                 traverseSynExpr expr
-                |> Option.map (fun expr -> expr)
+                |> Option.map id
 
         SyntaxTraversal.Traverse(pos, input, { new SyntaxVisitorBase<_>() with
             member _.VisitExpr(_, traverseSynExpr, defaultTraverse, expr) =

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1522,11 +1522,11 @@ type IncrementalBuilder(initialState: IncrementalBuilderInitialState, state: Inc
             // Start importing
 
             let tcConfigP = TcConfigProvider.Constant tcConfig
-            let beforeFileChecked = new Event<string>()
-            let fileChecked = new Event<string>()
+            let beforeFileChecked = Event<string>()
+            let fileChecked = Event<string>()
 
 #if !NO_EXTENSIONTYPING
-            let importsInvalidatedByTypeProvider = new Event<unit>()
+            let importsInvalidatedByTypeProvider = Event<unit>()
 #endif
 
             // Check for the existence of loaded sources and prepend them to the sources list if present.

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -9,7 +9,6 @@ open System.Threading
 open Internal.Utilities.Library
 open Internal.Utilities.Collections
 open FSharp.Compiler
-open FSharp.Compiler.AbstractIL
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILBinaryReader
 open FSharp.Compiler.CheckExpressions

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -165,7 +165,7 @@ module TcResolutionsExtensions =
                     | (Item.CustomBuilder _ | Item.CustomOperation _), ItemOccurence.Use, _, _, _, m ->
                         add m SemanticClassificationType.ComputationExpression
 
-                    | (Item.Value vref), _, _, _, _, m when isValRefMutable vref ->
+                    | Item.Value vref, _, _, _, _, m when isValRefMutable vref ->
                         add m SemanticClassificationType.MutableVar
 
                     | Item.Value KeywordIntrinsicValue, ItemOccurence.Use, _, _, _, m ->

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -18,7 +18,6 @@ open FSharp.Compiler.Text.Range
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
 
-[<RequireQualifiedAccess>]
 type SemanticClassificationType =
     | ReferenceType = 0
     | ValueType = 1

--- a/src/fsharp/service/SemanticClassification.fsi
+++ b/src/fsharp/service/SemanticClassification.fsi
@@ -10,7 +10,6 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.TypedTreeOps
 
 /// A kind that determines what range in a source's text is semantically classified as after type-checking.
-[<RequireQualifiedAccess>]
 type SemanticClassificationType =
     | ReferenceType = 0
     | ValueType = 1

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1021,7 +1021,7 @@ type FSharpChecker(legacyReferenceResolver,
 
     let mutable maxMB = maxMBDefault
 
-    let maxMemEvent = new Event<unit>()
+    let maxMemEvent = Event<unit>()
 
     /// Instantiate an interactive checker.    
     static member Create(

--- a/src/fsharp/symbols/Exprs.fs
+++ b/src/fsharp/symbols/Exprs.fs
@@ -539,11 +539,11 @@ module FSharpExprConvert =
         | Expr.Let _   // big linear sequences of 'let'
         | Expr.Match _   // big linear sequences of 'match ... -> ....' 
         | Expr.Sequential _ ->
-            ConvExprPrimLinear cenv env expr (fun e -> e)
+            ConvExprPrimLinear cenv env expr id
 
         | ModuleValueOrMemberUse cenv.g (vref, vFlags, _f, _fty, tyargs, curriedArgs) when (* (nonNil tyargs || nonNil curriedArgs) && *) vref.IsMemberOrModuleBinding ->
             // Process applications of top-level values in a tail-recursive way
-            ConvModuleValueOrMemberUseLinear cenv env (expr, vref, vFlags, tyargs, curriedArgs) (fun e -> e)
+            ConvModuleValueOrMemberUseLinear cenv env (expr, vref, vFlags, tyargs, curriedArgs) id
 
         | Expr.Val (vref, _vFlags, m) -> 
             ConvValRef cenv env m vref 

--- a/src/fsharp/utils/CompilerLocationUtils.fs
+++ b/src/fsharp/utils/CompilerLocationUtils.fs
@@ -378,10 +378,7 @@ module internal FSharpEnvironment =
 
     let fileExists pathToFile =
         try
-            if File.Exists(pathToFile) then
-                true
-            else
-                false
+            File.Exists(pathToFile)
         with | _ -> false
 
     // Look for global install of dotnet sdk

--- a/src/fsharp/utils/FileSystem.fs
+++ b/src/fsharp/utils/FileSystem.fs
@@ -369,7 +369,7 @@ module internal FileSystemUtils =
     let checkSuffix (x:string) (y:string) = x.EndsWithOrdinal(y)
 
     let hasExtensionWithValidate (validate:bool) (s:string) =
-        if validate then (checkPathForIllegalChars s) |> ignore
+        if validate then (checkPathForIllegalChars s)
         let sLen = s.Length
         (sLen >= 1 && s.[sLen - 1] = '.' && s <> ".." && s <> ".")
         || Path.HasExtension(s)
@@ -388,7 +388,7 @@ module internal FileSystemUtils =
         Path.GetFileName(s)
 
     let fileNameWithoutExtensionWithValidate (validate:bool) s =
-        if validate then checkPathForIllegalChars s |> ignore
+        if validate then checkPathForIllegalChars s
         Path.GetFileNameWithoutExtension(s)
 
     let fileNameWithoutExtension s = fileNameWithoutExtensionWithValidate true s

--- a/src/fsharp/utils/sformat.fs
+++ b/src/fsharp/utils/sformat.fs
@@ -320,7 +320,7 @@ module Layout =
 
     let semiListL layouts = tagListL (fun prefixL -> prefixL ^^ rightL semicolon) layouts
 
-    let spaceListL layouts = tagListL (fun prefixL -> prefixL) layouts
+    let spaceListL layouts = tagListL id layouts
 
     let sepListL layout1 layouts = tagListL (fun prefixL -> prefixL ^^ layout1) layouts
 


### PR DESCRIPTION
Some more cleanup:
* `RequireQualifiedAccess` has not effect on enum types
* remove redundant `ignore` applications
* remove redundant `if` expressions
* replace simple lambdas with `id`, `fst`, `snd`
* parens, `open`s, `new` cleanup after `main` rebase