### PR TITLE
don't run VS insertion until after symbols have been archived

### DIFF
--- a/eng/release/insert-into-vs.yml
+++ b/eng/release/insert-into-vs.yml
@@ -9,7 +9,7 @@ parameters:
 
 stages:
 - stage: insert
-  dependsOn: build
+  dependsOn: publish_using_darc
   displayName: Insert into VS
   jobs:
   - job: Insert_VS


### PR DESCRIPTION
The old way ran the VS insertion step immediately after build:
![image](https://user-images.githubusercontent.com/926281/139486539-2ccfd9a0-e477-49f8-bec6-df801a64cfab.png)

The new way puts the VS insertion after symbol publish (DARC):
![image](https://user-images.githubusercontent.com/926281/139486584-9cd5815c-40f8-437c-8e63-98a8e7b8c579.png)

This should solve the occasional issue where an auto-generated insertion fails because symbols haven't (yet) been archived, but re-running the symbol check then passes.