### PR TITLE
Fix commit of keywords just as with as other completions

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -43,23 +43,6 @@ type internal FSharpCompletionProvider
     static let [<Literal>] IndexPropName = "Index"
     static let [<Literal>] KeywordDescription = "KeywordDescription"
 
-    static let keywordCompletionItems =
-        FSharpKeywords.KeywordsWithDescription
-        |> List.filter (fun (keyword, _) -> not (PrettyNaming.IsOperatorDisplayName keyword))
-        |> List.sortBy (fun (keyword, _) -> keyword)
-        |> List.mapi (fun n (keyword, description) ->
-            FSharpCommonCompletionItem.Create(
-                displayText = keyword,
-                displayTextSuffix = "",
-                rules = CompletionItemRules.Default,
-                glyph = Nullable Glyph.Keyword,
-                sortText = sprintf "%06d" (1000000 + n))
-                .AddProperty(KeywordDescription, description))
-    
-    let settings: EditorOptions = workspace.Services.GetService()
-
-    let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(serviceProvider.XMLMemberIndexService)
-        
     static let noCommitOnSpaceRules = 
         // These are important.  They make sure we don't _commit_ autocompletion when people don't expect them to.  Some examples:
         //
@@ -79,6 +62,23 @@ type internal FSharpCompletionProvider
     
     static let getRules showAfterCharIsTyped = if showAfterCharIsTyped then noCommitOnSpaceRules else CompletionItemRules.Default
 
+    static let keywordCompletionItems =
+        FSharpKeywords.KeywordsWithDescription
+        |> List.filter (fun (keyword, _) -> not (PrettyNaming.IsOperatorDisplayName keyword))
+        |> List.sortBy (fun (keyword, _) -> keyword)
+        |> List.mapi (fun n (keyword, description) ->
+            FSharpCommonCompletionItem.Create(
+                displayText = keyword,
+                displayTextSuffix = "",
+                rules = noCommitOnSpaceRules,
+                glyph = Nullable Glyph.Keyword,
+                sortText = sprintf "%06d" (1000000 + n))
+                .AddProperty(KeywordDescription, description))
+    
+    let settings: EditorOptions = workspace.Services.GetService()
+
+    let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(serviceProvider.XMLMemberIndexService)
+        
     static let mruItems = Dictionary<(* Item.FullName *) string, (* hints *) int>()
     
     static member ShouldTriggerCompletionAux(sourceText: SourceText, caretPosition: int, trigger: CompletionTriggerKind, getInfo: (unit -> DocumentId * string * string list), intelliSenseOptions: IntelliSenseOptions) =

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -60,8 +60,6 @@ type internal FSharpCompletionProvider
 
         CompletionItemRules.Default.WithCommitCharacterRules(ImmutableArray.Create (CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, noCommitChars)))
     
-    static let getRules showAfterCharIsTyped = if showAfterCharIsTyped then noCommitOnSpaceRules else CompletionItemRules.Default
-
     static let keywordCompletionItems =
         FSharpKeywords.KeywordsWithDescription
         |> List.filter (fun (keyword, _) -> not (PrettyNaming.IsOperatorDisplayName keyword))
@@ -79,6 +77,8 @@ type internal FSharpCompletionProvider
 
     let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(serviceProvider.XMLMemberIndexService)
         
+    static let getRules showAfterCharIsTyped = if showAfterCharIsTyped then noCommitOnSpaceRules else CompletionItemRules.Default
+
     static let mruItems = Dictionary<(* Item.FullName *) string, (* hints *) int>()
     
     static member ShouldTriggerCompletionAux(sourceText: SourceText, caretPosition: int, trigger: CompletionTriggerKind, getInfo: (unit -> DocumentId * string * string list), intelliSenseOptions: IntelliSenseOptions) =
@@ -100,7 +100,6 @@ type internal FSharpCompletionProvider
                     let documentId, filePath, defines = getInfo()
                     CompletionUtils.shouldProvideCompletion(documentId, filePath, defines, sourceText, triggerPosition) &&
                     (triggerChar = '.' || (intelliSenseOptions.ShowAfterCharIsTyped && CompletionUtils.isStartingNewWord(sourceText, triggerPosition)))
-                
 
     static member ProvideCompletionsAsyncAux(document: Document, caretPosition: int, getAllSymbols: FSharpCheckFileResults -> AssemblySymbol list, intellisenseOptions: IntelliSenseOptions) = 
 

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -99,7 +99,7 @@ type internal FSharpCompletionProvider
                     CompletionUtils.shouldProvideCompletion(documentId, filePath, defines, sourceText, triggerPosition) &&
                     (triggerChar = '.' || (intelliSenseOptions.ShowAfterCharIsTyped && CompletionUtils.isStartingNewWord(sourceText, triggerPosition)))
 
-    static member ProvideCompletionsAsyncAux(document: Document, caretPosition: int, getAllSymbols: FSharpCheckFileResults -> AssemblySymbol list, intellisenseOptions: IntelliSenseOptions) = 
+    static member ProvideCompletionsAsyncAux(document: Document, caretPosition: int, getAllSymbols: FSharpCheckFileResults -> AssemblySymbol list) = 
 
         asyncMaybe {
             let! parseResults, checkFileResults = document.GetFSharpParseAndCheckResultsAsync("ProvideCompletionsAsyncAux") |> liftAsync
@@ -219,7 +219,7 @@ type internal FSharpCompletionProvider
                 then assemblyContentProvider.GetAllEntitiesInProjectAndReferencedAssemblies(fileCheckResults)
                 else []
             let! results = 
-                FSharpCompletionProvider.ProvideCompletionsAsyncAux(context.Document, context.Position, getAllSymbols, settings.IntelliSense)
+                FSharpCompletionProvider.ProvideCompletionsAsyncAux(context.Document, context.Position, getAllSymbols)
             context.AddItems(results)
         } |> Async.Ignore |> RoslynHelpers.StartAsyncUnitAsTask context.CancellationToken
 

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -77,8 +77,6 @@ type internal FSharpCompletionProvider
 
     let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(serviceProvider.XMLMemberIndexService)
         
-    static let getRules showAfterCharIsTyped = if showAfterCharIsTyped then noCommitOnSpaceRules else CompletionItemRules.Default
-
     static let mruItems = Dictionary<(* Item.FullName *) string, (* hints *) int>()
     
     static member ShouldTriggerCompletionAux(sourceText: SourceText, caretPosition: int, trigger: CompletionTriggerKind, getInfo: (unit -> DocumentId * string * string list), intelliSenseOptions: IntelliSenseOptions) =
@@ -154,7 +152,7 @@ type internal FSharpCompletionProvider
                     FSharpCommonCompletionItem.Create(
                         declarationItem.Name,
                         null,
-                        rules = getRules intellisenseOptions.ShowAfterCharIsTyped,
+                        rules = noCommitOnSpaceRules,
                         glyph = Nullable glyph,
                         filterText = filterText,
                         inlineDescription = namespaceName)

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -43,19 +43,19 @@ type internal FSharpCompletionProvider
     static let [<Literal>] IndexPropName = "Index"
     static let [<Literal>] KeywordDescription = "KeywordDescription"
 
+    // These are important.  They make sure we don't _commit_ autocompletion when people don't expect them to.  Some examples:
+    //
+    // * type Foo() =
+    //       member val a = 12 with get, <<---- Don't commit autocomplete!
+    //
+    // * type MyRecord = { name: <<---- Don't commit autocomplete!
+    //
+    // * type My< <<---- Don't commit autocomplete!
+    //
+    // * let myClassInstance = MyClass(Date= <<---- Don't commit autocomplete!
+    //
+    // * let xs = [1..10] <<---- Don't commit autocomplete! (same for arrays)
     static let noCommitOnSpaceRules = 
-        // These are important.  They make sure we don't _commit_ autocompletion when people don't expect them to.  Some examples:
-        //
-        // * type Foo() =
-        //       member val a = 12 with get, <<---- Don't commit autocomplete!
-        //
-        // * type MyRecord = { name: <<---- Don't commit autocomplete!
-        //
-        // * type My< <<---- Don't commit autocomplete!
-        //
-        // * let myClassInstance = MyClass(Date= <<---- Don't commit autocomplete!
-        //
-        // * let xs = [1..10] <<---- Don't commit autocomplete! (same for arrays)
         let noCommitChars = [|' '; '='; ','; '.'; '<'; '>'; '('; ')'; '!'; ':'; '['; ']'; '|'|].ToImmutableArray()
 
         CompletionItemRules.Default.WithCommitCharacterRules(ImmutableArray.Create (CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, noCommitChars)))

--- a/vsintegration/tests/UnitTests/CompletionProviderTests.fs
+++ b/vsintegration/tests/UnitTests/CompletionProviderTests.fs
@@ -56,7 +56,7 @@ let VerifyCompletionListWithOptions(fileContents: string, marker: string, expect
     let caretPosition = fileContents.IndexOf(marker) + marker.Length
     let document, _ = RoslynTestHelpers.CreateDocument(filePath, fileContents)
     let results = 
-        FSharpCompletionProvider.ProvideCompletionsAsyncAux(document, caretPosition, (fun _ -> []), IntelliSenseOptions.Default) 
+        FSharpCompletionProvider.ProvideCompletionsAsyncAux(document, caretPosition, (fun _ -> [])) 
         |> Async.RunSynchronously 
         |> Option.defaultValue (ResizeArray())
         |> Seq.map(fun result -> result.DisplayText)
@@ -107,7 +107,7 @@ let VerifyCompletionListExactly(fileContents: string, marker: string, expected: 
     let caretPosition = fileContents.IndexOf(marker) + marker.Length
     let document, _ = RoslynTestHelpers.CreateDocument(filePath, fileContents)
     let actual = 
-        FSharpCompletionProvider.ProvideCompletionsAsyncAux(document, caretPosition, (fun _ -> []), IntelliSenseOptions.Default) 
+        FSharpCompletionProvider.ProvideCompletionsAsyncAux(document, caretPosition, (fun _ -> [])) 
         |> Async.RunSynchronously 
         |> Option.defaultValue (ResizeArray())
         |> Seq.toList

--- a/vsintegration/tests/UnitTests/FsxCompletionProviderTests.fs
+++ b/vsintegration/tests/UnitTests/FsxCompletionProviderTests.fs
@@ -59,7 +59,7 @@ type Worker () =
         let document = RoslynTestHelpers.CreateDocument(filePath, SourceText.From(fileContents), options = projectOptions)
         let expected = expected |> Seq.toList
         let actual = 
-            let x = FSharpCompletionProvider.ProvideCompletionsAsyncAux(document, caretPosition, (fun _ -> []), IntelliSenseOptions.Default) 
+            let x = FSharpCompletionProvider.ProvideCompletionsAsyncAux(document, caretPosition, (fun _ -> [])) 
                     |> Async.RunSynchronously 
             x |> Option.defaultValue (ResizeArray())
             |> Seq.toList


### PR DESCRIPTION
Fixes #12317 and https://github.com/dotnet/fsharp/issues/11145 and https://github.com/dotnet/fsharp/issues/6099

Keyword completions are being committed when hitting characters like ":" or space.  Normal completions were fixed to avoid this behaviour long, long ago, but the fix was never applied to keyword completions.

Also, this shouldn't depend on the `intellisenseOptions.ShowAfterCharIsTyped`  option (which is normally on by default now, but can be turned off manually).  Even when you turn this off, typing ".", "]" and other such characters after manually invoking the completion list shouldn't do the completion - the completion item is selected by pressing "Return" not some arbitrary character.

