### PR TITLE
Import: don't try splitting nested type name twice

### DIFF
--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -2051,7 +2051,7 @@ and u_tycon_repr st =
                             | [] -> List.rev acc, tdefs.FindByName iltref.Name
                             | h :: t ->
                                 let nestedTypeDef = tdefs.FindByName h
-                                find (tdefs.FindByName h :: acc) t nestedTypeDef.NestedTypes
+                                find (nestedTypeDef :: acc) t nestedTypeDef.NestedTypes
                         let nestedILTypeDefs, ilTypeDef = find [] iltref.Enclosing iILModule.TypeDefs
                         TILObjectRepr(TILObjectReprData(st.iilscope, nestedILTypeDefs, ilTypeDef))
                     with _ ->


### PR DESCRIPTION
When importing a type, splitting the name inside `FindByName` is done twice on each step going through the containing types to the containing namespace.