### PR TITLE
Corrected .NET notation and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The F# compiler, F# core library, and F# editor tools
 
-You're invited to contribute to future releases of the F# compiler, core library, and tools. Development of this repository can be done on any OS supported by [.NET Core](https://dotnet.microsoft.com/).
+You're invited to contribute to future releases of the F# compiler, core library, and tools. Development of this repository can be done on any OS supported by [.NET](https://dotnet.microsoft.com/).
 
-You will also need the latest .NET 5 SDK installed from [here](https://dotnet.microsoft.com/download/dotnet/5.0).
+You will also need the latest .NET 6 SDK installed from [here](https://dotnet.microsoft.com/download/dotnet/6.0).
 
 ## Contributing
 


### PR DESCRIPTION
Corrected .NET notation and links as follows:
- .NET 5 to .NET 6
- .NET Core to .NET