### PR TITLE
Add KeyNotFoundException to Map.pick documentation

### DIFF
--- a/src/fsharp/FSharp.Core/map.fsi
+++ b/src/fsharp/FSharp.Core/map.fsi
@@ -260,10 +260,13 @@ module Map =
     [<CompiledName("TryPick")>]
     val tryPick: chooser:('Key -> 'T -> 'U option) -> table:Map<'Key,'T> -> 'U option
 
-    /// <summary>Searches the map looking for the first element where the given function returns a <c>Some</c> value</summary>
+    /// <summary>Searches the map looking for the first element where the given function returns a <c>Some</c> value.
+    /// Raise <c>KeyNotFoundException</c> if no such element exists.</summary>
     ///
     /// <param name="chooser">The function to generate options from the key/value pairs.</param>
     /// <param name="table">The input map.</param>
+    /// <exception cref="T:System.Collections.Generic.KeyNotFoundException">Thrown if no element returns a <c>Some</c>
+    /// value when evaluated by the chooser function</exception>
     ///
     /// <returns>The first result.</returns>
     /// 


### PR DESCRIPTION
I noticed that the possible KeyNotFoundException of Map.pick is not documented and added it to the summary of the function.
Is there anything else that I need to do, for updating the documentation of this function?