### PR TITLE
Make desktop the default again

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -61,6 +61,12 @@ this file.
 
       If Shim helpers are present then the values are valid and set by the Microsoft.FSharp.Helpers.props
     -->
+
+    <!-- Here we set the default value to true when noyhing is set, it will be removed in a future release when we default to the net sdk compiler -->
+    <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true'">
+        <FSharpPreferNetFrameworkTools Condition="'$(FSharpPreferNetFrameworkTools)' == ''">true</FSharpPreferNetFrameworkTools>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true' and '$(FSharpPreferNetFrameworkTools)' == 'true'">
         <FscToolPath>$(Fsc_NetFramework_ToolPath)</FscToolPath>
         <FscToolExe Condition="'$(FSharpPrefer64BitTools)' != 'false'">$(Fsc_NetFramework_AnyCpu_ToolExe)</FscToolExe>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -62,7 +62,7 @@ this file.
       If Shim helpers are present then the values are valid and set by the Microsoft.FSharp.Helpers.props
     -->
 
-    <!-- Here we set the default value to true when noyhing is set, it will be removed in a future release when we default to the net sdk compiler -->
+    <!-- Here we set the default value to true when nothing is set, it will be removed in a future release when we default to the net sdk compiler -->
     <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true'">
         <FSharpPreferNetFrameworkTools Condition="'$(FSharpPreferNetFrameworkTools)' == ''">true</FSharpPreferNetFrameworkTools>
     </PropertyGroup>

--- a/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Default Settings.proj
+++ b/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Default Settings.proj
@@ -9,9 +9,9 @@
   <PropertyGroup>
     <ExpectedFSharpShimPresent>true</ExpectedFSharpShimPresent>
     <ExpectedFSharpCompilerPath>/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFSharpCompilerPath>
-    <ExpectedFscToolExe>dotnet.exe</ExpectedFscToolExe>
-    <ExpectedFscToolPath>/_NetCoreRoot_/</ExpectedFscToolPath>
-    <ExpectedDotnetFscCompilerPath>/FSharp/fsc.dll</ExpectedDotnetFscCompilerPath>
+    <ExpectedFscToolExe>fscAnyCpu.exe</ExpectedFscToolExe>
+    <ExpectedFscToolPath>_VsInstallRoot_/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFscToolPath>
+    <ExpectedDotnetFscCompilerPath></ExpectedDotnetFscCompilerPath>
   </PropertyGroup>
 
   <Import Project="ToolsTest.props" />


### PR DESCRIPTION
This PR breaks my stubborn heart ---

For Visual Studio 2017 we have decided to make the F# desktop compiler the default.  This is because we believe the performance issue with the coreclr compiler is too significant for right now.

We will revisit this decision in a future major release of visual studio.

Fixes: #11941 


