### PR TITLE
Support the `TargetsTriggeredByCompilation` MSBuild property.

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -339,6 +339,7 @@ this file.
             <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />
         </ItemGroup>
 
+       <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
     </Target>
 
     <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />


### PR DESCRIPTION
Fixes #10141.

The change is simple; a one-line copy from `Microsoft.CSharp.Core.targets`.