### PR TITLE
Un-hardcode the image name on release/dev17.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,7 +202,7 @@ stages:
             # and there is an alternate build definition that sets this to a queue that is always scouting the
             # next preview of Visual Studio.
             name: NetCore1ESPool-Svc-Public
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open # hardcoding this vaule on servicing branch
+            demands: ImageOverride -equals $(WindowsMachineQueueName)
           timeoutInMinutes: 120
           strategy:
             maxParallel: 4


### PR DESCRIPTION
This doesn't need to be hardcoded anymore now that we've switched main over to using the new pools and changed this value in the build definition.

cc/ @ulisesh @lpatalas 