### PR TITLE
Add FSharp.Test.Utilities project to FCS solution

### DIFF
--- a/service/FSharp.Compiler.Service.sln
+++ b/service/FSharp.Compiler.Service.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharp_Analysis", "..\tests
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TestTP", "..\tests\service\data\TestTP\TestTP.fsproj", "{2EF674B9-8B56-4796-9933-42B2629E52C3}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Test.Utilities", "..\tests\FSharp.Test.Utilities\FSharp.Test.Utilities.fsproj", "{38A23D53-E2BF-4B76-907F-49F41D60C88E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{2EF674B9-8B56-4796-9933-42B2629E52C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2EF674B9-8B56-4796-9933-42B2629E52C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2EF674B9-8B56-4796-9933-42B2629E52C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38A23D53-E2BF-4B76-907F-49F41D60C88E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38A23D53-E2BF-4B76-907F-49F41D60C88E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38A23D53-E2BF-4B76-907F-49F41D60C88E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38A23D53-E2BF-4B76-907F-49F41D60C88E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -48,6 +54,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{BFE6E6F1-1B73-404F-A3A5-30B57E5E0731} = {875D91AC-BA4C-4191-AB11-AE461DB9B8DB}
 		{2EF674B9-8B56-4796-9933-42B2629E52C3} = {875D91AC-BA4C-4191-AB11-AE461DB9B8DB}
+		{38A23D53-E2BF-4B76-907F-49F41D60C88E} = {875D91AC-BA4C-4191-AB11-AE461DB9B8DB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F9A60F3B-D894-4C8E-BA0F-C51115B25A5A}

--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -28,11 +28,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SolutionName)' != 'FSharp.Compiler.Service'">
     <!-- CompilerAssert dependencies.
          Make sure they are getting built with the Utilities. -->
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\FSharp.Build.fsproj" />
-    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
     <ProjectReference Include="$(FSharpTestsRoot)\fsharpqa\testenv\src\PEVerify\PEVerify.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Due to an unresolved issue on Rider side, projects that are not present in a solution won't be added implicitly when there's a `ProjectReference`. This PR fixed build of the FCS solution in the IDE by explicitly adding `FSharp.Test.Utilities` project to the solution.

Also, another `FSharp.Core` reference has been added transitively, so I've added a solution name check for extra project references.