### PR TITLE
WIP: `with-` keyword support for anonymous records

### DIFF
--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -369,7 +369,7 @@ type SynType =
 
     | AnonRecd of
         isStruct: bool *
-        fields:(Ident * SynType) list *
+        fields: (Ident * SynType) list *
         range: range
 
     | Array of
@@ -477,8 +477,9 @@ type SynExpr =
 
     | AnonRecd of
         isStruct: bool *
-        copyInfo:(SynExpr * BlockSeparator) option *
-        recordFields:(Ident * SynExpr) list *
+        copyInfo: (SynExpr * BlockSeparator) option *
+        withoutFields: Ident list *
+        recordFields: (Ident * SynExpr) list *
         range: range
 
     | ArrayOrList of

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -462,7 +462,7 @@ type SynType =
     /// F# syntax: struct {| id: type; ...; id: type |}
     | AnonRecd of
         isStruct: bool *
-        fields:(Ident * SynType) list *
+        fields: (Ident * SynType) list *
         range: range
 
     /// F# syntax: type[]
@@ -579,6 +579,7 @@ type SynExpr =
     | AnonRecd of
         isStruct: bool *
         copyInfo:(SynExpr * BlockSeparator) option *
+        withoutFields: Ident list *
         recordFields:(Ident * SynExpr) list *
         range: range
 

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -685,9 +685,9 @@ let rec synExprContainsError inpExpr =
           | SynExpr.Tuple (_, es, _, _) ->
               walkExprs es
 
-          | SynExpr.AnonRecd (_, origExpr, flds, _) ->
+          | SynExpr.AnonRecd (_, origExpr, _withouts, flds, _) ->
               (match origExpr with Some (e, _) -> walkExpr e | None -> false) ||
-              walkExprs (List.map snd flds)
+              walkExprs (List.map snd flds) // || walkExprs withouts
 
           | SynExpr.Record (_, origExpr, fs, _) ->
               (match origExpr with Some (e, _) -> walkExpr e | None -> false) ||

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -886,6 +886,8 @@ rule token args skip = parse
 
  | "-" { MINUS }
 
+ | "with-" { WITH_MINUS }
+
  | "~" { RESERVED }
 
  | "`" { RESERVED }

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -247,6 +247,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %token LAZY OLAZY  MATCH MATCH_BANG  MUTABLE NEW OF 
 %token OPEN OR REC THEN TO TRUE TRY TYPE VAL INLINE INTERFACE INSTANCE CONST
 %token WHEN WHILE WITH HASH AMP AMP_AMP QUOTE LPAREN RPAREN RPAREN_COMING_SOON RPAREN_IS_HERE STAR COMMA RARROW GREATER_BAR_RBRACK LPAREN_STAR_RPAREN
+%token WITH_MINUS
 %token QMARK QMARK_QMARK DOT COLON COLON_COLON COLON_GREATER  COLON_QMARK_GREATER COLON_QMARK COLON_EQUALS SEMICOLON 
 %token SEMICOLON_SEMICOLON LARROW EQUALS  LBRACK  LBRACK_BAR  LBRACE_BAR  LBRACK_LESS 
 %token BAR_RBRACK BAR_RBRACE UNDERSCORE
@@ -4607,7 +4608,9 @@ recdExpr:
        (Some ($2, arg, rhs2 parseState 2 4, inheritsSep, rhs parseState 1), None, bindings) }
 
   | recdExprCore
-    { let a, b = $1 in (None, a, b) }
+    { let prevExpr, withouts, withs = $1
+      // TODO: Error if withouts is not None.
+      (None, prevExpr, withs) }
 
 recdExprCore:
   | appExpr EQUALS declExprBlock recdExprBindings opt_seps_recd
@@ -4616,7 +4619,7 @@ recdExprCore:
             let f = mkRecdField f
             let l = List.rev $4
             let l = rebindRanges (f, Some $3) l $5
-            (None, l)
+            (None, [], l)
        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsFieldBinding()) }
 
 /*
@@ -4628,7 +4631,7 @@ recdExprCore:
       reportParseErrorAt m (FSComp.SR.parsUnderscoreInvalidFieldName())
       reportParseErrorAt m (FSComp.SR.parsFieldBinding())
       let f = mkUnderscoreRecdField m
-      (None, [ (f, None, None)  ]) }
+      (None, [], [ (f, None, None)  ]) }
 
   | UNDERSCORE EQUALS
     { let m = rhs parseState 1
@@ -4637,28 +4640,57 @@ recdExprCore:
 
       reportParseErrorAt (rhs2 parseState 1 2) (FSComp.SR.parsFieldBinding())
       
-      (None, [ (f, None, None) ]) }
+      (None, [], [ (f, None, None) ]) }
 
   | UNDERSCORE EQUALS declExprBlock recdExprBindings opt_seps_recd
     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnderscoreInvalidFieldName())
       let f = mkUnderscoreRecdField (rhs parseState 1)
       let l = List.rev $4
       let l = rebindRanges (f, Some $3) l $5
-      (None, l) }
+      (None, [], l) }
 
 /* handles case like {x with}  */
   | appExpr WITH recdBinding recdExprBindings opt_seps_recd
      {  let l = List.rev $4
         let l = rebindRanges $3 l $5
-        (Some ($1, (rhs parseState 2, None)), l) }
+        (Some ($1, (rhs parseState 2, None)), [], l) }
 
-  | appExpr OWITH opt_seps_recd OEND
-     { (Some ($1, (rhs parseState 2, None)), []) }
+  | appExpr OWITH opt_seps_recd OEND  
+     { (Some ($1, (rhs parseState 2, None)), [], []) }
 
   | appExpr OWITH recdBinding recdExprBindings opt_seps_recd OEND
      {  let l = List.rev $4
         let l = rebindRanges $3 l $5
-        (Some ($1, (rhs parseState 2, None)), l) }
+        (Some ($1, (rhs parseState 2, None)), [], l) }
+
+  | appExpr WITH_MINUS commaSepIdentList WITH recdBinding recdExprBindings opt_seps_recd
+     {  let l = List.rev $6
+        let l = rebindRanges $5 l $7
+        (Some ($1, (rhs parseState 2, None)), $3, l) }
+
+  | appExpr WITH_MINUS commaSepIdentList OWITH recdBinding recdExprBindings opt_seps_recd OEND
+     {  let l = List.rev $6
+        let l = rebindRanges $5 l $7
+        (Some ($1, (rhs parseState 2, None)), $3, l) }
+
+/* A list of arguments in a 'with-' expression */
+commaSepIdentList:
+  | commaSepIdentListMore
+     { List.rev $1 }
+
+  | ident
+     { [$1] }
+  |
+     { [] }
+
+
+/* Part of the list of arguments in a 'with-' expression */
+commaSepIdentListMore:
+  | commaSepIdentListMore COMMA ident
+     { $3 :: $1 }
+
+  | ident COMMA ident
+     { [$3; $1] }
 
 opt_seps_recd:
   | seps_recd
@@ -4802,25 +4834,25 @@ braceBarExpr:
 
 braceBarExprCore:
   | LBRACE_BAR recdExprCore bar_rbrace
-     { let orig, flds = $2
+     { let orig, withouts, flds = $2
        let flds = 
            flds |> List.choose (function 
              | ((LongIdentWithDots([id], _), _), Some e, _) -> Some (id, e) 
              | ((LongIdentWithDots([id], _), _), None, _) -> Some (id, arbExpr("anonField", id.idRange)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 3
-       (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
+       (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, withouts, flds, m)) }
 
   | LBRACE_BAR recdExprCore recover 
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar())  
-       let orig, flds = $2 
+       let orig, withouts, flds = $2 
        let flds = 
            flds |> List.choose (function 
              | ((LongIdentWithDots([id], _), _), Some e, _) -> Some (id, e) 
              | ((LongIdentWithDots([id], _), _), None, _) -> Some (id, arbExpr("anonField", id.idRange)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 2
-       (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
+       (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, withouts, flds, m)) }
 
   | LBRACE_BAR error bar_rbrace
      { // silent recovery 
@@ -4830,11 +4862,11 @@ braceBarExprCore:
   | LBRACE_BAR recover
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar())  
        let m = rhs2 parseState 1 1
-       (fun isStruct -> SynExpr.AnonRecd (isStruct, None, [], m)) }
+       (fun isStruct -> SynExpr.AnonRecd (isStruct, None, [], [], m)) }
 
   | LBRACE_BAR bar_rbrace 
      { let m = rhs2 parseState 1 2
-       (fun isStruct -> SynExpr.AnonRecd (isStruct, None, [], m)) }
+       (fun isStruct -> SynExpr.AnonRecd (isStruct, None, [], [], m)) }
 
 anonLambdaExpr: 
   | FUN atomicPatterns RARROW typedSeqExprBlock 

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -549,7 +549,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                       | None -> ()
                       yield! walkExprs (fs |> List.choose p23)
 
-                  | SynExpr.AnonRecd (_isStruct, copyExprOpt, fs, _) ->
+                  | SynExpr.AnonRecd (_isStruct, copyExprOpt, _withoutFields, fs, _) ->
                       match copyExprOpt with
                       | Some (e, _) -> yield! walkExpr true e
                       | None -> ()

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -272,7 +272,7 @@ module internal TokenClassifications =
         | UPCAST   | DOWNCAST   | NULL   | RESERVED    | MODULE    | AND    | AS   | ASSERT   | ASR
         | DOWNTO   | EXCEPTION   | FALSE   | FOR   | FUN   | FUNCTION
         | FINALLY   | LAZY   | MATCH  | MATCH_BANG  | MUTABLE   | NEW   | OF    | OPEN   | OR | VOID | EXTERN
-        | INTERFACE | REC   | TO   | TRUE   | TRY   | TYPE   |  VAL   | INLINE   | WHEN  | WHILE   | WITH
+        | INTERFACE | REC   | TO   | TRUE   | TRY   | TYPE   |  VAL   | INLINE   | WHEN  | WHILE   | WITH | WITH_MINUS
         | IF | THEN  | ELSE | DO | DONE | LET _ | AND_BANG _ | IN | CONST
         | HIGH_PRECEDENCE_PAREN_APP | FIXED
         | HIGH_PRECEDENCE_BRACK_APP

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -260,7 +260,7 @@ module SyntaxTraversal =
                 | SynExpr.ArrayOrList (_, synExprList, _range) ->
                     synExprList |> List.map (fun x -> dive x x.Range traverseSynExpr) |> pick expr
                 
-                | SynExpr.AnonRecd (_isStruct, copyOpt, synExprList, _range) -> 
+                | SynExpr.AnonRecd (_isStruct, copyOpt, _withoutFields, synExprList, _range) -> 
                     [   match copyOpt with
                         | Some(expr, (withRange, _)) -> 
                             yield dive expr expr.Range traverseSynExpr 

--- a/tests/FSharp.Compiler.ComponentTests/Language/AnonymousRecordsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/AnonymousRecordsTests.fs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.Language
+
+open Xunit
+open FSharp.Test.Compiler
+
+module ``Anonymous records tests`` =
+
+    [<Fact>]
+    let ``Simple with- should remove one field`` () =
+        Fsx """
+type A = { X: int; Y: int }
+let a = { X = 1; Y = 2 }
+let b = {| a with- Y |}
+        """
+         |> compile
+         |> shouldSucceed
+    
+         [<Fact>]
+    let ``with- shouldn't remove the only field`` () =
+        Fsx """
+type A = { X: int }
+let a = { X = 1 }
+let b = {| a with- X |}
+        """
+         |> compile
+         |> shouldSucceed


### PR DESCRIPTION
This is pretty much a WIP or an experiment of adding a without (or `with-`) keyword support for anonymous records.

**Note**: things may change (e.g. keyword itself (as many people don't like `with-`), implementation details, language switch, etc).

**RFC**: https://github.com/fsharp/fslang-design/blob/main/RFCs/FS-1072-without-anonymous-records.md

**Discussion**: https://github.com/fsharp/fslang-design/discussions/616

Things to be done:
- [ ] Lexer/parser `with-` support for anonymous records expression.
- [ ] Actual logic to remove fields when creating new AnonRecd.
- [ ] Tests