### PR TITLE
Prevent inaccessible members from appearing in tooltips

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1733,7 +1733,7 @@ module private TastDefinitionPrinting =
                 match tcref.TypeReprInfo with 
                 | TProvidedTypeExtensionPoint info ->
                     [ 
-                        for nestedType in info.ProvidedType.PApplyArray((fun sty -> sty.GetNestedTypes() |> Array.filter (fun t -> t.IsPublic)), "GetNestedTypes", m) do 
+                        for nestedType in info.ProvidedType.PApplyArray((fun sty -> sty.GetNestedTypes() |> Array.filter (fun t -> t.IsPublic || t.IsNestedPublic)), "GetNestedTypes", m) do 
                             yield nestedType.PUntaint((fun t -> t.IsClass, t.Name), m)
                     ] 
                     |> List.sortBy snd

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -24,6 +24,7 @@ open FSharp.Compiler.Xml
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.AccessibilityLogic
 
 open FSharp.Core.Printf
 
@@ -1629,7 +1630,7 @@ module private TastDefinitionPrinting =
 
         let ctors =
             GetIntrinsicConstructorInfosOfType infoReader m ty
-            |> List.filter (fun v -> not v.IsClassConstructor && shouldShow v.ArbitraryValRef)
+            |> List.filter (fun v -> IsMethInfoAccessible amap m ad v && not v.IsClassConstructor && shouldShow v.ArbitraryValRef)
 
         let iimplsLs =
             if suppressInheritanceAndInterfacesForTyInSimplifiedDisplays g amap m ty then 
@@ -1702,7 +1703,7 @@ module private TastDefinitionPrinting =
                 []
             else
                 tycon.TrueFieldsAsList
-                |> List.filter (fun f -> f.IsStatic && not (isDiscard f.Name))
+                |> List.filter (fun f -> IsAccessible ad f.Accessibility && f.IsStatic && not (isDiscard f.Name))
                 |> List.map (fun f -> WordL.keywordStatic ^^ WordL.keywordVal ^^ layoutRecdField true denv infoReader tcref f)
 
         let instanceValsLs =
@@ -1710,7 +1711,7 @@ module private TastDefinitionPrinting =
                 []
             else
                 tycon.TrueInstanceFieldsAsList
-                |> List.filter (fun f -> not (isDiscard f.Name))
+                |> List.filter (fun f -> IsAccessible ad f.Accessibility && not (isDiscard f.Name))
                 |> List.map (fun f -> WordL.keywordVal ^^ layoutRecdField true denv infoReader tcref f)
     
         let propLs =
@@ -1732,7 +1733,7 @@ module private TastDefinitionPrinting =
                 match tcref.TypeReprInfo with 
                 | TProvidedTypeExtensionPoint info ->
                     [ 
-                        for nestedType in info.ProvidedType.PApplyArray((fun sty -> sty.GetNestedTypes()), "GetNestedTypes", m) do 
+                        for nestedType in info.ProvidedType.PApplyArray((fun sty -> sty.GetNestedTypes() |> Array.filter (fun t -> t.IsPublic)), "GetNestedTypes", m) do 
                             yield nestedType.PUntaint((fun t -> t.IsClass, t.Name), m)
                     ] 
                     |> List.sortBy snd

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -1103,7 +1103,7 @@ type internal TypeCheckInfo
                         |> Option.map (fun x -> x.ParseTree)
                         |> Option.map (fun parsedInput -> ParsedInput.GetFullNameOfSmallestModuleOrNamespaceAtPoint(mkPos line 0, parsedInput))
                     let isAttributeApplication = ctx = Some CompletionContext.AttributeApplication
-                    DeclarationListInfo.Create(infoReader,m,denv,getAccessibility,items,currentNamespaceOrModule,isAttributeApplication))
+                    DeclarationListInfo.Create(infoReader,tcAccessRights,m,denv,getAccessibility,items,currentNamespaceOrModule,isAttributeApplication))
             (fun msg ->
                 Trace.TraceInformation(sprintf "FCS: recovering from error in GetDeclarations: '%s'" msg)
                 DeclarationListInfo.Error msg)
@@ -1253,7 +1253,7 @@ type internal TypeCheckInfo
                     match declItemsOpt with
                     | None -> ToolTipText []
                     | Some(items, denv, _, m) ->
-                         ToolTipText(items |> List.map (fun x -> FormatStructuredDescriptionOfItem false infoReader m denv x.ItemWithInst)))
+                         ToolTipText(items |> List.map (fun x -> FormatStructuredDescriptionOfItem false infoReader tcAccessRights m denv x.ItemWithInst)))
 
                 (fun err ->
                     Trace.TraceInformation(sprintf "FCS: recovering from error in GetStructuredToolTipText: '%s'" err)
@@ -1325,7 +1325,7 @@ type internal TypeCheckInfo
                         match ctors with
                         | [] -> items
                         | ctors -> ctors
-                    MethodGroup.Create(infoReader, m, denv, items |> List.map (fun x -> x.ItemWithInst)))
+                    MethodGroup.Create(infoReader, tcAccessRights, m, denv, items |> List.map (fun x -> x.ItemWithInst)))
             (fun msg ->
                 Trace.TraceInformation(sprintf "FCS: recovering from error in GetMethods: '%s'" msg)
                 MethodGroup(msg,[| |]))

--- a/src/fsharp/service/ServiceDeclarationLists.fsi
+++ b/src/fsharp/service/ServiceDeclarationLists.fsi
@@ -10,6 +10,7 @@ open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
+open FSharp.Compiler.AccessibilityLogic
 
 /// A single data tip display element
 [<RequireQualifiedAccess>]
@@ -135,6 +136,7 @@ type public DeclarationListInfo =
     // Implementation details used by other code in the compiler    
     static member internal Create:
         infoReader:InfoReader * 
+        ad:AccessorDomain *
         m:range * 
         denv:DisplayEnv * 
         getAccessibility:(Item -> FSharpAccessibility) * 
@@ -202,10 +204,10 @@ type public MethodGroup =
     /// The methods (or other items) in the group
     member Methods: MethodGroupItem[] 
 
-    static member internal Create: InfoReader * range * DisplayEnv * ItemWithInst list -> MethodGroup
+    static member internal Create: InfoReader * AccessorDomain * range * DisplayEnv * ItemWithInst list -> MethodGroup
 
 module internal DeclarationListHelpers =
-    val FormatStructuredDescriptionOfItem: isDecl:bool -> InfoReader -> range -> DisplayEnv -> ItemWithInst -> ToolTipElement
+    val FormatStructuredDescriptionOfItem: isDecl:bool -> InfoReader -> AccessorDomain -> range -> DisplayEnv -> ItemWithInst -> ToolTipElement
 
     val RemoveDuplicateCompletionItems: TcGlobals -> CompletionItem list -> CompletionItem list
 

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -2070,8 +2070,7 @@ query."
               "  new : unit -> unit + 1 overload"
               "  member Next : unit -> int + 2 overloads";  
               "  member NextBytes : buffer: byte [] -> unit";
-              "  member NextDouble : unit -> float";
-              "  member Sample : unit -> float";]
+              "  member NextDouble : unit -> float"]
             )
 
     [<Test>]
@@ -2092,7 +2091,6 @@ query."
     /// Bug 4624: Check the order in which members are printed, C# classes
     [<Test>]
     member public this.``Regression.Class.Printing.CSharp.Classes.Bug4624``() =
-        //let f (x:System.Security.Policy.CodeConnectAccess) = x.
         this.AssertMemberDataTipContainsInOrder
             ((*code *)
               ["#light";
@@ -2104,16 +2102,13 @@ query."
              (* expect to see in order... *)
              // Pre fix output is mixed up
              [ "type CodeConnectAccess =";
-               "  new : allowScheme: string * allowPort: int -> unit + 2 overloads";
+               "  new : allowScheme: string * allowPort: int -> unit";
                "  member Equals : o: obj -> bool";
                "  member GetHashCode : unit -> int";
                "  static member CreateAnySchemeAccess : allowPort: int -> CodeConnectAccess";
                "  static member CreateOriginSchemeAccess : allowPort: int -> CodeConnectAccess";
-               "  static member IsValidScheme : scheme: string -> bool";
-               "  static val AnyPort : int";
                "  static val AnyScheme : string";
                "  static val DefaultPort : int";
-               "  static val NoPort : int";
                "  ...";
              ])
 


### PR DESCRIPTION
Tooltips would display private members which they shouldn't; they should only show what is accessible. Pretty easy fix by plumbing `AccessorDomain` around.

Before:
![before](https://user-images.githubusercontent.com/1278959/131057209-e0ce9f51-0c6b-400e-8acb-069b77b6f3b0.png)

After:
![after](https://user-images.githubusercontent.com/1278959/131057228-f9cd843e-cc23-4ced-afc3-ccd8d895f1f3.png)
