### PR TITLE
Remove three redundant package references from FSharp.Core.

### DIFF
--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -255,12 +255,6 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Linq.Queryable" Version="$(SystemLinqQueryableVersion)" />
-    <PackageReference Include="System.Net.Requests" Version="$(SystemNetRequestsVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(SystemThreadingTasksParallelVersion)" />
-  </ItemGroup>
-
   <Target Name="CopyToBuiltBin" BeforeTargets="BuiltProjectOutputGroup" AfterTargets="CoreCompile">
     <PropertyGroup>
       <BuildOutputGroupLocation>$(BaseOutputPath)\$(Configuration)\$(TargetFramework)</BuildOutputGroupLocation>


### PR DESCRIPTION
These packages date from the .NET Standard 1.x era, receive no more updates, and bloat the package dependency tree (that bloat would be exposed to consumers of `FSharp.Core` had it not used a custom `.nuspec`). They are not needed for projects targeting .NET Standard 2.x and this PR removes them.