### PR TITLE
Fix #11962 - Build VisualFSharp.sln fails with FSharpEmbedResXSource task failed unexpectedly.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,7 +35,7 @@
     <FSharpCompilerServiceVersion>$(FCSMajorVersion).$(FCSMinorVersion).$(FCSBuildVersion).$(FCSRevisionVersion)</FSharpCompilerServiceVersion>
     <FSharpCompilerServiceReleaseNotesVersion>$(FCSMajorVersion)$(FCSMinorVersion)$(FCSBuildVersion)</FSharpCompilerServiceReleaseNotesVersion>
     <!-- The current published nuget package -->
-    <FSharpCoreShippedPackageVersion>5.0.2</FSharpCoreShippedPackageVersion>
+    <FSharpCoreShippedPackageVersionProperty>5.0.2</FSharpCoreShippedPackageVersionProperty>
     <!-- The pattern for specifying the preview package -->
     <FSharpCorePreviewPackageVersion>$(FSCorePackageVersion)-$(PreReleaseVersionLabel).*</FSharpCorePreviewPackageVersion>
     <FSToolsMajorVersion>11</FSToolsMajorVersion>

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -35,16 +35,24 @@
     <NoneSubstituteText Include="Microsoft.FSharp.NetSdk.props" CopyToOutputDirectory="PreserveNewest">
       <TargetFileName>Microsoft.FSharp.NetSdk.props</TargetFileName>
       <Pattern1>{{FSharpCoreShippedPackageVersion}}</Pattern1>
-      <Replacement1>$(FSharpCoreShippedPackageVersion)</Replacement1>
+      <Replacement1>$(FSharpCoreShippedPackageVersionProperty)</Replacement1>
       <Pattern2>{{FSharpCorePreviewPackageVersion}}</Pattern2>
-      <Replacement2>$(FSharpCorePreviewPackageVersion)</Replacement2>
-      <Pattern3>{{FSCorePackageVersion}}</Pattern3>
+		<Replacement2>$(FSharpCorePreviewPackageVersion)</Replacement2>
+		<Pattern3>{{FSCorePackageVersion}}</Pattern3>
       <Replacement3>$(FSCorePackageVersion)</Replacement3>
     </NoneSubstituteText>
     <None Include="Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Proto'">
+    <!--
+        The FSharp.Build built here may be loaded directly into a shipped Visual Studio, to that end, we cannot 
+        rely on new API's just being added to FSharp.Core.
+    -->
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionProperty)"/>
+  </ItemGroup>
+
+  <ItemGroup  Condition="'$(Configuration)' != 'Proto'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj" />
   </ItemGroup>
 

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -37,8 +37,8 @@
       <Pattern1>{{FSharpCoreShippedPackageVersion}}</Pattern1>
       <Replacement1>$(FSharpCoreShippedPackageVersionProperty)</Replacement1>
       <Pattern2>{{FSharpCorePreviewPackageVersion}}</Pattern2>
-		<Replacement2>$(FSharpCorePreviewPackageVersion)</Replacement2>
-		<Pattern3>{{FSCorePackageVersion}}</Pattern3>
+      <Replacement2>$(FSharpCorePreviewPackageVersion)</Replacement2>
+      <Pattern3>{{FSCorePackageVersion}}</Pattern3>
       <Replacement3>$(FSCorePackageVersion)</Replacement3>
     </NoneSubstituteText>
     <None Include="Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/EndToEndBuildTests/BasicProvider/BasicProvider.DesignTime/BasicProvider.DesignTime.fsproj
+++ b/tests/EndToEndBuildTests/BasicProvider/BasicProvider.DesignTime/BasicProvider.DesignTime.fsproj
@@ -6,7 +6,7 @@
     <FSharpToolsDirectory>typeproviders</FSharpToolsDirectory>
     <DefineConstants>NO_GENERATIVE</DefineConstants>
     <DefineConstants>IS_DESIGNTIME</DefineConstants>
-    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersion)</FSharpCoreImplicitPackageVersion>
+    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersionProperty)</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/EndToEndBuildTests/BasicProvider/BasicProvider.Tests/BasicProvider.Tests.fsproj
+++ b/tests/EndToEndBuildTests/BasicProvider/BasicProvider.Tests/BasicProvider.Tests.fsproj
@@ -6,7 +6,7 @@
     <TargetFramework Condition=" '$(TestTargetFramework)' != '' ">$(TestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>NO_GENERATIVE</DefineConstants>
-    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersion)</FSharpCoreImplicitPackageVersion>
+    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersionProperty)</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/EndToEndBuildTests/BasicProvider/BasicProvider/BasicProvider.fsproj
+++ b/tests/EndToEndBuildTests/BasicProvider/BasicProvider/BasicProvider.fsproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net5.0;net472</TargetFrameworks>
     <FSharpToolsDirectory>typeproviders</FSharpToolsDirectory>
-    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersion)</FSharpCoreImplicitPackageVersion>
+    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersionProperty)</FSharpCoreImplicitPackageVersion>
     <PackagePath>typeproviders</PackagePath>
   </PropertyGroup>
 

--- a/tests/EndToEndBuildTests/ComboProvider/ComboProvider.Tests/ComboProvider.Tests.fsproj
+++ b/tests/EndToEndBuildTests/ComboProvider/ComboProvider.Tests/ComboProvider.Tests.fsproj
@@ -5,7 +5,7 @@
     <TargetFramework Condition=" '$(TestTargetFramework)' == '' ">net5.0</TargetFramework>
     <TargetFramework Condition=" '$(TestTargetFramework)' != '' ">$(TestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
-    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersion)</FSharpCoreImplicitPackageVersion>
+    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersionProperty)</FSharpCoreImplicitPackageVersion>
     <DefineConstants>NO_GENERATIVE</DefineConstants>
   </PropertyGroup>
 

--- a/tests/EndToEndBuildTests/ComboProvider/ComboProvider/ComboProvider.fsproj
+++ b/tests/EndToEndBuildTests/ComboProvider/ComboProvider/ComboProvider.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net5.0;net472</TargetFrameworks>
-    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersion)</FSharpCoreImplicitPackageVersion>
+    <FSharpCoreImplicitPackageVersion>$(FSharpCoreShippedPackageVersionProperty)</FSharpCoreImplicitPackageVersion>
     <TargetFrameworks>net5.0;net472</TargetFrameworks>
   </PropertyGroup>
 

--- a/tests/fsharp/SDKTests/tests/DefaultFSharpCore - IsPreviewSdkDisablePreviewCheck.proj
+++ b/tests/fsharp/SDKTests/tests/DefaultFSharpCore - IsPreviewSdkDisablePreviewCheck.proj
@@ -13,7 +13,7 @@
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
     <DisableFSharpCorePreviewCheck>true</DisableFSharpCorePreviewCheck>
     <ExpectsFSharpCore>true</ExpectsFSharpCore>
-    <ExpectedFSharpCorePackageVersion>$(FSharpCoreShippedPackageVersion)</ExpectedFSharpCorePackageVersion>
+    <ExpectedFSharpCorePackageVersion>$(FSharpCoreShippedPackageVersionProperty)</ExpectedFSharpCorePackageVersion>
   </PropertyGroup>
 
   <Import Project="Test.targets" />


### PR DESCRIPTION
When building FSharp.Build.dll we build against a freshly built FSharp.Core ... there is an issue with this, when that build relies on a new API in FSharp.Core.

This change, causes us to build against the most recently releleased FSharp.Core nuget package.  Which matches or is older than what is shipped in Visual Studio.


