### PR TITLE
Switch to 1ES servicing pools on release/dev17.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,7 +202,7 @@ stages:
             # and there is an alternate build definition that sets this to a queue that is always scouting the
             # next preview of Visual Studio.
             name: NetCore1ESPool-Svc-Public
-            demands: ImageOverride -equals Build Build.Windows.10.Amd64.VS2019.Open # hardcoding this vaule on servicing branch
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open # hardcoding this vaule on servicing branch
           timeoutInMinutes: 120
           strategy:
             maxParallel: 4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,8 +94,8 @@ stages:
         jobs:
         - job: Full_Signed
           pool:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2019
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2019
           timeoutInMinutes: 300
           variables:
           - group: DotNet-Blob-Feed
@@ -201,8 +201,8 @@ stages:
             #   WindowsMachineQueueName=BuildPool.Windows.10.Amd64.VS2019.Open
             # and there is an alternate build definition that sets this to a queue that is always scouting the
             # next preview of Visual Studio.
-            name: NetCorePublic-Pool
-            queue: $(WindowsMachineQueueName)
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build $(WindowsMachineQueueName)
           timeoutInMinutes: 120
           strategy:
             maxParallel: 4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,7 +202,7 @@ stages:
             # and there is an alternate build definition that sets this to a queue that is always scouting the
             # next preview of Visual Studio.
             name: NetCore1ESPool-Svc-Public
-            demands: ImageOverride -equals Build $(WindowsMachineQueueName)
+            demands: ImageOverride -equals Build Build.Windows.10.Amd64.VS2019.Open # hardcoding this vaule on servicing branch
           timeoutInMinutes: 120
           strategy:
             maxParallel: 4


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/core-eng/issues/14276

cc/ @ulisesh @lpatalas 