### PR TITLE
Add ICollection<T> shortcut for Seq.contains

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -534,12 +534,15 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Contains")>]
         let inline contains value (source : seq<'T>) =
-            checkNonNull "source" source
-            use e = source.GetEnumerator()
-            let mutable state = false
-            while (not state && e.MoveNext()) do
-                state <- value = e.Current
-            state
+            match source with
+            | :? ICollection<'T> as ic -> ic.Contains value
+            | _ ->
+                checkNonNull "source" source
+                use e = source.GetEnumerator()
+                let mutable state = false
+                while (not state && e.MoveNext()) do
+                    state <- value = e.Current
+                state
 
         [<CompiledName("ForAll")>]
         let forall predicate (source : seq<'T>) =


### PR DESCRIPTION
I noticed a performance difference between Linq's `Enumerable.Contains` and F#'s `Seq.contains`. Linq uses a test for `ICollection<T>` and if possible defers to `ICollection<T>.Contains`.

https://github.com/dotnet/runtime/blob/d019e70d2b7c2f7cd1137fac084dbcdc3d2e05f5/src/libraries/System.Linq/src/System/Linq/Contains.cs#L11-L12

The code change here introduces a similar shortcut to F#'s `Seq.contains`.
https://github.com/Jlobblet/fsharp/blob/9cb72dea06f52da7bfc682d3e9bb38a42b69ad29/src/fsharp/FSharp.Core/seq.fs#L535-L545

This generally has a performance gain for things that implement `ICollection<T>`, since they typically have faster ways of testing for whether they contain something than enumerating the entire collection.

I have prepared a BenchmarkDotNet benchmark suite to test the performance of this change over a variety of cases. It is available at https://github.com/Jlobblet/fsharp-seq-contains.

The following table compares performance of the existing `Seq.contains`, the version of `Seq.contains` proposed by this PR, and Linq's `Enumerable.Contains`.
Method is which of these methods was used to in the benchmark.
Init is what type of collection was used.
N is how many elements are in the collection. Collections are created from the range `1 .. N`.
containsBehaviour is what target value is passed to `Contains`. It is determined as follows:
```f#
this.target <-
    match this.containsBehaviour with
    | ContainsBehaviour.Start -> 1
    | ContainsBehaviour.Middle -> this.N / 2
    | ContainsBehaviour.End -> this.N
    | ContainsBehaviour.NotPresent -> 0
```

<details>
  <summary>Table of results</summary>
  
  ``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19042.1110 (20H2/October2020Update)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=5.0.302
  [Host]     : .NET 5.0.8 (5.0.821.31504), X64 RyuJIT DEBUG
  DefaultJob : .NET 5.0.8 (5.0.821.31504), X64 RyuJIT


```
|   Method |       Init |      N | containsBehaviour |             Mean |          Error |          StdDev |           Median |
|--------- |----------- |------- |------------------ |-----------------:|---------------:|----------------:|-----------------:|
|  **Current** |   **F# Array** |      **0** |             **Start** |        **24.572 ns** |      **0.4519 ns** |       **0.7425 ns** |        **24.561 ns** |
| Proposed |   F# Array |      0 |             Start |        17.425 ns |      0.3787 ns |       0.3163 ns |        17.394 ns |
|     Linq |   F# Array |      0 |             Start |        19.053 ns |      0.4007 ns |       0.7721 ns |        18.926 ns |
|  **Current** |   **F# Array** |      **0** |            **Middle** |        **20.946 ns** |      **0.4620 ns** |       **1.3549 ns** |        **20.602 ns** |
| Proposed |   F# Array |      0 |            Middle |        17.264 ns |      0.3830 ns |       0.6808 ns |        17.471 ns |
|     Linq |   F# Array |      0 |            Middle |        17.986 ns |      0.3976 ns |       0.6307 ns |        18.017 ns |
|  **Current** |   **F# Array** |      **0** |               **End** |        **20.681 ns** |      **0.4469 ns** |       **0.8610 ns** |        **20.873 ns** |
| Proposed |   F# Array |      0 |               End |        17.099 ns |      0.3773 ns |       0.6406 ns |        17.132 ns |
|     Linq |   F# Array |      0 |               End |        17.662 ns |      0.3689 ns |       0.3623 ns |        17.758 ns |
|  **Current** |   **F# Array** |      **0** |        **NotPresent** |        **20.251 ns** |      **0.4364 ns** |       **0.9579 ns** |        **20.355 ns** |
| Proposed |   F# Array |      0 |        NotPresent |        17.205 ns |      0.3819 ns |       0.5477 ns |        17.303 ns |
|     Linq |   F# Array |      0 |        NotPresent |        17.477 ns |      0.3786 ns |       0.4208 ns |        17.611 ns |
|  **Current** |   **F# Array** |      **1** |             **Start** |        **25.612 ns** |      **0.5452 ns** |       **0.8489 ns** |        **25.490 ns** |
| Proposed |   F# Array |      1 |             Start |        17.951 ns |      0.3521 ns |       0.5481 ns |        18.005 ns |
|     Linq |   F# Array |      1 |             Start |        18.473 ns |      0.3920 ns |       0.3850 ns |        18.437 ns |
|  **Current** |   **F# Array** |      **1** |            **Middle** |        **19.787 ns** |      **0.4274 ns** |       **0.7022 ns** |        **19.608 ns** |
| Proposed |   F# Array |      1 |            Middle |        16.898 ns |      0.3542 ns |       0.4079 ns |        16.761 ns |
|     Linq |   F# Array |      1 |            Middle |        17.578 ns |      0.3853 ns |       0.3956 ns |        17.590 ns |
|  **Current** |   **F# Array** |      **1** |               **End** |        **25.298 ns** |      **0.5259 ns** |       **0.4106 ns** |        **25.429 ns** |
| Proposed |   F# Array |      1 |               End |        17.748 ns |      0.3719 ns |       0.3479 ns |        17.801 ns |
|     Linq |   F# Array |      1 |               End |        18.808 ns |      0.3592 ns |       0.3184 ns |        18.861 ns |
|  **Current** |   **F# Array** |      **1** |        **NotPresent** |        **19.932 ns** |      **0.4202 ns** |       **0.5752 ns** |        **19.841 ns** |
| Proposed |   F# Array |      1 |        NotPresent |        16.741 ns |      0.3678 ns |       0.5276 ns |        16.651 ns |
|     Linq |   F# Array |      1 |        NotPresent |        17.894 ns |      0.3668 ns |       0.3431 ns |        17.948 ns |
|  **Current** |   **F# Array** |     **10** |             **Start** |        **26.404 ns** |      **0.5575 ns** |       **0.7632 ns** |        **26.355 ns** |
| Proposed |   F# Array |     10 |             Start |        15.632 ns |      0.3426 ns |       0.3204 ns |        15.753 ns |
|     Linq |   F# Array |     10 |             Start |        16.385 ns |      0.3567 ns |       0.3663 ns |        16.365 ns |
|  **Current** |   **F# Array** |     **10** |            **Middle** |        **47.995 ns** |      **0.9966 ns** |       **1.4916 ns** |        **47.784 ns** |
| Proposed |   F# Array |     10 |            Middle |        16.125 ns |      0.3466 ns |       0.4507 ns |        15.950 ns |
|     Linq |   F# Array |     10 |            Middle |        16.934 ns |      0.3734 ns |       0.3493 ns |        16.998 ns |
|  **Current** |   **F# Array** |     **10** |               **End** |        **75.839 ns** |      **1.5313 ns** |       **2.3384 ns** |        **76.171 ns** |
| Proposed |   F# Array |     10 |               End |        19.811 ns |      0.4052 ns |       0.4161 ns |        19.714 ns |
|     Linq |   F# Array |     10 |               End |        20.187 ns |      0.3920 ns |       0.3475 ns |        20.216 ns |
|  **Current** |   **F# Array** |     **10** |        **NotPresent** |        **20.387 ns** |      **0.4310 ns** |       **0.6181 ns** |        **20.452 ns** |
| Proposed |   F# Array |     10 |        NotPresent |        15.276 ns |      0.3334 ns |       0.3568 ns |        15.412 ns |
|     Linq |   F# Array |     10 |        NotPresent |        15.892 ns |      0.3227 ns |       0.3019 ns |        15.837 ns |
|  **Current** |   **F# Array** |   **1000** |             **Start** |        **25.179 ns** |      **0.5329 ns** |       **0.6929 ns** |        **25.150 ns** |
| Proposed |   F# Array |   1000 |             Start |        15.653 ns |      0.2900 ns |       0.2571 ns |        15.713 ns |
|     Linq |   F# Array |   1000 |             Start |        16.453 ns |      0.3634 ns |       0.4185 ns |        16.440 ns |
|  **Current** |   **F# Array** |   **1000** |            **Middle** |     **2,763.895 ns** |     **55.2321 ns** |      **77.4277 ns** |     **2,736.230 ns** |
| Proposed |   F# Array |   1000 |            Middle |       156.258 ns |      3.1471 ns |       3.9801 ns |       156.645 ns |
|     Linq |   F# Array |   1000 |            Middle |       151.890 ns |      2.4161 ns |       2.2600 ns |       152.423 ns |
|  **Current** |   **F# Array** |   **1000** |               **End** |     **5,508.473 ns** |    **109.7692 ns** |     **126.4104 ns** |     **5,492.419 ns** |
| Proposed |   F# Array |   1000 |               End |       307.050 ns |      6.0648 ns |       7.4481 ns |       309.572 ns |
|     Linq |   F# Array |   1000 |               End |       313.104 ns |      5.4332 ns |       4.8164 ns |       313.563 ns |
|  **Current** |   **F# Array** |   **1000** |        **NotPresent** |        **19.914 ns** |      **0.4232 ns** |       **0.4703 ns** |        **19.924 ns** |
| Proposed |   F# Array |   1000 |        NotPresent |        14.943 ns |      0.3037 ns |       0.2692 ns |        14.850 ns |
|     Linq |   F# Array |   1000 |        NotPresent |        16.495 ns |      0.3416 ns |       0.3355 ns |        16.612 ns |
|  **Current** |   **F# Array** | **100000** |             **Start** |        **26.436 ns** |      **0.5460 ns** |       **0.7654 ns** |        **26.430 ns** |
| Proposed |   F# Array | 100000 |             Start |        16.164 ns |      0.2412 ns |       0.2256 ns |        16.234 ns |
|     Linq |   F# Array | 100000 |             Start |        16.527 ns |      0.2116 ns |       0.1875 ns |        16.566 ns |
|  **Current** |   **F# Array** | **100000** |            **Middle** |   **275,900.021 ns** |  **5,466.2909 ns** |   **7,482.3207 ns** |   **276,312.549 ns** |
| Proposed |   F# Array | 100000 |            Middle |    13,547.143 ns |    235.4926 ns |     208.7580 ns |    13,530.002 ns |
|     Linq |   F# Array | 100000 |            Middle |    13,544.863 ns |    253.2478 ns |     260.0668 ns |    13,560.174 ns |
|  **Current** |   **F# Array** | **100000** |               **End** |   **543,555.491 ns** | **10,769.0041 ns** |  **13,225.3042 ns** |   **546,310.840 ns** |
| Proposed |   F# Array | 100000 |               End |    29,099.498 ns |    573.6598 ns |     804.1909 ns |    28,763.507 ns |
|     Linq |   F# Array | 100000 |               End |    29,091.438 ns |    577.2237 ns |     790.1103 ns |    28,944.771 ns |
|  **Current** |   **F# Array** | **100000** |        **NotPresent** |        **20.024 ns** |      **0.4169 ns** |       **0.4094 ns** |        **20.180 ns** |
| Proposed |   F# Array | 100000 |        NotPresent |        15.773 ns |      0.2514 ns |       0.2352 ns |        15.836 ns |
|     Linq |   F# Array | 100000 |        NotPresent |        15.792 ns |      0.3283 ns |       0.3071 ns |        15.861 ns |
|  **Current** |    **F# List** |      **0** |             **Start** |        **26.922 ns** |      **0.4499 ns** |       **0.3989 ns** |        **26.903 ns** |
| Proposed |    F# List |      0 |             Start |        34.319 ns |      0.7227 ns |       0.8323 ns |        34.220 ns |
|     Linq |    F# List |      0 |             Start |        35.105 ns |      0.6679 ns |       0.5920 ns |        35.179 ns |
|  **Current** |    **F# List** |      **0** |            **Middle** |        **23.909 ns** |      **0.4388 ns** |       **0.4105 ns** |        **23.897 ns** |
| Proposed |    F# List |      0 |            Middle |        28.956 ns |      0.6134 ns |       0.7064 ns |        28.873 ns |
|     Linq |    F# List |      0 |            Middle |        31.957 ns |      0.6686 ns |       0.7699 ns |        32.227 ns |
|  **Current** |    **F# List** |      **0** |               **End** |        **22.281 ns** |      **0.4651 ns** |       **0.5712 ns** |        **22.265 ns** |
| Proposed |    F# List |      0 |               End |        28.337 ns |      0.5526 ns |       0.5427 ns |        28.239 ns |
|     Linq |    F# List |      0 |               End |        32.328 ns |      0.6226 ns |       0.8522 ns |        32.256 ns |
|  **Current** |    **F# List** |      **0** |        **NotPresent** |        **23.763 ns** |      **0.5019 ns** |       **0.4930 ns** |        **23.843 ns** |
| Proposed |    F# List |      0 |        NotPresent |        28.678 ns |      0.6030 ns |       0.6452 ns |        28.638 ns |
|     Linq |    F# List |      0 |        NotPresent |        31.719 ns |      0.5911 ns |       0.5529 ns |        31.803 ns |
|  **Current** |    **F# List** |      **1** |             **Start** |        **31.324 ns** |      **0.6480 ns** |       **0.9294 ns** |        **31.338 ns** |
| Proposed |    F# List |      1 |             Start |        36.183 ns |      0.7499 ns |       0.9209 ns |        35.997 ns |
|     Linq |    F# List |      1 |             Start |        40.374 ns |      0.8016 ns |       1.7082 ns |        39.872 ns |
|  **Current** |    **F# List** |      **1** |            **Middle** |        **24.466 ns** |      **0.5260 ns** |       **1.3388 ns** |        **24.388 ns** |
| Proposed |    F# List |      1 |            Middle |        31.057 ns |      0.6537 ns |       1.8005 ns |        31.162 ns |
|     Linq |    F# List |      1 |            Middle |        33.843 ns |      0.6947 ns |       1.4653 ns |        33.849 ns |
|  **Current** |    **F# List** |      **1** |               **End** |        **31.899 ns** |      **0.6731 ns** |       **1.1965 ns** |        **31.802 ns** |
| Proposed |    F# List |      1 |               End |        39.889 ns |      0.8280 ns |       1.9996 ns |        39.693 ns |
|     Linq |    F# List |      1 |               End |        42.709 ns |      0.8677 ns |       1.2987 ns |        42.567 ns |
|  **Current** |    **F# List** |      **1** |        **NotPresent** |        **24.053 ns** |      **0.4998 ns** |       **0.4908 ns** |        **23.966 ns** |
| Proposed |    F# List |      1 |        NotPresent |        30.430 ns |      0.6125 ns |       0.5730 ns |        30.440 ns |
|     Linq |    F# List |      1 |        NotPresent |        33.790 ns |      0.5517 ns |       0.4891 ns |        33.869 ns |
|  **Current** |    **F# List** |     **10** |             **Start** |        **32.577 ns** |      **0.6900 ns** |       **1.2617 ns** |        **32.202 ns** |
| Proposed |    F# List |     10 |             Start |        38.131 ns |      0.7946 ns |       1.7773 ns |        37.763 ns |
|     Linq |    F# List |     10 |             Start |        42.965 ns |      0.8983 ns |       1.4248 ns |        43.182 ns |
|  **Current** |    **F# List** |     **10** |            **Middle** |        **60.606 ns** |      **1.2320 ns** |       **2.5716 ns** |        **60.787 ns** |
| Proposed |    F# List |     10 |            Middle |        66.290 ns |      1.3644 ns |       2.3536 ns |        66.176 ns |
|     Linq |    F# List |     10 |            Middle |        85.968 ns |      1.9886 ns |       5.3424 ns |        85.394 ns |
|  **Current** |    **F# List** |     **10** |               **End** |       **118.409 ns** |      **2.3945 ns** |       **2.9406 ns** |       **118.205 ns** |
| Proposed |    F# List |     10 |               End |       128.567 ns |      2.5719 ns |       3.4334 ns |       128.805 ns |
|     Linq |    F# List |     10 |               End |       130.990 ns |      2.6419 ns |       3.3411 ns |       129.827 ns |
|  **Current** |    **F# List** |     **10** |        **NotPresent** |        **33.645 ns** |      **2.5735 ns** |       **7.5476 ns** |        **29.963 ns** |
| Proposed |    F# List |     10 |        NotPresent |        32.368 ns |      0.6887 ns |       1.7655 ns |        32.204 ns |
|     Linq |    F# List |     10 |        NotPresent |        35.122 ns |      0.8751 ns |       2.5108 ns |        34.625 ns |
|  **Current** |    **F# List** |   **1000** |             **Start** |        **34.667 ns** |      **0.8245 ns** |       **2.3920 ns** |        **33.976 ns** |
| Proposed |    F# List |   1000 |             Start |        40.166 ns |      0.8154 ns |       1.3167 ns |        40.180 ns |
|     Linq |    F# List |   1000 |             Start |        45.019 ns |      0.9225 ns |       1.5412 ns |        44.790 ns |
|  **Current** |    **F# List** |   **1000** |            **Middle** |     **4,177.541 ns** |     **82.8319 ns** |     **163.5021 ns** |     **4,134.399 ns** |
| Proposed |    F# List |   1000 |            Middle |     4,070.790 ns |     81.3350 ns |     138.1131 ns |     4,078.710 ns |
|     Linq |    F# List |   1000 |            Middle |     4,126.259 ns |     81.7793 ns |     149.5380 ns |     4,104.058 ns |
|  **Current** |    **F# List** |   **1000** |               **End** |     **7,879.427 ns** |    **155.3649 ns** |     **272.1091 ns** |     **7,817.849 ns** |
| Proposed |    F# List |   1000 |               End |     8,401.951 ns |    167.5125 ns |     306.3060 ns |     8,388.686 ns |
|     Linq |    F# List |   1000 |               End |     8,197.380 ns |    153.8380 ns |     285.1487 ns |     8,118.596 ns |
|  **Current** |    **F# List** |   **1000** |        **NotPresent** |        **26.373 ns** |      **0.5672 ns** |       **0.9319 ns** |        **26.407 ns** |
| Proposed |    F# List |   1000 |        NotPresent |        32.830 ns |      0.6851 ns |       1.5741 ns |        32.456 ns |
|     Linq |    F# List |   1000 |        NotPresent |        35.827 ns |      0.7563 ns |       1.9522 ns |        35.618 ns |
|  **Current** |    **F# List** | **100000** |             **Start** |        **34.569 ns** |      **0.7322 ns** |       **1.6823 ns** |        **34.496 ns** |
| Proposed |    F# List | 100000 |             Start |        41.888 ns |      0.8596 ns |       2.2189 ns |        41.291 ns |
|     Linq |    F# List | 100000 |             Start |        46.756 ns |      0.8211 ns |       0.7681 ns |        46.833 ns |
|  **Current** |    **F# List** | **100000** |            **Middle** |   **412,063.874 ns** |  **8,032.0563 ns** |  **11,259.8211 ns** |   **410,256.055 ns** |
| Proposed |    F# List | 100000 |            Middle |   429,387.141 ns |  8,267.9596 ns |  12,872.2170 ns |   432,189.453 ns |
|     Linq |    F# List | 100000 |            Middle |   388,206.417 ns |  7,574.5604 ns |  11,102.6924 ns |   389,472.852 ns |
|  **Current** |    **F# List** | **100000** |               **End** |   **877,624.223 ns** | **16,290.1187 ns** |  **38,715.1906 ns** |   **871,745.215 ns** |
| Proposed |    F# List | 100000 |               End |   873,843.478 ns | 16,880.4026 ns |  26,280.7532 ns |   878,306.836 ns |
|     Linq |    F# List | 100000 |               End |   806,492.687 ns | 16,001.9066 ns |  17,121.8607 ns |   808,374.414 ns |
|  **Current** |    **F# List** | **100000** |        **NotPresent** |        **25.854 ns** |      **0.5454 ns** |       **0.5601 ns** |        **25.773 ns** |
| Proposed |    F# List | 100000 |        NotPresent |        33.085 ns |      0.7016 ns |       1.2830 ns |        32.920 ns |
|     Linq |    F# List | 100000 |        NotPresent |        36.187 ns |      0.7608 ns |       0.8762 ns |        36.312 ns |
|  **Current** |     **F# Set** |      **0** |             **Start** |        **81.287 ns** |      **1.6075 ns** |       **3.6935 ns** |        **81.296 ns** |
| Proposed |     F# Set |      0 |             Start |        13.053 ns |      0.2905 ns |       0.4773 ns |        13.029 ns |
|     Linq |     F# Set |      0 |             Start |        13.046 ns |      0.2921 ns |       0.4372 ns |        12.973 ns |
|  **Current** |     **F# Set** |      **0** |            **Middle** |        **64.977 ns** |      **1.3301 ns** |       **3.7734 ns** |        **64.504 ns** |
| Proposed |     F# Set |      0 |            Middle |        12.280 ns |      0.2806 ns |       0.4025 ns |        12.303 ns |
|     Linq |     F# Set |      0 |            Middle |        12.132 ns |      0.2781 ns |       0.3415 ns |        12.165 ns |
|  **Current** |     **F# Set** |      **0** |               **End** |        **61.031 ns** |      **1.2360 ns** |       **1.2693 ns** |        **61.122 ns** |
| Proposed |     F# Set |      0 |               End |        11.605 ns |      0.2703 ns |       0.2776 ns |        11.648 ns |
|     Linq |     F# Set |      0 |               End |        12.294 ns |      0.2765 ns |       0.3596 ns |        12.309 ns |
|  **Current** |     **F# Set** |      **0** |        **NotPresent** |        **61.231 ns** |      **0.8053 ns** |       **0.6287 ns** |        **61.198 ns** |
| Proposed |     F# Set |      0 |        NotPresent |        12.501 ns |      0.2512 ns |       0.3836 ns |        12.549 ns |
|     Linq |     F# Set |      0 |        NotPresent |        13.113 ns |      0.2950 ns |       0.5244 ns |        13.018 ns |
|  **Current** |     **F# Set** |      **1** |             **Start** |       **134.977 ns** |      **2.7375 ns** |       **7.7211 ns** |       **133.566 ns** |
| Proposed |     F# Set |      1 |             Start |        13.334 ns |      0.2983 ns |       0.4644 ns |        13.398 ns |
|     Linq |     F# Set |      1 |             Start |        15.096 ns |      0.3336 ns |       0.6663 ns |        14.954 ns |
|  **Current** |     **F# Set** |      **1** |            **Middle** |       **115.346 ns** |      **2.4621 ns** |       **7.1430 ns** |       **113.054 ns** |
| Proposed |     F# Set |      1 |            Middle |        19.033 ns |      0.4186 ns |       1.0503 ns |        18.890 ns |
|     Linq |     F# Set |      1 |            Middle |        18.734 ns |      0.3062 ns |       0.2864 ns |        18.659 ns |
|  **Current** |     **F# Set** |      **1** |               **End** |       **136.099 ns** |      **2.4979 ns** |       **4.0336 ns** |       **135.038 ns** |
| Proposed |     F# Set |      1 |               End |        14.262 ns |      0.3215 ns |       0.7515 ns |        14.172 ns |
|     Linq |     F# Set |      1 |               End |        14.908 ns |      0.3091 ns |       0.5079 ns |        14.863 ns |
|  **Current** |     **F# Set** |      **1** |        **NotPresent** |       **123.204 ns** |      **3.0189 ns** |       **8.7582 ns** |       **122.727 ns** |
| Proposed |     F# Set |      1 |        NotPresent |        20.436 ns |      0.4834 ns |       1.3634 ns |        20.346 ns |
|     Linq |     F# Set |      1 |        NotPresent |        21.139 ns |      0.4497 ns |       0.4812 ns |        21.285 ns |
|  **Current** |     **F# Set** |     **10** |             **Start** |       **212.069 ns** |      **4.2768 ns** |      **10.6508 ns** |       **209.800 ns** |
| Proposed |     F# Set |     10 |             Start |        22.775 ns |      0.4797 ns |       0.6880 ns |        22.519 ns |
|     Linq |     F# Set |     10 |             Start |        22.165 ns |      0.4666 ns |       0.8413 ns |        22.117 ns |
|  **Current** |     **F# Set** |     **10** |            **Middle** |       **356.347 ns** |      **6.8844 ns** |      **18.4945 ns** |       **353.678 ns** |
| Proposed |     F# Set |     10 |            Middle |        23.619 ns |      0.4542 ns |       0.7463 ns |        23.589 ns |
|     Linq |     F# Set |     10 |            Middle |        24.244 ns |      0.5675 ns |       1.6100 ns |        23.982 ns |
|  **Current** |     **F# Set** |     **10** |               **End** |       **553.596 ns** |     **11.1218 ns** |      **28.9071 ns** |       **555.161 ns** |
| Proposed |     F# Set |     10 |               End |        46.550 ns |      0.9545 ns |       1.8616 ns |        46.215 ns |
|     Linq |     F# Set |     10 |               End |        48.555 ns |      0.8665 ns |       1.0959 ns |        48.726 ns |
|  **Current** |     **F# Set** |     **10** |        **NotPresent** |       **192.180 ns** |      **3.8140 ns** |       **4.8235 ns** |       **192.703 ns** |
| Proposed |     F# Set |     10 |        NotPresent |        28.379 ns |      0.6079 ns |       1.4328 ns |        28.118 ns |
|     Linq |     F# Set |     10 |        NotPresent |        26.182 ns |      0.5600 ns |       1.1054 ns |        26.021 ns |
|  **Current** |     **F# Set** |   **1000** |             **Start** |       **600.721 ns** |     **16.7968 ns** |      **47.1000 ns** |       **593.586 ns** |
| Proposed |     F# Set |   1000 |             Start |        69.608 ns |      1.3512 ns |       3.3649 ns |        69.252 ns |
|     Linq |     F# Set |   1000 |             Start |        66.569 ns |      1.3675 ns |       2.7623 ns |        65.885 ns |
|  **Current** |     **F# Set** |   **1000** |            **Middle** |    **26,363.784 ns** |    **512.7424 ns** |     **503.5816 ns** |    **26,419.772 ns** |
| Proposed |     F# Set |   1000 |            Middle |        85.822 ns |      2.2487 ns |       6.5240 ns |        84.357 ns |
|     Linq |     F# Set |   1000 |            Middle |        83.374 ns |      1.7023 ns |       2.1529 ns |        83.010 ns |
|  **Current** |     **F# Set** |   **1000** |               **End** |    **49,552.401 ns** |    **972.9320 ns** |   **1,652.1123 ns** |    **49,715.549 ns** |
| Proposed |     F# Set |   1000 |               End |        99.197 ns |      1.8574 ns |       2.2111 ns |        99.672 ns |
|     Linq |     F# Set |   1000 |               End |       104.291 ns |      2.1306 ns |       2.6166 ns |       104.049 ns |
|  **Current** |     **F# Set** |   **1000** |        **NotPresent** |       **524.199 ns** |      **7.5574 ns** |       **6.6994 ns** |       **524.481 ns** |
| Proposed |     F# Set |   1000 |        NotPresent |        72.605 ns |      1.4933 ns |       2.5758 ns |        72.913 ns |
|     Linq |     F# Set |   1000 |        NotPresent |        70.891 ns |      1.3309 ns |       2.5959 ns |        70.503 ns |
|  **Current** |     **F# Set** | **100000** |             **Start** |       **911.607 ns** |     **17.1177 ns** |      **17.5786 ns** |       **915.676 ns** |
| Proposed |     F# Set | 100000 |             Start |       127.073 ns |      2.5870 ns |       2.4199 ns |       127.237 ns |
|     Linq |     F# Set | 100000 |             Start |       118.040 ns |      1.6885 ns |       1.5794 ns |       118.082 ns |
|  **Current** |     **F# Set** | **100000** |            **Middle** | **2,839,143.231 ns** | **56,649.1512 ns** | **150,225.5128 ns** | **2,777,182.227 ns** |
| Proposed |     F# Set | 100000 |            Middle |       129.358 ns |      1.8794 ns |       1.6661 ns |       129.168 ns |
|     Linq |     F# Set | 100000 |            Middle |       125.382 ns |      1.4929 ns |       1.3234 ns |       125.191 ns |
|  **Current** |     **F# Set** | **100000** |               **End** | **5,438,517.122 ns** | **94,090.6714 ns** |  **73,459.8072 ns** | **5,444,242.969 ns** |
| Proposed |     F# Set | 100000 |               End |       154.960 ns |      3.0781 ns |       5.0574 ns |       154.198 ns |
|     Linq |     F# Set | 100000 |               End |       142.048 ns |      1.2897 ns |       1.0769 ns |       142.010 ns |
|  **Current** |     **F# Set** | **100000** |        **NotPresent** |       **901.179 ns** |     **18.0218 ns** |      **23.4334 ns** |       **900.938 ns** |
| Proposed |     F# Set | 100000 |        NotPresent |       127.936 ns |      2.1940 ns |       2.1548 ns |       128.185 ns |
|     Linq |     F# Set | 100000 |        NotPresent |       127.845 ns |      2.5812 ns |       6.5701 ns |       127.013 ns |
|  **Current** | **HashSet&lt;T&gt;** |      **0** |             **Start** |        **31.933 ns** |      **0.6710 ns** |       **0.7727 ns** |        **31.619 ns** |
| Proposed | HashSet&lt;T&gt; |      0 |             Start |         9.226 ns |      0.2233 ns |       0.4027 ns |         9.184 ns |
|     Linq | HashSet&lt;T&gt; |      0 |             Start |         9.866 ns |      0.2354 ns |       0.2418 ns |         9.881 ns |
|  **Current** | **HashSet&lt;T&gt;** |      **0** |            **Middle** |        **27.963 ns** |      **0.5947 ns** |       **1.3544 ns** |        **27.687 ns** |
| Proposed | HashSet&lt;T&gt; |      0 |            Middle |        10.207 ns |      0.2220 ns |       0.2280 ns |        10.195 ns |
|     Linq | HashSet&lt;T&gt; |      0 |            Middle |        11.097 ns |      0.2475 ns |       0.2315 ns |        11.110 ns |
|  **Current** | **HashSet&lt;T&gt;** |      **0** |               **End** |        **27.273 ns** |      **0.5746 ns** |       **0.6148 ns** |        **27.189 ns** |
| Proposed | HashSet&lt;T&gt; |      0 |               End |        10.033 ns |      0.2286 ns |       0.2347 ns |         9.968 ns |
|     Linq | HashSet&lt;T&gt; |      0 |               End |        11.011 ns |      0.2558 ns |       0.4344 ns |        10.933 ns |
|  **Current** | **HashSet&lt;T&gt;** |      **0** |        **NotPresent** |        **27.470 ns** |      **0.5218 ns** |       **0.9541 ns** |        **27.475 ns** |
| Proposed | HashSet&lt;T&gt; |      0 |        NotPresent |        10.151 ns |      0.2400 ns |       0.3364 ns |        10.178 ns |
|     Linq | HashSet&lt;T&gt; |      0 |        NotPresent |        10.928 ns |      0.2531 ns |       0.2914 ns |        10.896 ns |
|  **Current** | **HashSet&lt;T&gt;** |      **1** |             **Start** |        **37.229 ns** |      **0.7771 ns** |       **1.5156 ns** |        **36.829 ns** |
| Proposed | HashSet&lt;T&gt; |      1 |             Start |        10.201 ns |      0.2427 ns |       0.3706 ns |        10.161 ns |
|     Linq | HashSet&lt;T&gt; |      1 |             Start |        11.272 ns |      0.2649 ns |       0.5926 ns |        11.240 ns |
|  **Current** | **HashSet&lt;T&gt;** |      **1** |            **Middle** |        **27.547 ns** |      **0.5679 ns** |       **0.6076 ns** |        **27.546 ns** |
| Proposed | HashSet&lt;T&gt; |      1 |            Middle |         9.983 ns |      0.2273 ns |       0.2126 ns |         9.915 ns |
|     Linq | HashSet&lt;T&gt; |      1 |            Middle |        11.060 ns |      0.2557 ns |       0.3828 ns |        11.003 ns |
|  **Current** | **HashSet&lt;T&gt;** |      **1** |               **End** |        **38.342 ns** |      **0.8079 ns** |       **2.2653 ns** |        **38.280 ns** |
| Proposed | HashSet&lt;T&gt; |      1 |               End |        11.168 ns |      0.2581 ns |       0.4653 ns |        11.159 ns |
|     Linq | HashSet&lt;T&gt; |      1 |               End |        11.401 ns |      0.2677 ns |       0.5467 ns |        11.280 ns |
|  **Current** | **HashSet&lt;T&gt;** |      **1** |        **NotPresent** |        **27.939 ns** |      **0.4823 ns** |       **0.4511 ns** |        **28.011 ns** |
| Proposed | HashSet&lt;T&gt; |      1 |        NotPresent |        10.218 ns |      0.2391 ns |       0.2558 ns |        10.174 ns |
|     Linq | HashSet&lt;T&gt; |      1 |        NotPresent |        11.226 ns |      0.2586 ns |       0.2419 ns |        11.286 ns |
|  **Current** | **HashSet&lt;T&gt;** |     **10** |             **Start** |        **37.405 ns** |      **0.7830 ns** |       **1.5637 ns** |        **37.091 ns** |
| Proposed | HashSet&lt;T&gt; |     10 |             Start |        10.192 ns |      0.2438 ns |       0.4638 ns |        10.052 ns |
|     Linq | HashSet&lt;T&gt; |     10 |             Start |        11.128 ns |      0.2618 ns |       0.3015 ns |        11.138 ns |
|  **Current** | **HashSet&lt;T&gt;** |     **10** |            **Middle** |        **71.399 ns** |      **1.4113 ns** |       **3.8635 ns** |        **70.821 ns** |
| Proposed | HashSet&lt;T&gt; |     10 |            Middle |         9.585 ns |      0.2252 ns |       0.4446 ns |         9.548 ns |
|     Linq | HashSet&lt;T&gt; |     10 |            Middle |        11.267 ns |      0.2611 ns |       0.4905 ns |        11.237 ns |
|  **Current** | **HashSet&lt;T&gt;** |     **10** |               **End** |       **137.012 ns** |      **2.7868 ns** |       **2.9818 ns** |       **137.053 ns** |
| Proposed | HashSet&lt;T&gt; |     10 |               End |        10.119 ns |      0.2408 ns |       0.2957 ns |        10.055 ns |
|     Linq | HashSet&lt;T&gt; |     10 |               End |        11.241 ns |      0.2482 ns |       0.3313 ns |        11.183 ns |
|  **Current** | **HashSet&lt;T&gt;** |     **10** |        **NotPresent** |        **28.302 ns** |      **0.5887 ns** |       **0.8812 ns** |        **28.244 ns** |
| Proposed | HashSet&lt;T&gt; |     10 |        NotPresent |        10.476 ns |      0.2486 ns |       0.5244 ns |        10.384 ns |
|     Linq | HashSet&lt;T&gt; |     10 |        NotPresent |        10.896 ns |      0.2564 ns |       0.3838 ns |        10.817 ns |
|  **Current** | **HashSet&lt;T&gt;** |   **1000** |             **Start** |        **37.855 ns** |      **0.6269 ns** |       **0.5557 ns** |        **37.890 ns** |
| Proposed | HashSet&lt;T&gt; |   1000 |             Start |        10.561 ns |      0.2491 ns |       0.3493 ns |        10.572 ns |
|     Linq | HashSet&lt;T&gt; |   1000 |             Start |        11.291 ns |      0.2501 ns |       0.4446 ns |        11.210 ns |
|  **Current** | **HashSet&lt;T&gt;** |   **1000** |            **Middle** |     **4,389.307 ns** |     **86.7973 ns** |     **115.8719 ns** |     **4,384.556 ns** |
| Proposed | HashSet&lt;T&gt; |   1000 |            Middle |        10.367 ns |      0.2434 ns |       0.3331 ns |        10.281 ns |
|     Linq | HashSet&lt;T&gt; |   1000 |            Middle |        11.023 ns |      0.2567 ns |       0.3152 ns |        11.038 ns |
|  **Current** | **HashSet&lt;T&gt;** |   **1000** |               **End** |     **9,305.787 ns** |    **142.0244 ns** |     **118.5968 ns** |     **9,295.753 ns** |
| Proposed | HashSet&lt;T&gt; |   1000 |               End |        10.908 ns |      0.2563 ns |       0.6431 ns |        10.846 ns |
|     Linq | HashSet&lt;T&gt; |   1000 |               End |        11.068 ns |      0.2576 ns |       0.3350 ns |        11.169 ns |
|  **Current** | **HashSet&lt;T&gt;** |   **1000** |        **NotPresent** |        **29.334 ns** |      **0.6261 ns** |       **1.4635 ns** |        **29.085 ns** |
| Proposed | HashSet&lt;T&gt; |   1000 |        NotPresent |        10.298 ns |      0.2450 ns |       0.4160 ns |        10.286 ns |
|     Linq | HashSet&lt;T&gt; |   1000 |        NotPresent |        11.310 ns |      0.2605 ns |       0.3000 ns |        11.277 ns |
|  **Current** | **HashSet&lt;T&gt;** | **100000** |             **Start** |        **36.480 ns** |      **0.7737 ns** |       **1.7931 ns** |        **36.139 ns** |
| Proposed | HashSet&lt;T&gt; | 100000 |             Start |        10.599 ns |      0.2508 ns |       0.5713 ns |        10.473 ns |
|     Linq | HashSet&lt;T&gt; | 100000 |             Start |        10.724 ns |      0.2315 ns |       0.2052 ns |        10.674 ns |
|  **Current** | **HashSet&lt;T&gt;** | **100000** |            **Middle** |   **478,765.981 ns** |  **9,503.6860 ns** |  **20,660.2313 ns** |   **470,046.094 ns** |
| Proposed | HashSet&lt;T&gt; | 100000 |            Middle |        10.178 ns |      0.2435 ns |       0.3167 ns |        10.177 ns |
|     Linq | HashSet&lt;T&gt; | 100000 |            Middle |        11.187 ns |      0.2542 ns |       0.2496 ns |        11.252 ns |
|  **Current** | **HashSet&lt;T&gt;** | **100000** |               **End** |   **871,068.862 ns** | **12,867.6759 ns** |  **11,406.8595 ns** |   **873,050.879 ns** |
| Proposed | HashSet&lt;T&gt; | 100000 |               End |        10.457 ns |      0.2479 ns |       0.5174 ns |        10.431 ns |
|     Linq | HashSet&lt;T&gt; | 100000 |               End |        11.121 ns |      0.2643 ns |       0.6178 ns |        11.033 ns |
|  **Current** | **HashSet&lt;T&gt;** | **100000** |        **NotPresent** |        **28.111 ns** |      **0.5979 ns** |       **0.9655 ns** |        **27.824 ns** |
| Proposed | HashSet&lt;T&gt; | 100000 |        NotPresent |        10.424 ns |      0.2472 ns |       0.4763 ns |        10.293 ns |
|     Linq | HashSet&lt;T&gt; | 100000 |        NotPresent |        11.093 ns |      0.2594 ns |       0.5121 ns |        10.980 ns |
|  **Current** |    **List&lt;T&gt;** |      **0** |             **Start** |        **33.898 ns** |      **0.7165 ns** |       **1.2549 ns** |        **33.615 ns** |
| Proposed |    List&lt;T&gt; |      0 |             Start |        12.271 ns |      0.2858 ns |       0.5368 ns |        12.214 ns |
|     Linq |    List&lt;T&gt; |      0 |             Start |        12.058 ns |      0.2691 ns |       0.3099 ns |        12.131 ns |
|  **Current** |    **List&lt;T&gt;** |      **0** |            **Middle** |        **27.275 ns** |      **0.5681 ns** |       **0.5314 ns** |        **27.088 ns** |
| Proposed |    List&lt;T&gt; |      0 |            Middle |        12.203 ns |      0.1936 ns |       0.1616 ns |        12.240 ns |
|     Linq |    List&lt;T&gt; |      0 |            Middle |        12.448 ns |      0.2839 ns |       0.2788 ns |        12.498 ns |
|  **Current** |    **List&lt;T&gt;** |      **0** |               **End** |        **28.486 ns** |      **0.6098 ns** |       **1.5632 ns** |        **27.934 ns** |
| Proposed |    List&lt;T&gt; |      0 |               End |        12.753 ns |      0.2900 ns |       0.5858 ns |        12.573 ns |
|     Linq |    List&lt;T&gt; |      0 |               End |        12.767 ns |      0.2855 ns |       0.2670 ns |        12.654 ns |
|  **Current** |    **List&lt;T&gt;** |      **0** |        **NotPresent** |        **27.186 ns** |      **0.5849 ns** |       **0.8006 ns** |        **27.094 ns** |
| Proposed |    List&lt;T&gt; |      0 |        NotPresent |        12.812 ns |      0.2879 ns |       0.4220 ns |        12.862 ns |
|     Linq |    List&lt;T&gt; |      0 |        NotPresent |        13.459 ns |      0.3095 ns |       0.7649 ns |        13.262 ns |
|  **Current** |    **List&lt;T&gt;** |      **1** |             **Start** |        **37.589 ns** |      **0.7952 ns** |       **1.1902 ns** |        **37.461 ns** |
| Proposed |    List&lt;T&gt; |      1 |             Start |        13.245 ns |      0.2940 ns |       0.3610 ns |        13.051 ns |
|     Linq |    List&lt;T&gt; |      1 |             Start |        13.859 ns |      0.3116 ns |       0.4159 ns |        13.947 ns |
|  **Current** |    **List&lt;T&gt;** |      **1** |            **Middle** |        **27.834 ns** |      **0.5913 ns** |       **0.8289 ns** |        **27.753 ns** |
| Proposed |    List&lt;T&gt; |      1 |            Middle |        12.411 ns |      0.2864 ns |       0.4286 ns |        12.312 ns |
|     Linq |    List&lt;T&gt; |      1 |            Middle |        12.690 ns |      0.2768 ns |       0.2589 ns |        12.673 ns |
|  **Current** |    **List&lt;T&gt;** |      **1** |               **End** |        **37.399 ns** |      **0.7947 ns** |       **1.2834 ns** |        **37.233 ns** |
| Proposed |    List&lt;T&gt; |      1 |               End |        13.722 ns |      0.3165 ns |       0.6174 ns |        13.574 ns |
|     Linq |    List&lt;T&gt; |      1 |               End |        13.385 ns |      0.3014 ns |       0.4023 ns |        13.403 ns |
|  **Current** |    **List&lt;T&gt;** |      **1** |        **NotPresent** |        **27.319 ns** |      **0.5857 ns** |       **1.6806 ns** |        **27.379 ns** |
| Proposed |    List&lt;T&gt; |      1 |        NotPresent |        12.628 ns |      0.2807 ns |       0.2883 ns |        12.663 ns |
|     Linq |    List&lt;T&gt; |      1 |        NotPresent |        13.514 ns |      0.3104 ns |       0.5101 ns |        13.533 ns |
|  **Current** |    **List&lt;T&gt;** |     **10** |             **Start** |        **40.322 ns** |      **0.8437 ns** |       **2.3239 ns** |        **40.028 ns** |
| Proposed |    List&lt;T&gt; |     10 |             Start |        12.299 ns |      0.2906 ns |       0.7954 ns |        12.188 ns |
|     Linq |    List&lt;T&gt; |     10 |             Start |        11.332 ns |      0.2733 ns |       0.6279 ns |        11.038 ns |
|  **Current** |    **List&lt;T&gt;** |     **10** |            **Middle** |        **75.632 ns** |      **1.5328 ns** |       **2.8411 ns** |        **74.911 ns** |
| Proposed |    List&lt;T&gt; |     10 |            Middle |        12.463 ns |      0.2885 ns |       0.6856 ns |        12.422 ns |
|     Linq |    List&lt;T&gt; |     10 |            Middle |        12.521 ns |      0.2890 ns |       0.5568 ns |        12.487 ns |
|  **Current** |    **List&lt;T&gt;** |     **10** |               **End** |       **131.337 ns** |      **2.6695 ns** |       **4.3861 ns** |       **131.531 ns** |
| Proposed |    List&lt;T&gt; |     10 |               End |        15.647 ns |      0.3542 ns |       0.8418 ns |        15.640 ns |
|     Linq |    List&lt;T&gt; |     10 |               End |        15.767 ns |      0.3588 ns |       0.9943 ns |        15.484 ns |
|  **Current** |    **List&lt;T&gt;** |     **10** |        **NotPresent** |        **27.853 ns** |      **0.5961 ns** |       **1.1484 ns** |        **27.884 ns** |
| Proposed |    List&lt;T&gt; |     10 |        NotPresent |        11.264 ns |      0.2331 ns |       0.3112 ns |        11.225 ns |
|     Linq |    List&lt;T&gt; |     10 |        NotPresent |        11.527 ns |      0.2463 ns |       0.2304 ns |        11.455 ns |
|  **Current** |    **List&lt;T&gt;** |   **1000** |             **Start** |        **35.065 ns** |      **0.7378 ns** |       **2.0323 ns** |        **34.938 ns** |
| Proposed |    List&lt;T&gt; |   1000 |             Start |        10.776 ns |      0.2504 ns |       0.4319 ns |        10.773 ns |
|     Linq |    List&lt;T&gt; |   1000 |             Start |        11.495 ns |      0.2558 ns |       0.3236 ns |        11.508 ns |
|  **Current** |    **List&lt;T&gt;** |   **1000** |            **Middle** |     **4,090.007 ns** |     **77.7002 ns** |      **83.1383 ns** |     **4,104.930 ns** |
| Proposed |    List&lt;T&gt; |   1000 |            Middle |       144.442 ns |      2.8175 ns |       3.3541 ns |       144.768 ns |
|     Linq |    List&lt;T&gt; |   1000 |            Middle |       145.454 ns |      2.9507 ns |       3.0302 ns |       144.298 ns |
|  **Current** |    **List&lt;T&gt;** |   **1000** |               **End** |     **8,028.248 ns** |    **156.0617 ns** |     **208.3378 ns** |     **8,045.221 ns** |
| Proposed |    List&lt;T&gt; |   1000 |               End |       290.074 ns |      5.8022 ns |       7.3380 ns |       290.287 ns |
|     Linq |    List&lt;T&gt; |   1000 |               End |       292.104 ns |      5.8885 ns |       5.7833 ns |       293.463 ns |
|  **Current** |    **List&lt;T&gt;** |   **1000** |        **NotPresent** |        **25.662 ns** |      **0.5483 ns** |       **0.6527 ns** |        **25.761 ns** |
| Proposed |    List&lt;T&gt; |   1000 |        NotPresent |        10.821 ns |      0.2061 ns |       0.1928 ns |        10.883 ns |
|     Linq |    List&lt;T&gt; |   1000 |        NotPresent |        10.434 ns |      0.2438 ns |       0.3254 ns |        10.401 ns |
|  **Current** |    **List&lt;T&gt;** | **100000** |             **Start** |        **34.059 ns** |      **0.6408 ns** |       **0.7123 ns** |        **34.061 ns** |
| Proposed |    List&lt;T&gt; | 100000 |             Start |        10.793 ns |      0.2055 ns |       0.1822 ns |        10.756 ns |
|     Linq |    List&lt;T&gt; | 100000 |             Start |        10.567 ns |      0.2407 ns |       0.2575 ns |        10.622 ns |
|  **Current** |    **List&lt;T&gt;** | **100000** |            **Middle** |   **429,805.505 ns** |  **7,394.9737 ns** |   **6,917.2630 ns** |   **431,695.508 ns** |
| Proposed |    List&lt;T&gt; | 100000 |            Middle |    13,658.578 ns |    268.3445 ns |     358.2323 ns |    13,814.983 ns |
|     Linq |    List&lt;T&gt; | 100000 |            Middle |    13,564.488 ns |    266.1620 ns |     326.8709 ns |    13,623.706 ns |
|  **Current** |    **List&lt;T&gt;** | **100000** |               **End** |   **797,209.290 ns** | **14,988.7146 ns** |  **14,720.9220 ns** |   **801,272.266 ns** |
| Proposed |    List&lt;T&gt; | 100000 |               End |    28,153.633 ns |    559.5860 ns |     523.4371 ns |    28,317.343 ns |
|     Linq |    List&lt;T&gt; | 100000 |               End |    28,011.587 ns |    540.3162 ns |     622.2289 ns |    28,016.371 ns |
|  **Current** |    **List&lt;T&gt;** | **100000** |        **NotPresent** |        **25.805 ns** |      **0.5265 ns** |       **0.6268 ns** |        **26.018 ns** |
| Proposed |    List&lt;T&gt; | 100000 |        NotPresent |        10.545 ns |      0.2385 ns |       0.2342 ns |        10.547 ns |
|     Linq |    List&lt;T&gt; | 100000 |        NotPresent |        10.732 ns |      0.1683 ns |       0.1492 ns |        10.746 ns |

</details>

Attached here is an html version of the above table, csv outputs from the benchmark, and the detailed output section from the benchmark run.
[results.zip](https://github.com/dotnet/fsharp/files/6873951/results.zip)

Here's a comparison of the IL emitted by the compiler.
<details>
    <summary>Current implementation</summary>

```
    .method public hidebysig instance bool
      Current() cil managed
    {
      .custom instance void [BenchmarkDotNet.Annotations]BenchmarkDotNet.Attributes.BenchmarkAttribute::.ctor()
        = (01 00 00 00 )
      .maxstack 4
      .locals init (
        [0] int32 V_0,
        [1] class [System.Runtime]System.Collections.Generic.IEnumerable`1<int32> V_1,
        [2] class [System.Runtime]System.Collections.Generic.IEnumerator`1<int32> V_2,
        [3] bool V_3,
        [4] bool V_4,
        [5] class [System.Runtime]System.IDisposable V_5
      )

      // [80 29 - 80 65]
      IL_0000: ldarg.0      // this
      IL_0001: ldfld        int32 fsharp_seq_contains.Benchmark/ContainsComparison::target@
      IL_0006: stloc.0      // V_0
      IL_0007: ldarg.0      // this
      IL_0008: ldfld        class [System.Runtime]System.Collections.Generic.IEnumerable`1<int32> fsharp_seq_contains.Benchmark/ContainsComparison::source@
      IL_000d: stloc.1      // V_1
      IL_000e: ldloc.1      // V_1
      IL_000f: brfalse.s    IL_0014

      IL_0011: nop
      IL_0012: br.s         IL_001f

      IL_0014: ldstr        "source"
      IL_0019: newobj       instance void [System.Runtime]System.ArgumentNullException::.ctor(string)
      IL_001e: throw
      IL_001f: ldloc.1      // V_1
      IL_0020: callvirt     instance class [System.Runtime]System.Collections.Generic.IEnumerator`1<!0/*int32*/> class [System.Runtime]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
      IL_0025: stloc.2      // V_2
      .try
      {
        IL_0026: ldc.i4.0
        IL_0027: stloc.s      V_4
        // start of loop, entry point: IL_0029
          IL_0029: ldloc.s      V_4
          IL_002b: brfalse.s    IL_0031

          IL_002d: ldc.i4.0

          IL_002e: nop
          IL_002f: br.s         IL_0038

          IL_0031: ldloc.2      // V_2
          IL_0032: callvirt     instance bool [System.Runtime]System.Collections.IEnumerator::MoveNext()

          IL_0037: nop

          IL_0038: brfalse.s    IL_0048

          // [80 29 - 80 41]
          IL_003a: ldloc.0      // V_0
          IL_003b: ldloc.2      // V_2
          IL_003c: callvirt     instance !0/*int32*/ class [System.Runtime]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
          IL_0041: ceq
          IL_0043: stloc.s      V_4

          IL_0045: nop
          IL_0046: br.s         IL_0029
        // end of loop
        IL_0048: ldloc.s      V_4
        IL_004a: stloc.3      // V_3
        IL_004b: leave.s      IL_0066
      } // end of .try
      finally
      {
        IL_004d: ldloc.2      // V_2
        IL_004e: isinst       [System.Runtime]System.IDisposable
        IL_0053: stloc.s      V_5
        IL_0055: ldloc.s      V_5
        IL_0057: brfalse.s    IL_0063

        IL_0059: ldloc.s      V_5
        IL_005b: callvirt     instance void [System.Runtime]System.IDisposable::Dispose()
        IL_0060: ldnull
        IL_0061: pop
        IL_0062: endfinally

        IL_0063: ldnull
        IL_0064: pop
        IL_0065: endfinally
      } // end of finally

      IL_0066: ldloc.3      // V_3
      IL_0067: ret

    } // end of method ContainsComparison::Current
```
</details>

<details>
    <summary>Proposed implementation</summary>

```
    .method public hidebysig instance bool
      Proposed() cil managed
    {
      .custom instance void [BenchmarkDotNet.Annotations]BenchmarkDotNet.Attributes.BenchmarkAttribute::.ctor()
        = (01 00 00 00 )
      .maxstack 4
      .locals init (
        [0] int32 V_0,
        [1] class [System.Runtime]System.Collections.Generic.IEnumerable`1<int32> V_1,
        [2] class [System.Runtime]System.Collections.Generic.ICollection`1<int32> V_2,
        [3] class [System.Runtime]System.Collections.Generic.ICollection`1<int32> V_3,
        [4] class [System.Runtime]System.Collections.Generic.IEnumerator`1<int32> V_4,
        [5] bool V_5,
        [6] bool V_6,
        [7] class [System.Runtime]System.IDisposable V_7
      )

      // [83 30 - 83 62]
      IL_0000: ldarg.0      // this
      IL_0001: ldfld        int32 fsharp_seq_contains.Benchmark/ContainsComparison::target@
      IL_0006: stloc.0      // V_0
      IL_0007: ldarg.0      // this
      IL_0008: ldfld        class [System.Runtime]System.Collections.Generic.IEnumerable`1<int32> fsharp_seq_contains.Benchmark/ContainsComparison::source@
      IL_000d: stloc.1      // V_1
      IL_000e: ldloc.1      // V_1
      IL_000f: isinst       class [System.Runtime]System.Collections.Generic.ICollection`1<int32>
      IL_0014: stloc.2      // V_2
      IL_0015: ldloc.2      // V_2
      IL_0016: brfalse.s    IL_0024

      IL_0018: ldloc.2      // V_2
      IL_0019: stloc.3      // V_3
      IL_001a: ldloc.3      // V_3
      IL_001b: ldloc.0      // V_0
      IL_001c: tail.
      IL_001e: callvirt     instance bool class [System.Runtime]System.Collections.Generic.ICollection`1<int32>::Contains(!0/*int32*/)
      IL_0023: ret

      IL_0024: ldloc.1      // V_1
      IL_0025: brfalse.s    IL_002a

      IL_0027: nop
      IL_0028: br.s         IL_0035

      IL_002a: ldstr        "source"
      IL_002f: newobj       instance void [System.Runtime]System.ArgumentNullException::.ctor(string)
      IL_0034: throw
      IL_0035: ldloc.1      // V_1
      IL_0036: callvirt     instance class [System.Runtime]System.Collections.Generic.IEnumerator`1<!0/*int32*/> class [System.Runtime]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
      IL_003b: stloc.s      V_4
      .try
      {
        IL_003d: ldc.i4.0
        IL_003e: stloc.s      V_6
        // start of loop, entry point: IL_0040

          // [17 9 - 17 42]
          IL_0040: ldloc.s      V_6
          IL_0042: brfalse.s    IL_0048

          IL_0044: ldc.i4.0

          IL_0045: nop
          IL_0046: br.s         IL_0050

          IL_0048: ldloc.s      V_4
          IL_004a: callvirt     instance bool [System.Runtime]System.Collections.IEnumerator::MoveNext()

          IL_004f: nop

          IL_0050: brfalse.s    IL_0061

          // [83 30 - 83 38]
          IL_0052: ldloc.0      // V_0
          IL_0053: ldloc.s      V_4
          IL_0055: callvirt     instance !0/*int32*/ class [System.Runtime]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
          IL_005a: ceq
          IL_005c: stloc.s      V_6

          IL_005e: nop
          IL_005f: br.s         IL_0040
        // end of loop
        IL_0061: ldloc.s      V_6
        IL_0063: stloc.s      V_5
        IL_0065: leave.s      IL_0081
      } // end of .try
      finally
      {
        IL_0067: ldloc.s      V_4
        IL_0069: isinst       [System.Runtime]System.IDisposable
        IL_006e: stloc.s      V_7
        IL_0070: ldloc.s      V_7
        IL_0072: brfalse.s    IL_007e

        IL_0074: ldloc.s      V_7
        IL_0076: callvirt     instance void [System.Runtime]System.IDisposable::Dispose()
        IL_007b: ldnull
        IL_007c: pop
        IL_007d: endfinally

        IL_007e: ldnull
        IL_007f: pop
        IL_0080: endfinally
      } // end of finally

      IL_0081: ldloc.s      V_5
      IL_0083: ret

    } // end of method ContainsComparison::Proposed
```
</details>

Among the collections benchmarked, the ones that implemented `ICollection<T>` showed a performance gain across the board. F#'s List, however, is slower with the new changes. I think this is because it does not implement `ICollection<T>`, so there is additional overhead on the `isinst` IL instruction. I don't understand, however, why the performance decrease is proportional to the size of the collection rather than being constant.

I'm more than happy to elaborate on anything further if required. Interested to see what you think, and thanks for taking the time to read the PR.