### PR TITLE
Parser: include binding augmentation in ObjExpr members

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1747,7 +1747,8 @@ memberCore:
                            { attrList with Attributes = attrList.Attributes |> List.map (fun a -> { a with AppliesToGetterAndSetter = true } ) })
 
                    let attrs = attrs @ optAttrs
-                   
+                   let mBindLhs = unionRanges rangeStart mBindLhs
+
                    let binding = bindingBuilder (visNoLongerUsed, optInline, isMutable, mBindLhs, DebugPointAtBinding.NoneAtInvisible, optReturnType, expr, exprm, [], attrs, Some (memFlagsBuilder SynMemberKind.Member))
                    let (SynBinding (vis, _, isInline, _, attrs, doc, valSynData, pv, _, _, mBindLhs, spBind)) = binding 
                    let memberKind = 


### PR DESCRIPTION
In the following expression the `P` property range doesn't include the member part and only includes the accessor range:
```fsharp
{ new I with
    member this.P with get () = () }
```

This PR unions the range with the member augmentation range passed externally.