### PR TITLE
Fix 12384: non-nested direct mutrec bindings

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -7552,8 +7552,12 @@ and GenModuleDef cenv (cgbuf: CodeGenBuffer) qname lazyInitInfo eenv x =
                 GenExnDef cenv cgbuf.mgbuf eenvinner m tc
             else
                 GenTypeDef cenv cgbuf.mgbuf lazyInitInfo eenvinner m tc
-        for mbind in mbinds do
-            GenModuleBinding cenv cgbuf qname lazyInitInfo eenvinner m mbind
+        if mbinds |> List.forall (function ModuleOrNamespaceBinding.Binding _ -> true | _ -> false) then
+            let recBinds = mbinds |> List.choose (function ModuleOrNamespaceBinding.Binding recBind -> Some recBind | _ -> None)
+            GenLetRecBindings cenv cgbuf eenv (recBinds, m)
+        else
+            for mbind in mbinds do
+                GenModuleBinding cenv cgbuf qname lazyInitInfo eenvinner m mbind
         eenvinner
 
     | TMDefLet(bind, _) ->

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -7562,7 +7562,9 @@ and GenModuleDef cenv (cgbuf: CodeGenBuffer) qname lazyInitInfo eenv x =
                     bindsRemaining
                     |> List.takeWhile (function ModuleOrNamespaceBinding.Binding _ -> true | _ -> false)
                     |> List.map (function ModuleOrNamespaceBinding.Binding recBind -> recBind | _ -> failwith "unexpected")
-                let otherBinds = mbinds |> List.skipWhile (function ModuleOrNamespaceBinding.Binding _ -> true | _ -> false) 
+                let otherBinds =
+                    bindsRemaining
+                    |> List.skipWhile (function ModuleOrNamespaceBinding.Binding _ -> true | _ -> false) 
                 GenLetRecBindings cenv cgbuf eenv (recBinds, m)
                 bindsRemaining <- otherBinds
             | (ModuleOrNamespaceBinding.Module _ as mbind) :: rest ->

--- a/tests/fsharp/core/letrec/test.fsx
+++ b/tests/fsharp/core/letrec/test.fsx
@@ -643,6 +643,33 @@ module Test3 =
     test "vwekjwve95" (tag()) 2
     test "vwekjwve96" (tag()) 3
 
+module Test12384 =
+    type Node =
+        {
+            Next: Node
+            Value: int
+        }
+
+    let rec one =
+        {
+            Next = two
+            Value = 1
+        }
+
+    and two =
+        {
+            Next = one
+            Value = 2
+        }
+    printfn "%A" one
+    printfn "%A" two
+    test "cweewlwne1" one.Value 1
+    test "cweewlwne2" one.Next.Value 2
+    test "cweewlwne3" one.Next.Next.Value 1
+    test "cweewlwne4" two.Value 2
+    test "cweewlwne5" two.Next.Value 1
+    test "cweewlwne6" two.Next.Next.Value 2
+
 #if TESTS_AS_APP
 let RUN() = !failures
 #else

--- a/tests/fsharp/core/letrec/test.fsx
+++ b/tests/fsharp/core/letrec/test.fsx
@@ -670,6 +670,68 @@ module Test12384 =
     test "cweewlwne5" two.Next.Value 1
     test "cweewlwne6" two.Next.Next.Value 2
 
+module Test12384b =
+    type Node =
+        {
+            Next: Node
+            Value: int
+        }
+
+    let rec one =
+        {
+            Next = two
+            Value = 1
+        }
+
+    and two =
+        {
+            Next = one
+            Value = 2
+        }
+    // Also test the case where the two recursive bindings occur with a nested module after
+    module M =
+        let f x = x + 1
+        
+    printfn "%A" one
+    printfn "%A" two
+    test "cweewlwne1a" one.Value 1
+    test "cweewlwne2a" one.Next.Value 2
+    test "cweewlwne3a" one.Next.Next.Value 1
+    test "cweewlwne4a" two.Value 2
+    test "cweewlwne5a" two.Next.Value 1
+    test "cweewlwne6a" two.Next.Next.Value 2
+
+module rec Test12384c =
+    type Node =
+        {
+            Next: Node
+            Value: int
+        }
+
+    let one =
+        {
+            Next = two
+            Value = 1
+        }
+
+    let two =
+        {
+            Next = one
+            Value = 2
+        }
+    // Also test the case where the two recursive bindings occur with a nested module after
+    module M =
+        let f x = x + 1
+        
+    printfn "%A" one
+    printfn "%A" two
+    test "cweewlwne1b" one.Value 1
+    test "cweewlwne2b" one.Next.Value 2
+    test "cweewlwne3b" one.Next.Next.Value 1
+    test "cweewlwne4b" two.Value 2
+    test "cweewlwne5b" two.Next.Value 1
+    test "cweewlwne6b" two.Next.Next.Value 2
+
 #if TESTS_AS_APP
 let RUN() = !failures
 #else

--- a/tests/fsharp/core/letrec/test.fsx
+++ b/tests/fsharp/core/letrec/test.fsx
@@ -732,6 +732,81 @@ module rec Test12384c =
     test "cweewlwne5b" two.Next.Value 1
     test "cweewlwne6b" two.Next.Next.Value 2
 
+
+//Note, this case doesn't initialize successfully because of the intervening module. Tracked by #12384
+  
+(*
+module rec Test12384d =
+    type Node =
+        {
+            Next: Node
+            Value: int
+        }
+
+    let one =
+        {
+            Next = two
+            Value = 1
+        }
+
+    // An intervening module declaration
+    module M =
+        let x() = one
+        
+    let two =
+        {
+            Next = one
+            Value = 2
+        }
+
+    printfn "%A" one
+    printfn "%A" two
+    test "cweewlwne1b" one.Value 1
+    test "cweewlwne2b" one.Next.Value 2
+    test "cweewlwne3b" one.Next.Next.Value 1
+    test "cweewlwne1b" (M.x()).Value 1
+    test "cweewlwne2b" (M.x()).Next.Value 2
+    test "cweewlwne3b" (M.x()).Next.Next.Value 1
+    test "cweewlwne4b" two.Value 2
+    test "cweewlwne5b" two.Next.Value 1
+    test "cweewlwne6b" two.Next.Next.Value 2
+*)
+
+module rec Test12384e =
+    type Node =
+        {
+            Next: Node
+            Value: int
+        }
+
+    let one =
+        {
+            Next = two
+            Value = 1
+        }
+
+    // An intervening type declaration
+    type M() =
+        static member X() = one
+        
+    let two =
+        {
+            Next = one
+            Value = 2
+        }
+
+    printfn "%A" one
+    printfn "%A" two
+    test "cweewlwne1b" one.Value 1
+    test "cweewlwne2b" one.Next.Value 2
+    test "cweewlwne3b" one.Next.Next.Value 1
+    test "cweewlwne1b" (M.X()).Value 1
+    test "cweewlwne2b" (M.X()).Next.Value 2
+    test "cweewlwne3b" (M.X()).Next.Next.Value 1
+    test "cweewlwne4b" two.Value 2
+    test "cweewlwne5b" two.Next.Value 1
+    test "cweewlwne6b" two.Next.Next.Value 2
+
 #if TESTS_AS_APP
 let RUN() = !failures
 #else


### PR DESCRIPTION
Fixes the most important cases of #12384.   

This was a bug in direct recursion between immutable record/union objects when not mediated by delayed computations (e.g. lambda expressions) and two or more objects are involved.    Note that this kind of "directly recursive immutable objects" is a rarely used feature from F# 1.0 and must have regressed at some point for the mutually-recursive case involving multiple objects, hence indicates that we have a lack of test cases for this feature.  I've added several tests here.

Note: there is still a remaining variation of this bug that I need to consider (and either adjust the code generator or most likely rule out in the type checker). That is when mutually recursive static data is split over an enclosing module definition, e.g. 

```fsharp
module rec Test12384d =
    type Node =
        {
            Next: Node
            Value: int
        }

    let one =
        {
            Next = two
            Value = 1
        }

    module M =
        let x() = one
        
    let two =
        {
            Next = one
            Value = 2
        }
```

THis will not be part of this PR