### PR TITLE
Introduce SynExpr.Operator

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -5639,7 +5639,7 @@ and TcExprUndelayed cenv (overallTy: OverallTy) env tpenv (synExpr: SynExpr) =
         TcExpr cenv overallTy env tpenv expr2
 
     | SynExpr.DotIndexedGet _ | SynExpr.DotIndexedSet _
-    | SynExpr.TypeApp _ | SynExpr.Ident _ | SynExpr.LongIdent _ | SynExpr.App _ | SynExpr.DotGet _ -> error(Error(FSComp.SR.tcExprUndelayed(), synExpr.Range))
+    | SynExpr.TypeApp _ | SynExpr.Ident _ | SynExpr.Operator _ | SynExpr.LongIdent _ | SynExpr.App _ | SynExpr.DotGet _ -> error(Error(FSComp.SR.tcExprUndelayed(), synExpr.Range))
 
     | SynExpr.Const (SynConst.String (s, _, m), _) ->
         CallExprHasTypeSink cenv.tcSink (m, env.NameEnv, overallTy.Commit, env.AccessRights)
@@ -8332,6 +8332,7 @@ and TcItemThen cenv (overallTy: OverallTy) env tpenv (tinstEnclosing, item, mIte
             | SynExpr.InterpolatedString _
             | SynExpr.Null _
             | SynExpr.Ident _
+            | SynExpr.Operator _
             | SynExpr.Const _
             | SynExpr.LongIdent _ -> true
 

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -654,6 +654,12 @@ type SynExpr =
     | Ident of
         ident: Ident
 
+    // nojaf test
+    | Operator of
+        originalText: string *
+        ident: Ident *
+        range: Range
+
     | LongIdent of
         isOptional: bool *
         longDotId: LongIdentWithDots *
@@ -909,7 +915,8 @@ type SynExpr =
         | SynExpr.MatchBang (range=m)
         | SynExpr.DoBang (range=m)
         | SynExpr.Fixed (range=m) 
-        | SynExpr.InterpolatedString (range=m) -> m
+        | SynExpr.InterpolatedString (range=m)
+        | SynExpr.Operator(range=m) -> m
         | SynExpr.Ident id -> id.idRange
 
     member e.RangeWithoutAnyExtraDot =

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -808,6 +808,12 @@ type SynExpr =
     | Ident of
         ident: Ident
 
+    // nojaf test
+    | Operator of
+        originalText: string *
+        ident: Ident *
+        range: Range
+    
     /// F# syntax: ident.ident...ident
     ///
     /// isOptional: true if preceded by a '?' for an optional named parameter

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -172,6 +172,8 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         let rec getIdentRangeForFuncExprInApp traverseSynExpr expr pos =
             match expr with
             | SynExpr.Ident ident -> Some ident.idRange
+            
+            | SynExpr.Operator (range=m) -> Some m
         
             | SynExpr.LongIdent (_, _, _, range) -> Some range
 
@@ -491,6 +493,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                   | SynExpr.LibraryOnlyStaticOptimization _
                   | SynExpr.Null _
                   | SynExpr.Ident _
+                  | SynExpr.Operator _
                   | SynExpr.ImplicitZero _
                   | SynExpr.Const _ -> 
                      ()

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -496,7 +496,8 @@ module SyntaxTraversal =
                      | Some x -> yield dive x x.Range traverseSynExpr]
                     |> pick expr
 
-                | SynExpr.Ident _ident -> None
+                | SynExpr.Ident _
+                | SynExpr.Operator _ -> None
 
                 | SynExpr.LongIdent (_, _longIdent, _altNameRefCell, _range) -> None
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -6516,6 +6516,12 @@ FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Collections.FSharpList`
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynInterfaceImpl] get_extraImpls()
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]] argOptions
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]] get_argOptions()
+FSharp.Compiler.Syntax.SynExpr+Operator: FSharp.Compiler.Syntax.Ident get_ident()
+FSharp.Compiler.Syntax.SynExpr+Operator: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynExpr+Operator: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynExpr+Operator: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynExpr+Operator: System.String get_originalText()
+FSharp.Compiler.Syntax.SynExpr+Operator: System.String originalText
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Text.Range get_leftParenRange()
@@ -6616,6 +6622,7 @@ FSharp.Compiler.Syntax.SynExpr+Tags: Int32 NamedIndexedPropertySet
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 New
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Null
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 ObjExpr
+FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Operator
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Paren
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Quote
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Record
@@ -6774,6 +6781,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean IsNamedIndexedPropertySet
 FSharp.Compiler.Syntax.SynExpr: Boolean IsNew
 FSharp.Compiler.Syntax.SynExpr: Boolean IsNull
 FSharp.Compiler.Syntax.SynExpr: Boolean IsObjExpr
+FSharp.Compiler.Syntax.SynExpr: Boolean IsOperator
 FSharp.Compiler.Syntax.SynExpr: Boolean IsParen
 FSharp.Compiler.Syntax.SynExpr: Boolean IsQuote
 FSharp.Compiler.Syntax.SynExpr: Boolean IsRecord
@@ -6840,6 +6848,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean get_IsNamedIndexedPropertySet()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsNew()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsNull()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsObjExpr()
+FSharp.Compiler.Syntax.SynExpr: Boolean get_IsOperator()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsParen()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsQuote()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsRecord()
@@ -6905,6 +6914,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNamedIndexedPr
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNew(Boolean, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewObjExpr(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynInterfaceImpl], FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewOperator(System.String, FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewParen(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewQuote(FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewRecord(Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]],FSharp.Compiler.Text.Range]], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExprRecordField], FSharp.Compiler.Text.Range)
@@ -6970,6 +6980,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+NamedIndexedPrope
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+New
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Null
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+ObjExpr
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Operator
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Paren
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Quote
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Record

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -617,6 +617,26 @@ for i = 1 to 10 do
             assertRange (2, 6) (2, 7) mEquals
         | _ -> Assert.Fail "Could not get valid AST"
 
+    [<Test>]
+    let ``SynExpr.Operator captures an operator`` () =
+
+        let ast =
+            """
+let v = 1 ++ 2
+let x = op_plus
+"""
+            |> getParseResults
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+                    SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                        SynModuleDecl.Let(bindings=[ SynBinding(expr = SynExpr.App(funcExpr = SynExpr.App(funcExpr = SynExpr.Operator(originalText=ot)))) ])
+                        SynModuleDecl.Let(bindings = [ SynBinding(expr = SynExpr.Ident _) ])
+                    ])
+                ])) ->
+            Assert.AreEqual("++", ot)
+        | _ -> Assert.Fail "Could not get valid AST"
+
 module Strings =
     let getBindingExpressionValue (parseResults: ParsedInput) =
         match parseResults with


### PR DESCRIPTION
Hi @dsyme,

Apologies for not creating an issue first, curiosity got the better of me while experimenting with this.
One problem we currently have is that Fantomas cannot distinguish operators and compiled operator names.

```fsharp
let a = 1 ++ 1
let b = op_PlusPlus 1 1
```

becomes

```fsharp
[Let
             (false,
              [SynBinding
                 (None, Normal, false, false, [],
                  PreXmlDoc ((1,4), FSharp.Compiler.Xml.XmlDocCollector),
                  SynValData
                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
                  Named (a, false, None, tmp.fsx (1,4--1,5)), None,
                  App
                    (NonAtomic, false,
                     App
                       (NonAtomic, true, Ident op_PlusPlus,
                        Const (Int32 1, tmp.fsx (1,8--1,9)), tmp.fsx (1,8--1,12)),
                     Const (Int32 1, tmp.fsx (1,13--1,14)), tmp.fsx (1,8--1,14)),
                  tmp.fsx (1,4--1,5), Yes tmp.fsx (1,0--1,14))],
              tmp.fsx (1,0--1,14));
           Let
             (false,
              [SynBinding
                 (None, Normal, false, false, [],
                  PreXmlDoc ((2,4), FSharp.Compiler.Xml.XmlDocCollector),
                  SynValData
                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
                  Named (b, false, None, tmp.fsx (2,4--2,5)), None,
                  App
                    (NonAtomic, false,
                     App
                       (NonAtomic, false, Ident op_PlusPlus,
                        Const (Int32 1, tmp.fsx (2,20--2,21)),
                        tmp.fsx (2,8--2,21)),
                     Const (Int32 1, tmp.fsx (2,22--2,23)), tmp.fsx (2,8--2,23)),
                  tmp.fsx (2,4--2,5), Yes tmp.fsx (2,0--2,23))],
              tmp.fsx (2,0--2,23))]
```

Notice how both lead to `Ident op_PlusPlus`.
I was hoping to tackle this by introducing a new union case `SynExpr.Operator`.
In the unit test, you can see how things would play out.

How do you feel about this approach? Would this be acceptable to have?

PS: I'm currently storing `originalText`, if all compiled operators can be decompiled without any problem then we could drop this as well.
PS2: The PR doesn't cover all cases yet. I noticed the `::` operator works a bit different. 