### PR TITLE
Fix 11816

### DIFF
--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -1635,6 +1635,7 @@ module MutRecBindingChecking =
 
                             // Phase2A: make incrClassCtorLhs - ctorv, thisVal etc, type depends on argty(s) 
                             let incrClassCtorLhs = TcImplicitCtorLhs_Phase2A(cenv, envForTycon, tpenv, tcref, vis, attrs, spats, thisIdOpt, baseValOpt, safeInitInfo, m, copyOfTyconTypars, objTy, thisTy, doc)
+
                             // Phase2A: Add copyOfTyconTypars from incrClassCtorLhs - or from tcref 
                             let envForTycon = AddDeclaredTypars CheckForDuplicateTypars incrClassCtorLhs.InstanceCtorDeclaredTypars envForTycon
                             let innerState = (Some incrClassCtorLhs, envForTycon, tpenv, recBindIdx, uncheckedBindsRev)
@@ -1676,6 +1677,7 @@ module MutRecBindingChecking =
                             // Phase2A: member binding - create prelim valspec (for recursive reference) and RecursiveBindingInfo 
                             let NormalizedBinding(_, _, _, _, _, _, _, valSynData, _, _, _, _) as bind = BindingNormalization.NormalizeBinding ValOrMemberBinding cenv envForTycon bind
                             let (SynValData(memberFlagsOpt, _, _)) = valSynData 
+
                             match tcref.TypeOrMeasureKind with
                             | TyparKind.Type -> ()
                             | TyparKind.Measure ->
@@ -1686,9 +1688,15 @@ module MutRecBindingChecking =
                                     match memberFlags.MemberKind with 
                                     | SynMemberKind.Constructor -> error(Error(FSComp.SR.tcMeasureDeclarationsRequireStaticMembersNotConstructors(), m))
                                     | _ -> ()
+
+                            let envForMember = 
+                                match incrClassCtorLhsOpt with
+                                | None -> AddDeclaredTypars CheckForDuplicateTypars copyOfTyconTypars envForTycon
+                                | Some _ -> envForTycon
+
                             let rbind = NormalizedRecBindingDefn(containerInfo, newslotsOK, declKind, bind)
                             let overridesOK = DeclKind.CanOverrideOrImplement declKind
-                            let (binds, _values), (tpenv, recBindIdx) = AnalyzeAndMakeAndPublishRecursiveValue overridesOK false cenv envForTycon (tpenv, recBindIdx) rbind
+                            let (binds, _values), (tpenv, recBindIdx) = AnalyzeAndMakeAndPublishRecursiveValue overridesOK false cenv envForMember (tpenv, recBindIdx) rbind
                             let cbinds = [ for rbind in binds -> Phase2AMember rbind ]
 
                             let innerState = (incrClassCtorLhsOpt, envForTycon, tpenv, recBindIdx, List.rev binds @ uncheckedBindsRev)

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -7,7 +7,6 @@ module internal FSharp.Compiler.CheckExpressions
 open System
 open System.Collections.Generic
 
-open Internal.Utilities
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -10708,7 +10707,7 @@ and AnalyzeRecursiveInstanceMemberDecl
 
          CheckForNonAbstractInterface declKind tcref memberFlags memberId.idRange
 
-         // Determine if a uniquely-identified-override List.exists based on the information
+         // Determine if a uniquely-identified-override exists based on the information
          // at the member signature. If so, we know the type of this member, and the full slotsig
          // it implements. Apply the inferred slotsig.
          let optInferredImplSlotTys, declaredTypars =

--- a/tests/fsharp/core/members/basics-hw/test.fsx
+++ b/tests/fsharp/core/members/basics-hw/test.fsx
@@ -5618,7 +5618,29 @@ module Devdiv2_5385_repro2 =
 
     printfn "test passed ok without NullReferenceException"
 
+module Fix11816 =
+    type IFoo<'T> = 
+        abstract X: 'T
 
+    type Bar<'T> =
+        // error FS0039: The type parameter 'T is not defined.
+        static member Do<'I when 'I :> IFoo<'T>> (i:'I) = i.X, i
+
+
+    type Test(x: int64) =
+        member _.X = x
+        interface IFoo<int64> with
+            member _.X = x
+
+
+    let t = Test(64L)
+
+    Bar<int64>.Do<Test> (t) |> printfn "%A"
+
+    let a,b = Bar<int64>.Do<Test>(t)
+
+    check "wwvwev" a 64L
+    check "wwvwev23" b.X 64L
 
 #if TESTS_AS_APP
 let RUN() = !failures


### PR DESCRIPTION
A simple fix to bring class-declared type parameters into scope when checking constraints on a generic method, in the case that there is no implicit constructor.

