### PR TITLE
Let compiler run on more restrictive platforms like WASM

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -3290,7 +3290,7 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
             match tryType (mkCoerceExpr(expr, ty, expr.Range, exprty), ty) with
             | Result res -> Some res
             | Exception e ->
-                PreserveStackTrace e
+                let e = PreserveStackTrace e
                 raise e
         else None
 
@@ -3305,7 +3305,7 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
     match probe ienumerable with
     | Some res -> res
     | None ->
-    PreserveStackTrace e
+    let e = PreserveStackTrace e
     raise e
 
 // Used inside sequence expressions

--- a/src/fsharp/ErrorLogger.fsi
+++ b/src/fsharp/ErrorLogger.fsi
@@ -174,7 +174,7 @@ module ErrorLoggerExtensions =
     val tryAndDetectDev15: bool
 
     /// Instruct the exception not to reset itself when thrown again.
-    val PreserveStackTrace: exn:'a -> unit
+    val PreserveStackTrace: exn:#exn -> exn
 
     /// Reraise an exception if it is one we want to report to Watson.
     val ReraiseIfWatsonable: exn:exn -> unit

--- a/src/fsharp/InnerLambdasToTopLevelFuncs.fs
+++ b/src/fsharp/InnerLambdasToTopLevelFuncs.fs
@@ -33,7 +33,7 @@ module Zmap =
         try Zmap.find k mp
         with e ->
             dprintf "Zmap.force: %s %s\n" str (soK k)
-            PreserveStackTrace e
+            let e = PreserveStackTrace e
             raise e
 
 //-------------------------------------------------------------------------

--- a/src/fsharp/SimulatedMSBuildReferenceResolver.fs
+++ b/src/fsharp/SimulatedMSBuildReferenceResolver.fs
@@ -55,6 +55,9 @@ let private SimulatedMSBuildResolver =
     /// Get the path to the .NET Framework implementation assemblies by using ToolLocationHelper.GetPathToDotNetFramework
     /// This is only used to specify the "last resort" path for assembly resolution.
     let GetPathToDotNetFrameworkImlpementationAssemblies v =
+        match int Environment.OSVersion.Platform with
+        | 7 -> [] // The platform is "other", so ToolLocationHelper probably won't be very helpful.
+        | _ ->
         let v =
             match v with
             | Net45 ->  Some TargetDotNetFrameworkVersion.Version45

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -176,7 +176,7 @@ module CompileHelpers =
                 match exec() with 
                 | None -> ()
                 | Some exn -> 
-                    PreserveStackTrace(exn)
+                    let exn = PreserveStackTrace(exn)
                     raise exn
 
         // Register the reflected definitions for the dynamically generated assembly

--- a/src/fsharp/utils/CompilerLocationUtils.fs
+++ b/src/fsharp/utils/CompilerLocationUtils.fs
@@ -370,7 +370,8 @@ module internal FSharpEnvironment =
     let getDefaultFsiLibraryLocation() = Path.Combine(getFSharpCompilerLocation(), fsiLibraryName + ".dll")
 
     // Path to the directory containing the fsharp compilers
-    let fsharpCompilerPath = Path.Combine(Path.GetDirectoryName(typeof<TypeInThisAssembly>.GetTypeInfo().Assembly.Location), "Tools")
+    //let fsharpCompilerPath = Path.Combine(Path.GetDirectoryName(typeof<TypeInThisAssembly>.GetTypeInfo().Assembly.Location), "Tools")
+    // ^^ that isn't actually *used* anywhere
 
     let isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 


### PR DESCRIPTION
This PR does a couple of things:
- It marks as `lazy` most accesses anything in `System.Diagnostics.Process`
  - Most of these are not actually needed for embedded compilation anyway, so this doesn't cause any issues for basic usage
- It tests `Environment.OSVersion.Platform` in `GetPathToDotNetFrameworkImlpementationAssemblies ` so that it doesn't call into MSBuild utilities on the `Other` platform, as that tries to spin up some threads which access `System.Diagnostics.Process` and cause errors when running in Blazor.
- It rethrows more internal exceptions in a way that is more debuggable from the outside, preserving stack traces from deep internal errors.
- It removes `FSharpEnvironment.fsharpCompilerPath` because it was not used, and its eager evaluation caused errors in Blazor.

I am almost certain that this will need a little bit of cleanup or refactoring, but the increased portability would be incredibly nice to have.
