### PR TITLE
fixTests

### DIFF
--- a/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
+++ b/src/fsharp/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.ProjectFile.fs
@@ -130,7 +130,6 @@ $(POUND_R)
     <TargetFramework>$(TARGETFRAMEWORK)</TargetFramework>
     <RuntimeIdentifier>$(RUNTIMEIDENTIFIER)</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
-    <_NETCoreSdkIsPreview>false</_NETCoreSdkIsPreview>                      <!-- Disable preview FSharp.Core for legacy DotNet Sdks -->
     <DisableFSharpCorePreviewCheck>true</DisableFSharpCorePreviewCheck>     <!-- Disable preview FSharp.Core current DotNet Sdks    -->
 
     <!-- Disable automagic FSharp.Core resolution when not using with FSharp scripts -->

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5664,6 +5664,7 @@ let checkContentAsScript content =
 [<Test>]
 let ``References from #r nuget are included in script project options`` () =
     let checkResults = checkContentAsScript """
+#i "nuget:https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 #r "nuget: Dapper"
 """
     let assemblyNames =


### PR DESCRIPTION
A recent change in the targets file removed access to the intenral feeds, which breaks a test in the : FSharp.CompilerService suite.