### PR TITLE
Revert default to coreclr compiler

### DIFF
--- a/setup/shims/Microsoft.FSharp.ShimHelpers.props
+++ b/setup/shims/Microsoft.FSharp.ShimHelpers.props
@@ -4,7 +4,11 @@
     <MicrosoftFSharpShimHelpersPropsIncluded>true</MicrosoftFSharpShimHelpersPropsIncluded>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(FSharpTryUseLegacyCompiler)' != 'true'">
+  <!--
+    If the Directory.Build.props file in the project directory specifies 'FSharpUseNETSdkCompiler' then Visual Studio / msbuild.exe will use the NETSDK compiler.
+    Otherwise stick with desktop compiler.
+  -->
+  <PropertyGroup Condition="'$(FSharpUseNETSdkCompiler)' == 'true'">
 
     <!-- We are in the msbuild/VS build path only, we want to forward to the installed net sdk always -->
     <FSharpCompilerPath Condition="'$(FSharpCompilerPath)' == ''">$(NetCoreRoot)sdk/$(NETCoreSdkVersion)/FSharp/</FSharpCompilerPath>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/fsharp/issues/11941


Here it is identified that the Coreclr compiler startup time is slower: #11907

So we should go back to using the ngened desktop compiler, until the performance issue is addressed.

It's a regression in the performance of Visual Studio, even though the coreclr has behaved this way for a long time.