### PR TITLE
Include range of attributes in SynExceptionDefnRepr, SynExceptionSig & SynModuleSigDecl.Exception.

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -827,8 +827,9 @@ moduleSpfn:
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let (SynExceptionSig(SynExceptionDefnRepr(cas, a, b, c, d, d2), withKeyword, members, range)) = $3
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
-        let mWhole = (d2, $1) ||> unionRangeWithListBy (fun a -> a.Range)
-        let ec = SynExceptionSig(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, mWhole), withKeyword, members, mWhole)
+        let mDefnReprWithAttributes = (d2, $1) ||> unionRangeWithListBy (fun a -> a.Range)
+        let mWhole = (mDefnReprWithAttributes, members) ||> unionRangeWithListBy (fun (m: SynMemberSig) -> m.Range)
+        let ec = SynExceptionSig(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, mDefnReprWithAttributes), withKeyword, members, mWhole)
         SynModuleSigDecl.Exception(ec, mWhole) }
 
   | openDecl

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -827,8 +827,9 @@ moduleSpfn:
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let (SynExceptionSig(SynExceptionDefnRepr(cas, a, b, c, d, d2), withKeyword, members, range)) = $3
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
-        let ec = SynExceptionSig(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, d2), withKeyword, members, range)
-        SynModuleSigDecl.Exception(ec, rhs parseState 3) }
+        let mWhole = (d2, $1) ||> unionRangeWithListBy (fun a -> a.Range)
+        let ec = SynExceptionSig(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, mWhole), withKeyword, members, mWhole)
+        SynModuleSigDecl.Exception(ec, mWhole) }
 
   | openDecl
       { SynModuleSigDecl.Open($1, (rhs parseState 1)) }

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1438,6 +1438,31 @@ exception SyntaxError of obj * range: range
             assertRange (5, 0) (6, 43) mException
         | _ -> Assert.Fail "Could not get valid AST"
 
+    [<Test>]
+    let ``Range of members should be included in SynExceptionSig and SynModuleSigDecl.Exception`` () =
+        let parseResults = 
+            getParseResultsOfSignatureFile
+                """
+module internal FSharp.Compiler.ParseHelpers
+
+exception SyntaxError of obj * range: range with
+    member Meh : string -> int
+
+open Foo
+"""
+
+        match parseResults with
+        | ParsedInput.SigFile (ParsedSigFileInput (modules=[
+            SynModuleOrNamespaceSig(decls=[
+                SynModuleSigDecl.Exception(
+                    SynExceptionSig(exnRepr=SynExceptionDefnRepr(range=mSynExceptionDefnRepr); range=mSynExceptionSig), mException)
+                SynModuleSigDecl.Open _
+            ] ) ])) ->
+            assertRange (4, 0) (4, 43) mSynExceptionDefnRepr
+            assertRange (4, 0) (5, 30) mSynExceptionSig
+            assertRange (4, 0) (5, 30) mException
+        | _ -> Assert.Fail "Could not get valid AST"
+
 module SynMatchClause =
     [<Test>]
     let ``Range of single SynMatchClause`` () =

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1413,6 +1413,31 @@ type Foo =
             assertRange (5, 30) (5, 34) mWithKeyword
         | _ -> Assert.Fail "Could not get valid AST"
 
+    [<Test>]
+    let ``Range of attribute should be included in SynExceptionDefnRepr and SynExceptionSig`` () =
+        let parseResults = 
+            getParseResultsOfSignatureFile
+                """
+module internal FSharp.Compiler.ParseHelpers
+
+/// The error raised by the parse_error_rich function, which is called by the parser engine
+[<NoEquality; NoComparison>]
+exception SyntaxError of obj * range: range
+
+
+"""
+
+        match parseResults with
+        | ParsedInput.SigFile (ParsedSigFileInput (modules=[
+            SynModuleOrNamespaceSig(decls=[
+                SynModuleSigDecl.Exception(
+                    SynExceptionSig(exnRepr=SynExceptionDefnRepr(range=mSynExceptionDefnRepr); range=mSynExceptionSig), mException)
+            ] ) ])) ->
+            assertRange (5, 0) (6, 43) mSynExceptionDefnRepr
+            assertRange (5, 0) (6, 43) mSynExceptionSig
+            assertRange (5, 0) (6, 43) mException
+        | _ -> Assert.Fail "Could not get valid AST"
+
 module SynMatchClause =
     [<Test>]
     let ``Range of single SynMatchClause`` () =


### PR DESCRIPTION
Fixes #12434, similar to https://github.com/dotnet/fsharp/pull/11483.
