### PR TITLE
Cleanup and preparatory work for adding 'open' declarations to information known at debug time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ scripts/*.patch
 /src/fsharp/FSharp.Compiler.Service/*.resources
 /src/fsharp/FSharp.Compiler.Service/*.sln
 /src/fsharp/FSharp.Compiler.Service/*.userprefs
+/src/fsharp/FSharp.Compiler.Service/StandardOutput.txt
+/src/fsharp/FSharp.Compiler.Service/StandardError.txt
 /src/*.log
 /src/fsharp/FSharp.LanguageService.Compiler/illex.*
 /src/fsharp/FSharp.LanguageService.Compiler/ilpars.*

--- a/src/fsharp/CheckDeclarations.fsi
+++ b/src/fsharp/CheckDeclarations.fsi
@@ -14,9 +14,24 @@ open FSharp.Compiler.TypedTree
 
 val AddLocalRootModuleOrNamespace : TcResultsSink -> TcGlobals -> ImportMap -> range -> TcEnv -> ModuleOrNamespaceType -> TcEnv
 
-val CreateInitialTcEnv : TcGlobals * ImportMap * range * assemblyName: string * (CcuThunk * string list * string list) list -> TcEnv 
+val CreateInitialTcEnv:
+    TcGlobals *
+    ImportMap *
+    range *
+    assemblyName: string *
+    (CcuThunk * string list * string list) list
+        -> OpenDeclaration list * TcEnv 
 
-val AddCcuToTcEnv: TcGlobals * ImportMap * range * TcEnv * assemblyName: string * ccu: CcuThunk * autoOpens: string list * internalsVisibleToAttributes: string list -> TcEnv 
+val AddCcuToTcEnv:
+    TcGlobals *
+    ImportMap *
+    range *
+    TcEnv *
+    assemblyName: string *
+    ccu: CcuThunk *
+    autoOpens: string list *
+    internalsVisibleToAttributes: string list
+        -> OpenDeclaration list * TcEnv
 
 type TopAttribs =
     { mainMethodAttrs: Attribs
@@ -33,12 +48,20 @@ val TcOpenModuleOrNamespaceDecl: TcResultsSink  -> TcGlobals -> ImportMap -> ran
 
 val AddLocalSubModule: g: TcGlobals -> amap: ImportMap -> m: range -> env: TcEnv -> modul: ModuleOrNamespace -> TcEnv
 
-val TypeCheckOneImplFile : 
-      TcGlobals * NiceNameGenerator * ImportMap * CcuThunk * (unit -> bool) * ConditionalDefines option * TcResultsSink * bool
-      -> TcEnv 
-      -> ModuleOrNamespaceType option
-      -> ParsedImplFileInput
-      -> Cancellable<TopAttribs * TypedImplFile * ModuleOrNamespaceType * TcEnv * bool>
+val TypeCheckOneImplFile: 
+    TcGlobals *
+    NiceNameGenerator *
+    ImportMap *
+    CcuThunk *
+    OpenDeclaration list *
+    (unit -> bool) *
+    ConditionalDefines option *
+    TcResultsSink *
+    bool * 
+    TcEnv *
+    ModuleOrNamespaceType option *
+    ParsedImplFileInput
+        -> Cancellable<TopAttribs * TypedImplFile * ModuleOrNamespaceType * TcEnv * bool>
 
 val TypeCheckOneSigFile : 
       TcGlobals * NiceNameGenerator * ImportMap * CcuThunk  * (unit -> bool) * ConditionalDefines option * TcResultsSink * bool

--- a/src/fsharp/CheckDeclarations.fsi
+++ b/src/fsharp/CheckDeclarations.fsi
@@ -29,7 +29,7 @@ val EmptyTopAttrs : TopAttribs
 
 val CombineTopAttrs : TopAttribs -> TopAttribs -> TopAttribs
 
-val TcOpenModuleOrNamespaceDecl: TcResultsSink  -> TcGlobals -> ImportMap -> range -> TcEnv -> LongIdent * range -> TcEnv
+val TcOpenModuleOrNamespaceDecl: TcResultsSink  -> TcGlobals -> ImportMap -> range -> TcEnv -> LongIdent * range -> TcEnv * OpenDeclaration list
 
 val AddLocalSubModule: g: TcGlobals -> amap: ImportMap -> m: range -> env: TcEnv -> modul: ModuleOrNamespace -> TcEnv
 

--- a/src/fsharp/CompilerImports.fs
+++ b/src/fsharp/CompilerImports.fs
@@ -1977,7 +1977,5 @@ let RequireDLL (ctok, tcImports: TcImports, tcEnv, thisAssemblyName, referenceRa
 
     let g = tcImports.GetTcGlobals()
     let amap = tcImports.GetImportMap()
-    let buildTcEnv tcEnv asm =
-        AddCcuToTcEnv(g, amap, referenceRange, tcEnv, thisAssemblyName, asm.FSharpViewOfMetadata, asm.AssemblyAutoOpenAttributes, asm.AssemblyInternalsVisibleToAttributes)
-    let tcEnv = (tcEnv, asms) ||> List.fold buildTcEnv
+    let _openDecls, tcEnv = (tcEnv, asms) ||> List.collectFold (fun tcEnv asm -> AddCcuToTcEnv(g, amap, referenceRange, tcEnv, thisAssemblyName, asm.FSharpViewOfMetadata, asm.AssemblyAutoOpenAttributes, asm.AssemblyInternalsVisibleToAttributes))
     tcEnv, (dllinfos, asms)

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -502,7 +502,7 @@
       <Link>TypedTree\CompilerGlobalState.fs</Link>
     </Compile>
     <Compile Include="..\TypedTree.fs">
-      <Link>TypedTree\TypedTreeBasics.fs</Link>
+      <Link>TypedTree\TypedTree.fs</Link>
     </Compile>
     <Compile Include="..\TypedTreeBasics.fsi">
       <Link>TypedTree\TypedTreeBasics.fsi</Link>

--- a/src/fsharp/FSharp.Compiler.Service/StandardError.txt
+++ b/src/fsharp/FSharp.Compiler.Service/StandardError.txt
@@ -1,7 +1,0 @@
-Could not execute because the application was not found or a compatible .NET SDK is not installed.
-Possible reasons for this include:
-  * You intended to execute a .NET program:
-      The application '--version' does not exist.
-  * You intended to execute a .NET SDK command:
-      A compatible installed .NET SDK for global.json version [6.0.100-preview.7.21379.14] from [C:\GitHub\dsyme\fsharp\global.json] was not found.
-      Install the [6.0.100-preview.7.21379.14] .NET SDK or update [C:\GitHub\dsyme\fsharp\global.json] with an installed .NET SDK:

--- a/src/fsharp/FSharp.Compiler.Service/StandardError.txt
+++ b/src/fsharp/FSharp.Compiler.Service/StandardError.txt
@@ -1,0 +1,7 @@
+Could not execute because the application was not found or a compatible .NET SDK is not installed.
+Possible reasons for this include:
+  * You intended to execute a .NET program:
+      The application '--version' does not exist.
+  * You intended to execute a .NET SDK command:
+      A compatible installed .NET SDK for global.json version [6.0.100-preview.7.21379.14] from [C:\GitHub\dsyme\fsharp\global.json] was not found.
+      Install the [6.0.100-preview.7.21379.14] .NET SDK or update [C:\GitHub\dsyme\fsharp\global.json] with an installed .NET SDK:

--- a/src/fsharp/FSharp.Compiler.Service/StandardOutput.txt
+++ b/src/fsharp/FSharp.Compiler.Service/StandardOutput.txt
@@ -1,6 +1,0 @@
-        3.1.412 [C:\Program Files\dotnet\sdk]
-        5.0.104 [C:\Program Files\dotnet\sdk]
-        5.0.206 [C:\Program Files\dotnet\sdk]
-        5.0.303 [C:\Program Files\dotnet\sdk]
-        5.0.400 [C:\Program Files\dotnet\sdk]
-        6.0.100-preview.6.21355.2 [C:\Program Files\dotnet\sdk]

--- a/src/fsharp/FSharp.Compiler.Service/StandardOutput.txt
+++ b/src/fsharp/FSharp.Compiler.Service/StandardOutput.txt
@@ -1,1 +1,6 @@
-5.0.104
+        3.1.412 [C:\Program Files\dotnet\sdk]
+        5.0.104 [C:\Program Files\dotnet\sdk]
+        5.0.206 [C:\Program Files\dotnet\sdk]
+        5.0.303 [C:\Program Files\dotnet\sdk]
+        5.0.400 [C:\Program Files\dotnet\sdk]
+        6.0.100-preview.6.21355.2 [C:\Program Files\dotnet\sdk]

--- a/src/fsharp/FindUnsolved.fs
+++ b/src/fsharp/FindUnsolved.fs
@@ -253,11 +253,12 @@ and accModuleOrNamespaceDefs cenv env x =
 
 and accModuleOrNamespaceDef cenv env x = 
     match x with 
-    | TMDefRec(_, tycons, mbinds, _m) -> 
+    | TMDefRec(_, _opens, tycons, mbinds, _m) -> 
         accTycons cenv env tycons
         accModuleOrNamespaceBinds cenv env mbinds 
     | TMDefLet(bind, _m)  -> accBind cenv env bind 
     | TMDefDo(e, _m)  -> accExpr cenv env e
+    | TMDefOpens __ -> ()
     | TMAbstract(def)  -> accModuleOrNamespaceExpr cenv env def
     | TMDefs(defs) -> accModuleOrNamespaceDefs cenv env defs 
 

--- a/src/fsharp/InnerLambdasToTopLevelFuncs.fs
+++ b/src/fsharp/InnerLambdasToTopLevelFuncs.fs
@@ -1088,7 +1088,6 @@ module Pass4_RewriteAssembly =
             if isNil tys && isNil args then
                 fx
             else Expr.App (fx, fty, tys, args, m)
-                              (* no change, f is expr *)
 
     //-------------------------------------------------------------------------
     // pass4: pass (over expr)
@@ -1279,10 +1278,12 @@ module Pass4_RewriteAssembly =
        | TDSuccess (es, n) ->
            let es, z = List.mapFold (TransExpr penv) z es
            TDSuccess(es, n), z
+
        | TDBind (bind, rest) ->
            let bind, z       = TransBindingRhs penv z bind
            let rest, z = TransDecisionTree penv z rest
            TDBind(bind, rest), z
+
        | TDSwitch (sp, e, cases, dflt, m) ->
            let e, z = TransExpr penv z e
            let TransDecisionTreeCase penv z (TCase (discrim, dtree)) =
@@ -1300,7 +1301,9 @@ module Pass4_RewriteAssembly =
         TTarget(vs, e, spTarget, flags), z
 
     and TransValBinding penv z bind = TransBindingRhs penv z bind
+
     and TransValBindings penv z binds = List.mapFold (TransValBinding penv) z  binds
+
     and TransModuleExpr penv z x =
         match x with
         | ModuleOrNamespaceExprWithSig(mty, def, m) ->
@@ -1308,11 +1311,12 @@ module Pass4_RewriteAssembly =
             ModuleOrNamespaceExprWithSig(mty, def, m), z
 
     and TransModuleDefs penv z x = List.mapFold (TransModuleDef penv) z x
+
     and TransModuleDef penv (z: RewriteState) x: ModuleOrNamespaceExpr * RewriteState =
         match x with
-        | TMDefRec(isRec, tycons, mbinds, m) ->
+        | TMDefRec(isRec, opens, tycons, mbinds, m) ->
             let mbinds, z = TransModuleBindings penv z mbinds
-            TMDefRec(isRec, tycons, mbinds, m), z
+            TMDefRec(isRec, opens, tycons, mbinds, m), z
         | TMDefLet(bind, m)            ->
             let bind, z = TransValBinding penv z bind
             TMDefLet(bind, m), z
@@ -1322,10 +1326,14 @@ module Pass4_RewriteAssembly =
         | TMDefs defs   ->
             let defs, z = TransModuleDefs penv z defs
             TMDefs defs, z
+        | TMDefOpens _ ->
+            x, z
         | TMAbstract mexpr ->
             let mexpr, z = TransModuleExpr penv z mexpr
             TMAbstract mexpr, z
+
     and TransModuleBindings penv z binds = List.mapFold (TransModuleBinding penv) z  binds
+
     and TransModuleBinding penv z x =
         match x with
         | ModuleOrNamespaceBinding.Binding bind ->
@@ -1350,7 +1358,7 @@ let RecreateUniqueBounds g expr =
 // entry point
 //-------------------------------------------------------------------------
 
-let MakeTLRDecisions ccu g expr =
+let MakeTopLevelRepresentationDecisions ccu g expr =
    try
       // pass1: choose the f to be TLR with arity(f)
       let tlrS, topValS, arityM = Pass1_DetermineTLRAndArities.DetermineTLRAndArities g expr

--- a/src/fsharp/InnerLambdasToTopLevelFuncs.fsi
+++ b/src/fsharp/InnerLambdasToTopLevelFuncs.fsi
@@ -5,4 +5,4 @@ module internal FSharp.Compiler.InnerLambdasToTopLevelFuncs
 open FSharp.Compiler.TypedTree 
 open FSharp.Compiler.TcGlobals
 
-val MakeTLRDecisions : CcuThunk -> TcGlobals -> TypedImplFile -> TypedImplFile
+val MakeTopLevelRepresentationDecisions : CcuThunk -> TcGlobals -> TypedImplFile -> TypedImplFile

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1601,25 +1601,6 @@ type ItemOccurence =
     /// This is a usage of a module or namespace name in open statement
     | Open
 
-type OpenDeclaration =
-    { Target: SynOpenDeclTarget
-      Range: range option
-      Modules: ModuleOrNamespaceRef list
-      Types: TType list
-      AppliedScope: range
-      IsOwnNamespace: bool }
-
-    static member Create(target: SynOpenDeclTarget, modules: ModuleOrNamespaceRef list, types: TType list, appliedScope: range, isOwnNamespace: bool) =
-        { Target = target
-          Range =
-            match target with 
-            | SynOpenDeclTarget.ModuleOrNamespace (range=m)
-            | SynOpenDeclTarget.Type (range=m) -> Some m
-          Types = types
-          Modules = modules
-          AppliedScope = appliedScope
-          IsOwnNamespace = isOwnNamespace }
-
 type FormatStringCheckContext =
     { SourceText: ISourceText
       LineStartPositions: int[] }

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -16,10 +16,15 @@ open FSharp.Compiler.TcGlobals
 
 /// A NameResolver is a context for name resolution. It primarily holds an InfoReader.
 type NameResolver =
+
     new: g:TcGlobals * amap:ImportMap * infoReader:InfoReader * instantiationGenerator:(range -> Typars -> TypeInst) -> NameResolver
+
     member InfoReader: InfoReader
+
     member amap: ImportMap
+
     member g: TcGlobals
+
     member languageSupportsNameOf: bool
 
 /// Get the active pattern elements defined in a module, if any. Cache in the slot in the module type.
@@ -30,6 +35,7 @@ val ActivePatternElemsOfModuleOrNamespace: g: TcGlobals -> ModuleOrNamespaceRef 
 type ArgumentContainer =
     /// The named argument is an argument of a method
     | Method of MethInfo
+
     /// The named argument is a static parameter to a provided type.
     | Type of TyconRef
 
@@ -257,8 +263,8 @@ val internal AddTypeContentsToNameEnv: TcGlobals -> ImportMap -> AccessorDomain 
 /// A flag which indicates if it is an error to have two declared type parameters with identical names
 /// in the name resolution environment.
 type CheckForDuplicateTyparFlag =
-  | CheckForDuplicateTypars
-  | NoCheckForDuplicateTypars
+    | CheckForDuplicateTypars
+    | NoCheckForDuplicateTypars
 
 /// Add some declared type parameters to the name resolution environment
 val internal AddDeclaredTyparsToNameEnv: CheckForDuplicateTyparFlag -> NameResolutionEnv -> Typar list -> NameResolutionEnv
@@ -268,10 +274,11 @@ val internal LookupTypeNameInEnvNoArity: FullyQualifiedFlag -> string -> NameRes
 
 /// Indicates whether we are resolving type names to type definitions or to constructor methods.
 type TypeNameResolutionFlag =
-  /// Indicates we are resolving type names to constructor methods.
-  | ResolveTypeNamesToCtors
-  /// Indicates we are resolving type names to type definitions
-  | ResolveTypeNamesToTypeRefs
+    /// Indicates we are resolving type names to constructor methods.
+    | ResolveTypeNamesToCtors
+
+    /// Indicates we are resolving type names to type definitions
+    | ResolveTypeNamesToTypeRefs
 
 /// Represents information about the generic argument count of a type name when resolving it. 
 ///
@@ -279,17 +286,21 @@ type TypeNameResolutionFlag =
 /// of generic arguments. In others, we know precisely how many generic arguments are needed.
 [<Sealed;NoEquality; NoComparison>]
 type TypeNameResolutionStaticArgsInfo = 
-  /// Indicates definite knowledge of empty type arguments, i.e. the logical equivalent of name< >
-  static member DefiniteEmpty: TypeNameResolutionStaticArgsInfo
-  /// Deduce definite knowledge of type arguments
-  static member FromTyArgs: numTyArgs:int -> TypeNameResolutionStaticArgsInfo
+
+    /// Indicates definite knowledge of empty type arguments, i.e. the logical equivalent of name< >
+    static member DefiniteEmpty: TypeNameResolutionStaticArgsInfo
+
+    /// Deduce definite knowledge of type arguments
+    static member FromTyArgs: numTyArgs:int -> TypeNameResolutionStaticArgsInfo
 
 /// Represents information which guides name resolution of types.
 [<NoEquality; NoComparison>]
 type TypeNameResolutionInfo = 
-  | TypeNameResolutionInfo of TypeNameResolutionFlag * TypeNameResolutionStaticArgsInfo
-  static member Default: TypeNameResolutionInfo
-  static member ResolveToTypeRefs: TypeNameResolutionStaticArgsInfo -> TypeNameResolutionInfo
+    | TypeNameResolutionInfo of TypeNameResolutionFlag * TypeNameResolutionStaticArgsInfo
+
+    static member Default: TypeNameResolutionInfo
+
+    static member ResolveToTypeRefs: TypeNameResolutionStaticArgsInfo -> TypeNameResolutionInfo
 
 /// Represents the kind of the occurrence when reporting a name in name resolution
 [<RequireQualifiedAccess; Struct>]
@@ -357,7 +368,6 @@ type internal TcResolutions =
     /// Represents the empty set of resolutions 
     static member Empty: TcResolutions
 
-
 [<Struct>]
 type TcSymbolUseData = 
    { ItemWithInst: ItemWithInst
@@ -381,30 +391,6 @@ type internal TcSymbolUses =
     /// Empty collection of symbol uses
     static member Empty: TcSymbolUses
 
-/// Represents open declaration statement.
-type internal OpenDeclaration =
-    { /// Syntax after 'open' as it's presented in source code.
-      Target: SynOpenDeclTarget
-      
-      /// Full range of the open declaration.
-      Range: range option
-
-      /// Modules or namespaces which is opened with this declaration.
-      Modules: ModuleOrNamespaceRef list 
-      
-      /// Types whose static content is opened with this declaration.
-      Types: TType list
-
-      /// Scope in which open declaration is visible.
-      AppliedScope: range 
-      
-      /// If it's `namespace Xxx.Yyy` declaration.
-      IsOwnNamespace: bool
-    }
-    
-    /// Create a new instance of OpenDeclaration.
-    static member Create: target: SynOpenDeclTarget * modules: ModuleOrNamespaceRef list * types: TType list * appliedScope: range * isOwnNamespace: bool -> OpenDeclaration
-    
 /// Source text and an array of line end positions, used for format string parsing
 type FormatStringCheckContext =
     { /// Source text

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -2033,10 +2033,11 @@ module private InferredSigPrinting =
 
         let rec isConcreteNamespace x = 
             match x with 
-            | TMDefRec(_, tycons, mbinds, _) -> 
+            | TMDefRec(_, _opens, tycons, mbinds, _) -> 
                 not (isNil tycons) || (mbinds |> List.exists (function ModuleOrNamespaceBinding.Binding _ -> true | ModuleOrNamespaceBinding.Module(x, _) -> not x.IsNamespace))
             | TMDefLet _ -> true
             | TMDefDo _ -> true
+            | TMDefOpens _ -> false
             | TMDefs defs -> defs |> List.exists isConcreteNamespace 
             | TMAbstract(ModuleOrNamespaceExprWithSig(_, def, _)) -> isConcreteNamespace def
 
@@ -2051,7 +2052,7 @@ module private InferredSigPrinting =
             let filterExtMem (v: Val) = v.IsExtensionMember
 
             match x with 
-            | TMDefRec(_, tycons, mbinds, _) -> 
+            | TMDefRec(_, _opens, tycons, mbinds, _) -> 
                 TastDefinitionPrinting.layoutTyconDefns denv infoReader ad m tycons @@ 
                 (mbinds 
                     |> List.choose (function ModuleOrNamespaceBinding.Binding bind -> Some bind | _ -> None) 
@@ -2079,6 +2080,8 @@ module private InferredSigPrinting =
                     |> List.map mkLocalValRef
                     |> List.map (PrintTastMemberOrVals.prettyLayoutOfValOrMemberNoInst denv infoReader) 
                     |> aboveListL)
+
+            | TMDefOpens _ -> emptyL
 
             | TMDefs defs -> imdefsL denv defs
 

--- a/src/fsharp/OptimizeInputs.fs
+++ b/src/fsharp/OptimizeInputs.fs
@@ -114,7 +114,7 @@ let ApplyAllOptimizations (tcConfig:TcConfig, tcGlobals, tcVal, outfile, importM
 
             let implFile =
                 if tcConfig.doTLR then
-                    implFile |> InnerLambdasToTopLevelFuncs.MakeTLRDecisions ccu tcGlobals
+                    implFile |> InnerLambdasToTopLevelFuncs.MakeTopLevelRepresentationDecisions ccu tcGlobals
                 else implFile
 
             let implFile =

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -3047,7 +3047,6 @@ and TryInlineApplication cenv env finfo (tyargs: TType list, args: Expr list, m)
         if isGetHashCode then None else
 
         // Inlining lambda 
-  (* ---------- printf "Inlining lambda near %a = %s\n" outputRange m (showL (exprL f2)) (* JAMES: *) ----------*)
         let f2R = CopyExprForInlining cenv false f2 m
 
         // Optimizing arguments after inlining
@@ -3055,6 +3054,7 @@ and TryInlineApplication cenv env finfo (tyargs: TType list, args: Expr list, m)
         // REVIEW: this is a cheapshot way of optimizing the arg expressions as well without the restriction of recursive  
         // inlining kicking into effect 
         let argsR = args |> List.map (fun e -> let eR, _einfo = OptimizeExpr cenv env e in eR) 
+
         // Beta reduce. MakeApplicationAndBetaReduce cenv.g does all the hard work. 
         // Inlining: beta reducing 
         let exprR = MakeApplicationAndBetaReduce cenv.g (f2R, f2ty, [tyargs], argsR, m)

--- a/src/fsharp/ParseAndCheckInputs.fs
+++ b/src/fsharp/ParseAndCheckInputs.fs
@@ -648,10 +648,15 @@ let GetInitialTcEnv (assemblyName: string, initm: range, tcConfig: TcConfig, tcI
     let tcEnv = CreateInitialTcEnv(tcGlobals, amap, initm, assemblyName, ccus)
 
     if tcConfig.checkOverflow then
-        try TcOpenModuleOrNamespaceDecl TcResultsSink.NoSink tcGlobals amap initm tcEnv (pathToSynLid initm (splitNamespace CoreOperatorsCheckedName), initm)
-        with e -> errorRecovery e initm; tcEnv
+        try 
+            let checkOperatorsModule = pathToSynLid initm (splitNamespace CoreOperatorsCheckedName)
+            let tcEnv, openDecls = TcOpenModuleOrNamespaceDecl TcResultsSink.NoSink tcGlobals amap initm tcEnv (checkOperatorsModule, initm)
+            tcEnv, openDecls
+        with e ->
+            errorRecovery e initm
+            tcEnv, []
     else
-        tcEnv
+        tcEnv, []
 
 /// Inject faults into checking
 let CheckSimulateException(tcConfig: TcConfig) =
@@ -698,6 +703,9 @@ type TcState =
       tcsRootSigs: RootSigs
       tcsRootImpls: RootImpls
       tcsCcuSig: ModuleOrNamespaceType
+      
+      /// The collected open declarations implied by '/checked' flag and processing F# interactive fragments that have an implied module.
+      tcsOpenDeclarations: OpenDeclaration list
     }
 
     member x.NiceNameGenerator = x.tcsNiceNameGen
@@ -722,7 +730,7 @@ type TcState =
 
 
 /// Create the initial type checking state for compiling an assembly
-let GetInitialTcState(m, ccuName, tcConfig: TcConfig, tcGlobals, tcImports: TcImports, niceNameGen, tcEnv0) =
+let GetInitialTcState(m, ccuName, tcConfig: TcConfig, tcGlobals, tcImports: TcImports, niceNameGen, tcEnv0, openDecls0) =
     ignore tcImports
 
     // Create a ccu to hold all the results of compilation
@@ -761,10 +769,20 @@ let GetInitialTcState(m, ccuName, tcConfig: TcConfig, tcGlobals, tcImports: TcIm
       tcsCreatesGeneratedProvidedTypes=false
       tcsRootSigs = Zmap.empty qnameOrder
       tcsRootImpls = Zset.empty qnameOrder
-      tcsCcuSig = Construct.NewEmptyModuleOrNamespaceType Namespace }
+      tcsCcuSig = Construct.NewEmptyModuleOrNamespaceType Namespace 
+      tcsOpenDeclarations = openDecls0
+    }
 
 /// Typecheck a single file (or interactive entry into F# Interactive)
-let TypeCheckOneInput (checkForErrors, tcConfig: TcConfig, tcImports: TcImports, tcGlobals, prefixPathOpt, tcSink, tcState: TcState, inp: ParsedInput, skipImplIfSigExists: bool) =
+let TypeCheckOneInput(checkForErrors,
+                      tcConfig: TcConfig,
+                      tcImports: TcImports,
+                      tcGlobals,
+                      prefixPathOpt,
+                      tcSink,
+                      tcState: TcState,
+                      inp: ParsedInput,
+                      skipImplIfSigExists: bool) =
 
     cancellable {
         try
@@ -796,9 +814,9 @@ let TypeCheckOneInput (checkForErrors, tcConfig: TcConfig, tcImports: TcImports,
               let ccuSigForFile = CombineCcuContentFragments m [sigFileType; tcState.tcsCcuSig]
 
               // Open the prefixPath for fsi.exe
-              let tcEnv =
+              let tcEnv, _openDecls1 =
                   match prefixPathOpt with
-                  | None -> tcEnv
+                  | None -> tcEnv, []
                   | Some prefixPath ->
                       let m = qualNameOfFile.Range
                       TcOpenModuleOrNamespaceDecl tcSink tcGlobals amap m tcEnv (prefixPath, m)
@@ -857,16 +875,16 @@ let TypeCheckOneInput (checkForErrors, tcConfig: TcConfig, tcImports: TcImports,
                   else AddLocalRootModuleOrNamespace TcResultsSink.NoSink tcGlobals amap m tcState.tcsTcSigEnv implFileSigType
 
               // Open the prefixPath for fsi.exe (tcImplEnv)
-              let tcImplEnv =
+              let tcImplEnv, openDecls =
                   match prefixPathOpt with
                   | Some prefixPath -> TcOpenModuleOrNamespaceDecl tcSink tcGlobals amap m tcImplEnv (prefixPath, m)
-                  | _ -> tcImplEnv
+                  | _ -> tcImplEnv, []
 
               // Open the prefixPath for fsi.exe (tcSigEnv)
-              let tcSigEnv =
+              let tcSigEnv, _ =
                   match prefixPathOpt with
                   | Some prefixPath when not hadSig -> TcOpenModuleOrNamespaceDecl tcSink tcGlobals amap m tcSigEnv (prefixPath, m)
-                  | _ -> tcSigEnv
+                  | _ -> tcSigEnv, []
 
               let ccuSigForFile = CombineCcuContentFragments m [implFileSigType; tcState.tcsCcuSig]
 
@@ -876,7 +894,9 @@ let TypeCheckOneInput (checkForErrors, tcConfig: TcConfig, tcImports: TcImports,
                         tcsTcImplEnv=tcImplEnv
                         tcsRootImpls=rootImpls
                         tcsCcuSig=ccuSigForFile
-                        tcsCreatesGeneratedProvidedTypes=tcState.tcsCreatesGeneratedProvidedTypes || createsGeneratedProvidedTypes }
+                        tcsCreatesGeneratedProvidedTypes=tcState.tcsCreatesGeneratedProvidedTypes || createsGeneratedProvidedTypes
+                        tcsOpenDeclarations = tcState.tcsOpenDeclarations @ openDecls
+                    }
               return (tcEnvAtEnd, topAttrs, Some implFile, ccuSigForFile), tcState
 
         with e ->

--- a/src/fsharp/ParseAndCheckInputs.fsi
+++ b/src/fsharp/ParseAndCheckInputs.fsi
@@ -54,7 +54,7 @@ val ParseInputFiles: TcConfig * Lexhelp.LexResourceManager * conditionalCompilat
 
 /// Get the initial type checking environment including the loading of mscorlib/System.Core, FSharp.Core
 /// applying the InternalsVisibleTo in referenced assemblies and opening 'Checked' if requested.
-val GetInitialTcEnv: assemblyName: string * range * TcConfig * TcImports * TcGlobals -> TcEnv
+val GetInitialTcEnv: assemblyName: string * range * TcConfig * TcImports * TcGlobals -> TcEnv * OpenDeclaration list
                 
 [<Sealed>]
 /// Represents the incremental type checking state for a set of inputs
@@ -80,7 +80,15 @@ type TcState =
 
 /// Get the initial type checking state for a set of inputs
 val GetInitialTcState: 
-    range * string * TcConfig * TcGlobals * TcImports * NiceNameGenerator * TcEnv -> TcState
+    range *
+    string *
+    TcConfig *
+    TcGlobals *
+    TcImports *
+    NiceNameGenerator *
+    TcEnv *
+    OpenDeclaration list
+        -> TcState
 
 /// Check one input, returned as an Eventually computation
 val TypeCheckOneInput:
@@ -112,7 +120,8 @@ val TypeCheckClosedInputSet:
     TcImports *
     TcGlobals *
     LongIdent option *
-    TcState * ParsedInput list
+    TcState *
+    ParsedInput list
       -> TcState * TopAttribs * TypedImplFile list * TcEnv
 
 /// Check a single input and finish the checking

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -2497,7 +2497,7 @@ and CheckNothingAfterEntryPoint cenv m =
 
 and CheckDefnInModule cenv env x = 
     match x with 
-    | TMDefRec(isRec, tycons, mspecs, m) -> 
+    | TMDefRec(isRec, _opens, tycons, mspecs, m) -> 
         CheckNothingAfterEntryPoint cenv m
         if isRec then BindVals cenv env (allValsOfModDef x |> Seq.toList)
         CheckEntityDefns cenv env tycons
@@ -2506,6 +2506,8 @@ and CheckDefnInModule cenv env x =
         CheckNothingAfterEntryPoint cenv m
         CheckModuleBinding cenv env bind 
         BindVal cenv env bind.Var
+    | TMDefOpens _ ->
+        ()
     | TMDefDo(e, m)  -> 
         CheckNothingAfterEntryPoint cenv m
         CheckNoReraise cenv None e

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -4996,6 +4996,39 @@ type ModuleOrNamespaceExprWithSig =
 
     override x.ToString() = "ModuleOrNamespaceExprWithSig(...)"
 
+/// Represents open declaration statement.
+type OpenDeclaration =
+    { /// Syntax after 'open' as it's presented in source code.
+      Target: SynOpenDeclTarget
+      
+      /// Full range of the open declaration.
+      Range: range option
+
+      /// Modules or namespaces which is opened with this declaration.
+      Modules: ModuleOrNamespaceRef list 
+      
+      /// Types whose static content is opened with this declaration.
+      Types: TType list
+
+      /// Scope in which open declaration is visible.
+      AppliedScope: range 
+      
+      /// If it's `namespace Xxx.Yyy` declaration.
+      IsOwnNamespace: bool
+    }
+
+    /// Create a new instance of OpenDeclaration.
+    static member Create(target: SynOpenDeclTarget, modules: ModuleOrNamespaceRef list, types: TType list, appliedScope: range, isOwnNamespace: bool) =
+        { Target = target
+          Range =
+            match target with 
+            | SynOpenDeclTarget.ModuleOrNamespace (range=m)
+            | SynOpenDeclTarget.Type (range=m) -> Some m
+          Types = types
+          Modules = modules
+          AppliedScope = appliedScope
+          IsOwnNamespace = isOwnNamespace }
+    
 /// The contents of a module-or-namespace-fragment definition 
 [<NoEquality; NoComparison (* ; StructuredFormatDisplay("{DebugText}") *) >]
 type ModuleOrNamespaceExpr = 
@@ -5005,6 +5038,9 @@ type ModuleOrNamespaceExpr =
     /// Indicates the module fragment is made of several module fragments in succession 
     | TMDefs of moduleOrNamespaceExprs: ModuleOrNamespaceExpr list  
 
+    /// Indicates the given 'open' declarations are active
+    | TMDefOpens of openDecls: OpenDeclaration list
+
     /// Indicates the module fragment is a 'let' definition 
     | TMDefLet of binding: Binding * range: range
 
@@ -5012,7 +5048,7 @@ type ModuleOrNamespaceExpr =
     | TMDefDo of expr: Expr * range: range
 
     /// Indicates the module fragment is a 'rec' or 'non-rec' definition of types and modules
-    | TMDefRec of isRec: bool * tycons: Tycon list * moduleOrNamespaceBindings: ModuleOrNamespaceBinding list * range: range
+    | TMDefRec of isRec: bool * opens: OpenDeclaration list * tycons: Tycon list * moduleOrNamespaceBindings: ModuleOrNamespaceBinding list * range: range
 
     // %+A formatting is used, so this is not needed
     //[<DebuggerBrowsable(DebuggerBrowsableState.Never)>]

--- a/src/fsharp/absil/il.fsi
+++ b/src/fsharp/absil/il.fsi
@@ -37,8 +37,8 @@ type ILSourceDocument =
     member File: string
 
 [<Sealed>]
-type internal ILSourceMarker =
-    static member Create: document: ILSourceDocument * line: int * column: int * endLine:int * endColumn: int-> ILSourceMarker
+type internal ILDebugPoint =
+    static member Create: document: ILSourceDocument * line: int * column: int * endLine:int * endColumn: int-> ILDebugPoint
     member Document: ILSourceDocument
     member Line: int
     member Column: int
@@ -579,7 +579,7 @@ type internal ILInstr =
     // statement covered by the given range - this is a
     // dummy instruction and is not emitted
     | I_break
-    | I_seqpoint of ILSourceMarker
+    | I_seqpoint of ILDebugPoint
 
     // Varargs - C++ only
     | I_arglist
@@ -750,7 +750,8 @@ type internal ILLocals = list<ILLocal>
 /// 
 /// Emitted to the PortablePDB format. Note the format supports additional variations on
 /// imported things that are not yet emitted in F#.
-type ILImport =
+[<RequireQualifiedAccess; NoEquality; NoComparison>]
+type ILDebugImport =
 
     /// Represents an 'open type XYZ' opening a type
     | ImportType of targetType: ILType // * alias: string option 
@@ -764,10 +765,10 @@ type ILImport =
 /// Defines a set of opened namespace, type relevant to a code location.
 /// 
 /// Emitted to the PortablePDB format.
-type ILImports =
+type ILDebugImports =
     {
-      Parent: ILImports option
-      Imports: ILImport[]
+      Parent: ILDebugImports option
+      Imports: ILDebugImport[]
     }
 
 /// IL method bodies
@@ -780,8 +781,8 @@ type internal ILMethodBody =
       AggressiveInlining: bool
       Locals: ILLocals
       Code: ILCode
-      SourceMarker: ILSourceMarker option
-      Imports: ILImports option
+      DebugPoint: ILDebugPoint option
+      DebugImports: ILDebugImports option
     }
 
 /// Member Access
@@ -1833,9 +1834,9 @@ val internal mkILLocal: ILType -> (string * int * int) option -> ILLocal
 val internal mkILEmptyGenericParams: ILGenericParameterDefs
 
 /// Make method definitions.
-val internal mkILMethodBody: initlocals:bool * ILLocals * int * ILCode * ILSourceMarker option * ILImports option -> ILMethodBody
+val internal mkILMethodBody: initlocals:bool * ILLocals * int * ILCode * ILDebugPoint option * ILDebugImports option -> ILMethodBody
 
-val internal mkMethodBody: bool * ILLocals * int * ILCode * ILSourceMarker option * ILImports option -> MethodBody
+val internal mkMethodBody: bool * ILLocals * int * ILCode * ILDebugPoint option * ILDebugImports option -> MethodBody
 
 val internal methBodyNotAvailable: Lazy<MethodBody>
 
@@ -1847,7 +1848,7 @@ val internal mkILCtor: ILMemberAccess * ILParameter list * MethodBody -> ILMetho
 
 val internal mkILClassCtor: MethodBody -> ILMethodDef
 
-val internal mkILNonGenericEmptyCtor: ILType * ILSourceMarker option * ILImports option -> ILMethodDef
+val internal mkILNonGenericEmptyCtor: ILType * ILDebugPoint option * ILDebugImports option -> ILMethodDef
 
 val internal mkILStaticMethod: ILGenericParameterDefs * string * ILMemberAccess * ILParameter list * ILReturn * MethodBody -> ILMethodDef
 
@@ -1890,14 +1891,14 @@ val internal prependInstrsToMethod: ILInstr list -> ILMethodDef -> ILMethodDef
 /// Injecting initialization code into a class.
 /// Add some code to the end of the .cctor for a type.  Create a .cctor
 /// if one doesn't exist already.
-val internal prependInstrsToClassCtor: ILInstr list -> ILSourceMarker option -> ILImports option -> ILTypeDef -> ILTypeDef
+val internal prependInstrsToClassCtor: ILInstr list -> ILDebugPoint option -> ILDebugImports option -> ILTypeDef -> ILTypeDef
 
 /// Derived functions for making some simple constructors
-val internal mkILStorageCtor: ILInstr list * ILType * (string * ILType) list * ILMemberAccess * ILSourceMarker option * ILImports option -> ILMethodDef
+val internal mkILStorageCtor: ILInstr list * ILType * (string * ILType) list * ILMemberAccess * ILDebugPoint option * ILDebugImports option -> ILMethodDef
 
-val internal mkILSimpleStorageCtor: ILTypeSpec option * ILType * ILParameter list * (string * ILType) list * ILMemberAccess * ILSourceMarker option * ILImports option -> ILMethodDef
+val internal mkILSimpleStorageCtor: ILTypeSpec option * ILType * ILParameter list * (string * ILType) list * ILMemberAccess * ILDebugPoint option * ILDebugImports option -> ILMethodDef
 
-val internal mkILSimpleStorageCtorWithParamNames: ILTypeSpec option * ILType * ILParameter list * (string * string * ILType) list * ILMemberAccess * ILSourceMarker option * ILImports option -> ILMethodDef
+val internal mkILSimpleStorageCtorWithParamNames: ILTypeSpec option * ILType * ILParameter list * (string * string * ILType) list * ILMemberAccess * ILDebugPoint option * ILDebugImports option -> ILMethodDef
 
 val internal mkILDelegateMethods: ILMemberAccess -> ILGlobals -> ILType * ILType -> ILParameter list * ILReturn -> ILMethodDef list
 

--- a/src/fsharp/absil/ilprint.fs
+++ b/src/fsharp/absil/ilprint.fs
@@ -583,7 +583,7 @@ let goutput_freevar env os l =
 let goutput_freevars env os ps =
   output_parens (output_seq ", " (goutput_freevar env)) os ps
 
-let output_source os (s:ILSourceMarker) =
+let output_source os (s:ILDebugPoint) =
   if s.Document.File <> "" then
     output_string os " .line "
     output_int os s.Line

--- a/src/fsharp/absil/ilread.fs
+++ b/src/fsharp/absil/ilread.fs
@@ -2880,7 +2880,7 @@ and seekReadMethodRVA (pectxt: PEReader) (ctxt: ILMetadataReader) (idx, nm, _int
                            // reader API. They should return an index into the array of documents for the reader
                            let sourcedoc = get_doc (pdbDocumentGetURL sp.pdbSeqPointDocument)
                            let source =
-                               ILSourceMarker.Create(document = sourcedoc,
+                               ILDebugPoint.Create(document = sourcedoc,
                                    line = sp.pdbSeqPointLine,
                                    column = sp.pdbSeqPointColumn,
                                    endLine = sp.pdbSeqPointEndLine,
@@ -2937,9 +2937,9 @@ and seekReadMethodRVA (pectxt: PEReader) (ctxt: ILMetadataReader) (idx, nm, _int
              NoInlining=noinline
              AggressiveInlining=aggressiveinline
              Locals=List.empty
-             SourceMarker=methRangePdbInfo
              Code=code
-             Imports=None
+             DebugPoint=methRangePdbInfo
+             DebugImports=None
            }
 
        else
@@ -3064,8 +3064,8 @@ and seekReadMethodRVA (pectxt: PEReader) (ctxt: ILMetadataReader) (idx, nm, _int
              AggressiveInlining=aggressiveinline
              Locals = locals
              Code=code
-             SourceMarker=methRangePdbInfo
-             Imports = None
+             DebugPoint=methRangePdbInfo
+             DebugImports = None
            })
 
 and int32AsILVariantType (ctxt: ILMetadataReader) (n: int32) =

--- a/src/fsharp/absil/ilsupp.fs
+++ b/src/fsharp/absil/ilsupp.fs
@@ -997,7 +997,7 @@ type PdbMethod  = { symMethod: ISymbolMethod }
 type PdbVariable = { symVariable: ISymbolVariable }
 type PdbMethodScope = { symScope: ISymbolScope }
 
-type PdbSequencePoint =
+type PdbDebugPoint =
     { pdbSeqPointOffset: int
       pdbSeqPointDocument: PdbDocument
       pdbSeqPointLine: int
@@ -1072,7 +1072,7 @@ let pdbMethodGetToken (meth: PdbMethod) : int32 =
     let token = meth.symMethod.Token
     token.GetToken()
 
-let pdbMethodGetSequencePoints (meth: PdbMethod) : PdbSequencePoint[] =
+let pdbMethodGetDebugPoints (meth: PdbMethod) : PdbDebugPoint[] =
     let  pSize = meth.symMethod.SequencePointCount
     let offsets = Array.zeroCreate pSize
     let docs = Array.zeroCreate pSize

--- a/src/fsharp/absil/ilsupp.fsi
+++ b/src/fsharp/absil/ilsupp.fsi
@@ -39,7 +39,7 @@ type PdbMethod
 type PdbVariable
 type PdbMethodScope
 
-type PdbSequencePoint = 
+type PdbDebugPoint = 
     { pdbSeqPointOffset: int;
       pdbSeqPointDocument: PdbDocument;
       pdbSeqPointLine: int;
@@ -61,7 +61,7 @@ val pdbDocumentGetLanguageVendor: PdbDocument -> byte[] (* guid *)
 val pdbDocumentFindClosestLine: PdbDocument -> int -> int
 
 val pdbMethodGetToken: PdbMethod -> int32
-val pdbMethodGetSequencePoints: PdbMethod -> PdbSequencePoint array
+val pdbMethodGetDebugPoints: PdbMethod -> PdbDebugPoint array
 
 val pdbScopeGetChildren: PdbMethodScope -> PdbMethodScope array
 val pdbScopeGetOffsets: PdbMethodScope -> int * int

--- a/src/fsharp/absil/ilwrite.fs
+++ b/src/fsharp/absil/ilwrite.fs
@@ -222,59 +222,57 @@ type RowElement(tag: int32, idx: int32) =
 
 // These create RowElements
 let UShort (x: uint16) = RowElement(RowElementTags.UShort, int32 x)
+
 let ULong (x: int32) = RowElement(RowElementTags.ULong, x)
+
 /// Index into cenv.data or cenv.resources. Gets fixed up later once we known an overall
 /// location for the data section. flag indicates if offset is relative to cenv.resources.
 let Data (x: int, k: bool) = RowElement((if k then RowElementTags.DataResources else RowElementTags.Data ), x)
+
 /// pos. in guid array
 let Guid (x: int) = RowElement(RowElementTags.Guid, x)
+
 /// pos. in blob array
 let Blob (x: int) = RowElement(RowElementTags.Blob, x)
+
 /// pos. in string array
 let StringE (x: int) = RowElement(RowElementTags.String, x)
+
 /// pos. in some table
 let SimpleIndex (t, x: int) = RowElement(RowElementTags.SimpleIndex t, x)
+
 let TypeDefOrRefOrSpec (t, x: int) = RowElement(RowElementTags.TypeDefOrRefOrSpec t, x)
+
 let TypeOrMethodDef (t, x: int) = RowElement(RowElementTags.TypeOrMethodDef t, x)
+
 let HasConstant (t, x: int) = RowElement(RowElementTags.HasConstant t, x)
+
 let HasCustomAttribute (t, x: int) = RowElement(RowElementTags.HasCustomAttribute t, x)
+
 let HasFieldMarshal (t, x: int) = RowElement(RowElementTags.HasFieldMarshal t, x)
+
 let HasDeclSecurity (t, x: int) = RowElement(RowElementTags.HasDeclSecurity t, x)
+
 let MemberRefParent (t, x: int) = RowElement(RowElementTags.MemberRefParent t, x)
+
 let HasSemantics (t, x: int) = RowElement(RowElementTags.HasSemantics t, x)
+
 let MethodDefOrRef (t, x: int) = RowElement(RowElementTags.MethodDefOrRef t, x)
+
 let MemberForwarded (t, x: int) = RowElement(RowElementTags.MemberForwarded t, x)
+
 let Implementation (t, x: int) = RowElement(RowElementTags.Implementation t, x)
+
 let CustomAttributeType (t, x: int) = RowElement(RowElementTags.CustomAttributeType t, x)
+
 let ResolutionScope (t, x: int) = RowElement(RowElementTags.ResolutionScope t, x)
-(*
-type RowElement =
-    | UShort of uint16
-    | ULong of int32
-    | Data of int * bool // Index into cenv.data or cenv.resources. Will be adjusted later in writing once we fix an overall location for the data section. flag indicates if offset is relative to cenv.resources.
-    | Guid of int // pos. in guid array
-    | Blob of int // pos. in blob array
-    | String of int // pos. in string array
-    | SimpleIndex of TableName * int // pos. in some table
-    | TypeDefOrRefOrSpec of TypeDefOrRefTag * int
-    | TypeOrMethodDef of TypeOrMethodDefTag * int
-    | HasConstant of HasConstantTag * int
-    | HasCustomAttribute of HasCustomAttributeTag * int
-    | HasFieldMarshal of HasFieldMarshalTag * int
-    | HasDeclSecurity of HasDeclSecurityTag * int
-    | MemberRefParent of MemberRefParentTag * int
-    | HasSemantics of HasSemanticsTag * int
-    | MethodDefOrRef of MethodDefOrRefTag * int
-    | MemberForwarded of MemberForwardedTag * int
-    | Implementation of ImplementationTag * int
-    | CustomAttributeType of CustomAttributeTypeTag * int
-    | ResolutionScope of ResolutionScopeTag * int
-*)
 
 type BlobIndex = int
+
 type StringIndex = int
 
 let BlobIndex (x: BlobIndex) : int = x
+
 let StringIndex (x: StringIndex) : int = x
 
 let inline combineHash x2 acc = 37 * acc + x2 // (acc <<< 6 + acc >>> 2 + x2 + 0x9e3779b9)
@@ -295,7 +293,6 @@ let equalRows (elems: RowElement[]) (elems2: RowElement[]) =
         i <- i + 1
     ok
 
-
 type GenericRow = RowElement[]
 
 /// This is the representation of shared rows is used for most shared row types.
@@ -303,8 +300,11 @@ type GenericRow = RowElement[]
 /// representations.
 [<Struct; CustomEquality; NoComparison>]
 type SharedRow(elems: RowElement[], hashCode: int) =
+
     member x.GenericRow = elems
+
     override x.GetHashCode() = hashCode
+
     override x.Equals(obj: obj) =
         match obj with
         | :? SharedRow as y -> equalRows elems y.GenericRow
@@ -329,13 +329,15 @@ let MemberRefRow(mrp: RowElement, nmIdx: StringIndex, blobIdx: BlobIndex) =
 /// hash code for these rows, and indeed the GetHashCode and Equals should not be needed.
 [<Struct; CustomEquality; NoComparison>]
 type UnsharedRow(elems: RowElement[]) =
+
     member x.GenericRow = elems
+
     override x.GetHashCode() = hashRow elems
+
     override x.Equals(obj: obj) =
         match obj with
         | :? UnsharedRow as y -> equalRows elems y.GenericRow
         | _ -> false
-
 
 //=====================================================================
 //=====================================================================
@@ -360,30 +362,19 @@ let envForOverrideSpec (ospec: ILOverridesSpec) = { EnclosingTyparCount=ospec.De
 type MetadataTable<'T> =
     { name: string
       dict: Dictionary<'T, int> // given a row, find its entry number
-#if DEBUG
-      mutable lookups: int
-#endif
       mutable rows: ResizeArray<'T> }
+
     member x.Count = x.rows.Count
 
     static member New(nm, hashEq) =
         { name=nm
-#if DEBUG
-          lookups=0
-#endif
           dict = Dictionary<_, _>(100, hashEq)
           rows= ResizeArray<_>() }
 
     member tbl.EntriesAsArray =
-#if DEBUG
-        if showEntryLookups then dprintf "--> table %s had %d entries and %d lookups\n" tbl.name tbl.Count tbl.lookups
-#endif
         tbl.rows |> ResizeArray.toArray
 
     member tbl.Entries =
-#if DEBUG
-        if showEntryLookups then dprintf "--> table %s had %d entries and %d lookups\n" tbl.name tbl.Count tbl.lookups
-#endif
         tbl.rows |> ResizeArray.toList
 
     member tbl.AddSharedEntry x =
@@ -398,9 +389,6 @@ type MetadataTable<'T> =
         n
 
     member tbl.FindOrAddSharedEntry x =
-#if DEBUG
-        tbl.lookups <- tbl.lookups + 1
-#endif
         match tbl.dict.TryGetValue x with
         | true, res -> res
         | _ -> tbl.AddSharedEntry x
@@ -435,14 +423,21 @@ type MethodDefKey(ilg:ILGlobals, tidx: int, garity: int, nm: string, rty: ILType
        |> combineHash (hash argtys.Length)
        |> combineHash (hash isStatic)
 
-    member key.TypeIdx = tidx
-    member key.GenericArity = garity
-    member key.Name = nm
-    member key.ReturnType = rty
-    member key.ArgTypes = argtys
-    member key.IsStatic = isStatic
-    override x.GetHashCode() = hashCode
-    override x.Equals(obj: obj) =
+    member _.TypeIdx = tidx
+
+    member _.GenericArity = garity
+
+    member _.Name = nm
+
+    member _.ReturnType = rty
+
+    member _.ArgTypes = argtys
+
+    member _.IsStatic = isStatic
+
+    override _.GetHashCode() = hashCode
+
+    override _.Equals(obj: obj) =
         match obj with
         | :? MethodDefKey as y ->
             let compareILTypes o1 o2 =
@@ -462,11 +457,16 @@ type MethodDefKey(ilg:ILGlobals, tidx: int, garity: int, nm: string, rty: ILType
 type FieldDefKey(tidx: int, nm: string, ty: ILType) =
     // precompute the hash. hash doesn't include the type
     let hashCode = hash tidx |> combineHash (hash nm)
-    member key.TypeIdx = tidx
-    member key.Name = nm
-    member key.Type = ty
-    override x.GetHashCode() = hashCode
-    override x.Equals(obj: obj) =
+
+    member _.TypeIdx = tidx
+
+    member _.Name = nm
+
+    member _.Type = ty
+
+    override _.GetHashCode() = hashCode
+
+    override _.Equals(obj: obj) =
         match obj with
         | :? FieldDefKey as y ->
             tidx = y.TypeIdx &&
@@ -475,7 +475,9 @@ type FieldDefKey(tidx: int, nm: string, ty: ILType) =
         | _ -> false
 
 type PropertyTableKey = PropKey of int (* type. def. idx. *) * string * ILType * ILTypes
+
 type EventTableKey = EventKey of int (* type. def. idx. *) * string
+
 type TypeDefTableKey = TdKey of string list (* enclosing *) * string (* type name *)
 
 //---------------------------------------------------------------------
@@ -497,25 +499,39 @@ type MetadataTable =
 [<NoEquality; NoComparison>]
 type cenv =
     { ilg: ILGlobals
+
       emitTailcalls: bool
+
       deterministic: bool
+
       showTimes: bool
+
       desiredMetadataVersion: ILVersionInfo
+
       requiredDataFixups: (int32 * (int * bool)) list ref
+
       /// References to strings in codestreams: offset of code and a (fixup-location, string token) list)
       mutable requiredStringFixups: (int32 * (int * int) list) list
+
       codeChunks: ByteBuffer
+
       mutable nextCodeAddr: int32
 
-      // Collected debug information
+      /// Collected debug information
       mutable moduleGuid: byte[]
+
       generatePdb: bool
+
       pdbinfo: ResizeArray<PdbMethodData>
+
       documents: MetadataTable<PdbDocumentData>
+
       /// Raw data, to go into the data section
       data: ByteBuffer
+
       /// Raw resource data, to go into the data section
       resources: ByteBuffer
+
       mutable entrypoint: (bool * int) option
 
       /// Caches
@@ -523,18 +539,32 @@ type cenv =
 
       /// The following are all used to generate unique items in the output
       tables: MetadataTable[]
+
       AssemblyRefs: MetadataTable<SharedRow>
+
       fieldDefs: MetadataTable<FieldDefKey>
+
       methodDefIdxsByKey: MetadataTable<MethodDefKey>
+
       methodDefIdxs: Dictionary<ILMethodDef, int>
+
       propertyDefs: MetadataTable<PropertyTableKey>
+
       eventDefs: MetadataTable<EventTableKey>
+
       typeDefs: MetadataTable<TypeDefTableKey>
+
       guids: MetadataTable<byte[]>
+
       blobs: MetadataTable<byte[]>
+
       strings: MetadataTable<string>
+
       userStrings: MetadataTable<string>
+
       normalizeAssemblyRefs: ILAssemblyRef -> ILAssemblyRef
+
+      pdbImports: Dictionary<ILDebugImports, PdbImports>
     }
     member cenv.GetTable (tab: TableName) = cenv.tables.[tab.Index]
 
@@ -1492,7 +1522,7 @@ type CodeBuffer =
 
     member codebuf.EmitExceptionClause seh = codebuf.seh <- seh :: codebuf.seh
 
-    member codebuf.EmitSeqPoint cenv (m: ILSourceMarker) =
+    member codebuf.EmitSeqPoint cenv (m: ILDebugPoint) =
         if cenv.generatePdb then
           // table indexes are 1-based, document array indexes are 0-based
           let doc = (cenv.documents.FindOrAddSharedEntry m.Document) - 1
@@ -2187,8 +2217,23 @@ let GetFieldDefTypeAsBlobIdx cenv env ty =
                                               EmitType cenv env bb ty)
     GetBytesAsBlobIdx cenv bytes
 
-let GenPdbImports _cenv _env (_il: ILImports option) : PdbImports option =
-    failwith "tbd"
+let GenPdbImport (cenv: cenv) env (input: ILDebugImport) =
+    match input with 
+    | ILDebugImport.ImportType ty -> PdbImport.ImportType (GetTypeAsBlobIdx cenv env ty)
+    | ILDebugImport.ImportNamespace nsp -> PdbImport.ImportNamespace nsp
+
+let rec GenPdbImports (cenv: cenv) env (input: ILDebugImports option) =
+    match input with 
+    | None -> None
+    | Some ilImports -> 
+        match cenv.pdbImports.TryGetValue(ilImports) with
+        | true, v -> Some v
+        | _ ->
+            let v : PdbImports = 
+                { Imports = ilImports.Imports |> Array.map (GenPdbImport cenv env)
+                  Parent = GenPdbImports cenv env ilImports.Parent }
+            cenv.pdbImports.[ilImports] <- v
+            Some v
 
 let GenILMethodBody mname cenv env (il: ILMethodBody) =
     let localSigs =
@@ -2201,7 +2246,7 @@ let GenILMethodBody mname cenv env (il: ILMethodBody) =
       else
         [| |]
 
-    let imports = GenPdbImports cenv env il.Imports
+    let imports = GenPdbImports cenv env il.DebugImports
     let requiredStringFixups, seh, code, seqpoints, scopes = Codebuf.EmitMethodCode cenv imports localSigs env mname il.Code
     let codeSize = code.Length
     use methbuf = ByteBuffer.Create (codeSize * 3)
@@ -2485,7 +2530,7 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
                 Params= [| |] (* REVIEW *)
                 RootScope = Some rootScope
                 Range=
-                  match ilmbody.SourceMarker with
+                  match ilmbody.DebugPoint with
                   | Some m when cenv.generatePdb ->
                       // table indexes are 1-based, document array indexes are 0-based
                       let doc = (cenv.documents.FindOrAddSharedEntry m.Document) - 1
@@ -2897,6 +2942,20 @@ let ResourceCapacity = 200
 let generateIL requiredDataFixups (desiredMetadataVersion, generatePdb, ilg : ILGlobals, emitTailcalls, deterministic, showTimes) (m : ILModuleDef) cilStartAddress normalizeAssemblyRefs =
     let isDll = m.IsDLL
 
+    let tables =
+        Array.init 64 (fun i ->
+            if (i = TableNames.AssemblyRef.Index ||
+                i = TableNames.MemberRef.Index ||
+                i = TableNames.ModuleRef.Index ||
+                i = TableNames.File.Index ||
+                i = TableNames.TypeRef.Index ||
+                i = TableNames.TypeSpec.Index ||
+                i = TableNames.MethodSpec.Index ||
+                i = TableNames.StandAloneSig.Index ||
+                i = TableNames.GenericParam.Index) then
+                MetadataTable.Shared (MetadataTable<SharedRow>.New ("row table "+string i, EqualityComparer.Default))
+            else
+                MetadataTable.Unshared (MetadataTable<UnsharedRow>.New ("row table "+string i, EqualityComparer.Default)))
     use cenv =
         { emitTailcalls=emitTailcalls
           deterministic = deterministic
@@ -2909,21 +2968,7 @@ let generateIL requiredDataFixups (desiredMetadataVersion, generatePdb, ilg : IL
           nextCodeAddr = cilStartAddress
           data = ByteBuffer.Create DataCapacity
           resources = ByteBuffer.Create ResourceCapacity
-          tables=
-              Array.init 64 (fun i ->
-                  if (i = TableNames.AssemblyRef.Index ||
-                      i = TableNames.MemberRef.Index ||
-                      i = TableNames.ModuleRef.Index ||
-                      i = TableNames.File.Index ||
-                      i = TableNames.TypeRef.Index ||
-                      i = TableNames.TypeSpec.Index ||
-                      i = TableNames.MethodSpec.Index ||
-                      i = TableNames.StandAloneSig.Index ||
-                      i = TableNames.GenericParam.Index) then
-                      MetadataTable.Shared (MetadataTable<SharedRow>.New ("row table "+string i, EqualityComparer.Default))
-                    else
-                      MetadataTable.Unshared (MetadataTable<UnsharedRow>.New ("row table "+string i, EqualityComparer.Default)))
-
+          tables= tables
           AssemblyRefs = MetadataTable<_>.New("ILAssemblyRef", EqualityComparer.Default)
           documents=MetadataTable<_>.New("pdbdocs", EqualityComparer.Default)
           trefCache=Dictionary<_, _>(100)
@@ -2943,7 +2988,8 @@ let generateIL requiredDataFixups (desiredMetadataVersion, generatePdb, ilg : IL
           blobs= MetadataTable<_>.New("blobs", HashIdentity.Structural)
           strings= MetadataTable<_>.New("strings", EqualityComparer.Default)
           userStrings= MetadataTable<_>.New("user strings", EqualityComparer.Default)
-          normalizeAssemblyRefs = normalizeAssemblyRefs }
+          normalizeAssemblyRefs = normalizeAssemblyRefs 
+          pdbImports = Dictionary<_, _>(HashIdentity.Reference) }
 
     // Now the main compilation step
     GenModule cenv m

--- a/src/fsharp/absil/ilwrite.fs
+++ b/src/fsharp/absil/ilwrite.fs
@@ -2219,7 +2219,7 @@ let GetFieldDefTypeAsBlobIdx cenv env ty =
 
 let GenPdbImport (cenv: cenv) env (input: ILDebugImport) =
     match input with 
-    | ILDebugImport.ImportType ty -> PdbImport.ImportType (GetTypeAsBlobIdx cenv env ty)
+    | ILDebugImport.ImportType ty -> PdbImport.ImportType (getTypeDefOrRefAsUncodedToken (GetTypeAsTypeDefOrRef cenv env ty))
     | ILDebugImport.ImportNamespace nsp -> PdbImport.ImportNamespace nsp
 
 let rec GenPdbImports (cenv: cenv) env (input: ILDebugImports option) =

--- a/src/fsharp/absil/ilwritepdb.fs
+++ b/src/fsharp/absil/ilwritepdb.fs
@@ -669,6 +669,8 @@ type PortablePdbGenerator (embedAllSource: bool, embedSourceList: string list, s
     member _.Emit() =
         sortMethods showTimes info
         metadata.SetCapacity(TableIndex.MethodDebugInformation, info.Methods.Length)
+
+// Currently disabled, see 
 #if EMIT_IMPORT_SCOPES
         defineModuleImportScope()
 #else

--- a/src/fsharp/absil/ilx.fs
+++ b/src/fsharp/absil/ilx.fs
@@ -131,26 +131,24 @@ type IlxClosureInfo =
       cloUseStaticField: bool}
 
 type IlxUnionInfo = 
-    { /// is the representation public? 
-      cudReprAccess: ILMemberAccess 
+    { 
+      UnionCasesAccessibility: ILMemberAccess 
 
-      /// are the representation public? 
-      cudHelpersAccess: ILMemberAccess 
+      HelpersAccessibility: ILMemberAccess 
 
-      /// generate the helpers? 
-      cudHasHelpers: IlxUnionHasHelpers 
+      HasHelpers: IlxUnionHasHelpers 
 
-      /// generate the helpers? 
-      cudDebugProxies: bool 
+      GenerateDebugProxies: bool 
 
-      cudDebugDisplayAttributes: ILAttribute list
+      DebugDisplayAttributes: ILAttribute list
 
-      cudAlternatives: IlxUnionCase[]
+      UnionCases: IlxUnionCase[]
 
-      cudNullPermitted: bool
+      IsNullPermitted: bool
 
-      /// debug info for generated code for classunions 
-      cudWhere: ILSourceMarker option
+      DebugPoint: ILDebugPoint option
+
+      DebugImports: ILDebugImports option
      }
 
 // --------------------------------------------------------------------

--- a/src/fsharp/absil/ilx.fsi
+++ b/src/fsharp/absil/ilx.fsi
@@ -36,7 +36,7 @@ type IlxUnionHasHelpers =
    
 /// Union references 
 type IlxUnionRef = 
-    | IlxUnionRef of boxity: ILBoxity * ILTypeRef * IlxUnionCase[] * bool (* cudNullPermitted *)  * IlxUnionHasHelpers (* cudHasHelpers *)
+    | IlxUnionRef of boxity: ILBoxity * ILTypeRef * IlxUnionCase[] * bool (* IsNullPermitted *)  * IlxUnionHasHelpers (* HasHelpers *)
 
 type IlxUnionSpec = 
     | IlxUnionSpec of IlxUnionRef * ILGenericArgs
@@ -125,24 +125,27 @@ type IlxClosureInfo =
 type IlxUnionInfo = 
     { 
       /// Is the representation public? 
-      cudReprAccess: ILMemberAccess 
+      UnionCasesAccessibility: ILMemberAccess 
 
       /// Are the representation helpers public? 
-      cudHelpersAccess: ILMemberAccess 
+      HelpersAccessibility: ILMemberAccess 
 
       /// Generate the helpers? 
-      cudHasHelpers: IlxUnionHasHelpers 
+      HasHelpers: IlxUnionHasHelpers 
 
-      cudDebugProxies: bool 
+      GenerateDebugProxies: bool 
 
-      cudDebugDisplayAttributes: ILAttribute list
+      DebugDisplayAttributes: ILAttribute list
 
-      cudAlternatives: IlxUnionCase[]
+      UnionCases: IlxUnionCase[]
 
-      cudNullPermitted: bool
+      IsNullPermitted: bool
 
       /// Debug info for generated code for classunions.
-      cudWhere: ILSourceMarker option  
+      DebugPoint: ILDebugPoint option  
+
+      /// Debug info for generated code for classunions 
+      DebugImports: ILDebugImports option
     }
 
 // -------------------------------------------------------------------- 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1070,7 +1070,7 @@ let internal mkBoundValueTypedImpl tcGlobals m moduleName name ty =
     let bindExpr = mkCallDefaultOf tcGlobals range0 ty
     let binding = Binding.TBind(v, bindExpr, DebugPointAtBinding.NoneAtLet)
     let mbinding = ModuleOrNamespaceBinding.Module(moduleOrNamespace, TMDefs([TMDefLet(binding, m)]))
-    let expr = ModuleOrNamespaceExprWithSig(mty, TMDefs([TMDefs[TMDefRec(false, [], [mbinding], m)]]), range0)
+    let expr = ModuleOrNamespaceExprWithSig(mty, TMDefs([TMDefs[TMDefRec(false, [], [], [mbinding], m)]]), range0)
     moduleOrNamespace, v, TypedImplFile.TImplFile(QualifiedNameOfFile.QualifiedNameOfFile(Ident(moduleName, m)), [], expr, false, false, StampMap.Empty)
 
 /// Encapsulates the coordination of the typechecking, optimization and code generation
@@ -1683,10 +1683,10 @@ type internal FsiDynamicCompiler
         let tcConfig = TcConfig.Create(tcConfigB,validate=false)
         let optEnv0 = GetInitialOptimizationEnv (tcImports, tcGlobals)
         let emEnv = emEnv0
-        let tcEnv = GetInitialTcEnv (assemblyName, rangeStdin, tcConfig, tcImports, tcGlobals)
+        let tcEnv, openDecls0 = GetInitialTcEnv (assemblyName, rangeStdin, tcConfig, tcImports, tcGlobals)
         let ccuName = assemblyName
 
-        let tcState = GetInitialTcState (rangeStdin, ccuName, tcConfig, tcGlobals, tcImports, niceNameGen, tcEnv)
+        let tcState = GetInitialTcState (rangeStdin, ccuName, tcConfig, tcGlobals, tcImports, niceNameGen, tcEnv, openDecls0)
 
         let ilxGenerator = CreateIlxAssemblyGenerator (tcConfig, tcImports, tcGlobals, (LightweightTcValForUsingInBuildMethodCall tcGlobals), tcState.Ccu)
         {optEnv    = optEnv0

--- a/src/fsharp/ilx/EraseClosures.fs
+++ b/src/fsharp/ilx/EraseClosures.fs
@@ -366,7 +366,9 @@ let rec convIlxClosureDef cenv encl (td: ILTypeDef) clo =
       let nowCloRef = IlxClosureRef(nowTypeRef, clo.cloStructure, nowFields)
       let nowCloSpec = mkILFormalCloRef td.GenericParams nowCloRef clo.cloUseStaticField
       let nowMethods = List.map (convMethodDef (Some nowCloSpec)) td.Methods.AsList
-      let tagApp = (Lazy.force clo.cloCode).SourceMarker
+      let ilCloCode = Lazy.force clo.cloCode
+      let cloTag = ilCloCode.DebugPoint
+      let cloImports = ilCloCode.DebugImports
       
       let tyargsl, tmargsl, laterStruct = stripSupportedAbstraction clo.cloStructure
 
@@ -445,19 +447,16 @@ let rec convIlxClosureDef cenv encl (td: ILTypeDef) clo =
             // This is the code which will get called when then "now" 
             // arguments get applied. Convert it with the information 
             // that it is the code for a closure... 
-              let nowCode = 
-                mkILMethodBody
-                  (false, [], nowFields.Length + 1, 
-                   nonBranchingInstrsToCode
-                     begin 
-                       // Load up the environment, including self... 
-                       (nowFields |> Array.toList |> List.collect (mkLdFreeVar nowCloSpec))  @
-                       [ mkLdarg0 ] @
-                       // Make the instance of the delegated closure && return it. 
-                       // This passes the method type params. as class type params. 
-                       [ I_newobj (laterCloSpec.Constructor, None) ] 
-                     end, 
-                   tagApp)
+              let nowInstrs = 
+                // Load up the environment, including self... 
+                [ for fld in nowFields do
+                    yield! mkLdFreeVar nowCloSpec fld
+                  mkLdarg0 
+                  // Make the instance of the delegated closure && return it. 
+                  // This passes the method type params. as class type params. 
+                  I_newobj (laterCloSpec.Constructor, None) ] 
+
+              let nowCode = mkILMethodBody (false, [], nowFields.Length + 1, nonBranchingInstrsToCode nowInstrs, cloTag, cloImports)
 
               let nowTypeDefs = 
                 convIlxClosureDef cenv encl td {clo with cloStructure=nowStruct 
@@ -529,21 +528,19 @@ let rec convIlxClosureDef cenv encl (td: ILTypeDef) clo =
               let laterFields = Array.append nowFields laterFreeVars
               let laterCloRef = IlxClosureRef(laterTypeRef, laterStruct, laterFields)
               let laterCloSpec = mkILFormalCloRef laterGenericParams laterCloRef false
-              
+
+              let nowInstrs =              
+                  [ // Load up the environment 
+                    for nowField in nowFields do 
+                        yield! mkLdFreeVar nowCloSpec nowField
+                    // Load up all the arguments (including self), which become free variables in the delegated closure 
+                    for (n, _) in argToFreeVarMap do
+                        mkLdarg (uint16 n)
+                    // Make the instance of the delegated closure && return it. 
+                    I_newobj (laterCloSpec.Constructor, None) ] 
+
               // This is the code which will first get called. 
-              let nowCode = 
-                  mkILMethodBody
-                    (false, [], argToFreeVarMap.Length + nowFields.Length, 
-                     nonBranchingInstrsToCode
-                       begin 
-                         // Load up the environment 
-                         (nowFields |> Array.toList |> List.collect (mkLdFreeVar nowCloSpec))  @
-                         // Load up all the arguments (including self), which become free variables in the delegated closure 
-                         (argToFreeVarMap  |> List.map (fun (n, _) -> mkLdarg (uint16 n))) @
-                         // Make the instance of the delegated closure && return it. 
-                         [ I_newobj (laterCloSpec.Constructor, None) ] 
-                       end, 
-                     tagApp)
+              let nowCode =  mkILMethodBody (false, [], argToFreeVarMap.Length + nowFields.Length, nonBranchingInstrsToCode nowInstrs, cloTag, cloImports)
 
               let nowTypeDefs = 
                 convIlxClosureDef cenv encl td {clo with cloStructure=nowStruct
@@ -580,11 +577,11 @@ let rec convIlxClosureDef cenv encl (td: ILTypeDef) clo =
 
                     let ctorMethodDef = 
                         mkILStorageCtor 
-                           (None, 
-                            [ mkLdarg0; mkNormalCall (mkILCtorMethSpecForTy (nowEnvParentClass, [])) ], 
+                           ([ mkLdarg0; mkNormalCall (mkILCtorMethSpecForTy (nowEnvParentClass, [])) ], 
                             nowTy, 
                             mkILCloFldSpecs cenv nowFields, 
-                            ILMemberAccess.Assembly)
+                            ILMemberAccess.Assembly,
+                            None, cloImports)
                         |> cenv.addMethodGeneratedAttrs 
 
                     ILTypeDef(name = td.Name,
@@ -616,7 +613,7 @@ let rec convIlxClosureDef cenv encl (td: ILTypeDef) clo =
           // No code is being declared: just bake a (mutable) environment 
           let cloCodeR = 
             match td.Extends with 
-            | None ->  (mkILNonGenericEmptyCtor None cenv.ilg.typ_Object).MethodBody 
+            | None ->  (mkILNonGenericEmptyCtor (cenv.ilg.typ_Object, None, cloImports)).MethodBody 
             | Some  _ -> convILMethodBody (Some nowCloSpec, None)  (Lazy.force clo.cloCode)
 
           let ctorMethodDef = 

--- a/src/fsharp/ilx/EraseUnions.fs
+++ b/src/fsharp/ilx/EraseUnions.fs
@@ -173,10 +173,10 @@ type NoTypesGeneratedViaThisReprDecider = NoTypesGeneratedViaThisReprDecider
 
 let cudefRepr = 
     UnionReprDecisions
-        ((fun (_td,cud) -> cud.cudAlternatives),
-         (fun (_td,cud) -> cud.cudNullPermitted), 
+        ((fun (_td,cud) -> cud.UnionCases),
+         (fun (_td,cud) -> cud.IsNullPermitted), 
          (fun (alt:IlxUnionCase) -> alt.IsNullary),
-         (fun (_td,cud) -> cud.cudHasHelpers = IlxUnionHasHelpers.SpecialFSharpListHelpers),
+         (fun (_td,cud) -> cud.HasHelpers = IlxUnionHasHelpers.SpecialFSharpListHelpers),
          (fun (td:ILTypeDef,_cud) -> td.IsStruct),
          (fun (alt:IlxUnionCase) -> alt.Name),
          (fun (_td,_cud) -> NoTypesGeneratedViaThisReprDecider),
@@ -607,7 +607,7 @@ let emitDataSwitch ilg (cg: ICodeGen<'Mark>) (avoidHelpers, cuspec, cases) =
 //---------------------------------------------------
 // Generate the union classes
 
-let mkMethodsAndPropertiesForFields (addMethodGeneratedAttrs, addPropertyGeneratedAttrs) access attr hasHelpers (ilTy: ILType) (fields: IlxUnionCaseField[]) = 
+let mkMethodsAndPropertiesForFields (addMethodGeneratedAttrs, addPropertyGeneratedAttrs) access attr imports hasHelpers (ilTy: ILType) (fields: IlxUnionCaseField[]) = 
     let basicProps = 
         fields 
         |> Array.map (fun field -> 
@@ -631,13 +631,17 @@ let mkMethodsAndPropertiesForFields (addMethodGeneratedAttrs, addPropertyGenerat
                   mkILNonGenericInstanceMethod
                      ("get_" + adjustFieldName hasHelpers field.Name,
                       access, [], mkILReturn field.Type,
-                      mkMethodBody(true,[],2,nonBranchingInstrsToCode [ mkLdarg 0us; mkNormalLdfld fspec ], attr))
+                      mkMethodBody(true,[],2,nonBranchingInstrsToCode [ mkLdarg 0us; mkNormalLdfld fspec ], attr, imports))
                   |> addMethodGeneratedAttrs ]
     
     basicProps, basicMethods
 
-let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addPropertyNeverAttrs, addFieldGeneratedAttrs, addFieldNeverAttrs, mkDebuggerTypeProxyAttribute) (ilg: ILGlobals) num (td:ILTypeDef) cud info cuspec (baseTy:ILType) (alt:IlxUnionCase) =
-    let attr = cud.cudWhere
+let convAlternativeDef 
+       (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addPropertyNeverAttrs, addFieldGeneratedAttrs, addFieldNeverAttrs, mkDebuggerTypeProxyAttribute)
+       (ilg: ILGlobals) num (td:ILTypeDef) (cud : IlxUnionInfo) info cuspec (baseTy:ILType) (alt:IlxUnionCase) =
+
+    let imports = cud.DebugImports
+    let attr = cud.DebugPoint
     let altName = alt.Name
     let fields = alt.FieldDefs
     let altTy = tyForAlt cuspec alt
@@ -650,13 +654,13 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
     //
     // Microsoft.FSharp.Collections.List`1 is indeed logically immutable, but we use mutation on this type internally
     // within FSharp.Core.dll on fresh unpublished cons cells.
-    let isTotallyImmutable = (cud.cudHasHelpers <> SpecialFSharpListHelpers)
+    let isTotallyImmutable = (cud.HasHelpers <> SpecialFSharpListHelpers)
     
     let altUniqObjMeths  = 
 
          // This method is only generated if helpers are not available. It fetches the unique object for the alternative
          // without exposing direct access to the underlying field
-         match cud.cudHasHelpers with 
+         match cud.HasHelpers with 
          | AllHelpers  
          | SpecialFSharpOptionHelpers  
          | SpecialFSharpListHelpers  -> []
@@ -666,10 +670,8 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
                  let meth =
                      mkILNonGenericStaticMethod
                            (methName,
-                            cud.cudReprAccess,[],mkILReturn(baseTy),
-                            mkMethodBody(true,[],fields.Length,
-                                    nonBranchingInstrsToCode 
-                                      [ I_ldsfld (Nonvolatile,mkConstFieldSpec altName baseTy) ], attr))
+                            cud.UnionCasesAccessibility,[],mkILReturn(baseTy),
+                            mkMethodBody(true,[],fields.Length, nonBranchingInstrsToCode [ I_ldsfld (Nonvolatile,mkConstFieldSpec altName baseTy) ], attr, imports))
                          |> addMethodGeneratedAttrs 
                  [meth]
                      
@@ -678,21 +680,20 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
 
     let baseMakerMeths, baseMakerProps = 
 
-        match cud.cudHasHelpers with 
+        match cud.HasHelpers with 
         | AllHelpers
         | SpecialFSharpOptionHelpers  
         | SpecialFSharpListHelpers  -> 
 
             let baseTesterMeths, baseTesterProps = 
-                if cud.cudAlternatives.Length <= 1 then [], []
+                if cud.UnionCases.Length <= 1 then [], []
                 elif repr.RepresentOneAlternativeAsNull info then [], []
                 else
                     [ mkILNonGenericInstanceMethod
                          ("get_" + mkTesterName altName,
-                          cud.cudHelpersAccess,[],
+                          cud.HelpersAccessibility,[],
                           mkILReturn ilg.typ_Bool,
-                          mkMethodBody(true,[],2,nonBranchingInstrsToCode 
-                                    ([ mkLdarg0 ] @ mkIsData ilg (true, cuspec, num)), attr))
+                          mkMethodBody(true,[],2,nonBranchingInstrsToCode ([ mkLdarg0 ] @ mkIsData ilg (true, cuspec, num)), attr, imports))
                       |> addMethodGeneratedAttrs ],
                     [ ILPropertyDef(name = mkTesterName altName,
                                     attributes = PropertyAttributes.None,
@@ -715,8 +716,8 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
                     let nullaryMeth = 
                         mkILNonGenericStaticMethod
                           ("get_" + altName,
-                           cud.cudHelpersAccess, [], mkILReturn baseTy,
-                           mkMethodBody(true,[],fields.Length, nonBranchingInstrsToCode (convNewDataInstrInternal ilg cuspec num), attr))
+                           cud.HelpersAccessibility, [], mkILReturn baseTy,
+                           mkMethodBody(true,[],fields.Length, nonBranchingInstrsToCode (convNewDataInstrInternal ilg cuspec num), attr, imports))
                         |> addMethodGeneratedAttrs 
                         |> addAltAttribs
 
@@ -737,16 +738,19 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
                     [nullaryMeth],[nullaryProp]
                   
                 else
+                    let ilInstrs =
+                        [ for i in 0..fields.Length-1 do 
+                            mkLdarg (uint16 i)
+                          yield! convNewDataInstrInternal ilg cuspec num ]
+                        |> nonBranchingInstrsToCode
+
                     let mdef = 
                          mkILNonGenericStaticMethod
                            (mkMakerName cuspec altName,
-                            cud.cudHelpersAccess,
+                            cud.HelpersAccessibility,
                             fields |> Array.map (fun fd -> mkILParamNamed (fd.LowerName, fd.Type)) |> Array.toList,
                             mkILReturn baseTy,
-                            mkMethodBody(true,[],fields.Length,
-                                    nonBranchingInstrsToCode 
-                                      (Array.toList (Array.mapi (fun i _ -> mkLdarg (uint16 i)) fields) @
-                                       (convNewDataInstrInternal ilg cuspec num)), attr))
+                            mkMethodBody(true, [], fields.Length, ilInstrs, attr, imports))
                          |> addMethodGeneratedAttrs 
                          |> addAltAttribs
 
@@ -779,7 +783,7 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
               if repr.OptimizeAlternativeToRootClass (info,alt) then [], [] else
                 
               let altDebugTypeDefs, debugAttrs = 
-                  if not cud.cudDebugProxies then  [],  []
+                  if not cud.GenerateDebugProxies then  [],  []
                   else
                     
                     let debugProxyTypeName = altTy.TypeSpec.Name + "@DebugTypeProxy"
@@ -789,17 +793,18 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
                     let debugProxyFields = 
                         [ mkILInstanceField  (debugProxyFieldName,altTy, None, ILMemberAccess.Assembly)  |> addFieldNeverAttrs |> addFieldGeneratedAttrs]
 
+                    let debugProxyCode = 
+                        [ mkLdarg0 
+                          mkNormalCall (mkILCtorMethSpecForTy (ilg.typ_Object,[]))  
+                          mkLdarg0 
+                          mkLdarg 1us
+                          mkNormalStfld (mkILFieldSpecInTy (debugProxyTy,debugProxyFieldName,altTy)) ]
+                        |> nonBranchingInstrsToCode
+
                     let debugProxyCtor = 
                         mkILCtor(ILMemberAccess.Public (* must always be public - see jared parson blog entry on implementing debugger type proxy *),
                                 [ mkILParamNamed ("obj",altTy) ],
-                                mkMethodBody
-                                  (false,[],3,
-                                   nonBranchingInstrsToCode
-                                     [ yield mkLdarg0 
-                                       yield mkNormalCall (mkILCtorMethSpecForTy (ilg.typ_Object,[]))  
-                                       yield mkLdarg0 
-                                       yield mkLdarg 1us
-                                       yield mkNormalStfld (mkILFieldSpecInTy (debugProxyTy,debugProxyFieldName,altTy)) ],None))
+                                mkMethodBody (false, [], 3, debugProxyCode, None, imports))
 
                         |> addMethodGeneratedAttrs 
 
@@ -807,16 +812,15 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
                         fields 
                         |> Array.map (fun field -> 
                             let fldName,fldTy = mkUnionCaseFieldId field
-                            mkILNonGenericInstanceMethod
-                               ("get_" + field.Name,
-                                ILMemberAccess.Public,[],
-                                mkILReturn field.Type,
-                                mkMethodBody(true,[],2,
-                                        nonBranchingInstrsToCode 
-                                          [ mkLdarg0
-                                            (if td.IsStruct then mkNormalLdflda else mkNormalLdfld)  
-                                                (mkILFieldSpecInTy (debugProxyTy,debugProxyFieldName,altTy)) 
-                                            mkNormalLdfld (mkILFieldSpecInTy(altTy,fldName,fldTy))],None))
+                            let instrs =
+                                [ mkLdarg0
+                                  (if td.IsStruct then mkNormalLdflda else mkNormalLdfld)  (mkILFieldSpecInTy (debugProxyTy,debugProxyFieldName,altTy)) 
+                                  mkNormalLdfld (mkILFieldSpecInTy(altTy,fldName,fldTy))]
+                                |> nonBranchingInstrsToCode
+
+                            let mbody = mkMethodBody(true,[],2, instrs, None, imports)
+                            
+                            mkILNonGenericInstanceMethod ("get_" + field.Name, ILMemberAccess.Public, [], mkILReturn field.Type, mbody)
                             |> addMethodGeneratedAttrs )
                         |> Array.toList
 
@@ -849,7 +853,7 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
                                           ILTypeInit.BeforeField)
 
                     [ debugProxyTypeDef.WithSpecialName(true) ],
-                    ( [mkDebuggerTypeProxyAttribute debugProxyTy] @ cud.cudDebugDisplayAttributes)
+                    ( [mkDebuggerTypeProxyAttribute debugProxyTy] @ cud.DebugDisplayAttributes)
                                     
               let altTypeDef = 
                   let basicFields = 
@@ -861,30 +865,32 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
                       |> Array.toList
 
 
-                  let basicProps, basicMethods = mkMethodsAndPropertiesForFields (addMethodGeneratedAttrs, addPropertyGeneratedAttrs) cud.cudReprAccess attr cud.cudHasHelpers altTy fields 
+                  let basicProps, basicMethods = mkMethodsAndPropertiesForFields (addMethodGeneratedAttrs, addPropertyGeneratedAttrs) cud.UnionCasesAccessibility attr imports cud.HasHelpers altTy fields 
                   
-                  let basicCtorMeth = 
-                      mkILStorageCtor 
-                         (attr  ,
-                          [ yield mkLdarg0 
-                            match repr.DiscriminationTechnique info with 
-                            | IntegerTag -> 
-                                yield mkLdcInt32 num
-                                yield mkNormalCall (mkILCtorMethSpecForTy (baseTy,[mkTagFieldType ilg cuspec])) 
-                            | SingleCase 
-                            | RuntimeTypes ->
-                                yield mkNormalCall (mkILCtorMethSpecForTy (baseTy,[])) 
-                            | TailOrNull -> 
-                                failwith "unreachable" ],
-                          altTy,
-                          (basicFields |> List.map (fun fdef -> fdef.Name, fdef.FieldType) ),
-                          (if cuspec.HasHelpers = AllHelpers then ILMemberAccess.Assembly else cud.cudReprAccess))
+                  let basicCtorInstrs = 
+                      [ yield mkLdarg0 
+                        match repr.DiscriminationTechnique info with 
+                        | IntegerTag -> 
+                            yield mkLdcInt32 num
+                            yield mkNormalCall (mkILCtorMethSpecForTy (baseTy,[mkTagFieldType ilg cuspec])) 
+                        | SingleCase 
+                        | RuntimeTypes ->
+                            yield mkNormalCall (mkILCtorMethSpecForTy (baseTy,[])) 
+                        | TailOrNull -> 
+                            failwith "unreachable" ]
+
+                  let basicCtorAccess = (if cuspec.HasHelpers = AllHelpers then ILMemberAccess.Assembly else cud.UnionCasesAccessibility)
+
+                  let basicCtorFields = basicFields |> List.map (fun fdef -> fdef.Name, fdef.FieldType) 
+                  
+                  let basicCtorMeth =
+                      mkILStorageCtor  (basicCtorInstrs, altTy, basicCtorFields, basicCtorAccess, attr, imports)
                       |> addMethodGeneratedAttrs 
 
                   let altTypeDef = 
                       mkILGenericClass (altTy.TypeSpec.Name, 
                                         // Types for nullary's become private, they also have names like _Empty
-                                        ILTypeDefAccess.Nested (if alt.IsNullary && cud.cudHasHelpers = IlxUnionHasHelpers.AllHelpers then ILMemberAccess.Assembly else cud.cudReprAccess), 
+                                        ILTypeDefAccess.Nested (if alt.IsNullary && cud.HasHelpers = IlxUnionHasHelpers.AllHelpers then ILMemberAccess.Assembly else cud.UnionCasesAccessibility), 
                                         td.GenericParams, 
                                         baseTy, [], 
                                         mkILMethods ([basicCtorMeth] @ basicMethods), 
@@ -908,13 +914,13 @@ let convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addP
 let mkClassUnionDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addPropertyNeverAttrs, addFieldGeneratedAttrs: ILFieldDef -> ILFieldDef, addFieldNeverAttrs: ILFieldDef -> ILFieldDef, mkDebuggerTypeProxyAttribute) ilg tref (td:ILTypeDef) cud = 
     let boxity = if td.IsStruct then ILBoxity.AsValue else ILBoxity.AsObject
     let baseTy = mkILFormalNamedTy boxity tref td.GenericParams
-    let cuspec = IlxUnionSpec(IlxUnionRef(boxity,baseTy.TypeRef, cud.cudAlternatives, cud.cudNullPermitted, cud.cudHasHelpers), baseTy.GenericArgs)
+    let cuspec = IlxUnionSpec(IlxUnionRef(boxity,baseTy.TypeRef, cud.UnionCases, cud.IsNullPermitted, cud.HasHelpers), baseTy.GenericArgs)
     let info = (td,cud)
     let repr = cudefRepr 
-    let isTotallyImmutable = (cud.cudHasHelpers <> SpecialFSharpListHelpers)
+    let isTotallyImmutable = (cud.HasHelpers <> SpecialFSharpListHelpers)
 
     let results = 
-        cud.cudAlternatives 
+        cud.UnionCases 
         |> List.ofArray 
         |> List.mapi (fun i alt -> convAlternativeDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addPropertyNeverAttrs, addFieldGeneratedAttrs, addFieldNeverAttrs, mkDebuggerTypeProxyAttribute) ilg i td cud info cuspec baseTy alt)
 
@@ -934,7 +940,7 @@ let mkClassUnionDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addProp
 
     let selfFields, selfMeths, selfProps = 
 
-        [ for cidx, alt in Array.indexed cud.cudAlternatives do 
+        [ for cidx, alt in Array.indexed cud.UnionCases do 
            if repr.RepresentAlternativeAsFreshInstancesOfRootClass (info,alt) || 
               repr.RepresentAlternativeAsStructValue info then
         // TODO
@@ -946,23 +952,26 @@ let mkClassUnionDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addProp
                 | Some ilTy -> Some ilTy.TypeSpec
 
             let extraParamsForCtor = 
-                if isStruct && takesExtraParams cud.cudAlternatives then 
+                if isStruct && takesExtraParams cud.UnionCases then 
                     let extraTys, _extraInstrs = extraTysAndInstrsForStructCtor ilg cidx 
                     List.map mkILParamAnon extraTys 
                 else 
                     []
 
+            let ctorAccess = (if cuspec.HasHelpers = AllHelpers then ILMemberAccess.Assembly else cud.UnionCasesAccessibility)
+            
             let ctor = 
                 mkILSimpleStorageCtor 
-                   (cud.cudWhere,
-                    baseInit,
+                   (baseInit,
                     baseTy,
                     extraParamsForCtor,
                     (fields @ tagFieldsInObject),
-                    (if cuspec.HasHelpers = AllHelpers then ILMemberAccess.Assembly else cud.cudReprAccess))
+                    ctorAccess,
+                    cud.DebugPoint,
+                    cud.DebugImports)
                 |> addMethodGeneratedAttrs 
 
-            let props, meths = mkMethodsAndPropertiesForFields (addMethodGeneratedAttrs, addPropertyGeneratedAttrs) cud.cudReprAccess cud.cudWhere cud.cudHasHelpers baseTy alt.FieldDefs                 
+            let props, meths = mkMethodsAndPropertiesForFields (addMethodGeneratedAttrs, addPropertyGeneratedAttrs) cud.UnionCasesAccessibility cud.DebugPoint cud.DebugImports cud.HasHelpers baseTy alt.FieldDefs                 
             yield (fields,([ctor] @ meths),props) ]
          |> List.unzip3
          |> (fun (a,b,c) -> List.concat a, List.concat b, List.concat c)
@@ -975,18 +984,20 @@ let mkClassUnionDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addProp
     let ctorMeths =
         if (List.isEmpty selfFields && List.isEmpty tagFieldsInObject && not (List.isEmpty selfMeths))
             || isStruct
-            ||  cud.cudAlternatives |> Array.forall (fun alt -> repr.RepresentAlternativeAsFreshInstancesOfRootClass (info,alt))  then 
+            ||  cud.UnionCases |> Array.forall (fun alt -> repr.RepresentAlternativeAsFreshInstancesOfRootClass (info,alt))  then 
 
             [] (* no need for a second ctor in these cases *)
 
         else 
+            let baseTySpec = (match td.Extends with None -> ilg.typ_Object | Some ilTy -> ilTy).TypeSpec
             [ mkILSimpleStorageCtor 
-                 (cud.cudWhere,
-                  Some (match td.Extends with None -> ilg.typ_Object | Some ilTy -> ilTy).TypeSpec,
+                 (Some baseTySpec,
                   baseTy,
                   [],
                   tagFieldsInObject,
-                  ILMemberAccess.Assembly) // cud.cudReprAccess)
+                  ILMemberAccess.Assembly,
+                  cud.DebugPoint,
+                  cud.DebugImports) 
               |> addMethodGeneratedAttrs ]
 
     // Now initialize the constant fields wherever they are stored... 
@@ -1010,29 +1021,31 @@ let mkClassUnionDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addProp
                       else
                           yield mkNormalNewobj (mkILCtorMethSpecForTy (altTy,[])) 
                   yield mkNormalStsfld constFieldSpec ]
-              cud.cudWhere
+              cud.DebugPoint
+              cud.DebugImports
               cd
 
     let tagMeths, tagProps, tagEnumFields = 
         let tagFieldType = mkTagFieldType ilg cuspec
         let tagEnumFields = 
-            cud.cudAlternatives 
+            cud.UnionCases 
             |> Array.mapi (fun num alt -> mkILLiteralField (alt.Name, tagFieldType, ILFieldInit.Int32 num, None, ILMemberAccess.Public))
             |> Array.toList
 
         
         let tagMeths,tagProps = 
 
-          let body = mkMethodBody(true,[],2,genWith (fun cg -> emitLdDataTagPrim ilg (Some mkLdarg0) cg (true, cuspec); cg.EmitInstr I_ret), cud.cudWhere)
+          let code = genWith (fun cg -> emitLdDataTagPrim ilg (Some mkLdarg0) cg (true, cuspec); cg.EmitInstr I_ret)
+          let body = mkMethodBody(true, [], 2, code, cud.DebugPoint, cud.DebugImports)
           // // If we are using NULL as a representation for an element of this type then we cannot 
           // // use an instance method 
           if (repr.RepresentOneAlternativeAsNull info) then
-              [ mkILNonGenericStaticMethod("Get" + tagPropertyName,cud.cudHelpersAccess,[mkILParamAnon baseTy],mkILReturn tagFieldType,body)
+              [ mkILNonGenericStaticMethod("Get" + tagPropertyName,cud.HelpersAccessibility,[mkILParamAnon baseTy],mkILReturn tagFieldType,body)
                 |> addMethodGeneratedAttrs ], 
               [] 
 
           else
-              [ mkILNonGenericInstanceMethod("get_" + tagPropertyName,cud.cudHelpersAccess,[],mkILReturn tagFieldType,body) 
+              [ mkILNonGenericInstanceMethod("get_" + tagPropertyName,cud.HelpersAccessibility,[],mkILReturn tagFieldType,body) 
                 |> addMethodGeneratedAttrs ], 
           
               [ ILPropertyDef(name = tagPropertyName,
@@ -1050,7 +1063,7 @@ let mkClassUnionDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addProp
         tagMeths, tagProps, tagEnumFields
 
     // The class can be abstract if each alternative is represented by a derived type
-    let isAbstract = (altTypeDefs.Length = cud.cudAlternatives.Length)        
+    let isAbstract = (altTypeDefs.Length = cud.UnionCases.Length)        
 
     let existingMeths = td.Methods.AsList 
     let existingProps = td.Properties.AsList
@@ -1076,7 +1089,7 @@ let mkClassUnionDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addProp
                           events=emptyILEvents,
                           properties=emptyILProperties,
                           customAttrs= emptyILCustomAttrs)
-                      .WithNestedAccess(cud.cudReprAccess)
+                      .WithNestedAccess(cud.UnionCasesAccessibility)
                       .WithAbstract(true)
                       .WithSealed(true)
                       .WithImport(false)

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -768,8 +768,8 @@ module IncrementalBuilderHelpers =
                 return frameworkTcImports
           }
 
-        let tcInitial = GetInitialTcEnv (assemblyName, rangeStartup, tcConfig, tcImports, tcGlobals)
-        let tcState = GetInitialTcState (rangeStartup, assemblyName, tcConfig, tcGlobals, tcImports, niceNameGen, tcInitial)
+        let tcInitial, openDecls0 = GetInitialTcEnv (assemblyName, rangeStartup, tcConfig, tcImports, tcGlobals)
+        let tcState = GetInitialTcState (rangeStartup, assemblyName, tcConfig, tcGlobals, tcImports, niceNameGen, tcInitial, openDecls0)
         let loadClosureErrors =
            [ match loadClosureOpt with
              | None -> ()

--- a/src/fsharp/symbols/Exprs.fs
+++ b/src/fsharp/symbols/Exprs.fs
@@ -1341,7 +1341,7 @@ and FSharpImplementationFileContents(cenv, mimpl) =
 
     and getDecls mdef = 
         match mdef with 
-        | TMDefRec(_isRec, tycons, mbinds, _m) ->
+        | TMDefRec(_isRec, _opens, tycons, mbinds, _m) ->
             [ for tycon in tycons do 
                   let entity = FSharpEntity(cenv, mkLocalEntityRef tycon)
                   yield FSharpImplementationFileDeclaration.Entity(entity, []) 
@@ -1355,6 +1355,8 @@ and FSharpImplementationFileContents(cenv, mimpl) =
         | TMAbstract mexpr -> getDecls2 mexpr
         | TMDefLet(bind, _m)  ->
             [ yield getBind bind  ]
+        | TMDefOpens _ ->
+            [ ]
         | TMDefDo(expr, _m)  ->
             [ let expr = FSharpExprConvert.ConvExprOnDemand cenv (ExprTranslationEnv.Empty(cenv.g)) expr
               yield FSharpImplementationFileDeclaration.InitAction expr  ]

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -10481,3 +10481,29 @@ FSharp.Compiler.Xml.XmlDoc: System.String[] GetElaboratedXmlLines()
 FSharp.Compiler.Xml.XmlDoc: System.String[] UnprocessedLines
 FSharp.Compiler.Xml.XmlDoc: System.String[] get_UnprocessedLines()
 FSharp.Compiler.Xml.XmlDoc: Void .ctor(System.String[], FSharp.Compiler.Text.Range)
+FSharp.Compiler.AbstractIL.IL+ILDebugImport+ImportNamespace: System.String get_targetNamespace()
+FSharp.Compiler.AbstractIL.IL+ILDebugImport+ImportNamespace: System.String targetNamespace
+FSharp.Compiler.AbstractIL.IL+ILDebugImport+ImportType: ILType get_targetType()
+FSharp.Compiler.AbstractIL.IL+ILDebugImport+ImportType: ILType targetType
+FSharp.Compiler.AbstractIL.IL+ILDebugImport+Tags: Int32 ImportNamespace
+FSharp.Compiler.AbstractIL.IL+ILDebugImport+Tags: Int32 ImportType
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: Boolean IsImportNamespace
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: Boolean IsImportType
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: Boolean get_IsImportNamespace()
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: Boolean get_IsImportType()
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: FSharp.Compiler.AbstractIL.IL+ILDebugImport+ImportNamespace
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: FSharp.Compiler.AbstractIL.IL+ILDebugImport+ImportType
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: FSharp.Compiler.AbstractIL.IL+ILDebugImport+Tags
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: ILDebugImport NewImportNamespace(System.String)
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: ILDebugImport NewImportType(ILType)
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: Int32 Tag
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: Int32 get_Tag()
+FSharp.Compiler.AbstractIL.IL+ILDebugImport: System.String ToString()
+FSharp.Compiler.AbstractIL.IL+ILDebugImports: ILDebugImport[] Imports
+FSharp.Compiler.AbstractIL.IL+ILDebugImports: ILDebugImport[] get_Imports()
+FSharp.Compiler.AbstractIL.IL+ILDebugImports: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.AbstractIL.IL+ILDebugImports] Parent
+FSharp.Compiler.AbstractIL.IL+ILDebugImports: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.AbstractIL.IL+ILDebugImports] get_Parent()
+FSharp.Compiler.AbstractIL.IL+ILDebugImports: System.String ToString()
+FSharp.Compiler.AbstractIL.IL+ILDebugImports: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.AbstractIL.IL+ILDebugImports], ILDebugImport[])
+FSharp.Compiler.AbstractIL.IL: FSharp.Compiler.AbstractIL.IL+ILDebugImport
+FSharp.Compiler.AbstractIL.IL: FSharp.Compiler.AbstractIL.IL+ILDebugImports

--- a/tests/service/data/TestTP/ProvidedTypes.fs
+++ b/tests/service/data/TestTP/ProvidedTypes.fs
@@ -2530,7 +2530,7 @@ module internal AssemblyReader =
 
 
 #if DEBUG_INFO
-    type ILSourceMarker =
+    type ILDebugPoint =
         { sourceDocument: ILSourceDocument;
           sourceLine: int;
           sourceColumn: int;
@@ -2650,7 +2650,7 @@ module internal AssemblyReader =
 
       | I_break 
 #if EMIT_DEBUG_INFO
-      | I_seqpoint of ILSourceMarker
+      | I_seqpoint of ILDebugPoint
 #endif
       | I_arglist  
 
@@ -2710,7 +2710,7 @@ module internal AssemblyReader =
           Locals: ILLocals
           Code:  ILCode
 #if EMIT_DEBUG_INFO
-          SourceMarker: ILSourceMarker option 
+          DebugPoint: ILDebugPoint option 
 #endif
          }
 
@@ -10824,7 +10824,7 @@ namespace ProviderImplementation.ProvidedTypes
             member codebuf.EmitExceptionClause seh = codebuf.seh.Add(seh)
 
 #if DEBUG_INFO
-            member codebuf.EmitSeqPoint cenv (m:ILSourceMarker)  = ()
+            member codebuf.EmitSeqPoint cenv (m:ILDebugPoint)  = ()
                 if cenv.generatePdb then 
                   // table indexes are 1-based, document array indexes are 0-based 
                   let doc = (cenv.documents.FindOrAddSharedEntry m.Document) - 1  
@@ -11828,7 +11828,7 @@ namespace ProviderImplementation.ProvidedTypes
                         Params= [| |] (* REVIEW *)
                         RootScope = Some rootScope
                         Range=  
-                          match ilmbody.SourceMarker with 
+                          match ilmbody.DebugPoint with 
                           | Some m  when cenv.generatePdb -> 
                               // table indexes are 1-based, document array indexes are 0-based 
                               let doc = (cenv.documents.FindOrAddSharedEntry m.Document) - 1 

--- a/tests/service/data/TestTP/ProvidedTypes.fs
+++ b/tests/service/data/TestTP/ProvidedTypes.fs
@@ -10806,7 +10806,7 @@ namespace ProviderImplementation.ProvidedTypes
               /// data for exception handling clauses 
               mutable seh: ResizeArray<ExceptionClauseSpec>
 #if DEBUG_INFO
-              seqpoints: ResizeArray<PdbSequencePoint> 
+              seqpoints: ResizeArray<PdbDebugPoint> 
 #endif
              }
 
@@ -11001,7 +11001,7 @@ namespace ProviderImplementation.ProvidedTypes
                   tab
               let newReqdStringFixups = Array.map (fun (origFixupLoc, stok) -> adjuster origFixupLoc, stok) origReqdStringFixups
 #if EMIT_DEBUG_INFO
-              let newSeqPoints = Array.map (fun (sp:PdbSequencePoint) -> {sp with Offset=adjuster sp.Offset}) origSeqPoints
+              let newSeqPoints = Array.map (fun (sp:PdbDebugPoint) -> {sp with Offset=adjuster sp.Offset}) origSeqPoints
 #endif
               let newExnClauses = 
                   origExnClauses |> Array.map (fun (st1, sz1, st2, sz2, kind) ->
@@ -11840,7 +11840,7 @@ namespace ProviderImplementation.ProvidedTypes
                                       Line=m.EndLine
                                       Column=m.EndColumn })
                           | _ -> None
-                        SequencePoints=seqpoints }
+                        DebugPoints=seqpoints }
 #endif
 
                   cenv.AddCode code
@@ -11856,7 +11856,7 @@ namespace ProviderImplementation.ProvidedTypes
                         Params = [| |]
                         RootScope = None
                         Range = None
-                        SequencePoints = [| |] }
+                        DebugPoints = [| |] }
                   0x0000
               | MethodBody.Native -> 
                   failwith "cannot write body of native method - Abstract IL cannot roundtrip mixed native/managed binaries"


### PR DESCRIPTION
This is cleanup and preparatory work for adding 'open' declarations to information known at debug time
related to very long-standing bug #1003 

* [x] Collect information about "open" declarations during checking
* [x] Cleanup

Some issues arise when actually propagating this information into the PDB - see the comments at the end of the PR.  However the cleanup and information-plumbing is a good basis for future work on debugging (and I'd like to get it in as a basis for fixing other debugging bugs we have - it would be much easier not to handle the conflicts, and the code is now quite a lot cleaner)

NOTE: the original version of this PR also emitted the information into the PDB.