### PR TITLE
Fix for 12184 - correct pre-processing of type information from overloads involving SRTP constraints

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -9139,7 +9139,9 @@ and TcMethodApplication
                             if (calledObjArgTys, callerObjArgTys) ||> Seq.forall2 (fun calledTy callerTy -> 
                                 let noEagerConstraintApplication = MethInfoHasAttribute cenv.g mMethExpr cenv.g.attrib_NoEagerConstraintApplicationAttribute meth.Method
 
-                                if not (cenv.g.langVersion.SupportsFeature LanguageFeature.ResumableStateMachines) then
+                                // The logic associated with NoEagerConstraintApplicationAttribute is part of the
+                                // Tasks and Resumable Code RFC
+                                if noEagerConstraintApplication && not (cenv.g.langVersion.SupportsFeature LanguageFeature.ResumableStateMachines) then
                                     errorR(Error(FSComp.SR.tcNoEagerConstraintApplicationAttribute(), mMethExpr))
 
                                 let extraRigidTps = if noEagerConstraintApplication then Zset.ofList typarOrder (freeInTypeLeftToRight cenv.g true callerTy) else emptyFreeTypars

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -9133,10 +9133,13 @@ and TcMethodApplication
             let lambdaPropagationInfo =
                 if preArgumentTypeCheckingCalledMethGroup.Length > 1 then
                     [| for meth in preArgumentTypeCheckingCalledMethGroup do
-                        match ExamineMethodForLambdaPropagation meth ad with
+                        match ExamineMethodForLambdaPropagation cenv.g mMethExpr meth ad with
                         | Some (unnamedInfo, namedInfo) ->
                             let calledObjArgTys = meth.CalledObjArgTys mMethExpr
-                            if (calledObjArgTys, callerObjArgTys) ||> Seq.forall2 (fun calledTy callerTy -> AddCxTypeMustSubsumeTypeMatchingOnlyUndoIfFailed denv cenv.css mMethExpr calledTy callerTy) then
+                            if (calledObjArgTys, callerObjArgTys) ||> Seq.forall2 (fun calledTy callerTy -> 
+                                let noEagerConstraintApplication = MethInfoHasAttribute cenv.g mMethExpr cenv.g.attrib_NoEagerConstraintApplicationAttribute meth.Method
+                                let extraRigidTps = if noEagerConstraintApplication then Zset.ofList typarOrder (freeInTypeLeftToRight cenv.g true callerTy) else emptyFreeTypars
+                                AddCxTypeMustSubsumeTypeMatchingOnlyUndoIfFailed denv cenv.css mMethExpr extraRigidTps calledTy callerTy) then
                                 yield (List.toArraySquared unnamedInfo, List.toArraySquared namedInfo)
                         | None -> () |]
                 else
@@ -9434,7 +9437,7 @@ and TcMethodNamedArg cenv env (lambdaPropagationInfo, tpenv) (CallerNamedArg(id,
     let arg', (lambdaPropagationInfo, tpenv) = TcMethodArg cenv env (lambdaPropagationInfo, tpenv) (lambdaPropagationInfoForArg, arg)
     CallerNamedArg(id, arg'), (lambdaPropagationInfo, tpenv)
 
-and TcMethodArg cenv env (lambdaPropagationInfo, tpenv) (lambdaPropagationInfoForArg, CallerArg(argTy, mArg, isOpt, argExpr)) =
+and TcMethodArg cenv env (lambdaPropagationInfo, tpenv) (lambdaPropagationInfoForArg, CallerArg(callerArgTy, mArg, isOpt, argExpr)) =
 
     // Apply the F# 3.1 rule for extracting information for lambdas
     //
@@ -9469,9 +9472,9 @@ and TcMethodArg cenv env (lambdaPropagationInfo, tpenv) (lambdaPropagationInfoFo
                                     if AddCxTypeEqualsTypeUndoIfFailed env.DisplayEnv cenv.css mArg calledLambdaArgTy callerLambdaDomainTy then
                                         loop callerLambdaRangeTy (lambdaVarNum + 1)
                                 | _ -> ()
-                    loop argTy 0
+                    loop callerArgTy 0
 
-    let e', tpenv = TcExprFlex2 cenv argTy env true tpenv argExpr
+    let e', tpenv = TcExprFlex2 cenv callerArgTy env true tpenv argExpr
 
     // After we have checked, propagate the info from argument into the overloads that receive it.
     //
@@ -9483,11 +9486,16 @@ and TcMethodArg cenv env (lambdaPropagationInfo, tpenv) (lambdaPropagationInfoFo
               | ArgDoesNotMatch _ -> ()
               | NoInfo | CallerLambdaHasArgTypes _ ->
                   yield info
-              | CalledArgMatchesType adjustedCalledTy ->
-                  if AddCxTypeMustSubsumeTypeMatchingOnlyUndoIfFailed env.DisplayEnv cenv.css mArg adjustedCalledTy argTy then
+              | CalledArgMatchesType (adjustedCalledArgTy, noEagerConstraintApplication) ->
+                  // If matching, we can solve 'tp1 --> tp2' but we can't transfer extra
+                  // constraints from tp1 to tp2.  
+                  //
+                  // The 'task' feature requires this fix to SRTP resolution. 
+                  let extraRigidTps = if noEagerConstraintApplication then Zset.ofList typarOrder (freeInTypeLeftToRight cenv.g true callerArgTy) else emptyFreeTypars
+                  if AddCxTypeMustSubsumeTypeMatchingOnlyUndoIfFailed env.DisplayEnv cenv.css mArg extraRigidTps adjustedCalledArgTy callerArgTy then
                      yield info |]
 
-    CallerArg(argTy, mArg, isOpt, e'), (lambdaPropagationInfo, tpenv)
+    CallerArg(callerArgTy, mArg, isOpt, e'), (lambdaPropagationInfo, tpenv)
 
 /// Typecheck "new Delegate(fun x y z -> ...)" constructs
 and TcNewDelegateThen cenv (overallTy: OverallTy) env tpenv mDelTy mExprAndArg delegateTy arg atomicFlag delayed =

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -9138,8 +9138,14 @@ and TcMethodApplication
                             let calledObjArgTys = meth.CalledObjArgTys mMethExpr
                             if (calledObjArgTys, callerObjArgTys) ||> Seq.forall2 (fun calledTy callerTy -> 
                                 let noEagerConstraintApplication = MethInfoHasAttribute cenv.g mMethExpr cenv.g.attrib_NoEagerConstraintApplicationAttribute meth.Method
+
+                                if not (cenv.g.langVersion.SupportsFeature LanguageFeature.ResumableStateMachines) then
+                                    errorR(Error(FSComp.SR.tcNoEagerConstraintApplicationAttribute(), mMethExpr))
+
                                 let extraRigidTps = if noEagerConstraintApplication then Zset.ofList typarOrder (freeInTypeLeftToRight cenv.g true callerTy) else emptyFreeTypars
+
                                 AddCxTypeMustSubsumeTypeMatchingOnlyUndoIfFailed denv cenv.css mMethExpr extraRigidTps calledTy callerTy) then
+
                                 yield (List.toArraySquared unnamedInfo, List.toArraySquared namedInfo)
                         | None -> () |]
                 else

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1106,10 +1106,10 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
     // type vars inside forall-types may be alpha-equivalent 
     | TType_var tp1, TType_var tp2 when typarEq tp1 tp2 || (match aenv.EquivTypars.TryFind tp1 with | Some v when typeEquiv g v ty2 -> true | _ -> false) -> CompleteD
 
-    | TType_var tp1, TType_var tp2 when PreferUnifyTypar tp1 tp2 -> SolveTyparEqualsType csenv ndeep m2 trace sty1 ty2
+    | TType_var tp1, TType_var tp2 when (not csenv.MatchingOnly || tp1.Constraints.IsEmpty) && PreferUnifyTypar tp1 tp2 -> SolveTyparEqualsType csenv ndeep m2 trace sty1 ty2
     | TType_var tp1, TType_var tp2 when not csenv.MatchingOnly && PreferUnifyTypar tp2 tp1 -> SolveTyparEqualsType csenv ndeep m2 trace sty2 ty1
 
-    | TType_var r, _ when (r.Rigidity <> TyparRigidity.Rigid) -> SolveTyparEqualsType csenv ndeep m2 trace sty1 ty2
+    | TType_var r, _ when (r.Rigidity <> TyparRigidity.Rigid) && (not csenv.MatchingOnly || r.Constraints.IsEmpty) -> SolveTyparEqualsType csenv ndeep m2 trace sty1 ty2
     | _, TType_var r when (r.Rigidity <> TyparRigidity.Rigid) && not csenv.MatchingOnly -> SolveTyparEqualsType csenv ndeep m2 trace sty2 ty1
 
     // Catch float<_>=float<1>, float32<_>=float32<1> and decimal<_>=decimal<1> 

--- a/src/fsharp/ConstraintSolver.fsi
+++ b/src/fsharp/ConstraintSolver.fsi
@@ -182,7 +182,7 @@ val AddCxTypeMustSubsumeType: ContextInfo -> DisplayEnv -> ConstraintSolverState
 
 val AddCxTypeMustSubsumeTypeUndoIfFailed: DisplayEnv -> ConstraintSolverState -> range -> TType -> TType -> bool
 
-val AddCxTypeMustSubsumeTypeMatchingOnlyUndoIfFailed: DisplayEnv -> ConstraintSolverState -> range -> TType -> TType -> bool
+val AddCxTypeMustSubsumeTypeMatchingOnlyUndoIfFailed: DisplayEnv -> ConstraintSolverState -> range -> extraRigidTypars: FreeTypars -> TType -> TType -> bool
 
 val AddCxMethodConstraint: DisplayEnv -> ConstraintSolverState -> range -> OptionalTrace -> TraitConstraintInfo -> unit
 

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1615,6 +1615,7 @@ forFormatInvalidForInterpolated4,"Interpolated strings used as type IFormattable
 3501,tcResumableCodeArgMustHaveRightKind,"Invalid resumable code. A resumable code parameter must be of delegate or function type"
 3501,tcResumableCodeContainsLetRec,"Invalid resumable code. A 'let rec' occured in the resumable code specification"
 3510,tcResumableCodeNotSupported,"Using resumable code or resumable state machines requires /langversion:preview"
+3510,tcNoEagerConstraintApplicationAttribute,"Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later"
 3511,reprStateMachineNotCompilable,"This state machine is not statically compilable. %s. An alternative dynamic implementation will be used, which may be slower. Consider adjusting your code to ensure this state machine is statically compilable, or else suppress this warning."
 3512,reprStateMachineNotCompilableNoAlternative,"This state machine is not statically compilable and no alternative is available. %s. Use an 'if __useResumableCode then <state-machine> else <alternative>' to give an alternative."
 3513,tcResumableCodeInvocation,"Resumable code invocation. Suppress this warning if you are defining new low-level resumable code in terms of existing resumable code."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1615,7 +1615,7 @@ forFormatInvalidForInterpolated4,"Interpolated strings used as type IFormattable
 3501,tcResumableCodeArgMustHaveRightKind,"Invalid resumable code. A resumable code parameter must be of delegate or function type"
 3501,tcResumableCodeContainsLetRec,"Invalid resumable code. A 'let rec' occured in the resumable code specification"
 3510,tcResumableCodeNotSupported,"Using resumable code or resumable state machines requires /langversion:preview"
-3510,tcNoEagerConstraintApplicationAttribute,"Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later"
+3510,tcNoEagerConstraintApplicationAttribute,"Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later"
 3511,reprStateMachineNotCompilable,"This state machine is not statically compilable. %s. An alternative dynamic implementation will be used, which may be slower. Consider adjusting your code to ensure this state machine is statically compilable, or else suppress this warning."
 3512,reprStateMachineNotCompilableNoAlternative,"This state machine is not statically compilable and no alternative is available. %s. Use an 'if __useResumableCode then <state-machine> else <alternative>' to give an alternative."
 3513,tcResumableCodeInvocation,"Resumable code invocation. Suppress this warning if you are defining new low-level resumable code in terms of existing resumable code."

--- a/src/fsharp/FSharp.Core/resumable.fs
+++ b/src/fsharp/FSharp.Core/resumable.fs
@@ -20,6 +20,11 @@ open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
 open Microsoft.FSharp.Control
 open Microsoft.FSharp.Collections
 
+[<AttributeUsage (AttributeTargets.Method, AllowMultiple=false)>]  
+[<Sealed>]
+type NoEagerConstraintApplicationAttribute() = 
+    inherit System.Attribute()
+
 type IResumableStateMachine<'Data> =
     abstract ResumptionPoint: int
     abstract Data: 'Data with get, set

--- a/src/fsharp/FSharp.Core/resumable.fsi
+++ b/src/fsharp/FSharp.Core/resumable.fsi
@@ -210,11 +210,6 @@ module StateMachineHelpers =
 /// lambda constraint propagation, then member trait constraints from a method overload
 /// are eagerly applied to the caller argument type. This causes that overload to be preferred,
 /// regardless of other method overload resolution rules. Using this attribute suppresses this behaviour. 
-///
-/// The default method resolution behaviour is creates a
-/// way to get a preferred method resolution when no type information is available. However
-/// it can cause different overloaded members to interact poorly. In these cases, this attribute
-/// can be used to suppress the default behaviour.
 /// </remarks>
 ///
 /// <example>
@@ -228,9 +223,9 @@ module StateMachineHelpers =
 /// let inline f x = 
 ///     OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 
 /// </code>
-/// Without the attribute, the overload resolution succeeds, because the constraint is
-/// eagerly applied, making the second member non-applicable.  With the attribute, the overload
-/// resolution fails, because both members are applicable.
+/// With the attribute, the overload resolution fails, because both members are applicable.
+/// Without the attribute, the overload resolution succeeds, because the member constraint is
+/// eagerly applied, making the second member non-applicable.  
 /// </example>
 /// <category>Attributes</category>
 [<AttributeUsage (AttributeTargets.Method,AllowMultiple=false)>]  

--- a/src/fsharp/FSharp.Core/resumable.fsi
+++ b/src/fsharp/FSharp.Core/resumable.fsi
@@ -201,4 +201,45 @@ module StateMachineHelpers =
         afterCode: AfterCode<'Data, 'Result> 
             -> 'Result
 
+/// <summary>Adding this attribute to the method adjusts the processing of some generic methods
+/// during overload resolution.</summary>
+///
+/// <remarks>During overload resolution, caller arguments are matched with called arguments
+/// to extract type information. By default, when the caller argument type is unconstrained (for example
+/// a simple value <c>x</c> without known type information), and a method qualifies for
+/// lambda constraint propagation, then member trait constraints from a method overload
+/// are eagerly applied to the caller argument type. This causes that overload to be preferred,
+/// regardless of other method overload resolution rules. Using this attribute suppresses this behaviour. 
+///
+/// The default method resolution behaviour is creates a
+/// way to get a preferred method resolution when no type information is available. However
+/// it can cause different overloaded members to interact poorly. In these cases, this attribute
+/// can be used to suppress the default behaviour.
+/// </remarks>
+///
+/// <example>
+/// Consider the following overloads:
+/// <code>
+/// type OverloadsWithSrtp() =
+///     [&lt;NoEagerConstraintApplicationAttribute&gt;]
+///     static member inline SomeMethod&lt; ^T when ^T : (member Number: int) &gt; (x: ^T, f: ^T -> int) = 1
+///     static member SomeMethod(x: 'T list, f: 'T list -> int) = 2
+/// 
+/// let inline f x = 
+///     OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 
+/// </code>
+/// Without the attribute, the overload resolution succeeds, because the constraint is
+/// eagerly applied, making the second member non-applicable.  With the attribute, the overload
+/// resolution fails, because both members are applicable.
+/// </example>
+/// <category>Attributes</category>
+[<AttributeUsage (AttributeTargets.Method,AllowMultiple=false)>]  
+[<Sealed>]
+type NoEagerConstraintApplicationAttribute =
+    inherit Attribute
+
+    /// <summary>Creates an instance of the attribute</summary>
+    /// <returns>NoEagerConstraintApplicationAttribute</returns>
+    new : unit -> NoEagerConstraintApplicationAttribute
+
 #endif

--- a/src/fsharp/FSharp.Core/tasks.fs
+++ b/src/fsharp/FSharp.Core/tasks.fs
@@ -42,8 +42,8 @@ namespace Microsoft.FSharp.Control
 
     type TaskBuilderBase() =
 
-        member inline _.Delay(f : unit -> TaskCode<'TOverall, 'T>) : TaskCode<'TOverall, 'T> =
-            TaskCode<'TOverall, 'T>(fun sm -> (f()).Invoke(&sm))
+        member inline _.Delay(generator : unit -> TaskCode<'TOverall, 'T>) : TaskCode<'TOverall, 'T> =
+            TaskCode<'TOverall, 'T>(fun sm -> (generator()).Invoke(&sm))
 
         /// Used to represent no-ops like the implicit empty "else" branch of an "if" expression.
         [<DefaultValue>]
@@ -258,6 +258,7 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
         // Low priority extensions
         type TaskBuilderBase with
 
+            [<NoEagerConstraintApplication>]
             static member inline BindDynamic< ^TaskLike, 'TResult1, 'TResult2, ^Awaiter , 'TOverall
                                                 when  ^TaskLike: (member GetAwaiter:  unit ->  ^Awaiter)
                                                 and ^Awaiter :> ICriticalNotifyCompletion
@@ -280,6 +281,7 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
                         sm.ResumptionDynamicInfo.ResumptionFunc <- cont
                         false
 
+            [<NoEagerConstraintApplication>]
             member inline _.Bind< ^TaskLike, 'TResult1, 'TResult2, ^Awaiter , 'TOverall
                                                 when  ^TaskLike: (member GetAwaiter:  unit ->  ^Awaiter)
                                                 and ^Awaiter :> ICriticalNotifyCompletion
@@ -311,6 +313,7 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
                     //-- RESUMABLE CODE END
                 )
 
+            [<NoEagerConstraintApplication>]
             member inline this.ReturnFrom< ^TaskLike, ^Awaiter, 'T
                                                   when  ^TaskLike: (member GetAwaiter:  unit ->  ^Awaiter)
                                                   and ^Awaiter :> ICriticalNotifyCompletion

--- a/src/fsharp/FSharp.Core/tasks.fsi
+++ b/src/fsharp/FSharp.Core/tasks.fsi
@@ -24,13 +24,13 @@ namespace Microsoft.FSharp.Control
         /// Holds the final result of the state machine
         /// </summary>
         [<DefaultValue(false)>]
-        val mutable Result : 'T
+        val mutable Result: 'T
 
         /// <summary>
         /// Holds the MethodBuilder for the state machine
         /// </summary>
         [<DefaultValue(false)>]
-        val mutable MethodBuilder : AsyncTaskMethodBuilder<'T>
+        val mutable MethodBuilder: AsyncTaskMethodBuilder<'T>
 
     /// <summary>
     /// This is used by the compiler as a template for creating state machine structs
@@ -71,7 +71,7 @@ namespace Microsoft.FSharp.Control
         /// Specifies the delayed execution of a unit of task code.
         /// </summary>
         [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
-        member inline Delay: f: (unit -> TaskCode<'TOverall, 'T>) -> TaskCode<'TOverall, 'T>
+        member inline Delay: generator: (unit -> TaskCode<'TOverall, 'T>) -> TaskCode<'TOverall, 'T>
     
         /// <summary>
         /// Specifies the iterative execution of a unit of task code.
@@ -193,6 +193,7 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
     open System.Threading.Tasks
     open Microsoft.FSharp.Core
     open Microsoft.FSharp.Control
+    open Microsoft.FSharp.Core.CompilerServices
 
     /// <summary>
     /// Contains low-priority overloads for the `task` computation expression builder.
@@ -212,6 +213,7 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
             /// satisfying the GetAwaiter pattern and calls a continuation.
             /// </summary>
             [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
+            [<NoEagerConstraintApplication>]
             member inline Bind< ^TaskLike, 'TResult1, 'TResult2, ^Awaiter, 'TOverall > :
                 task: ^TaskLike *
                 continuation: ( 'TResult1 -> TaskCode<'TOverall, 'TResult2>)
@@ -226,6 +228,7 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
             /// satisfying the GetAwaiter pattern.
             /// </summary>
             [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
+            [<NoEagerConstraintApplication>]
             member inline ReturnFrom< ^TaskLike, ^Awaiter, 'T> : 
                 task: ^TaskLike
                     -> TaskCode< 'T, 'T > 
@@ -238,6 +241,7 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
             /// The entry point for the dynamic implementation of the corresponding operation. Do not use directly, only used when executing quotations that involve tasks or other reflective execution of F# code.
             /// </summary>
             [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
+            [<NoEagerConstraintApplication>]
             static member inline BindDynamic< ^TaskLike, 'TResult1, 'TResult2, ^Awaiter, 'TOverall > :
                 sm: byref<TaskStateMachine<'TOverall>> *
                 task: ^TaskLike *
@@ -252,7 +256,10 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
             /// Specifies a unit of task code which binds to the resource implementing IDisposable and disposes it synchronously
             /// </summary>
             [<Experimental("Experimental library feature, requires '--langversion:preview'")>]
-            member inline Using: resource: 'Resource * body: ('Resource -> TaskCode<'TOverall, 'T>) -> TaskCode<'TOverall, 'T> when 'Resource :> IDisposable
+            member inline Using:
+                resource: 'Resource *
+                body: ('Resource -> TaskCode<'TOverall, 'T>)
+                    -> TaskCode<'TOverall, 'T> when 'Resource :> IDisposable
 
     /// <summary>
     /// Contains medium-priority overloads for the `task` computation expression builder.

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -837,8 +837,12 @@ let ExamineArgumentForLambdaPropagation (infoReader: InfoReader) ad noEagerConst
         
 let ExamineMethodForLambdaPropagation (g: TcGlobals) m (meth: CalledMeth<SynExpr>) ad =
     let noEagerConstraintApplication = MethInfoHasAttribute g m g.attrib_NoEagerConstraintApplicationAttribute meth.Method
-    if not (g.langVersion.SupportsFeature LanguageFeature.ResumableStateMachines) then
+
+    // The logic associated with NoEagerConstraintApplicationAttribute is part of the
+    // Tasks and Resumable Code RFC
+    if noEagerConstraintApplication && not (g.langVersion.SupportsFeature LanguageFeature.ResumableStateMachines) then
         errorR(Error(FSComp.SR.tcNoEagerConstraintApplicationAttribute(), m))
+
     let unnamedInfo = meth.AssignedUnnamedArgs |> List.mapSquared (ExamineArgumentForLambdaPropagation meth.infoReader ad noEagerConstraintApplication)
     let namedInfo = meth.AssignedNamedArgs |> List.mapSquared (fun arg -> (arg.NamedArgIdOpt.Value, ExamineArgumentForLambdaPropagation meth.infoReader ad noEagerConstraintApplication arg))
     if unnamedInfo |> List.existsSquared (function CallerLambdaHasArgTypes _ -> true | _ -> false) || 

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -800,7 +800,7 @@ type ArgumentAnalysis =
     | NoInfo
     | ArgDoesNotMatch 
     | CallerLambdaHasArgTypes of TType list
-    | CalledArgMatchesType of TType
+    | CalledArgMatchesType of adjustedCalledArgTy: TType * noEagerConstraintApplication: bool
 
 let InferLambdaArgsForLambdaPropagation origRhsExpr = 
     let rec loop e = 
@@ -810,7 +810,7 @@ let InferLambdaArgsForLambdaPropagation origRhsExpr =
         | _ -> 0
     loop origRhsExpr
 
-let ExamineArgumentForLambdaPropagation (infoReader: InfoReader) ad (arg: AssignedCalledArg<SynExpr>) =
+let ExamineArgumentForLambdaPropagation (infoReader: InfoReader) ad noEagerConstraintApplication (arg: AssignedCalledArg<SynExpr>) =
     let g = infoReader.g
 
     // Find the explicit lambda arguments of the caller. Ignore parentheses.
@@ -833,12 +833,12 @@ let ExamineArgumentForLambdaPropagation (infoReader: InfoReader) ad (arg: Assign
             NoInfo
     else
         // not a lambda on the caller side - push information from caller to called
-        CalledArgMatchesType(adjustedCalledArgTy)  
+        CalledArgMatchesType(adjustedCalledArgTy, noEagerConstraintApplication)  
         
-
-let ExamineMethodForLambdaPropagation (x: CalledMeth<SynExpr>) ad =
-    let unnamedInfo = x.AssignedUnnamedArgs |> List.mapSquared (ExamineArgumentForLambdaPropagation x.infoReader ad)
-    let namedInfo = x.AssignedNamedArgs |> List.mapSquared (fun arg -> (arg.NamedArgIdOpt.Value, ExamineArgumentForLambdaPropagation x.infoReader ad arg))
+let ExamineMethodForLambdaPropagation (g: TcGlobals) m (meth: CalledMeth<SynExpr>) ad =
+    let noEagerConstraintApplication = MethInfoHasAttribute g m g.attrib_NoEagerConstraintApplicationAttribute meth.Method
+    let unnamedInfo = meth.AssignedUnnamedArgs |> List.mapSquared (ExamineArgumentForLambdaPropagation meth.infoReader ad noEagerConstraintApplication)
+    let namedInfo = meth.AssignedNamedArgs |> List.mapSquared (fun arg -> (arg.NamedArgIdOpt.Value, ExamineArgumentForLambdaPropagation meth.infoReader ad noEagerConstraintApplication arg))
     if unnamedInfo |> List.existsSquared (function CallerLambdaHasArgTypes _ -> true | _ -> false) || 
        namedInfo |> List.existsSquared (function _, CallerLambdaHasArgTypes _ -> true | _ -> false) then 
         Some (unnamedInfo, namedInfo)

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -837,6 +837,8 @@ let ExamineArgumentForLambdaPropagation (infoReader: InfoReader) ad noEagerConst
         
 let ExamineMethodForLambdaPropagation (g: TcGlobals) m (meth: CalledMeth<SynExpr>) ad =
     let noEagerConstraintApplication = MethInfoHasAttribute g m g.attrib_NoEagerConstraintApplicationAttribute meth.Method
+    if not (g.langVersion.SupportsFeature LanguageFeature.ResumableStateMachines) then
+        errorR(Error(FSComp.SR.tcNoEagerConstraintApplicationAttribute(), m))
     let unnamedInfo = meth.AssignedUnnamedArgs |> List.mapSquared (ExamineArgumentForLambdaPropagation meth.infoReader ad noEagerConstraintApplication)
     let namedInfo = meth.AssignedNamedArgs |> List.mapSquared (fun arg -> (arg.NamedArgIdOpt.Value, ExamineArgumentForLambdaPropagation meth.infoReader ad noEagerConstraintApplication arg))
     if unnamedInfo |> List.existsSquared (function CallerLambdaHasArgTypes _ -> true | _ -> false) || 

--- a/src/fsharp/MethodCalls.fsi
+++ b/src/fsharp/MethodCalls.fsi
@@ -289,9 +289,9 @@ type ArgumentAnalysis =
     | NoInfo
     | ArgDoesNotMatch
     | CallerLambdaHasArgTypes of TType list
-    | CalledArgMatchesType of TType
+    | CalledArgMatchesType of adjustedCalledArgTy: TType * noEagerConstraintApplication: bool
 
-val ExamineMethodForLambdaPropagation: x:CalledMeth<SynExpr> -> ad:AccessorDomain -> (ArgumentAnalysis list list * (Ident * ArgumentAnalysis) list list) option
+val ExamineMethodForLambdaPropagation: g: TcGlobals -> m: range -> meth:CalledMeth<SynExpr> -> ad:AccessorDomain -> (ArgumentAnalysis list list * (Ident * ArgumentAnalysis) list list) option
 
 /// Is this a 'base' call
 val IsBaseCall: objArgs:Expr list -> bool

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -556,6 +556,9 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
   let mk_MFCore_attrib nm : BuiltinAttribInfo =
       AttribInfo(mkILTyRef(ilg.fsharpCoreAssemblyScopeRef, FSharpLib.Core + "." + nm), mk_MFCore_tcref fslibCcu nm)
 
+  let mk_MFCompilerServices_attrib nm : BuiltinAttribInfo =
+      AttribInfo(mkILTyRef(ilg.fsharpCoreAssemblyScopeRef, FSharpLib.Core + "." + nm), mk_MFCompilerServices_tcref fslibCcu nm)
+
   let mk_doc filename = ILSourceDocument.Create(language=None, vendor=None, documentType=None, file=filename)
   // Build the memoization table for files
   let v_memoize_file = MemoizationTable<int, ILSourceDocument>((fileOfFileIndex >> FileSystem.GetFullFilePathInDirectoryShim directoryToResolveRelativePaths >> mk_doc), keyComparer=HashIdentity.Structural)
@@ -1208,6 +1211,7 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
   member val attrib_ThreadStaticAttribute   = tryFindSysAttrib "System.ThreadStaticAttribute"
   member val attrib_SpecialNameAttribute   = tryFindSysAttrib "System.Runtime.CompilerServices.SpecialNameAttribute"
   member val attrib_VolatileFieldAttribute   = mk_MFCore_attrib "VolatileFieldAttribute"
+  member val attrib_NoEagerConstraintApplicationAttribute = mk_MFCompilerServices_attrib "NoEagerConstraintApplicationAttribute"
   member val attrib_ContextStaticAttribute  = tryFindSysAttrib "System.ContextStaticAttribute"
   member val attrib_FlagsAttribute          = findSysAttrib "System.FlagsAttribute"
   member val attrib_DefaultMemberAttribute  = findSysAttrib "System.Reflection.DefaultMemberAttribute"

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -692,6 +692,11 @@
         <target state="translated">K hodnotě označené jako literál se {0} nedá přiřadit.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">Tento výraz podporuje indexování, třeba expr.[index]. Syntaxe expr[index] vyžaduje /langversion:preview. Více informací: https://aka.ms/fsharp-index-notation</target>

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -692,6 +692,11 @@
         <target state="translated">"{0}" kann keinem als Literal markierten Wert zugewiesen werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">Dieser Ausdruck unterstützt die Indizierung, z. B. "expr.[index]". Die Syntax "expr[index]" erfordert /langversion:preview. Siehe https://aka.ms/fsharp-index-notation.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -692,6 +692,11 @@
         <target state="translated">No se puede asignar "{0}" a un valor marcado como literal</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">Esta expresión admite indexación, por ejemplo "expr.[index]". La sintaxis "expr[index]" requiere /langversion:preview. Ver https://aka.ms/fsharp-index-notation.</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Impossible d'affecter '{0}' à une valeur marquée comme littérale</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">Cette expression prend en charge l’indexation, par exemple « expr.[index] ». La syntaxe « expr[index] » requiert /langversion:preview. Voir https://aka.ms/fsharp-index-notation.</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Non è possibile assegnare '{0}' a un valore contrassegnato come letterale</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">Questa espressione supporta l'indicizzazione, ad esempio 'expr.[index]'. La sintassi 'expr[index]' richiede/langversion:preview. Vedere https://aka.ms/fsharp-index-notation..</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -692,6 +692,11 @@
         <target state="translated">リテラルとしてマークされた値に '{0}' を割り当てることはできません</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">この式は、'expr. [index]' などのインデックスをサポートしています。構文 'expr[index]' には　/langversion:preview が必要です。https://aka.ms/fsharp-index-notation を参照してください。</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -692,6 +692,11 @@
         <target state="translated">리터럴로 표시된 값에 '{0}'을(를) 할당할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">이 식은 인덱싱을 지원합니다. 'expr.[index]'. 'expr[index]' 구문에는 /langversion:preview가 필요합니다. https://aka.ms/fsharp-index-notation을 참조하세요.</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Nie można przypisać elementu „{0}” do wartości oznaczonej jako literał</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">To wyrażenie obsługuje indeksowanie, np. „expr.[index]”. Składnia wyrażenia „expr[index]” wymaga parametru /langversion:preview. Zobacz: https://aka.ms/fsharp-index-notation.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Não é possível atribuir '{0}' a um valor marcado como literal</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">Essa expressão oferece suporte à indexação, por exemplo, 'expr. [index]'. A sintaxe 'expr[index]' requer /langversion:preview. Consulte https://aka.ms/fsharp-index-notation.</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Невозможно присвоить "{0}" значению, помеченному как литерал</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">Это выражение поддерживает индексирование, например, "expr. [index]". Для синтаксиса "expr[index]" требуется /langversion:preview. См. https://aka.ms/fsharp-index-notation.</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Sabit değer olarak işaretlenen bir değere '{0}' atanamaz</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">Bu ifade dizin oluşturmayı destekler, örn. “expr.[index]”. Söz dizimi “expr.[index]” /langversion:preview gerektirir. https://aka.ms/fsharp-index-notation'a bakın.</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -692,6 +692,11 @@
         <target state="translated">无法将“{0}”分配给标记为文本的值</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">此表达式支持索引，例如“expr.[index]”。语法“expr[index]”需要 /langversion:preview。请参阅 https://aka.ms/fsharp-index-notation。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -692,6 +692,11 @@
         <target state="translated">無法將 '{0}' 指派給標記為常值的值</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcNoEagerConstraintApplicationAttribute">
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">
         <source>This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation.</source>
         <target state="translated">此運算式支援編製索引，例如 'expr.[index]'。語法 'expr[index]' 需要 /langversion:preview。請參閱 https://aka.ms/fsharp-index-notation。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -693,8 +693,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcNoEagerConstraintApplicationAttribute">
-        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</source>
-        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later</target>
+        <source>Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</source>
+        <target state="new">Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later</target>
         <note />
       </trans-unit>
       <trans-unit id="tcNotAFunctionButIndexerIndexingNotYetEnabled">

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -5,6 +5,7 @@ namespace FSharp.Compiler.ComponentTests.EmittedIL
 open Xunit
 open FSharp.Test.Compiler
 
+#if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
 module ``StringFormatAndInterpolation`` =
     [<Fact>]
     let ``Interpolated string with no holes is reduced to a string or simple format when used in printf``() =
@@ -30,3 +31,6 @@ IL_0011:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.PrintfModule::PrintF
                                                                                                                                                  class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
 IL_0016:  pop
 IL_0017:  ret"""]
+
+#endif
+

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TupleElimination.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TupleElimination.fs
@@ -710,6 +710,7 @@ public static int z()
 
 
 
+#if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
 
     [<Fact>]
     let ``Branching let binding of tuple with capture doesn't promote``() =
@@ -760,7 +761,7 @@ let testFunction(a,b) =
 
 """ ]
 
-
+#endif
 
 
     [<Fact>]

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
@@ -194,14 +194,30 @@ type Issue12184() =
         task {
             // This should not do an early commit to "task like" nor
             // propogate SRTP constraints from the task-like overload for Bind.
+            //
+            // The overload resolution commits to 'Task' as the return type
             let! result = this.AsyncMethod(21)
             return result
         }
 
-    member _.AsyncMethod(value: int) =
+    member _.AsyncMethod(value: int) : Async<int> =
         async { // error FS0193: The type 'Async<'a>' does not support the operator 'GetAwaiter'
             return (value * 2)
         }
+
+type Issue12184b() =
+    member this.TaskMethod() =
+        task {
+            // This should not do an early commit to "task like" nor
+            // propogate SRTP constraints from the task-like overload for Bind.
+            //
+            // The overload resolution commits to 'Task' as the return type
+            let! result = this.AsyncMethod(21)
+            return result
+        }
+
+    member _.AsyncMethod(_value: int) : System.Runtime.CompilerServices.YieldAwaitable =
+        Task.Yield()
 
 exception TestException of string
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
@@ -189,6 +189,20 @@ type SmokeTestsForCompilation() =
             if t.Result <> 5 then failwith "failed"
 
 
+type Issue12184() =
+    member this.TaskMethod() =
+        task {
+            // This should not do an early commit to "task like" nor
+            // propogate SRTP constraints from the task-like overload for Bind.
+            let! result = this.AsyncMethod(21)
+            return result
+        }
+
+    member _.AsyncMethod(value: int) =
+        async { // error FS0193: The type 'Async<'a>' does not support the operator 'GetAwaiter'
+            return (value * 2)
+        }
+
 exception TestException of string
 
 [<AutoOpen>]

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
@@ -1267,26 +1267,20 @@ type BasicsNotInParallel() =
 type Issue12184() =
     member this.TaskMethod() =
         task {
-            // This should not do an early commit to "task like" nor
-            // propogate SRTP constraints from the task-like overload for Bind.
-            //
-            // The overload resolution commits to 'Task' as the return type
+            // The overload resolution for Bind commits to 'Async<int>' since the type annotation is present.
             let! result = this.AsyncMethod(21)
             return result
         }
 
     member _.AsyncMethod(value: int) : Async<int> =
-        async { // error FS0193: The type 'Async<'a>' does not support the operator 'GetAwaiter'
+        async {
             return (value * 2)
         }
 
 type Issue12184b() =
     member this.TaskMethod() =
         task {
-            // This should not do an early commit to "task like" nor
-            // propogate SRTP constraints from the task-like overload for Bind.
-            //
-            // The overload resolution commits to 'Task' as the return type
+            // The overload resolution for Bind commits to 'YieldAwaitable' since the type annotation is present.
             let! result = this.AsyncMethod(21)
             return result
         }
@@ -1298,6 +1292,9 @@ type Issue12184b() =
 module Issue12184c =
     let TaskMethod(t) =
         task {
+            // The overload resolution for Bind commits to 'Task<_>' via overload since no type annotation is available
+            //
+            // This should not do an early commit to "task like" nor propogate SRTP constraints from the task-like overload for Bind.
             let! result = t
             return result
         }
@@ -1307,6 +1304,7 @@ module Issue12184c =
 module Issue12184d =
     let TaskMethod(t: ValueTask) =
         task {
+            // The overload resolution for Bind commits to 'ValueTask' via SRTP pattern since the type annotation is available
             let! result = t
             return result
         }
@@ -1315,6 +1313,7 @@ module Issue12184d =
 module Issue12184e =
     let TaskMethod(t: ValueTask<int>) =
         task {
+            // The overload resolution for Bind commits to 'ValueTask<_>' via SRTP pattern since the type annotation is available
             let! result = t
             return result
         }
@@ -1324,6 +1323,7 @@ module Issue12184e =
 module Issue12184f =
     let TaskMethod(t: Task) =
         task {
+            // The overload resolution for Bind commits to 'Task' via SRTP pattern since the type annotation is available
             let! result = t
             return result
         }

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
@@ -1302,6 +1302,7 @@ module Issue12184c =
             return result
         }
 
+#if NETCOREAPP
 // check this compiles 
 module Issue12184d =
     let TaskMethod(t: ValueTask) =
@@ -1317,6 +1318,7 @@ module Issue12184e =
             let! result = t
             return result
         }
+#endif
 
 // check this compiles 
 module Issue12184f =

--- a/tests/FSharp.Core.UnitTests/SurfaceArea.fs
+++ b/tests/FSharp.Core.UnitTests/SurfaceArea.fs
@@ -811,6 +811,7 @@ Microsoft.FSharp.Core.CompilerServices.MoveNextMethodImpl`1[TData]: System.IAsyn
 Microsoft.FSharp.Core.CompilerServices.MoveNextMethodImpl`1[TData]: Void .ctor(System.Object, IntPtr)
 Microsoft.FSharp.Core.CompilerServices.MoveNextMethodImpl`1[TData]: Void EndInvoke(System.IAsyncResult)
 Microsoft.FSharp.Core.CompilerServices.MoveNextMethodImpl`1[TData]: Void Invoke(Microsoft.FSharp.Core.CompilerServices.ResumableStateMachine`1[TData] ByRef)
+Microsoft.FSharp.Core.CompilerServices.NoEagerConstraintApplicationAttribute: Void .ctor()
 Microsoft.FSharp.Core.CompilerServices.ResumableCode: Boolean CombineDynamic[TData,T](Microsoft.FSharp.Core.CompilerServices.ResumableStateMachine`1[TData] ByRef, Microsoft.FSharp.Core.CompilerServices.ResumableCode`2[TData,Microsoft.FSharp.Core.Unit], Microsoft.FSharp.Core.CompilerServices.ResumableCode`2[TData,T])
 Microsoft.FSharp.Core.CompilerServices.ResumableCode: Boolean TryFinallyAsyncDynamic[TData,T](Microsoft.FSharp.Core.CompilerServices.ResumableStateMachine`1[TData] ByRef, Microsoft.FSharp.Core.CompilerServices.ResumableCode`2[TData,T], Microsoft.FSharp.Core.CompilerServices.ResumableCode`2[TData,Microsoft.FSharp.Core.Unit])
 Microsoft.FSharp.Core.CompilerServices.ResumableCode: Boolean TryWithDynamic[TData,T](Microsoft.FSharp.Core.CompilerServices.ResumableStateMachine`1[TData] ByRef, Microsoft.FSharp.Core.CompilerServices.ResumableCode`2[TData,T], Microsoft.FSharp.Core.FSharpFunc`2[System.Exception,Microsoft.FSharp.Core.CompilerServices.ResumableCode`2[TData,T]])

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ComputationExpressionOptimizations.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ComputationExpressionOptimizations.fs
@@ -7,6 +7,7 @@ open NUnit.Framework
 
 open System
 
+#if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
 [<TestFixture>]
 module ComputationExpressionOptimizations =
 
@@ -315,3 +316,4 @@ module Examples =
             """
             ])
 
+#endif

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/DelegateAndFuncOptimizations.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/DelegateAndFuncOptimizations.fs
@@ -5,6 +5,7 @@ namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 open FSharp.Test
 open NUnit.Framework
 
+#if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
 [<TestFixture>]
 module DelegateAndFuncOptimizations =
 
@@ -528,3 +529,4 @@ let ApplyComputedDelegate(c: int) =
             """
             ])
 
+#endif

--- a/tests/fsharp/Compiler/Stress/LargeExprTests.fs
+++ b/tests/fsharp/Compiler/Stress/LargeExprTests.fs
@@ -5,6 +5,7 @@ namespace FSharp.Compiler.UnitTests
 open NUnit.Framework
 open FSharp.Test
 
+#if !DEBUG // requires release version of compiler to avoid very deep stacks
 [<TestFixture>]
 module LargeExprTests =
 
@@ -5515,3 +5516,4 @@ let test () : unit =
 test ()
 """
         CompilerAssert.RunScript source []
+#endif

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2471,7 +2471,7 @@ module TypecheckTests =
     [<Test>]
     let ``sigs pos40`` () =
         let cfg = testConfig "typecheck/sigs"
-        fsc cfg "%s --target:exe -o:pos40.exe" cfg.fsc_flags ["pos40.fs"]
+        fsc cfg "%s --langversion:6.0 --target:exe -o:pos40.exe" cfg.fsc_flags ["pos40.fs"]
         peverify cfg "pos40.exe"
         exec cfg ("." ++ "pos40.exe") ""
 
@@ -3035,7 +3035,10 @@ module TypecheckTests =
     let ``type check neg130`` () = singleNegTest (testConfig "typecheck/sigs") "neg130"
 
     [<Test>]
-    let ``type check neg131`` () = singleNegTest (testConfig "typecheck/sigs") "neg131"
+    let ``type check neg131`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "6.0" "neg131"
+
+    [<Test>]
+    let ``type check neg132`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "5.0" "neg132"
 
     [<Test>]
     let ``type check neg_anon_1`` () = singleNegTest (testConfig "typecheck/sigs") "neg_anon_1"

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3035,7 +3035,7 @@ module TypecheckTests =
     let ``type check neg130`` () = singleNegTest (testConfig "typecheck/sigs") "neg130"
 
     [<Test>]
-    let ``type check neg131`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "preview" "neg131"
+    let ``type check neg131`` () = singleNegTest (testConfig "typecheck/sigs") "neg131"
 
     [<Test>]
     let ``type check neg_anon_1`` () = singleNegTest (testConfig "typecheck/sigs") "neg_anon_1"

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2471,7 +2471,7 @@ module TypecheckTests =
     [<Test>]
     let ``sigs pos40`` () =
         let cfg = testConfig "typecheck/sigs"
-        fsc cfg "%s --langversion:preview --target:exe -o:pos39.exe" cfg.fsc_flags ["pos40.fs"]
+        fsc cfg "%s --target:exe -o:pos40.exe" cfg.fsc_flags ["pos40.fs"]
         peverify cfg "pos40.exe"
         exec cfg ("." ++ "pos40.exe") ""
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2770,8 +2770,10 @@ module TypecheckTests =
     [<Test>]
     let ``type check neg44`` () = singleNegTest (testConfig "typecheck/sigs") "neg44"
 
+#if !DEBUG // requires release version of compiler to avoid very deep stacks
     [<Test>]
     let ``type check neg45`` () = singleNegTest (testConfig "typecheck/sigs") "neg45"
+#endif
 
     [<Test>]
     let ``type check neg46`` () = singleNegTest (testConfig "typecheck/sigs") "neg46"

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2469,6 +2469,13 @@ module TypecheckTests =
         exec cfg ("." ++ "pos39.exe") ""
 
     [<Test>]
+    let ``sigs pos40`` () =
+        let cfg = testConfig "typecheck/sigs"
+        fsc cfg "%s --langversion:preview --target:exe -o:pos39.exe" cfg.fsc_flags ["pos40.fs"]
+        peverify cfg "pos40.exe"
+        exec cfg ("." ++ "pos40.exe") ""
+
+    [<Test>]
     let ``sigs pos23`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos23.exe" cfg.fsc_flags ["pos23.fs"]
@@ -3026,6 +3033,9 @@ module TypecheckTests =
 
     [<Test>]
     let ``type check neg130`` () = singleNegTest (testConfig "typecheck/sigs") "neg130"
+
+    [<Test>]
+    let ``type check neg131`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "preview" "neg131"
 
     [<Test>]
     let ``type check neg_anon_1`` () = singleNegTest (testConfig "typecheck/sigs") "neg_anon_1"

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2471,7 +2471,7 @@ module TypecheckTests =
     [<Test>]
     let ``sigs pos40`` () =
         let cfg = testConfig "typecheck/sigs"
-        fsc cfg "%s --langversion:6.0 --target:exe -o:pos40.exe" cfg.fsc_flags ["pos40.fs"]
+        fsc cfg "%s --langversion:preview --target:exe -o:pos40.exe" cfg.fsc_flags ["pos40.fs"]
         peverify cfg "pos40.exe"
         exec cfg ("." ++ "pos40.exe") ""
 
@@ -3035,7 +3035,7 @@ module TypecheckTests =
     let ``type check neg130`` () = singleNegTest (testConfig "typecheck/sigs") "neg130"
 
     [<Test>]
-    let ``type check neg131`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "6.0" "neg131"
+    let ``type check neg131`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "preview" "neg131"
 
     [<Test>]
     let ``type check neg132`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "5.0" "neg132"

--- a/tests/fsharp/typecheck/sigs/neg131.bsl
+++ b/tests/fsharp/typecheck/sigs/neg131.bsl
@@ -1,0 +1,8 @@
+
+neg131.fs(14,9,14,55): typecheck error FS0041: A unique overload for method 'SomeMethod' could not be determined based on type information prior to this program point. A type annotation may be needed.
+
+Known types of arguments: 'a * ('b -> int)
+
+Candidates:
+ - static member OverloadsWithSrtp.SomeMethod: x:  ^T * f: ( ^T -> int) -> int when  ^T: (member get_Length:  ^T -> int)
+ - static member OverloadsWithSrtp.SomeMethod: x: 'T list * f: ('T list -> int) -> int

--- a/tests/fsharp/typecheck/sigs/neg131.bsl
+++ b/tests/fsharp/typecheck/sigs/neg131.bsl
@@ -1,5 +1,5 @@
 
-neg131.fs(14,9,14,55): typecheck error FS0041: A unique overload for method 'SomeMethod' could not be determined based on type information prior to this program point. A type annotation may be needed.
+neg131.fs(15,9,15,55): typecheck error FS0041: A unique overload for method 'SomeMethod' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known types of arguments: 'a * ('b -> int)
 

--- a/tests/fsharp/typecheck/sigs/neg131.fs
+++ b/tests/fsharp/typecheck/sigs/neg131.fs
@@ -1,15 +1,15 @@
 module Neg131
 
 open System
-
+open FSharp.Core.CompilerServices
 module TestOverloadsWithSrtpThatDontResolve1 =
 
     type OverloadsWithSrtp() =
-        [<FSharp.Core.CompilerServices.NoEagerConstraintApplication>]
+        [<NoEagerConstraintApplication>]
         static member inline SomeMethod< ^T when ^T : (member Length: int) > (x: ^T, f: ^T -> int) = 1
         static member  SomeMethod(x: 'T list, f: 'T list -> int) = 2
 
-    // Here, 'x' doesn't contain any type information so the overload doesn't resolve
-    // The second overload is generic so is not preferred
+    // 'x' doesn't contain any type information so the overload doesn't resolve.
+
     let inline f x = 
         OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 

--- a/tests/fsharp/typecheck/sigs/neg131.fs
+++ b/tests/fsharp/typecheck/sigs/neg131.fs
@@ -1,0 +1,14 @@
+module Neg131
+
+open System
+
+module TestOverloadsWithSrtpThatDontResolve1 =
+
+    type OverloadsWithSrtp() =
+        static member inline SomeMethod< ^T when ^T : (member Length: int) > (x: ^T, f: ^T -> int) = 1
+        static member inline SomeMethod(x: 'T list, f: 'T list -> int) = 2
+
+    // Here, 'x' doesn't contain any type information so the overload doesn't resolve
+    // The second overload is generic so is not preferred
+    let inline f x = 
+        OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 

--- a/tests/fsharp/typecheck/sigs/neg131.fs
+++ b/tests/fsharp/typecheck/sigs/neg131.fs
@@ -5,8 +5,9 @@ open System
 module TestOverloadsWithSrtpThatDontResolve1 =
 
     type OverloadsWithSrtp() =
+        [<FSharp.Core.CompilerServices.NoEagerConstraintApplication>]
         static member inline SomeMethod< ^T when ^T : (member Length: int) > (x: ^T, f: ^T -> int) = 1
-        static member inline SomeMethod(x: 'T list, f: 'T list -> int) = 2
+        static member  SomeMethod(x: 'T list, f: 'T list -> int) = 2
 
     // Here, 'x' doesn't contain any type information so the overload doesn't resolve
     // The second overload is generic so is not preferred

--- a/tests/fsharp/typecheck/sigs/neg132.bsl
+++ b/tests/fsharp/typecheck/sigs/neg132.bsl
@@ -1,7 +1,7 @@
 
-neg132.fs(15,9,15,55): typecheck error FS3510: Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later
+neg132.fs(15,9,15,55): typecheck error FS3510: Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later
 
-neg132.fs(15,9,15,55): typecheck error FS3510: Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later
+neg132.fs(15,9,15,55): typecheck error FS3510: Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later
 
 neg132.fs(15,9,15,55): typecheck error FS0041: A unique overload for method 'SomeMethod' could not be determined based on type information prior to this program point. A type annotation may be needed.
 

--- a/tests/fsharp/typecheck/sigs/neg132.bsl
+++ b/tests/fsharp/typecheck/sigs/neg132.bsl
@@ -1,0 +1,12 @@
+
+neg132.fs(15,9,15,55): typecheck error FS3510: Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later
+
+neg132.fs(15,9,15,55): typecheck error FS3510: Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:6.0 or later
+
+neg132.fs(15,9,15,55): typecheck error FS0041: A unique overload for method 'SomeMethod' could not be determined based on type information prior to this program point. A type annotation may be needed.
+
+Known types of arguments: 'a * ('b -> int)
+
+Candidates:
+ - static member OverloadsWithSrtp.SomeMethod: x:  ^T * f: ( ^T -> int) -> int when  ^T: (member get_Length:  ^T -> int)
+ - static member OverloadsWithSrtp.SomeMethod: x: 'T list * f: ('T list -> int) -> int

--- a/tests/fsharp/typecheck/sigs/neg132.bsl
+++ b/tests/fsharp/typecheck/sigs/neg132.bsl
@@ -1,8 +1,6 @@
 
 neg132.fs(15,9,15,55): typecheck error FS3510: Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later
 
-neg132.fs(15,9,15,55): typecheck error FS3510: Using methods with 'NoEagerConstraintApplicationAttribute' requires /langversion:preview or later
-
 neg132.fs(15,9,15,55): typecheck error FS0041: A unique overload for method 'SomeMethod' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known types of arguments: 'a * ('b -> int)

--- a/tests/fsharp/typecheck/sigs/neg132.fs
+++ b/tests/fsharp/typecheck/sigs/neg132.fs
@@ -1,0 +1,15 @@
+module Neg132
+
+open System
+open FSharp.Core.CompilerServices
+module TestOverloadsWithSrtpThatDontResolve1 =
+
+    type OverloadsWithSrtp() =
+        [<NoEagerConstraintApplication>]
+        static member inline SomeMethod< ^T when ^T : (member Length: int) > (x: ^T, f: ^T -> int) = 1
+        static member  SomeMethod(x: 'T list, f: 'T list -> int) = 2
+
+    // this will give a "requires version 6.0 or greater" error
+
+    let inline f x = 
+        OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 

--- a/tests/fsharp/typecheck/sigs/pos40.fs
+++ b/tests/fsharp/typecheck/sigs/pos40.fs
@@ -1,0 +1,41 @@
+module Pos40
+
+module TestOverloadsWithSrtpThatDoResolve2 =
+
+    type OverloadsWithSrtp() =
+        static member inline SomeMethod< ^T when ^T : (member Length: int) > (x: ^T, f: ^T -> int) = 1
+        static member inline SomeMethod(x: string, f: string -> int) = 2
+
+    // Here, 'x' doesn't contain any type information so the overload doesn't resolve
+    // The second overload is not generic so is preferred according to standard overloading rules.
+    let inline f x = 
+        OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 
+
+    // Here, 'x' does contain enough type information so the overload does resolve
+    // The lambda argument 'a' gets type 'string'
+    let f4 (x: string) = 
+        OverloadsWithSrtp.SomeMethod (x, (fun a -> a.Length)) 
+
+module TestOverloadsWithSrtpThatDoResolve3 =
+
+    type OverloadsWithSrtp() =
+        static member inline SomeMethod< ^T when ^T : (member Length: int) > (x: ^T, f: ^T -> int) = 1
+        static member inline SomeMethod(x: string, f: string -> int) = 2
+
+    // Here, 'x' does contain enough type information so the overload does resolve.
+    // The lambda argument 'a' gets constrained type
+    let inline f2< ^T when ^T : (member Length: int)> (x: ^T) = 
+        OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 
+
+    // Here, 'x' does contain enough type information so the overload does resolve
+    // The lambda argument 'a' gets constrained type
+    let inline f3< ^T when ^T : (member Length: int) and ^T : (member Length2: int)> (x: ^T) = 
+        OverloadsWithSrtp.SomeMethod (x, (fun a -> 2)) 
+
+    // Here, 'x' does contain enough type information so the overload does resolve
+    // The lambda argument 'a' gets type 'int'
+    let f4 (x: int list) = 
+        OverloadsWithSrtp.SomeMethod (x, (fun a -> a.Length))
+
+printfn "test completed"
+exit 0

--- a/tests/fsharp/typecheck/sigs/pos40.fs
+++ b/tests/fsharp/typecheck/sigs/pos40.fs
@@ -1,18 +1,26 @@
 module Pos40
 
+open FSharp.Core.CompilerServices
+
+// Test a number of cases relating to https://github.com/dotnet/fsharp/pull/12202/files
 module TestOverloadsWithSrtpThatDoResolve1 =
 
     type OverloadsWithSrtp() =
+        // Note: no attribute
+        //[<NoEagerConstraintApplication>]
         static member inline SomeMethod< ^T when ^T : (member Foo: int) > (x: ^T, f: ^T -> int) = 1
         static member SomeMethod(x: string, f: string -> int) = 2
 
     // Here, 'x' doesn't contain any type information. However the presence of an SRTP-constrained
     // method causes the Foo constraint to be applied to the caller argument type and the
-    // method is resolved.
-    //
-    // The second overload is not generic so is preferred according to standard overloading rules.
+    // method is resolved to the first overload.
     let inline f x = 
         OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 
+
+    type C() =
+       member x.Foo = 3
+       
+    let v = f (C()) // this should now resolve 
 
     // Here, 'x' contains enough type informationto resolve the overload.
     // Lambda propagation applies and the lambda argument 'a' gets known type 'string'.
@@ -22,7 +30,7 @@ module TestOverloadsWithSrtpThatDoResolve1 =
 module TestOverloadsWithSrtpThatDoResolve2 =
 
     type OverloadsWithSrtp() =
-        [<FSharp.Core.CompilerServices.NoEagerConstraintApplication>]
+        [<NoEagerConstraintApplication>]
         static member inline SomeMethod< ^T when ^T : (member Foo: int) > (x: ^T, f: ^T -> int) = 1
         static member SomeMethod(x: string, f: string -> int) = 2
 
@@ -30,8 +38,10 @@ module TestOverloadsWithSrtpThatDoResolve2 =
     // method does not causes the Foo constraint to be applied to the caller argument type because NoEagerConstraintApplication is present.
     //
     // Overload resolution proceeds. The second overload is not generic so is preferred according to standard overloading rules.
-    let inline f x = 
+    let f x = 
         OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 
+
+    let v = f "hello" // this should now resolve since 'x' was inferred to have type 'string'
 
     // Here, 'x' contains enough type informationto resolve the overload.
     // Lambda propagation applies and the lambda argument 'a' gets known type 'string'.
@@ -41,7 +51,7 @@ module TestOverloadsWithSrtpThatDoResolve2 =
 module TestOverloadsWithSrtpThatDoResolve3 =
 
     type OverloadsWithSrtp() =
-        [<FSharp.Core.CompilerServices.NoEagerConstraintApplication>]
+        [<NoEagerConstraintApplication>]
         static member inline SomeMethod< ^T when ^T : (member Length: int) > (x: ^T, f: ^T -> int) = 1
         static member SomeMethod(x: string, f: string -> int) = 2
 
@@ -49,6 +59,9 @@ module TestOverloadsWithSrtpThatDoResolve3 =
     // The lambda argument 'a' gets constrained type
     let inline f2< ^T when ^T : (member Length: int)> (x: ^T) = 
         OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 
+
+    let v1 = f2 [1]
+    let v2 = f2 [| 1 |]
 
     // Here, 'x' contains enough type informationto resolve the overload
     // The lambda argument 'a' gets constrained type
@@ -59,6 +72,8 @@ module TestOverloadsWithSrtpThatDoResolve3 =
     // The lambda argument 'a' gets type 'int'
     let f4 (x: int list) = 
         OverloadsWithSrtp.SomeMethod (x, (fun a -> a.Length))
+
+    let v4 = f4 [ 1 ]
 
 printfn "test completed"
 exit 0


### PR DESCRIPTION
This fixes #12184 

The problem is with resolution of this kind of amiguous code:
```fsharp
    let TaskMethod t =
        task {
            let! result = t
            return result
        }
```
Here `let!` uses overload resolution on `task.Bind`.  This has multiple overloads:
```
member Bind: Task<'T> * ('T -> TaskCode<...>)
member Bind: Async<'T> * ('T -> TaskCode<...>)
member Bind: ^TaskLike * ('T -> TaskCode<...>) when ... 
```
The intention of the RFC is that the overloads are used in the above priority order - that is, if no type information is available then `Task<'T>` is assumed. The actual RFC uses extension methods as the basis to ensure this priority order. With this design, overloads are resolved eagerly, and the highest priority one will be chosen based on available type annotations, so if you don't specify a type, `Task<_>` will be assumed.  For example

```fsharp
let TaskMethod t =
    task {
        let! result = t
        return result
    }
```
will compile and infer type
```fsharp
val TaskMethod: t: Task<'a> -> Task<'a>
```

This differs from TaskBuilder.fs but is the intended design (among other things it prevents SRTP constraints floating everywhere throughout resolution, with their accompanying difficult error messages, and prevents default solutions for SRTP constraints causing strange errors).

However, the priority order was not applying.  The reason is subtle: a rule in overload resolution called "eager constraint application" meant the SRTP overload is being given absolute priority in the absence of other type information - the details are explained below.  This is established behaviour and even useful in some situations, and thus can't be changed universally (that is, some existing code will depend on it).  

As a result, this PR adopts a conservative approach to fixing this, allowing an overload to declare that "eager constraint application" doesn't apply.   This attribute is not expected to be used by anyone except the most advanced F# programmers and is really designed to correct what was effectively a mistake (or at best inadvertent behaviour that has since proved useful to some users) and allow for the design of overload sets with more normal properties.

I will add this to the "task" RFC

### Detailed background

As background, one of the phases of F# overload resolution is to propagate "known type information" into lambda expression arguments, e.g. for the overloads

```fsharp
    type Overloads() =
        static member SomeMethod(x: 'T array, f: 'T -> int, n: int) = ()
        static member SomeMethod(x: 'T array, f: 'T -> int, s: string) = ()

    Overloads.SomeMethod([| "a" |], (fun a -> a.Length), 1)
    Overloads.SomeMethod([| "a" |], (fun a -> a.Length), "a")
```

Here the type `string` is applied to `'T` based on processing the first argument, then, prior to processing the second argument, the type of "a" is known to be string because both overloads have a lambda of the same shape in the same position.  This process is called "LambdaPropagationInfo" and uses the constraint solver in "MatchingOnly" mode which works out values for type variables in the overload matrix, without affecting the types on the callsite (we can't affect these as the overload has not been committed yet).

Now, when some overloads use SRTP the "MatchingOnly" mode was incorrectly pushing an SRTP constraint into the types on the callsite.  For example
```fsharp
    type OverloadsWithSrtp() =
        static member inline SomeMethod< ^T when ^T : (member Foo: int) > (x: ^T, f: ^T -> int) = 1
        static member inline SomeMethod(x: 'T list, f: 'T list -> int) = 2

    let inline f x = 
        OverloadsWithSrtp.SomeMethod (x, (fun a -> 1)) 
```
Here the call contains no specific information, and there is no grounds to prefer the SRTP overload.  So the overload should not resolve.  However, because one of the methods is an SRTP method, the constraint is eagerly applied to the argument type for "x".  This means that the second method becomes non-applicable, and thus the overload does resolve.  This happens regardless of other overload resolution rules.

