### PR TITLE
`WarningsNotAsErrors` is not forwarded to the compiler

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -364,6 +364,7 @@ this file.
               VisualStudioStyleErrors="$(VisualStudioStyleErrors)"
               WarningLevel="$(WarningLevel)"
               WarningsAsErrors="$(WarningsAsErrors)"
+              WarningsNotAsErrors="$(WarningsNotAsErrors)"
               WarnOn="$(WarnOn)"
               Win32IconFile="$(ApplicationIcon)"
               Win32ManifestFile="$(Win32Manifest)"


### PR DESCRIPTION
Add `WarningsNotAsErrors`
to be forwarded to the compiler