### PR TITLE
[release/dev17.0] Remove implicit dotnet-tools feed add

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -53,10 +53,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackageFSharpDesignTimeTools</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <RestoreAdditionalProjectSources Condition="'$(_NETCoreSdkIsPreview)' != 'false' and '$(DisableFSharpCorePreviewCheck)' != 'true'">$(RestoreAdditionalProjectSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</RestoreAdditionalProjectSources>
-  </PropertyGroup>
-
   <Target Name="CollectFSharpDesignTimeTools" BeforeTargets="BeforeCompile" DependsOnTargets="_GetFrameworkAssemblyReferences">
     <ItemGroup>
       <PropertyNames Include = "Pkg$([System.String]::Copy('%(PackageReference.FileName)').Replace('.','_'))" Condition = " '%(PackageReference.IsFSharpDesignTimeProvider)' == 'true' and '%(PackageReference.Extension)' == '' "/>


### PR DESCRIPTION
This feed shouldn't be implicitly added (or mentioned) in our shipping Preview/RC/RTM F# SDKs because the contents of this feed, while generally only tools packages, could contain unexpected or unsigned packages if someone accidentally assigned another repo's build to it.