### PR TITLE
Use CapturingErrorLogger instead of CompilationErrorLogger in incrementalbuild.fs

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-<!--
     <Compile Include="EmittedIL\Operators.fs" />
     <Compile Include="EmittedIL\Literals.fs" />
     <Compile Include="EmittedIL\Misc.fs" />
@@ -102,7 +101,6 @@
     <Compile Include="Diagnostics\async.fs" />
     <Compile Include="Diagnostics\General.fs" />
     <Compile Include="Globalization\GlobalizationTestCases.fs" />
-	  -->
     <Compile Include="OCamlCompat\OCamlCompat.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
GetErrorLoggerFilteringByScopedPragmas has been updated to do what CompilationErrorLogger does here.  So rather than evaluating warningsaserrors twice just use a plain old capturinglogger