### PR TITLE
Disable apphost on downlevel frameworks during source-build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -41,7 +41,7 @@
     <Exec
       Command="./build.sh --bootstrap --skipBuild"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
-      EnvironmentVariables="@(InnerBuildEnv)" />
+      EnvironmentVariables="@(InnerBuildEnv);DotNetBuildFromSource=true" />
   </Target>
 
 </Project>

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -240,29 +240,34 @@ function BuildSolution {
   node_reuse=false
 
   # build bootstrap tools
-  bootstrap_config=Proto
-  bootstrap_dir=$artifacts_dir/Bootstrap
-  if [[ "$force_bootstrap" == true ]]; then
-     rm -fr $bootstrap_dir
-  fi
-  if [ ! -f "$bootstrap_dir/fslex.dll" ]; then
-    BuildMessage="Error building tools"
-    MSBuild "$repo_root/src/buildtools/buildtools.proj" \
-      /restore \
-      /p:Configuration=$bootstrap_config
+  # source_build=true means we are currently in the outer/wrapper source-build,
+  # and building bootstrap needs to wait. The source-build targets will run this
+  # script again without setting source_build=true when it is done setting up
+  # the build environment. See 'eng/SourceBuild.props'.
+  if [[ "$source_build" != true ]]; then
+    bootstrap_config=Proto
+    bootstrap_dir=$artifacts_dir/Bootstrap
+    if [[ "$force_bootstrap" == true ]]; then
+      rm -fr $bootstrap_dir
+    fi
+    if [ ! -f "$bootstrap_dir/fslex.dll" ]; then
+      BuildMessage="Error building tools"
+      MSBuild "$repo_root/src/buildtools/buildtools.proj" \
+        /restore \
+        /p:Configuration=$bootstrap_config
 
-    mkdir -p "$bootstrap_dir"
-    cp -pr $artifacts_dir/bin/fslex/$bootstrap_config/net5.0 $bootstrap_dir/fslex
-    cp -pr $artifacts_dir/bin/fsyacc/$bootstrap_config/net5.0 $bootstrap_dir/fsyacc
-  fi
-  if [ ! -f "$bootstrap_dir/fsc.exe" ]; then
-    BuildMessage="Error building bootstrap"
-    MSBuild "$repo_root/proto.proj" \
-      /restore \
-      /p:Configuration=$bootstrap_config \
+      mkdir -p "$bootstrap_dir"
+      cp -pr $artifacts_dir/bin/fslex/$bootstrap_config/net5.0 $bootstrap_dir/fslex
+      cp -pr $artifacts_dir/bin/fsyacc/$bootstrap_config/net5.0 $bootstrap_dir/fsyacc
+    fi
+    if [ ! -f "$bootstrap_dir/fsc.exe" ]; then
+      BuildMessage="Error building bootstrap"
+      MSBuild "$repo_root/proto.proj" \
+        /restore \
+        /p:Configuration=$bootstrap_config
 
-
-    cp -pr $artifacts_dir/bin/fsc/$bootstrap_config/net5.0 $bootstrap_dir/fsc
+      cp -pr $artifacts_dir/bin/fsc/$bootstrap_config/net5.0 $bootstrap_dir/fsc
+    fi
   fi
 
   if [[ "$skip_build" != true ]]; then

--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/buildtools/fslex/fslex.fsproj
+++ b/src/buildtools/fslex/fslex.fsproj
@@ -5,6 +5,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <DefineConstants>INTERNALIZED_FSLEXYACC_RUNTIME;$(DefineConstants)</DefineConstants>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/buildtools/fsyacc/fsyacc.fsproj
+++ b/src/buildtools/fsyacc/fsyacc.fsproj
@@ -5,6 +5,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <DefineConstants>INTERNALIZED_FSLEXYACC_RUNTIME;$(DefineConstants)</DefineConstants>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsharp/fsc/fsc.fsproj
+++ b/src/fsharp/fsc/fsc.fsproj
@@ -12,6 +12,7 @@
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <NGenBinary>true</NGenBinary>
     <UseAppHost>true</UseAppHost>
+    <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -13,6 +13,7 @@
     <Win32Resource>fsi.res</Win32Resource>
     <NGenBinary>true</NGenBinary>
     <UseAppHost>true</UseAppHost>
+    <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
During source-build, disable apphost build for 'fsi' and 'fsc', and
'fsyacc', 'fslex', and 'AssemblyCheck' during the bootstrap build.

Creating an apphost for a net5.0 project while building with a net6.0
SDK downloads the apphost pack as a prebuilt. Stopping the projects from
creating the apphost removes the prebuilt for source-build.

To make disabling the apphost work in the bootstrapping build, add a
check to eng/build.sh to skip the bootstrap build if we're currently
running the "outer" source-build. That gives source-build the ability to
run bootstrapping on its own terms. Now, when eng/SourceBuild.props runs
bootstrapping, it can pass the DotNetBuildFromSource property through
the environment so it takes effect.

---

* For https://github.com/dotnet/fsharp/issues/12282

I've run this through a source-build tarball build locally and it seems to remove the prebuilt 5.0 apphost: https://github.com/dotnet/installer/pull/12456.

/cc @dotnet/source-build-internal 