### PR TITLE
Revert "[Backported for Dev17][VS] Strongly hold C#/VB compilations until we get a result"

### DIFF
--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -107,7 +107,7 @@ type internal DelayedILModuleReader =
 [<RequireQualifiedAccess;NoComparison;CustomEquality>]
 type FSharpReferencedProject =
     | FSharpReference of projectFileName: string * options: FSharpProjectOptions
-    | PEReference of projectFileName: string * getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
+    | PEReference of projectFileName: string * stamp: DateTime * delayedReader: DelayedILModuleReader
     | ILModuleReference of projectFileName: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader)
 
     member this.FileName =
@@ -119,8 +119,8 @@ type FSharpReferencedProject =
     static member CreateFSharp(projectFileName, options) =
         FSharpReference(projectFileName, options)
 
-    static member CreatePortableExecutable(projectFileName, getStamp, getStream) =
-        PEReference(projectFileName, getStamp, DelayedILModuleReader(projectFileName, getStream))
+    static member CreatePortableExecutable(projectFileName, stamp, getStream) =
+        PEReference(projectFileName, stamp, DelayedILModuleReader(projectFileName, getStream))
 
     static member CreateFromILModuleReader(projectFileName, getStamp, getReader) =
         ILModuleReference(projectFileName, getStamp, getReader)
@@ -131,8 +131,8 @@ type FSharpReferencedProject =
             match this, o with
             | FSharpReference(projectFileName1, options1), FSharpReference(projectFileName2, options2) ->
                 projectFileName1 = projectFileName2 && options1 = options2
-            | PEReference(projectFileName1, getStamp1, _), PEReference(projectFileName2, getStamp2, _) ->
-                projectFileName1 = projectFileName2 && (getStamp1()) = (getStamp2())
+            | PEReference(projectFileName1, stamp1, _), PEReference(projectFileName2, stamp2, _) ->
+                projectFileName1 = projectFileName2 && stamp1 = stamp2
             | ILModuleReference(projectFileName1, getStamp1, _), ILModuleReference(projectFileName2, getStamp2, _) ->
                 projectFileName1 = projectFileName2 && (getStamp1()) = (getStamp2())
             | _ ->
@@ -181,8 +181,8 @@ and FSharpProjectOptions =
             match r1, r2 with
             | FSharpReferencedProject.FSharpReference(n1,a), FSharpReferencedProject.FSharpReference(n2,b) ->
                 n1 = n2 && FSharpProjectOptions.AreSameForChecking(a,b)
-            | FSharpReferencedProject.PEReference(n1, getStamp1, _), FSharpReferencedProject.PEReference(n2, getStamp2, _) ->
-                n1 = n2 && (getStamp1()) = (getStamp2())
+            | FSharpReferencedProject.PEReference(n1, stamp1, _), FSharpReferencedProject.PEReference(n2, stamp2, _) ->
+                n1 = n2 && stamp1 = stamp2
             | _ ->
                 false) &&
         options1.LoadTime = options2.LoadTime

--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -97,7 +97,7 @@ type public FSharpProjectOptions =
 and [<NoComparison;CustomEquality>] public FSharpReferencedProject =
     internal
     | FSharpReference of projectFileName: string * options: FSharpProjectOptions
-    | PEReference of projectFileName: string * getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
+    | PEReference of projectFileName: string * stamp: DateTime * delayedReader: DelayedILModuleReader
     | ILModuleReference of projectFileName: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader)
 
     member FileName : string
@@ -109,7 +109,7 @@ and [<NoComparison;CustomEquality>] public FSharpReferencedProject =
     /// The stream will be automatically disposed when there are no references to FSharpReferencedProject and is GC collected.
     /// Once the stream is evaluated, the function that constructs the stream will no longer be referenced by anything.
     /// If the stream evaluation throws an exception, it will be automatically handled.
-    static member CreatePortableExecutable : projectFileName: string * getStamp: (unit -> DateTime) * getStream: (CancellationToken -> Stream option) -> FSharpReferencedProject
+    static member CreatePortableExecutable : projectFileName: string * stamp: DateTime * getStream: (CancellationToken -> Stream option) -> FSharpReferencedProject
 
     /// Creates a reference from an ILModuleReader.
     static member CreateFromILModuleReader : projectFileName: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader) -> FSharpReferencedProject

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -269,7 +269,7 @@ type BackgroundCompiler(
                                 self.TryGetLogicalTimeStampForProject(cache, opts)
                             member x.FileName = nm }
                             
-                | FSharpReferencedProject.PEReference(nm,getStamp,delayedReader) ->
+                | FSharpReferencedProject.PEReference(nm,stamp,delayedReader) ->
                     yield
                         { new IProjectReference with 
                             member x.EvaluateRawContents() = 
@@ -285,7 +285,7 @@ type BackgroundCompiler(
                                     // continue to try to use an on-disk DLL
                                     return ProjectAssemblyDataResult.Unavailable false
                               }
-                            member x.TryGetLogicalTimeStamp _ = getStamp() |> Some
+                            member x.TryGetLogicalTimeStamp _ = stamp |> Some
                             member x.FileName = nm }
 
                 | FSharpReferencedProject.ILModuleReference(nm,getStamp,getReader) ->

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -2133,7 +2133,7 @@ FSharp.Compiler.CodeAnalysis.FSharpReferencedProject
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean Equals(System.Object)
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreateFSharp(System.String, FSharp.Compiler.CodeAnalysis.FSharpProjectOptions)
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreateFromILModuleReader(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader])
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreatePortableExecutable(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreatePortableExecutable(System.String, System.DateTime, Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 GetHashCode()
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String FileName
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String ToString()

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -42,8 +42,7 @@ namespace CSharpTest
                 ms :> Stream
                 |> Some
 
-        let stamp = DateTime.UtcNow
-        let csRefProj = FSharpReferencedProject.CreatePortableExecutable("""Z:\csharp_test.dll""", (fun () -> stamp), getStream)
+        let csRefProj = FSharpReferencedProject.CreatePortableExecutable("""Z:\csharp_test.dll""", DateTime.UtcNow, getStream)
 
         let fsOptions = CompilerAssert.DefaultProjectOptions
         let fsOptions =

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -114,12 +114,7 @@ type private FSharpProjectOptionsReactor (checker: FSharpChecker) =
         match weakPEReferences.TryGetValue comp with
         | true, fsRefProj -> fsRefProj
         | _ ->
-            let mutable strongComp = comp
             let weakComp = WeakReference<Compilation>(comp)
-            let stamp = DateTime.UtcNow
-
-            // Getting a C# reference assembly can fail if there are compilation errors that cannot be resolved.
-            // To mitigate this, we store the last successful compilation of a C# project and re-use it until we get a new successful compilation.
             let getStream =
                 fun ct ->
                     let tryStream (comp: Compilation) =
@@ -129,22 +124,15 @@ type private FSharpProjectOptionsReactor (checker: FSharpChecker) =
                             let result = comp.Emit(ms, options = emitOptions, cancellationToken = ct)
 
                             if result.Success then
-                                strongComp <- Unchecked.defaultof<_> // Stop strongly holding the compilation since we have a result.
                                 lastSuccessfulCompilations.[projectId] <- comp
                                 ms.Position <- 0L
                                 ms :> Stream
                                 |> Some
                             else
-                                strongComp <- Unchecked.defaultof<_> // Stop strongly holding the compilation since we have a result.
                                 ms.Dispose() // it failed, dispose of stream
                                 None
                         with
-                        | :? OperationCanceledException ->
-                            // Since we cancelled, do not null out the strong compilation ref.
-                            ms.Dispose()
-                            None
                         | _ ->
-                            strongComp <- Unchecked.defaultof<_> // Stop strongly holding the compilation since we have a result.
                             ms.Dispose() // it failed, dispose of stream
                             None
 
@@ -158,14 +146,12 @@ type private FSharpProjectOptionsReactor (checker: FSharpChecker) =
                     | _ ->
                         match lastSuccessfulCompilations.TryGetValue(projectId) with
                         | true, comp -> tryStream comp
-                        | _ -> None
-                        
-            let getStamp = fun () -> stamp
+                        | _ -> None                           
 
             let fsRefProj =
                 FSharpReferencedProject.CreatePortableExecutable(
                     referencedProject.OutputFilePath, 
-                    getStamp,
+                    DateTime.UtcNow,
                     getStream
                 )
             weakPEReferences.Add(comp, fsRefProj)


### PR DESCRIPTION
Reverts dotnet/fsharp#12287

This is a temporary step in the complicated Dance of the Signed Builds.

This revert will be shortly reverted.