### PR TITLE
Fix build issues

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -381,7 +381,10 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $msbuildVersion = [Version]::new((Get-Item $msbuildCmd.Path).VersionInfo.ProductVersion.Split([char[]]@('-', '+'))[0])
 
       if ($msbuildVersion -ge $vsMinVersion) {
-        return $global:_MSBuildExe = $msbuildCmd.Path
+        #
+        # Work around for 64 bit msbuild.  We have an issue with nuget producing type match errors on 64 bit msbuild on this repo
+        # this strips AMD64 from the path causing us to use the 32 bit version which doesn't have that issue.
+        return $global:_MSBuildExe = ($msbuildCmd.Path) -replace '\\AMD64\\msbuild.exe', '\msbuild.exe'
       }
 
       # Report error - the developer environment is initialized with incompatible VS version.


### PR DESCRIPTION
Recently I have been seeing build failures like this:

They appear often enough to derail my work, but are not consistent.

````
Build FAILED.

C:\Program Files\dotnet\sdk\6.0.100\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(110,
5): error MSB4018: The "GetPackOutputItemsTask" task failed unexpectedly. [C:\kevinransom\fsharp\src\fsharp\FSharp.Comp
iler.Service\FSharp.Compiler.Service.fsproj]
C:\Program Files\dotnet\sdk\6.0.100\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(110,
5): error MSB4018: System.ArrayTypeMismatchException: Attempted to access an element as a type incompatible with the ar
ray. [C:\kevinransom\fsharp\src\fsharp\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj]
C:\Program Files\dotnet\sdk\6.0.100\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(110,
5): error MSB4018:    at System.Collections.Generic.List`1.Add(T item) [C:\kevinransom\fsharp\src\fsharp\FSharp.Compile
r.Service\FSharp.Compiler.Service.fsproj]
C:\Program Files\dotnet\sdk\6.0.100\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(110,
5): error MSB4018:    at NuGet.Build.Tasks.Pack.GetPackOutputItemsTask.Execute() [C:\kevinransom\fsharp\src\fsharp\FSha
rp.Compiler.Service\FSharp.Compiler.Service.fsproj]
C:\Program Files\dotnet\sdk\6.0.100\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(110,
5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
 [C:\kevinransom\fsharp\src\fsharp\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj]
C:\Program Files\dotnet\sdk\6.0.100\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(110,
5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [C:\kevinransom\
fsharp\src\fsharp\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj]
    0 Warning(s)
    1 Error(s)

Time Elapsed 00:04:08.76
Build failed with exit code 1. Check errors above.
See log: C:\kevinransom\fsharp\artifacts\log\release\Build.binlog
````

I believe the errors are due to msbuild defaulting to using nodereuse.  This disables nodereuse in our windows build scripts.


