### PR TITLE
Fix fsharpcore unit tests running on vs 2022

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/DiscriminatedUnionType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/DiscriminatedUnionType.fs
@@ -102,57 +102,6 @@ type UseUnionsWithData() =
 [<Struct>]
 type StructUnion = SU of C : int * D : int
 
-let private hasAttribute<'T,'Attr>() =
-    typeof<'T>.GetTypeInfo().GetCustomAttributes() |> Seq.exists  (fun x -> x.GetType() = typeof<'Attr>)
-
-
-let [<Fact>] ``struct unions hold [<Struct>] metadata`` () =
-    Assert.True (hasAttribute<StructUnion,StructAttribute>())
-
-
-let [<Fact>] ``struct unions are comparable`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        i1 <> i2 ==>
-        let sr1 = SU (i1, i2)
-        let sr2 = SU (i1, i2)
-        let sr3 = SU (i2, i1)
-        (sr1 = sr2)                    |@ "sr1 = sr2" .&.
-        (sr1 <> sr3)                    |@ "sr1 <> sr3" .&.
-        (sr1.Equals sr2)               |@ "sr1.Equals sr2"
-
-
-let [<Fact>] ``struct unions support pattern matching`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        let sr1 = SU(i1, i2)
-        (match sr1 with
-        | SU(c,d) when c = i1 && d = i2 -> true
-        | _ -> false) 
-        |@ "with pattern match on struct union" .&.
-        (sr1 |> function 
-        | SU(c,d) when c = i1 && d = i2 -> true
-        | _ -> false)
-        |@ "function pattern match on struct union"
-
-
-let [<Fact>] ``struct unions support let binds using `` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        let sr1 = SU(i1,i2)
-        let (SU (c1,d2))  as sr2 = sr1
-        (sr1 = sr2)          |@ "sr1 = sr2" .&.
-        (c1 = i1 && d2 = i2) |@ "c1 = i1 && d2 = i2"
-
-
-let [<Fact>] ``struct unions support function argument bindings`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        let sr1 = SU(i1,i2)
-        let test sr1 (SU (c1,d2) as sr2) =
-            sr1 = sr2 && c1 = i1 && d2 = i2
-        test sr1 sr1
-
 [<Struct>]
 [<CustomComparison; CustomEquality>]
 type ComparisonStructUnion =
@@ -171,72 +120,126 @@ type ComparisonStructUnion =
             | :? ComparisonStructUnion as o -> compare (self.C1 + self.C2) (o.C1 + o.C2)
             | _ -> invalidArg "other" "cannot compare values of different types"
 
-
-[<Fact>]
-let ``struct unions support [<CustomEquality>]`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        let sr1 = SU2(i1,i2)
-        let sr2 = SU2(i1,i2)
-        (sr1.Equals sr2)      
-
-[<Fact>]
-let ``struct unions support [<CustomComparison>]`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) (k1:int) (k2:int) ->        
-        let sr1 = SU2(i1,i2)
-        let sr2 = SU2(k1,k2)
-        if   sr1 > sr2 then compare sr1 sr2 = 1
-        elif sr1 < sr2 then compare sr1 sr2 = -1
-        elif sr1 = sr2 then compare sr1 sr2 = 0
-        else false
-
-
-[<Fact>]
-let ``struct unions hold [<CustomComparison>] [<CustomEquality>] metadata`` () =
-    Assert.True (hasAttribute<ComparisonStructUnion,CustomComparisonAttribute>())
-    Assert.True (hasAttribute<ComparisonStructUnion,CustomEqualityAttribute>())
-
-
 [<Struct>]
 [<NoComparison; NoEquality>]
 type NoComparisonStructUnion =
     | SU3 of int * int
 
+let private hasAttribute<'T,'Attr>() =
+    typeof<'T>.GetTypeInfo().GetCustomAttributes() |> Seq.exists  (fun x -> x.GetType() = typeof<'Attr>)
 
 
-[<Fact>]
-let ``struct unions hold [<NoComparison>] [<NoEquality>] metadata`` () =
-    Assert.True (hasAttribute<NoComparisonStructUnion,NoComparisonAttribute>())
-    Assert.True (hasAttribute<NoComparisonStructUnion,NoEqualityAttribute>())
+type UnionsFSCheckTests () =
+    inherit TestClassWithSimpleNameAppDomainResolver ()
+
+    [<Fact>]
+    member _.``struct unions hold [<Struct>] metadata`` () =
+        Assert.True (hasAttribute<StructUnion,StructAttribute>())
+
+    [<Fact>]
+    member _.``struct unions are comparable`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            i1 <> i2 ==>
+            let sr1 = SU (i1, i2)
+            let sr2 = SU (i1, i2)
+            let sr3 = SU (i2, i1)
+            (sr1 = sr2)                    |@ "sr1 = sr2" .&.
+            (sr1 <> sr3)                    |@ "sr1 <> sr3" .&.
+            (sr1.Equals sr2)               |@ "sr1.Equals sr2"
 
 
-let [<Fact>] ``can properly construct a struct union using FSharpValue.MakeUnionCase, and we get the fields`` () =
-    let cases = Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<StructUnion>)
+    [<Fact>]
+    member _.``struct unions support pattern matching`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            let sr1 = SU(i1, i2)
+            (match sr1 with
+            | SU(c,d) when c = i1 && d = i2 -> true
+            | _ -> false) 
+            |@ "with pattern match on struct union" .&.
+            (sr1 |> function 
+            | SU(c,d) when c = i1 && d = i2 -> true
+            | _ -> false)
+            |@ "function pattern match on struct union"
 
-    Assert.AreEqual (1, cases.Length)
-    let case = cases.[0]
+    [<Fact>]
+    member _.``struct unions support let binds using `` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            let sr1 = SU(i1,i2)
+            let (SU (c1,d2))  as sr2 = sr1
+            (sr1 = sr2)          |@ "sr1 = sr2" .&.
+            (c1 = i1 && d2 = i2) |@ "c1 = i1 && d2 = i2"
 
-    Assert.AreEqual ("SU", case.Name)
+
+    [<Fact>]
+    member _.``struct unions support function argument bindings`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            let sr1 = SU(i1,i2)
+            let test sr1 (SU (c1,d2) as sr2) =
+                sr1 = sr2 && c1 = i1 && d2 = i2
+            test sr1 sr1
+
+    [<Fact>]
+    member _.``struct unions support [<CustomEquality>]`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            let sr1 = SU2(i1,i2)
+            let sr2 = SU2(i1,i2)
+            (sr1.Equals sr2)      
+
+    [<Fact>]
+    member _.``struct unions support [<CustomComparison>]`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) (k1:int) (k2:int) ->        
+            let sr1 = SU2(i1,i2)
+            let sr2 = SU2(k1,k2)
+            if   sr1 > sr2 then compare sr1 sr2 = 1
+            elif sr1 < sr2 then compare sr1 sr2 = -1
+            elif sr1 = sr2 then compare sr1 sr2 = 0
+            else false
+
+    [<Fact>]
+    member _.``struct unions hold [<CustomComparison>] [<CustomEquality>] metadata`` () =
+        Assert.True (hasAttribute<ComparisonStructUnion,CustomComparisonAttribute>())
+        Assert.True (hasAttribute<ComparisonStructUnion,CustomEqualityAttribute>())
+
+    [<Fact>]
+    member _.``struct unions hold [<NoComparison>] [<NoEquality>] metadata`` () =
+        Assert.True (hasAttribute<NoComparisonStructUnion,NoComparisonAttribute>())
+        Assert.True (hasAttribute<NoComparisonStructUnion,NoEqualityAttribute>())
+
+
+    [<Fact>]
+    member _.``can properly construct a struct union using FSharpValue.MakeUnionCase, and we get the fields`` () =
+        let cases = Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<StructUnion>)
+
+        Assert.AreEqual (1, cases.Length)
+        let case = cases.[0]
+
+        Assert.AreEqual ("SU", case.Name)
     
-    let structUnion = Microsoft.FSharp.Reflection.FSharpValue.MakeUnion (case, [|box 1234; box 3456|])
+        let structUnion = Microsoft.FSharp.Reflection.FSharpValue.MakeUnion (case, [|box 1234; box 3456|])
 
-    Assert.True (structUnion.GetType().IsValueType)
+        Assert.True (structUnion.GetType().IsValueType)
 
-    let _uc, fieldVals = Microsoft.FSharp.Reflection.FSharpValue.GetUnionFields(structUnion, typeof<StructUnion>)
+        let _uc, fieldVals = Microsoft.FSharp.Reflection.FSharpValue.GetUnionFields(structUnion, typeof<StructUnion>)
 
-    Assert.AreEqual (2, fieldVals.Length)
+        Assert.AreEqual (2, fieldVals.Length)
 
-    let c = (fieldVals.[0] :?> int)
-    Assert.AreEqual (1234, c)
+        let c = (fieldVals.[0] :?> int)
+        Assert.AreEqual (1234, c)
 
-    let c2 = (fieldVals.[1] :?> int)
-    Assert.AreEqual (3456, c2)
+        let c2 = (fieldVals.[1] :?> int)
+        Assert.AreEqual (3456, c2)
 
-let [<Fact>] ``struct unions does optimization correctly on pattern matching`` () =
-    let arr = ResizeArray()
-    match arr.Add(1); ValueSome () with
-    | ValueSome () -> ()
-    | ValueNone -> ()
+    [<Fact>]
+    member _.``struct unions does optimization correctly on pattern matching`` () =
+        let arr = ResizeArray()
+        match arr.Add(1); ValueSome () with
+        | ValueSome () -> ()
+        | ValueNone -> ()
 
-    Assert.AreEqual(1, arr.Count)
+        Assert.AreEqual(1, arr.Count)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayProperties.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayProperties.fs
@@ -1,33 +1,36 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
-module FSharp.Core.UnitTests.Collections.ArrayProperties
+namespace FSharp.Core.UnitTests.Collections
 
 open System
 open System.Collections.Generic
-
+open System.Reflection
 open Xunit
 open FsCheck
 open Utils
 
-let isStable sorted = sorted |> Seq.pairwise |> Seq.forall (fun ((ia, a),(ib, b)) -> if a = b then ia < ib else true)
+type ArrayProperties() =
+    inherit TestClassWithSimpleNameAppDomainResolver()
+
+    member _.isStable sorted = sorted |> Seq.pairwise |> Seq.forall (fun ((ia, a),(ib, b)) -> if a = b then ia < ib else true)
+
+    member this.distinctByStable<'a when 'a : comparison> (xs : 'a []) =
+       let indexed = xs |> Seq.indexed |> Seq.toArray
+       let sorted = indexed |> Array.distinctBy snd
+       this.isStable sorted
+
+    member _.blitWorksLikeCopy<'a when 'a : comparison> (source : 'a [], sourceIndex, target : 'a [], targetIndex, count) =
+        let target1 = Array.copy target
+        let target2 = Array.copy target
+        let a = runAndCheckIfAnyError (fun () -> Array.blit source sourceIndex target1 targetIndex count)
+        let b = runAndCheckIfAnyError (fun () -> Array.Copy(source, sourceIndex, target2, targetIndex, count))
+        a = b && target1 = target2
  
-let distinctByStable<'a when 'a : comparison> (xs : 'a []) =
-    let indexed = xs |> Seq.indexed |> Seq.toArray
-    let sorted = indexed |> Array.distinctBy snd
-    isStable sorted
+    [<Fact>]
+    member this.``Array.distinctBy is stable`` () =
+        Check.QuickThrowOnFailure this.distinctByStable<int>
+        Check.QuickThrowOnFailure this.distinctByStable<string>
  
-[<Fact>]
-let ``Array.distinctBy is stable`` () =
-    Check.QuickThrowOnFailure distinctByStable<int>
-    Check.QuickThrowOnFailure distinctByStable<string>
- 
-let blitWorksLikeCopy<'a when 'a : comparison> (source : 'a [], sourceIndex, target : 'a [], targetIndex, count) =
-    let target1 = Array.copy target
-    let target2 = Array.copy target
-    let a = runAndCheckIfAnyError (fun () -> Array.blit source sourceIndex target1 targetIndex count)
-    let b = runAndCheckIfAnyError (fun () -> Array.Copy(source, sourceIndex, target2, targetIndex, count))
-    a = b && target1 = target2
- 
-[<Fact>]
-let ``Array.blit works like Array.Copy`` () =
-    Check.QuickThrowOnFailure blitWorksLikeCopy<int>
-    Check.QuickThrowOnFailure blitWorksLikeCopy<string>
+    [<Fact>]
+    member this.``Array.blit works like Array.Copy`` () =
+        Check.QuickThrowOnFailure this.blitWorksLikeCopy<int>
+        Check.QuickThrowOnFailure this.blitWorksLikeCopy<string>

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListProperties.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListProperties.fs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
-module FSharp.Core.UnitTests.Collections.ListProperties
+namespace FSharp.Core.UnitTests.Collections
 
 open System
 open System.Collections.Generic
@@ -7,850 +7,850 @@ open Xunit
 open FsCheck
 open Utils
 
-let chunkBySize_and_collect<'a when 'a : equality> (xs : 'a list) size =
-    size > 0 ==> (lazy
-        let a = List.chunkBySize size xs
-        let b = List.collect id a
-        b = xs)
+type ListProperties () =
+    inherit TestClassWithSimpleNameAppDomainResolver ()
 
-[<Fact>]
-let ``chunkBySize is reversable with collect`` () =
-    Check.QuickThrowOnFailure chunkBySize_and_collect<int>
-    Check.QuickThrowOnFailure chunkBySize_and_collect<string>
-    Check.QuickThrowOnFailure chunkBySize_and_collect<NormalFloat>
+    member _.chunkBySize_and_collect<'a when 'a : equality> (xs : 'a list) size =
+        size > 0 ==> (lazy
+            let a = List.chunkBySize size xs
+            let b = List.collect id a
+            b = xs)
 
-let windowed_and_length<'a when 'a : equality> (xs : 'a list) size =
-    size > 0 ==> (lazy
-        List.windowed size xs
-        |> List.forall (fun x -> x.Length = size))
+    [<Fact>]
+    member this.``chunkBySize is reversable with collect`` () =
+        Check.QuickThrowOnFailure this.chunkBySize_and_collect<int>
+        Check.QuickThrowOnFailure this.chunkBySize_and_collect<string>
+        Check.QuickThrowOnFailure this.chunkBySize_and_collect<NormalFloat>
+
+    member _.windowed_and_length<'a when 'a : equality> (xs : 'a list) size =
+        size > 0 ==> (lazy
+            List.windowed size xs
+            |> List.forall (fun x -> x.Length = size))
 
 
-[<Fact>]
-let ``windowed returns list with correct length`` () =
-    Check.QuickThrowOnFailure windowed_and_length<int>
-    Check.QuickThrowOnFailure windowed_and_length<string>
-    Check.QuickThrowOnFailure windowed_and_length<NormalFloat>
+    [<Fact>]
+    member this.``windowed returns list with correct length`` () =
+        Check.QuickThrowOnFailure this.windowed_and_length<int>
+        Check.QuickThrowOnFailure this.windowed_and_length<string>
+        Check.QuickThrowOnFailure this.windowed_and_length<NormalFloat>
 
-let windowed_and_order<'a when 'a : equality> (listsize:PositiveInt) size =
-    size > 1 ==> (lazy
-        let xs = [1..(int listsize)]
+    member _.windowed_and_order<'a when 'a : equality> (listsize:PositiveInt) size =
+        size > 1 ==> (lazy
+            let xs = [1..(int listsize)]
 
-        List.windowed size xs
-        |> List.forall (fun w -> w = List.sort w))
+            List.windowed size xs
+            |> List.forall (fun w -> w = List.sort w))
 
-[<Fact>]
-let ``windowed returns succeeding elements`` () =
-    Check.QuickThrowOnFailure windowed_and_order<int>
-    Check.QuickThrowOnFailure windowed_and_order<string>
-    Check.QuickThrowOnFailure windowed_and_order<NormalFloat>
+    [<Fact>]
+    member this.``windowed returns succeeding elements`` () =
+        Check.QuickThrowOnFailure this.windowed_and_order<int>
+        Check.QuickThrowOnFailure this.windowed_and_order<string>
+        Check.QuickThrowOnFailure this.windowed_and_order<NormalFloat>
 
-let partition_and_sort<'a when 'a : comparison> (xs : 'a list) =
-    let rec qsort xs = 
-        match xs with
-        | [] -> []
-        | (x:'a)::xs -> 
-            let smaller,larger = List.partition (fun y -> y <= x) xs
-            qsort smaller @ [x] @ qsort larger
+    member _.partition_and_sort<'a when 'a : comparison> (xs : 'a list) =
+        let rec qsort xs = 
+            match xs with
+            | [] -> []
+            | (x:'a)::xs -> 
+                let smaller,larger = List.partition (fun y -> y <= x) xs
+                qsort smaller @ [x] @ qsort larger
 
-    qsort xs = (List.sort xs)
+        qsort xs = (List.sort xs)
 
-[<Fact>]
-let ``partition can be used to sort`` () =
-    Check.QuickThrowOnFailure partition_and_sort<int>
-    Check.QuickThrowOnFailure partition_and_sort<string>
-    Check.QuickThrowOnFailure partition_and_sort<NormalFloat>
+    [<Fact>]
+    member this.``partition can be used to sort`` () =
+        Check.QuickThrowOnFailure this.partition_and_sort<int>
+        Check.QuickThrowOnFailure this.partition_and_sort<string>
+        Check.QuickThrowOnFailure this.partition_and_sort<NormalFloat>
 
-let windowed_and_pairwise<'a when 'a : equality> (xs : 'a list) =
-    let a = List.windowed 2 xs
-    let b = List.pairwise xs |> List.map (fun (x,y) -> [x;y])
+    member _.windowed_and_pairwise<'a when 'a : equality> (xs : 'a list) =
+        let a = List.windowed 2 xs
+        let b = List.pairwise xs |> List.map (fun (x,y) -> [x;y])
 
-    a = b
-
-[<Fact>]
-let ``windowed 2 is like pairwise`` () =
-    Check.QuickThrowOnFailure windowed_and_pairwise<int>
-    Check.QuickThrowOnFailure windowed_and_pairwise<string>
-    Check.QuickThrowOnFailure windowed_and_pairwise<NormalFloat>
-
-[<Fact>]
-let ``chunkBySize produces chunks exactly of size `chunkSize`, except the last one, which can be smaller, but not empty``() =
-    let prop (a: _ list) (PositiveInt chunkSize) =   
-        match a |> List.chunkBySize chunkSize |> Seq.toList with
-        | [] -> a = []
-        | h :: [] -> h.Length <= chunkSize
-        | chunks ->
-            let lastChunk = chunks |> List.last
-            let headChunks = chunks |> Seq.take (chunks.Length - 1) |> Seq.toList
-
-            headChunks |> List.forall (List.length >> (=) chunkSize)
-            &&
-            lastChunk <> []
-            &&
-            lastChunk.Length <= chunkSize
-
-    Check.QuickThrowOnFailure prop
-
-let splitInto_and_collect<'a when 'a : equality> (xs : 'a list) count =
-    count > 0 ==> (lazy
-        let a = List.splitInto count xs
-        let b = List.collect id a
-        b = xs)
-
-[<Fact>]
-let ``splitInto is reversable with collect`` () =
-    Check.QuickThrowOnFailure splitInto_and_collect<int>
-    Check.QuickThrowOnFailure splitInto_and_collect<string>
-    Check.QuickThrowOnFailure splitInto_and_collect<NormalFloat>
-
-let splitAt_and_append<'a when 'a : equality> (xs : 'a list) index =
-    (index >= 0 && index <= xs.Length) ==> (lazy
-        let a1,a2 = List.splitAt index xs
-        let b = List.append a1 a2
-        b = xs && a1.Length = index)
-
-[<Fact>]
-let ``splitAt is reversable with append`` () =
-    Check.QuickThrowOnFailure splitAt_and_append<int>
-    Check.QuickThrowOnFailure splitAt_and_append<string>
-    Check.QuickThrowOnFailure splitAt_and_append<NormalFloat>
-
-let indexed_and_zip<'a when 'a : equality> (xs : 'a list) =
-    let a = [0..xs.Length-1]
-    let b = List.indexed xs
-    b = List.zip a xs
-
-[<Fact>]
-let ``indexed is adding correct indexes`` () =
-    Check.QuickThrowOnFailure indexed_and_zip<int>
-    Check.QuickThrowOnFailure indexed_and_zip<string>
-    Check.QuickThrowOnFailure indexed_and_zip<NormalFloat>
-
-let zip_and_zip3<'a when 'a : equality> (xs' : ('a*'a*'a) list) =
-    let xs = List.map (fun (x,y,z) -> x) xs'
-    let xs2 = List.map (fun (x,y,z) -> y) xs'
-    let xs3 = List.map (fun (x,y,z) -> z) xs'
-
-    let a = List.zip3 xs xs2 xs3
-    let b = List.zip (List.zip xs xs2) xs3 |> List.map (fun ((a,b),c) -> a,b,c)
-    a = b
-
-[<Fact>]
-let ``two zips can be used for zip3`` () =
-    Check.QuickThrowOnFailure zip_and_zip3<int>
-    Check.QuickThrowOnFailure zip_and_zip3<string>
-    Check.QuickThrowOnFailure zip_and_zip3<NormalFloat>
-
-let zip_and_unzip<'a when 'a : equality> (xs' : ('a*'a) list) =
-    let xs,xs2 = List.unzip xs'
-    List.zip xs xs2 = xs'
-
-[<Fact>]
-let ``zip and unzip are dual`` () =
-    Check.QuickThrowOnFailure zip_and_unzip<int>
-    Check.QuickThrowOnFailure zip_and_unzip<string>
-    Check.QuickThrowOnFailure zip_and_unzip<NormalFloat>
-
-let zip3_and_unzip3<'a when 'a : equality> (xs' : ('a*'a*'a) list) =
-    let xs,xs2,xs3 = List.unzip3 xs'
-    List.zip3 xs xs2 xs3 = xs'
-
-[<Fact>]
-let ``zip3 and unzip3 are dual`` () =
-    Check.QuickThrowOnFailure zip3_and_unzip3<int>
-    Check.QuickThrowOnFailure zip3_and_unzip3<string>
-    Check.QuickThrowOnFailure zip3_and_unzip3<NormalFloat>
-
-[<Fact>]
-let ``splitInto produces chunks exactly `count` chunks with equal size (+/- 1)``() =
-    let prop (a: _ list) (PositiveInt count') =
-        let count = min a.Length count'
-        match a |> List.splitInto count' |> Seq.toList with
-        | [] -> a = []
-        | h :: [] -> (a.Length = 1 || count = 1) && h = a
-        | chunks ->
-            let lastChunk = chunks |> List.last
-            let lastLength = lastChunk |> List.length
-
-            chunks.Length = count
-            &&
-            chunks |> List.forall (fun c -> List.length c = lastLength || List.length c = lastLength + 1)
-
-    Check.QuickThrowOnFailure prop
-
-let sort_and_sortby (xs : list<float>) (xs2 : list<float>) =
-    let a = List.sortBy id xs |> Seq.toArray 
-    let b = List.sort xs |> Seq.toArray
-    let mutable result = true
-    for i in 0 .. a.Length - 1 do
-        if a.[i] <> b.[i] then
-            if System.Double.IsNaN a.[i] <> System.Double.IsNaN b.[i] then
-                result <- false
-    result 
-
-[<Fact>]
-let ``sort behaves like sortby id`` () =   
-    Check.QuickThrowOnFailure sort_and_sortby
-
-let filter_and_except<'a when 'a : comparison>  (xs : list<'a>) (itemsToExclude : Set<'a>) =
-    let a = List.filter (fun x -> Set.contains x itemsToExclude |> not) xs |> List.distinct
-    let b = List.except itemsToExclude xs
-    a = b
-
-[<Fact>]
-let ``filter and except work similar`` () =   
-    Check.QuickThrowOnFailure filter_and_except<int>
-    Check.QuickThrowOnFailure filter_and_except<string>
-    Check.QuickThrowOnFailure filter_and_except<NormalFloat>    
-
-let filter_and_where<'a when 'a : comparison>  (xs : list<'a>) predicate =
-    let a = List.filter predicate xs
-    let b = List.where predicate xs
-    a = b
-
-[<Fact>]
-let ``filter and where work similar`` () =   
-    Check.QuickThrowOnFailure filter_and_where<int>
-    Check.QuickThrowOnFailure filter_and_where<string>
-    Check.QuickThrowOnFailure filter_and_where<NormalFloat>
-
-let find_and_pick<'a when 'a : comparison>  (xs : list<'a>) predicate =
-    let a = runAndCheckIfAnyError (fun () -> List.find predicate xs)
-    let b = runAndCheckIfAnyError (fun () -> List.pick (fun x -> if predicate x then Some x else None) xs)
-    a = b
-
-[<Fact>]
-let ``pick works like find`` () =   
-    Check.QuickThrowOnFailure find_and_pick<int>
-    Check.QuickThrowOnFailure find_and_pick<string>
-    Check.QuickThrowOnFailure find_and_pick<NormalFloat>
-
-let choose_and_pick<'a when 'a : comparison>  (xs : list<'a>) predicate =
-    let a = runAndCheckIfAnyError (fun () -> List.choose predicate xs |> List.head)
-    let b = runAndCheckIfAnyError (fun () -> List.pick predicate xs)
-    a = b
-
-[<Fact>]
-let ``pick works like choose + head`` () =   
-    Check.QuickThrowOnFailure choose_and_pick<int>
-    Check.QuickThrowOnFailure choose_and_pick<string>
-    Check.QuickThrowOnFailure choose_and_pick<NormalFloat>
-
-let head_and_tail<'a when 'a : comparison>  (xs : list<'a>) =
-    xs <> [] ==> (lazy
-        let h = List.head xs
-        let t = List.tail xs
-        xs = h :: t)
-
-[<Fact>]
-let ``head and tail gives the list`` () =   
-    Check.QuickThrowOnFailure head_and_tail<int>
-    Check.QuickThrowOnFailure head_and_tail<string>
-    Check.QuickThrowOnFailure head_and_tail<NormalFloat>
-
-let tryHead_and_tail<'a when 'a : comparison>  (xs : list<'a>) =
-    match xs with
-    | [] -> List.tryHead xs = None
-    | _ ->
-        let h = (List.tryHead xs).Value
-        let t = List.tail xs
-        xs = h :: t
-
-[<Fact>]
-let ``tryHead and tail gives the list`` () =   
-    Check.QuickThrowOnFailure tryHead_and_tail<int>
-    Check.QuickThrowOnFailure tryHead_and_tail<string>
-    Check.QuickThrowOnFailure tryHead_and_tail<NormalFloat>
-
-let skip_and_take<'a when 'a : comparison>  (xs : list<'a>) (count:NonNegativeInt) =
-    let count = int count
-    if xs <> [] && count <= xs.Length then
-        let s = List.skip count xs
-        let t = List.take count xs
-        xs = t @ s
-    else true
-
-[<Fact>]
-let ``skip and take gives the list`` () =   
-    Check.QuickThrowOnFailure skip_and_take<int>
-    Check.QuickThrowOnFailure skip_and_take<string>
-    Check.QuickThrowOnFailure skip_and_take<NormalFloat>
-
-let truncate_and_take<'a when 'a : comparison>  (xs : list<'a>) (count:NonNegativeInt) =
-    let count = int count
-    if xs <> [] && count <= xs.Length then
-        let a = List.take (min count xs.Length) xs
-        let b = List.truncate count xs
         a = b
-    else true
 
-[<Fact>]
-let ``truncate and take work similar`` () =   
-    Check.QuickThrowOnFailure truncate_and_take<int>
-    Check.QuickThrowOnFailure truncate_and_take<string>
-    Check.QuickThrowOnFailure truncate_and_take<NormalFloat>
+    [<Fact>]
+    member this.``windowed 2 is like pairwise`` () =
+        Check.QuickThrowOnFailure this.windowed_and_pairwise<int>
+        Check.QuickThrowOnFailure this.windowed_and_pairwise<string>
+        Check.QuickThrowOnFailure this.windowed_and_pairwise<NormalFloat>
 
-let skipWhile_and_takeWhile<'a when 'a : comparison>  (xs : list<'a>) f =
-    if xs <> [] then
-        let s = List.skipWhile f xs
-        let t = List.takeWhile f xs
-        xs = t @ s
-    else true
+    [<Fact>]
+    member this.``chunkBySize produces chunks exactly of size `chunkSize`, except the last one, which can be smaller, but not empty``() =
+        let prop (a: _ list) (PositiveInt chunkSize) =   
+            match a |> List.chunkBySize chunkSize |> Seq.toList with
+            | [] -> a = []
+            | h :: [] -> h.Length <= chunkSize
+            | chunks ->
+                let lastChunk = chunks |> List.last
+                let headChunks = chunks |> Seq.take (chunks.Length - 1) |> Seq.toList
 
-[<Fact>]
-let ``skipWhile and takeWhile gives the list`` () =   
-    Check.QuickThrowOnFailure skipWhile_and_takeWhile<int>
-    Check.QuickThrowOnFailure skipWhile_and_takeWhile<string>
-    Check.QuickThrowOnFailure skipWhile_and_takeWhile<NormalFloat>
+                headChunks |> List.forall (List.length >> (=) chunkSize)
+                &&
+                lastChunk <> []
+                &&
+                lastChunk.Length <= chunkSize
 
-let find_and_exists<'a when 'a : comparison>  (xs : list<'a>) f =
-    let a = 
-        try
-            List.find f xs |> ignore
-            true
-        with
-        | _ -> false
-    let b = List.exists f xs
-    a = b
+        Check.QuickThrowOnFailure prop
 
-[<Fact>]
-let ``find and exists work similar`` () =   
-    Check.QuickThrowOnFailure find_and_exists<int>
-    Check.QuickThrowOnFailure find_and_exists<string>
-    Check.QuickThrowOnFailure find_and_exists<NormalFloat>
+    member _.splitInto_and_collect<'a when 'a : equality> (xs : 'a list) count =
+        count > 0 ==> (lazy
+            let a = List.splitInto count xs
+            let b = List.collect id a
+            b = xs)
 
-let exists_and_forall<'a when 'a : comparison>  (xs : list<'a>) (F (_, predicate)) =
-    let a = List.forall (predicate >> not) xs
-    let b = List.exists predicate xs
-    a = not b
+    [<Fact>]
+    member  this.``splitInto is reversable with collect`` () =
+        Check.QuickThrowOnFailure this.splitInto_and_collect<int>
+        Check.QuickThrowOnFailure this.splitInto_and_collect<string>
+        Check.QuickThrowOnFailure this.splitInto_and_collect<NormalFloat>
 
-[<Fact>]
-let ``exists and forall are dual`` () =   
-    Check.QuickThrowOnFailure exists_and_forall<int>
-    Check.QuickThrowOnFailure exists_and_forall<string>
-    Check.QuickThrowOnFailure exists_and_forall<NormalFloat>
+    member _.splitAt_and_append<'a when 'a : equality> (xs : 'a list) index =
+        (index >= 0 && index <= xs.Length) ==> (lazy
+            let a1,a2 = List.splitAt index xs
+            let b = List.append a1 a2
+            b = xs && a1.Length = index)
 
-let head_and_isEmpty<'a when 'a : comparison>  (xs : list<'a>) =
-    let a = 
-        try
-            List.head xs |> ignore
-            true
-        with
-        | _ -> false
-    let b = List.isEmpty xs
+    [<Fact>]
+    member this.``splitAt is reversable with append`` () =
+        Check.QuickThrowOnFailure this.splitAt_and_append<int>
+        Check.QuickThrowOnFailure this.splitAt_and_append<string>
+        Check.QuickThrowOnFailure this.splitAt_and_append<NormalFloat>
 
-    a = not b
+    member _.indexed_and_zip<'a when 'a : equality> (xs : 'a list) =
+        let a = [0..xs.Length-1]
+        let b = List.indexed xs
+        b = List.zip a xs
 
-[<Fact>]
-let ``head fails when list isEmpty`` () =   
-    Check.QuickThrowOnFailure head_and_isEmpty<int>
-    Check.QuickThrowOnFailure head_and_isEmpty<string>
-    Check.QuickThrowOnFailure head_and_isEmpty<NormalFloat>
+    [<Fact>]
+    member this.``indexed is adding correct indexes`` () =
+        Check.QuickThrowOnFailure this.indexed_and_zip<int>
+        Check.QuickThrowOnFailure this.indexed_and_zip<string>
+        Check.QuickThrowOnFailure this.indexed_and_zip<NormalFloat>
 
-let head_and_last<'a when 'a : comparison>  (xs : list<'a>) =
-    let a = run (fun () -> xs |> List.rev |> List.last)
-    let b = run (fun () -> List.head xs)
+    member _.zip_and_zip3<'a when 'a : equality> (xs' : ('a*'a*'a) list) =
+        let xs = List.map (fun (x,y,z) -> x) xs'
+        let xs2 = List.map (fun (x,y,z) -> y) xs'
+        let xs3 = List.map (fun (x,y,z) -> z) xs'
 
-    a = b
+        let a = List.zip3 xs xs2 xs3
+        let b = List.zip (List.zip xs xs2) xs3 |> List.map (fun ((a,b),c) -> a,b,c)
+        a = b
 
-[<Fact>]
-let ``head is the same as last of a reversed list`` () =   
-    Check.QuickThrowOnFailure head_and_last<int>
-    Check.QuickThrowOnFailure head_and_last<string>
-    Check.QuickThrowOnFailure head_and_last<NormalFloat>
+    [<Fact>]
+    member this.``two zips can be used for zip3`` () =
+        Check.QuickThrowOnFailure this.zip_and_zip3<int>
+        Check.QuickThrowOnFailure this.zip_and_zip3<string>
+        Check.QuickThrowOnFailure this.zip_and_zip3<NormalFloat>
 
-let head_and_item<'a when 'a : comparison>  (xs : list<'a>) =
-    let a = runAndCheckErrorType (fun () -> xs |> List.item 0)
-    let b = runAndCheckErrorType (fun () -> List.head xs)
+    member _.zip_and_unzip<'a when 'a : equality> (xs' : ('a*'a) list) =
+        let xs,xs2 = List.unzip xs'
+        List.zip xs xs2 = xs'
 
-    a = b
+    [<Fact>]
+    member this.``zip and unzip are dual`` () =
+        Check.QuickThrowOnFailure this.zip_and_unzip<int>
+        Check.QuickThrowOnFailure this.zip_and_unzip<string>
+        Check.QuickThrowOnFailure this.zip_and_unzip<NormalFloat>
 
-[<Fact>]
-let ``head is the same as item 0`` () =   
-    Check.QuickThrowOnFailure head_and_item<int>
-    Check.QuickThrowOnFailure head_and_item<string>
-    Check.QuickThrowOnFailure head_and_item<NormalFloat>
+    member _.zip3_and_unzip3<'a when 'a : equality> (xs' : ('a*'a*'a) list) =
+        let xs,xs2,xs3 = List.unzip3 xs'
+        List.zip3 xs xs2 xs3 = xs'
 
-let item_and_tryItem<'a when 'a : comparison>  (xs : list<'a>) pos =
-    let a = runAndCheckErrorType (fun () -> xs |> List.item pos)
-    let b = List.tryItem pos xs
+    [<Fact>]
+    member this.``zip3 and unzip3 are dual`` () =
+        Check.QuickThrowOnFailure this.zip3_and_unzip3<int>
+        Check.QuickThrowOnFailure this.zip3_and_unzip3<string>
+        Check.QuickThrowOnFailure this.zip3_and_unzip3<NormalFloat>
 
-    match a with
-    | Success a -> b.Value = a
-    | _ -> b = None
+    [<Fact>]
+    member _.``splitInto produces chunks exactly `count` chunks with equal size (+/- 1)``() =
+        let prop (a: _ list) (PositiveInt count') =
+            let count = min a.Length count'
+            match a |> List.splitInto count' |> Seq.toList with
+            | [] -> a = []
+            | h :: [] -> (a.Length = 1 || count = 1) && h = a
+            | chunks ->
+                let lastChunk = chunks |> List.last
+                let lastLength = lastChunk |> List.length
 
-[<Fact>]
-let ``tryItem is safe item`` () =   
-    Check.QuickThrowOnFailure item_and_tryItem<int>
-    Check.QuickThrowOnFailure item_and_tryItem<string>
-    Check.QuickThrowOnFailure item_and_tryItem<NormalFloat>
+                chunks.Length = count
+                &&
+                chunks |> List.forall (fun c -> List.length c = lastLength || List.length c = lastLength + 1)
 
-let pick_and_tryPick<'a when 'a : comparison>  (xs : list<'a>) f =
-    let a = runAndCheckErrorType (fun () -> xs |> List.pick f)
-    let b = List.tryPick f xs
+        Check.QuickThrowOnFailure prop
 
-    match a with
-    | Success a -> b.Value = a
-    | _ -> b = None
+    member _.sort_and_sortby (xs : list<float>) (xs2 : list<float>) =
+        let a = List.sortBy id xs |> Seq.toArray 
+        let b = List.sort xs |> Seq.toArray
+        let mutable result = true
+        for i in 0 .. a.Length - 1 do
+            if a.[i] <> b.[i] then
+                if System.Double.IsNaN a.[i] <> System.Double.IsNaN b.[i] then
+                    result <- false
+        result 
 
-[<Fact>]
-let ``tryPick is safe pick`` () =   
-    Check.QuickThrowOnFailure pick_and_tryPick<int>
-    Check.QuickThrowOnFailure pick_and_tryPick<string>
-    Check.QuickThrowOnFailure pick_and_tryPick<NormalFloat>
+    [<Fact>]
+    member this.``sort behaves like sortby id`` () =   
+        Check.QuickThrowOnFailure this.sort_and_sortby
 
-let last_and_tryLast<'a when 'a : comparison>  (xs : list<'a>) =
-    let a = runAndCheckErrorType (fun () -> xs |> List.last)
-    let b = List.tryLast xs
+    member _. filter_and_except<'a when 'a : comparison>  (xs : list<'a>) (itemsToExclude : Set<'a>) =
+        let a = List.filter (fun x -> Set.contains x itemsToExclude |> not) xs |> List.distinct
+        let b = List.except itemsToExclude xs
+        a = b
 
-    match a with
-    | Success a -> b.Value = a
-    | _ -> b = None
+    [<Fact>]
+    member this.``filter and except work similar`` () =   
+        Check.QuickThrowOnFailure this.filter_and_except<int>
+        Check.QuickThrowOnFailure this.filter_and_except<string>
+        Check.QuickThrowOnFailure this.filter_and_except<NormalFloat>    
 
-[<Fact>]
-let ``tryLast is safe last`` () =   
-    Check.QuickThrowOnFailure last_and_tryLast<int>
-    Check.QuickThrowOnFailure last_and_tryLast<string>
-    Check.QuickThrowOnFailure last_and_tryLast<NormalFloat>
+    member _.filter_and_where<'a when 'a : comparison>  (xs : list<'a>) predicate =
+        let a = List.filter predicate xs
+        let b = List.where predicate xs
+        a = b
 
-let length_and_isEmpty<'a when 'a : comparison>  (xs : list<'a>) =
-    let a = List.length xs = 0
-    let b = List.isEmpty xs
+    [<Fact>]
+    member this.``filter and where work similar`` () =   
+        Check.QuickThrowOnFailure this.filter_and_where<int>
+        Check.QuickThrowOnFailure this.filter_and_where<string>
+        Check.QuickThrowOnFailure this.filter_and_where<NormalFloat>
 
-    a = b
+    member _.find_and_pick<'a when 'a : comparison>  (xs : list<'a>) predicate =
+        let a = runAndCheckIfAnyError (fun () -> List.find predicate xs)
+        let b = runAndCheckIfAnyError (fun () -> List.pick (fun x -> if predicate x then Some x else None) xs)
+        a = b
 
-[<Fact>]
-let ``list isEmpty if and only if length is 0`` () =   
-    Check.QuickThrowOnFailure length_and_isEmpty<int>
-    Check.QuickThrowOnFailure length_and_isEmpty<string>
-    Check.QuickThrowOnFailure length_and_isEmpty<NormalFloat>
+    [<Fact>]
+    member this.``pick works like find`` () =   
+        Check.QuickThrowOnFailure this.find_and_pick<int>
+        Check.QuickThrowOnFailure this.find_and_pick<string>
+        Check.QuickThrowOnFailure this.find_and_pick<NormalFloat>
 
-let min_and_max (xs : list<int>) =
-    let a = run (fun () -> List.min xs)
-    let b = run (fun () -> xs |> List.map ((*) -1) |> List.max |> fun x -> -x)
+    member _.choose_and_pick<'a when 'a : comparison>  (xs : list<'a>) predicate =
+        let a = runAndCheckIfAnyError (fun () -> List.choose predicate xs |> List.head)
+        let b = runAndCheckIfAnyError (fun () -> List.pick predicate xs)
+        a = b
 
-    a = b
+    [<Fact>]
+    member this.``pick works like choose + head`` () =   
+        Check.QuickThrowOnFailure this.choose_and_pick<int>
+        Check.QuickThrowOnFailure this.choose_and_pick<string>
+        Check.QuickThrowOnFailure this.choose_and_pick<NormalFloat>
 
-[<Fact>]
-let ``min is opposite of max`` () =   
-    Check.QuickThrowOnFailure min_and_max
+    member _.head_and_tail<'a when 'a : comparison>  (xs : list<'a>) =
+        xs <> [] ==> (lazy
+            let h = List.head xs
+            let t = List.tail xs
+            xs = h :: t)
 
-let minBy_and_maxBy (xs : list<int>) f =
-    let a = run (fun () -> List.minBy f xs)
-    let b = run (fun () -> xs |> List.map ((*) -1) |> List.maxBy f |> fun x -> -x)
+    [<Fact>]
+    member this.``head and tail gives the list`` () =   
+        Check.QuickThrowOnFailure this.head_and_tail<int>
+        Check.QuickThrowOnFailure this.head_and_tail<string>
+        Check.QuickThrowOnFailure this.head_and_tail<NormalFloat>
 
-    a = b
+    member _.tryHead_and_tail<'a when 'a : comparison>  (xs : list<'a>) =
+        match xs with
+        | [] -> List.tryHead xs = None
+        | _ ->
+            let h = (List.tryHead xs).Value
+            let t = List.tail xs
+            xs = h :: t
 
-[<Fact>]
-let ``minBy is opposite of maxBy`` () =   
-    Check.QuickThrowOnFailure minBy_and_maxBy
+    [<Fact>]
+    member this.``tryHead and tail gives the list`` () =   
+        Check.QuickThrowOnFailure this.tryHead_and_tail<int>
+        Check.QuickThrowOnFailure this.tryHead_and_tail<string>
+        Check.QuickThrowOnFailure this.tryHead_and_tail<NormalFloat>
 
-let minBy_and_min (xs : list<int>) =
-    let a = run (fun () -> List.minBy id xs)
-    let b = run (fun () -> xs |> List.min)
+    member _.skip_and_take<'a when 'a : comparison>  (xs : list<'a>) (count:NonNegativeInt) =
+        let count = int count
+        if xs <> [] && count <= xs.Length then
+            let s = List.skip count xs
+            let t = List.take count xs
+            xs = t @ s
+        else true
 
-    a = b
+    [<Fact>]
+    member this.``skip and take gives the list`` () =   
+        Check.QuickThrowOnFailure this.skip_and_take<int>
+        Check.QuickThrowOnFailure this.skip_and_take<string>
+        Check.QuickThrowOnFailure this.skip_and_take<NormalFloat>
 
-[<Fact>]
-let ``minBy id is same as min`` () =   
-    Check.QuickThrowOnFailure minBy_and_min
+    member _.truncate_and_take<'a when 'a : comparison>  (xs : list<'a>) (count:NonNegativeInt) =
+        let count = int count
+        if xs <> [] && count <= xs.Length then
+            let a = List.take (min count xs.Length) xs
+            let b = List.truncate count xs
+            a = b
+        else true
 
-let min_and_sort<'a when 'a : comparison>  (xs : list<'a>) =
-    let a = runAndCheckErrorType (fun () -> List.min xs)
-    let b = runAndCheckErrorType (fun () -> xs |> List.sort |> List.head)
+    [<Fact>]
+    member this.``truncate and take work similar`` () =   
+        Check.QuickThrowOnFailure this.truncate_and_take<int>
+        Check.QuickThrowOnFailure this.truncate_and_take<string>
+        Check.QuickThrowOnFailure this.truncate_and_take<NormalFloat>
 
-    a = b
+    member this.skipWhile_and_takeWhile<'a when 'a : comparison>  (xs : list<'a>) f =
+        if xs <> [] then
+            let s = List.skipWhile f xs
+            let t = List.takeWhile f xs
+            xs = t @ s
+        else true
 
-[<Fact>]
-let ``head element after sort is min element`` () =   
-    Check.QuickThrowOnFailure min_and_sort<int>
-    Check.QuickThrowOnFailure min_and_sort<string>
-    Check.QuickThrowOnFailure min_and_sort<NormalFloat>
+    [<Fact>]
+    member this.``skipWhile and takeWhile gives the list`` () =   
+        Check.QuickThrowOnFailure this.skipWhile_and_takeWhile<int>
+        Check.QuickThrowOnFailure this.skipWhile_and_takeWhile<string>
+        Check.QuickThrowOnFailure this.skipWhile_and_takeWhile<NormalFloat>
 
-let pairwise<'a when 'a : comparison>  (xs : list<'a>) =
-    let xs' = List.pairwise xs 
-    let f = xs' |> List.map fst
-    let s = xs' |> List.map snd
-    let a = List.length xs'
-    let b = List.length xs
+    member this.find_and_exists<'a when 'a : comparison>  (xs : list<'a>) f =
+        let a = 
+            try
+                List.find f xs |> ignore
+                true
+            with
+            | _ -> false
+        let b = List.exists f xs
+        a = b
 
-    if xs = [] then 
-        xs' = []
-    else 
-        a = b - 1 &&
-          f = (xs |> List.rev |> List.tail |> List.rev) && // all elements but last one
-          s = (xs |> List.tail) // all elements but first one
+    [<Fact>]
+    member this.``find and exists work similar`` () =   
+        Check.QuickThrowOnFailure this.find_and_exists<int>
+        Check.QuickThrowOnFailure this.find_and_exists<string>
+        Check.QuickThrowOnFailure this.find_and_exists<NormalFloat>
 
-[<Fact>]
-let ``pairwise works as expected`` () =   
-    Check.QuickThrowOnFailure pairwise<int>
-    Check.QuickThrowOnFailure pairwise<string>
-    Check.QuickThrowOnFailure pairwise<NormalFloat>
+    member _.exists_and_forall<'a when 'a : comparison>  (xs : list<'a>) (F (_, predicate)) =
+        let a = List.forall (predicate >> not) xs
+        let b = List.exists predicate xs
+        a = not b
 
-let permute<'a when 'a : comparison>  (xs' : list<int*'a>) =
-    let xs = List.map snd xs'
+    [<Fact>]
+    member this.``exists and forall are dual`` () =   
+        Check.QuickThrowOnFailure this.exists_and_forall<int>
+        Check.QuickThrowOnFailure this.exists_and_forall<string>
+        Check.QuickThrowOnFailure this.exists_and_forall<NormalFloat>
+
+    member _.head_and_isEmpty<'a when 'a : comparison>  (xs : list<'a>) =
+        let a = 
+            try
+                List.head xs |> ignore
+                true
+            with
+            | _ -> false
+        let b = List.isEmpty xs
+
+        a = not b
+
+    [<Fact>]
+    member this.``head fails when list isEmpty`` () =   
+        Check.QuickThrowOnFailure this.head_and_isEmpty<int>
+        Check.QuickThrowOnFailure this.head_and_isEmpty<string>
+        Check.QuickThrowOnFailure this.head_and_isEmpty<NormalFloat>
+
+    member _.head_and_last<'a when 'a : comparison>  (xs : list<'a>) =
+        let a = run (fun () -> xs |> List.rev |> List.last)
+        let b = run (fun () -> List.head xs)
+        a = b
+
+    [<Fact>]
+    member this.``head is the same as last of a reversed list`` () =   
+        Check.QuickThrowOnFailure this.head_and_last<int>
+        Check.QuickThrowOnFailure this.head_and_last<string>
+        Check.QuickThrowOnFailure this.head_and_last<NormalFloat>
+
+    member _.head_and_item<'a when 'a : comparison>  (xs : list<'a>) =
+        let a = runAndCheckErrorType (fun () -> xs |> List.item 0)
+        let b = runAndCheckErrorType (fun () -> List.head xs)
+
+        a = b
+
+    [<Fact>]
+    member this.``head is the same as item 0`` () =   
+        Check.QuickThrowOnFailure this.head_and_item<int>
+        Check.QuickThrowOnFailure this.head_and_item<string>
+        Check.QuickThrowOnFailure this.head_and_item<NormalFloat>
+
+    member _.item_and_tryItem<'a when 'a : comparison>  (xs : list<'a>) pos =
+        let a = runAndCheckErrorType (fun () -> xs |> List.item pos)
+        let b = List.tryItem pos xs
+
+        match a with
+        | Success a -> b.Value = a
+        | _ -> b = None
+
+    [<Fact>]
+    member this.``tryItem is safe item`` () =   
+        Check.QuickThrowOnFailure this.item_and_tryItem<int>
+        Check.QuickThrowOnFailure this.item_and_tryItem<string>
+        Check.QuickThrowOnFailure this.item_and_tryItem<NormalFloat>
+
+    member _.pick_and_tryPick<'a when 'a : comparison>  (xs : list<'a>) f =
+        let a = runAndCheckErrorType (fun () -> xs |> List.pick f)
+        let b = List.tryPick f xs
+
+        match a with
+        | Success a -> b.Value = a
+        | _ -> b = None
+
+    [<Fact>]
+    member this.``tryPick is safe pick`` () =   
+        Check.QuickThrowOnFailure this.pick_and_tryPick<int>
+        Check.QuickThrowOnFailure this.pick_and_tryPick<string>
+        Check.QuickThrowOnFailure this.pick_and_tryPick<NormalFloat>
+
+    member _.last_and_tryLast<'a when 'a : comparison>  (xs : list<'a>) =
+        let a = runAndCheckErrorType (fun () -> xs |> List.last)
+        let b = List.tryLast xs
+
+        match a with
+        | Success a -> b.Value = a
+        | _ -> b = None
+
+    [<Fact>]
+    member this.``tryLast is safe last`` () =   
+        Check.QuickThrowOnFailure this.last_and_tryLast<int>
+        Check.QuickThrowOnFailure this.last_and_tryLast<string>
+        Check.QuickThrowOnFailure this.last_and_tryLast<NormalFloat>
+
+    member _.length_and_isEmpty<'a when 'a : comparison>  (xs : list<'a>) =
+        let a = List.length xs = 0
+        let b = List.isEmpty xs
+
+        a = b
+
+    [<Fact>]
+    member this.``list isEmpty if and only if length is 0`` () =   
+        Check.QuickThrowOnFailure this.length_and_isEmpty<int>
+        Check.QuickThrowOnFailure this.length_and_isEmpty<string>
+        Check.QuickThrowOnFailure this.length_and_isEmpty<NormalFloat>
+
+    member _.min_and_max (xs : list<int>) =
+        let a = run (fun () -> List.min xs)
+        let b = run (fun () -> xs |> List.map ((*) -1) |> List.max |> fun x -> -x)
+
+        a = b
+
+    [<Fact>]
+    member this.``min is opposite of max`` () =   
+        Check.QuickThrowOnFailure this.min_and_max
+
+    member _.minBy_and_maxBy (xs : list<int>) f =
+        let a = run (fun () -> List.minBy f xs)
+        let b = run (fun () -> xs |> List.map ((*) -1) |> List.maxBy f |> fun x -> -x)
+
+        a = b
+
+    [<Fact>]
+    member this.``minBy is opposite of maxBy`` () =   
+        Check.QuickThrowOnFailure this.minBy_and_maxBy
+
+    member _.minBy_and_min (xs : list<int>) =
+        let a = run (fun () -> List.minBy id xs)
+        let b = run (fun () -> xs |> List.min)
+
+        a = b
+
+    [<Fact>]
+    member this.``minBy id is same as min`` () =   
+        Check.QuickThrowOnFailure this.minBy_and_min
+
+    member _.min_and_sort<'a when 'a : comparison>  (xs : list<'a>) =
+        let a = runAndCheckErrorType (fun () -> List.min xs)
+        let b = runAndCheckErrorType (fun () -> xs |> List.sort |> List.head)
+
+        a = b
+
+    [<Fact>]
+    member this.``head element after sort is min element`` () =   
+        Check.QuickThrowOnFailure this.min_and_sort<int>
+        Check.QuickThrowOnFailure this.min_and_sort<string>
+        Check.QuickThrowOnFailure this.min_and_sort<NormalFloat>
+
+    member _.pairwise<'a when 'a : comparison>  (xs : list<'a>) =
+        let xs' = List.pairwise xs 
+        let f = xs' |> List.map fst
+        let s = xs' |> List.map snd
+        let a = List.length xs'
+        let b = List.length xs
+
+        if xs = [] then 
+            xs' = []
+        else 
+            a = b - 1 &&
+              f = (xs |> List.rev |> List.tail |> List.rev) && // all elements but last one
+              s = (xs |> List.tail) // all elements but first one
+
+    [<Fact>]
+    member this.``pairwise works as expected`` () =   
+        Check.QuickThrowOnFailure this.pairwise<int>
+        Check.QuickThrowOnFailure this.pairwise<string>
+        Check.QuickThrowOnFailure this.pairwise<NormalFloat>
+
+    member _.permute<'a when 'a : comparison>  (xs' : list<int*'a>) =
+        let xs = List.map snd xs'
  
-    let permutations = 
-        List.map fst xs'
-        |> List.indexed
-        |> List.sortBy snd
-        |> List.map fst
-        |> List.indexed
-        |> dict
+        let permutations = 
+            List.map fst xs'
+            |> List.indexed
+            |> List.sortBy snd
+            |> List.map fst
+            |> List.indexed
+            |> dict
 
-    let permutation x = permutations.[x]
-
-
-    match run (fun () -> xs |> List.indexed |> List.permute permutation) with
-    | Success s ->         
-        let originals = s |> List.map fst
-        let rs = s |> List.map snd
-        for o in originals do
-            let x' = xs |> List.item o
-            let x = rs |> List.item (permutation o)
-            Assert.AreEqual(x',x)
-        true
-    | _ -> true
-
-[<Fact>]
-let ``permute works as expected`` () =   
-    Check.QuickThrowOnFailure permute<int>
-    Check.QuickThrowOnFailure permute<string>
-    Check.QuickThrowOnFailure permute<NormalFloat>
-
-let mapi_and_map<'a when 'a : comparison>  (xs : list<'a>) f =
-    let indices = System.Collections.Generic.List<int>()
-    let f' i x =
-        indices.Add i
-        f x
-    let a = List.map f xs
-    let b = List.mapi f' xs
-
-    a = b && (Seq.toList indices = [0..xs.Length-1])
-
-[<Fact>]
-let ``mapi behaves like map with correct order`` () =   
-    Check.QuickThrowOnFailure mapi_and_map<int>
-    Check.QuickThrowOnFailure mapi_and_map<string>
-    Check.QuickThrowOnFailure mapi_and_map<NormalFloat>
-
-let reduce_and_fold<'a when 'a : comparison> (xs : list<'a>) seed (F (_, f)) =
-    match xs with
-    | [] -> List.fold f seed xs = seed
-    | _ ->
-        let ar = xs |> List.fold f seed
-        let br = seed :: xs  |> List.reduce f
-        ar = br
-
-[<Fact>]
-let ``reduce works like fold with given seed`` () =
-    Check.QuickThrowOnFailure reduce_and_fold<int>
-    Check.QuickThrowOnFailure reduce_and_fold<string>
-    Check.QuickThrowOnFailure reduce_and_fold<NormalFloat>
-
-let scan_and_fold<'a when 'a : comparison> (xs : list<'a>) seed (F (_, f)) =
-    let ar : 'a list = List.scan f seed xs
-    let f' (l,c) x =
-        let c' = f c x
-        c'::l,c'
-
-    let br,_ = List.fold f' ([seed],seed) xs
-    ar = List.rev br
+        let permutation x = permutations.[x]
 
 
-[<Fact>]
-let ``scan works like fold but returns intermediate values`` () =
-    Check.QuickThrowOnFailure scan_and_fold<int>
-    Check.QuickThrowOnFailure scan_and_fold<string>
-    Check.QuickThrowOnFailure scan_and_fold<NormalFloat>
-
-let scanBack_and_foldBack<'a when 'a : comparison> (xs : list<'a>) seed (F (_, f)) =
-    let ar : 'a list = List.scanBack f xs seed
-    let f' x (l,c) =
-        let c' = f x c
-        c'::l,c'
-
-    let br,_ = List.foldBack f' xs ([seed],seed)
-    ar = br
-
-
-[<Fact>]
-let ``scanBack works like foldBack but returns intermediate values`` () =
-    Check.QuickThrowOnFailure scanBack_and_foldBack<int>
-    Check.QuickThrowOnFailure scanBack_and_foldBack<string>
-    Check.QuickThrowOnFailure scanBack_and_foldBack<NormalFloat>
-
-let reduceBack_and_foldBack<'a when 'a : comparison> (xs : list<'a>) seed (F (_, f)) =
-    match xs with
-    | [] -> List.foldBack f xs seed = seed
-    | _ ->
-        let ar = List.foldBack f xs seed
-        let br = List.reduceBack f (xs @ [seed])
-        ar = br
-
-[<Fact>]
-let ``reduceBack works like foldBack with given seed`` () =
-    Check.QuickThrowOnFailure reduceBack_and_foldBack<int>
-    Check.QuickThrowOnFailure reduceBack_and_foldBack<string>
-    Check.QuickThrowOnFailure reduceBack_and_foldBack<NormalFloat>
-
-let replicate<'a when 'a : comparison> (x:'a) (count:NonNegativeInt) =
-    let count = int count
-    let xs = List.replicate count x
-    xs.Length = count && List.forall ((=) x) xs
-
-[<Fact>]
-let ``replicate creates n instances of the given element`` () =
-    Check.QuickThrowOnFailure replicate<int>
-    Check.QuickThrowOnFailure replicate<string>
-    Check.QuickThrowOnFailure replicate<NormalFloat>
-
-let singleton_and_replicate<'a when 'a : comparison> (x:'a) (count:NonNegativeInt) =
-    let count = int count
-    let xs = List.replicate count x
-    let ys = [for i in 1..count -> List.singleton x] |> List.concat
-    xs = ys
-
-[<Fact>]
-let ``singleton can be used to replicate`` () =
-    Check.QuickThrowOnFailure singleton_and_replicate<int>
-    Check.QuickThrowOnFailure singleton_and_replicate<string>
-    Check.QuickThrowOnFailure singleton_and_replicate<NormalFloat>
-
-let mapFold_and_map_and_fold<'a when 'a : comparison> (xs : list<'a>) mapF foldF start =
-    let f s x = 
-        let x' = mapF x
-        let s' = foldF s x'
-        x',s'
-
-    let a,ar = xs |> List.mapFold f start
-    let b = xs |> List.map mapF 
-    let br = b |> List.fold foldF start
-    a = b && ar = br
-
-[<Fact>]
-let ``mapFold works like map + fold`` () =   
-    Check.QuickThrowOnFailure mapFold_and_map_and_fold<int>
-    Check.QuickThrowOnFailure mapFold_and_map_and_fold<string>
-    Check.QuickThrowOnFailure mapFold_and_map_and_fold<NormalFloat>
-
-let mapFoldBack_and_map_and_foldBack<'a when 'a : comparison> (xs : list<'a>) mapF foldF start =
-    let f x s = 
-        let x' = mapF x
-        let s' = foldF x' s
-        x',s'
-
-    let a,ar = List.mapFoldBack f xs start
-    let b = xs |> List.map mapF 
-    let br = List.foldBack foldF b start
-    a = b && ar = br
-
-[<Fact>]
-let ``mapFoldBack works like map + foldBack`` () =   
-    Check.QuickThrowOnFailure mapFoldBack_and_map_and_foldBack<int>
-    Check.QuickThrowOnFailure mapFoldBack_and_map_and_foldBack<string>
-    Check.QuickThrowOnFailure mapFoldBack_and_map_and_foldBack<NormalFloat>
-
-let findBack_and_exists<'a when 'a : comparison>  (xs : list<'a>) f =
-    let a = 
-        try
-            List.findBack f xs |> ignore
+        match run (fun () -> xs |> List.indexed |> List.permute permutation) with
+        | Success s ->         
+            let originals = s |> List.map fst
+            let rs = s |> List.map snd
+            for o in originals do
+                let x' = xs |> List.item o
+                let x = rs |> List.item (permutation o)
+                Assert.AreEqual(x',x)
             true
-        with
-        | _ -> false
-    let b = List.exists f xs
-    a = b
+        | _ -> true
 
-[<Fact>]
-let ``findBack and exists work similar`` () =   
-    Check.QuickThrowOnFailure findBack_and_exists<int>
-    Check.QuickThrowOnFailure findBack_and_exists<string>
-    Check.QuickThrowOnFailure findBack_and_exists<NormalFloat>
+    [<Fact>]
+    member this.``permute works as expected`` () =   
+        Check.QuickThrowOnFailure this.permute<int>
+        Check.QuickThrowOnFailure this.permute<string>
+        Check.QuickThrowOnFailure this.permute<NormalFloat>
 
-let findBack_and_find<'a when 'a : comparison>  (xs : list<'a>) predicate =
-    let a = run (fun () -> xs |> List.findBack predicate)
-    let b = run (fun () -> xs |> List.rev |> List.find predicate)
-    a = b
+    member _.mapi_and_map<'a when 'a : comparison>  (xs : list<'a>) f =
+        let indices = System.Collections.Generic.List<int>()
+        let f' i x =
+            indices.Add i
+            f x
+        let a = List.map f xs
+        let b = List.mapi f' xs
 
-[<Fact>]
-let ``findBack and find work in reverse`` () =   
-    Check.QuickThrowOnFailure findBack_and_find<int>
-    Check.QuickThrowOnFailure findBack_and_find<string>
-    Check.QuickThrowOnFailure findBack_and_find<NormalFloat>
+        a = b && (Seq.toList indices = [0..xs.Length-1])
 
-let tryFindBack_and_tryFind<'a when 'a : comparison>  (xs : list<'a>) predicate =
-    let a = xs |> List.tryFindBack predicate
-    let b = xs |> List.rev |> List.tryFind predicate
-    a = b
+    [<Fact>]
+    member this.``mapi behaves like map with correct order`` () =   
+        Check.QuickThrowOnFailure this.mapi_and_map<int>
+        Check.QuickThrowOnFailure this.mapi_and_map<string>
+        Check.QuickThrowOnFailure this.mapi_and_map<NormalFloat>
 
-[<Fact>]
-let ``tryFindBack and tryFind work in reverse`` () =   
-    Check.QuickThrowOnFailure tryFindBack_and_tryFind<int>
-    Check.QuickThrowOnFailure tryFindBack_and_tryFind<string>
-    Check.QuickThrowOnFailure tryFindBack_and_tryFind<NormalFloat>
+    member _.reduce_and_fold<'a when 'a : comparison> (xs : list<'a>) seed (F (_, f)) =
+        match xs with
+        | [] -> List.fold f seed xs = seed
+        | _ ->
+            let ar = xs |> List.fold f seed
+            let br = seed :: xs  |> List.reduce f
+            ar = br
 
-let tryFindIndexBack_and_tryFindIndex<'a when 'a : comparison>  (xs : list<'a>) predicate =
-    let a = xs |> List.tryFindIndexBack predicate
-    let b = xs |> List.rev |> List.tryFindIndex predicate
-    match a,b with
-    | Some a, Some b -> a = (xs.Length - b - 1)
-    | _ -> a = b
+    [<Fact>]
+    member this.``reduce works like fold with given seed`` () =
+        Check.QuickThrowOnFailure this.reduce_and_fold<int>
+        Check.QuickThrowOnFailure this.reduce_and_fold<string>
+        Check.QuickThrowOnFailure this.reduce_and_fold<NormalFloat>
 
-[<Fact>]
-let ``tryFindIndexBack and tryIndexFind work in reverse`` () =   
-    Check.QuickThrowOnFailure tryFindIndexBack_and_tryFindIndex<int>
-    Check.QuickThrowOnFailure tryFindIndexBack_and_tryFindIndex<string>
-    Check.QuickThrowOnFailure tryFindIndexBack_and_tryFindIndex<NormalFloat>
+    member _.scan_and_fold<'a when 'a : comparison> (xs : list<'a>) seed (F (_, f)) =
+        let ar : 'a list = List.scan f seed xs
+        let f' (l,c) x =
+            let c' = f c x
+            c'::l,c'
 
-let rev<'a when 'a : comparison>  (xs : list<'a>) =
-    let list = System.Collections.Generic.List<_>()
-    for x in xs do
-        list.Insert(0,x)
+        let br,_ = List.fold f' ([seed],seed) xs
+        ar = List.rev br
 
-    xs |> List.rev |> List.rev = xs && Seq.toList list = List.rev xs
+    [<Fact>]
+    member this.``scan works like fold but returns intermediate values`` () =
+        Check.QuickThrowOnFailure this.scan_and_fold<int>
+        Check.QuickThrowOnFailure this.scan_and_fold<string>
+        Check.QuickThrowOnFailure this.scan_and_fold<NormalFloat>
 
-[<Fact>]
-let ``rev reverses a list`` () =   
-    Check.QuickThrowOnFailure rev<int>
-    Check.QuickThrowOnFailure rev<string>
-    Check.QuickThrowOnFailure rev<NormalFloat>
+    member _.scanBack_and_foldBack<'a when 'a : comparison> (xs : list<'a>) seed (F (_, f)) =
+        let ar : 'a list = List.scanBack f xs seed
+        let f' x (l,c) =
+            let c' = f x c
+            c'::l,c'
 
-let findIndexBack_and_findIndex<'a when 'a : comparison>  (xs : list<'a>) (F (_, predicate)) =
-    let a = run (fun () -> xs |> List.findIndex predicate)
-    let b = run (fun () -> xs |> List.rev |> List.findIndexBack predicate)
-    match a,b with
-    | Success a, Success b -> a = (xs.Length - b - 1)
-    | _ -> a = b
+        let br,_ = List.foldBack f' xs ([seed],seed)
+        ar = br
 
-[<Fact>]
-let ``findIndexBack and findIndex work in reverse`` () =
-    Check.QuickThrowOnFailure findIndexBack_and_findIndex<int>
-    Check.QuickThrowOnFailure findIndexBack_and_findIndex<string>
-    Check.QuickThrowOnFailure findIndexBack_and_findIndex<NormalFloat>
+    [<Fact>]
+    member this.``scanBack works like foldBack but returns intermediate values`` () =
+        Check.QuickThrowOnFailure this.scanBack_and_foldBack<int>
+        Check.QuickThrowOnFailure this.scanBack_and_foldBack<string>
+        Check.QuickThrowOnFailure this.scanBack_and_foldBack<NormalFloat>
 
-let skip_and_skipWhile<'a when 'a : comparison>  (xs : list<'a>) (count:NonNegativeInt) =
-    let count = int count
-    count <= xs.Length ==> (lazy 
-        let ys = List.indexed xs
-        let a = runAndCheckErrorType (fun () -> List.skip count ys)
-        let b = runAndCheckErrorType (fun () -> List.skipWhile (fun (p,_) -> p < count) ys)
+    member _.reduceBack_and_foldBack<'a when 'a : comparison> (xs : list<'a>) seed (F (_, f)) =
+        match xs with
+        | [] -> List.foldBack f xs seed = seed
+        | _ ->
+            let ar = List.foldBack f xs seed
+            let br = List.reduceBack f (xs @ [seed])
+            ar = br
 
-        a = b)
+    [<Fact>]
+    member this.``reduceBack works like foldBack with given seed`` () =
+        Check.QuickThrowOnFailure this.reduceBack_and_foldBack<int>
+        Check.QuickThrowOnFailure this.reduceBack_and_foldBack<string>
+        Check.QuickThrowOnFailure this.reduceBack_and_foldBack<NormalFloat>
 
-[<Fact>]
-let ``skip and skipWhile are consistent`` () =   
-    Check.QuickThrowOnFailure skip_and_skipWhile<int>
-    Check.QuickThrowOnFailure skip_and_skipWhile<string>
-    Check.QuickThrowOnFailure skip_and_skipWhile<NormalFloat>
+    member _.replicate<'a when 'a : comparison> (x:'a) (count:NonNegativeInt) =
+        let count = int count
+        let xs = List.replicate count x
+        xs.Length = count && List.forall ((=) x) xs
 
-let distinct_works_like_set<'a when 'a : comparison> (xs : 'a list) =
-    let a = List.distinct xs
-    let b = Set.ofList xs
+    [<Fact>]
+    member this.``replicate creates n instances of the given element`` () =
+        Check.QuickThrowOnFailure this.replicate<int>
+        Check.QuickThrowOnFailure this.replicate<string>
+        Check.QuickThrowOnFailure this.replicate<NormalFloat>
 
-    let mutable result = (a.Length = b.Count)
-    for x in a do
-        if Set.contains x b |> not then
-            result <- false
+    member _.singleton_and_replicate<'a when 'a : comparison> (x:'a) (count:NonNegativeInt) =
+        let count = int count
+        let xs = List.replicate count x
+        let ys = [for i in 1..count -> List.singleton x] |> List.concat
+        xs = ys
 
-    for x in b do
-        if List.exists ((=) x) a |> not then
-            result <- false
-    result
+    [<Fact>]
+    member this.``singleton can be used to replicate`` () =
+        Check.QuickThrowOnFailure this.singleton_and_replicate<int>
+        Check.QuickThrowOnFailure this.singleton_and_replicate<string>
+        Check.QuickThrowOnFailure this.singleton_and_replicate<NormalFloat>
 
-[<Fact>]
-let ``distinct creates same elements like a set`` () =
-    Check.QuickThrowOnFailure distinct_works_like_set<int>
-    Check.QuickThrowOnFailure distinct_works_like_set<string>
-    Check.QuickThrowOnFailure distinct_works_like_set<NormalFloat>
+    member _.mapFold_and_map_and_fold<'a when 'a : comparison> (xs : list<'a>) mapF foldF start =
+        let f s x = 
+            let x' = mapF x
+            let s' = foldF s x'
+            x',s'
 
-let sort_and_sortDescending<'a when 'a : comparison>  (xs : list<'a>) =
-    let a = run (fun () -> xs |> List.sort)
-    let b = run (fun () -> xs |> List.sortDescending |> List.rev)
-    a = b
+        let a,ar = xs |> List.mapFold f start
+        let b = xs |> List.map mapF 
+        let br = b |> List.fold foldF start
+        a = b && ar = br
 
-[<Fact>]
-let ``sort and sortDescending work in reverse`` () =   
-    Check.QuickThrowOnFailure sort_and_sortDescending<int>
-    Check.QuickThrowOnFailure sort_and_sortDescending<string>
-    Check.QuickThrowOnFailure sort_and_sortDescending<NormalFloat>
+    [<Fact>]
+    member this.``mapFold works like map + fold`` () =   
+        Check.QuickThrowOnFailure this.mapFold_and_map_and_fold<int>
+        Check.QuickThrowOnFailure this.mapFold_and_map_and_fold<string>
+        Check.QuickThrowOnFailure this.mapFold_and_map_and_fold<NormalFloat>
 
-let sortByStable<'a when 'a : comparison> (xs : 'a []) =
-    let indexed = xs |> Seq.indexed |> Seq.toList
-    let sorted = indexed |> List.sortBy snd
-    isStable sorted
+    member _.mapFoldBack_and_map_and_foldBack<'a when 'a : comparison> (xs : list<'a>) mapF foldF start =
+        let f x s = 
+            let x' = mapF x
+            let s' = foldF x' s
+            x',s'
+
+        let a,ar = List.mapFoldBack f xs start
+        let b = xs |> List.map mapF 
+        let br = List.foldBack foldF b start
+        a = b && ar = br
+
+    [<Fact>]
+    member this.``mapFoldBack works like map + foldBack`` () =   
+        Check.QuickThrowOnFailure this.mapFoldBack_and_map_and_foldBack<int>
+        Check.QuickThrowOnFailure this.mapFoldBack_and_map_and_foldBack<string>
+        Check.QuickThrowOnFailure this.mapFoldBack_and_map_and_foldBack<NormalFloat>
+
+    member _.findBack_and_exists<'a when 'a : comparison>  (xs : list<'a>) f =
+        let a = 
+            try
+                List.findBack f xs |> ignore
+                true
+            with
+            | _ -> false
+        let b = List.exists f xs
+        a = b
+
+    [<Fact>]
+    member this.``findBack and exists work similar`` () =   
+        Check.QuickThrowOnFailure this.findBack_and_exists<int>
+        Check.QuickThrowOnFailure this.findBack_and_exists<string>
+        Check.QuickThrowOnFailure this.findBack_and_exists<NormalFloat>
+
+    member _.findBack_and_find<'a when 'a : comparison>  (xs : list<'a>) predicate =
+        let a = run (fun () -> xs |> List.findBack predicate)
+        let b = run (fun () -> xs |> List.rev |> List.find predicate)
+        a = b
+
+    [<Fact>]
+    member this.``findBack and find work in reverse`` () =   
+        Check.QuickThrowOnFailure this.findBack_and_find<int>
+        Check.QuickThrowOnFailure this.findBack_and_find<string>
+        Check.QuickThrowOnFailure this.findBack_and_find<NormalFloat>
+
+    member _.tryFindBack_and_tryFind<'a when 'a : comparison>  (xs : list<'a>) predicate =
+        let a = xs |> List.tryFindBack predicate
+        let b = xs |> List.rev |> List.tryFind predicate
+        a = b
+
+    [<Fact>]
+    member this.``tryFindBack and tryFind work in reverse`` () =   
+        Check.QuickThrowOnFailure this.tryFindBack_and_tryFind<int>
+        Check.QuickThrowOnFailure this.tryFindBack_and_tryFind<string>
+        Check.QuickThrowOnFailure this.tryFindBack_and_tryFind<NormalFloat>
+
+    member _.tryFindIndexBack_and_tryFindIndex<'a when 'a : comparison>  (xs : list<'a>) predicate =
+        let a = xs |> List.tryFindIndexBack predicate
+        let b = xs |> List.rev |> List.tryFindIndex predicate
+        match a,b with
+        | Some a, Some b -> a = (xs.Length - b - 1)
+        | _ -> a = b
+
+    [<Fact>]
+    member this.``tryFindIndexBack and tryIndexFind work in reverse`` () =   
+        Check.QuickThrowOnFailure this.tryFindIndexBack_and_tryFindIndex<int>
+        Check.QuickThrowOnFailure this.tryFindIndexBack_and_tryFindIndex<string>
+        Check.QuickThrowOnFailure this.tryFindIndexBack_and_tryFindIndex<NormalFloat>
+
+    member _.rev<'a when 'a : comparison>  (xs : list<'a>) =
+        let list = System.Collections.Generic.List<_>()
+        for x in xs do
+            list.Insert(0,x)
+
+        xs |> List.rev |> List.rev = xs && Seq.toList list = List.rev xs
+
+    [<Fact>]
+    member this.``rev reverses a list`` () =   
+        Check.QuickThrowOnFailure this.rev<int>
+        Check.QuickThrowOnFailure this.rev<string>
+        Check.QuickThrowOnFailure this.rev<NormalFloat>
+
+    member _.findIndexBack_and_findIndex<'a when 'a : comparison>  (xs : list<'a>) (F (_, predicate)) =
+        let a = run (fun () -> xs |> List.findIndex predicate)
+        let b = run (fun () -> xs |> List.rev |> List.findIndexBack predicate)
+        match a,b with
+        | Success a, Success b -> a = (xs.Length - b - 1)
+        | _ -> a = b
+
+    [<Fact>]
+    member this.``findIndexBack and findIndex work in reverse`` () =
+        Check.QuickThrowOnFailure this.findIndexBack_and_findIndex<int>
+        Check.QuickThrowOnFailure this.findIndexBack_and_findIndex<string>
+        Check.QuickThrowOnFailure this.findIndexBack_and_findIndex<NormalFloat>
+
+    member _.skip_and_skipWhile<'a when 'a : comparison>  (xs : list<'a>) (count:NonNegativeInt) =
+        let count = int count
+        count <= xs.Length ==> (lazy 
+            let ys = List.indexed xs
+            let a = runAndCheckErrorType (fun () -> List.skip count ys)
+            let b = runAndCheckErrorType (fun () -> List.skipWhile (fun (p,_) -> p < count) ys)
+
+            a = b)
+
+    [<Fact>]
+    member this.``skip and skipWhile are consistent`` () =   
+        Check.QuickThrowOnFailure this.skip_and_skipWhile<int>
+        Check.QuickThrowOnFailure this.skip_and_skipWhile<string>
+        Check.QuickThrowOnFailure this.skip_and_skipWhile<NormalFloat>
+
+    member _.distinct_works_like_set<'a when 'a : comparison> (xs : 'a list) =
+        let a = List.distinct xs
+        let b = Set.ofList xs
+
+        let mutable result = (a.Length = b.Count)
+        for x in a do
+            if Set.contains x b |> not then
+                result <- false
+
+        for x in b do
+            if List.exists ((=) x) a |> not then
+                result <- false
+        result
+
+    [<Fact>]
+    member this.``distinct creates same elements like a set`` () =
+        Check.QuickThrowOnFailure this.distinct_works_like_set<int>
+        Check.QuickThrowOnFailure this.distinct_works_like_set<string>
+        Check.QuickThrowOnFailure this.distinct_works_like_set<NormalFloat>
+
+    member _.sort_and_sortDescending<'a when 'a : comparison>  (xs : list<'a>) =
+        let a = run (fun () -> xs |> List.sort)
+        let b = run (fun () -> xs |> List.sortDescending |> List.rev)
+        a = b
+
+    [<Fact>]
+    member this.``sort and sortDescending work in reverse`` () =   
+        Check.QuickThrowOnFailure this.sort_and_sortDescending<int>
+        Check.QuickThrowOnFailure this.sort_and_sortDescending<string>
+        Check.QuickThrowOnFailure this.sort_and_sortDescending<NormalFloat>
+
+    member _.sortByStable<'a when 'a : comparison> (xs : 'a []) =
+        let indexed = xs |> Seq.indexed |> Seq.toList
+        let sorted = indexed |> List.sortBy snd
+        isStable sorted
     
-[<Fact>]
-let ``List.sortBy is stable`` () =
-    Check.QuickThrowOnFailure sortByStable<int>
-    Check.QuickThrowOnFailure sortByStable<string>
+    [<Fact>]
+    member this.``List.sortBy is stable`` () =
+        Check.QuickThrowOnFailure this.sortByStable<int>
+        Check.QuickThrowOnFailure this.sortByStable<string>
 
-let sortWithStable<'a when 'a : comparison> (xs : 'a []) =
-    let indexed = xs |> Seq.indexed |> Seq.toList
-    let sorted = indexed |> List.sortWith (fun x y -> compare (snd x) (snd y))
-    isStable sorted
+    member _.sortWithStable<'a when 'a : comparison> (xs : 'a []) =
+        let indexed = xs |> Seq.indexed |> Seq.toList
+        let sorted = indexed |> List.sortWith (fun x y -> compare (snd x) (snd y))
+        isStable sorted
     
-[<Fact>]
-let ``List.sortWithStable is stable`` () =
-    Check.QuickThrowOnFailure sortWithStable<int>
-    Check.QuickThrowOnFailure sortWithStable<string>
+    [<Fact>]
+    member this.``List.sortWithStable is stable`` () =
+        Check.QuickThrowOnFailure this.sortWithStable<int>
+        Check.QuickThrowOnFailure this.sortWithStable<string>
 
-let distinctByStable<'a when 'a : comparison> (xs : 'a []) =
-    let indexed = xs |> Seq.indexed |> Seq.toList
-    let sorted = indexed |> List.distinctBy snd
-    isStable sorted
+    member _.distinctByStable<'a when 'a : comparison> (xs : 'a []) =
+        let indexed = xs |> Seq.indexed |> Seq.toList
+        let sorted = indexed |> List.distinctBy snd
+        isStable sorted
     
-[<Fact>]
-let ``List.distinctBy is stable`` () =
-    Check.QuickThrowOnFailure distinctByStable<int>
-    Check.QuickThrowOnFailure distinctByStable<string>
+    [<Fact>]
+    member this.``List.distinctBy is stable`` () =
+        Check.QuickThrowOnFailure this.distinctByStable<int>
+        Check.QuickThrowOnFailure this.distinctByStable<string>
     
-[<Fact>]
-let ``List.sum calculates the sum`` () =
-    let sum (xs : int list) =
-        let s = List.sum xs
-        let mutable r = 0
-        for x in xs do r <- r + x    
-        s = r
-    Check.QuickThrowOnFailure sum
+    [<Fact>]
+    member _.``List.sum calculates the sum`` () =
+        let sum (xs : int list) =
+            let s = List.sum xs
+            let mutable r = 0
+            for x in xs do r <- r + x    
+            s = r
+        Check.QuickThrowOnFailure sum
 
-let sumBy<'a> (xs : 'a list) (f:'a -> int) =
-    let s = xs |> List.map f |> List.sum
-    let r = List.sumBy f xs
-    r = s
+    member this.sumBy<'a> (xs : 'a list) (f:'a -> int) =
+        let s = xs |> List.map f |> List.sum
+        let r = List.sumBy f xs
+        r = s
 
-[<Fact>]
-let ``List.sumBy calculates the sum of the mapped list`` () =
-    Check.QuickThrowOnFailure sumBy<int>
-    Check.QuickThrowOnFailure sumBy<string> 
-    Check.QuickThrowOnFailure sumBy<float>
+    [<Fact>]
+    member this.``List.sumBy calculates the sum of the mapped list`` () =
+        Check.QuickThrowOnFailure this.sumBy<int>
+        Check.QuickThrowOnFailure this.sumBy<string> 
+        Check.QuickThrowOnFailure this.sumBy<float>
 
-let allPairsCount<'a, 'b> (xs : 'a list) (ys : 'b list) =
-    let pairs = List.allPairs xs ys
-    pairs.Length = xs.Length * ys.Length
+    member _.allPairsCount<'a, 'b> (xs : 'a list) (ys : 'b list) =
+        let pairs = List.allPairs xs ys
+        pairs.Length = xs.Length * ys.Length
 
-[<Fact>]
-let ``List.allPairs produces the correct number of pairs`` () =
-    Check.QuickThrowOnFailure allPairsCount<int, int>
-    Check.QuickThrowOnFailure allPairsCount<string, string>
-    Check.QuickThrowOnFailure allPairsCount<float, float>
+    [<Fact>]
+    member this.``List.allPairs produces the correct number of pairs`` () =
+        Check.QuickThrowOnFailure this.allPairsCount<int, int>
+        Check.QuickThrowOnFailure this.allPairsCount<string, string>
+        Check.QuickThrowOnFailure this.allPairsCount<float, float>
 
-let allPairsFst<'a, 'b when 'a : equality> (xs : 'a list) (ys : 'b list) =
-    let pairsFst = List.allPairs xs ys |> List.map fst
-    let check = xs |> List.collect (List.replicate ys.Length)
-    pairsFst = check
+    member _.allPairsFst<'a, 'b when 'a : equality> (xs : 'a list) (ys : 'b list) =
+        let pairsFst = List.allPairs xs ys |> List.map fst
+        let check = xs |> List.collect (List.replicate ys.Length)
+        pairsFst = check
 
-[<Fact>]
-let ``List.allPairs first elements are correct`` () =
-    Check.QuickThrowOnFailure allPairsFst<int, int>
-    Check.QuickThrowOnFailure allPairsFst<string, string>
-    Check.QuickThrowOnFailure allPairsFst<NormalFloat, NormalFloat>
+    [<Fact>]
+    member this.``List.allPairs first elements are correct`` () =
+        Check.QuickThrowOnFailure this.allPairsFst<int, int>
+        Check.QuickThrowOnFailure this.allPairsFst<string, string>
+        Check.QuickThrowOnFailure this.allPairsFst<NormalFloat, NormalFloat>
 
-let allPairsSnd<'a, 'b when 'b : equality> (xs : 'a list) (ys : 'b list) =
-    let pairsSnd = List.allPairs xs ys |> List.map snd
-    let check = [ for i in 1 .. xs.Length do yield! ys ]
-    pairsSnd = check
+    member _.allPairsSnd<'a, 'b when 'b : equality> (xs : 'a list) (ys : 'b list) =
+        let pairsSnd = List.allPairs xs ys |> List.map snd
+        let check = [ for i in 1 .. xs.Length do yield! ys ]
+        pairsSnd = check
 
-[<Fact>]
-let ``List.allPairs second elements are correct`` () =
-    Check.QuickThrowOnFailure allPairsFst<int, int>
-    Check.QuickThrowOnFailure allPairsFst<string, string>
-    Check.QuickThrowOnFailure allPairsFst<NormalFloat, NormalFloat>
+    [<Fact>]
+    member this.``List.allPairs second elements are correct`` () =
+        Check.QuickThrowOnFailure this.allPairsFst<int, int>
+        Check.QuickThrowOnFailure this.allPairsFst<string, string>
+        Check.QuickThrowOnFailure this.allPairsFst<NormalFloat, NormalFloat>

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqProperties.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqProperties.fs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
-module FSharp.Core.UnitTests.Collections.SeqProperties
+namespace FSharp.Core.UnitTests.Collections
 
 open System
 open System.Collections.Generic
@@ -7,32 +7,35 @@ open Xunit
 open FsCheck
 open Utils
 
-let sortByStable<'a when 'a : comparison> (xs : 'a []) =
-    let indexed = xs |> Seq.indexed
-    let sorted = indexed |> Seq.sortBy snd
-    isStable sorted
+type SeqProperties () =
+    inherit TestClassWithSimpleNameAppDomainResolver ()
 
-[<Fact>]
-let ``Seq.sortBy is stable`` () =
-    Check.QuickThrowOnFailure sortByStable<int>
-    Check.QuickThrowOnFailure sortByStable<string>
+    member _.sortByStable<'a when 'a : comparison> (xs : 'a []) =
+        let indexed = xs |> Seq.indexed
+        let sorted = indexed |> Seq.sortBy snd
+        isStable sorted
 
-let sortWithStable<'a when 'a : comparison> (xs : 'a []) =
-    let indexed = xs |> Seq.indexed |> Seq.toList
-    let sorted = indexed |> Seq.sortWith (fun x y -> compare (snd x) (snd y))
-    isStable sorted
+    [<Fact>]
+    member this.``Seq.sortBy is stable`` () =
+        Check.QuickThrowOnFailure this.sortByStable<int>
+        Check.QuickThrowOnFailure this.sortByStable<string>
+
+    member _.sortWithStable<'a when 'a : comparison> (xs : 'a []) =
+        let indexed = xs |> Seq.indexed |> Seq.toList
+        let sorted = indexed |> Seq.sortWith (fun x y -> compare (snd x) (snd y))
+        isStable sorted
     
-[<Fact>]
-let ``Seq.sortWithStable is stable`` () =
-    Check.QuickThrowOnFailure sortWithStable<int>
-    Check.QuickThrowOnFailure sortWithStable<string>
+    [<Fact>]
+    member this.``Seq.sortWithStable is stable`` () =
+        Check.QuickThrowOnFailure this.sortWithStable<int>
+        Check.QuickThrowOnFailure this.sortWithStable<string>
     
-let distinctByStable<'a when 'a : comparison> (xs : 'a []) =
-    let indexed = xs |> Seq.indexed
-    let sorted = indexed |> Seq.distinctBy snd
-    isStable sorted
+    member _.distinctByStable<'a when 'a : comparison> (xs : 'a []) =
+        let indexed = xs |> Seq.indexed
+        let sorted = indexed |> Seq.distinctBy snd
+        isStable sorted
     
-[<Fact>]
-let ``Seq.distinctBy is stable`` () =
-    Check.QuickThrowOnFailure distinctByStable<int>
-    Check.QuickThrowOnFailure distinctByStable<string>
+    [<Fact>]
+    member this.``Seq.distinctBy is stable`` () =
+        Check.QuickThrowOnFailure this.distinctByStable<int>
+        Check.QuickThrowOnFailure this.distinctByStable<string>

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/RecordTypes.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/RecordTypes.fs
@@ -16,91 +16,20 @@ type Record =
         B: int
     }
 
-
-let [<Fact>] ``can compare records`` () = 
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        i1 <> i2 ==>
-        let r1 = { A = i1; B = i2 }
-        let r2 = { A = i1; B = i2 }
-        (r1 = r2)                   |@ "r1 = r2" .&.
-        ({ r1 with A = r1.B} <> r2) |@ "{r1 with A = r1.B} <> r2" .&.
-        (r1.Equals r2)              |@ "r1.Equals r2"
-
-
 [<Struct>]
 type StructRecord =
     {   C: int
         D: int
     }
 
-let private hasAttribute<'T,'Attr>() =
-    typeof<'T>.GetTypeInfo().GetCustomAttributes() |> Seq.exists  (fun x -> x.GetType() = typeof<'Attr>)
-
-
-let [<Fact>] ``struct records hold [<Struct>] metadata`` () =
-    Assert.True (hasAttribute<StructRecord,StructAttribute>())
-
-
-let [<Fact>] ``struct records are comparable`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        i1 <> i2 ==>
-        let sr1 = { C = i1; D = i2 }
-        let sr2 = { C = i1; D = i2 }
-        (sr1 = sr2)                    |@ "sr1 = sr2" .&.
-        ({ sr1 with C = sr1.D} <> sr2) |@ "{sr1 with C = sr1.D} <> sr2" .&.
-        (sr1.Equals sr2)               |@ "sr1.Equals sr2"
-
-
-let [<Fact>] ``struct records support pattern matching`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        let sr1 = { C = i1; D = i2 }
-        (match sr1 with
-        | { C = c; D = d } when c = i1 && d = i2 -> true
-        | _ -> false) 
-        |@ "with pattern match on struct record" .&.
-        (sr1 |> function 
-        | { C = c; D = d } when c = i1 && d = i2 -> true
-        | _ -> false)
-        |@ "function pattern match on struct record"
-
-
-let [<Fact>] ``struct records support let binds using `` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        let sr1 = { C = i1; D = i2 }
-        let { C = c1; D = d2 } as sr2 = sr1
-        (sr1 = sr2)          |@ "sr1 = sr2" .&.
-        (c1 = i1 && d2 = i2) |@ "c1 = i1 && d2 = i2"
-
-
-let [<Fact>] ``struct records support function argument bindings`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        let sr1 = { C = i1; D = i2 }
-        let test sr1 ({ C = c1; D = d2 } as sr2) =
-            sr1 = sr2 && c1 = i1 && d2 = i2
-        test sr1 sr1      
-        
-        
 [<Struct>]
 type MutableStructRecord =
     {   mutable M1: int
         mutable M2: int
     }                  
     
-
-let [<Fact>] ``struct recrods fields can be mutated`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) (m1:int) (m2:int) ->
-        (i1 <> m1 && i2 <> m2) ==>
-            let mutable sr1 = { M1 = i1; M2 = i2}
-            sr1.M1 <- m1
-            sr1.M2 <- m2
-            sr1.M1 = m1 && sr1.M2 = m2
-
+let private hasAttribute<'T,'Attr>() =
+    typeof<'T>.GetTypeInfo().GetCustomAttributes() |> Seq.exists  (fun x -> x.GetType() = typeof<'Attr>)
 
 [<Struct>]
 type StructRecordDefaultValue =
@@ -109,8 +38,8 @@ type StructRecordDefaultValue =
         R2: StructRecord
     }
 
-
 let [<Fact>] ``struct records have correct behaviour with a [<DefaultValue>] on a ref type field`` () =
+    use _ = new AlreadyLoadedBySimpleNameAppDomainResolver()
     Check.QuickThrowOnFailure <|
     fun (i1:int) (i2:int) ->
         let s = { C = i1; D = i2 }
@@ -126,15 +55,14 @@ type StructRecordDefaultValue2 =
         R2: StructRecord
     }
 
-
 let [<Fact>] ``struct records have correct behaviour with a [<DefaultValue>] on a value type field`` () =
+    use _ = new AlreadyLoadedBySimpleNameAppDomainResolver()
     Check.QuickThrowOnFailure <|
     fun (i1:int) (i2:int) ->
         let r = { A = i1; B = i2 }
         let r1 = { R1 = r }
         (r1.R1 = { A = i1; B = i2 }) |@ "r1.R1 = { A = i1; B = i2 }" .&.
         (r1.R2 = { C = 0; D = 0 })   |@ "r1.R2 = { C = 0; D = 0 }"
-
 
 let [<Fact>] ``struct records exhibit correct behaviour for Unchecked.defaultof`` () =
     let x1 = { C = 0; D = 0 }
@@ -154,7 +82,13 @@ let [<Fact>] ``struct records exhibit correct behaviour for Unchecked.defaultof`
     Assert.True (( (obj.ReferenceEquals (x3.R1, null)) = (obj.ReferenceEquals (y3.R1, null)) ))
     Assert.True ((x3.R2 = x1))
     Assert.True ((y3.R2 = x1))
- 
+
+[<Struct>]
+[<NoComparison; NoEquality>]
+type NoComparisonStructRecord =
+    {   N1 : int
+        N2 : int
+    }
 
 [<Struct>]
 [<CustomComparison; CustomEquality>]
@@ -174,60 +108,13 @@ type ComparisonStructRecord =
             | :? ComparisonStructRecord as o -> compare (self.C1 + self.C2) (o.C1 + o.C2)
             | _ -> invalidArg "other" "cannot compare values of different types"
 
-
-let [<Fact>] ``struct records support [<CustomEquality>]`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) ->
-        let sr1 = { C1 = i1; C2 = i2 }
-        let sr2 = { C1 = i1; C2 = i2 }
-        (sr1.Equals sr2)      
-
-
-let [<Fact>] ``struct records support [<CustomComparison>]`` () =
-    Check.QuickThrowOnFailure <|
-    fun (i1:int) (i2:int) (k1:int) (k2:int) ->        
-        let sr1 = { C1 = i1; C2 = i2 }
-        let sr2 = { C1 = k1; C2 = k2 }
-        if   sr1 > sr2 then compare sr1 sr2 = 1
-        elif sr1 < sr2 then compare sr1 sr2 = -1
-        elif sr1 = sr2 then compare sr1 sr2 = 0
-        else false
-
-
-let [<Fact>] ``struct records hold [<CustomComparison>] [<CustomEquality>] metadata`` () =
-    Assert.True (hasAttribute<ComparisonStructRecord,CustomComparisonAttribute>())
-    Assert.True (hasAttribute<ComparisonStructRecord,CustomEqualityAttribute>())
-
-
-[<Struct>]
-[<NoComparison; NoEquality>]
-type NoComparisonStructRecord =
-    {   N1 : int
-        N2 : int
-    }
-
-
-let [<Fact>] ``struct records hold [<NoComparison>] [<NoEquality>] metadata`` () =
-    Assert.True (hasAttribute<NoComparisonStructRecord,NoComparisonAttribute>())
-    Assert.True (hasAttribute<NoComparisonStructRecord,NoEqualityAttribute>())
-
-
-[<Struct>]
+ [<Struct>]
 [<StructLayout(LayoutKind.Explicit)>]
 type ExplicitLayoutStructRecord =
     {   [<FieldOffset 8>] Z : int
         [<FieldOffset 4>] Y : int
         [<FieldOffset 0>] X : int
     }
-
-
-let [<Fact>] ``struct records offset fields correctly with [<StructLayout(LayoutKind.Explicit)>] and [<FieldOffset x>]`` () =
-    let checkOffset fieldName offset = 
-        offset = int (Marshal.OffsetOf (typeof<ExplicitLayoutStructRecord>, fieldName))
-    Assert.True (checkOffset "X@" 0)
-    Assert.True (checkOffset "Y@" 4)
-    Assert.True (checkOffset "Z@" 8)
-
 
 [<Struct>]
 [<StructLayout(LayoutKind.Explicit)>]
@@ -237,15 +124,6 @@ type ExplicitLayoutMutableStructRecord =
         [<FieldOffset 0>] mutable X : int
     }
 
-
-let [<Fact>] ``struct records offset mutable fields correctly with [<StructLayout(LayoutKind.Explicit)>] and [<FieldOffset x>]`` () =
-    let checkOffset fieldName offset = 
-        offset = int (Marshal.OffsetOf (typeof<ExplicitLayoutMutableStructRecord>, fieldName))
-    Assert.True (checkOffset "X@" 0)
-    Assert.True (checkOffset "Y@" 4)
-    Assert.True (checkOffset "Z@" 8)
-
-
 [<Struct>]
 type DefaultLayoutStructRecord =
     {   First   : int
@@ -253,7 +131,6 @@ type DefaultLayoutStructRecord =
         Third   : decimal
         Fourth  : int
     }
-
 
 [<Struct>]
 [<StructLayout(LayoutKind.Sequential)>]
@@ -264,26 +141,6 @@ type SequentialLayoutStructRecord =
         Fourth  : int
     }
 
-
-let [<Fact>] ``struct records order fields correctly with [<StructLayout(LayoutKind.Sequential)>]`` () =
-    let compareOffsets field1 fn field2 = 
-        fn  (Marshal.OffsetOf (typeof<SequentialLayoutStructRecord>, field1))
-            (Marshal.OffsetOf (typeof<SequentialLayoutStructRecord>, field2))
-    Assert.True (compareOffsets "First@"  (<) "Second@")
-    Assert.True (compareOffsets "Second@" (<) "Third@")
-    Assert.True (compareOffsets "Third@"  (<) "Fourth@")
-
-
-let [<Fact>] ``struct records default field order matches [<StructLayout(LayoutKind.Sequential)>]`` () =
-    let compareOffsets field1 fn field2 = 
-        fn  (Marshal.OffsetOf (typeof<DefaultLayoutStructRecord>, field1))
-            (Marshal.OffsetOf (typeof<SequentialLayoutStructRecord>, field2))
-    Assert.True (compareOffsets "First@"  (=) "First@")
-    Assert.True (compareOffsets "Second@" (=) "Second@")
-    Assert.True (compareOffsets "Third@"  (=) "Third@")
-    Assert.True (compareOffsets "Fourth@" (=) "Fourth@")
-
-
 [<Struct>]
 [<StructLayout(LayoutKind.Sequential)>]
 type SequentialLayoutMutableStructRecord =
@@ -292,28 +149,6 @@ type SequentialLayoutMutableStructRecord =
         mutable Third   : decimal
         mutable Fourth  : int
     }
-
-
-let [<Fact>] ``struct records order mutable field correctly with [<StructLayout(LayoutKind.Sequential)>]`` () =
-    let compareOffsets field1 fn field2 = 
-        fn  (Marshal.OffsetOf (typeof<SequentialLayoutMutableStructRecord>, field1))
-            (Marshal.OffsetOf (typeof<SequentialLayoutMutableStructRecord>, field2))
-    Assert.True (compareOffsets "First@"  (<) "Second@")
-    Assert.True (compareOffsets "Second@" (<) "Third@")
-    Assert.True (compareOffsets "Third@"  (<) "Fourth@")
-
-let [<Fact>] ``can properly construct a struct record using FSharpValue.MakeRecord, and we get the fields by FSharpValue.GetRecordFields`` () =
-    let structRecord = Microsoft.FSharp.Reflection.FSharpValue.MakeRecord (typeof<StructRecord>, [|box 1234;box 999|])
-
-    Assert.True (structRecord.GetType().IsValueType)
-
-    let fields = Microsoft.FSharp.Reflection.FSharpValue.GetRecordFields structRecord
-
-    let c = (fields.[0] :?> int)
-    Assert.AreEqual (1234, c)
-
-    let d = (fields.[1] :?> int)
-    Assert.AreEqual (999, d)
 
 type DefaultLayoutMutableRecord =
     {   mutable First   : int
@@ -331,32 +166,190 @@ let inline CX_get_C(x: ^T) =
 let inline CX_set_First(x: ^T, v) = 
     ( (^T : (member First : int with set) (x,v)) )
 
-
 type Members() = 
     static member CreateMutableStructRecord() = { M1 = 1; M2 = 2 } 
 
+type RecordTypesTestClass () =
+    inherit TestClassWithSimpleNameAppDomainResolver ()
 
-let [<Fact>] ``inline constraints resolve correctly`` () =
-    let v = CX_get_A ({ A = 1; B = 2 })
-    Assert.AreEqual (1, v)
+    [<Fact>]
+    member _.``can compare records`` () = 
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            i1 <> i2 ==>
+            let r1 = { A = i1; B = i2 }
+            let r2 = { A = i1; B = i2 }
+            (r1 = r2)                   |@ "r1 = r2" .&.
+            ({ r1 with A = r1.B} <> r2) |@ "{r1 with A = r1.B} <> r2" .&.
+            (r1.Equals r2)              |@ "r1.Equals r2"
 
-    let v2 = CX_get_C ({ C = 1; D = 2 })
-    Assert.AreEqual (1, v2)
+    [<Fact>]
+    member _.``struct records hold [<Struct>] metadata`` () =
+        Assert.True (hasAttribute<StructRecord,StructAttribute>())
+
+    [<Fact>]
+    member _.``struct records are comparable`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            i1 <> i2 ==>
+            let sr1 = { C = i1; D = i2 }
+            let sr2 = { C = i1; D = i2 }
+            (sr1 = sr2)                    |@ "sr1 = sr2" .&.
+            ({ sr1 with C = sr1.D} <> sr2) |@ "{sr1 with C = sr1.D} <> sr2" .&.
+            (sr1.Equals sr2)               |@ "sr1.Equals sr2"
+
+    [<Fact>]
+    member _.``struct records support pattern matching`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            let sr1 = { C = i1; D = i2 }
+            (match sr1 with
+            | { C = c; D = d } when c = i1 && d = i2 -> true
+            | _ -> false) 
+            |@ "with pattern match on struct record" .&.
+            (sr1 |> function 
+            | { C = c; D = d } when c = i1 && d = i2 -> true
+            | _ -> false)
+            |@ "function pattern match on struct record"
+
+    [<Fact>]
+    member _.``struct records support let binds using `` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            let sr1 = { C = i1; D = i2 }
+            let { C = c1; D = d2 } as sr2 = sr1
+            (sr1 = sr2)          |@ "sr1 = sr2" .&.
+            (c1 = i1 && d2 = i2) |@ "c1 = i1 && d2 = i2"
+
+    [<Fact>]
+    member _.``struct records support function argument bindings`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            let sr1 = { C = i1; D = i2 }
+            let test sr1 ({ C = c1; D = d2 } as sr2) =
+                sr1 = sr2 && c1 = i1 && d2 = i2
+            test sr1 sr1      
+        
+        
+    [<Fact>]
+    member _.``struct recrods fields can be mutated`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) (m1:int) (m2:int) ->
+            (i1 <> m1 && i2 <> m2) ==>
+                let mutable sr1 = { M1 = i1; M2 = i2}
+                sr1.M1 <- m1
+                sr1.M2 <- m2
+                sr1.M1 = m1 && sr1.M2 = m2
+
+    [<Fact>]
+    member _.``struct records support [<CustomEquality>]`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) ->
+            let sr1 = { C1 = i1; C2 = i2 }
+            let sr2 = { C1 = i1; C2 = i2 }
+            (sr1.Equals sr2)      
+
+    [<Fact>]
+    member _.``struct records support [<CustomComparison>]`` () =
+        Check.QuickThrowOnFailure <|
+        fun (i1:int) (i2:int) (k1:int) (k2:int) ->        
+            let sr1 = { C1 = i1; C2 = i2 }
+            let sr2 = { C1 = k1; C2 = k2 }
+            if   sr1 > sr2 then compare sr1 sr2 = 1
+            elif sr1 < sr2 then compare sr1 sr2 = -1
+            elif sr1 = sr2 then compare sr1 sr2 = 0
+            else false
+
+    [<Fact>]
+    member _.``struct records hold [<CustomComparison>] [<CustomEquality>] metadata`` () =
+        Assert.True (hasAttribute<ComparisonStructRecord,CustomComparisonAttribute>())
+        Assert.True (hasAttribute<ComparisonStructRecord,CustomEqualityAttribute>())
+
+    [<Fact>]
+    member _.``struct records hold [<NoComparison>] [<NoEquality>] metadata`` () =
+        Assert.True (hasAttribute<NoComparisonStructRecord,NoComparisonAttribute>())
+        Assert.True (hasAttribute<NoComparisonStructRecord,NoEqualityAttribute>())
+
+    [<Fact>]
+    member _.``struct records offset fields correctly with [<StructLayout(LayoutKind.Explicit)>] and [<FieldOffset x>]`` () =
+        let checkOffset fieldName offset = 
+            offset = int (Marshal.OffsetOf (typeof<ExplicitLayoutStructRecord>, fieldName))
+        Assert.True (checkOffset "X@" 0)
+        Assert.True (checkOffset "Y@" 4)
+        Assert.True (checkOffset "Z@" 8)
+
+    [<Fact>]
+    member _.``struct records offset mutable fields correctly with [<StructLayout(LayoutKind.Explicit)>] and [<FieldOffset x>]`` () =
+        let checkOffset fieldName offset = 
+            offset = int (Marshal.OffsetOf (typeof<ExplicitLayoutMutableStructRecord>, fieldName))
+        Assert.True (checkOffset "X@" 0)
+        Assert.True (checkOffset "Y@" 4)
+        Assert.True (checkOffset "Z@" 8)
+
+    [<Fact>]
+    member _.``struct records order fields correctly with [<StructLayout(LayoutKind.Sequential)>]`` () =
+        let compareOffsets field1 fn field2 = 
+            fn  (Marshal.OffsetOf (typeof<SequentialLayoutStructRecord>, field1))
+                (Marshal.OffsetOf (typeof<SequentialLayoutStructRecord>, field2))
+        Assert.True (compareOffsets "First@"  (<) "Second@")
+        Assert.True (compareOffsets "Second@" (<) "Third@")
+        Assert.True (compareOffsets "Third@"  (<) "Fourth@")
+
+    [<Fact>]
+    member _.``struct records default field order matches [<StructLayout(LayoutKind.Sequential)>]`` () =
+        let compareOffsets field1 fn field2 = 
+            fn  (Marshal.OffsetOf (typeof<DefaultLayoutStructRecord>, field1))
+                (Marshal.OffsetOf (typeof<SequentialLayoutStructRecord>, field2))
+        Assert.True (compareOffsets "First@"  (=) "First@")
+        Assert.True (compareOffsets "Second@" (=) "Second@")
+        Assert.True (compareOffsets "Third@"  (=) "Third@")
+        Assert.True (compareOffsets "Fourth@" (=) "Fourth@")
+
+    [<Fact>]
+    member _.``struct records order mutable field correctly with [<StructLayout(LayoutKind.Sequential)>]`` () =
+        let compareOffsets field1 fn field2 = 
+            fn  (Marshal.OffsetOf (typeof<SequentialLayoutMutableStructRecord>, field1))
+                (Marshal.OffsetOf (typeof<SequentialLayoutMutableStructRecord>, field2))
+        Assert.True (compareOffsets "First@"  (<) "Second@")
+        Assert.True (compareOffsets "Second@" (<) "Third@")
+        Assert.True (compareOffsets "Third@"  (<) "Fourth@")
+
+    [<Fact>]
+    member _.``can properly construct a struct record using FSharpValue.MakeRecord, and we get the fields by FSharpValue.GetRecordFields`` () =
+        let structRecord = Microsoft.FSharp.Reflection.FSharpValue.MakeRecord (typeof<StructRecord>, [|box 1234;box 999|])
+
+        Assert.True (structRecord.GetType().IsValueType)
+
+        let fields = Microsoft.FSharp.Reflection.FSharpValue.GetRecordFields structRecord
+
+        let c = (fields.[0] :?> int)
+        Assert.AreEqual (1234, c)
+
+        let d = (fields.[1] :?> int)
+        Assert.AreEqual (999, d)
+
+    [<Fact>]
+    member _.``inline constraints resolve correctly`` () =
+        let v = CX_get_A ({ A = 1; B = 2 })
+        Assert.AreEqual (1, v)
+
+        let v2 = CX_get_C ({ C = 1; D = 2 })
+        Assert.AreEqual (1, v2)
     
-    let mutable m : DefaultLayoutMutableRecord =
-        {   First   = 0xbaad1
-            Second  = 0.987654
-            Third   = 100.32M
-            Fourth  = 0xbaad4 }
+        let mutable m : DefaultLayoutMutableRecord =
+            {   First   = 0xbaad1
+                Second  = 0.987654
+                Third   = 100.32M
+                Fourth  = 0xbaad4 }
 
-    let v3 = CX_set_First (m,1)
-    Assert.AreEqual (1, m.First)
+        let v3 = CX_set_First (m,1)
+        Assert.AreEqual (1, m.First)
 
-let [<Fact>] ``member setters resolve correctly`` () =
+    [<Fact>]
+    member _.``member setters resolve correctly`` () =
 
-    let v = Members.CreateMutableStructRecord()
-    Assert.AreEqual (1, v.M1)
+        let v = Members.CreateMutableStructRecord()
+        Assert.AreEqual (1, v.M1)
     
-    //let v2 = Members.CreateMutableStructRecord(M1 = 100)
-    //Assert.AreEqual (100, v2.M1)
-    
+        //let v2 = Members.CreateMutableStructRecord(M1 = 100)
+        //Assert.AreEqual (100, v2.M1)


### PR DESCRIPTION
The fsharp core unit tests failed that run with fscheck failed when run using visual studio 2022.  I guess theat the test runner no longer honours binding redirects in the test.dll.config file.

The fix was to add an assembly resolution handler to resolve fsharp.core for fscheck.

Because modules don't have a constructor or destructor and xunit doesn't have a test initialize mechanism, I had to to turn some test modules into test classes.