### PR TITLE
Update SDK to the latest public version (rc1)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.7.21379.14",
+    "version": "6.0.100-rc.1.21458.32",
     "allowPrerelease": true,
     "rollForward": "minor"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.7.21379.14",
+    "dotnet": "6.0.100-rc.1.21458.32",
     "vs": {
       "version": "16.8",
       "components": [


### PR DESCRIPTION
This will fail until FSharp.Core 6 NuGet is uploaded to a nuget repo.