### PR TITLE
stack overflow resolving .resources

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1874,26 +1874,29 @@ module internal MagicAssemblyResolution =
 
         let ResolveAssembly (ctok, m, tcConfigB, tcImports: TcImports, fsiDynamicCompiler: FsiDynamicCompiler, fsiConsoleOutput: FsiConsoleOutput, fullAssemName: string) =
 
-           try 
+           try
                // Grab the name of the assembly
                let tcConfig = TcConfig.Create(tcConfigB,validate=false)
                let simpleAssemName = fullAssemName.Split([| ',' |]).[0]
-               if progress then fsiConsoleOutput.uprintfn "ATTEMPT MAGIC LOAD ON ASSEMBLY, simpleAssemName = %s" simpleAssemName // "Attempting to load a dynamically required assembly in response to an AssemblyResolve event by using known static assembly references..." 
+
+               // "Attempting to load a dynamically required assembly in response to an AssemblyResolve event by using known static assembly references..." 
+               if progress then fsiConsoleOutput.uprintfn "ATTEMPT MAGIC LOAD ON ASSEMBLY, simpleAssemName = %s" simpleAssemName
 
                // Special case: Mono Windows Forms attempts to load an assembly called something like "Windows.Forms.resources"
                // We can't resolve this, so don't try.
                // REVIEW: Suggest 4481, delete this special case.
-               if (runningOnMono && simpleAssemName.EndsWith(".resources",StringComparison.OrdinalIgnoreCase)) ||
+               if (simpleAssemName.EndsWith(".resources",StringComparison.OrdinalIgnoreCase)) ||
                   simpleAssemName.EndsWith(".XmlSerializers", StringComparison.OrdinalIgnoreCase) ||
                   (runningOnMono && simpleAssemName = "UIAutomationWinforms") then null
-               else
+
                // Special case: Is this the global unique dynamic assembly for FSI code? In this case just
-               // return the dynamic assembly itself.       
-               if fsiDynamicCompiler.DynamicAssemblyName = simpleAssemName then fsiDynamicCompiler.DynamicAssembly else
+               // return the dynamic assembly itself.
+               elif fsiDynamicCompiler.DynamicAssemblyName = simpleAssemName then fsiDynamicCompiler.DynamicAssembly
 
                // Otherwise continue
-               let assemblyReferenceTextDll = (simpleAssemName + ".dll") 
-               let assemblyReferenceTextExe = (simpleAssemName + ".exe") 
+               else
+               let assemblyReferenceTextDll = (simpleAssemName + ".dll")
+               let assemblyReferenceTextExe = (simpleAssemName + ".exe")
                let overallSearchResult =
 
                    // OK, try to resolve as an existing DLL in the resolved reference set.  This does unification by assembly name
@@ -1902,27 +1905,27 @@ module internal MagicAssemblyResolution =
 
                    match searchResult with
                    | Some r -> OkResult ([], Choice1Of2 r)
-                   | _ -> 
+                   | _ ->
 
                    // OK, try to resolve as a .dll
                    let searchResult = tcImports.TryResolveAssemblyReference (ctok, AssemblyReference (m, assemblyReferenceTextDll, None), ResolveAssemblyReferenceMode.Speculative)
 
                    match searchResult with
                    | OkResult (warns,[r]) -> OkResult (warns, Choice1Of2 r.resolvedPath)
-                   | _ -> 
+                   | _ ->
 
                    // OK, try to resolve as a .exe
                    let searchResult = tcImports.TryResolveAssemblyReference (ctok, AssemblyReference (m, assemblyReferenceTextExe, None), ResolveAssemblyReferenceMode.Speculative)
 
                    match searchResult with
                    | OkResult (warns, [r]) -> OkResult (warns, Choice1Of2 r.resolvedPath)
-                   | _ -> 
+                   | _ ->
 
                    if progress then fsiConsoleOutput.uprintfn "ATTEMPT LOAD, assemblyReferenceTextDll = %s" assemblyReferenceTextDll
                    /// Take a look through the files quoted, perhaps with explicit paths
-                   let searchResult = 
-                       (tcConfig.referencedDLLs 
-                            |> List.tryPick (fun assemblyReference -> 
+                   let searchResult =
+                       (tcConfig.referencedDLLs
+                            |> List.tryPick (fun assemblyReference ->
                              if progress then fsiConsoleOutput.uprintfn "ATTEMPT MAGIC LOAD ON FILE, referencedDLL = %s" assemblyReference.Text
                              if System.String.Compare(Filename.fileNameOfPath assemblyReference.Text, assemblyReferenceTextDll,StringComparison.OrdinalIgnoreCase) = 0 ||
                                 System.String.Compare(Filename.fileNameOfPath assemblyReference.Text, assemblyReferenceTextExe,StringComparison.OrdinalIgnoreCase) = 0 then
@@ -1931,12 +1934,12 @@ module internal MagicAssemblyResolution =
 
                    match searchResult with
                    | Some (OkResult (warns,[r])) -> OkResult (warns, Choice1Of2 r.resolvedPath)
-                   | _ -> 
+                   | _ ->
 
 #if !NO_EXTENSIONTYPING
                    match tcImports.TryFindProviderGeneratedAssemblyByName(ctok, simpleAssemName) with
                    | Some(assembly) -> OkResult([],Choice2Of2 assembly)
-                   | None -> 
+                   | None ->
 #endif
 
                    // As a last resort, try to find the reference without an extension


### PR DESCRIPTION
Fixes: #12033 

Somehow, when dotnet is trying to resolve types from managed .resources files it files and assembly resolve event when it can't find an assembly.  Because we have in fsi a magic assembly resolve handler we get invoked too.

Our handler then does a ton of work and finally just tries to do an assemlby load, which results in the handler being called again.

None of this is necessary for .resources, since they should be prob-able alongside the assembly for which they are the resources.

It seems we already had a special case for this on mono, I merely extended it for all platforms.