### PR TITLE
Fix for #12011 (backport to dev17.0)

### DIFF
--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -61,8 +61,9 @@ type Context =
     | CtxtParen of token * Position 
     // Position is position of following token 
     | CtxtSeqBlock of FirstInSequence * Position * AddBlockEnd   
-    // first bool indicates "was this 'with' followed immediately by a '|'"? 
-    | CtxtMatchClauses of bool * Position   
+    // Indicates we're processing the second part of a match, after the 'with'
+    // First bool indicates "was this 'with' followed immediately by a '|'"?
+    | CtxtMatchClauses of bool * Position
 
     member c.StartPos = 
         match c with 
@@ -952,12 +953,17 @@ type LexFilterImpl (lightStatus: LightSyntaxStatus, compilingFsLib, lexer, lexbu
         if debug then dprintf "--> pushing, stack = %A\n" newOffsideStack
         offsideStack <- newOffsideStack
 
-    let popCtxt() = 
-        match offsideStack with 
+    let rec popCtxt() =
+        match offsideStack with
         | [] -> ()
-        | h :: rest -> 
-             if debug then dprintf "<-- popping Context(%A), stack = %A\n" h rest
-             offsideStack <- rest
+        | h :: rest ->
+            if debug then dprintf "<-- popping Context(%A), stack = %A\n" h rest
+            offsideStack <- rest
+            // For CtxtMatchClauses, also pop the CtxtMatch, if present (we expect it always will be).
+            if relaxWhitespace2 then
+                match h, rest with
+                | CtxtMatchClauses _ , CtxtMatch _ :: _ -> popCtxt()
+                | _ -> ()
 
     let replaceCtxt p ctxt = popCtxt(); pushCtxt p ctxt
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/Basic/OffsideExceptions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/Basic/OffsideExceptions.fs
@@ -38,7 +38,7 @@ module OffsideExceptions =
         |> withLangVersionPreview
         |> verifyBaseline
         |> ignore
-        
+
     [<Fact>]
     let RelaxWhitespace2_Indentation() =
         Fsx """
@@ -5167,3 +5167,36 @@ exit 1
           Message =
            "Possible incorrect indentation: this token is offside of context started at position (3901:16). Try indenting this token further or using standard formatting conventions." }
         |]
+
+    [<Fact>]
+    let ``RelaxedWhitespaces2 - match expression regression (https://github.com/dotnet/fsharp/issues/12011)`` () =
+        Fsx """
+match
+    match "" with
+    | null -> ""
+    | s -> s
+    with
+| "" -> ""
+| _ -> failwith ""
+        """
+        |> withLangVersionPreview
+        |> withOptions ["--nowarn:20"]
+        |> typecheck
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``RelaxedWhitespaces2 - try expression regression (https://github.com/dotnet/fsharp/issues/12011)`` () =
+        Fsx """
+try
+    match true with
+    | true -> "true"
+    | false -> "false"
+    with
+    | ex -> ex.Message
+        """
+        |> withLangVersionPreview
+        |> withOptions ["--nowarn:20"]
+        |> typecheck
+        |> shouldSucceed
+        |> ignore

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -371,7 +371,8 @@ module rec Compiler =
 
     let private parseFSharp (fsSource: FSharpCompilationSource) : TestResult =
         let source = getSource fsSource.Source
-        let parseResults = CompilerAssert.Parse source
+        let fileName = if fsSource.SourceKind = SourceKind.Fsx then "test.fsx" else "test.fs"
+        let parseResults = CompilerAssert.Parse(source, fileName = fileName)
         let failed = parseResults.ParseHadErrors
 
         let diagnostics =  parseResults.Diagnostics |> fromFSharpDiagnostic

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -692,13 +692,13 @@ Updated automatically, please check diffs in your pull request, changes must be 
     static member RunScript source expectedErrorMessages =
         CompilerAssert.RunScriptWithOptions [||] source expectedErrorMessages
 
-    static member Parse (source: string, ?langVersion: string) =
+    static member Parse (source: string, ?langVersion: string, ?fileName: string) =
         let langVersion = defaultArg langVersion "default"
-        let sourceFileName = "test.fs"
+        let sourceFileName = defaultArg fileName "test.fsx"
         let parsingOptions =
             { FSharpParsingOptions.Default with
                 SourceFiles = [| sourceFileName |]
-                LangVersionText=langVersion }
+                LangVersionText = langVersion }
         checker.ParseFile(sourceFileName, SourceText.ofString source, parsingOptions) |> Async.RunImmediate
 
     static member ParseWithErrors (source: string, ?langVersion: string) = fun expectedParseErrors -> 


### PR DESCRIPTION
A fix and couple of tests for #12011 - outcome of today's sessions with @dsyme

PR for main: https://github.com/dotnet/fsharp/pull/12225