### PR TITLE
Fix debug tailcalls for pipelines if /tailcalls+ is explicitly specified

### DIFF
--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/Testfunction15.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/Testfunction15.il.bsl
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 5:0:0:0
+  .ver 6:0:0:0
 }
 .assembly TestFunction15
 {
@@ -36,13 +36,13 @@
   // Offset: 0x000001F0 Length: 0x00000072
 }
 .module TestFunction15.exe
-// MVID: {611B0ED4-A624-4662-A745-0383D40E1B61}
+// MVID: {6197D1F9-A624-4662-A745-0383F9D19761}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x07120000
+// Image base: 0x06AD0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -95,7 +95,7 @@
   .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
           TestFunction15(int32 inp) cil managed
   {
-    // Code size       40 (0x28)
+    // Code size       42 (0x2a)
     .maxstack  6
     .locals init ([0] int32 x,
              [1] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'Pipe #1 input at line 6')
@@ -119,9 +119,10 @@
     .line 6,6 : 16,41 ''
     IL_001c:  ldsfld     class TestFunction15/TestFunction15@6 TestFunction15/TestFunction15@6::@_instance
     IL_0021:  ldloc.1
-    IL_0022:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!1> [FSharp.Core]Microsoft.FSharp.Collections.ListModule::Map<int32,int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+    IL_0022:  tail.
+    IL_0024:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!1> [FSharp.Core]Microsoft.FSharp.Collections.ListModule::Map<int32,int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0>)
-    IL_0027:  ret
+    IL_0029:  ret
   } // end of method TestFunction15::TestFunction15
 
 } // end of class TestFunction15


### PR DESCRIPTION
This adds back tailcalls for debug code pipelines if /tailcalls+ is explicitly specified

https://github.com/dotnet/fsharp/issues/12413

There's an existing codegen test case that spots this 