### PR TITLE
Check qualifier reported types after filtering errors

### DIFF
--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -542,13 +542,14 @@ type internal TypeCheckInfo
                     not (isFunTy nenv.DisplayEnv.g ty))
             |> Seq.toArray
 
-        let thereWereSomeQuals = not (Array.isEmpty quals)
         // filter out errors
 
         let quals = quals
                     |> Array.filter (fun (ty,nenv,_,_) ->
                         let denv = nenv.DisplayEnv
                         not (isTyparTy denv.g ty && (destTyparTy denv.g ty).IsFromError))
+
+        let thereWereSomeQuals = not (Array.isEmpty quals)
         thereWereSomeQuals, quals
 
     /// obtains captured typing for the given position


### PR DESCRIPTION
I've been experimenting with reporting more expression types and discovered that completion may fail when an unresolved qualifier expression type is reported, like here:

```fsharp
module Module =
    let x = 1

Module.{caret}
```

This PR moves the qualifiers check so it happens after filtering bad types. Let's see if there's anything that may get fixed or broken with this change.