### PR TITLE
add fantomas tool to repo

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas-tool": {
+      "version": "4.6.0-alpha-007",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
All going well the "fantomas" packages we want to use in the repo should be present in the pinned-down pacakge feeds

We can ask ".NET Core Eng Service Partners" --> "First Responders" to add new versions to the feeds.

The tool restore seems to happen automatically as part of the build.

Note the tool isn't being used as yet, we just want this available to devs in this repo for `dotnet fantomas ...` 