### PR TITLE
Parser: produce attributes without owner

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1329,7 +1329,7 @@ moduleDefn:
   /* unattached custom attributes */
   | attributes recover
       { errorR(Error(FSComp.SR.parsAttributeOnIncompleteCode(), rhs parseState 1))
-        [] }
+        [ SynModuleDecl.Attributes($1, rhs parseState 1) ] }
 
   /* 'open' declarations */
   | openDecl


### PR DESCRIPTION
Prevents attributes from being thrown away when there's no attributes owner (yet).

Let's see if it breaks anything on CI.