### PR TITLE
Array.skip does not fail on negative count, updated docstring

### DIFF
--- a/src/fsharp/FSharp.Core/array.fsi
+++ b/src/fsharp/FSharp.Core/array.fsi
@@ -995,13 +995,13 @@ namespace Microsoft.FSharp.Collections
 
         /// <summary>Builds a new array that contains the elements of the given array, excluding the first N elements.</summary>
         ///
-        /// <param name="count">The number of elements to skip.</param>
+        /// <param name="count">The number of elements to skip. If negative the full array will be returned as a copy.</param>
         /// <param name="array">The input array.</param>
         ///
         /// <returns>A copy of the input array, after removing the first N elements.</returns>
         ///
         /// <exception cref="T:System.ArgumentNullException">Thrown when the input array is null.</exception>
-        /// <exception cref="T:System.ArgumentException">Thrown when count is negative or exceeds the number of 
+        /// <exception cref="T:System.ArgumentException">Thrown when count exceeds the number of 
         /// elements in the array.</exception>
         [<CompiledName("Skip")>]
         val skip: count:int -> array:'T[] -> 'T[]


### PR DESCRIPTION
Array.skip does not fail on negative count.
 updated doc string.
 see https://github.com/dotnet/fsharp/blob/f1d420b4389d798e04fadcdf44ac3f22707409cf/src/fsharp/FSharp.Core/array.fs#L742