### PR TITLE
Parser: better tree for unfinished paren patterns

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -3149,9 +3149,9 @@ atomicPatsOrNamePatPairs:
       { SynArgPats.NamePatPairs $2, snd $2 }
 
   | atomicPatterns
-      { let mWhole = rhs parseState 1
-        let m = (mWhole.StartRange, $1) ||> unionRangeWithListBy (fun p -> p.Range)
-        SynArgPats.Pats $1, m }
+      { let mParsed = rhs parseState 1
+        let mAll = (mParsed.StartRange, $1) ||> unionRangeWithListBy (fun p -> p.Range)
+        SynArgPats.Pats $1, mAll }
 
 atomicPatterns: 
   | atomicPattern atomicPatterns %prec pat_args 
@@ -3209,20 +3209,26 @@ atomicPattern:
   | NULL 
       { SynPat.Null(lhs parseState) }
 
-  | LPAREN parenPatternBody rparen 
-      { let m = (lhs parseState)
-        SynPat.Paren($2 m, m) } 
+  | LPAREN parenPatternBody rparen
+      { let m = lhs parseState
+        SynPat.Paren($2 m, m) }
 
-  | LPAREN parenPatternBody recover 
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen()) 
-        patFromParseError ($2 (rhs2 parseState 1 2)) }
+  | LPAREN parenPatternBody recover
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
+        let m = rhs2 parseState 1 2
+        let parenPat = SynPat.Paren($2 m, m)
+        patFromParseError parenPat }
 
-  | LPAREN error rparen 
-      { (* silent recovery *) SynPat.Wild (lhs parseState) }
+  | LPAREN error rparen
+      { let innerPat = patFromParseError (SynPat.Wild (rhs parseState 2))
+        SynPat.Paren(innerPat, lhs parseState) }
 
-  | LPAREN recover 
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen()) 
-        SynPat.Wild (lhs parseState)}  
+  | LPAREN recover
+      { let parenM = rhs parseState 1
+        reportParseErrorAt parenM (FSComp.SR.parsUnmatchedParen())
+        let innerPat = patFromParseError (SynPat.Wild parenM.EndRange)
+        let parenPat = SynPat.Paren(innerPat, parenM)
+        patFromParseError parenPat }
 
   | STRUCT LPAREN tupleParenPatternElements rparen
       { SynPat.Tuple(true, List.rev $3, lhs parseState) }

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -1003,9 +1003,8 @@ module ParsedInput =
                         | SynPat.LongIdent(_, _, _, ctorArgs, _, _) ->
                             match ctorArgs with
                             | SynArgPats.Pats pats ->
-                                pats |> List.tryPick (fun pat ->
+                                pats |> List.tryPick (fun (SkipFromParseErrorPat pat) ->
                                     match pat with
-                                    | SynPat.FromParseError(pat, _)
                                     | SynPat.Paren(pat, _) -> 
                                         match pat with
                                         | SynPat.Tuple(_, pats, _) ->

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -257,10 +257,15 @@ let getSingleModuleMemberDecls (input: ParsedInput) =
     let (SynModuleOrNamespace (decls = decls)) = getSingleModuleLikeDecl input
     decls
 
-let getSingleExprInModule (input: ParsedInput) =
+let getSingleDeclInModule (input: ParsedInput) =
     match getSingleModuleMemberDecls input with
-    | [ SynModuleDecl.DoExpr (_, expr, _) ] -> expr
-    | _ -> failwith "Can't get single expression"
+    | [ decl ] -> decl
+    | _ -> failwith "Can't get single module member declaration"
+
+let getSingleExprInModule (input: ParsedInput) =
+    match getSingleDeclInModule input with
+    | SynModuleDecl.DoExpr (_, expr, _) -> expr
+    | _ -> failwith "Unexpected expression"
 
 
 let parseSourceCodeAndGetModule (source: string) =

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -104,6 +104,38 @@ match () with
     | _ -> failwith "Unexpected tree"
 
 [<Test>]
+let ``Match clause 06`` () =
+    let parseResults = getParseResults """
+match () with
+| (x
+| y -> ()
+"""
+
+    match getSingleExprInModule parseResults with
+    | SynExpr.Match (_, _, [ SynMatchClause (pat = pat) ], _) ->
+        match pat with
+        | SynPat.FromParseError (SynPat.Paren (SynPat.Or (SynPat.Named _, SynPat.Named _, _), _), _) -> ()
+        | _ -> failwith "Unexpected pattern"
+    | _ -> failwith "Unexpected tree"
+
+[<Test>]
+let ``Match clause 07`` () =
+    let parseResults = getParseResults """
+match () with
+| (x,
+| y -> ()
+"""
+
+    match getSingleExprInModule parseResults with
+    | SynExpr.Match (_, _, [ SynMatchClause (pat = pat) ], _) ->
+        match pat with
+        | SynPat.Or
+            (SynPat.FromParseError (SynPat.Paren (SynPat.FromParseError (SynPat.Wild _, _), _), _),
+             SynPat.Named _, _) -> ()
+        | _ -> failwith "Unexpected pattern"
+    | _ -> failwith "Unexpected tree"
+
+[<Test>]
 let ``Let - Parameter - Paren 01`` () =
     let parseResults = getParseResults """
 let f (x
@@ -129,3 +161,15 @@ let f (x, y
         | _ -> failwith "Unexpected tree"
     | _ -> failwith "Unexpected tree"
 
+[<Test>]
+let ``Let - Parameter - Paren 03 - Tuple`` () =
+    let parseResults = getParseResults """
+let f (x,
+"""
+
+    match getSingleDeclInModule parseResults with
+    | SynModuleDecl.Let (_, [ SynBinding (headPat = SynPat.LongIdent (argPats = SynArgPats.Pats [ pat ])) ], _) ->
+        match pat with
+        | SynPat.FromParseError (SynPat.Paren (SynPat.FromParseError (SynPat.Wild _, _), _), _) -> ()
+        | _ -> failwith "Unexpected tree"
+    | _ -> failwith "Unexpected tree"

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -102,3 +102,30 @@ match () with
     | SynExpr.Match (_, _, [ SynMatchClause (_, _, _, SynExpr.ArbitraryAfterError _, _, _)
                              SynMatchClause (_, _, _, SynExpr.Const _, _, _) ], _) -> ()
     | _ -> failwith "Unexpected tree"
+
+[<Test>]
+let ``Let - Parameter - Paren 01`` () =
+    let parseResults = getParseResults """
+let f (x
+"""
+
+    match getSingleDeclInModule parseResults with
+    | SynModuleDecl.Let (_, [ SynBinding (headPat = headPat) ], _) ->
+        match headPat with
+        | SynPat.LongIdent (_, _, _, SynArgPats.Pats [ SynPat.FromParseError (SynPat.Paren (SynPat.Named _, _), _) ], _, _) -> ()
+        | _ -> failwith "Unexpected tree"
+    | _ -> failwith "Unexpected tree"
+
+[<Test>]
+let ``Let - Parameter - Paren 02 - Tuple`` () =
+    let parseResults = getParseResults """
+let f (x, y
+"""
+
+    match getSingleDeclInModule parseResults with
+    | SynModuleDecl.Let (_, [ SynBinding (headPat = headPat) ], _) ->
+        match headPat with
+        | SynPat.LongIdent (_, _, _, SynArgPats.Pats [ SynPat.FromParseError (SynPat.Paren (SynPat.Tuple _, _), _) ], _, _) -> ()
+        | _ -> failwith "Unexpected tree"
+    | _ -> failwith "Unexpected tree"
+


### PR DESCRIPTION
In the following examples `(` parens or `struct (` were ignored:

```fsharp
let f1 (x

let f2 (x, y
```

PR makes it properly produce paren patterns.