### PR TITLE
Fix: #12575 - Build error when EnablePreviewFeatures is set to true

### DIFF
--- a/src/fsharp/CompilerOptions.fs
+++ b/src/fsharp/CompilerOptions.fs
@@ -846,7 +846,8 @@ let setLanguageVersion specifiedVersion =
         exit 0
 
     if specifiedVersion = "?" then dumpAllowedValues ()
-    if not (languageVersion.ContainsVersion specifiedVersion) then error(Error(FSComp.SR.optsUnrecognizedLanguageVersion specifiedVersion, rangeCmdArgs))
+    elif specifiedVersion.ToUpperInvariant() = "PREVIEW" then ()
+    elif not (languageVersion.ContainsVersion specifiedVersion) then error(Error(FSComp.SR.optsUnrecognizedLanguageVersion specifiedVersion, rangeCmdArgs))
     languageVersion
 
 let languageFlags tcConfigB =

--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -59,7 +59,7 @@ type LanguageVersion (versionText) =
     static let latestVersion = defaultVersion           // Language version when latest specified
     static let latestMajorVersion = languageVersion60   // Language version when latestmajor specified
 
-    static let validOptions = [| "preview"; "default"; "latest"; "latestmajor" |]
+    static let validOptions = [| "PREVIEW"; "DEFAULT"; "LATEST"; "LATESTMAJOR" |]
     static let languageVersions = set [| languageVersion46; languageVersion47; languageVersion50; languageVersion60 |]
 
     static let features =
@@ -104,21 +104,23 @@ type LanguageVersion (versionText) =
 
     static let defaultLanguageVersion = LanguageVersion("default")
 
-    let specified =
-        match versionText with
+    static let getVersionFromString (version:string) =
+        match version.ToUpperInvariant() with
         | "?" -> 0m
-        | "preview" -> previewVersion
-        | "default" -> defaultVersion
-        | "latest" -> latestVersion
-        | "latestmajor" -> latestMajorVersion
+        | "PREVIEW" -> previewVersion
+        | "DEFAULT" -> defaultVersion
+        | "LATEST" -> latestVersion
+        | "LATESTMAJOR" -> latestMajorVersion
         | "4.6" -> languageVersion46
         | "4.7" -> languageVersion47
-        | "5.0" -> languageVersion50
-        | "6.0" -> languageVersion60
+        | "5.0" | "5" -> languageVersion50
+        | "6.0" | "6" -> languageVersion60
         | _ -> 0m
 
+    let specified = getVersionFromString versionText
+
     let versionToString v =
-        if v = previewVersion then "'preview'"
+        if v = previewVersion then "'PREVIEW'"
         else string v
 
     let specifiedString = versionToString specified
@@ -131,11 +133,8 @@ type LanguageVersion (versionText) =
 
     /// Has preview been explicitly specified
     member _.IsExplicitlySpecifiedAs50OrBefore() =
-        match versionText with
-        | "4.6" -> true
-        | "4.7" -> true
-        | "5.0" -> true
-        | _ -> false
+        let v = getVersionFromString versionText
+        v <> 0.0m && v <= 5.0m
 
     /// Has preview been explicitly specified
     member _.IsPreviewEnabled =
@@ -143,9 +142,8 @@ type LanguageVersion (versionText) =
 
     /// Does the languageVersion support this version string
     member _.ContainsVersion version =
-        match version with
-        | "?" | "preview" | "default" | "latest" | "latestmajor" -> true
-        | _ -> languageVersions.Contains specified
+        let langVersion = getVersionFromString version
+        langVersion <> 0m && languageVersions.Contains langVersion
 
     /// Get a list of valid strings for help text
     member _.ValidOptions = validOptions

--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -59,7 +59,7 @@ type LanguageVersion (versionText) =
     static let latestVersion = defaultVersion           // Language version when latest specified
     static let latestMajorVersion = languageVersion60   // Language version when latestmajor specified
 
-    static let validOptions = [| "PREVIEW"; "DEFAULT"; "LATEST"; "LATESTMAJOR" |]
+    static let validOptions = [| "preview"; "default"; "latest"; "latestmajor" |]
     static let languageVersions = set [| languageVersion46; languageVersion47; languageVersion50; languageVersion60 |]
 
     static let features =

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/langversion.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/langversion.fs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.ComponentTests.CompilerOptions
+
+open Xunit
+open FSharp.Test.Compiler
+open FSharp.Test.Xunit.Attributes
+
+module langversion =
+
+    [<Fact>]
+    let ``fsc langversion is case insensitive - --langversion:pRevIew``() =
+        FSharp """
+printfn "Hello, World"
+        """
+        |> asExe
+        |> withOptions ["--langversion:pRevIew"]
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``fsi langversion is case insensitive - --langversion:pRevIew``() =
+        FSharp """
+printfn "Hello, World"
+        """
+        |> asFsx
+        |> withOptions ["--langversion:pRevIew"]
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``fsc langversion is case insensitive - --langversion:laTestmaJor``() =
+        FSharp """
+printfn "Hello, World"
+        """
+        |> asExe
+        |> withOptions ["--langversion:laTestmaJor"]
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``fsi langversion is case insensitive - --langversion:laTestmaJor``() =
+        FSharp """
+printfn "Hello, World"
+        """
+        |> asFsx
+        |> withOptions ["--langversion:laTestmaJor"]
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``fsc langversion supports simple version number - --langversion:5``() =
+        FSharp """
+    printfn "Hello, World"
+        """
+        |> asExe
+        |> withOptions ["--langversion:5"]
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``fsc langversion supports full version number - --langversion:5.0``() =
+        FSharp """
+    printfn "Hello, World"
+        """
+        |> asExe
+        |> withOptions ["--langversion:5.0"]
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``fsc langversion supports full version number - --langversion:4``() =
+        FSharp """
+    printfn "Hello, World"
+        """
+        |> asExe
+        |> withOptions ["--langversion:4"]
+        |> compile
+        |> shouldFail
+        |> withErrorCode 246
+        |> withDiagnosticMessageMatches "Unrecognized value '4' for --langversion use --langversion:\? for complete list"
+        |> ignore
+
+    [<Fact>]
+    let ``fsc langversion fails with invalid version number - --langversion:4.1 which never existed``() =
+        FSharp """
+    printfn "Hello, World"
+        """
+        |> asExe
+        |> withOptions ["--langversion:4.1"]
+        |> compile
+        |> shouldFail
+        |> withErrorCode 246
+        |> withDiagnosticMessageMatches "Unrecognized value '4.1' for --langversion use --langversion:\? for complete list"
+        |> ignore

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-<!--
     <Compile Include="EmittedIL\Operators.fs" />
     <Compile Include="EmittedIL\Literals.fs" />
     <Compile Include="EmittedIL\Misc.fs" />
@@ -65,6 +64,7 @@
     <Compile Include="Interop\VisibilityTests.fs" />
     <Compile Include="Scripting\Interactive.fs" />
     <Compile Include="TypeChecks\CheckDeclarationsTests.fs" />
+    <Compile Include="CompilerOptions\fsc\langversion.fs" />
     <Compile Include="CompilerOptions\fsc\noframework.fs" />
     <Compile Include="CompilerOptions\fsc\platform.fs" />
     <Compile Include="CompilerOptions\fsc\times.fs" />
@@ -102,7 +102,6 @@
     <Compile Include="Diagnostics\async.fs" />
     <Compile Include="Diagnostics\General.fs" />
     <Compile Include="Globalization\GlobalizationTestCases.fs" />
-	  -->
     <Compile Include="OCamlCompat\OCamlCompat.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
https://github.com/dotnet/fsharp/issues/12575

- The underlying issue is a case sensitive comparison of the langversion strings.
- Also enable --langversion:5  and langversion:6 for compatability with C# usage when the language version is a whole number.
- Add some new langversion tests
- Re-enable all of the component tests, which I inadvertently commented out on ocaml compat tests pr.


