### PR TITLE
add moniker for net6.0

### DIFF
--- a/src/fsharp/utils/CompilerLocationUtils.fs
+++ b/src/fsharp/utils/CompilerLocationUtils.fs
@@ -260,7 +260,7 @@ module internal FSharpEnvironment =
         if typeof<obj>.Assembly.GetName().Name = "mscorlib" then
             [| "net48"; "net472"; "net471";"net47";"net462";"net461"; "net452"; "net451"; "net45"; "netstandard2.0" |]
         elif typeof<obj>.Assembly.GetName().Name = "System.Private.CoreLib" then
-            [| "net5.0"; "netcoreapp3.1"; "netcoreapp3.0"; "netstandard2.1"; "netcoreapp2.2"; "netcoreapp2.1"; "netcoreapp2.0"; "netstandard2.0" |]
+            [| "net6.0"; "net5.0"; "netcoreapp3.1"; "netcoreapp3.0"; "netstandard2.1"; "netcoreapp2.2"; "netcoreapp2.1"; "netcoreapp2.0"; "netstandard2.0" |]
         else
             Debug.Assert(false, "Couldn't determine runtime tooling context, assuming it supports at least .NET Standard 2.0")
             [| "netstandard2.0" |]

--- a/tests/fsharp/TypeProviderTests.fs
+++ b/tests/fsharp/TypeProviderTests.fs
@@ -300,7 +300,9 @@ let splitAssembly subdir project =
 
     // check a few load locations
     let someLoadPaths =
-        [ subdir ++ "fsharp41" ++ "net461"
+        [ subdir ++ "fsharp41" ++ "net48"
+          subdir ++ "fsharp41" ++ "net472"
+          subdir ++ "fsharp41" ++ "net461"
           subdir ++ "fsharp41" ++ "net45"
           // include up one directory
           ".." ++ subdir ++ "fsharp41" ++ "net45"


### PR DESCRIPTION

This isn't critical, but for consistency for type provider loading we should add the "net6.0" moniker to the paths probed when loading type providers.
