### PR TITLE
Fixes 12414:  int32 --> Nullable Int64 additional implicit conversion

### DIFF
--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -1462,7 +1462,8 @@ let AdjustCallerArgForOptional tcVal tcFieldInit eCallerMemberName (infoReader: 
                     else
                         let calledNonOptTy = destNullableTy g calledArgTy
                         let _, callerArgExpr2 = AdjustCallerArgExpr tcVal g amap infoReader ad isOutArg calledNonOptTy reflArgInfo callerArgTy m callerArgExpr
-                        MakeNullableExprIfNeeded infoReader calledArgTy callerArgTy callerArgExpr2 m
+                        let callerArgTy2 = tyOfExpr g callerArgExpr2
+                        MakeNullableExprIfNeeded infoReader calledArgTy callerArgTy2 callerArgExpr2 m
                 else
                     failwith "unreachable" // see case above
             
@@ -1493,7 +1494,8 @@ let AdjustCallerArgForOptional tcVal tcFieldInit eCallerMemberName (infoReader: 
                             // CSharpMethod(x=b) when 'x' has nullable type and 'b' does not --> CSharpMethod(x=Nullable(b))
                             let calledNonOptTy = destNullableTy g calledArgTy
                             let _, callerArgExpr2 = AdjustCallerArgExpr tcVal g amap infoReader ad isOutArg calledNonOptTy reflArgInfo callerArgTy m callerArgExpr
-                            MakeNullableExprIfNeeded infoReader calledArgTy callerArgTy callerArgExpr2 m
+                            let callerArgTy2 = tyOfExpr g callerArgExpr2
+                            MakeNullableExprIfNeeded infoReader calledArgTy callerArgTy2 callerArgExpr2 m
                     else 
                         // CSharpMethod(x=b) --> CSharpMethod(?x=b)
                         let _, callerArgExpr2 = AdjustCallerArgExpr tcVal g amap infoReader ad isOutArg calledArgTy reflArgInfo callerArgTy m callerArgExpr

--- a/tests/fsharp/core/fsfromfsviacs/compilation.errors.output.bsl
+++ b/tests/fsharp/core/fsfromfsviacs/compilation.errors.output.bsl
@@ -1,10 +1,10 @@
 
-test.fsx(217,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(216,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(218,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(217,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x: int
 
@@ -12,7 +12,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(219,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(218,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y: string
 
@@ -20,7 +20,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(220,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(219,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x: int option
 
@@ -28,7 +28,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(221,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(220,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y: string option
 
@@ -36,7 +36,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(222,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(221,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x: 'a option
 
@@ -44,7 +44,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(223,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(222,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y: 'a option
 
@@ -52,7 +52,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(224,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(223,34): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d: 'a option
 
@@ -60,7 +60,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(227,42): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(226,42): error FS0041: A unique overload for method 'OverloadedMethodTakingOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a0
 
@@ -68,12 +68,12 @@ Candidates:
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int
  - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int
 
-test.fsx(229,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(228,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(230,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(229,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y: string
 
@@ -81,9 +81,17 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(231,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(230,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d: Nullable<float>
+
+Candidates:
+ - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
+ - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
+
+test.fsx(231,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+
+Known type of argument: d: float
 
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
@@ -91,7 +99,7 @@ Candidates:
 
 test.fsx(232,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
-Known type of argument: d: float
+Known type of argument: d: float option
 
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
@@ -99,7 +107,7 @@ Candidates:
 
 test.fsx(233,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
-Known type of argument: d: float option
+Known type of argument: x: 'a option
 
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
@@ -107,21 +115,13 @@ Candidates:
 
 test.fsx(234,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
-Known type of argument: x: 'a option
-
-Candidates:
- - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
- - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
-
-test.fsx(235,36): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
-
 Known type of argument: d: 'a option
 
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(237,43): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(236,43): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionalsWithDefaults' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a0
 
@@ -129,12 +129,12 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(239,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(238,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(240,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(239,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: y: string
 
@@ -142,7 +142,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(241,33): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(240,33): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d: float
 
@@ -150,7 +150,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(242,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(241,34): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d: Nullable<float>
 
@@ -158,7 +158,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(243,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(242,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d: float
 
@@ -166,7 +166,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(244,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(243,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d: float option
 
@@ -174,7 +174,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(245,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(244,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: x: 'a option
 
@@ -182,7 +182,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(246,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(245,35): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: d: 'a option
 
@@ -190,7 +190,7 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(247,42): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(246,42): error FS0041: A unique overload for method 'OverloadedMethodTakingNullableOptionals' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a0
 
@@ -198,9 +198,9 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int
 
-test.fsx(249,93): error FS0691: Named arguments must appear after all other arguments
+test.fsx(248,93): error FS0691: Named arguments must appear after all other arguments
 
-test.fsx(250,88): error FS0041: A unique overload for method 'OverloadedMethodTakingNullables' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(249,88): error FS0041: A unique overload for method 'OverloadedMethodTakingNullables' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known types of arguments: Nullable<'a> * string * Nullable<'b> when 'a: (new: unit -> 'a) and 'a: struct and 'a :> ValueType and 'b: (new: unit -> 'b) and 'b: struct and 'b :> ValueType
 
@@ -208,6 +208,18 @@ Candidates:
  - SomeClass.OverloadedMethodTakingNullables(x: Nullable<int64>, y: string, d: Nullable<float>) : int
  - SomeClass.OverloadedMethodTakingNullables(x: Nullable<int>, y: string, d: Nullable<float>) : int
 
-test.fsx(267,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+test.fsx(266,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
 
-test.fsx(284,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+test.fsx(283,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+
+test.fsx(457,94): error FS0193: Type constraint mismatch. The type 
+    'Nullable<int>'    
+is not compatible with type
+    'Nullable<int64>'    
+
+
+test.fsx(458,82): error FS0193: Type constraint mismatch. The type 
+    'Nullable<int>'    
+is not compatible with type
+    'Nullable<int64>'    
+

--- a/tests/fsharp/core/fsfromfsviacs/compilation.langversion.old.output.bsl
+++ b/tests/fsharp/core/fsfromfsviacs/compilation.langversion.old.output.bsl
@@ -391,3 +391,13 @@ test.fsx(453,84): error FS0193: Type constraint mismatch. The type
 is not compatible with type
     'Nullable<int64>'    
 
+
+test.fsx(467,24): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int'    
+
+test.fsx(471,24): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int'    

--- a/tests/fsharp/core/fsfromfsviacs/compilation.langversion.old.output.bsl
+++ b/tests/fsharp/core/fsfromfsviacs/compilation.langversion.old.output.bsl
@@ -118,11 +118,276 @@ is not compatible with type
     'Nullable<float>'    
 
 
-test.fsx(267,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+test.fsx(152,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
 
-test.fsx(284,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+test.fsx(152,79): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
 
-test.fsx(418,29): error FS0041: A unique overload for method 'SimpleOverload' could not be determined based on type information prior to this program point. A type annotation may be needed.
+test.fsx(153,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(154,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(155,89): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(156,88): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(158,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(158,81): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(159,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(160,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(161,91): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(162,90): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(164,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(164,83): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(165,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(166,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(167,93): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(168,92): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(170,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(170,83): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(171,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(172,66): error FS0001: This expression was expected to have type
+    'Nullable<int>'    
+but here has type
+    'int'    
+
+test.fsx(173,93): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(174,92): error FS0001: This expression was expected to have type
+    'Nullable<float>'    
+but here has type
+    'float'    
+
+test.fsx(190,34): error FS0041: No overloads match for method 'OverloadedMethodTakingOptionals'.
+
+Known type of argument: d: float option
+
+Available overloads:
+ - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float) : int // Argument 'd' doesn't match
+ - SomeClass.OverloadedMethodTakingOptionals(?x: int, ?y: string, ?d: float32) : int // Argument 'd' doesn't match
+
+test.fsx(192,34): error FS0041: No overloads match for method 'OverloadedMethodTakingNullableOptionalsWithDefaults'.
+
+Known type of argument: x: int
+
+Available overloads:
+ - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+ - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+
+test.fsx(197,35): error FS0041: No overloads match for method 'OverloadedMethodTakingNullableOptionalsWithDefaults'.
+
+Known type of argument: x: int
+
+Available overloads:
+ - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+ - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+
+test.fsx(200,35): error FS0041: No overloads match for method 'OverloadedMethodTakingNullableOptionalsWithDefaults'.
+
+Known type of argument: x: int option
+
+Available overloads:
+ - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+ - SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+
+test.fsx(202,34): error FS0041: No overloads match for method 'OverloadedMethodTakingNullableOptionals'.
+
+Known type of argument: x: int
+
+Available overloads:
+ - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+ - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+
+test.fsx(207,35): error FS0041: No overloads match for method 'OverloadedMethodTakingNullableOptionals'.
+
+Known type of argument: x: int
+
+Available overloads:
+ - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int64>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+ - SomeClass.OverloadedMethodTakingNullableOptionals(?x: Nullable<int>, ?y: string, ?d: Nullable<float>) : int // Argument 'x' doesn't match
+
+test.fsx(209,35): error FS0041: No overloads match for method 'OverloadedMethodTakingNullables'.
+
+Known types of arguments: int * string * float
+
+Available overloads:
+ - SomeClass.OverloadedMethodTakingNullables(x: Nullable<int64>, y: string, d: Nullable<float>) : int // Argument 'x' doesn't match
+ - SomeClass.OverloadedMethodTakingNullables(x: Nullable<int>, y: string, d: Nullable<float>) : int // Argument 'x' doesn't match
+
+test.fsx(210,35): error FS0041: No overloads match for method 'OverloadedMethodTakingNullables'.
+
+Known types of arguments: Nullable<int> * string * float
+
+Available overloads:
+ - SomeClass.OverloadedMethodTakingNullables(x: Nullable<int64>, y: string, d: Nullable<float>) : int // Argument 'x' doesn't match
+ - SomeClass.OverloadedMethodTakingNullables(x: Nullable<int>, y: string, d: Nullable<float>) : int // Argument 'd' doesn't match
+
+test.fsx(266,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+
+test.fsx(283,15): warning FS0025: Incomplete pattern matches on this expression. For example, the value 'U2 (_, U1 (_, "a"))' may indicate a case not covered by the pattern(s).
+
+test.fsx(417,29): error FS0041: A unique overload for method 'SimpleOverload' could not be determined based on type information prior to this program point. A type annotation may be needed.
 Candidates:
  - SomeClass.SimpleOverload(?x: Nullable<int>) : int
  - SomeClass.SimpleOverload(?x: int) : int
+
+test.fsx(431,74): error FS0001: This expression was expected to have type
+    'int64'    
+but here has type
+    'int'    
+
+test.fsx(432,75): error FS0193: Type constraint mismatch. The type 
+    'int option'    
+is not compatible with type
+    'int64'    
+
+
+test.fsx(434,75): error FS0193: Type constraint mismatch. The type 
+    'int64 option'    
+is not compatible with type
+    'int64'    
+
+
+test.fsx(438,94): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int'    
+
+test.fsx(439,95): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int'    
+
+test.fsx(440,96): error FS0193: Type constraint mismatch. The type 
+    'int option'    
+is not compatible with type
+    'Nullable<int64>'    
+
+
+test.fsx(441,94): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int64'    
+
+test.fsx(443,95): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int64'    
+
+test.fsx(444,96): error FS0193: Type constraint mismatch. The type 
+    'int64 option'    
+is not compatible with type
+    'Nullable<int64>'    
+
+
+test.fsx(447,82): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int'    
+
+test.fsx(448,83): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int'    
+
+test.fsx(449,84): error FS0193: Type constraint mismatch. The type 
+    'int option'    
+is not compatible with type
+    'Nullable<int64>'    
+
+
+test.fsx(450,82): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int64'    
+
+test.fsx(452,83): error FS0001: This expression was expected to have type
+    'Nullable<int64>'    
+but here has type
+    'int64'    
+
+test.fsx(453,84): error FS0193: Type constraint mismatch. The type 
+    'int64 option'    
+is not compatible with type
+    'Nullable<int64>'    
+

--- a/tests/fsharp/core/fsfromfsviacs/lib3.cs
+++ b/tests/fsharp/core/fsfromfsviacs/lib3.cs
@@ -34,11 +34,28 @@ namespace CSharpOptionalParameters
         {
             return x + y.Length + (int) d;
         }
+        public static long MethodTakingOptionalsInt64(long x = 3, string y = "abc", double d = 5.0)
+        {
+            return x + y.Length + (int) d;
+        }
         public static int MethodTakingNullableOptionalsWithDefaults(int? x = 3, string y = "abc", double? d = 5.0)
         {
             return (x.HasValue ? x.Value : -100) + y.Length + (int) (d.HasValue ? d.Value : 0.0);
         }
+        public static long MethodTakingNullableOptionalsWithDefaultsInt64(long? x = 3, string y = "abc", double? d = 5.0)
+        {
+            return (x.HasValue ? x.Value : -100) + y.Length + (int) (d.HasValue ? d.Value : 0.0);
+        }
         public static int MethodTakingNullableOptionals(int? x = null, string y = null, double? d = null)
+        {
+            int length;
+            if (y == null)
+                length = -1;
+            else
+                length = y.Length;
+            return (x.HasValue ? x.Value : -1) + length + (int) (d.HasValue ? d.Value : -1.0);
+        }
+        public static long MethodTakingNullableOptionalsInt64(long? x = null, string y = null, double? d = null)
         {
             int length;
             if (y == null)
@@ -91,6 +108,15 @@ namespace CSharpOptionalParameters
             return (x.HasValue ? x.Value : -1) + length + (int) (d.HasValue ? d.Value : -1.0);
         }
 
+        public static long MethodTakingNullablesInt64(long? x, string y, double? d)
+        {
+            int length;
+            if (y == null)
+                length = -1;
+            else
+                length = y.Length;
+            return (x.HasValue ? x.Value : -1) + length + (int) (d.HasValue ? d.Value : -1.0);
+        }
         public static int OverloadedMethodTakingNullables(int? x, string y, double? d)
         {
             int length;

--- a/tests/fsharp/core/fsfromfsviacs/test.fsx
+++ b/tests/fsharp/core/fsfromfsviacs/test.fsx
@@ -148,7 +148,7 @@ module TestConsumeCSharpOptionalParameter =
     // Check the type inferred for an un-annotated first-class use of the method
     check "csoptional23982f55" (let f = SomeClass.MethodTakingNullableOptionals in ((f : unit -> int) ())) -3
 
-#if LANGVERSION_PREVIEW
+
     check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", 8.0)) 20
     check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", Nullable 8.0)) 20
     check "acsoptional23982f51" (SomeClass.MethodTakingNullables(6, "aaaaaa", Nullable ())) 11
@@ -175,7 +175,7 @@ module TestConsumeCSharpOptionalParameter =
 
     // Check the type inferred for an un-annotated first-class use of the method
     check "acsoptional23982f55" (let f = SomeClass.MethodTakingNullables in ((f : Nullable<int> * string * Nullable<double> -> int) (Nullable 1,"aaaa",Nullable 3.0))) 8
-#endif
+
 
 // This tests overloaded variaitons of the methods, where the overloads vary by type but not nullability
 //
@@ -186,7 +186,7 @@ module TestConsumeCSharpOptionalParameterOverloads =
 
     check "csoptional23982f34o" (SomeClass.OverloadedMethodTakingOptionals(d = 8.0)) 14
 
-#if LANGVERSION_PREVIEW
+
     check "csoptional23982f3ao" (SomeClass.OverloadedMethodTakingOptionals(?d = Some 8.0)) 14
     
     check "csoptional23982f42o" (SomeClass.OverloadedMethodTakingNullableOptionalsWithDefaults(x = 6)) 14 // can provide non-nullable 
@@ -210,7 +210,6 @@ module TestConsumeCSharpOptionalParameterOverloads =
     check "csoptional23982f52o2" (SomeClass.OverloadedMethodTakingNullables(Nullable(6), "aaaaaa", 8.0)) 20 // can provide nullable 
     check "csoptional23982f52o3" (SomeClass.OverloadedMethodTakingNullables(Nullable(6), "aaaaaa", Nullable(8.0))) 20 // can provide nullable 
 
-#endif
 
 #if CHECK_ERRORS
     // in these cases there's not enough information to resolve the overload
@@ -422,6 +421,42 @@ module TestConsumeCSharpOptionalParameterOverloads_ByNullability =
     check "cenwceoweioij5" (SomeClass.SimpleOverload(Nullable())) 100
     check "cenwceoweioij4" (SomeClass.SimpleOverload(x=Nullable(6))) 6
     check "cenwceoweioij5" (SomeClass.SimpleOverload(x=Nullable())) 100
+
+module TestOptionalsAndNullablesInt32ToInt64 = 
+    open System
+    open CSharpOptionalParameters
+
+    // Check can give 32-bit or 64-bit
+    check "csoptional23982f31" (SomeClass.MethodTakingOptionalsInt64()) 11L
+    check "csoptional23982f32" (SomeClass.MethodTakingOptionalsInt64(x = 6)) 14L
+    check "csoptional23982f3a" (SomeClass.MethodTakingOptionalsInt64(?x = Some 6)) 14L
+    check "csoptional23982f32" (SomeClass.MethodTakingOptionalsInt64(x = 6L)) 14L
+    check "csoptional23982f3a" (SomeClass.MethodTakingOptionalsInt64(?x = Some 6L)) 14L
+
+    // Check can take 32-bit or 64-bit
+    check "csoptional23982f41" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64()) 11L
+    check "csoptional23982f42" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64(x = 6)) 14L // can provide non-nullable 
+    check "csoptional23982f431" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64(x = 6)) 14L
+    check "csoptional23982f435" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64(?x = Some 6)) 14L
+    check "csoptional23982f42" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64(x = 6L)) 14L // can provide non-nullable 
+    check "csoptional23982f42" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64(x = Nullable 6L)) 14L // can provide nullable for legacy
+    check "csoptional23982f431" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64(x = 6L)) 14L
+    check "csoptional23982f435" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64(?x = Some 6L)) 14L
+
+    check "csoptional23982f51" (SomeClass.MethodTakingNullableOptionalsInt64()) -3L
+    check "csoptional23982f52" (SomeClass.MethodTakingNullableOptionalsInt64(x = 6)) 4L // can provide nullable for legacy
+    check "csoptional23982f523" (SomeClass.MethodTakingNullableOptionalsInt64(x = 6)) 4L
+    check "csoptional23982f527" (SomeClass.MethodTakingNullableOptionalsInt64(?x = Some 6)) 4L
+    check "csoptional23982f52" (SomeClass.MethodTakingNullableOptionalsInt64(x = 6L)) 4L // can provide nullable for legacy
+    check "csoptional23982f52" (SomeClass.MethodTakingNullableOptionalsInt64(x = Nullable 6L)) 4L // can provide nullable for legacy
+    check "csoptional23982f523" (SomeClass.MethodTakingNullableOptionalsInt64(x = 6L)) 4L
+    check "csoptional23982f527" (SomeClass.MethodTakingNullableOptionalsInt64(?x = Some 6L)) 4L
+
+#if CHECK_ERRORS
+    // A 32-bit to 64-bit type directed conversion is not allowed for the legacy support of passing a Nullable as named argument
+    check "csoptional23982f42" (SomeClass.MethodTakingNullableOptionalsWithDefaultsInt64(x = Nullable 6)) 14 // can provide nullable for legacy
+    check "csoptional23982f52" (SomeClass.MethodTakingNullableOptionalsInt64(x = Nullable 6)) 4 // can provide nullable for legacy
+#endif
 
 #if TESTS_AS_APP
 let RUN() = !failures

--- a/tests/fsharp/core/fsfromfsviacs/test.fsx
+++ b/tests/fsharp/core/fsfromfsviacs/test.fsx
@@ -458,6 +458,28 @@ module TestOptionalsAndNullablesInt32ToInt64 =
     check "csoptional23982f52" (SomeClass.MethodTakingNullableOptionalsInt64(x = Nullable 6)) 4 // can provide nullable for legacy
 #endif
 
+module Test12414 =
+    open System
+    type C() =
+        member val ContentLength: Nullable<int64> = Nullable<int64>(0L) with get, set
+
+    let c = C()
+    c.ContentLength <- 0
+    
+    check "welewcvwlej1" c.ContentLength (Nullable<int64>(0L))
+
+    c.ContentLength <- 6
+    
+    check "welewcvwlej2" c.ContentLength (Nullable<int64>(6L))
+
+    c.ContentLength <- Nullable 7L
+    
+    check "welewcvwlej3" c.ContentLength (Nullable<int64>(7L))
+
+    c.ContentLength <- Nullable<int64>()
+    
+    check "welewcvwlej4" c.ContentLength (Nullable<int64>())
+
 #if TESTS_AS_APP
 let RUN() = !failures
 #else

--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -3255,7 +3255,6 @@ module TestMatchBang =
 
     testSimpleMatchBang()
     
-#if LANGVERSION_PREVIEW
 module WitnessTests = 
     open FSharp.Data.UnitSystems.SI.UnitSymbols
 
@@ -4063,8 +4062,6 @@ module ComputationExpressionWithOptionalsAndParamArray =
     check "vewhkvh4" email.Validators.Length 2
     check "vewhkvh5" password.Label (Some "Password")
     check "vewhkvh6" password.Validators.Length 3
-
-#endif
 
 module QuotationOfComputationExpressionZipOperation =
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -866,42 +866,42 @@ module CoreTests =
 
         csc cfg """/nologo /target:library /r:"%s" /out:lib3.dll  /langversion:7.2""" cfg.FSCOREDLLPATH ["lib3.cs"]
 
-        // some features missing in 4.7
-        for version in ["4.7"] do
-            let outFile = "compilation.langversion.old.output.txt"
-            let expectedFile = "compilation.langversion.old.output.bsl"
-            fscBothToOutExpectFail cfg outFile "%s -r:lib.dll -r:lib2.dll -r:lib3.dll -o:test.exe -g --nologo --define:LANGVERSION_%s --langversion:%s" cfg.fsc_flags (version.Replace(".","_")) version ["test.fsx"]
-
-            let diffs = fsdiff cfg outFile expectedFile
-            match diffs with
-            | "" -> ()
-            | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" outFile expectedFile diffs)
-
         // all features available in preview
-        fsc cfg "%s -r:lib.dll -r:lib2.dll -r:lib3.dll -o:test.exe -g --define:LANGVERSION_PREVIEW --langversion:preview" cfg.fsc_flags ["test.fsx"]
+        fsc cfg "%s -r:lib.dll -r:lib2.dll -r:lib3.dll -o:test.exe -g" cfg.fsc_flags ["test.fsx"]
 
         peverify cfg "test.exe"
 
         exec cfg ("." ++ "test.exe") ""
 
         // Same with library references the other way around
-        fsc cfg "%s -r:lib.dll -r:lib3.dll -r:lib2.dll -o:test.exe -g --define:LANGVERSION_PREVIEW --langversion:preview" cfg.fsc_flags ["test.fsx"]
+        fsc cfg "%s -r:lib.dll -r:lib3.dll -r:lib2.dll -o:test.exe -g" cfg.fsc_flags ["test.fsx"]
 
         peverify cfg "test.exe"
 
         exec cfg ("." ++ "test.exe") ""
 
         // Same without the reference to lib.dll - testing an incomplete reference set, but only compiling a subset of the code
-        fsc cfg "%s --define:NO_LIB_REFERENCE -r:lib3.dll -r:lib2.dll -o:test.exe -g --define:LANGVERSION_PREVIEW --langversion:preview" cfg.fsc_flags ["test.fsx"]
+        fsc cfg "%s --define:NO_LIB_REFERENCE -r:lib3.dll -r:lib2.dll -o:test.exe -g" cfg.fsc_flags ["test.fsx"]
 
         peverify cfg "test.exe"
 
         exec cfg ("." ++ "test.exe") ""
 
+        // some features missing in 4.7
+        for version in ["4.7"] do
+            let outFile = "compilation.langversion.old.output.txt"
+            let expectedFile = "compilation.langversion.old.output.bsl"
+            fscBothToOutExpectFail cfg outFile "%s -r:lib.dll -r:lib2.dll -r:lib3.dll -o:test.exe -g --nologo --langversion:%s" cfg.fsc_flags version ["test.fsx"]
+
+            let diffs = fsdiff cfg outFile expectedFile
+            match diffs with
+            | "" -> ()
+            | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" outFile expectedFile diffs)
+
         // check error messages for some cases
         let outFile = "compilation.errors.output.txt"
         let expectedFile = "compilation.errors.output.bsl"
-        fscBothToOutExpectFail cfg outFile "%s -r:lib.dll -r:lib2.dll -r:lib3.dll -o:test.exe -g --nologo --define:LANGVERSION_PREVIEW --langversion:preview --define:CHECK_ERRORS" cfg.fsc_flags ["test.fsx"]
+        fscBothToOutExpectFail cfg outFile "%s -r:lib.dll -r:lib2.dll -r:lib3.dll -o:test.exe -g --nologo  --define:CHECK_ERRORS" cfg.fsc_flags ["test.fsx"]
 
         let diffs = fsdiff cfg outFile expectedFile
         match diffs with
@@ -1197,7 +1197,7 @@ module CoreTests =
 
         csc cfg """/nologo  /target:library /out:cslib.dll""" ["cslib.cs"]
 
-        fsc cfg "%s --define:LANGVERSION_PREVIEW --langversion:preview -o:test.exe -r cslib.dll -g" cfg.fsc_flags ["test.fsx"]
+        fsc cfg "%s  -o:test.exe -r cslib.dll -g" cfg.fsc_flags ["test.fsx"]
 
         peverify cfg "test.exe"
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/12414.  For int32 --> Nullable Int64 additional implicit conversion we building a Nullable of the wrong type (Nullable int32 not Nullable int64)

