### PR TITLE
don't use 'abs' in hash codes

### DIFF
--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -729,7 +729,7 @@ type Set<[<EqualityConditionalOn>]'T when 'T: comparison >(comparer:IComparer<'T
         let mutable res = 0
         for x in this do
             res <- combineHash res (hash x)
-        abs res
+        res
 
     override this.GetHashCode() = this.ComputeHashCode()
 

--- a/src/fsharp/utils/TaggedCollections.fs
+++ b/src/fsharp/utils/TaggedCollections.fs
@@ -582,7 +582,7 @@ namespace Internal.Utilities.Collections.Tagged
                 let mutable res = 0
                 for x in this do
                     res <- combineHash res (Unchecked.hash x)
-                abs res
+                res
 
         override this.GetHashCode() = this.ComputeHashCode()
           
@@ -1072,7 +1072,7 @@ namespace Internal.Utilities.Collections.Tagged
             for KeyValue(x,y) in this do
                 res <- combineHash res (Unchecked.hash x)
                 res <- combineHash res (Unchecked.hash y)
-            abs res
+            res
 
         override this.GetHashCode() = this.ComputeHashCode()
 

--- a/tests/fsharp/core/map/test.fsx
+++ b/tests/fsharp/core/map/test.fsx
@@ -166,6 +166,9 @@ module Bug_FSharp_1_0_6307 =
     // below does not parse
     let t = typeof<global.System.Int32>
 
+module TestSetHashCodeCase =
+    let s = Set.singleton 2147483017
+    s.GetHashCode()  // this was failing due to use of 'abs' in GetHashCode
 
 #if TESTS_AS_APP
 let RUN() = !failures


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/11964

Found two other places where the code had leaked to

Will add the test from the repro