### PR TITLE
Intern namespace parts

### DIFF
--- a/src/fsharp/absil/il.fs
+++ b/src/fsharp/absil/il.fs
@@ -52,6 +52,17 @@ type PrimaryAssembly =
 // Utilities: type names
 // --------------------------------------------------------------------
 
+/// Global State. All namespace splits ever seen
+// ++GLOBAL MUTABLE STATE (concurrency-safe)
+let memoizeNamespaceTable = ConcurrentDictionary<string, string list>()
+
+//  ++GLOBAL MUTABLE STATE (concurrency-safe)
+let memoizeNamespaceRightTable = ConcurrentDictionary<string, string option * string>()
+
+// ++GLOBAL MUTABLE STATE (concurrency-safe)
+let memoizeNamespacePartTable = ConcurrentDictionary<string, string>()
+
+
 let splitNameAt (nm: string) idx =
     if idx < 0 then failwith "splitNameAt: idx < 0"
     let last = nm.Length - 1
@@ -64,14 +75,8 @@ let rec splitNamespaceAux (nm: string) =
     | -1 -> [nm]
     | idx ->
         let s1, s2 = splitNameAt nm idx
+        let s1 = memoizeNamespacePartTable.GetOrAdd(s1, id)
         s1 :: splitNamespaceAux s2
-
-/// Global State. All namespace splits ever seen
-// ++GLOBAL MUTABLE STATE (concurrency-safe)
-let memoizeNamespaceTable = ConcurrentDictionary<string, string list>()
-
-//  ++GLOBAL MUTABLE STATE (concurrency-safe)
-let memoizeNamespaceRightTable = ConcurrentDictionary<string, string option * string>()
 
 
 let splitNamespace nm =


### PR DESCRIPTION
Adds interning for namespace parts in addition to existing namespace lists interning.

Looking at a memory snapshot with ReSharper.FSharp solution opened, there're many string duplicates coming from `ILPreTypeDefImpl` instances.

<img width="1193" alt="Screenshot 2021-09-20 at 18 25 53" src="https://user-images.githubusercontent.com/3923587/134029145-f6fc9cab-d276-4530-a3f3-d9c9ee659e56.png">

The solution references FCS and ReSharper.SDK, so there are many namespaces starting with common names.

The most of most duplicated strings held by `ILPreTypeDefImpl` instances:

* `JetBrains`: 4500+ instances
* `ReSharper`: 3200+
* `Microsoft`: 900+
* `CodeAnalysis`: 720+
* `Features`: 570+
