### PR TITLE
Update some code for F# 6

### DIFF
--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -1683,7 +1683,7 @@ let mkSeqAppend (cenv: cenv) env m genTy e1 e2 =
     let e2 = mkCoerceIfNeeded cenv.g (mkSeqTy cenv.g genResultTy) (tyOfExpr cenv.g e2) e2
     mkCallSeqAppend cenv.g m genResultTy e1 e2 
 
-let mkSeqFromFunctions (cenv: cenv) env m genTy e1 e2 =
+let mkSeqGenerated (cenv: cenv) env m genTy e1 e2 =
     let genResultTy = NewInferenceType ()
     UnifyTypes cenv env m genTy (mkSeqTy cenv.g genResultTy)
     let e2 = mkCoerceIfNeeded cenv.g (mkSeqTy cenv.g genResultTy) (tyOfExpr cenv.g e2) e2
@@ -1787,7 +1787,7 @@ let TcSequenceExpression (cenv: cenv) env tpenv comp (overallTy: OverallTy) m =
                 | _ -> guardExprMark
 
             let innerExpr = mkDelayedExpr mWhile innerExpr
-            Some(mkSeqFromFunctions cenv env guardExprMark genOuterTy guardExpr innerExpr, tpenv)
+            Some(mkSeqGenerated cenv env guardExprMark genOuterTy guardExpr innerExpr, tpenv)
 
         | SynExpr.TryFinally (innerComp, unwindExpr, mTryToLast, spTry, spFinally) ->
             let innerExpr, tpenv = tcSequenceExprBody env genOuterTy tpenv innerComp

--- a/src/fsharp/LowerCallsAndSeqs.fs
+++ b/src/fsharp/LowerCallsAndSeqs.fs
@@ -136,8 +136,8 @@ let (|SeqWhile|_|) g expr =
          when not (isVarFreeInExpr dummyv gd) ->
         
         // The debug point for 'while' is attached to the second argument, see TcSequenceExpression
-        let dpWhile = arg2.Range
-        Some (gd, arg2, dpWhile, m)
+        let mWhile = arg2.Range
+        Some (gd, arg2, mWhile, m)
 
     | _ ->
         None
@@ -351,7 +351,7 @@ let ConvertSequenceExprToObject g amap overallExpr =
             | _ ->
                 None
 
-        | SeqWhile g (guardExpr, bodyExpr, dpWhile, m) ->
+        | SeqWhile g (guardExpr, bodyExpr, mWhile, m) ->
             // printfn "found Seq.while"
             let resBody = ConvertSeqExprCode false false noDisposeContinuationLabel currentDisposeContinuationLabel bodyExpr
             match resBody with
@@ -364,7 +364,7 @@ let ConvertSequenceExprToObject g amap overallExpr =
 
                 Some { phase2 = (fun ctxt ->
                             let generate2, dispose2, checkDispose2 = res2.phase2 ctxt
-                            let generate = mkWhile g (DebugPointAtWhile.Yes dpWhile, NoSpecialWhileLoopMarker, guardExpr, generate2, m)
+                            let generate = mkWhile g (DebugPointAtWhile.Yes mWhile, NoSpecialWhileLoopMarker, guardExpr, generate2, m)
                             let dispose = dispose2
                             let checkDispose = checkDispose2
                             generate, dispose, checkDispose)

--- a/src/fsharp/LowerCallsAndSeqs.fs
+++ b/src/fsharp/LowerCallsAndSeqs.fs
@@ -136,8 +136,8 @@ let (|SeqWhile|_|) g expr =
          when not (isVarFreeInExpr dummyv gd) ->
         
         // The debug point for 'while' is attached to the second argument, see TcSequenceExpression
-        let mWhile = arg2.Range
-        Some (gd, arg2, mWhile, m)
+        let dpWhile = arg2.Range
+        Some (gd, arg2, dpWhile, m)
 
     | _ ->
         None
@@ -351,7 +351,7 @@ let ConvertSequenceExprToObject g amap overallExpr =
             | _ ->
                 None
 
-        | SeqWhile g (guardExpr, bodyExpr, mWhile, m) ->
+        | SeqWhile g (guardExpr, bodyExpr, dpWhile, m) ->
             // printfn "found Seq.while"
             let resBody = ConvertSeqExprCode false false noDisposeContinuationLabel currentDisposeContinuationLabel bodyExpr
             match resBody with
@@ -364,7 +364,7 @@ let ConvertSequenceExprToObject g amap overallExpr =
 
                 Some { phase2 = (fun ctxt ->
                             let generate2, dispose2, checkDispose2 = res2.phase2 ctxt
-                            let generate = mkWhile g (DebugPointAtWhile.Yes mWhile, NoSpecialWhileLoopMarker, guardExpr, generate2, m)
+                            let generate = mkWhile g (DebugPointAtWhile.Yes dpWhile, NoSpecialWhileLoopMarker, guardExpr, generate2, m)
                             let dispose = dispose2
                             let checkDispose = checkDispose2
                             generate, dispose, checkDispose)

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -343,7 +343,7 @@ let rec CheckTypeDeep (cenv: cenv) (visitTy, visitTyconRefOpt, visitAppTyOpt, vi
         for cx in tp.Constraints do
             match cx with 
             | TyparConstraint.MayResolveMember(TTrait(_, _, _, _, _, soln), _) -> 
-                 match visitTraitSolutionOpt, !soln with 
+                 match visitTraitSolutionOpt, soln.Value with 
                  | Some visitTraitSolution, Some sln -> visitTraitSolution sln
                  | _ -> ()
             | _ -> ()
@@ -423,7 +423,7 @@ and CheckTraitInfoDeep cenv (_, _, _, visitTraitSolutionOpt, _ as f) g env (TTra
     CheckTypesDeep cenv f g env tys 
     CheckTypesDeep cenv f g env argtys 
     Option.iter (CheckTypeDeep cenv f g env true ) rty
-    match visitTraitSolutionOpt, !soln with 
+    match visitTraitSolutionOpt, soln.Value with 
     | Some visitTraitSolution, Some sln -> visitTraitSolution sln
     | _ -> ()
 
@@ -1144,8 +1144,10 @@ and CheckExpr (cenv: cenv) (env: env) origExpr (context: PermitByRefExpr) : Limi
                 let data1 = doData true
                 let data2 = doData false
                 match savedConv.Value with 
-                | None -> savedConv:= Some (data1, data2)
-                | Some _ -> ()
+                | None ->
+                    savedConv.Value <- Some (data1, data2)
+                | Some _ ->
+                    ()
             with QuotationTranslator.InvalidQuotedTerm e -> 
                 errorRecovery e m
                 

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -273,7 +273,7 @@ and remapTraitWitnessInfo tyenv (TraitWitnessInfo(tys, nm, mf, argtys, rty)) =
 
 and remapTraitInfo tyenv (TTrait(tys, nm, mf, argtys, rty, slnCell)) =
     let slnCell = 
-        match !slnCell with 
+        match slnCell.Value with 
         | None -> None
         | _ when tyenv.removeTraitSolutions -> None
         | Some sln -> 
@@ -1163,7 +1163,7 @@ let ensureCcuHasModuleOrNamespaceAtPath (ccu: CcuThunk) path (CompPath(_, cpath)
 /// Look through the Expr.Link nodes arising from type inference
 let rec stripExpr e = 
     match e with 
-    | Expr.Link eref -> stripExpr !eref
+    | Expr.Link eref -> stripExpr eref.Value
     | _ -> e    
 
 let mkCase (a, b) = TCase(a, b)
@@ -1182,7 +1182,7 @@ let rec rangeOfExpr x =
     | Expr.StaticOptimization (_, _, _, m) | Expr.Lambda (_, _, _, _, _, m, _) 
     | Expr.WitnessArg (_, m)
     | Expr.TyLambda (_, _, _, m, _)| Expr.TyChoose (_, _, m) | Expr.LetRec (_, _, m, _) | Expr.Let (_, _, m, _) | Expr.Match (_, _, _, _, m, _) -> m
-    | Expr.Link eref -> rangeOfExpr (!eref)
+    | Expr.Link eref -> rangeOfExpr eref.Value
 
 type Expr with 
     member x.Range = rangeOfExpr x
@@ -3965,7 +3965,7 @@ module DebugPrint =
             | Expr.Let (bind, body, _, _) -> 
                 letL g bind (exprL body) |> wrap
             | Expr.Link rX -> 
-                (wordL(tagText "RecLink") --- atomL (!rX)) |> wrap
+                (wordL(tagText "RecLink") --- atomL rX.Value) |> wrap
             | Expr.Match (_, _, dtree, targets, _, _) -> 
                 leftL(tagText "[") ^^ (decisionTreeL g dtree @@ aboveListL (List.mapi targetL (targets |> Array.toList)) ^^ rightL(tagText "]"))
             | Expr.Op (TOp.UnionCase c, _, args, _) -> 
@@ -4066,9 +4066,10 @@ module DebugPrint =
                    (wordL(tagText "|") ^^ exprL csx --- (wordL(tagText "when...") ))
            
         // For tracking ranges through expr rewrites 
-        if !layoutRanges 
-        then leftL(tagText "{") ^^ (rangeL expr.Range ^^ rightL(tagText ":")) ++ lay ^^ rightL(tagText "}")
-        else lay
+        if layoutRanges.Value then
+            leftL(tagText "{") ^^ (rangeL expr.Range ^^ rightL(tagText ":")) ++ lay ^^ rightL(tagText "}")
+        else
+            lay
 
     and implFilesL g implFiles =
         aboveListL (List.map (implFileL g) implFiles)
@@ -4770,7 +4771,8 @@ and accFreeInExprNonLinear opts x acc =
              (accFreeVarsInTys opts tyargs
                 (accFreeInExprs opts args acc)))
 
-    | Expr.Link eref -> accFreeInExpr opts !eref acc
+    | Expr.Link eref ->
+        accFreeInExpr opts eref.Value acc
 
     | Expr.Sequential (expr1, expr2, _, _, _) -> 
         let acc = accFreeInExpr opts expr1 acc
@@ -5318,7 +5320,7 @@ and remapExpr (g: TcGlobals) (compgen: ValCopyFlag) (tmenv: Remap) expr =
         remapAppExpr g compgen tmenv (e1, e1ty, tyargs, args, m) expr
 
     | Expr.Link eref -> 
-        remapExpr g compgen tmenv !eref
+        remapExpr g compgen tmenv eref.Value
 
     | Expr.StaticOptimization (cs, e2, e3, m) -> 
        // note that type instantiation typically resolve the static constraints here 
@@ -5847,7 +5849,7 @@ let rec remarkExpr m x =
 
     | Expr.Link eref -> 
         // Preserve identity of fixup nodes during remarkExpr
-        eref := remarkExpr m !eref
+        eref.Value <- remarkExpr m eref.Value
         x
 
     | Expr.App (e1, e1ty, tyargs, args, _) ->
@@ -6737,7 +6739,7 @@ type ExprFolders<'State> (folders: ExprFolder<'State>) =
             let z = valBindF false z bind
             exprF z body
                 
-        | Expr.Link rX -> exprF z (!rX)
+        | Expr.Link rX -> exprF z rX.Value
 
         | Expr.Match (_spBind, _exprm, dtree, targets, _m, _ty) -> 
             let z = dtreeF z dtree
@@ -8791,7 +8793,7 @@ and rewriteExprStructure env expr =
       mkObjExpr(ty, basev, RewriteExpr env basecall, List.map (rewriteObjExprOverride env) overrides, 
                   List.map (rewriteObjExprInterfaceImpl env) iimpls, m)
   | Expr.Link eref -> 
-      RewriteExpr env !eref
+      RewriteExpr env eref.Value
 
   | Expr.Op (c, tyargs, args, m) -> 
       let args' = rewriteExprs env args

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -5,7 +5,6 @@
     <TargetFrameworks Condition="'$(OS)' != 'Unix'">net472;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">net5.0</TargetFrameworks>
     <NoWarn>$(NoWarn);44;75;</NoWarn>
-	<OtherFlags>$(OtherFlags) --langversion:preview</OtherFlags>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -5,6 +5,7 @@
     <TargetFrameworks Condition="'$(OS)' != 'Unix'">net472;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">net5.0</TargetFrameworks>
     <NoWarn>$(NoWarn);44;75;</NoWarn>
+	<OtherFlags>$(OtherFlags) --langversion:preview</OtherFlags>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/Array2Module.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/Array2Module.fs
@@ -301,21 +301,21 @@ type Array2Module() =
     member this.Iter() =
         // integer array  
         let intArr = Array2D.init 2 3 (fun i j -> i*100 + j)
-        let resultInt = ref 0 
+        let mutable resultInt = 0 
         let funInt (x:int) =   
-            resultInt := !resultInt + x              
+            resultInt <- resultInt + x              
             () 
         Array2D.iter funInt intArr 
-        if !resultInt <> 306 then Assert.Fail()
+        if resultInt <> 306 then Assert.Fail()
         
         // string array 
         let strArr = Array2D.init 2 3 (fun i j -> i.ToString() + "-" + j.ToString())
-        let resultStr = ref ""
+        let mutable resultStr = ""
         let funStr (x:string) =
-            resultStr := (!resultStr) + x + ","  
+            resultStr <- resultStr + x + ","  
             ()
         Array2D.iter funStr strArr  
-        if !resultStr <> "0-0,0-1,0-2,1-0,1-1,1-2," then Assert.Fail()
+        if resultStr <> "0-0,0-1,0-2,1-0,1-1,1-2," then Assert.Fail()
         
         // null array
         let nullArr = null:string[,]    
@@ -325,33 +325,33 @@ type Array2Module() =
     [<Fact>]
     member this.IterNonZeroBased() =
         let a = Array2D.createBased 1 5 10 10 1
-        let result = ref 0
-        a |> Array2D.iter (fun n -> result := !result + n)
-        if !result <> 100 then Assert.Fail()
-        result := 0
-        a |> Array2D.iteri (fun i j x -> result := !result + i + j + x)
-        if !result <> 1600 then Assert.Fail()
+        let mutable result = 0
+        a |> Array2D.iter (fun n -> result <- result + n)
+        if result <> 100 then Assert.Fail()
+        result <- 0
+        a |> Array2D.iteri (fun i j x -> result <- result + i + j + x)
+        if result <> 1600 then Assert.Fail()
         ()
 
     [<Fact>]
     member this.Iteri() =
         // integer array  
         let intArr = Array2D.init 2 3 (fun i j -> i*100 + j)
-        let resultInt = ref 0 
+        let mutable resultInt = 0 
         let funInt (x:int) (y:int) (z:int) =   
-            resultInt := !resultInt + x  + y  + z         
+            resultInt <- resultInt + x  + y  + z         
             () 
         Array2D.iteri funInt intArr 
-        if !resultInt <> 315 then Assert.Fail()
+        if resultInt <> 315 then Assert.Fail()
         
         // string array 
         let strArr = Array2D.init 2 3 (fun i j -> i.ToString() + "-" + j.ToString())
-        let resultStr = ref ""
+        let mutable resultStr = ""
         let funStr (x:int) (y:int) (z:string) =
-            resultStr := (!resultStr) + "[" + x.ToString() + "," + y.ToString() + "]" + "=" + z + "; "  
+            resultStr <- resultStr + "[" + x.ToString() + "," + y.ToString() + "]" + "=" + z + "; "  
             ()
         Array2D.iteri funStr strArr  
-        if !resultStr <> "[0,0]=0-0; [0,1]=0-1; [0,2]=0-2; [1,0]=1-0; [1,1]=1-1; [1,2]=1-2; " then Assert.Fail()
+        if resultStr <> "[0,0]=0-0; [0,1]=0-1; [0,2]=0-2; [1,0]=1-0; [1,1]=1-1; [1,2]=1-2; " then Assert.Fail()
             
         // null array
         let nullArr = null:string[,]    

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/Array3Module.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/Array3Module.fs
@@ -111,20 +111,20 @@ type Array3Module() =
         // integer array  
         let intArr = Array3D.init 2 3 2 (fun i j k -> i*100 + j*10 + k)
         
-        let resultInt = ref 0 
-        let addToTotal x = resultInt := !resultInt + x              
+        let mutable resultInt = 0 
+        let addToTotal x = resultInt <- resultInt + x              
         
         Array3D.iter addToTotal intArr 
-        Assert.True(!resultInt = 726)
+        Assert.True((resultInt = 726))
         
         // string array 
         let strArr = Array3D.init 2 3 2 (fun i j k-> i.ToString() + "-" + j.ToString() + "-" + k.ToString())
         
-        let resultStr = ref ""
-        let addElement (x:string) = resultStr := (!resultStr) + x + ","  
+        let mutable resultStr = ""
+        let addElement (x:string) = resultStr <- resultStr + x + ","  
 
         Array3D.iter addElement strArr  
-        Assert.True(!resultStr = "0-0-0,0-0-1,0-1-0,0-1-1,0-2-0,0-2-1,1-0-0,1-0-1,1-1-0,1-1-1,1-2-0,1-2-1,")
+        Assert.True((resultStr = "0-0-0,0-0-1,0-1-0,0-1-1,0-2-0,0-2-1,1-0-0,1-0-1,1-1-0,1-1-1,1-2-0,1-2-1,"))
         
         // empty array
         let emptyArray = Array3D.create 0 0 0 0
@@ -140,22 +140,22 @@ type Array3Module() =
 
         // integer array  
         let intArr = Array3D.init 2 3 2 (fun i j k -> i*100 + j*10 + k)
-        let resultInt = ref 0 
+        let mutable resultInt = 0 
         let funInt (x:int) (y:int) (z:int) (a:int) =   
-            resultInt := !resultInt + x  + y + z + a         
+            resultInt <- resultInt + x  + y + z + a         
             () 
             
         Array3D.iteri funInt intArr 
-        if !resultInt <> 750 then Assert.Fail()
+        if resultInt <> 750 then Assert.Fail()
         
         // string array 
         let strArr = Array3D.init 2 3 2 (fun i j k-> i.ToString() + "-" + j.ToString() + "-" + k.ToString())
-        let resultStr = ref ""
+        let mutable resultStr = ""
         let funStr (x:int) (y:int) (z:int) (a:string)=
-            resultStr := (!resultStr) + "[" + x.ToString() + "," + y.ToString()+"," + z.ToString() + "]" + "=" + a + "; "  
+            resultStr <- resultStr + "[" + x.ToString() + "," + y.ToString()+"," + z.ToString() + "]" + "=" + a + "; "  
             ()
         Array3D.iteri funStr strArr  
-        if !resultStr <> "[0,0,0]=0-0-0; [0,0,1]=0-0-1; [0,1,0]=0-1-0; [0,1,1]=0-1-1; [0,2,0]=0-2-0; [0,2,1]=0-2-1; [1,0,0]=1-0-0; [1,0,1]=1-0-1; [1,1,0]=1-1-0; [1,1,1]=1-1-1; [1,2,0]=1-2-0; [1,2,1]=1-2-1; " then Assert.Fail()
+        if resultStr <> "[0,0,0]=0-0-0; [0,0,1]=0-0-1; [0,1,0]=0-1-0; [0,1,1]=0-1-1; [0,2,0]=0-2-0; [0,2,1]=0-2-1; [1,0,0]=1-0-0; [1,0,1]=1-0-1; [1,1,0]=1-1-0; [1,1,1]=1-1-1; [1,2,0]=1-2-0; [1,2,1]=1-2-1; " then Assert.Fail()
         
         // empty array    
         let emptyArray = Array3D.create 0 0 0 0

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
@@ -21,7 +21,7 @@ Make sure each method works on:
 type ArrayModule() =
 
     [<Fact>]
-    member this.Empty() =
+    member _.Empty() =
         let emptyArray = Array.empty
         if Array.length emptyArray <> 0 then Assert.Fail()    
         
@@ -34,7 +34,7 @@ type ArrayModule() =
 
 
     [<Fact>]
-    member this.AllPairs() =
+    member _.AllPairs() =
         // integer array
         let resultInt =  Array.allPairs [|1..3|] [|2..2..6|]
         if resultInt <> [|(1,2);(1,4);(1,6)
@@ -62,7 +62,7 @@ type ArrayModule() =
         ()
 
     [<Fact>]
-    member this.Append() =
+    member _.Append() =
         // integer array
         let intArray = Array.append [| 1; 2 |] [| 3; 4 |]
         Assert.True( (intArray = [| 1; 2; 3; 4 |]) )
@@ -90,7 +90,7 @@ type ArrayModule() =
         ()
 
     [<Fact>]
-    member this.Average() =   
+    member _.Average() =   
       
         // empty float32 array
         let emptyFloatArray = Array.empty<float32> 
@@ -126,7 +126,7 @@ type ArrayModule() =
         ()
 
     [<Fact>]
-    member this.AverageBy() =
+    member _.AverageBy() =
 
         // empty double array
         let emptyDouArray = Array.empty<System.Double>
@@ -162,7 +162,7 @@ type ArrayModule() =
         ()
 
     [<Fact>]
-    member this.ChunkBySize() =
+    member _.ChunkBySize() =
 
         // int Seq
         Assert.True([| [|1..4|]; [|5..8|] |] = Array.chunkBySize 4 [|1..8|])
@@ -188,7 +188,7 @@ type ArrayModule() =
         ()
 
     [<Fact>]
-    member this.SplitInto() =
+    member _.SplitInto() =
 
         // int array
         Assert.True([| [|1..4|]; [|5..7|]; [|8..10|] |] = Array.splitInto 3 [|1..10|])
@@ -215,7 +215,7 @@ type ArrayModule() =
         ()
 
     [<Fact>]
-    member this.distinct() =
+    member _.distinct() =
         // distinct should work on empty array
         Assert.AreEqual([||], Array.distinct [||])
 
@@ -235,7 +235,7 @@ type ArrayModule() =
         Assert.AreEqual([|null, list|], Array.distinct [|null, list|])
         
     [<Fact>]
-    member this.distinctBy() =
+    member _.distinctBy() =
         // distinctBy should work on empty array
         Assert.AreEqual([||], Array.distinctBy (fun _ -> failwith "should not be executed") [||])
 
@@ -257,7 +257,7 @@ type ArrayModule() =
         Assert.AreEqual([|null, list|], Array.distinctBy id [|null, list|])
 
     [<Fact>]
-    member this.Except() =
+    member _.Except() =
         // integer array
         let intArr1 = [| yield! {1..100}
                          yield! {1..100} |]
@@ -289,7 +289,7 @@ type ArrayModule() =
         ()
 
     [<Fact>]
-    member this.Take() =
+    member _.Take() =
         Assert.AreEqual([||],Array.take 0 [||])
         Assert.AreEqual([||],Array.take 0 [|"str1";"str2";"str3";"str4"|])
         Assert.AreEqual([|1;2;4|],Array.take 3 [|1;2;4;5;7|])
@@ -302,7 +302,7 @@ type ArrayModule() =
         CheckThrowsArgumentNullException (fun () -> Array.take 5 null |> ignore)
         
     [<Fact>]
-    member this.takeWhile() =
+    member _.takeWhile() =
         Assert.AreEqual([||],Array.takeWhile (fun x -> failwith "should not be used") [||])
         Assert.AreEqual([|1;2;4;5|],Array.takeWhile (fun x -> x < 6) [|1;2;4;5;6;7|])
         Assert.AreEqual([|"a"; "ab"; "abc"|],Array.takeWhile (fun (x:string) -> x.Length < 4) [|"a"; "ab"; "abc"; "abcd"; "abcde"|])
@@ -315,7 +315,7 @@ type ArrayModule() =
         CheckThrowsArgumentNullException (fun () -> Array.takeWhile (fun _ -> failwith "should not be used") null |> ignore) 
 
     [<Fact>]
-    member this.splitAt() =        
+    member _.splitAt() =        
         Assert.AreEqual([||], Array.splitAt 0 [||] |> fst)  
         Assert.AreEqual([||], Array.splitAt 0 [||] |> snd)
 
@@ -343,7 +343,7 @@ type ArrayModule() =
         CheckThrowsArgumentNullException (fun () -> Array.splitAt 1 null |> ignore)
 
     [<Fact>]
-    member this.replicate() =
+    member _.replicate() =
         // replicate should create multiple copies of the given value
         Assert.AreEqual([||],Array.replicate 0 null)
         Assert.AreEqual([||],Array.replicate 0 1)
@@ -353,7 +353,7 @@ type ArrayModule() =
         CheckThrowsArgumentException (fun () ->  Array.replicate -1 null |> ignore)
         
     [<Fact>]
-    member this.Blit() = 
+    member _.Blit() = 
         // int array   
         let intSrc = [| 1..10 |]
         let intDes:int[] = Array.zeroCreate 10 
@@ -446,16 +446,16 @@ type ArrayModule() =
         this.CollectTester Array.collect Array.collect
         
     [<Fact>]
-    member this.CollectWithSideEffects () =
-        let stamp = ref 0
-        let f x = stamp := !stamp + 1; [| x |]
+    member _.CollectWithSideEffects () =
+        let mutable stamp = 0
+        let f x = stamp <- stamp + 1; [| x |]
         
         Array.collect f [| |] |> ignore
-        Assert.AreEqual(0, !stamp)
+        Assert.AreEqual(0, stamp)
         
-        stamp := 0
+        stamp <- 0
         Array.collect f [|1;2;3|] |> ignore
-        Assert.AreEqual(3,!stamp)
+        Assert.AreEqual(3, stamp)
         
     [<Fact>]
     member this.``Parallel.Collect`` () =
@@ -1278,16 +1278,16 @@ type ArrayModule() =
         
     [<Fact>]
     member this.InitWithSideEffects () =
-        let stamp = ref 0
+        let mutable stamp = 0
         let f i = 
-            stamp := !stamp + 1; 
+            stamp <- stamp + 1
             i 
         Array.init 0 f |> ignore
-        Assert.AreEqual (0, !stamp)
+        Assert.AreEqual (0, stamp)
         
-        stamp := 0
+        stamp <- 0
         Array.init 10 f |> ignore
-        Assert.AreEqual (10, !stamp)
+        Assert.AreEqual (10, stamp)
         
     [<Fact>]
     member this.``Parallel.Init``() = 
@@ -1320,27 +1320,27 @@ type ArrayModule() =
     member this.Iter() =
         // integer array
         let intArr = [| 1..10 |]  
-        let resultInt = ref 0    
+        let mutable resultInt = 0    
         let funInt (x:int) =   
-            resultInt := !resultInt + x              
+            resultInt <- resultInt + x              
             () 
         Array.iter funInt intArr 
-        if !resultInt <> 55 then Assert.Fail()    
+        if resultInt <> 55 then Assert.Fail()    
         
         // string array
         let strArr = [|"Lists"; "are";  "commonly" ; "list" |]
-        let resultStr = ref ""
-        let funStr (x : string) =
-            resultStr := (!resultStr) + x   
+        let mutable resultStr = ""
+        let funStr (x: string) =
+            resultStr <- resultStr + x   
             ()
         Array.iter funStr strArr  
-        if !resultStr <> "Listsarecommonlylist" then Assert.Fail()   
+        if resultStr <> "Listsarecommonlylist" then Assert.Fail()   
         
         // empty array    
         let emptyArr : int[] = [| |]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         Array.iter funInt emptyArr 
-        if !resultEpt <> 0 then Assert.Fail()    
+        if resultEpt <> 0 then Assert.Fail()    
 
         // null array
         let nullArr = null : string[]  
@@ -1351,26 +1351,26 @@ type ArrayModule() =
     [<Fact>]
     member this.Iter2() =
         // integer array
-        let resultInt = ref 0    
+        let mutable resultInt = 0    
         let funInt (x:int) (y:int) =   
-            resultInt := !resultInt + x + y             
+            resultInt <- resultInt + x + y             
             () 
         Array.iter2 funInt [| 1..10 |] [|2..2..20|] 
-        if !resultInt <> 165 then Assert.Fail()    
+        if resultInt <> 165 then Assert.Fail()    
         
         // string array
-        let resultStr = ref ""
+        let mutable resultStr = ""
         let funStr (x:string) (y:string) =
-            resultStr := (!resultStr) + x  + y 
+            resultStr <- resultStr + x  + y 
             ()
         Array.iter2 funStr [|"A"; "B";  "C" ; "D" |] [|"a"; "b"; "c"; "d"|]  
-        if !resultStr <> "AaBbCcDd" then Assert.Fail()   
+        if resultStr <> "AaBbCcDd" then Assert.Fail()   
         
         // empty array    
         let emptyArr:int[] = [| |]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         Array.iter2 funInt emptyArr emptyArr 
-        if !resultEpt <> 0 then Assert.Fail()    
+        if resultEpt <> 0 then Assert.Fail()    
 
         // null array
         let nullArr = null:string[]  
@@ -1388,27 +1388,27 @@ type ArrayModule() =
     member this.Iteri() =
         // integer array
         let intArr = [| 1..10 |]  
-        let resultInt = ref 0    
+        let mutable resultInt = 0    
         let funInt (x:int) y =   
-            resultInt := !resultInt + x + y             
+            resultInt <- resultInt + x + y             
             () 
         Array.iteri funInt intArr 
-        if !resultInt <> 100 then Assert.Fail()    
+        if resultInt <> 100 then Assert.Fail()    
         
         // string array
         let strArr = [|"Lists"; "are";  "commonly" ; "list" |]
-        let resultStr = ref 0
+        let mutable resultStr = 0
         let funStr (x:int) (y:string) =
-            resultStr := (!resultStr) + x + y.Length
+            resultStr <- resultStr + x + y.Length
             ()
         Array.iteri funStr strArr  
-        if !resultStr <> 26 then Assert.Fail()   
+        if resultStr <> 26 then Assert.Fail()   
         
         // empty array    
         let emptyArr:int[] = [| |]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         Array.iteri funInt emptyArr 
-        if !resultEpt <> 0 then Assert.Fail()    
+        if resultEpt <> 0 then Assert.Fail()    
 
         // null array
         let nullArr = null:string[] 
@@ -1419,26 +1419,26 @@ type ArrayModule() =
     [<Fact>]
     member this.Iteri2() =
         // integer array
-        let resultInt = ref 0    
+        let mutable resultInt = 0    
         let funInt (x:int) (y:int) (z:int) =   
-            resultInt := !resultInt + x + y + z            
+            resultInt <- resultInt + x + y + z            
             () 
         Array.iteri2 funInt [| 1..10 |] [|2..2..20|] 
-        if !resultInt <> 210 then Assert.Fail()    
+        if resultInt <> 210 then Assert.Fail()    
         
         // string array
-        let resultStr = ref ""
+        let mutable resultStr = ""
         let funStr (x:int) (y:string) (z:string) =
-            resultStr := (!resultStr) + x.ToString()  + y + z
+            resultStr <- resultStr + x.ToString()  + y + z
             ()
         Array.iteri2 funStr [|"A"; "B";  "C" ; "D" |] [|"a"; "b"; "c"; "d"|]  
-        if !resultStr <> "0Aa1Bb2Cc3Dd" then Assert.Fail()   
+        if resultStr <> "0Aa1Bb2Cc3Dd" then Assert.Fail()   
         
         // empty array    
         let emptyArr:int[] = [| |]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         Array.iteri2 funInt emptyArr emptyArr 
-        if !resultEpt <> 0 then Assert.Fail()    
+        if resultEpt <> 0 then Assert.Fail()    
 
         // null array
         let nullArr = null:string[]
@@ -1488,22 +1488,22 @@ type ArrayModule() =
         this.MapTester Array.map Array.map
         
     [<Fact>]
-    member this.MapWithSideEffects () =
-        let stamp = ref 0
-        let f x = stamp := !stamp + 1; x + 1
+    member _.MapWithSideEffects () =
+        let mutable stamp = 0
+        let f x = stamp <- stamp + 1; x + 1
         
         Array.map f [| |] |> ignore
-        Assert.AreEqual(0,!stamp)
+        Assert.AreEqual(0,stamp)
         
-        stamp := 0
+        stamp <- 0
         Array.map f [| 1..100 |] |> ignore
-        Assert.AreEqual(100,!stamp)
+        Assert.AreEqual(100,stamp)
         
     [<Fact>]
     member this.``Parallel.Map`` () =
         this.MapTester Array.Parallel.map Array.Parallel.map
 
-    member private this.MapiTester mapiInt mapiString =
+    member private _.MapiTester mapiInt mapiString =
         // empty array 
         let f i x = (i, x + 1)
         let result = mapiInt f [| |]
@@ -1527,16 +1527,16 @@ type ArrayModule() =
         
 
     [<Fact>]
-    member this.MapiWithSideEffects () =
-        let stamp = ref 0
-        let f i x = stamp := !stamp + 1; (i, x + 1)
+    member _.MapiWithSideEffects () =
+        let mutable stamp = 0
+        let f i x = stamp <- stamp + 1; (i, x + 1)
        
         Array.mapi f [| |] |> ignore
-        Assert.AreEqual(0,!stamp)
+        Assert.AreEqual(0,stamp)
        
-        stamp := 0
+        stamp <- 0
         Array.mapi f [| 1..100 |] |> ignore
-        Assert.AreEqual(100,!stamp)
+        Assert.AreEqual(100,stamp)
         ()
         
     [<Fact>]
@@ -1545,30 +1545,31 @@ type ArrayModule() =
         ()
         
     [<Fact>]
-    member this.``Parallel.Iter``() =
+    member _.``Parallel.Iter``() =
         // integer array
         let intArr = [| 1..10 |]  
-        let resultInt = ref 0    
+        let lockObj = obj()
+        let mutable resultInt = 0    
         let funInt (x:int) =   
-            lock resultInt (fun () -> resultInt := !resultInt + x)
+            lock lockObj (fun () -> resultInt <- resultInt + x)
             () 
         Array.Parallel.iter funInt intArr 
-        if !resultInt <> 55 then Assert.Fail()    
+        if resultInt <> 55 then Assert.Fail()    
         
         // string array
         let strArr = [|"Lists"; "are";  "commonly" ; "list" |]
-        let resultStr = ref 0
+        let mutable resultStr = 0
         let funStr (x : string) =
-            lock resultStr (fun () -> resultStr := (!resultStr) + x.Length)
+            lock lockObj (fun () -> resultStr <- resultStr + x.Length)
             ()
         Array.Parallel.iter funStr strArr  
-        if !resultStr <> 20 then Assert.Fail()   
+        if resultStr <> 20 then Assert.Fail()   
         
         // empty array    
         let emptyArr : int[] = [| |]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         Array.Parallel.iter funInt emptyArr 
-        if !resultEpt <> 0 then Assert.Fail()    
+        if resultEpt <> 0 then Assert.Fail()    
 
         // null array
         let nullArr = null : string[]  
@@ -1577,31 +1578,32 @@ type ArrayModule() =
         ()
         
     [<Fact>]
-    member this.``Parallel.Iteri``() =   
+    member _.``Parallel.Iteri``() =   
         // integer array
         let intArr = [| 1..10 |] 
                  
-        let resultInt = ref 0    
+        let lockObj = obj()
+        let mutable resultInt = 0    
         let funInt (x:int) y =   
-            lock resultInt (fun () -> resultInt := !resultInt + x + y)
+            lock lockObj (fun () -> resultInt <- resultInt + x + y)
             () 
         Array.Parallel.iteri funInt intArr 
-        if !resultInt <> 100 then Assert.Fail()    
+        if resultInt <> 100 then Assert.Fail()    
         
         // string array
         let strArr = [|"Lists"; "are";  "commonly" ; "list" |]
-        let resultStr = ref 0
+        let mutable resultStr = 0
         let funStr (x:int) (y:string) =
-            lock resultStr (fun () -> resultStr := (!resultStr) + x + y.Length)
+            lock lockObj (fun () -> resultStr <- resultStr + x + y.Length)
             ()
         Array.Parallel.iteri funStr strArr  
-        if !resultStr <> 26 then Assert.Fail()   
+        if resultStr <> 26 then Assert.Fail()   
         
         // empty array    
         let emptyArr:int[] = [| |]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         Array.Parallel.iteri funInt emptyArr 
-        if !resultEpt <> 0 then Assert.Fail()    
+        if resultEpt <> 0 then Assert.Fail()    
 
         // null array
         let nullArr = null:string[] 
@@ -1646,7 +1648,7 @@ type ArrayModule() =
         this.PartitionTester Array.partition Array.partition    
 
     [<Fact>]
-    member this.Singleton() =
+    member _.Singleton() =
         Assert.AreEqual([|null|],Array.singleton null)
         Assert.AreEqual([|"1"|],Array.singleton "1")
         Assert.AreEqual([|[]|], Array.singleton [])
@@ -1657,7 +1659,7 @@ type ArrayModule() =
         this.PartitionTester Array.Parallel.partition Array.Parallel.partition    
 
     [<Fact>]
-    member this.Contains() =
+    member _.Contains() =
         // integer array
         let intArr = [| 2;4;6;8 |]
         let resultInt = Array.contains 6 intArr
@@ -1678,39 +1680,39 @@ type ArrayModule() =
         CheckThrowsArgumentNullException (fun () -> Array.contains "empty" nullArr |> ignore)
 
     [<Fact>]
-    member this.``Slicing with first index reverse behaves as expected``()  = 
+    member _.``Slicing with first index reverse behaves as expected``()  = 
         let arr = [| 1;2;3;4;5 |]
 
         Assert.AreEqual(arr.[^3..], arr.[1..])
 
     
     [<Fact>]
-    member this.``Slicing with second index reverse behaves as expected``()  = 
+    member _.``Slicing with second index reverse behaves as expected``()  = 
         let arr = [| 1;2;3;4;5 |]
 
         Assert.AreEqual(arr.[..^1], arr.[..3])
 
     
     [<Fact>]
-    member this.``Slicing with both index reverse behaves as expected``()  = 
+    member _.``Slicing with both index reverse behaves as expected``()  = 
         let arr = [| 1;2;3;4;5 |]
 
         Assert.AreEqual(arr.[^3..^1], arr.[1..3])
 
     [<Fact>]
-    member this.``Slicing with first index reverse and second index non reverse behaves as expected``()=
+    member _.``Slicing with first index reverse and second index non reverse behaves as expected``()=
         let arr = [|1;2;3;4;5|]
 
         Assert.AreEqual(arr.[^3..4], arr.[1..4])
 
     [<Fact>]
-    member this.``Slicing with first index non reverse and second index reverse behaves as expected``()=
+    member _.``Slicing with first index non reverse and second index reverse behaves as expected``()=
         let arr = [|1;2;3;4;5|]
 
         Assert.AreEqual(arr.[3..^0], arr.[3..4])
 
     [<Fact>]
-    member this.``Set slice with first index reverse behaves as expected``()  = 
+    member _.``Set slice with first index reverse behaves as expected``()  = 
         let arr1 = [| 1;2;3;4;5 |]
         let arr2 = [| 1;2;3;4;5 |]
 
@@ -1720,7 +1722,7 @@ type ArrayModule() =
         Assert.AreEqual(arr1, arr2)
 
     [<Fact>]
-    member this.``Set slice with second index reverse behaves as expected``()  = 
+    member _.``Set slice with second index reverse behaves as expected``()  = 
         let arr1 = [| 1;2;3;4;5 |]
         let arr2 = [| 1;2;3;4;5 |]
 
@@ -1730,7 +1732,7 @@ type ArrayModule() =
         Assert.AreEqual(arr1, arr2)
 
     [<Fact>]
-    member this.``Set slice with both index reverse behaves as expected``()  = 
+    member _.``Set slice with both index reverse behaves as expected``()  = 
         let arr1 = [| 1;2;3;4;5 |]
         let arr2 = [| 1;2;3;4;5 |]
 
@@ -1740,19 +1742,19 @@ type ArrayModule() =
         Assert.AreEqual(arr1, arr2)
 
     [<Fact>]
-    member this.``Get item with reverse index behaves as expected``() = 
+    member _.``Get item with reverse index behaves as expected``() = 
         let arr = [|1;2;3;4;5|]
         Assert.AreEqual(arr.[^1], 4)
 
     [<Fact>]
-    member this.``Set item with reverse index behaves as expected``() = 
+    member _.``Set item with reverse index behaves as expected``() = 
         let arr = [|1;2;3;4;5|]
 
         arr.[^0] <- 9
         Assert.AreEqual(arr.[4], 9)
 
     [<Fact>] 
-    member this.SlicingUnboundedEnd() = 
+    member _.SlicingUnboundedEnd() = 
         let arr = [|1;2;3;4;5;6|]
 
         Assert.AreEqual(arr.[-1..], arr)
@@ -1765,7 +1767,7 @@ type ArrayModule() =
 
     
     [<Fact>] 
-    member this.SlicingUnboundedStart() = 
+    member _.SlicingUnboundedStart() = 
         let arr = [|1;2;3;4;5;6|]
 
         Assert.AreEqual(arr.[..(-1)], ([||]: int array))
@@ -1780,7 +1782,7 @@ type ArrayModule() =
 
 
     [<Fact>]
-    member this.SlicingBoundedStartEnd() =
+    member _.SlicingBoundedStartEnd() =
         let arr = [|1;2;3;4;5;6|]
 
         Assert.AreEqual(arr.[*], arr)
@@ -1806,7 +1808,7 @@ type ArrayModule() =
 
 
     [<Fact>]
-    member this.SlicingEmptyArray() = 
+    member _.SlicingEmptyArray() = 
 
         let empty : obj array = Array.empty
         Assert.AreEqual(empty.[*], ([||]: obj array))
@@ -1818,7 +1820,7 @@ type ArrayModule() =
 
 
     [<Fact>]
-    member this.SlicingOutOfBounds() = 
+    member _.SlicingOutOfBounds() = 
         let arr = [|1;2;3;4;5;6|]
        
         Assert.AreEqual(arr.[..6], [|1;2;3;4;5;6|])

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/CollectionModulesConsistency.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/CollectionModulesConsistency.fs
@@ -1198,10 +1198,10 @@ let ``tryPick is consistent`` () =
 
 let unfold<'a,'b when 'b : equality> f (start:'a) =
     let f() =
-        let c = ref 0
+        let mutable c = 0
         fun x -> 
-            if !c > 100 then None else // prevent infinity seqs
-            c := !c + 1
+            if c > 100 then None else // prevent infinity seqs
+            c <- c + 1
             f x
     let s : 'b [] = Seq.unfold (f()) start |> Seq.toArray
     let l = List.unfold (f()) start |> List.toArray

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
@@ -19,7 +19,7 @@ Make sure each method works on:
 
 type ListModule() =
     [<Fact>]
-    member this.Empty() =
+    member _.Empty() =
         let emptyList = List.empty
         let resultEpt = List.length emptyList
         Assert.AreEqual(0, resultEpt)   
@@ -30,7 +30,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.AllPairs() =
+    member _.AllPairs() =
         // integer List
         let resultInt =  List.allPairs [1..3] [2..2..6]
         Assert.AreEqual([(1,2);(1,4);(1,6)
@@ -52,7 +52,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Append() =
+    member _.Append() =
         // integer List
         let intList = List.append [ 1; 2 ] [ 3; 4 ]
         Assert.AreEqual([ 1; 2; 3; 4 ],intList)
@@ -67,7 +67,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Average() =     
+    member _.Average() =     
         // empty float32 List
         let emptyFloatList = List.empty<System.Single> 
         CheckThrowsArgumentException(fun () -> List.average emptyFloatList |> ignore)
@@ -99,7 +99,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.AverageBy() =
+    member _.AverageBy() =
         // empty double List
         let emptyDouList = List.empty<System.Double>
         CheckThrowsArgumentException (fun () -> List.averageBy (fun x -> x + 6.7) emptyDouList |> ignore)
@@ -130,7 +130,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.ChunkBySize() =
+    member _.ChunkBySize() =
 
         // int list
         Assert.True([ [1..4]; [5..8] ] = List.chunkBySize 4 [1..8])
@@ -150,7 +150,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.SplitInto() =
+    member _.SplitInto() =
 
         // int list
         Assert.True([ [1..4]; [5..7]; [8..10] ] = List.splitInto 3 [1..10])
@@ -173,7 +173,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.distinct() = 
+    member _.distinct() = 
         // distinct should work on empty list
         Assert.AreEqual([], List.distinct [])
 
@@ -190,7 +190,7 @@ type ListModule() =
         Assert.True([null, list] = List.distinct [null, list])
 
     [<Fact>]
-    member this.distinctBy() =
+    member _.distinctBy() =
         // distinctBy should work on empty list
         Assert.AreEqual([], List.distinctBy (fun _ -> failwith "should not be executed") [])
         
@@ -209,7 +209,7 @@ type ListModule() =
         Assert.True([null, list] = List.distinctBy id [null, list])
 
     [<Fact>]
-    member this.Take() =
+    member _.Take() =
         Assert.AreEqual(([] : int list) ,List.take 0 ([] : int list))
         Assert.AreEqual(([] : string list),List.take 0 ["str1";"str2";"str3";"str4"])
         Assert.AreEqual([1;2;4],List.take 3 [1;2;4;5;7])
@@ -220,7 +220,7 @@ type ListModule() =
         CheckThrowsInvalidOperationExn (fun () -> List.take 5 ["str1";"str2";"str3";"str4"] |> ignore)
               
     [<Fact>]
-    member this.Choose() = 
+    member _.Choose() = 
         // int List
         let intSrc:int list = [ 1..100 ]    
         let funcInt x = if (x%5=0) then Some (x*x) else None       
@@ -252,7 +252,7 @@ type ListModule() =
         () 
 
     [<Fact>]
-    member this.compareWith() =
+    member _.compareWith() =
         // compareWith should work on empty lists
         Assert.AreEqual(0,List.compareWith (fun _ -> failwith "should not be executed")  [] [])
         Assert.AreEqual(-1,List.compareWith (fun _ -> failwith "should not be executed") [] [1])
@@ -273,7 +273,7 @@ type ListModule() =
         Assert.AreEqual(-1,List.compareWith (fun x y -> -1) ["1";"2"] ["1";"3"])
         
     [<Fact>]
-    member this.takeWhile() =
+    member _.takeWhile() =
         Assert.AreEqual(([] : int list),List.takeWhile (fun x -> failwith "should not be used") ([] : int list))
         Assert.AreEqual([1;2;4;5],List.takeWhile (fun x -> x < 6) [1;2;4;5;6;7])
         Assert.AreEqual(["a"; "ab"; "abc"],List.takeWhile (fun (x:string) -> x.Length < 4) ["a"; "ab"; "abc"; "abcd"; "abcde"])        
@@ -284,7 +284,7 @@ type ListModule() =
         Assert.AreEqual(["a"],List.takeWhile (fun x -> x <> "ab") ["a"; "ab"; "abc"; "abcd"; "abcde"])
 
     [<Fact>]
-    member this.Concat() =
+    member _.Concat() =
         // integer List
         let seqInt = 
             seq { for i in 1..10 do                
@@ -310,7 +310,7 @@ type ListModule() =
         () 
 
     [<Fact>]
-    member this.splitAt() =        
+    member _.splitAt() =        
         Assert.AreEqual((([] : int list),([] : int list)), List.splitAt 0 ([] : int list))
 
         Assert.AreEqual([1..4], List.splitAt 4 [1..10] |> fst)       
@@ -335,7 +335,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.countBy() =
+    member _.countBy() =
         // countBy should work on empty list
         Assert.AreEqual(0,List.countBy (fun _ -> failwith "should not be executed") [] |> List.length)
 
@@ -344,7 +344,7 @@ type ListModule() =
         Assert.AreEqual([3,3; 2,2; 1,3],List.countBy (fun x -> if x < 3 then x else 3) [5;2;1;2;3;3;1;1])
 
     [<Fact>]
-    member this.Except() =
+    member _.Except() =
         // integer list
         let intList1 = [ yield! {1..100}
                          yield! {1..100} ]
@@ -373,7 +373,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Exists() =
+    member _.Exists() =
         // integer List
         let intArr = [ 2;4;6;8 ]
         let funcInt x = if (x%2 = 0) then true else false
@@ -393,7 +393,7 @@ type ListModule() =
                
         ()
     [<Fact>]
-    member this.Exists2() =
+    member _.Exists2() =
         // integer List
         let intFir = [ 2;4;6;8 ]
         let intSec = [ 1;2;3;4 ]
@@ -417,7 +417,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Filter() =
+    member _.Filter() =
         // integer List
         let intArr = [ 1..20 ]
         let funcInt x = if (x%5 = 0) then true else false
@@ -438,7 +438,7 @@ type ListModule() =
         ()   
 
     [<Fact>]
-    member this.Where() =
+    member _.Where() =
         // integer List
         let intArr = [ 1..20 ]
         let funcInt x = if (x%5 = 0) then true else false
@@ -459,7 +459,7 @@ type ListModule() =
         ()   
 
     [<Fact>]
-    member this.``where should work like filter``() =
+    member _.``where should work like filter``() =
         Assert.AreEqual(([] : int list), List.where (fun x -> x % 2 = 0) [])
         Assert.AreEqual([0;2;4;6;8], List.where (fun x -> x % 2 = 0) [0..9])
         Assert.AreEqual(["a";"b";"c"], List.where (fun _ -> true) ["a";"b";"c"])
@@ -467,7 +467,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Find() =
+    member _.Find() =
         // integer List
         let intArr = [ 1..20 ]
         let funcInt x = if (x%5 = 0) then true else false
@@ -490,7 +490,7 @@ type ListModule() =
         () 
 
     [<Fact>]
-    member this.replicate() = 
+    member _.replicate() = 
         // replicate should create multiple copies of the given value
         Assert.AreEqual(0,List.replicate 0 null |> List.length)
         Assert.AreEqual(0,List.replicate 0 1 |> List.length)
@@ -500,7 +500,7 @@ type ListModule() =
         CheckThrowsArgumentException (fun () ->  List.replicate -1 null |> ignore)
 
     [<Fact>]
-    member this.FindBack() =
+    member _.FindBack() =
         // integer List
         let funcInt x = if (x%5 = 0) then true else false
         Assert.AreEqual(20, List.findBack funcInt [ 1..20 ])
@@ -523,7 +523,7 @@ type ListModule() =
 
 
     [<Fact>]
-    member this.FindIndex() =
+    member _.FindIndex() =
         // integer List
         let intArr = [ 1..20 ]
         let funcInt x = if (x%5 = 0) then true else false
@@ -546,7 +546,7 @@ type ListModule() =
         () 
         
     [<Fact>]
-    member this.FindIndexBack() =
+    member _.FindIndexBack() =
         // integer List
         let funcInt x = if (x%5 = 0) then true else false
         Assert.AreEqual(19, List.findIndexBack funcInt [ 1..20 ])
@@ -568,7 +568,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.TryPick() =
+    member _.TryPick() =
         // integer List
         let intArr = [ 1..10 ]    
         let funcInt x = 
@@ -595,7 +595,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Fold() =
+    member _.Fold() =
         // integer List
         let intArr = [ 1..10 ]    
         let funcInt x y = x+y
@@ -616,7 +616,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Fold2() =
+    member _.Fold2() =
         // integer List  
         let funcInt x y z = x + y + z
         let resultInt = List.fold2 funcInt 9 [ 1..10 ]  [1..2..20]        
@@ -635,7 +635,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.FoldBack() =
+    member _.FoldBack() =
         // integer List
         let intArr = [ 1..10 ]    
         let funcInt x y = x+y
@@ -673,7 +673,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.FoldBack2() =
+    member _.FoldBack2() =
         // integer List  
         let funcInt x y z = x + y + z
         let resultInt = List.foldBack2 funcInt  [ 1..10 ]  [1..2..20] 9        
@@ -713,7 +713,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.ForAll() =
+    member _.ForAll() =
         // integer List
         let resultInt = List.forall (fun x -> x > 2) [ 3..2..10 ]        
         Assert.True(resultInt)
@@ -729,7 +729,7 @@ type ListModule() =
         ()
         
     [<Fact>]
-    member this.ForAll2() =
+    member _.ForAll2() =
         // integer List
         let resultInt = List.forall2 (fun x y -> x < y) [ 1..10 ] [2..2..20]        
         Assert.True(resultInt)
@@ -745,7 +745,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.GroupBy() =
+    member _.GroupBy() =
         let funcInt x = x%5
              
         let IntList = [ 0 .. 9 ]
@@ -781,7 +781,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Hd() =
+    member _.Hd() =
         // integer List
         let resultInt = List.head  [2..2..20]        
         Assert.AreEqual(2, resultInt)
@@ -794,35 +794,35 @@ type ListModule() =
         ()    
 
     [<Fact>]
-    member this.``exactlyOne should return the element from singleton lists``() =
+    member _.``exactlyOne should return the element from singleton lists``() =
         Assert.AreEqual(1, List.exactlyOne [1])
         Assert.AreEqual("2", List.exactlyOne ["2"])
         ()
 
     [<Fact>]
-    member this.``exactlyOne should fail on empty list``() = 
+    member _.``exactlyOne should fail on empty list``() = 
         CheckThrowsArgumentException(fun () -> List.exactlyOne [] |> ignore)
 
     [<Fact>]
-    member this.``exactlyOne should fail on lists with more than one element``() =
+    member _.``exactlyOne should fail on lists with more than one element``() =
         CheckThrowsArgumentException(fun () -> List.exactlyOne ["1"; "2"] |> ignore)
 
     [<Fact>]
-    member this.``tryExactlyOne should return the element from singleton lists``() =
+    member _.``tryExactlyOne should return the element from singleton lists``() =
         Assert.AreEqual(Some 1, List.tryExactlyOne [1])
         Assert.AreEqual(Some "2", List.tryExactlyOne ["2"])
         ()
 
     [<Fact>]
-    member this.``tryExactlyOne should return None for empty list``() =
+    member _.``tryExactlyOne should return None for empty list``() =
         Assert.AreEqual(None, List.tryExactlyOne [])
 
     [<Fact>]
-    member this.``tryExactlyOne should return None for lists with more than one element``() =
+    member _.``tryExactlyOne should return None for lists with more than one element``() =
         Assert.AreEqual(None, List.tryExactlyOne ["1"; "2"])
 
     [<Fact>]
-    member this.TryHead() =
+    member _.TryHead() =
         // integer List
         let resultInt = List.tryHead  [2..2..20]        
         Assert.AreEqual(2, resultInt.Value)
@@ -835,7 +835,7 @@ type ListModule() =
         Assert.AreEqual(None, resultNone)
 
     [<Fact>]
-    member this.TryLast() =
+    member _.TryLast() =
         // integer List
         let intResult = List.tryLast [1..9]
         Assert.AreEqual(9, intResult.Value)
@@ -850,7 +850,7 @@ type ListModule() =
         () 
 
     [<Fact>]
-    member this.last() =
+    member _.last() =
         // last should fail on empty list
         CheckThrowsArgumentException(fun () -> List.last [] |> ignore)
 
@@ -860,7 +860,7 @@ type ListModule() =
         Assert.AreEqual(["4"], List.last [["1"; "3"]; []; ["4"]])
 
     [<Fact>]
-    member this.Init() = 
+    member _.Init() = 
         // integer List
         let resultInt = List.init 3 (fun x -> x + 3)         
         Assert.AreEqual([3;4;5], resultInt)
@@ -883,7 +883,7 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.IsEmpty() =
+    member _.IsEmpty() =
         // integer List
         let intArr = [ 3;4;7;8;10 ]    
         let resultInt = List.isEmpty intArr         
@@ -901,115 +901,115 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.Iter() =
+    member _.Iter() =
         // integer List
         let intArr = [ 1..10 ]  
-        let resultInt = ref 0    
+        let mutable resultInt = 0    
         let funInt (x:int) =   
-            resultInt := !resultInt + x              
+            resultInt <- resultInt + x              
             () 
         List.iter funInt intArr         
-        Assert.AreEqual(55, !resultInt)
+        Assert.AreEqual(55, resultInt)
         
         // string List
         let strArr = ["a";"b";"c";"d"]
-        let resultStr = ref ""
+        let mutable resultStr = ""
         let funStr (x:string) =
-            resultStr := (!resultStr) + x   
+            resultStr <- resultStr + x   
             ()
         List.iter funStr strArr          
-        Assert.AreEqual("abcd", !resultStr)
+        Assert.AreEqual("abcd", resultStr)
         
         // empty List    
         let emptyArr:int list = [ ]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         List.iter funInt emptyArr         
-        Assert.AreEqual(0, !resultEpt)
+        Assert.AreEqual(0, resultEpt)
         
         ()
        
     [<Fact>]
-    member this.Iter2() =
+    member _.Iter2() =
         // integer List
-        let resultInt = ref 0    
+        let mutable resultInt = 0    
         let funInt (x:int) (y:int) =   
-            resultInt := !resultInt + x + y             
+            resultInt <- resultInt + x + y             
             () 
         List.iter2 funInt [ 1..10 ] [2..2..20]         
-        Assert.AreEqual(165, !resultInt)
+        Assert.AreEqual(165, resultInt)
         
         // string List
-        let resultStr = ref ""
+        let mutable resultStr = ""
         let funStr (x:string) (y:string) =
-            resultStr := (!resultStr) + x  + y 
+            resultStr <- resultStr + x  + y 
             ()
         List.iter2 funStr ["a";"b";"c";"d"] ["A";"B";"C";"D"]          
-        Assert.AreEqual("aAbBcCdD", !resultStr)
+        Assert.AreEqual("aAbBcCdD", resultStr)
         
         // empty List    
         let emptyArr:int list = [ ]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         List.iter2 funInt emptyArr emptyArr         
-        Assert.AreEqual(0, !resultEpt)
+        Assert.AreEqual(0, resultEpt)
         
         ()
         
     [<Fact>]
-    member this.Iteri() =
+    member _.Iteri() =
         // integer List
         let intArr = [ 1..10 ]  
-        let resultInt = ref 0    
+        let mutable resultInt = 0    
         let funInt (x:int) y =   
-            resultInt := !resultInt + x + y             
+            resultInt <- resultInt + x + y             
             () 
         List.iteri funInt intArr         
-        Assert.AreEqual(100, !resultInt)
+        Assert.AreEqual(100, resultInt)
         
         // string List
         let strArr = ["a";"b";"c";"d"]
-        let resultStr = ref 0
+        let mutable resultStr = 0
         let funStr (x:int) (y:string) =
-            resultStr := (!resultStr) + x + y.Length
+            resultStr <- resultStr + x + y.Length
             ()
         List.iteri funStr strArr          
-        Assert.AreEqual(10, !resultStr)
+        Assert.AreEqual(10, resultStr)
         
         // empty List    
         let emptyArr:int list = [ ]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         List.iteri funInt emptyArr         
-        Assert.AreEqual(0, !resultEpt)
+        Assert.AreEqual(0, resultEpt)
         
         ()
         
     [<Fact>]
-    member this.Iteri2() =
+    member _.Iteri2() =
         // integer List
-        let resultInt = ref 0    
+        let mutable resultInt = 0    
         let funInt (x:int) (y:int) (z:int) =   
-            resultInt := !resultInt + x + y + z            
+            resultInt <- resultInt + x + y + z            
             () 
         List.iteri2 funInt [ 1..10 ] [2..2..20]         
-        Assert.AreEqual(210, !resultInt)
+        Assert.AreEqual(210, resultInt)
         
         // string List
-        let resultStr = ref ""
+        let mutable resultStr = ""
         let funStr (x:int) (y:string) (z:string) =
-            resultStr := (!resultStr) + x.ToString()  + y + z
+            resultStr <- resultStr + x.ToString()  + y + z
             ()
         List.iteri2 funStr ["a";"b";"c";"d"] ["A";"B";"C";"D"]          
-        Assert.AreEqual("0aA1bB2cC3dD", !resultStr)
+        Assert.AreEqual("0aA1bB2cC3dD", resultStr)
         
         // empty List    
         let emptyArr:int list = [ ]
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         List.iteri2 funInt emptyArr emptyArr         
-        Assert.AreEqual(0, !resultEpt)
+        Assert.AreEqual(0, resultEpt)
         
         ()        
 
     [<Fact>]
-    member this.Contains() =
+    member _.Contains() =
         // integer List
         let intList = [ 2;4;6;8 ]
         let resultInt = List.contains 4 intList
@@ -1026,7 +1026,7 @@ type ListModule() =
         Assert.False(resultEpt)
         
     [<Fact>]
-    member this.Singleton() =
+    member _.Singleton() =
         Assert.AreEqual([null],List.singleton null)
         Assert.AreEqual(["1"],List.singleton "1")   
         Assert.AreEqual([[]],List.singleton [])
@@ -1034,44 +1034,44 @@ type ListModule() =
         ()
 
     [<Fact>]
-    member this.``pairwise should return pairs of the input list``() =
+    member _.``pairwise should return pairs of the input list``() =
         Assert.AreEqual(([] : (int*int) list), List.pairwise [1])
         Assert.AreEqual([1,2], List.pairwise [1;2])
         Assert.AreEqual([1,2; 2,3], List.pairwise [1;2;3])
         Assert.AreEqual(["H","E"; "E","L"; "L","L"; "L","O"], List.pairwise ["H";"E";"L";"L";"O"])
 
     [<Fact>]
-    member this.``Slicing with first index reverse behaves as expected``()  = 
+    member _.``Slicing with first index reverse behaves as expected``()  = 
         let list = [ 1;2;3;4;5 ]
 
         Assert.AreEqual(list.[^3..], list.[1..])
 
     [<Fact>]
-    member this.``Slicing with second index reverse behaves as expected``()  = 
+    member _.``Slicing with second index reverse behaves as expected``()  = 
         let list = [ 1;2;3;4;5 ]
 
         Assert.AreEqual(list.[..^1], list.[..3])
 
     [<Fact>]
-    member this.``Slicing with both index reverse behaves as expected``()  = 
+    member _.``Slicing with both index reverse behaves as expected``()  = 
         let list = [ 1;2;3;4;5 ]
 
         Assert.AreEqual(list.[^3..^1], list.[1..3])
 
     [<Fact>]
-    member this.``Slicing with first index reverse and second index non reverse behaves as expected``()=
+    member _.``Slicing with first index reverse and second index non reverse behaves as expected``()=
         let list = [1;2;3;4;5]
 
         Assert.AreEqual(list.[^3..4], list.[1..4])
 
     [<Fact>]
-    member this.``Slicing with first index non reverse and second index reverse behaves as expected``()=
+    member _.``Slicing with first index non reverse and second index reverse behaves as expected``()=
         let list = [1;2;3;4;5]
 
         Assert.AreEqual(list.[3..^0], list.[3..4])
 
     [<Fact>]
-    member this.``Get item with reverse index behaves as expected``() = 
+    member _.``Get item with reverse index behaves as expected``() = 
         let list = [1;2;3;4;5]
 
         Assert.AreEqual(list.[^1], 4)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListProperties.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListProperties.fs
@@ -180,12 +180,12 @@ let ``splitInto produces chunks exactly `count` chunks with equal size (+/- 1)``
 let sort_and_sortby (xs : list<float>) (xs2 : list<float>) =
     let a = List.sortBy id xs |> Seq.toArray 
     let b = List.sort xs |> Seq.toArray
-    let result = ref true
+    let mutable result = true
     for i in 0 .. a.Length - 1 do
         if a.[i] <> b.[i] then
             if System.Double.IsNaN a.[i] <> System.Double.IsNaN b.[i] then
-                result := false
-    !result 
+                result <- false
+    result 
 
 [<Fact>]
 let ``sort behaves like sortby id`` () =   
@@ -746,15 +746,15 @@ let distinct_works_like_set<'a when 'a : comparison> (xs : 'a list) =
     let a = List.distinct xs
     let b = Set.ofList xs
 
-    let result = ref (a.Length = b.Count)
+    let mutable result = (a.Length = b.Count)
     for x in a do
         if Set.contains x b |> not then
-            result := false
+            result <- false
 
     for x in b do
         if List.exists ((=) x) a |> not then
-            result := false
-    !result
+            result <- false
+    result
 
 [<Fact>]
 let ``distinct creates same elements like a set`` () =
@@ -807,9 +807,9 @@ let ``List.distinctBy is stable`` () =
 let ``List.sum calculates the sum`` () =
     let sum (xs : int list) =
         let s = List.sum xs
-        let r = ref 0
-        for x in xs do r := !r + x    
-        s = !r
+        let mutable r = 0
+        for x in xs do r <- r + x    
+        s = r
     Check.QuickThrowOnFailure sum
 
 let sumBy<'a> (xs : 'a list) (f:'a -> int) =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/MapModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/MapModule.fs
@@ -22,7 +22,7 @@ Make sure each method works on:
 
 type MapModule() =
     [<Fact>]
-    member this.Empty() =
+    member _.Empty() =
         let emptyMap = Map.empty
         Assert.True(Map.isEmpty emptyMap)
         
@@ -33,7 +33,7 @@ type MapModule() =
         ()
 
     [<Fact>]
-    member this.Add() =
+    member _.Add() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.add 1 "a" valueKeyMap        
@@ -63,7 +63,7 @@ type MapModule() =
         ()
 
     [<Fact>]
-    member this.Change() =
+    member _.Change() =
 
         let a = (Map.ofArray [|(1,1);(2,4);(3,9)|])
         let b = Map.change 4 (fun current -> Assert.AreEqual(current, None); Some 16) a
@@ -97,7 +97,7 @@ type MapModule() =
         ()
 
     [<Fact>]
-    member this.Exists() =
+    member _.Exists() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.exists (fun x y -> x > 3) valueKeyMap        
@@ -122,7 +122,7 @@ type MapModule() =
         ()
         
     [<Fact>]
-    member this.Filter() =
+    member _.Filter() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap =valueKeyMap |> Map.filter (fun x y -> x % 3 = 0)         
@@ -147,7 +147,7 @@ type MapModule() =
 
 
     [<Fact>]
-    member this.Find() =
+    member _.Find() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.find 5 valueKeyMap        
@@ -170,7 +170,7 @@ type MapModule() =
         ()  
 
     [<Fact>]
-    member this.FindIndex() =
+    member _.FindIndex() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap =valueKeyMap |> Map.findKey (fun x y -> x % 3 = 0)         
@@ -193,7 +193,7 @@ type MapModule() =
         ()          
      
     [<Fact>]
-    member this.TryPick() =
+    member _.TryPick() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = valueKeyMap |> Map.tryPick (fun x y -> if x % 3 = 0 then Some (x) else None)         
@@ -218,7 +218,7 @@ type MapModule() =
         ()     
 
     [<Fact>]
-    member this.Pick() =
+    member _.Pick() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValue = valueKeyMap |> Map.pick (fun x y -> if x % 3 = 0 then Some (y) else None)         
@@ -245,7 +245,7 @@ type MapModule() =
         ()
 
     [<Fact>]
-    member this.Fold() =
+    member _.Fold() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = valueKeyMap |> Map.fold (fun x y z -> x + y + z.Length) 10         
@@ -269,7 +269,7 @@ type MapModule() =
         ()
 
     [<Fact>]
-    member this.FoldBack() =
+    member _.FoldBack() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.foldBack (fun x y z -> x.ToString() + y + z.ToString()) valueKeyMap "*"     
@@ -293,7 +293,7 @@ type MapModule() =
         ()
         
     [<Fact>]
-    member this.ForAll() =
+    member _.ForAll() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = valueKeyMap |> Map.forall (fun x y -> x % 3 = 0)         
@@ -318,7 +318,7 @@ type MapModule() =
 
 
     [<Fact>]
-    member this.IsEmpty() =
+    member _.IsEmpty() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.isEmpty  valueKeyMap        
@@ -342,47 +342,47 @@ type MapModule() =
         ()  
 
     [<Fact>]
-    member this.Iter() =
+    member _.Iter() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
-        let resultValueMap = ref 0    
+        let mutable resultValueMap = 0    
         let funInt (x:int) (y:string) =   
-            resultValueMap := !resultValueMap + x + y.Length             
+            resultValueMap <- resultValueMap + x + y.Length             
             () 
         Map.iter funInt valueKeyMap        
-        Assert.AreEqual(!resultValueMap,18)
+        Assert.AreEqual(resultValueMap,18)
         
         // reference keys
         let refMap = Map.ofSeq [for c in ["."; ".."; "..."; "...."] do yield (c, c.Length) ]
-        let resultRefMap = ref ""
+        let mutable resultRefMap = ""
         let funStr (x:string) (y:int) = 
-            resultRefMap := !resultRefMap + x + y.ToString()
+            resultRefMap <- resultRefMap + x + y.ToString()
             ()
         Map.iter funStr refMap        
-        Assert.AreEqual(!resultRefMap,".1..2...3....4")
+        Assert.AreEqual(resultRefMap,".1..2...3....4")
         
         // One-element Map
         let oeleMap = Map.ofSeq [(1, "one")]
-        let resultOele = ref ""
+        let mutable resultOele = ""
         let funMix  (x:int) (y:string) =
-            resultOele := !resultOele + x.ToString() + y
+            resultOele <- resultOele + x.ToString() + y
             ()
         Map.iter funMix oeleMap        
-        Assert.AreEqual(!resultOele,"1one")
+        Assert.AreEqual(resultOele,"1one")
         
         // empty Map
         let eptMap = Map.empty
-        let resultEpt = ref 0    
+        let mutable resultEpt = 0    
         let funEpt (x:int) (y:int) =   
-            resultEpt := !resultEpt + x + y              
+            resultEpt <- resultEpt + x + y              
             () 
         Map.iter funEpt eptMap        
-        Assert.AreEqual(!resultEpt,0)
+        Assert.AreEqual(resultEpt,0)
                
         ()          
      
     [<Fact>]
-    member this.Map() =
+    member _.Map() =
 
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
@@ -407,7 +407,7 @@ type MapModule() =
         ()     
 
     [<Fact>]
-    member this.Contains() =
+    member _.Contains() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.containsKey 2 valueKeyMap        
@@ -431,7 +431,7 @@ type MapModule() =
         () 
         
     [<Fact>]
-    member this.Of_Array_Of_List_Of_Seq() =
+    member _.Of_Array_Of_List_Of_Seq() =
         // value keys    
         let valueKeyMapOfArr = Map.ofArray [|(2,"b"); (3,"c"); (4,"d"); (5,"e")|]     
         let valueKeyMapOfList = Map.ofList [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
@@ -462,7 +462,7 @@ type MapModule() =
         ()
 
     [<Fact>]
-    member this.Partition() =
+    member _.Partition() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.partition (fun x y  -> x%2 = 0) valueKeyMap         
@@ -493,7 +493,7 @@ type MapModule() =
     
         
     [<Fact>]
-    member this.Remove() =
+    member _.Remove() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.remove 5 valueKeyMap        
@@ -524,7 +524,7 @@ type MapModule() =
         ()
         
     [<Fact>]
-    member this.To_Array() =
+    member _.To_Array() =
         // value keys    
         let valueKeyMapOfArr = Map.ofArray [|(1,1);(2,4);(3,9)|]     
         let resultValueMap = Map.toArray valueKeyMapOfArr        
@@ -548,7 +548,7 @@ type MapModule() =
         () 
 
     [<Fact>]
-    member this.To_List() =
+    member _.To_List() =
         // value keys    
         let valueKeyMapOfArr = Map.ofList [(1,1);(2,4);(3,9)]     
         let resultValueMap = Map.toList valueKeyMapOfArr        
@@ -573,7 +573,7 @@ type MapModule() =
         ()     
 
     [<Fact>]
-    member this.To_Seq() =
+    member _.To_Seq() =
         // value keys    
         let valueKeyMapOfArr = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]  
         let resultValueMap = Map.toSeq valueKeyMapOfArr
@@ -598,7 +598,7 @@ type MapModule() =
         ()           
 
     [<Fact>]
-    member this.TryFind() =
+    member _.TryFind() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = Map.tryFind 5 valueKeyMap        
@@ -622,7 +622,7 @@ type MapModule() =
         ()      
 
     [<Fact>]
-    member this.TryFindIndex() =
+    member _.TryFindIndex() =
         // value keys
         let valueKeyMap = Map.ofSeq [(2,"b"); (3,"c"); (4,"d"); (5,"e")]
         let resultValueMap = valueKeyMap |> Map.tryFindKey (fun x y -> x+y.Length >30)         
@@ -646,7 +646,7 @@ type MapModule() =
         ()  
 
     [<Fact>]
-    member this.Keys() =
+    member _.Keys() =
         // reference keys
         let m = Map.ofArray [| ("1", "1"); ("2", "4"); ("3", "9") |]
         Assert.AreEqual(["1"; "2"; "3"], Map.keys m |> Seq.toList)
@@ -664,7 +664,7 @@ type MapModule() =
         Assert.AreEqual([], Map.keys m |> Seq.toList)
         
     [<Fact>]
-    member this.Values() =
+    member _.Values() =
         // reference keys
         let m = Map.ofArray [| ("1", "2"); ("3", "4"); ("5", "6") |]
         Assert.AreEqual(["2"; "4"; "6"], Map.values m |> Seq.toList)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule.fs
@@ -22,7 +22,7 @@ Make sure each method works on:
 type SeqModule() =
 
     [<Fact>]
-    member this.AllPairs() =
+    member _.AllPairs() =
 
         // integer Seq
         let resultInt = Seq.allPairs (seq [1..7]) (seq [11..17])
@@ -49,15 +49,15 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.CachedSeq_Clear() =
+    member _.CachedSeq_Clear() =
         
-        let evaluatedItems : int list ref = ref []
+        let mutable evaluatedItems : int list = []
         let cachedSeq = 
-            Seq.initInfinite (fun i -> evaluatedItems := i :: !evaluatedItems; i)
+            Seq.initInfinite (fun i -> evaluatedItems <- i :: evaluatedItems; i)
             |> Seq.cache
         
         // Verify no items have been evaluated from the Seq yet
-        Assert.AreEqual(List.length !evaluatedItems, 0)
+        Assert.AreEqual(List.length evaluatedItems, 0)
         
         // Force evaluation of 10 elements
         Seq.take 10 cachedSeq
@@ -65,7 +65,7 @@ type SeqModule() =
         |> ignore
         
         // verify ref clear switch length
-        Assert.AreEqual(List.length !evaluatedItems, 10)
+        Assert.AreEqual(List.length evaluatedItems, 10)
 
         // Force evaluation of 10 elements
         Seq.take 10 cachedSeq
@@ -73,7 +73,7 @@ type SeqModule() =
         |> ignore
         
         // Verify ref clear switch length (should be cached)
-        Assert.AreEqual(List.length !evaluatedItems, 10)
+        Assert.AreEqual(List.length evaluatedItems, 10)
 
         
         // Clear
@@ -85,11 +85,11 @@ type SeqModule() =
         |> ignore
         
         // Verify length of evaluatedItemList is 20
-        Assert.AreEqual(List.length !evaluatedItems, 20)
+        Assert.AreEqual(List.length evaluatedItems, 20)
         ()
         
     [<Fact>]
-    member this.Append() =
+    member _.Append() =
 
         // empty Seq 
         let emptySeq1 = Seq.empty
@@ -134,7 +134,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.replicate() =
+    member _.replicate() =
         // replicate should create multiple copies of the given value
         Assert.True(Seq.isEmpty <| Seq.replicate 0 null)
         Assert.True(Seq.isEmpty <| Seq.replicate 0 1)
@@ -145,7 +145,7 @@ type SeqModule() =
         
         
     [<Fact>]
-    member this.Average() =
+    member _.Average() =
         // empty Seq 
         let emptySeq:seq<double> = Seq.empty<double>
         
@@ -181,7 +181,7 @@ type SeqModule() =
         
         
     [<Fact>]
-    member this.AverageBy() =
+    member _.AverageBy() =
         // empty Seq 
         let emptySeq:seq<double> = Seq.empty<double>
         
@@ -215,7 +215,7 @@ type SeqModule() =
         ()
         
     [<Fact>]
-    member this.Cache() =
+    member _.Cache() =
         // empty Seq 
         let emptySeq:seq<double> = Seq.empty<double>
         
@@ -256,7 +256,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.Case() =
+    member _.Case() =
 
         // integer Seq
         let integerArray = [|1;2|]
@@ -303,7 +303,7 @@ type SeqModule() =
         ()
         
     [<Fact>]
-    member this.Choose() =
+    member _.Choose() =
         
         // int Seq
         let intSeq = seq [1..20]    
@@ -342,7 +342,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.ChunkBySize() =
+    member _.ChunkBySize() =
 
         let verify expected actual =
             Seq.zip expected actual
@@ -378,7 +378,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.SplitInto() =
+    member _.SplitInto() =
 
         let verify expected actual =
             Seq.zip expected actual
@@ -409,7 +409,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.Compare() =
+    member _.Compare() =
     
         // int Seq
         let intSeq1 = seq [1;3;7;9]    
@@ -445,7 +445,7 @@ type SeqModule() =
         ()
         
     [<Fact>]
-    member this.Concat() =
+    member _.Concat() =
          // integer Seq
         let seqInt = 
             seq { for i in 0..9 do                
@@ -481,7 +481,7 @@ type SeqModule() =
         () 
         
     [<Fact>]
-    member this.CountBy() =
+    member _.CountBy() =
         // integer Seq
         let funcIntCount_by (x:int) = x%3 
         let seqInt = 
@@ -515,7 +515,7 @@ type SeqModule() =
         () 
     
     [<Fact>]
-    member this.Distinct() =
+    member _.Distinct() =
         
         // integer Seq
         let IntDistinctSeq =  
@@ -549,7 +549,7 @@ type SeqModule() =
         () 
     
     [<Fact>]
-    member this.DistinctBy () =
+    member _.DistinctBy () =
         // integer Seq
         let funcInt x = x % 3 
         let IntDistinct_bySeq =  
@@ -584,7 +584,7 @@ type SeqModule() =
         () 
 
     [<Fact>]
-    member this.Except() =
+    member _.Except() =
         // integer Seq
         let intSeq1 = seq { yield! {1..100}
                             yield! {1..100} }
@@ -623,7 +623,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.Exists() =
+    member _.Exists() =
 
         // Integer Seq
         let funcInt x = (x % 2 = 0) 
@@ -658,7 +658,7 @@ type SeqModule() =
         () 
     
     [<Fact>]
-    member this.Exists2() =
+    member _.Exists2() =
         // Integer Seq
         let funcInt x y = (x+y)%3=0 
         let Intexists2Seq1 =  seq [1;3;7]
@@ -686,7 +686,7 @@ type SeqModule() =
     
     
     [<Fact>]
-    member this.Filter() =
+    member _.Filter() =
         // integer Seq
         let funcInt x = if (x % 5 = 0) then true else false
         let IntSeq =
@@ -725,7 +725,7 @@ type SeqModule() =
         () 
     
     [<Fact>]
-    member this.Find() =
+    member _.Find() =
         
         // integer Seq
         let funcInt x = if (x % 5 = 0) then true else false
@@ -754,7 +754,7 @@ type SeqModule() =
         ()
     
     [<Fact>]
-    member this.FindBack() =
+    member _.FindBack() =
         // integer Seq
         let funcInt x = x % 5 = 0
         Assert.AreEqual(20, Seq.findBack funcInt <| seq { 1..20 })
@@ -781,7 +781,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.FindIndex() =
+    member _.FindIndex() =
         
         // integer Seq
         let digits = [1 .. 100] |> Seq.ofList
@@ -796,7 +796,7 @@ type SeqModule() =
         ()
     
     [<Fact>]
-    member this.Permute() =
+    member _.Permute() =
         let mapIndex i = (i + 1) % 4
 
         // integer seq
@@ -822,7 +822,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.FindIndexBack() =
+    member _.FindIndexBack() =
         // integer Seq
         let digits = seq { 1..100 }
         let idx = digits |> Seq.findIndexBack (fun i -> i.ToString().Length = 1)
@@ -842,7 +842,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.Pick() =
+    member _.Pick() =
     
         let digits = [| 1 .. 10 |] |> Seq.ofArray
         let result = Seq.pick (fun i -> if i > 5 then Some(i.ToString()) else None) digits
@@ -856,7 +856,7 @@ type SeqModule() =
         ()
         
     [<Fact>]
-    member this.Fold() =
+    member _.Fold() =
         let funcInt x y = x+y
              
         let IntSeq =
@@ -888,7 +888,7 @@ type SeqModule() =
 
 
     [<Fact>]
-    member this.Fold2() =
+    member _.Fold2() =
         Assert.AreEqual([(3,5); (2,3); (1,1)],Seq.fold2 (fun acc x y -> (x,y)::acc) [] (seq [ 1..3 ])  (seq [1..2..6]))
 
         // integer List  
@@ -920,7 +920,7 @@ type SeqModule() =
         ()
         
     [<Fact>]
-    member this.FoldBack() =
+    member _.FoldBack() =
         // int Seq
         let funcInt x y = x-y
         let IntSeq = seq { 1..4 }
@@ -956,7 +956,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.foldBack2() =
+    member _.foldBack2() =
         // int Seq
         let funcInt x y z = x + y + z
         let intSeq = seq { 1..10 }
@@ -995,7 +995,7 @@ type SeqModule() =
         ()
 
     [<Fact>]
-    member this.ForAll() =
+    member _.ForAll() =
 
         let funcInt x  = if x%2 = 0 then true else false
         let IntSeq =
@@ -1026,7 +1026,7 @@ type SeqModule() =
         () 
         
     [<Fact>]
-    member this.ForAll2() =
+    member _.ForAll2() =
 
         let funcInt x y = if (x+y)%2 = 0 then true else false
         let IntSeq =
@@ -1057,7 +1057,7 @@ type SeqModule() =
         CheckThrowsArgumentNullException (fun () -> Seq.forall2 funcInt  nullSeq nullSeq |> ignore) 
         
     [<Fact>]
-    member this.GroupBy() =
+    member _.GroupBy() =
         
         let funcInt x = x%5
              
@@ -1100,20 +1100,20 @@ type SeqModule() =
         () 
     
     [<Fact>]
-    member this.DisposalOfUnstartedEnumerator() =
-        let run = ref false
+    member _.DisposalOfUnstartedEnumerator() =
+        let mutable run = false
         let f() = seq {                
                 try
                     ()
                 finally 
-                    run := true
+                    run <- true
               }
   
         f().GetEnumerator().Dispose() 
-        Assert.False(!run)
+        Assert.False(run)
 
     [<Fact>]
-    member this.WeirdLocalNames() =
+    member _.WeirdLocalNames() =
        
         let f pc = seq {                
                 yield pc
@@ -1134,7 +1134,7 @@ type SeqModule() =
         Assert.AreEqual([6;7;8], l)
 
     [<Fact>]
-    member this.Contains() =
+    member _.Contains() =
 
         // Integer Seq
         let intSeq = seq { 0..9 }

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
@@ -379,23 +379,22 @@ type SeqModule2() =
     
         //seq int
         let seqint =  seq [ 1..3]
-        let cacheint = ref 0
+        let mutable cacheint = 0
        
-        let funcint x y = cacheint := !cacheint + x+y
+        let funcint x y = cacheint <- cacheint + x+y
         Seq.iter2 funcint seqint seqint
-        Assert.AreEqual(12,!cacheint)
+        Assert.AreEqual(12, cacheint)
               
         //seq str
         let seqStr = seq ["first";"second"]
-        let cachestr =ref ""
-        let funcstr x y = cachestr := !cachestr+x+y
+        let mutable cachestr = ""
+        let funcstr x y = cachestr <- cachestr+x+y
         Seq.iter2 funcstr seqStr seqStr
          
-        Assert.AreEqual("firstfirstsecondsecond",!cachestr)
+        Assert.AreEqual("firstfirstsecondsecond",cachestr)
         
          // empty array    
         let emptyseq = Seq.empty
-        let resultEpt = ref 0
         Seq.iter2 (fun x y-> Assert.Fail()) emptyseq  emptyseq 
 
         // null seqay
@@ -409,25 +408,25 @@ type SeqModule2() =
     
         // seq int
         let seqint =  seq [ 1..10]
-        let cacheint = ref 0
+        let mutable cacheint = 0
        
-        let funcint x y = cacheint := !cacheint + x+y
+        let funcint x y = cacheint <- cacheint + x+y
         Seq.iteri funcint seqint
-        Assert.AreEqual(100,!cacheint)
+        Assert.AreEqual(100, cacheint)
               
         // seq str
         let seqStr = seq ["first";"second"]
-        let cachestr =ref 0
-        let funcstr (x:int) (y:string) = cachestr := !cachestr+ x + y.Length
+        let mutable cachestr = 0
+        let funcstr (x:int) (y:string) = cachestr <- cachestr+ x + y.Length
         Seq.iteri funcstr seqStr
          
-        Assert.AreEqual(12,!cachestr)
+        Assert.AreEqual(12, cachestr)
         
          // empty array    
         let emptyseq = Seq.empty
-        let resultEpt = ref 0
+        let mutable resultEpt = 0
         Seq.iteri funcint emptyseq
-        Assert.AreEqual(0,!resultEpt)
+        Assert.AreEqual(0, resultEpt)
 
         // null seqay
         let nullseq:seq<'a> =  null
@@ -439,23 +438,22 @@ type SeqModule2() =
 
         //seq int
         let seqint = seq [ 1..3]
-        let cacheint = ref 0
+        let mutable cacheint = 0
        
-        let funcint x y z = cacheint := !cacheint + x + y + z
+        let funcint x y z = cacheint <- cacheint + x + y + z
         Seq.iteri2 funcint seqint seqint
-        Assert.AreEqual(15,!cacheint)
+        Assert.AreEqual(15, cacheint)
               
         //seq str
         let seqStr = seq ["first";"second"]
-        let cachestr = ref 0
-        let funcstr (x:int) (y:string) (z:string) = cachestr := !cachestr + x + y.Length + z.Length
+        let mutable cachestr = 0
+        let funcstr (x:int) (y:string) (z:string) = cachestr <- cachestr + x + y.Length + z.Length
         Seq.iteri2 funcstr seqStr seqStr
          
-        Assert.AreEqual(23,!cachestr)
+        Assert.AreEqual(23, cachestr)
         
         // empty seq
         let emptyseq = Seq.empty
-        let resultEpt = ref 0
         Seq.iteri2 (fun x y z -> Assert.Fail()) emptyseq emptyseq 
 
         // null seq
@@ -467,10 +465,10 @@ type SeqModule2() =
         let longerSeq = seq { 2..2..100 }
 
         let testSeqLengths seq1 seq2 =
-            let cache = ref 0
-            let f x y z = cache := !cache + x + y + z
+            let mutable cache = 0
+            let f x y z = cache <- cache + x + y + z
             Seq.iteri2 f seq1 seq2
-            !cache
+            cache
 
         Assert.AreEqual(21, testSeqLengths shorterSeq longerSeq)
         Assert.AreEqual(21, testSeqLengths longerSeq shorterSeq)
@@ -503,9 +501,9 @@ type SeqModule2() =
 
          // integer Seq
         let funcInt x = 
-                match x with
-                | _ when x % 2 = 0 -> 10*x            
-                | _ -> x
+            match x with
+            | _ when x % 2 = 0 -> 10*x            
+            | _ -> x
        
         let resultInt = Seq.map funcInt { 1..10 }
         let expectedint = seq [1;20;3;40;5;60;7;80;9;100]
@@ -639,40 +637,40 @@ type SeqModule2() =
         ()
 
     member private this.MapWithSideEffectsTester (map : (int -> int) -> seq<int> -> seq<int>) expectExceptions =
-        let i = ref 0
-        let f x = i := !i + 1; x*x
+        let mutable i = 0
+        let f x = i <- i + 1; x*x
         let e = ([1;2] |> map f).GetEnumerator()
         
         if expectExceptions then
             CheckThrowsInvalidOperationExn  (fun _ -> e.Current|>ignore)
-            Assert.AreEqual(0, !i)
+            Assert.AreEqual(0, i)
         if not (e.MoveNext()) then Assert.Fail()
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         let _ = e.Current
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         let _ = e.Current
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         
         if not (e.MoveNext()) then Assert.Fail()
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         let _ = e.Current
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         let _ = e.Current
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
 
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         if expectExceptions then
             CheckThrowsInvalidOperationExn (fun _ -> e.Current |> ignore)
-            Assert.AreEqual(2, !i)
+            Assert.AreEqual(2, i)
 
         
-        i := 0
+        i <- 0
         let e = ([] |> map f).GetEnumerator()
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(0,!i)
+        Assert.AreEqual(0, i)
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(0,!i)
+        Assert.AreEqual(0, i)
         
         
     member private this.MapWithExceptionTester (map : (int -> int) -> seq<int> -> seq<int>) =
@@ -710,105 +708,105 @@ type SeqModule2() =
         
     [<Fact>]
     member _.MapiWithSideEffects () =
-        let i = ref 0
-        let f _ x = i := !i + 1; x*x
+        let mutable i = 0
+        let f _ x = i <- i + 1; x*x
         let e = ([1;2] |> Seq.mapi f).GetEnumerator()
         
         CheckThrowsInvalidOperationExn  (fun _ -> e.Current|>ignore)
-        Assert.AreEqual(0, !i)
+        Assert.AreEqual(0, i)
         if not (e.MoveNext()) then Assert.Fail()
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         let _ = e.Current
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         let _ = e.Current
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         
         if not (e.MoveNext()) then Assert.Fail()
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         let _ = e.Current
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         let _ = e.Current
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         CheckThrowsInvalidOperationExn  (fun _ -> e.Current|>ignore)
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         
-        i := 0
+        i <- 0
         let e = ([] |> Seq.mapi f).GetEnumerator()
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(0,!i)
+        Assert.AreEqual(0,i)
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(0,!i)
+        Assert.AreEqual(0,i)
         
     [<Fact>]
     member _.Map2WithSideEffects () =
-        let i = ref 0
-        let f x y = i := !i + 1; x*x
+        let mutable i = 0
+        let f x y = i <- i + 1; x*x
         let e = (Seq.map2 f [1;2] [1;2]).GetEnumerator()
         
         CheckThrowsInvalidOperationExn  (fun _ -> e.Current|>ignore)
-        Assert.AreEqual(0, !i)
+        Assert.AreEqual(0, i)
         if not (e.MoveNext()) then Assert.Fail()
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         let _ = e.Current
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         let _ = e.Current
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         
         if not (e.MoveNext()) then Assert.Fail()
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         let _ = e.Current
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         let _ = e.Current
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
 
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(2,!i)
+        Assert.AreEqual(2, i)
         CheckThrowsInvalidOperationExn  (fun _ -> e.Current|>ignore)
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         
-        i := 0
+        i <- 0
         let e = (Seq.map2 f [] []).GetEnumerator()
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(0,!i)
+        Assert.AreEqual(0, i)
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(0,!i)
+        Assert.AreEqual(0, i)
         
     [<Fact>]
     member _.Mapi2WithSideEffects () =
-        let i = ref 0
-        let f _ x y = i := !i + 1; x*x
+        let mutable i = 0
+        let f _ x y = i <- i + 1; x*x
         let e = (Seq.mapi2 f [1;2] [1;2]).GetEnumerator()
 
         CheckThrowsInvalidOperationExn  (fun _ -> e.Current|>ignore)
-        Assert.AreEqual(0, !i)
+        Assert.AreEqual(0, i)
         if not (e.MoveNext()) then Assert.Fail()
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         let _ = e.Current
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
         let _ = e.Current
-        Assert.AreEqual(1, !i)
+        Assert.AreEqual(1, i)
 
         if not (e.MoveNext()) then Assert.Fail()
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         let _ = e.Current
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
         let _ = e.Current
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
 
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(2,!i)
+        Assert.AreEqual(2, i)
         CheckThrowsInvalidOperationExn  (fun _ -> e.Current|>ignore)
-        Assert.AreEqual(2, !i)
+        Assert.AreEqual(2, i)
 
-        i := 0
+        i <- 0
         let e = (Seq.mapi2 f [] []).GetEnumerator()
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(0,!i)
+        Assert.AreEqual(0, i)
         if e.MoveNext() then Assert.Fail()
-        Assert.AreEqual(0,!i)
+        Assert.AreEqual(0, i)
 
     [<Fact>]
     member _.Collect() =
@@ -1236,12 +1234,12 @@ type SeqModule2() =
         CheckThrowsFormatException(fun() -> Seq.head resultEx |> ignore)
 
         // Result consumes entire input sequence as soon as it is accesses an element
-        let i = ref 0
-        let funcState x s = (i := !i + x); x+s
+        let mutable i = 0
+        let funcState x s = (i <- i + x); x+s
         let resultState = Seq.scanBack funcState (seq {1..3}) 0
-        Assert.AreEqual(0, !i)
+        Assert.AreEqual(0, i)
         use e = resultState.GetEnumerator()
-        Assert.AreEqual(6, !i)
+        Assert.AreEqual(6, i)
 
         ()
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
@@ -18,7 +18,7 @@ type SeqWindowedTestInput<'t> =
 type SeqModule2() =
 
     [<Fact>]
-    member this.Hd() =
+    member _.Hd() =
 
         let IntSeq =
             seq { for i in 0 .. 9 do
@@ -40,7 +40,7 @@ type SeqModule2() =
         () 
 
     [<Fact>]
-    member this.TryHead() =
+    member _.TryHead() =
         // int Seq     
         let IntSeq =
             seq { for i in 0 .. 9 -> i }
@@ -61,7 +61,7 @@ type SeqModule2() =
         () 
         
     [<Fact>]
-    member this.Tl() =
+    member _.Tl() =
         // integer seq  
         let resultInt = Seq.tail <| seq { 1..10 }        
         Assert.AreEqual(Array.ofSeq (seq { 2..10 }), Array.ofSeq resultInt)
@@ -79,7 +79,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Last() =
+    member _.Last() =
              
         let IntSeq =
             seq { for i in 0 .. 9 do
@@ -151,7 +151,7 @@ type SeqModule2() =
         
 
     [<Fact>]
-    member this.TryLast() =
+    member _.TryLast() =
              
         let IntSeq =
             seq { for i in 0 .. 9 -> i }
@@ -228,7 +228,7 @@ type SeqModule2() =
 
         
     [<Fact>]
-    member this.ExactlyOne() =
+    member _.ExactlyOne() =
              
         let IntSeq =
             seq { for i in 7 .. 7 do
@@ -254,7 +254,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.TryExactlyOne() =
+    member _.TryExactlyOne() =
         let IntSeq =
             seq { for i in 7 .. 7 do
                     yield i }
@@ -279,7 +279,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Init() =
+    member _.Init() =
 
         let funcInt x = x
         let init_finiteInt = Seq.init 9 funcInt
@@ -304,7 +304,7 @@ type SeqModule2() =
         () 
         
     [<Fact>]
-    member this.InitInfinite() =
+    member _.InitInfinite() =
 
         let funcInt x = x
         let init_infiniteInt = Seq.initInfinite funcInt
@@ -322,7 +322,7 @@ type SeqModule2() =
        
        
     [<Fact>]
-    member this.IsEmpty() =
+    member _.IsEmpty() =
         
         //seq int
         let seqint = seq [1;2;3]
@@ -347,26 +347,25 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Iter() =
+    member _.Iter() =
         //seq int
         let seqint =  seq [ 1..3]
-        let cacheint = ref 0
+        let mutable cacheint = 0
        
-        let funcint x = cacheint := !cacheint + x
+        let funcint x = cacheint <- cacheint + x
         Seq.iter funcint seqint
-        Assert.AreEqual(6,!cacheint)
+        Assert.AreEqual(6, cacheint)
               
         //seq str
         let seqStr = seq ["first";"second"]
-        let cachestr =ref ""
-        let funcstr x = cachestr := !cachestr+x
+        let mutable cachestr = ""
+        let funcstr x = cachestr <- cachestr+x
         Seq.iter funcstr seqStr
          
-        Assert.AreEqual("firstsecond",!cachestr)
+        Assert.AreEqual("firstsecond",cachestr)
         
          // empty array    
         let emptyseq = Seq.empty
-        let resultEpt = ref 0
         Seq.iter (fun x -> Assert.Fail()) emptyseq   
 
         // null seqay
@@ -376,7 +375,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Iter2() =
+    member _.Iter2() =
     
         //seq int
         let seqint =  seq [ 1..3]
@@ -406,7 +405,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Iteri() =
+    member _.Iteri() =
     
         // seq int
         let seqint =  seq [ 1..10]
@@ -436,7 +435,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Iteri2() =
+    member _.Iteri2() =
 
         //seq int
         let seqint = seq [ 1..3]
@@ -479,7 +478,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Length() =
+    member _.Length() =
 
          // integer seq  
         let resultInt = Seq.length {1..8}
@@ -500,7 +499,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Map() =
+    member _.Map() =
 
          // integer Seq
         let funcInt x = 
@@ -531,7 +530,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Map2() =
+    member _.Map2() =
          // integer Seq
         let funcInt x y = x+y
         let resultInt = Seq.map2 funcInt { 1..10 } {2..2..20} 
@@ -558,7 +557,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Map3() = 
+    member _.Map3() = 
         // Integer seq
         let funcInt a b c = (a + b) * c
         let resultInt = Seq.map3 funcInt { 1..8 } { 2..9 } { 3..10 }
@@ -590,7 +589,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.MapFold() =
+    member _.MapFold() =
         // integer Seq
         let funcInt acc x = if x % 2 = 0 then 10*x, acc + 1 else x, acc
         let resultInt,resultIntAcc = Seq.mapFold funcInt 100 <| seq { 1..10 }
@@ -615,7 +614,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.MapFoldBack() =
+    member _.MapFoldBack() =
         // integer Seq
         let funcInt x acc = if acc < 105 then 10*x, acc + 2 else x, acc
         let resultInt,resultIntAcc = Seq.mapFoldBack funcInt (seq { 1..10 }) 100
@@ -710,7 +709,7 @@ type SeqModule2() =
         this.MapWithExceptionTester (fun f s -> System.Linq.Enumerable.Select(s, Func<_,_>(f)))
         
     [<Fact>]
-    member this.MapiWithSideEffects () =
+    member _.MapiWithSideEffects () =
         let i = ref 0
         let f _ x = i := !i + 1; x*x
         let e = ([1;2] |> Seq.mapi f).GetEnumerator()
@@ -744,7 +743,7 @@ type SeqModule2() =
         Assert.AreEqual(0,!i)
         
     [<Fact>]
-    member this.Map2WithSideEffects () =
+    member _.Map2WithSideEffects () =
         let i = ref 0
         let f x y = i := !i + 1; x*x
         let e = (Seq.map2 f [1;2] [1;2]).GetEnumerator()
@@ -778,7 +777,7 @@ type SeqModule2() =
         Assert.AreEqual(0,!i)
         
     [<Fact>]
-    member this.Mapi2WithSideEffects () =
+    member _.Mapi2WithSideEffects () =
         let i = ref 0
         let f _ x y = i := !i + 1; x*x
         let e = (Seq.mapi2 f [1;2] [1;2]).GetEnumerator()
@@ -812,7 +811,7 @@ type SeqModule2() =
         Assert.AreEqual(0,!i)
 
     [<Fact>]
-    member this.Collect() =
+    member _.Collect() =
          // integer Seq
         let funcInt x = seq [x+1]
         let resultInt = Seq.collect funcInt { 1..10 } 
@@ -842,7 +841,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Mapi() =
+    member _.Mapi() =
 
          // integer Seq
         let funcInt x y = x+y
@@ -871,7 +870,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Mapi2() =
+    member _.Mapi2() =
          // integer Seq
         let funcInt x y z = x+y+z
         let resultInt = Seq.mapi2 funcInt { 1..10 } {2..2..20}
@@ -907,7 +906,7 @@ type SeqModule2() =
         VerifySeqsEqual (seq [3;6;9;12;15;18;21;24;27;30]) (testSeqLengths longerSeq shorterSeq)
 
     [<Fact>]
-    member this.Indexed() =
+    member _.Indexed() =
 
          // integer Seq
         let resultInt = Seq.indexed { 10..2..20 }
@@ -932,7 +931,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Max() =
+    member _.Max() =
          // integer Seq
         let resultInt = Seq.max { 10..20 } 
         
@@ -953,7 +952,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.MaxBy() =
+    member _.MaxBy() =
     
         // integer Seq
         let funcInt x = x % 8
@@ -975,7 +974,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.MinBy() =
+    member _.MinBy() =
     
         // integer Seq
         let funcInt x = x % 8
@@ -998,7 +997,7 @@ type SeqModule2() =
         
           
     [<Fact>]
-    member this.Min() =
+    member _.Min() =
 
          // integer Seq
         let resultInt = Seq.min { 10..20 } 
@@ -1018,7 +1017,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Item() =
+    member _.Item() =
          // integer Seq
         let resultInt = Seq.item 3 { 10..20 }
         Assert.AreEqual(13, resultInt)
@@ -1043,7 +1042,7 @@ type SeqModule2() =
            CheckThrowsArgumentException (fun () -> Seq.item i { 10 .. 20 } |> ignore)
 
     [<Fact>]
-    member this.``item should fail with correct number of missing elements``() =
+    member _.``item should fail with correct number of missing elements``() =
         try
             Seq.item 0 (Array.zeroCreate<int> 0) |> ignore
             failwith "error expected"
@@ -1057,7 +1056,7 @@ type SeqModule2() =
         | exn when exn.Message.Contains("seq was short by 3 elements") -> ()
 
     [<Fact>]
-    member this.Of_Array() =
+    member _.Of_Array() =
          // integer Seq
         let resultInt = Seq.ofArray [|1..10|]
         let expectedInt = {1..10}
@@ -1076,7 +1075,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Of_List() =
+    member _.Of_List() =
          // integer Seq
         let resultInt = Seq.ofList [1..10]
         let expectedInt = {1..10}
@@ -1096,7 +1095,7 @@ type SeqModule2() =
         
           
     [<Fact>]
-    member this.Pairwise() =
+    member _.Pairwise() =
          // integer Seq
         let resultInt = Seq.pairwise {1..3}
        
@@ -1116,7 +1115,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Reduce() =
+    member _.Reduce() =
          
         // integer Seq
         let resultInt = Seq.reduce (fun x y -> x/y) (seq [5*4*3*2; 4;3;2;1])
@@ -1135,7 +1134,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.ReduceBack() =
+    member _.ReduceBack() =
         // int Seq
         let funcInt x y = x - y
         let IntSeq = seq { 1..4 }
@@ -1164,7 +1163,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Rev() =
+    member _.Rev() =
         // integer Seq
         let resultInt = Seq.rev (seq [5;4;3;2;1])
         VerifySeqsEqual (seq [1;2;3;4;5]) resultInt
@@ -1182,7 +1181,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Scan() =
+    member _.Scan() =
         // integer Seq
         let funcInt x y = x+y
         let resultInt = Seq.scan funcInt 9 {1..10}
@@ -1207,7 +1206,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.ScanBack() =
+    member _.ScanBack() =
         // integer Seq
         let funcInt x y = x+y
         let resultInt = Seq.scanBack funcInt { 1..10 } 9
@@ -1247,7 +1246,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Singleton() =
+    member _.Singleton() =
         // integer Seq
         let resultInt = Seq.singleton 1
        
@@ -1267,7 +1266,7 @@ type SeqModule2() =
     
         
     [<Fact>]
-    member this.Skip() =
+    member _.Skip() =
     
         // integer Seq
         let resultInt = Seq.skip 2 (seq [1;2;3;4])
@@ -1289,7 +1288,7 @@ type SeqModule2() =
         ()
        
     [<Fact>]
-    member this.Skip_While() =
+    member _.Skip_While() =
     
         // integer Seq
         let funcInt x = (x < 3)
@@ -1312,7 +1311,7 @@ type SeqModule2() =
         ()
        
     [<Fact>]
-    member this.Sort() =
+    member _.Sort() =
 
         // integer Seq
         let resultInt = Seq.sort (seq [1;3;2;4;6;5;7])
@@ -1334,7 +1333,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.SortBy() =
+    member _.SortBy() =
 
         // integer Seq
         let funcInt x = Math.Abs(x-5)
@@ -1358,7 +1357,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.SortDescending() =
+    member _.SortDescending() =
 
         // integer Seq
         let resultInt = Seq.sortDescending (seq [1;3;2;Int32.MaxValue;4;6;Int32.MinValue;5;7;0])
@@ -1397,7 +1396,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.SortByDescending() =
+    member _.SortByDescending() =
 
         // integer Seq
         let funcInt x = Math.Abs(x-5)
@@ -1433,7 +1432,7 @@ type SeqModule2() =
         CheckThrowsArgumentNullException(fun() -> Seq.sortByDescending funcInt null  |> ignore)
         ()
         
-    member this.SortWith() =
+    member _.SortWith() =
 
         // integer Seq
         let intComparer a b = compare (a%3) (b%3)
@@ -1456,7 +1455,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Sum() =
+    member _.Sum() =
     
         // integer Seq
         let resultInt = Seq.sum (seq [1..10])
@@ -1496,7 +1495,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.SumBy() =
+    member _.SumBy() =
 
         // integer Seq
         let resultInt = Seq.sumBy int (seq [1..10])
@@ -1535,7 +1534,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Take() =
+    member _.Take() =
         // integer Seq
         
         let resultInt = Seq.take 3 (seq [1;2;4;5;7])
@@ -1561,7 +1560,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.takeWhile() =
+    member _.takeWhile() =
         // integer Seq
         let funcInt x = (x < 6)
         let resultInt = Seq.takeWhile funcInt (seq [1;2;4;5;6;7])
@@ -1585,7 +1584,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.ToArray() =
+    member _.ToArray() =
         // integer Seq
         let resultInt = Seq.toArray(seq [1;2;4;5;7])
      
@@ -1607,32 +1606,32 @@ type SeqModule2() =
         ()
         
     [<Fact>]    
-    member this.ToArrayFromICollection() =
+    member _.ToArrayFromICollection() =
         let inputCollection = ResizeArray(seq [1;2;4;5;7])
         let resultInt = Seq.toArray(inputCollection)
         let expectedInt = [|1;2;4;5;7|]
         Assert.AreEqual(expectedInt,resultInt)        
     
     [<Fact>]    
-    member this.ToArrayEmptyInput() =
+    member _.ToArrayEmptyInput() =
         let resultInt = Seq.toArray(Seq.empty<int>)
         let expectedInt = Array.empty<int>
         Assert.AreEqual(expectedInt,resultInt)        
 
     [<Fact>]    
-    member this.ToArrayFromArray() =
+    member _.ToArrayFromArray() =
         let resultInt = Seq.toArray([|1;2;4;5;7|])
         let expectedInt = [|1;2;4;5;7|]
         Assert.AreEqual(expectedInt,resultInt)        
     
     [<Fact>]    
-    member this.ToArrayFromList() =
+    member _.ToArrayFromList() =
         let resultInt = Seq.toArray([1;2;4;5;7])
         let expectedInt = [|1;2;4;5;7|]
         Assert.AreEqual(expectedInt,resultInt)        
 
     [<Fact>]
-    member this.ToList() =
+    member _.ToList() =
         // integer Seq
         let resultInt = Seq.toList (seq [1;2;4;5;7])
         let expectedInt = [1;2;4;5;7]
@@ -1652,7 +1651,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Transpose() =
+    member _.Transpose() =
         // integer seq
         VerifySeqsEqual [seq [1; 4]; seq [2; 5]; seq [3; 6]] <| Seq.transpose (seq [seq {1..3}; seq {4..6}])
         VerifySeqsEqual [seq [1]; seq [2]; seq [3]] <| Seq.transpose (seq [seq {1..3}])
@@ -1677,7 +1676,7 @@ type SeqModule2() =
         VerifySeqsEqual [seq ["a";"c"]; seq ["b";"d"]] <| Seq.transpose (seq { yield ["a";"b"]; yield ["c";"d"] })
 
     [<Fact>]
-    member this.Truncate() =
+    member _.Truncate() =
         // integer Seq
         let resultInt = Seq.truncate 3 (seq [1;2;4;5;7])
         let expectedInt = [1;2;4]
@@ -1702,7 +1701,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.tryFind() =
+    member _.tryFind() =
         // integer Seq
         let resultInt = Seq.tryFind (fun x -> (x%2=0)) (seq [1;2;4;5;7])
         Assert.AreEqual(Some(2), resultInt)
@@ -1729,7 +1728,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.TryFindBack() =
+    member _.TryFindBack() =
         // integer Seq
         let resultInt = Seq.tryFindBack (fun x -> (x%2=0)) (seq [1;2;4;5;7])
         Assert.AreEqual(Some 4, resultInt)
@@ -1755,7 +1754,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.TryFindIndex() =
+    member _.TryFindIndex() =
 
         // integer Seq
         let resultInt = Seq.tryFindIndex (fun x -> (x % 5 = 0)) [8; 9; 10]
@@ -1783,7 +1782,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.TryFindIndexBack() =
+    member _.TryFindIndexBack() =
 
         // integer Seq
         let resultInt = Seq.tryFindIndexBack (fun x -> (x % 5 = 0)) [5; 9; 10; 12]
@@ -1810,7 +1809,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.Unfold() =
+    member _.Unfold() =
         // integer Seq
         
         let resultInt = Seq.unfold (fun x -> if x = 1 then Some(7,2) else  None) 1
@@ -1824,7 +1823,7 @@ type SeqModule2() =
         
         
     [<Fact>]
-    member this.Windowed() =
+    member _.Windowed() =
 
         let testWindowed config =
             try
@@ -1888,7 +1887,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Zip() =
+    member _.Zip() =
     
         // integer Seq
         let resultInt = Seq.zip (seq [1..7]) (seq [11..17])
@@ -1913,7 +1912,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.Zip3() =
+    member _.Zip3() =
         // integer Seq
         let resultInt = Seq.zip3 (seq [1..7]) (seq [11..17]) (seq [21..27])
         let expectedInt = 
@@ -1938,7 +1937,7 @@ type SeqModule2() =
         ()
         
     [<Fact>]
-    member this.tryPick() =
+    member _.tryPick() =
          // integer Seq
         let resultInt = Seq.tryPick (fun x-> if x = 1 then Some("got") else None) (seq [1..5])
          
@@ -1961,7 +1960,7 @@ type SeqModule2() =
         ()
 
     [<Fact>]
-    member this.tryItem() =
+    member _.tryItem() =
         // integer Seq
         let resultInt = Seq.tryItem 3 { 10..20 }
         Assert.AreEqual(Some(13), resultInt)
@@ -1987,7 +1986,7 @@ type SeqModule2() =
         Assert.AreEqual(None, resultIndexGreater)
         
     [<Fact>]
-    member this.RemoveAt() =
+    member _.RemoveAt() =
         // integer list
         Assert.AreEqual([2; 3; 4; 5], (Seq.removeAt 0 [1..5] |> Seq.toList))
         Assert.AreEqual([1; 2; 4; 5], (Seq.removeAt 2 [1..5] |> Seq.toList))
@@ -2004,7 +2003,7 @@ type SeqModule2() =
         CheckThrowsArgumentException (fun () -> Seq.removeAt 2 [1] |> Seq.toList |> ignore)
         
     [<Fact>]
-    member this.RemoveManyAt() =
+    member _.RemoveManyAt() =
         // integer list
         Assert.AreEqual([3; 4; 5], (Seq.removeManyAt 0 2 [1..5] |> Seq.toList))
         Assert.AreEqual([1; 2; 5], (Seq.removeManyAt 2 2 [1..5] |> Seq.toList))
@@ -2021,7 +2020,7 @@ type SeqModule2() =
         CheckThrowsArgumentException (fun () -> Seq.removeManyAt 2 2 [1] |> Seq.toList |> ignore)
         
     [<Fact>]
-    member this.UpdateAt() =
+    member _.UpdateAt() =
         // integer list
         Assert.AreEqual([0; 2; 3; 4; 5], (Seq.updateAt 0 0 [1..5] |> Seq.toList))
         Assert.AreEqual([1; 2; 0; 4; 5], (Seq.updateAt 2 0 [1..5] |> Seq.toList))
@@ -2038,7 +2037,7 @@ type SeqModule2() =
         CheckThrowsArgumentException (fun () -> Seq.updateAt 2 0 [1] |> Seq.toList |> ignore)
         
     [<Fact>]
-    member this.InsertAt() =
+    member _.InsertAt() =
         // integer list
         Assert.AreEqual([0; 1; 2; 3; 4; 5], (Seq.insertAt 0 0 [1..5] |> Seq.toList))
         Assert.AreEqual([1; 2; 0; 3; 4; 5], (Seq.insertAt 2 0 [1..5] |> Seq.toList))
@@ -2055,7 +2054,7 @@ type SeqModule2() =
         CheckThrowsArgumentException (fun () -> Seq.insertAt 2 0 [1] |> Seq.toList |> ignore)
         
     [<Fact>]
-    member this.InsertManyAt() =
+    member _.InsertManyAt() =
         // integer list
         Assert.AreEqual([0; 0; 1; 2; 3; 4; 5], (Seq.insertManyAt 0 [0; 0] [1..5] |> Seq.toList))
         Assert.AreEqual([1; 2; 0; 0; 3; 4; 5], (Seq.insertManyAt 2 [0; 0] [1..5] |> Seq.toList))

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqMultipleIteration.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqMultipleIteration.fs
@@ -5,43 +5,43 @@ open Xunit
 
 module SeqMultipleIteration =
     let makeNewSeq () =
-        let haveCalled = false |> ref
+        let mutable haveCalled = false
         seq {
-            if !haveCalled then failwith "Should not have iterated this sequence before"
-            haveCalled := true
+            if haveCalled then failwith "Should not have iterated this sequence before"
+            haveCalled <- true
             yield 3
-        }, haveCalled
+        }, (fun () -> haveCalled)
 
     [<Fact>]
     let ``Seq.distinct only evaluates the seq once`` () =
         let s, haveCalled = makeNewSeq ()
         let distincts = Seq.distinct s
-        Assert.False !haveCalled
+        Assert.False (haveCalled())
         CollectionAssert.AreEqual (distincts |> Seq.toList, [3])
-        Assert.True !haveCalled
+        Assert.True (haveCalled())
 
     [<Fact>]
     let ``Seq.distinctBy only evaluates the seq once`` () =
         let s, haveCalled = makeNewSeq ()
         let distincts = Seq.distinctBy id s
-        Assert.False !haveCalled
+        Assert.False (haveCalled())
         CollectionAssert.AreEqual (distincts |> Seq.toList, [3])
-        Assert.True !haveCalled
+        Assert.True (haveCalled())
 
     [<Fact>]
     let ``Seq.groupBy only evaluates the seq once`` () =
         let s, haveCalled = makeNewSeq ()
         let groups : seq<int * seq<int>> = Seq.groupBy id s
-        Assert.False !haveCalled
+        Assert.False (haveCalled())
         let groups : list<int * seq<int>> = Seq.toList groups
         // Seq.groupBy iterates the entire sequence as soon as it begins iteration.
-        Assert.True !haveCalled
+        Assert.True (haveCalled())
 
     [<Fact>]
     let ``Seq.countBy only evaluates the seq once`` () =
         let s, haveCalled = makeNewSeq ()
         let counts : seq<int * int> = Seq.countBy id s
-        Assert.False !haveCalled
+        Assert.False (haveCalled())
         let counts : list<int * int> = Seq.toList counts
-        Assert.True !haveCalled
+        Assert.True (haveCalled())
         CollectionAssert.AreEqual (counts |> Seq.toList, [(3, 1)])

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SetModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SetModule.fs
@@ -20,7 +20,7 @@ Make sure each method works on:
 type SetModule() =
 
     [<Fact>]
-    member this.Empty() =
+    member _.Empty() =
         let emptySet = Set.empty
         if Set.count emptySet <> 0 then Assert.Fail()    
         
@@ -29,7 +29,7 @@ type SetModule() =
         ()
 
     [<Fact>]
-    member this.Singleton() =
+    member _.Singleton() =
         let intSingleton = Set.singleton 5
         Assert.True(intSingleton.Count = 1)
         Assert.True(intSingleton.Contains(5))
@@ -38,7 +38,7 @@ type SetModule() =
         Assert.False(stringSingleton.Contains(""))
         
     [<Fact>]
-    member this.Add() =
+    member _.Add() =
         let empty = Set.empty
         let x     = Set.add 'x' empty
         let xy    = Set.add 'y' x
@@ -50,7 +50,7 @@ type SetModule() =
         Assert.True(Set.count wxyz = 4)
         
     [<Fact>]
-    member this.Contains() =
+    member _.Contains() =
         // Empty set searching for null = false
         if Set.contains null (Set.empty) <> false then Assert.Fail()
 
@@ -63,7 +63,7 @@ type SetModule() =
         ()
         
     [<Fact>]
-    member this.Count() = 
+    member _.Count() = 
         let empty = Set.empty
         if Set.count empty <> 0 then Assert.Fail()
         
@@ -75,7 +75,7 @@ type SetModule() =
         ()
         
     [<Fact>]
-    member this.Diff() = 
+    member _.Diff() = 
         // Given a large set and removing 0, 1, x elements...
         let alphabet = new Set<char>([| 'a' .. 'z' |])
         let emptyChar = Set.empty : Set<char>
@@ -108,7 +108,7 @@ type SetModule() =
         ()
 
     [<Fact>]
-    member this.Equal() =
+    member _.Equal() =
         let emptySet1 : Set<string> = Set.empty
         let emptySet2 : Set<string> = Set.empty
         if (emptySet1 = emptySet2) <> true then Assert.Fail()
@@ -123,7 +123,7 @@ type SetModule() =
         ()
         
     [<Fact>]
-    member this.Compare() =
+    member _.Compare() =
         // Comparing empty sets
         let emptyString1 = Set.empty : Set<string>
         let emptyString2 = Set.empty : Set<string>
@@ -151,7 +151,7 @@ type SetModule() =
         ()
 
     [<Fact>]
-    member this.Exists() =
+    member _.Exists() =
         
         let emptyInt = Set.empty : Set<int>
         if Set.exists (fun _ -> true) emptyInt <> false then Assert.Fail()
@@ -166,7 +166,7 @@ type SetModule() =
         ()
         
     [<Fact>]
-    member this.Filter() =
+    member _.Filter() =
         
         let emptyComplex = Set.empty : Set<int * List<string * Set<decimal>> * Set<int * string * (char * char * char)>>
         let fileredEmpty = Set.filter (fun _ -> false) emptyComplex 
@@ -185,7 +185,7 @@ type SetModule() =
         
 
     [<Fact>]
-    member this.Map() =
+    member _.Map() =
         let emptySet : Set<string> = Set.empty
         
         let result = Set.map (fun _ -> Assert.Fail(); "") emptySet
@@ -198,43 +198,43 @@ type SetModule() =
         ()
 
     [<Fact>]
-    member this.Fold() =
+    member _.Fold() =
         
         let emptySet : Set<decimal> = Set.empty
         let result = Set.fold (fun _ _ -> Assert.Fail(); -1I) 0I emptySet
         if result <> 0I then Assert.Fail()
         
-        let callOrder = ref ([] : (int * int) list)
+        let mutable callOrder = ([] : (int * int) list)
         let input = new Set<_>([1; 2; 3; 4; 5])
         
         let result = Set.fold 
-                            (fun acc i -> callOrder := (acc, i) :: !callOrder; acc + i) 
+                            (fun acc i -> callOrder <- (acc, i) :: callOrder; acc + i) 
                             0 
                             input
         if result    <> 15 then Assert.Fail()
-        if !callOrder <> [(10, 5); (6, 4); (3, 3); (1, 2); (0, 1)] then Assert.Fail()
+        if callOrder <> [(10, 5); (6, 4); (3, 3); (1, 2); (0, 1)] then Assert.Fail()
         ()
         
     [<Fact>]
-    member this.FoldBack() =
+    member _.FoldBack() =
         
         let emptySet : Set<decimal> = Set.empty
         let result = Set.foldBack (fun _ _ -> Assert.Fail(); -1I) emptySet 0I
         if result <> 0I then Assert.Fail()
         
-        let callOrder = ref ([] : (int * int) list)
+        let mutable callOrder = ([] : (int * int) list)
         let input = new Set<_>([1; 2; 3; 4; 5])
         
         let result = Set.foldBack
-                            (fun i acc -> callOrder := (acc, i) :: !callOrder; acc + i) 
+                            (fun i acc -> callOrder <- (acc, i) :: callOrder; acc + i) 
                             input
                             0
         if result    <> 15 then Assert.Fail()
-        if !callOrder <> [(14, 1); (12, 2); (9, 3); (5, 4); (0, 5)] then Assert.Fail()
+        if callOrder <> [(14, 1); (12, 2); (9, 3); (5, 4); (0, 5)] then Assert.Fail()
         ()
 
     [<Fact>]
-    member this.ForAll() =
+    member _.ForAll() =
 
         let emptySet : Set<string> = Set.empty
         let result = Set.forall (fun x -> Assert.Fail(); false) emptySet
@@ -250,7 +250,7 @@ type SetModule() =
         ()
 
     [<Fact>]
-    member this.Intersect() =
+    member _.Intersect() =
         
         let emptySet1 : Set<int> = Set.empty
         let emptySet2 : Set<int> = Set.empty
@@ -267,7 +267,7 @@ type SetModule() =
         ()
     
     [<Fact>]
-    member this.Intersect2() =
+    member _.Intersect2() =
         let a = new Set<int>([3; 4; 5; 6])
         let b = new Set<int>([5; 6; 7; 8])
         
@@ -277,7 +277,7 @@ type SetModule() =
 
     
     [<Fact>]
-    member this.IntersectMany() =
+    member _.IntersectMany() =
         (* IntersectAll
             1234567
              234567
@@ -299,7 +299,7 @@ type SetModule() =
         Assert.True(contains 7 result)
                   
     [<Fact>]
-    member this.IntersectMany2() =
+    member _.IntersectMany2() =
         let all   = new Set<_>([1 .. 10])
         let odds  = new Set<_>([1 .. 2 .. 10])
         let evens = new Set<_>([2 .. 2 .. 10])
@@ -308,7 +308,7 @@ type SetModule() =
         Assert.True(Set.count result = 0)
 
     [<Fact>]
-    member this.IntersectMany3() =
+    member _.IntersectMany3() =
         let all   = new Set<_>([1 .. 10])
         let empty = Set.empty : Set<int>
         
@@ -317,12 +317,12 @@ type SetModule() =
         
         
     [<Fact>]
-    member this.IntersectMany4() =
+    member _.IntersectMany4() =
         CheckThrowsArgumentException (fun () -> Set.intersectMany (Seq.empty : seq<Set<int>>) |> ignore)
         ()
 
     [<Fact>]
-    member this.Union() =
+    member _.Union() =
         let emptySet1 : Set<int> = Set.empty
         let emptySet2 : Set<int> = Set.empty
         let four                 = Set.singleton 4
@@ -338,7 +338,7 @@ type SetModule() =
         ()
     
     [<Fact>]
-    member this.Union2() =
+    member _.Union2() =
         let a = new Set<int>([1; 2; 3; 4])
         let b = new Set<int>([5; 6; 7; 8])
         
@@ -347,7 +347,7 @@ type SetModule() =
         Assert.True( (union = expectedResult) )
 
     [<Fact>]
-    member this.Union3() =
+    member _.Union3() =
         let x = 
             Set.singleton 1
             |> Set.union (Set.singleton 1)
@@ -357,7 +357,7 @@ type SetModule() =
         Assert.True(x.Count = 1)
         
     [<Fact>]
-    member this.UnionMany() =
+    member _.UnionMany() =
         let odds  = new Set<int>([1 .. 2 .. 10])
         let evens = new Set<int>([2 .. 2 .. 10])
         let empty = Set.empty : Set<int>
@@ -368,12 +368,12 @@ type SetModule() =
         Assert.True(result.Count = 20)
 
     [<Fact>]
-    member this.UnionMany2() =
+    member _.UnionMany2() =
         let result = Set.unionMany (Seq.empty : seq<Set<string>>)
         Assert.True(result.Count = 0)
         
     [<Fact>]
-    member this.IsEmpty() =
+    member _.IsEmpty() =
         let zero  = Set.empty : Set<decimal>
         let zero2 = new Set<int>([])
         let one   = Set.singleton "foo"
@@ -386,7 +386,7 @@ type SetModule() =
         Assert.False(Set.isEmpty n)
         
     [<Fact>]
-    member this.Iter() =
+    member _.Iter() =
 
         // Empty set
         Set.empty |> Set.iter (fun _ -> Assert.Fail())
@@ -401,7 +401,7 @@ type SetModule() =
         Assert.True (Array.forall ( (=) true ) elements)
 
     [<Fact>]
-    member this.Parition() =
+    member _.Parition() =
         
         // Empty
         let resulta, resultb = Set.partition (fun (x : int) -> Assert.Fail(); false) Set.empty
@@ -425,7 +425,7 @@ type SetModule() =
         Assert.True(resulta.Count = 5 && resultb.Count = 21)
 
     [<Fact>]
-    member this.Remove() =
+    member _.Remove() =
         
         let emptySet : Set<int> = Set.empty
         let result = Set.remove 42 emptySet
@@ -452,7 +452,7 @@ type SetModule() =
         Assert.False(Set.exists ( (=) 3 ) c)
 
     [<Fact>]
-    member this.Of_List() =
+    member _.Of_List() =
         
         // Empty
         let emptySet = Set.ofList ([] : (string * int * Set<int>) list)
@@ -470,7 +470,7 @@ type SetModule() =
         Assert.True( (multi = expected) )
 
     [<Fact>]
-    member this.To_List() =
+    member _.To_List() =
 
         // Empty
         let emptySet : Set<byte> = Set.empty
@@ -485,7 +485,7 @@ type SetModule() =
         Assert.True(Set.toList multi = [1; 2; 3; 4; 5])
 
     [<Fact>]
-    member this.Of_Array() =
+    member _.Of_Array() =
         
         // Empty
         let emptySet = Set.ofArray ([| |] : (string * int * Set<int>) [])
@@ -503,7 +503,7 @@ type SetModule() =
         Assert.True( (multi = expected) )
 
     [<Fact>]
-    member this.To_Array() =
+    member _.To_Array() =
 
         // Empty
         let emptySet : Set<byte> = Set.empty
@@ -519,7 +519,7 @@ type SetModule() =
 
 
     [<Fact>]
-    member this.Of_Seq() =
+    member _.Of_Seq() =
         
         // Empty
         let emptySet = Set.ofSeq ([| |] : (string * int * Set<int>) [])
@@ -537,7 +537,7 @@ type SetModule() =
         Assert.True( (multi = expected) )
 
     [<Fact>]
-    member this.To_Seq() =
+    member _.To_Seq() =
 
         // Empty
         let emptySet : Set<byte> = Set.empty
@@ -556,7 +556,7 @@ type SetModule() =
         
 
     [<Fact>]
-    member this.MinElement() =
+    member _.MinElement() =
         
         // Check for an argument exception "Set contains no members"
         CheckThrowsArgumentException(fun () -> Set.minElement Set.empty |> ignore)
@@ -568,7 +568,7 @@ type SetModule() =
         Assert.AreEqual(Set.minElement set2, "a")
         
     [<Fact>]
-    member this.MaxElement() =
+    member _.MaxElement() =
         
         // Check for an argument exception "Set contains no members"
         CheckThrowsArgumentException(fun () -> Set.maxElement Set.empty |> ignore)
@@ -581,7 +581,7 @@ type SetModule() =
 
 
     [<Fact>]
-    member this.IsProperSubset() =
+    member _.IsProperSubset() =
         
         let set1 = Set.ofList [10; 8; 100]
         let set2 = Set.ofList [100]
@@ -591,7 +591,7 @@ type SetModule() =
         Assert.False(Set.isProperSubset set1 set2)
 
     [<Fact>]
-    member this.IsProperSuperset() =
+    member _.IsProperSuperset() =
         
         let set1 = Set.ofList [10; 8; 100]
         let set2 = Set.ofList [100; 8]
@@ -604,7 +604,7 @@ type SetModule() =
     // ----- Not associated with a module function -----
 
     [<Fact>]
-    member this.GeneralTest1() =
+    member _.GeneralTest1() =
         
         // Returns a random permutation of integers between the two bounds.
         let randomPermutation lowerBound upperBound = 
@@ -623,17 +623,18 @@ type SetModule() =
         for i in 0..50 do
             let permutation = randomPermutation 0 i
             
-            let set : Set<int> ref = ref Set.empty
+            let mutable set : Set<int> = Set.empty
             // Add permutation items to set in order
-            Array.iter (fun i -> set := Set.add i !set) permutation
+            permutation |> Array.iter (fun i -> 
+                set <- Set.add i set) 
             // Check that the set equals the full list
-            Assert.True(Set.toList !set = [0 .. i])
+            Assert.True(Set.toList set = [0 .. i])
             // Remove items in permutation order, ensuring set is delt with correctly
             Array.iteri
-                (fun idx i -> set := Set.remove i !set
+                (fun idx i -> set <- Set.remove i set
                               // Verify all elements have been correctly removed
                               let removedElements = Array.sub permutation 0 (idx + 1) |> Set.ofSeq
-                              let inter = Set.intersect !set removedElements
+                              let inter = Set.intersect set removedElements
                               Assert.True(inter.Count = 0))
                 permutation
         ()

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/StringModule.fs
@@ -21,7 +21,7 @@ Make sure each method works on:
 type StringModule() =
 
     [<Fact>]
-    member this.Concat() =
+    member _.Concat() =
         /// This tests the three paths of String.concat w.r.t. array, list, seq
         let execTest f expected arg = 
             let r1 = f (List.toSeq arg)
@@ -45,27 +45,27 @@ type StringModule() =
         CheckThrowsArgumentNullException(fun () -> String.concat "%%%" null |> ignore)
 
     [<Fact>]
-    member this.Iter() =
-        let result = ref 0
-        do String.iter (fun c -> result := !result + (int c)) "foo"
-        Assert.AreEqual(324, !result)
+    member _.Iter() =
+        let mutable result = 0
+        do String.iter (fun c -> result <- result + (int c)) "foo"
+        Assert.AreEqual(324, result)
 
-        do result := 0
-        do String.iter (fun c -> result := !result + (int c)) null
-        Assert.AreEqual(0, !result)
-
-    [<Fact>]
-    member this.IterI() =
-        let result = ref 0
-        do String.iteri(fun i c -> result := !result + (i*(int c))) "foo"
-        Assert.AreEqual(333, !result)
-
-        result := 0
-        do String.iteri(fun i c -> result := !result + (i*(int c))) null
-        Assert.AreEqual(0, !result)
+        do result <- 0
+        do String.iter (fun c -> result <- result + (int c)) null
+        Assert.AreEqual(0, result)
 
     [<Fact>]
-    member this.Map() =
+    member _.IterI() =
+        let mutable result = 0
+        do String.iteri(fun i c -> result <- result + (i*(int c))) "foo"
+        Assert.AreEqual(333, result)
+
+        result <- 0
+        do String.iteri(fun i c -> result <- result + (i*(int c))) null
+        Assert.AreEqual(0, result)
+
+    [<Fact>]
+    member _.Map() =
         let e1 = String.map id "xyz"
         Assert.AreEqual("xyz", e1)
 
@@ -97,7 +97,7 @@ type StringModule() =
         Assert.AreEqual(e8, "bdfhj")
 
     [<Fact>]
-    member this.MapI() =
+    member _.MapI() =
         let e1 = String.mapi (fun _ c -> c) "12345"
         Assert.AreEqual("12345", e1)
 
@@ -129,7 +129,7 @@ type StringModule() =
         Assert.AreEqual(e9, "acfjo")
 
     [<Fact>]
-    member this.Filter() =
+    member _.Filter() =
         let e1 = String.filter (fun c -> true) "Taradiddle"
         Assert.AreEqual("Taradiddle", e1)
 
@@ -150,7 +150,7 @@ type StringModule() =
         Assert.AreEqual(String.replicate 5_000 "RCDR", e5)
 
     [<Fact>]
-    member this.Collect() =
+    member _.Collect() =
         let e1 = String.collect (fun c -> "a"+string c) "foo"
         Assert.AreEqual("afaoao", e1)
 
@@ -161,7 +161,7 @@ type StringModule() =
         Assert.AreEqual("", e3)
 
     [<Fact>]
-    member this.Init() =
+    member _.Init() =
         let e1 = String.init 0 (fun i -> "foo")
         Assert.AreEqual("", e1)
 
@@ -174,7 +174,7 @@ type StringModule() =
         CheckThrowsArgumentException(fun () -> String.init -1 (fun c -> "") |> ignore)
 
     [<Fact>]
-    member this.Replicate() = 
+    member _.Replicate() = 
         let e1 = String.replicate 0 "Snickersnee"
         Assert.AreEqual("", e1)
 
@@ -214,7 +214,7 @@ type StringModule() =
         CheckThrowsArgumentException(fun () -> String.replicate -1 "foo" |> ignore)
 
     [<Fact>]
-    member this.Forall() = 
+    member _.Forall() = 
         let e1 = String.forall (fun c -> true) ""
         Assert.AreEqual(true, e1)
 
@@ -234,7 +234,7 @@ type StringModule() =
         Assert.AreEqual(true, e6)
 
     [<Fact>]
-    member this.Exists() = 
+    member _.Exists() = 
         let e1 = String.exists (fun c -> true) ""
         Assert.AreEqual(false, e1)
 
@@ -251,7 +251,7 @@ type StringModule() =
         Assert.AreEqual(false, e5)
 
     [<Fact>]
-    member this.Length() = 
+    member _.Length() = 
         let e1 = String.length ""
         Assert.AreEqual(0, e1)
 
@@ -262,19 +262,19 @@ type StringModule() =
         Assert.AreEqual(0, e3)
 
     [<Fact>]
-    member this.``Slicing with both index reverse behaves as expected``()  = 
+    member _.``Slicing with both index reverse behaves as expected``()  = 
         let str = "abcde"
 
         Assert.AreEqual(str.[^3..^1], str.[1..3])
 
     [<Fact>]
-    member this.``Indexer with reverse index behaves as expected``() =
+    member _.``Indexer with reverse index behaves as expected``() =
         let str = "abcde"
 
         Assert.AreEqual(str.[^1], 'd')
 
     [<Fact>] 
-    member this.SlicingUnboundedEnd() = 
+    member _.SlicingUnboundedEnd() = 
         let str = "123456"
 
         Assert.AreEqual(str.[-1..], str)
@@ -287,7 +287,7 @@ type StringModule() =
 
     
     [<Fact>] 
-    member this.SlicingUnboundedStart() = 
+    member _.SlicingUnboundedStart() = 
         let str = "123456"
 
         Assert.AreEqual(str.[..(-1)], (""))
@@ -302,7 +302,7 @@ type StringModule() =
 
 
     [<Fact>]
-    member this.SlicingBoundedStartEnd() =
+    member _.SlicingBoundedStartEnd() =
         let str = "123456"
 
         Assert.AreEqual(str.[*], str)
@@ -328,7 +328,7 @@ type StringModule() =
 
 
     [<Fact>]
-    member this.SlicingEmptyString() = 
+    member _.SlicingEmptyString() = 
 
         let empty = ""
         Assert.AreEqual(empty.[*], (""))
@@ -340,7 +340,7 @@ type StringModule() =
 
 
     [<Fact>]
-    member this.SlicingOutOfBounds() = 
+    member _.SlicingOutOfBounds() = 
         let str = "123456"
        
         Assert.AreEqual(str.[..6], "123456")

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -18,9 +18,9 @@ module Utils =
             cache.GetOrAdd(x, fun x -> f(x) |> Async.StartAsTask) |> Async.AwaitTask
 
 type [<Struct>] Dummy (x: int) =
-  member this.X = x
+  member _.X = x
   interface IDisposable with
-    member this.Dispose () = ()
+    member _.Dispose () = ()
 
 
 [<AutoOpen>]
@@ -134,14 +134,14 @@ module ChoiceUtils =
         if not <| List.isEmpty ops then
             let minTimeout = getMinTime()
             let minTimeoutOps = ops |> Seq.filter (fun op -> op.Timeout <= minTimeout) |> Seq.length
-            Assert.True(!completed <= minTimeoutOps)
+            Assert.True(completed.Value <= minTimeoutOps)
 
 module LeakUtils =
     // when testing for liveness, the things that we want to observe must always be created in
     // a nested function call to avoid the GC (possibly) treating them as roots past the last use in the block.
     // We also need something non trivial to dissuade the compiler from inlining in Release builds.
     type ToRun<'a>(f : unit -> 'a) =
-        member this.Invoke() = f()
+        member _.Invoke() = f()
    
     let run (toRun : ToRun<'a>) = toRun.Invoke()
 
@@ -153,13 +153,13 @@ type AsyncModule() =
     let getTicksTask =
         async {
             do! Async.SwitchToThreadPool()
-            let tickstamps = ref [] // like timestamps but for ticks :)
+            let mutable tickstamps = [] // like timestamps but for ticks :)
             
             for i = 1 to 10 do
-                tickstamps := DateTime.UtcNow.Ticks :: !tickstamps
+                tickstamps <- DateTime.UtcNow.Ticks :: tickstamps
                 do! Async.Sleep(20)
                 
-            return !tickstamps
+            return tickstamps
         }
 
     let wait (wh : System.Threading.WaitHandle) (timeoutMilliseconds : int) = 
@@ -187,10 +187,10 @@ type AsyncModule() =
 
             wait barrier 100
             |> ignore
-            if !c = 2 then Assert.Fail("both error and cancel continuations were called")
+            if c.Value = 2 then Assert.Fail("both error and cancel continuations were called")
 
     [<Fact>]
-    member this.AwaitIAsyncResult() =
+    member _.AwaitIAsyncResult() =
 
         let beginOp, endOp, cancelOp = Async.AsBeginEnd(fun() -> getTicksTask)
 
@@ -217,7 +217,7 @@ type AsyncModule() =
         | false -> ()
 
     [<Fact(Skip = "Flaky")>]
-    member this.``AwaitWaitHandle.Timeout``() = 
+    member _.``AwaitWaitHandle.Timeout``() = 
         use waitHandle = new System.Threading.ManualResetEvent(false)
         let startTime = DateTime.UtcNow
 
@@ -232,7 +232,7 @@ type AsyncModule() =
         Assert.True(delta.TotalMilliseconds < 1100.0, sprintf "Expected faster timeout than %.0f ms" delta.TotalMilliseconds)
 
     [<Fact>]
-    member this.``AwaitWaitHandle.TimeoutWithCancellation``() = 
+    member _.``AwaitWaitHandle.TimeoutWithCancellation``() = 
         use barrier = new System.Threading.ManualResetEvent(false)
         use waitHandle = new System.Threading.ManualResetEvent(false)
         let cts = new System.Threading.CancellationTokenSource()
@@ -259,7 +259,7 @@ type AsyncModule() =
         if not ok then Assert.Fail("Async computation was not completed in given time")
 
     [<Fact>]
-    member this.``AwaitWaitHandle.DisposedWaitHandle1``() = 
+    member _.``AwaitWaitHandle.DisposedWaitHandle1``() = 
         let wh = new System.Threading.ManualResetEvent(false)
         
         dispose wh
@@ -275,7 +275,7 @@ type AsyncModule() =
 
     // test is flaky: https://github.com/dotnet/fsharp/issues/11586
     //[<Fact>]
-    member this.``OnCancel.RaceBetweenCancellationHandlerAndDisposingHandlerRegistration``() = 
+    member _.``OnCancel.RaceBetweenCancellationHandlerAndDisposingHandlerRegistration``() = 
         let test() = 
             use flag = new ManualResetEvent(false)
             use cancelHandlerRegistered = new ManualResetEvent(false)
@@ -299,14 +299,14 @@ type AsyncModule() =
 
     // test is flaky: https://github.com/dotnet/fsharp/issues/11586
     //[<Fact>]
-    member this.``OnCancel.RaceBetweenCancellationAndDispose``() = 
-        let flag = ref 0
+    member _.``OnCancel.RaceBetweenCancellationAndDispose``() = 
+        let mutable flag = 0
         let cts = new System.Threading.CancellationTokenSource()
         let go = async {
             use disp =
                 cts.Cancel()
                 { new IDisposable with
-                    override _.Dispose() = incr flag }
+                    override _.Dispose() = flag <- flag + 1}
             while true do
                 do! Async.Sleep 50
             }
@@ -314,11 +314,11 @@ type AsyncModule() =
             Async.RunSynchronously (go, cancellationToken = cts.Token)
         with
             :? System.OperationCanceledException -> ()
-        Assert.AreEqual(1, !flag)
+        Assert.AreEqual(1, flag)
 
     // test is flaky: https://github.com/dotnet/fsharp/issues/11586
     //[<Fact>]
-    member this.``OnCancel.CancelThatWasSignalledBeforeRunningTheComputation``() = 
+    member _.``OnCancel.CancelThatWasSignalledBeforeRunningTheComputation``() = 
         let test() = 
             let cts = new System.Threading.CancellationTokenSource()
             let go e (flag : bool ref) = async {
@@ -343,7 +343,7 @@ type AsyncModule() =
 
 #if EXPENSIVE
     [<Test; Category("Expensive"); Explicit>]
-    member this.``Async.AwaitWaitHandle does not leak memory`` () =
+    member _.``Async.AwaitWaitHandle does not leak memory`` () =
         // This test checks that AwaitWaitHandle does not leak continuations (described in #131),
         // We only test the worst case - when the AwaitWaitHandle is already set.
         use manualResetEvent = new System.Threading.ManualResetEvent(true)
@@ -378,7 +378,7 @@ type AsyncModule() =
 #endif
 
     [<Fact>]
-    member this.``AwaitWaitHandle.DisposedWaitHandle2``() = 
+    member _.``AwaitWaitHandle.DisposedWaitHandle2``() = 
         let wh = new System.Threading.ManualResetEvent(false)
         let barrier = new System.Threading.ManualResetEvent(false)
 
@@ -398,7 +398,7 @@ type AsyncModule() =
         if not ok then Assert.Fail("Async computation was not completed in given time")
 
     [<Fact>]
-    member this.``RunSynchronously.NoThreadJumpsAndTimeout``() = 
+    member _.``RunSynchronously.NoThreadJumpsAndTimeout``() = 
             let longRunningTask = async { sleep(5000) }
             try
                 Async.RunSynchronously(longRunningTask, timeout = 500)
@@ -407,7 +407,7 @@ type AsyncModule() =
                 :? System.TimeoutException -> ()
 
     [<Fact>]
-    member this.``RunSynchronously.NoThreadJumpsAndTimeout.DifferentSyncContexts``() = 
+    member _.``RunSynchronously.NoThreadJumpsAndTimeout.DifferentSyncContexts``() = 
         let run syncContext =
             let old = System.Threading.SynchronizationContext.Current
             System.Threading.SynchronizationContext.SetSynchronizationContext(syncContext)
@@ -424,38 +424,38 @@ type AsyncModule() =
         run (System.Threading.SynchronizationContext())
 
     [<Fact>]
-    member this.``RaceBetweenCancellationAndError.AwaitWaitHandle``() = 
+    member _.``RaceBetweenCancellationAndError.AwaitWaitHandle``() = 
         let disposedEvent = new System.Threading.ManualResetEvent(false)
         dispose disposedEvent
         testErrorAndCancelRace "RaceBetweenCancellationAndError.AwaitWaitHandle" (Async.AwaitWaitHandle disposedEvent)
 
     [<Fact>]
-    member this.``RaceBetweenCancellationAndError.Sleep``() =
+    member _.``RaceBetweenCancellationAndError.Sleep``() =
         testErrorAndCancelRace "RaceBetweenCancellationAndError.Sleep" (Async.Sleep (-5))
 
 #if EXPENSIVE
 #if NET46
     [<Test; Category("Expensive"); Explicit>] // takes 3 minutes!
-    member this.``Async.Choice specification test``() =
+    member _.``Async.Choice specification test``() =
         ThreadPool.SetMinThreads(100,100) |> ignore
         Check.One ({Config.QuickThrowOnFailure with EndSize = 20}, normalize >> runChoice)
 #endif
 #endif
 
     [<Fact>]
-    member this.``dispose should not throw when called on null``() =
+    member _.``dispose should not throw when called on null``() =
         let result = async { use x = null in return () } |> Async.RunSynchronously
 
         Assert.AreEqual((), result)
 
     [<Fact>]
-    member this.``dispose should not throw when called on null struct``() =
+    member _.``dispose should not throw when called on null struct``() =
         let result = async { use x = new Dummy(1) in return () } |> Async.RunSynchronously
 
         Assert.AreEqual((), result)
 
     [<Fact>]
-    member this.``error on one workflow should cancel all others``() =
+    member _.``error on one workflow should cancel all others``() =
         let counter = 
             async {
                 let counter = ref 0
@@ -474,7 +474,7 @@ type AsyncModule() =
         Assert.AreEqual(0, counter)
 
     [<Fact>]
-    member this.``AwaitWaitHandle.ExceptionsAfterTimeout``() = 
+    member _.``AwaitWaitHandle.ExceptionsAfterTimeout``() = 
         let wh = new System.Threading.ManualResetEvent(false)
         let test = async {
             try
@@ -488,7 +488,7 @@ type AsyncModule() =
         Async.RunSynchronously(test)
         
     [<Fact>]
-    member this.``FromContinuationsCanTailCallCurrentThread``() = 
+    member _.``FromContinuationsCanTailCallCurrentThread``() = 
         let cnt = ref 0
         let origTid = System.Threading.Thread.CurrentThread.ManagedThreadId 
         let finalTid = ref -1
@@ -509,7 +509,7 @@ type AsyncModule() =
         Assert.AreEqual(5000, !cnt)
 
     [<Fact>]
-    member this.``AwaitWaitHandle With Cancellation``() = 
+    member _.``AwaitWaitHandle With Cancellation``() = 
         let run wh = async {
             let! r = Async.AwaitWaitHandle wh
             Assert.True(r, "Timeout not expected")
@@ -534,7 +534,7 @@ type AsyncModule() =
         for _ in 1..1000 do test()
 
     [<Fact>]
-    member this.``StartWithContinuationsVersusDoBang``() = 
+    member _.``StartWithContinuationsVersusDoBang``() = 
         // worthwhile to note these three
         // case 1
         let r = ref ""
@@ -561,7 +561,7 @@ type AsyncModule() =
 
 #if IGNORED
     [<Test; Ignore("See https://github.com/Microsoft/visualfsharp/issues/4887")>]
-    member this.``SleepContinuations``() = 
+    member _.``SleepContinuations``() = 
         let okCount = ref 0
         let errCount = ref 0
         let test() = 
@@ -589,13 +589,13 @@ type AsyncModule() =
 #endif
 
     [<Fact>]
-    member this.``Async caching should work``() = 
-        let x = ref 0
+    member _.``Async caching should work``() = 
+        let mutable x = 0
         let someSlowFunc _mykey = async { 
             Console.WriteLine "Simulated downloading..."
             do! Async.Sleep 400
             Console.WriteLine "Simulated downloading Done."
-            x := !x + 1 // Side effect!
+            x <- x + 1 // Side effect!
             return "" }
 
         let memFunc : string -> Async<string> = Utils.memoizeAsync <| someSlowFunc
@@ -624,10 +624,10 @@ type AsyncModule() =
                 |> Async.Parallel |> Async.Ignore
         } |> Async.RunSynchronously
         Console.WriteLine "Checking result...."
-        Assert.AreEqual(1, !x)
+        Assert.AreEqual(1, x)
 
     [<Fact>]
-    member this.``Parallel with maxDegreeOfParallelism`` () =
+    member _.``Parallel with maxDegreeOfParallelism`` () =
         let mutable i = 1
         let action j = async {
             do! Async.Sleep 1
@@ -640,7 +640,7 @@ type AsyncModule() =
         Async.RunSynchronously(computation) |> ignore
 
     [<Fact>]
-    member this.``maxDegreeOfParallelism can not be 0`` () =
+    member _.``maxDegreeOfParallelism can not be 0`` () =
         try
             [| for i in 1 .. 10 -> async { return i } |]
             |> fun cs -> Async.Parallel(cs, 0)
@@ -652,7 +652,7 @@ type AsyncModule() =
             Assert.True(exc.Message.Contains("maxDegreeOfParallelism must be positive, was 0"))
 
     [<Fact>]
-    member this.``maxDegreeOfParallelism can not be negative`` () =
+    member _.``maxDegreeOfParallelism can not be negative`` () =
         try
             [| for i in 1 .. 10 -> async { return i } |]
             |> fun cs -> Async.Parallel(cs, -1)
@@ -664,19 +664,19 @@ type AsyncModule() =
             Assert.True(exc.Message.Contains("maxDegreeOfParallelism must be positive, was -1"))
 
     [<Fact>]
-    member this.``RaceBetweenCancellationAndError.Parallel(maxDegreeOfParallelism)``() =
+    member _.``RaceBetweenCancellationAndError.Parallel(maxDegreeOfParallelism)``() =
         [| for i in 1 .. 1000 -> async { failwith "boom" } |]
         |> fun cs -> Async.Parallel(cs, 1)
         |> testErrorAndCancelRace "RaceBetweenCancellationAndError.Parallel(maxDegreeOfParallelism)"
 
     [<Fact>]
-    member this.``RaceBetweenCancellationAndError.Parallel``() =
+    member _.``RaceBetweenCancellationAndError.Parallel``() =
         [| for i in 1 .. 1000 -> async { failwith "boom" } |]
         |> fun cs -> Async.Parallel(cs)
         |> testErrorAndCancelRace "RaceBetweenCancellationAndError.Parallel"
 
     [<Fact>]
-    member this.``error on one workflow should cancel all others with maxDegreeOfParallelism``() =
+    member _.``error on one workflow should cancel all others with maxDegreeOfParallelism``() =
         let counter =
             async {
                 let counter = ref 0
@@ -693,7 +693,7 @@ type AsyncModule() =
         Assert.AreEqual(54, counter)
 
     [<Fact>]
-    member this.``async doesn't do cancel check between do! and try-finally``() =
+    member _.``async doesn't do cancel check between do! and try-finally``() =
         let gate = obj()
         for i in 0..10 do
             let procCount = 3

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Cancellation.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Cancellation.fs
@@ -29,12 +29,12 @@ type CancellationType() =
     member this.CancellationRegistration() =
         let cts = new CancellationTokenSource()
         let token = cts.Token
-        let called = ref false
-        let r = token.Register(Action<obj>(fun _ -> called := true), null)
-        Assert.False(!called)
+        let mutable called = false
+        let r = token.Register(Action<obj>(fun _ -> called <- true), null)
+        Assert.False(called)
         r.Dispose()
         cts.Cancel()
-        Assert.False(!called)
+        Assert.False(called)
         
     [<Fact>]
     member this.CancellationWithCallbacks() =
@@ -43,12 +43,12 @@ type CancellationType() =
         let is1Called = ref false
         let is2Called = ref false
         let is3Called = ref false
-        let assertAndOff (expected:bool) (r:bool ref) = Assert.AreEqual(expected,!r); r := false
-        let r1 = cts1.Token.Register(Action<obj>(fun _ -> is1Called := true), null)
-        let r2 = cts1.Token.Register(Action<obj>(fun _ -> is2Called := true), null)
-        let r3 = cts2.Token.Register(Action<obj>(fun _ -> is3Called := true), null) 
-        Assert.False(!is1Called)
-        Assert.False(!is2Called)
+        let assertAndOff (expected:bool) (r:bool ref) = Assert.AreEqual(expected,r.Value); r.Value <- false
+        let r1 = cts1.Token.Register(Action<obj>(fun _ -> is1Called.Value <- true), null)
+        let r2 = cts1.Token.Register(Action<obj>(fun _ -> is2Called.Value <- true), null)
+        let r3 = cts2.Token.Register(Action<obj>(fun _ -> is3Called.Value <- true), null) 
+        Assert.False(is1Called.Value)
+        Assert.False(is2Called.Value)
         r2.Dispose()
         
         // Cancelling cts1: r2 is disposed and r3 is for cts2, only r1 should be called
@@ -59,7 +59,7 @@ type CancellationType() =
         Assert.True(cts1.Token.IsCancellationRequested)
         
         let isAnotherOneCalled = ref false
-        let _ = cts1.Token.Register(Action<obj>(fun _ -> isAnotherOneCalled := true), null)
+        let _ = cts1.Token.Register(Action<obj>(fun _ -> isAnotherOneCalled.Value <- true), null)
         assertAndOff true isAnotherOneCalled
         
         // Cancelling cts2: only r3 should be called

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/EventModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/EventModule.fs
@@ -45,21 +45,21 @@ type EventModule() =
                         elif amtOverflowing < 10.0<ml> then Some("Medium")
                         else Some("Large"))
 
-        let lastCleanup = ref ""
-        needToCleanupEvent.Add(fun amount -> lastCleanup := amount)
+        let mutable lastCleanup = ""
+        needToCleanupEvent.Add(fun amount -> lastCleanup <- amount)
         
         // Refil the cup, Overflow event will fire, will fire our 'needToCleanupEvent'
         coffeeCup.Refil(20.0<ml>)
-        Assert.AreEqual("Large", !lastCleanup)
+        Assert.AreEqual("Large", lastCleanup)
         
         // Refil the cup, Overflow event will fire, will fire our 'needToCleanupEvent'
         coffeeCup.Refil(8.0<ml>)
-        Assert.AreEqual("Medium", !lastCleanup)
+        Assert.AreEqual("Medium", lastCleanup)
     
         // Refil the cup, Overflow event will fire, will NOT fire our 'needToCleanupEvent'
-        lastCleanup := "NA"
+        lastCleanup <- "NA"
         coffeeCup.Refil(2.5<ml>)
-        Assert.AreEqual("NA", !lastCleanup)
+        Assert.AreEqual("NA", lastCleanup)
         
         ()
 
@@ -204,17 +204,17 @@ type EventModule() =
             numEvent.Publish 
             |> Event.scan(fun acc i -> acc + i) 0
             
-        let lastSum = ref 0
-        sumEvent.Add(fun sum -> lastSum := sum)
+        let mutable lastSum = 0
+        sumEvent.Add(fun sum -> lastSum <- sum)
         
         numEvent.Trigger(1)
-        Assert.AreEqual(!lastSum, 1)
+        Assert.AreEqual(lastSum, 1)
         
         numEvent.Trigger(10)
-        Assert.AreEqual(!lastSum, 11)
+        Assert.AreEqual(lastSum, 11)
         
         numEvent.Trigger(100)
-        Assert.AreEqual(!lastSum, 111)
+        Assert.AreEqual(lastSum, 111)
         
         ()
         

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/ObservableModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/ObservableModule.fs
@@ -119,8 +119,9 @@ type ObservableModule() =
             kexp.BroadcastSignal
             |> Observable.filter(fun broadEventArgs -> broadEventArgs.Message.Contains("Flight of the Penguins"))
         
-        let songsHeard = ref []
-        fotpSongs.Add(fun rbEventArgs -> songsHeard := rbEventArgs.Message :: !songsHeard)
+        let mutable songsHeard = []
+        fotpSongs.Add(fun rbEventArgs -> 
+            songsHeard <- rbEventArgs.Message :: songsHeard)
         
         // Firing the main event, we should only listen in on those we want to hear
         kexp.BeginBroadcasting(
@@ -131,8 +132,8 @@ type ObservableModule() =
                 "Flight of the Penguins - song 2"
             ])
 
-        Assert.AreEqual(!songsHeard, ["Flight of the Penguins - song 2"; 
-                                      "Flight of the Penguins - song 1"])
+        Assert.AreEqual(songsHeard, ["Flight of the Penguins - song 2"; 
+                                     "Flight of the Penguins - song 1"])
         ()
 
     [<Fact>]
@@ -141,9 +142,10 @@ type ObservableModule() =
         let kqfc = new RadioStation(90.3, "KEXP")
         
 
-        let timesListened = ref 0
+        let mutable timesListened = 0
         kqfc.BroadcastSignal
-        |> Observable.add(fun rbEventArgs -> incr timesListened)
+        |> Observable.add(fun rbEventArgs -> 
+            timesListened <- timesListened + 1)
 
         kqfc.BeginBroadcasting(
             [
@@ -153,7 +155,7 @@ type ObservableModule() =
             ])
             
         // The broadcast event should have fired 3 times
-        Assert.AreEqual(!timesListened, 3)
+        Assert.AreEqual(timesListened, 3)
     
         ()
 
@@ -185,15 +187,16 @@ type ObservableModule() =
         
         let numberEvent = Observable.merge evensEvent.Publish oddsEvent.Publish
         
-        let lastResult = ref 0
-        numberEvent.Add(fun i -> lastResult := i)
+        let mutable lastResult = 0
+        numberEvent.Add(fun i -> 
+            lastResult <- i)
         
         // Verify triggering either the evens or oddsEvent fires the 'numberEvent'
         evensEvent.Trigger(2)
-        Assert.AreEqual(!lastResult, 2)
+        Assert.AreEqual(lastResult, 2)
 
         oddsEvent.Trigger(3)
-        Assert.AreEqual(!lastResult, 3)
+        Assert.AreEqual(lastResult, 3)
         
         ()
 
@@ -204,18 +207,19 @@ type ObservableModule() =
         
         let pairwiseEvent = Observable.pairwise numEvent.Publish
         
-        let lastResult = ref (-1, -1)
-        pairwiseEvent.Add(fun (x, y) -> lastResult := (x, y))
+        let mutable lastResult = (-1, -1)
+        pairwiseEvent.Add(fun (x, y) -> 
+            lastResult <- (x, y))
 
         // Verify not fired until second call        
         numEvent.Trigger(1)
-        Assert.AreEqual(!lastResult, (-1, -1))
+        Assert.AreEqual(lastResult, (-1, -1))
         
         numEvent.Trigger(2)
-        Assert.AreEqual(!lastResult, (1, 2))
+        Assert.AreEqual(lastResult, (1, 2))
         
         numEvent.Trigger(3)
-        Assert.AreEqual(!lastResult, (2, 3))
+        Assert.AreEqual(lastResult, (2, 3))
         
         ()
         

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/ObservableModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/ObservableModule.fs
@@ -92,21 +92,21 @@ type ObservableModule() =
                         elif amtOverflowing < 10.0<ml> then Some("Medium")
                         else Some("Large"))
 
-        let lastCleanup = ref ""
-        needToCleanupEvent.Add(fun amount -> lastCleanup := amount)
+        let mutable lastCleanup = ""
+        needToCleanupEvent.Add(fun amount -> lastCleanup <- amount)
         
         // Refil the cup, Overflow event will fire, will fire our 'needToCleanupEvent'
         coffeeCup.Refil(20.0<ml>)
-        Assert.AreEqual("Large", !lastCleanup)
+        Assert.AreEqual("Large", lastCleanup)
         
         // Refil the cup, Overflow event will fire, will fire our 'needToCleanupEvent'
         coffeeCup.Refil(8.0<ml>)
-        Assert.AreEqual("Medium", !lastCleanup)
+        Assert.AreEqual("Medium", lastCleanup)
     
         // Refil the cup, Overflow event will fire, will NOT fire our 'needToCleanupEvent'
-        lastCleanup := "NA"
+        lastCleanup <- "NA"
         coffeeCup.Refil(2.5<ml>)
-        Assert.AreEqual("NA", !lastCleanup)
+        Assert.AreEqual("NA", lastCleanup)
         
         ()
 
@@ -166,15 +166,15 @@ type ObservableModule() =
             numEvent.Publish
             |> Observable.map(fun i -> i.ToString())
         
-        let results = ref ""
+        let mutable results = ""
         
-        getStr |> Observable.add(fun msg -> results := msg + !results)
+        getStr |> Observable.add(fun msg -> results <- msg + results)
         
         numEvent.Trigger(1)
         numEvent.Trigger(22)
         numEvent.Trigger(333)
         
-        Assert.AreEqual(!results, "333221")
+        Assert.AreEqual(results, "333221")
         ()
 
     [<Fact>]
@@ -226,19 +226,19 @@ type ObservableModule() =
         
         let oddsEvent, evensEvent = Observable.partition (fun i -> (i % 2 = 1)) numEvent.Publish
         
-        let lastOdd = ref 0
-        oddsEvent.Add(fun i -> lastOdd := i)
+        let mutable lastOdd = 0
+        oddsEvent.Add(fun i -> lastOdd <- i)
         
-        let lastEven = ref 0
-        evensEvent.Add(fun i -> lastEven := i)
+        let mutable lastEven = 0
+        evensEvent.Add(fun i -> lastEven <- i)
         
         numEvent.Trigger(1)
-        Assert.AreEqual(1, !lastOdd)
-        Assert.AreEqual(0,!lastEven)
+        Assert.AreEqual(1, lastOdd)
+        Assert.AreEqual(0,lastEven)
         
         numEvent.Trigger(2)
-        Assert.AreEqual(1, !lastOdd) // Not updated
-        Assert.AreEqual(2, !lastEven)
+        Assert.AreEqual(1, lastOdd) // Not updated
+        Assert.AreEqual(2, lastEven)
 
         ()
  
@@ -251,17 +251,17 @@ type ObservableModule() =
             numEvent.Publish 
             |> Observable.scan(fun acc i -> acc + i) 0
             
-        let lastSum = ref 0
-        sumEvent.Add(fun sum -> lastSum := sum)
+        let mutable lastSum = 0
+        sumEvent.Add(fun sum -> lastSum <- sum)
         
         numEvent.Trigger(1)
-        Assert.AreEqual(!lastSum, 1)
+        Assert.AreEqual(lastSum, 1)
         
         numEvent.Trigger(10)
-        Assert.AreEqual(!lastSum, 11)
+        Assert.AreEqual(lastSum, 11)
         
         numEvent.Trigger(100)
-        Assert.AreEqual(!lastSum, 111)
+        Assert.AreEqual(lastSum, 111)
         
         ()
         
@@ -275,14 +275,14 @@ type ObservableModule() =
             numEvent.Publish |> Observable.split(fun i -> if i > 0 then Choice1Of2(i.ToString(), i)
                                                           else          Choice2Of2(i.ToString(), i.ToString()))
                  
-        let lastResult = ref ""
-        positiveEvent.Add(fun (msg, i)    -> lastResult := sprintf "Positive [%s][%d]" msg i)
-        negativeEvent.Add(fun (msg, msg2) -> lastResult := sprintf "Negative [%s][%s]" msg msg2)
+        let mutable lastResult = ""
+        positiveEvent.Add(fun (msg, i)    -> lastResult <- sprintf "Positive [%s][%d]" msg i)
+        negativeEvent.Add(fun (msg, msg2) -> lastResult <- sprintf "Negative [%s][%s]" msg msg2)
         
         numEvent.Trigger(10)
-        Assert.AreEqual("Positive [10][10]", !lastResult)
+        Assert.AreEqual("Positive [10][10]", lastResult)
         
         numEvent.Trigger(-3)
-        Assert.AreEqual("Negative [-3][-3]", !lastResult)
+        Assert.AreEqual("Negative [-3][-3]", lastResult)
         
         ()

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Core/IntConversionsTestGenerator.fsx
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Core/IntConversionsTestGenerator.fsx
@@ -32,12 +32,12 @@ do
     use file = new StreamWriter("IntConversionsGenerated.fs")
     
     // indentation 'framework'
-    let depth = ref 0
+    let mutable depth = 0
     let indent () =
-        for i = 1 to !depth do
+        for i = 1 to depth do
             file.Write("  ") 
-    let shift () = depth := !depth + 1
-    let unshift () = depth := !depth - 1
+    let shift () = depth <- depth + 1
+    let unshift () = depth <- depth - 1
     let prn (format : Format<'T,TextWriter,unit,unit>) : 'T = 
         indent (); fprintfn<'T> file format 
     

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
@@ -14,6 +14,7 @@ open FSharp.Core.UnitTests.LibraryTestFx
 
 open Xunit
 
+#nowarn "3370"
 
 /// If this type compiles without error it is correct
 /// Wrong if you see: FS0670 This code is not sufficiently generic. The type variable ^T could not be generalized because it would escape its scope.

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
@@ -213,19 +213,19 @@ type OperatorsModule2() =
         // lock
         printfn "test8 started"
         let syncRoot = System.Object()
-        let k = ref 0
-        let comp _ = async { return lock syncRoot (fun () -> incr k
+        let mutable k = 0
+        let comp _ = async { return lock syncRoot (fun () -> k <- k + 1
                                                              System.Threading.Thread.Sleep(1)
-                                                             !k ) }
+                                                             k ) }
         let arr = Async.RunSynchronously (Async.Parallel(Seq.map comp [1..50]))
         Assert.AreEqual([|1..50|], Array.sort arr)
         
         // without lock
         let syncRoot = System.Object()
-        let k = ref 0
-        let comp _ = async { do incr k
+        let mutable k = 0
+        let comp _ = async { do k <- k + 1
                              do! Async.Sleep (10)
-                             return !k }
+                             return k }
         let arr = Async.RunSynchronously (Async.Parallel(Seq.map comp [1..100]))
         Assert.AreNotEqual ([|1..100|], Array.sort arr)
         

--- a/tests/service/ServiceUntypedParseTests.fs
+++ b/tests/service/ServiceUntypedParseTests.fs
@@ -22,10 +22,10 @@ let private (=>) (source: string) (expected: CompletionContext option) =
 
     let lines =
         use reader = new StringReader(source)
-        [| let line = ref (reader.ReadLine())
-           while not (isNull !line) do
-              yield !line
-              line := reader.ReadLine()
+        [| let mutable line = reader.ReadLine()
+           while not (isNull line) do
+              yield line
+              line <- reader.ReadLine()
            if source.EndsWith "\n" then
               yield "" |]
         

--- a/tests/service/StructureTests.fs
+++ b/tests/service/StructureTests.fs
@@ -23,10 +23,10 @@ type Range = Line * Col * Line * Col
 let (=>) (source: string) (expectedRanges: (Range * Range) list) =
     let lines =
         use reader = new StringReader(source)
-        [| let line = ref (reader.ReadLine())
-           while not (isNull !line) do
-               yield !line
-               line := reader.ReadLine()
+        [| let mutable line = reader.ReadLine()
+           while not (isNull line) do
+               yield line
+               line <- reader.ReadLine()
            if source.EndsWith "\n" then
                // last trailing space not returned
                // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak

--- a/tests/service/TokenizerTests.fs
+++ b/tests/service/TokenizerTests.fs
@@ -15,14 +15,14 @@ open NUnit.Framework
 let sourceTok = FSharpSourceTokenizer([], Some "C:\\test.fsx")
 
 let rec parseLine(line: string, state: FSharpTokenizerLexState ref, tokenizer: FSharpLineTokenizer) = seq {
-  match tokenizer.ScanToken(!state) with
+  match tokenizer.ScanToken(state.Value) with
   | Some(tok), nstate ->
       let str = line.Substring(tok.LeftColumn, tok.RightColumn - tok.LeftColumn + 1)
       yield str, tok
-      state := nstate
+      state.Value <- nstate
       yield! parseLine(line, state, tokenizer)
   | None, nstate -> 
-      state := nstate }
+      state.Value <- nstate }
 
 let tokenizeLines (lines:string[]) =
   [ let state = ref FSharpTokenizerLexState.Initial

--- a/tests/service/data/TestTP/ProvidedTypes.fs
+++ b/tests/service/data/TestTP/ProvidedTypes.fs
@@ -5,6 +5,7 @@
 namespace ProviderImplementation.ProvidedTypes
 
 #nowarn "1182"
+#nowarn "3370"
 
 // This file contains a set of helper types and methods for providing types in an implementation
 // of ITypeProvider.
@@ -14189,7 +14190,7 @@ namespace ProviderImplementation.ProvidedTypes
                     ilg.Emit(I_conv DT_I1)
                 elif t1 = typeof<byte> then
                     ilg.Emit(I_conv DT_U1)
-            /// emits given expression to corresponding IL
+            // emits given expression to corresponding IL
             match expr with
             | ForIntegerRangeLoop(loopVar, first, last, body) ->
                 // for(loopVar = first..last) body

--- a/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
+++ b/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
@@ -201,7 +201,7 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
                                 None,true
                             | FSharpCheckFileAnswer.Succeeded results -> Some results, false
 
-                        sr := None
+                        sr.Value <- None
                         parseResults,typedResults,true,aborted,int64 req.Timestamp
                 
                 // Now that we have the parseResults, we can SetDependencyFiles().

--- a/vsintegration/src/FSharp.LanguageService/Colorize.fs
+++ b/vsintegration/src/FSharp.LanguageService/Colorize.fs
@@ -123,15 +123,15 @@ type internal FSharpScanner_DEPRECATED(makeLineTokenizer : string -> FSharpLineT
 
     /// Scan a token from a line. This should only be used in cases where color information is irrelevant.
     /// Used by GetFullLineInfo (and only thus in a small workaroud in GetDeclarations) and GetTokenInformationAt (thus GetF1KeywordString).
-    member ws.ScanTokenWithDetails lexState =
-        let colorInfoOption, newLexState = lineTokenizer.ScanToken(!lexState)
-        lexState := newLexState
+    member ws.ScanTokenWithDetails (lexState: _ ref) =
+        let colorInfoOption, newLexState = lineTokenizer.ScanToken(lexState.Value)
+        lexState.Value <- newLexState
         colorInfoOption
 
     /// Scan a token from a line and write information about it into the tokeninfo object.
-    member ws.ScanTokenAndProvideInfoAboutIt(_line, tokenInfo:TokenInfo, lexState) =
+    member ws.ScanTokenAndProvideInfoAboutIt(_line, tokenInfo:TokenInfo, lexState: _ ref) =
         let colorInfoOption, newLexState = lineTokenizer.ScanToken(!lexState)
-        lexState := newLexState
+        lexState.Value <- newLexState
         match colorInfoOption with
         | None -> false
         | Some colorInfo ->

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/AppConfigHelper.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/AppConfigHelper.fs
@@ -237,11 +237,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             let APPCFG_VERSION = "version"
             let APPCFG_SKU = "sku"
             
-            let dirty = ref false
+            let mutable dirty = false
             let (startupNode, _) = LangConfigFile.EnsureChildElement(root, APPCFG_STARTUP)
             
             if startupNode <> null then
-                let foundExistingNode = ref false
+                let mutable foundExistingNode = false
                
                 let fixupSku (n : System.Xml.Linq.XElement) =
                     // Figure out what to do with the SKU.  A NULL passed-in SKU parameter
@@ -252,18 +252,18 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     if sku = null  then
                         if skuAttribute <> null then
                             skuAttribute.Remove()
-                            dirty := true
+                            dirty <- true
                     else
                         // Check if the SKU attribute is the same
                         if skuAttribute <> null  then
                             if String.Compare(skuAttribute.Value, sku, true, CultureInfo.InvariantCulture) <> 0 then
                                 // Ok, set the value
                                 skuAttribute.Value <- sku
-                                dirty := true
+                                dirty <- true
                         else
                             let newAttribute = new System.Xml.Linq.XAttribute(System.Xml.Linq.XName.Get(APPCFG_SKU), sku)
                             n.Add(newAttribute)
-                            dirty := true                
+                            dirty <- true                
                 
                 startupNode.Elements()
                 |> Seq.toList
@@ -272,17 +272,17 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                                 let versionAttribute = n.Attribute(System.Xml.Linq.XName.Get(APPCFG_VERSION))
                                 
                                 // Correct node?  If so, then keep it; otherwise, remove it.
-                                if String.Compare(versionAttribute.Value, version, true, CultureInfo.InvariantCulture) = 0  && not !foundExistingNode then
-                                    foundExistingNode := true
+                                if String.Compare(versionAttribute.Value, version, true, CultureInfo.InvariantCulture) = 0  && not foundExistingNode then
+                                    foundExistingNode <- true
                                     fixupSku n
                                 else
                                     n.Remove()
-                                    dirty := true
+                                    dirty <- true
                             )
                 
                 // Did we find a node?  If not, then we need to create one.
                 
-                if not !foundExistingNode then
+                if not foundExistingNode then
                     let (runtimeNode, _) = LangConfigFile.EnsureChildElement(startupNode, APPCFG_SUPPORTED_RUNTIME)
                     
                     // Fix up the version - either add it or update it
@@ -290,16 +290,16 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     let versionAttribute = runtimeNode.Attribute(System.Xml.Linq.XName.Get(APPCFG_VERSION))
                     if versionAttribute <> null then
                         versionAttribute.Value <- version
-                        dirty := true
+                        dirty <- true
                     else
                         let versionAttribute = new System.Xml.Linq.XAttribute(System.Xml.Linq.XName.Get(APPCFG_VERSION), version)
                         runtimeNode.Add(versionAttribute)
-                        dirty := true
+                        dirty <- true
                         
                     // fix up the sku
                     fixupSku runtimeNode
                 
-            !dirty
+            dirty
 
         member x.EnsureSupportedRuntimeElement(version : string, sku : string) =
 

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/MSBuildUtilities.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/MSBuildUtilities.fs
@@ -293,21 +293,21 @@ type internal MSBuildUtilities() =
     static member private MoveFolderUpHelper(folderToBeMoved : string, itemToMoveBefore : ProjectItemElement, projectNode : ProjectNode) =
         let msbuildProject = projectNode.BuildProject
         let big = EnsureValid msbuildProject projectNode true
-        let index = ref 0
-        let itemToMoveBeforeIndex = ref -1
+        let mutable index = 0
+        let mutable itemToMoveBeforeIndex = -1
         let itemsToMove = 
             [for bi in EnumerateItems(big) do
                 let curFolder = ComputeFolder(GetUnescapedUnevaluatedInclude(bi), projectNode.BaseURI)
                 if curFolder.StartsWith(folderToBeMoved, StringComparison.OrdinalIgnoreCase) then
-                    yield (bi, !index)
+                    yield (bi, index)
                 if Same(bi, itemToMoveBefore) then
-                    itemToMoveBeforeIndex := !index
-                index := !index + 1]
-        if !itemToMoveBeforeIndex = -1 then
+                    itemToMoveBeforeIndex <- index
+                index <- index + 1]
+        if itemToMoveBeforeIndex = -1 then
             Debug.Assert(false, sprintf "did not find item to move before <%s Include=\"%s\">" (GetItemType itemToMoveBefore) (GetUnescapedUnevaluatedInclude itemToMoveBefore))
         for (item,i) in itemsToMove do
             Debug.Assert(i <> 0, "item is already at top")
-            Debug.Assert(!itemToMoveBeforeIndex < i, "not moving up")
+            Debug.Assert(itemToMoveBeforeIndex < i, "not moving up")
             big.RemoveChild(item)
             big.InsertBeforeChild(item, itemToMoveBefore)
 
@@ -320,21 +320,21 @@ type internal MSBuildUtilities() =
     static member private MoveFolderDownHelper(folderToBeMoved : string, itemToMoveAfter : ProjectItemElement, projectNode : ProjectNode) =
         let msbuildProject = projectNode.BuildProject
         let big = EnsureValid msbuildProject projectNode true
-        let index = ref 0
-        let itemToMoveAfterIndex = ref -1
+        let mutable index = 0
+        let mutable itemToMoveAfterIndex = -1
         let itemsToMove = 
             [for bi in EnumerateItems(big) do
                 let curFolder = ComputeFolder(GetUnescapedUnevaluatedInclude(bi), projectNode.BaseURI)
                 if curFolder.StartsWith(folderToBeMoved, StringComparison.OrdinalIgnoreCase) then
-                    yield (bi, !index)
+                    yield (bi, index)
                 if Same(bi, itemToMoveAfter) then
-                    itemToMoveAfterIndex := !index
-                index := !index + 1]
-        if !itemToMoveAfterIndex = -1 then
+                    itemToMoveAfterIndex <- index
+                index <- index + 1]
+        if itemToMoveAfterIndex = -1 then
             Debug.Assert(false, sprintf "did not find item to move after <%s Include=\"%s\">" (GetItemType itemToMoveAfter) (GetUnescapedUnevaluatedInclude itemToMoveAfter))
         for (item,i) in List.rev itemsToMove do
-            Debug.Assert(i <> !index - 1, "item is already at bottom")
-            Debug.Assert(!itemToMoveAfterIndex > i, "not moving down")
+            Debug.Assert(i <> index - 1, "item is already at bottom")
+            Debug.Assert(itemToMoveAfterIndex > i, "not moving down")
             big.RemoveChild(item)
             big.InsertAfterChild(item, itemToMoveAfter)
 

--- a/vsintegration/tests/Salsa/VsMocks.fs
+++ b/vsintegration/tests/Salsa/VsMocks.fs
@@ -321,12 +321,12 @@ module internal VsMocks =
             }
             
         static member MakeTextLineMarker() =
-            let markerSpan = ref (new TextSpan(iStartLine = 0, iEndLine = 0, iStartIndex = 0, iEndIndex = 0))
+            let mutable markerSpan = new TextSpan(iStartLine = 0, iEndLine = 0, iStartIndex = 0, iEndIndex = 0)
             {new IVsTextLineMarker with
                 member tl.DrawGlyph(hdc, pRect) = notimpl()
                 member tl.ExecMarkerCommand(iItem) = notimpl()
                 member tl.GetBehavior(pdwBehavior) = notimpl()
-                member tl.GetCurrentSpan(pSpan) = pSpan.[0] <- !markerSpan ; 0
+                member tl.GetCurrentSpan(pSpan) = pSpan.[0] <- markerSpan ; 0
                 member tl.GetLineBuffer(ppBuffer) = notimpl()
                 member tl.GetMarkerCommandInfo(iItem, pbstrText, pcmdf) = notimpl()
                 member tl.GetPriorityIndex(piPriorityIndex) = notimpl()
@@ -335,7 +335,7 @@ module internal VsMocks =
                 member tl.GetVisualStyle(pdwFlags) = notimpl()
                 member tl.Invalidate() = 0
                 member tl.ResetSpan(iSL, iSI, iEL, iEI) = 
-                    markerSpan := new TextSpan(iStartLine = iSL, iEndLine = iEL, iStartIndex = iSI, iEndIndex = iEI) ; 
+                    markerSpan <- new TextSpan(iStartLine = iSL, iEndLine = iEL, iStartIndex = iSI, iEndIndex = iEI) ; 
                     0
                 member tl.SetBehavior(dwBehavior) = notimpl()
                 member tl.SetType(iMarkerType) = notimpl()
@@ -695,42 +695,42 @@ module internal VsMocks =
             }
             
         static member DelegateHierarchy(oldh:IVsHierarchy, ?getCanonicalName, ?getProperty) = 
-            let inner = ref oldh
+            let mutable inner = oldh
             {new IVsHierarchy with            
-                member h.SetSite(psp) = (!inner).SetSite(psp)
-                member h.GetSite(ppSP) = (!inner).GetSite(ref ppSP)
-                member h.QueryClose(pfCanClose) = (!inner).QueryClose(ref pfCanClose)
-                member h.Close() = (!inner).Close()
-                member h.GetGuidProperty(itemid, propid, pguid) = (!inner).GetGuidProperty(itemid, propid, ref pguid)
-                member h.SetGuidProperty(itemid, propid, rguid) = (!inner).SetGuidProperty(itemid, propid, ref rguid)
+                member h.SetSite(psp) = inner.SetSite(psp)
+                member h.GetSite(ppSP) = inner.GetSite(ref ppSP)
+                member h.QueryClose(pfCanClose) = inner.QueryClose(ref pfCanClose)
+                member h.Close() = inner.Close()
+                member h.GetGuidProperty(itemid, propid, pguid) = inner.GetGuidProperty(itemid, propid, ref pguid)
+                member h.SetGuidProperty(itemid, propid, rguid) = inner.SetGuidProperty(itemid, propid, ref rguid)
                 member h.GetProperty(itemid, propid, pvar) = 
                     let propid:__VSHPROPID  = enum propid
-                    let next itemid propid = (!inner).GetProperty(itemid, int32 propid)
+                    let next itemid propid = inner.GetProperty(itemid, int32 propid)
                     let hr,var = impl2 getProperty next itemid propid
                     pvar<-var
                     hr
-                member h.SetProperty(itemid, propid, var) = (!inner).SetProperty(itemid, propid, var)
-                member h.GetNestedHierarchy(itemid, iidHierarchyNested, ppHierarchyNested, pitemidNested) = (!inner).GetNestedHierarchy(itemid,ref iidHierarchyNested, ref ppHierarchyNested, ref pitemidNested)
+                member h.SetProperty(itemid, propid, var) = inner.SetProperty(itemid, propid, var)
+                member h.GetNestedHierarchy(itemid, iidHierarchyNested, ppHierarchyNested, pitemidNested) = inner.GetNestedHierarchy(itemid,ref iidHierarchyNested, ref ppHierarchyNested, ref pitemidNested)
                 /// For project files, returns the fully qualified path to the file including the filename itself.
                 member h.GetCanonicalName(itemid, pbstrName) = 
-                    let next itemid = (!inner).GetCanonicalName(itemid)
+                    let next itemid = inner.GetCanonicalName(itemid)
                     let hr,n = impl1 getCanonicalName next itemid
                     pbstrName<-n
                     hr                     
-                member h.ParseCanonicalName(pszName, pitemid) = (!inner).ParseCanonicalName(pszName, ref pitemid)
-                member h.Unused0() = (!inner).Unused0()
-                member h.AdviseHierarchyEvents(pEventSink, pdwCookie) = (!inner).AdviseHierarchyEvents(pEventSink, ref pdwCookie)
-                member h.UnadviseHierarchyEvents(dwCookie) = (!inner).UnadviseHierarchyEvents(dwCookie)
-                member h.Unused1() = (!inner).Unused1()
-                member h.Unused2() = (!inner).Unused2()
-                member h.Unused3() = (!inner).Unused3()
-                member h.Unused4() = (!inner).Unused4()
+                member h.ParseCanonicalName(pszName, pitemid) = inner.ParseCanonicalName(pszName, ref pitemid)
+                member h.Unused0() = inner.Unused0()
+                member h.AdviseHierarchyEvents(pEventSink, pdwCookie) = inner.AdviseHierarchyEvents(pEventSink, ref pdwCookie)
+                member h.UnadviseHierarchyEvents(dwCookie) = inner.UnadviseHierarchyEvents(dwCookie)
+                member h.Unused1() = inner.Unused1()
+                member h.Unused2() = inner.Unused2()
+                member h.Unused3() = inner.Unused3()
+                member h.Unused4() = inner.Unused4()
              interface IDelegable<IVsHierarchy> with
-                member id.GetInner() = !inner
-                member id.SetInner(i) = inner := i
+                member id.GetInner() = inner
+                member id.SetInner(i) = inner <- i
                 
              interface IProvideProjectSite with
-                member x.GetProjectSite() = ((!inner) :?> IProvideProjectSite).GetProjectSite()
+                member x.GetProjectSite() = (inner :?> IProvideProjectSite).GetProjectSite()
 
              }       
              

--- a/vsintegration/tests/Salsa/salsa.fs
+++ b/vsintegration/tests/Salsa/salsa.fs
@@ -1364,12 +1364,12 @@ module internal Salsa =
                 let snapshot = VsActual.createTextBuffer(file.CombinedLines).CurrentSnapshot 
                 let pr   = project.Solution.Vs.LanguageService.BackgroundRequests.CreateBackgroundRequest(row, col, ti, file.CombinedLines, snapshot, MethodTipMiscellany_DEPRECATED.Typing, System.IO.Path.GetFullPath file.Filename, BackgroundRequestReason.QuickInfo, view, sink, null, file.Source.ChangeCount, false)
                 file.ExecuteBackgroundRequestForScope(pr,canRetryAfterWaiting=true)
-              let keyword = ref None
+              let mutable keyword = None
               let span = new Microsoft.VisualStudio.TextManager.Interop.TextSpan(iStartIndex=col,iStartLine=row,iEndIndex=col,iEndLine=row)
-              let context = Salsa.VsMocks.Vs.VsUserContext (fun (_,key,value) -> (if key = "keyword" then keyword := Some value); VSConstants.S_OK)
+              let context = Salsa.VsMocks.Vs.VsUserContext (fun (_,key,value) -> (if key = "keyword" then keyword <- Some value); VSConstants.S_OK)
                 
               currentAuthoringScope.GetF1KeywordString(span, context) 
-              !keyword
+              keyword
 
             /// grab a particular line from a file
             member file.GetLineNumber n =

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.GotoDefinition.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.GotoDefinition.fs
@@ -647,26 +647,26 @@ type UsingMSBuild()  =
       let origins = Dictionary<string, int*int>()
       let targets = Dictionary<string, int*int>()
       let lines =
-        [   let lineNo = ref 0
+        [   let mutable lineNo = 0
             for l in lines do
                 let builder = new System.Text.StringBuilder(l)
-                let cont = ref true
-                while !cont do
+                let mutable cont = true
+                while cont do
                     let s = builder.ToString()
                     let index = s.IndexOfAny([|'$';'#'|])
                     if index < 0 then
-                        cont := false
+                        cont <- false
                     else
                         let c = s.[index]
                         let nextIndex = s.IndexOf(c, index+1) 
                         let marker = s.Substring(index+1, nextIndex - (index+1))
                         if c = '$' then 
-                            origins.Add(marker, (!lineNo+1,index+1)) // caret positions are 1-based, but...
+                            origins.Add(marker, (lineNo+1,index+1)) // caret positions are 1-based, but...
                         else 
-                            targets.Add(marker, (!lineNo,index)) // ...spans are 0-based. Argh. Thank you, Salsa!
+                            targets.Add(marker, (lineNo,index)) // ...spans are 0-based. Argh. Thank you, Salsa!
                         builder.Remove(index, nextIndex - index + 1) |> ignore
                 yield builder.ToString()
-                lineNo := !lineNo + 1
+                lineNo <- lineNo + 1
         ]
 
       let (_, _, file) = this.CreateSingleFileProject(lines)
@@ -1429,8 +1429,8 @@ type UsingMSBuild()  =
         let definitionCode = "module Foo(*Mark*) ="
         this.VerifyGoToDefnSuccessAtStartOfMarker(fileContents,"(*Mark*)",definitionCode) 
 
-    [<Test>]
     /// GotoDef on abbreviation
+    [<Test>]
     member public this.``GotoDefinition.Abbreviation.Bug193064``() =
         let fileContents = """
             type X = int
@@ -1438,9 +1438,9 @@ type UsingMSBuild()  =
         let definitionCode = "let f (x:X) = x(*Marker*)"
         this.VerifyGoToDefnSuccessAtStartOfMarker(fileContents,"x(*Marker*)",definitionCode) 
 
-    [<Test>]
     /// Verify the GotoDefinition on UoM yield does NOT jump out error dialog, 
     /// will do nothing in automation lab machine or GTD SI.fs on dev machine with enlistment.
+    [<Test>]
     member public this.``GotoDefinition.UnitOfMeasure.Bug193064``() =
         let fileContents = """
             open Microsoft.FSharp.Data.UnitSystems.SI

--- a/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.ProjectItems.fs
+++ b/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.ProjectItems.fs
@@ -27,7 +27,7 @@ type ProjectItems() =
                 project.CompilationOptions
                 |> Array.exists (fun f -> f.IndexOf("System.Numerics") <> -1)
 
-            let wasCalled = ref false
+            let mutable wasCalled = false
             Assert.IsTrue(containsSystemNumerics (), "Project should contains reference to System.Numerics")
 
             let refContainer = project.GetReferenceContainer()
@@ -35,11 +35,11 @@ type ProjectItems() =
                 refContainer.EnumReferences() 
                 |> Seq.find(fun r -> r.SimpleName = "System.Numerics")
             (
-                use _guard = listener.OnAfterRemoveFiles.Subscribe(fun _ -> wasCalled := true)
+                use _guard = listener.OnAfterRemoveFiles.Subscribe(fun _ -> wasCalled <- true)
                 reference.Remove(false)
             )
 
-            Assert.IsFalse(!wasCalled, "No events from IVsTrackProjectDocuments2 are expected")
+            Assert.IsFalse(wasCalled, "No events from IVsTrackProjectDocuments2 are expected")
             Assert.IsFalse(containsSystemNumerics(), "Project should not contains reference to System.Numerics")            
             ))
 

--- a/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.References.fs
+++ b/vsintegration/tests/UnitTests/LegacyProjectSystem/Tests.ProjectSystem.References.fs
@@ -131,10 +131,10 @@ type References() =
                                     "System.Net", true ]
             let refContainer = GetReferenceContainerNode(project)
             let actualRefInfo = [
-                let r = ref(refContainer.FirstChild :?> ReferenceNode)
-                while !r <> null do
-                    yield ((!r).Caption, ((!r).CanShowDefaultIcon()))
-                    r := (!r).NextSibling :?> ReferenceNode
+                let mutable r = (refContainer.FirstChild :?> ReferenceNode)
+                while r <> null do
+                    yield (r.Caption, (r.CanShowDefaultIcon()))
+                    r <- r.NextSibling :?> ReferenceNode
                 ]
             AssertEqual expectedRefInfo actualRefInfo
             ))
@@ -147,10 +147,10 @@ type References() =
                                     "System", true] // one will be ok, but in F# both show up as ok.  Bug?  Not worth the effort to fix.
             let refContainer = GetReferenceContainerNode(project)
             let actualRefInfo = [
-                let r = ref(refContainer.FirstChild :?> ReferenceNode)
-                while !r <> null do
-                    yield ((!r).Caption, ((!r).CanShowDefaultIcon()))
-                    r := (!r).NextSibling :?> ReferenceNode
+                let mutable r = (refContainer.FirstChild :?> ReferenceNode)
+                while r <> null do
+                    yield (r.Caption, (r.CanShowDefaultIcon()))
+                    r <- r.NextSibling :?> ReferenceNode
                 ]
             AssertEqual expectedRefInfo actualRefInfo
             ))
@@ -162,10 +162,10 @@ type References() =
                                     "System.dll", true] // one will be ok
             let refContainer = GetReferenceContainerNode(project)
             let actualRefInfo = [
-                let r = ref(refContainer.FirstChild :?> ReferenceNode)
-                while !r <> null do
-                    yield ((!r).Caption, ((!r).CanShowDefaultIcon()))
-                    r := (!r).NextSibling :?> ReferenceNode
+                let mutable r = (refContainer.FirstChild :?> ReferenceNode)
+                while r <> null do
+                    yield (r.Caption, (r.CanShowDefaultIcon()))
+                    r <- (r.NextSibling :?> ReferenceNode)
                 ]
             AssertEqual expectedRefInfo actualRefInfo
             ))
@@ -178,10 +178,10 @@ type References() =
             let expectedRefInfo = [ ssmw, true ]
             let refContainer = GetReferenceContainerNode(project)
             let actualRefInfo = [
-              let r = ref(refContainer.FirstChild :?> ReferenceNode)
-              while !r <> null do
-                  yield ((!r).Caption, ((!r).CanShowDefaultIcon()))
-                  r := (!r).NextSibling :?> ReferenceNode
+              let mutable r = (refContainer.FirstChild :?> ReferenceNode)
+              while r <> null do
+                  yield (r.Caption, (r.CanShowDefaultIcon()))
+                  r <- r.NextSibling :?> ReferenceNode
               ]
             AssertEqual expectedRefInfo actualRefInfo
             ))
@@ -195,10 +195,10 @@ type References() =
                                     "System.Net", true ]
             let refContainer = GetReferenceContainerNode(project)
             let actualRefInfo = [
-                let r = ref(refContainer.FirstChild :?> ReferenceNode)
-                while !r <> null do
-                    yield ((!r).Caption, ((!r).CanShowDefaultIcon()))
-                    r := (!r).NextSibling :?> ReferenceNode
+                let mutable r = (refContainer.FirstChild :?> ReferenceNode)
+                while r <> null do
+                    yield (r.Caption, (r.CanShowDefaultIcon()))
+                    r <- r.NextSibling :?> ReferenceNode
                 ]
             AssertEqual expectedRefInfo actualRefInfo
             ))
@@ -209,10 +209,11 @@ type References() =
     member public this.ReferenceResolutionHelper(tab : AddReferenceDialogTab, fullPath : string, expectedFsprojRegex : string, targetFrameworkVersion : string, originalReferences : string list) =
         // Trace.Log <- "ProjectSystemReferenceResolution" // can be useful
         this.MakeProjectAndDo(["doesNotMatter.fs"], originalReferences, "", targetFrameworkVersion, (fun project ->
-            let cType = match tab with
-                        | AddReferenceDialogTab.DotNetTab -> VSCOMPONENTTYPE.VSCOMPONENTTYPE_ComPlus
-                        | AddReferenceDialogTab.BrowseTab -> VSCOMPONENTTYPE.VSCOMPONENTTYPE_File
-                        | _ -> failwith "unexpected"
+            let cType = 
+                match tab with
+                | AddReferenceDialogTab.DotNetTab -> VSCOMPONENTTYPE.VSCOMPONENTTYPE_ComPlus
+                | AddReferenceDialogTab.BrowseTab -> VSCOMPONENTTYPE.VSCOMPONENTTYPE_File
+                | _ -> failwith "unexpected"
             let selectorData = new VSCOMPONENTSELECTORDATA(``type`` = cType, bstrFile = fullPath)
             let refContainer = GetReferenceContainerNode(project)
             refContainer.AddReferenceFromSelectorData(selectorData) |> Assert.IsNotNull

--- a/vsintegration/tests/UnitTests/TestLib.Utils.fs
+++ b/vsintegration/tests/UnitTests/TestLib.Utils.fs
@@ -207,12 +207,13 @@ module Spawn =
 
     let Batch batchText = 
         let outlock = obj()
-        let captured = ref []
+        let mutable captured = []
         let capture (msg:DataReceivedEventArgs) = 
-            lock outlock (fun () -> captured := msg.Data :: !captured)
+            lock outlock (fun () -> 
+                captured <- msg.Data :: captured)
 
         let exitWithResult command arguments actualCode _ = 
-            actualCode, (!captured)|>List.rev|>Array.ofList
+            actualCode, captured|>List.rev|>Array.ofList
 
         FilesystemHelpers.DoWithTempFile
             "$$temp-batch.cmd"


### PR DESCRIPTION
Cleanup to basically remove all uses of `:=` and `incr` and `!expr` from our codebase, these generate informational warnings in F# 6.

The changes are entirely routine