### PR TITLE
Name resolution: add Item.UnqualifiedType

### DIFF
--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -126,7 +126,8 @@ type Item =
     | SetterArg of Ident * Item 
 
     /// Represents the potential resolution of an unqualified name to a type.
-    | UnqualifiedType of TyconRef list
+    | UnqualifiedType of TyconRef
+    | UnqualifiedTypes of TyconRef list
 
     /// The text for the item to use in the declaration list.
     /// This does not include backticks, parens etc.

--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -1031,6 +1031,7 @@ type internal TypeCheckInfo
                          | Item.ModuleOrNamespaces _
                          | Item.Types _
                          | Item.UnqualifiedType _
+                         | Item.UnqualifiedTypes _
                          | Item.ExnCase _ -> true
                          | _ -> false), denv, m)
 
@@ -1154,7 +1155,8 @@ type internal TypeCheckInfo
                             match d.Item with
                             | Item.Types (_,TType_app(tcref,_) :: _)
                             | Item.ExnCase tcref -> tcref.LogicalName
-                            | Item.UnqualifiedType(tcref :: _)
+                            | Item.UnqualifiedType tcref
+                            | Item.UnqualifiedTypes(tcref :: _)
                             | Item.FakeInterfaceCtor (TType_app(tcref,_))
                             | Item.DelegateCtor (TType_app(tcref,_)) -> tcref.CompiledName
                             | Item.CtorGroup (_, cinfo :: _) ->

--- a/src/fsharp/service/ItemKey.fs
+++ b/src/fsharp/service/ItemKey.fs
@@ -364,7 +364,8 @@ and [<Sealed>] ItemKeyStoreBuilder() =
         | Item.Types(_, [ty]) ->
             writeType true ty
 
-        | Item.UnqualifiedType [tcref] ->
+        | Item.UnqualifiedType tcref
+        | Item.UnqualifiedTypes [tcref] ->
             writeEntityRef tcref
 
         | Item.MethodGroup(_, [info], _)
@@ -405,7 +406,7 @@ and [<Sealed>] ItemKeyStoreBuilder() =
         | Item.ImplicitOp _ -> ()
         | Item.ArgName _ -> ()
         | Item.SetterArg _ -> ()
-        | Item.UnqualifiedType _ -> ()
+        | Item.UnqualifiedTypes _ -> ()
 
         let postCount = b.Count
 

--- a/src/fsharp/service/SemanticClassification.fs
+++ b/src/fsharp/service/SemanticClassification.fs
@@ -338,7 +338,8 @@ module TcResolutionsExtensions =
                     | Item.SetterArg _, _, _, _, _, m ->
                         add m SemanticClassificationType.Property
 
-                    | Item.UnqualifiedType (tcref :: _), LegitTypeOccurence, _, _, _, m ->
+                    | Item.UnqualifiedType tcref, LegitTypeOccurence, _, _, _, m
+                    | Item.UnqualifiedTypes (tcref :: _), LegitTypeOccurence, _, _, _, m ->
                         if tcref.IsEnumTycon || tcref.IsILEnumTycon then
                             add m SemanticClassificationType.Enumeration
                         elif tcref.IsExceptionDecl then

--- a/src/fsharp/service/ServiceDeclarationLists.fs
+++ b/src/fsharp/service/ServiceDeclarationLists.fs
@@ -364,7 +364,8 @@ module DeclarationListHelpers =
 
         // Types.
         | Item.Types(_, TType_app(tcref, _) :: _)
-        | Item.UnqualifiedType (tcref :: _) -> 
+        | Item.UnqualifiedType tcref 
+        | Item.UnqualifiedTypes (tcref :: _) -> 
             let denv = { denv with
                             // tooltips are space-constrained, so use shorter names
                             shortTypeNames = true
@@ -848,7 +849,8 @@ module internal DescriptionListsImpl =
             | Item.MethodGroup _ -> FSharpGlyph.Method
             | Item.TypeVar _ 
             | Item.Types _  -> FSharpGlyph.Class
-            | Item.UnqualifiedType (tcref :: _) -> 
+            | Item.UnqualifiedType tcref 
+            | Item.UnqualifiedTypes (tcref :: _) -> 
                 if tcref.IsEnumTycon || tcref.IsILEnumTycon then FSharpGlyph.Enum
                 elif tcref.IsExceptionDecl then FSharpGlyph.Exception
                 elif tcref.IsFSharpDelegateTycon then FSharpGlyph.Delegate

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -291,7 +291,8 @@ type FSharpSymbol(cenv: SymbolEnv, item: unit -> Item, access: FSharpSymbol -> C
         | Item.DelegateCtor (AbbrevOrAppTy tcref) -> 
             FSharpEntity(cenv, tcref) :>_ 
 
-        | Item.UnqualifiedType(tcref :: _)  
+        | Item.UnqualifiedType tcref  
+        | Item.UnqualifiedTypes(tcref :: _)  
         | Item.Types(_, AbbrevOrAppTy tcref :: _) -> 
             FSharpEntity(cenv, tcref) :>_  
 
@@ -328,7 +329,7 @@ type FSharpSymbol(cenv: SymbolEnv, item: unit -> Item, access: FSharpSymbol -> C
         | Item.NewDef _ -> dflt()
         // These cases cover unreachable cases
         | Item.CustomOperation (_, _, None) 
-        | Item.UnqualifiedType []
+        | Item.UnqualifiedTypes []
         | Item.ModuleOrNamespaces []
         | Item.Property (_, [])
         | Item.MethodGroup (_, [], _)
@@ -354,7 +355,7 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
                          (fun () -> 
                               checkEntityIsResolved entity
                               if entity.IsModuleOrNamespace then Item.ModuleOrNamespaces [entity] 
-                              else Item.UnqualifiedType [entity]), 
+                              else Item.UnqualifiedType entity), 
                          (fun _this thisCcu2 ad -> 
                              checkForCrossProjectAccessibility cenv.g.ilg (thisCcu2, ad) (cenv.thisCcu, getApproxFSharpAccessibilityOfEntity entity)) 
                              // && AccessibilityLogic.IsEntityAccessible cenv.amap range0 ad entity)


### PR DESCRIPTION
During a discussion with @dsyme some time ago, I've suggested to add additional `Item` cases that would hold a single element, since currently environments contain many single element lists. This PR covers one of the cases. The pattern match duplications could be removed with struct active patterns in future.

@dsyme What do you think about this approach? If it still sounds good, I'll do it for the rest of the `Item` cases (properties, types, methods/constructors).