### PR TITLE
Fix8560

### DIFF
--- a/src/fsharp/utils/CompilerLocationUtils.fs
+++ b/src/fsharp/utils/CompilerLocationUtils.fs
@@ -372,13 +372,13 @@ module internal FSharpEnvironment =
             path
 
     // Fallback to ambient FSharp.CompilerService.dll
-    let getFSharpCompilerLocation() = getFSharpCompilerLocationWithDefaultFromType(typeof<TypeInThisAssembly>)
+    let getFSharpCompilerLocation() = Path.Combine(getFSharpCompilerLocationWithDefaultFromType(typeof<TypeInThisAssembly>));
 
     // Fallback to ambient FSharp.Core.dll
-    let getDefaultFSharpCoreLocation() = getFSharpCompilerLocationWithDefaultFromType(typeof<Unit>)
+    let getDefaultFSharpCoreLocation() = Path.Combine(getFSharpCompilerLocationWithDefaultFromType(typeof<Unit>), getFSharpCoreLibraryName + ".dll")
 
     // Must be alongside the location of FSharp.CompilerService.dll
-    let getDefaultFsiLibraryLocation() = Path.Combine(getFSharpCompilerLocation(), fsiLibraryName + ".dll")
+    let getDefaultFsiLibraryLocation() = Path.Combine(Path.GetDirectoryName(getFSharpCompilerLocation()), fsiLibraryName + ".dll")
 
     // Path to the directory containing the fsharp compilers
     let fsharpCompilerPath = Path.Combine(Path.GetDirectoryName(getFSharpCompilerLocation()), "Tools")


### PR DESCRIPTION
Improve FSharp.Core fallback location to be the ambient FSharp.Core.
Do not throw when using types from an in-memory assembly.

Fixes: https://github.com/dotnet/fsharp/issues/8560
