### PR TITLE
Rename FSharpReferencedProject.ProjectFileName for clarity

### DIFF
--- a/src/fsharp/service/FSharpCheckerResults.fs
+++ b/src/fsharp/service/FSharpCheckerResults.fs
@@ -106,41 +106,41 @@ type internal DelayedILModuleReader =
 
 [<RequireQualifiedAccess;NoComparison;CustomEquality>]
 type FSharpReferencedProject =
-    | FSharpReference of projectFileName: string * options: FSharpProjectOptions
-    | PEReference of projectFileName: string * getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
-    | ILModuleReference of projectFileName: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader)
+    | FSharpReference of projectOutputFile: string * options: FSharpProjectOptions
+    | PEReference of projectOutputFile: string * getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
+    | ILModuleReference of projectOutputFile: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader)
 
-    member this.FileName =
+    member this.OutputFile =
         match this with
-        | FSharpReference(projectFileName=projectFileName)
-        | PEReference(projectFileName=projectFileName)
-        | ILModuleReference(projectFileName=projectFileName) -> projectFileName
+        | FSharpReference(projectOutputFile=projectOutputFile)
+        | PEReference(projectOutputFile=projectOutputFile)
+        | ILModuleReference(projectOutputFile=projectOutputFile) -> projectOutputFile
 
-    static member CreateFSharp(projectFileName, options) =
-        FSharpReference(projectFileName, options)
+    static member CreateFSharp(projectOutputFile, options) =
+        FSharpReference(projectOutputFile, options)
 
-    static member CreatePortableExecutable(projectFileName, getStamp, getStream) =
-        PEReference(projectFileName, getStamp, DelayedILModuleReader(projectFileName, getStream))
+    static member CreatePortableExecutable(projectOutputFile, getStamp, getStream) =
+        PEReference(projectOutputFile, getStamp, DelayedILModuleReader(projectOutputFile, getStream))
 
-    static member CreateFromILModuleReader(projectFileName, getStamp, getReader) =
-        ILModuleReference(projectFileName, getStamp, getReader)
+    static member CreateFromILModuleReader(projectOutputFile, getStamp, getReader) =
+        ILModuleReference(projectOutputFile, getStamp, getReader)
 
     override this.Equals(o) =
         match o with
         | :? FSharpReferencedProject as o ->
             match this, o with
-            | FSharpReference(projectFileName1, options1), FSharpReference(projectFileName2, options2) ->
-                projectFileName1 = projectFileName2 && options1 = options2
-            | PEReference(projectFileName1, getStamp1, _), PEReference(projectFileName2, getStamp2, _) ->
-                projectFileName1 = projectFileName2 && (getStamp1()) = (getStamp2())
-            | ILModuleReference(projectFileName1, getStamp1, _), ILModuleReference(projectFileName2, getStamp2, _) ->
-                projectFileName1 = projectFileName2 && (getStamp1()) = (getStamp2())
+            | FSharpReference(projectOutputFile1, options1), FSharpReference(projectOutputFile2, options2) ->
+                projectOutputFile1 = projectOutputFile2 && options1 = options2
+            | PEReference(projectOutputFile1, getStamp1, _), PEReference(projectOutputFile2, getStamp2, _) ->
+                projectOutputFile1 = projectOutputFile2 && (getStamp1()) = (getStamp2())
+            | ILModuleReference(projectOutputFile1, getStamp1, _), ILModuleReference(projectOutputFile2, getStamp2, _) ->
+                projectOutputFile1 = projectOutputFile2 && (getStamp1()) = (getStamp2())
             | _ ->
                 false
         | _ ->
             false
 
-    override this.GetHashCode() = this.FileName.GetHashCode()
+    override this.GetHashCode() = this.OutputFile.GetHashCode()
 
 // NOTE: may be better just to move to optional arguments here
 and FSharpProjectOptions =

--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -96,23 +96,39 @@ type public FSharpProjectOptions =
 
 and [<NoComparison;CustomEquality>] public FSharpReferencedProject =
     internal
-    | FSharpReference of projectFileName: string * options: FSharpProjectOptions
-    | PEReference of projectFileName: string * getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
-    | ILModuleReference of projectFileName: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader)
+    | FSharpReference of projectOutputFile: string * options: FSharpProjectOptions
+    | PEReference of projectOutputFile: string * getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
+    | ILModuleReference of projectOutputFile: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader)
 
-    member FileName : string
+    ///<summary>
+    /// The fully qualified path to the output of the referenced project. This should be the same value as the <code>-r</code>
+    /// reference in the project options for this referenced project.
+    ///</summary>
+    member OutputFile : string
 
+    ///<summary>
     /// Creates a reference for an F# project. The physical data for it is stored/cached inside of the compiler service.
-    static member CreateFSharp : projectFileName: string * options: FSharpProjectOptions -> FSharpReferencedProject
+    ///</summary>
+    ///<param name="projectOutputFile">The fully qualified path to the output of the referenced project. This should be the same value as the <code>-r</code> reference in the project options for this referenced project.</param>
+    ///<param name="options">The Project Options for this F# project</param>
+    static member CreateFSharp : projectOutputFile: string * options: FSharpProjectOptions -> FSharpReferencedProject
 
+    ///<summary>
     /// Creates a reference for any portable executable, including F#. The stream is owned by this reference.
     /// The stream will be automatically disposed when there are no references to FSharpReferencedProject and is GC collected.
     /// Once the stream is evaluated, the function that constructs the stream will no longer be referenced by anything.
     /// If the stream evaluation throws an exception, it will be automatically handled.
-    static member CreatePortableExecutable : projectFileName: string * getStamp: (unit -> DateTime) * getStream: (CancellationToken -> Stream option) -> FSharpReferencedProject
+    ///</summary>
+    ///<param name="projectOutputFile">The fully qualified path to the output of the referenced project. This should be the same value as the <code>-r</code> reference in the project options for this referenced project.</param>
+    ///<param name="getStamp">A function that calculates a last-modified timestamp for this reference. This will be used to determine if the reference is up-to-date.</param>
+    ///<param name="getStream">A function that opens a Portable Executable data stream for reading.</param>
+    static member CreatePortableExecutable : projectOutputFile: string * getStamp: (unit -> DateTime) * getStream: (CancellationToken -> Stream option) -> FSharpReferencedProject
 
-    /// Creates a reference from an ILModuleReader.
-    static member CreateFromILModuleReader : projectFileName: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader) -> FSharpReferencedProject
+    ///<summary>Creates a reference from an ILModuleReader.</summary>
+    ///<param name="projectOutputFile">The fully qualified path to the output of the referenced project. This should be the same value as the <code>-r</code> reference in the project options for this referenced project.</param>
+    ///<param name="getStamp">A function that calculates a last-modified timestamp for this reference. This will be used to determine if the reference is up-to-date.</param>
+    ///<param name="getReader">A function that creates an ILModuleReader for reading module data.</param>
+    static member CreateFromILModuleReader : projectOutputFile: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader) -> FSharpReferencedProject
 
 /// Represents the use of an F# symbol from F# source code
 [<Sealed>]

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -2131,9 +2131,9 @@ FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalys
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreateFromILModuleReader(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader])
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreatePortableExecutable(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 GetHashCode()
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String FileName
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String OutputFile
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String ToString()
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String get_FileName()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String get_OutputFile()
 FSharp.Compiler.CodeAnalysis.FSharpSymbolUse
 FSharp.Compiler.CodeAnalysis.FSharpSymbolUse: Boolean IsFromAttribute
 FSharp.Compiler.CodeAnalysis.FSharpSymbolUse: Boolean IsFromComputationExpression


### PR DESCRIPTION
This renames the `projectFileName` field and `FileName` property to reflect the
actual use: the project's output file. This was unclear based on docs, but clear based on usage,
and so docs were added to help ensure correct usage.