### PR TITLE
Fix appdomains under visual studio

### DIFF
--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -91,16 +91,17 @@ type CompilerAssert private () =
             ctxt.Unload()
 #else
 
-    static let pathToThisDll = Assembly.GetExecutingAssembly().CodeBase
-
     static let adSetup =
         let setup = new System.AppDomainSetup ()
-        setup.PrivateBinPath <- pathToThisDll
+        let directory = Path.GetDirectoryName(typeof<Worker>.Assembly.Location)
+        setup.ApplicationBase <- directory
         setup
 
     static let executeBuiltApp assembly deps =
         let ad = AppDomain.CreateDomain((Guid()).ToString(), null, adSetup)
-        let worker = (ad.CreateInstanceFromAndUnwrap(pathToThisDll, typeof<Worker>.FullName)) :?> Worker
+        let worker =
+            use _ = new AlreadyLoadedAppDomainResolver()
+            (ad.CreateInstanceFromAndUnwrap(typeof<Worker>.Assembly.CodeBase, typeof<Worker>.FullName)) :?> Worker
         worker.ExecuteTestCase assembly (deps |> Array.ofList) |>ignore
 #endif
 

--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -30,6 +30,20 @@ module Utilities =
                 cancellationToken)
             task.Result
 
+    /// Disposable type to implement a simple resolve handler that searches the currently loaded assemblies to see if the requested assembly is already loaded.
+    type AlreadyLoadedAppDomainResolver () =
+        let resolveHandler =
+            ResolveEventHandler(fun _ args ->
+                let assemblies = AppDomain.CurrentDomain.GetAssemblies()
+                let assembly = assemblies |> Array.tryFind(fun a -> String.Compare(a.FullName, args.Name,StringComparison.OrdinalIgnoreCase) = 0)
+                assembly |> Option.defaultValue Unchecked.defaultof<Assembly>
+                )
+        do AppDomain.CurrentDomain.add_AssemblyResolve(resolveHandler)
+
+        interface IDisposable with
+            member this.Dispose() = AppDomain.CurrentDomain.remove_AssemblyResolve(resolveHandler)
+
+
     [<RequireQualifiedAccess>]
     type TargetFramework =
         | NetStandard20


### PR DESCRIPTION
When executing the FSharp.Compiler.ComponentTests  under visual studio every test that relied on App Domains failed.  I have no idea how long this has been going on or when it was introduced.  I suspect it's been a while.  I also supsect some changes in the test hosting under VS, but it could also have been changes we have done in probing I suppose.

The solution has been to add a AlreadyLoadedAppDomainResolver when creating the worker, the issue is that a FSharp.Test.Utilities.dll is loaded in an appdomain, via loadfrom.  Since it is not resolvable under vs because the vs host is not in artifacts.  When we create the appdomain the marshalling needs to do an assembly load.  We handle this using the new AlreadyLoadedAppDomainResolver, which checks already loaded assemblies when the resolve fails.

Oh yeah and adds a new command line option to build to just build the FSharp.Compiler.ComponentTests, and re-aligns the help text:
   **-testCompilerComponentTests**

Fixes: #12495



