### PR TITLE
Enable parallelism for VS find-all-refs

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -39,7 +39,7 @@ module internal SymbolHelpers =
     let getSymbolUsesInProjects (symbol: FSharpSymbol, projects: Project list, onFound: Document -> TextSpan -> range -> Async<unit>) =
         projects
         |> Seq.map (fun project -> project.FindFSharpReferencesAsync(symbol, onFound, "getSymbolUsesInProjects"))
-        |> Async.Sequential
+        |> Async.Parallel
 
     let getSymbolUsesInSolution (symbol: FSharpSymbol, declLoc: SymbolDeclarationLocation, checkFileResults: FSharpCheckFileResults, solution: Solution) =
         async {


### PR DESCRIPTION
Our find-all-refs feature in VS was sequential largely due to large number of allocations happening all at once; we were 32-bit then and could not risk trying to do this in parallel without OOMing.

With 64-bit VS, we can enable this now.