### PR TITLE
fix bad codegen for tasks

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6394,7 +6394,9 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv sp (TBind(vspec, rhsExpr, _)) isSt
 and GetStoreValCtxt cenv cgbuf eenv (vspec: Val) =
     // Emit the ldarg0 if needed
     match StorageForVal cenv.g vspec.Range vspec eenv with
-    | Env (ilCloTy, _, _) -> CG.EmitInstr cgbuf (pop 0) (Push [ilCloTy]) mkLdarg0
+    | Env (ilCloTy, _, _) ->
+        let ilCloAddrTy = if ilCloTy.Boxity = ILBoxity.AsValue then ILType.Byref ilCloTy else ilCloTy
+        CG.EmitInstr cgbuf (pop 0) (Push [ilCloAddrTy]) mkLdarg0
     | _ -> ()
 
 //-------------------------------------------------------------------------

--- a/tests/fsharp/core/asyncStackTraces/test.fsx
+++ b/tests/fsharp/core/asyncStackTraces/test.fsx
@@ -135,6 +135,17 @@ let asyncTop3(f) = async {
     return ()
 }
 
+module TestFailingTaskCodeGen =
+    let zzzzzzzzzzzzzz0 (arr) =
+        task {
+            let w = arr |> Array.map (fun w -> w + 1) |> Array.head
+            do!  System.Threading.Tasks.Task.Yield()
+            return w + 3
+        }
+
+    // Threw an NRE
+    let res = zzzzzzzzzzzzzz0([| 1 |]).Result
+    check "elhwvehl" res 5
 
 
 asyncCheckEnvironmentStackTracesTop() |> Async.RunSynchronously


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/12359

The fix is very simple, and corresponds to the problem we were seeing.  

When there is a loop or other control flow, we empty the IL stack into locals. To do this, we need to keep track of the logical types on the IL stack, so we can create the necessary locals.  We were getting the type of the "this" pointer wrong for struct state machines in this case.

I've searched other places we emit `ldarg0` and the seem ok.

The analysis corresponds to the report - the problem will occur whenever there is a loop "where there are things on the IL stack", i.e. 
* we are about to store into a state machine local
* we are in the middle ov evaluation an expression

Now Array.map is inlined and causes such a loop - in the example case we are about to store into the state machine local `w`.

