### PR TITLE
Correct ranges for nested modules in signature files.

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -896,7 +896,10 @@ tyconSpfn:
       { let mWithKwd, members = $2
         let m =
             match members with
-            | [] -> lhs parseState
+            | [] ->
+                match mWithKwd with
+                | None -> rhs parseState 1
+                | Some mWithKwd -> unionRanges (rhs parseState 1) mWithKwd
             | decls ->
                 let (SynComponentInfo(range=start)) = $1
                 (start, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -816,11 +816,10 @@ moduleSpfn:
         _xmlDoc.MarkAsInvalid()
         let attrs = $1 @ cas
         let mTc =
-            let keywordM = rhs parseState 3
-            (keywordM, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range) |> unionRanges range
+            (d3, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range) |> unionRanges range
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
         let tc = (SynTypeDefnSig(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), equalsRange, typeRepr, withKeyword, members, mTc))
-        let m = (mTc, $5) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range)
+        let m = (mTc, $5) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range) |> unionRanges (rhs parseState 3)
         SynModuleSigDecl.Types (tc :: $5, m) }
 
   | opt_attributes opt_declVisibility exconSpfn
@@ -895,7 +894,13 @@ tyconSpfn:
         $3 lhsm $1 (Some mEquals) }
   | typeNameInfo  opt_classSpfn       
       { let mWithKwd, members = $2
-        SynTypeDefnSig($1, None, SynTypeDefnSigRepr.Simple (SynTypeDefnSimpleRepr.None (lhs parseState), lhs parseState), mWithKwd, members, lhs parseState) }
+        let m =
+            match members with
+            | [] -> lhs parseState
+            | decls ->
+                let (SynComponentInfo(range=start)) = $1
+                (start, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
+        SynTypeDefnSig($1, None, SynTypeDefnSigRepr.Simple (SynTypeDefnSimpleRepr.None m, m), mWithKwd, members, m) }
 
 
 /* The right-hand-side of a type definition in a signature */
@@ -930,8 +935,14 @@ tyconSpfnRhs:
            SynTypeDefnSig(nameInfo, mEquals, SynTypeDefnSigRepr.Simple ($1, $1.Range), None, augmentation, mWhole)) }
 
   | tyconClassSpfn 
-     { let objectModelRange = lhs parseState 
-       let needsCheck, (kind, decls) = $1
+     {  let needsCheck, (kind, decls) = $1
+        let objectModelRange =
+            match decls with
+            | [] -> lhs parseState
+            | decls ->
+                let start = mkSynRange parseState.ResultStartPosition parseState.ResultStartPosition
+                (start, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
+
        (fun nameRange nameInfo mEquals augmentation -> 
            if needsCheck && isNil decls then
               reportParseErrorAt nameRange (FSComp.SR.parsEmptyTypeDefinition())

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1138,8 +1138,9 @@ type MyRecord =
 
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
-            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [SynTypeDefnSig.SynTypeDefnSig(range = r)])]) ])) ->
-            assertRange (2, 0) (4, 30) r
+            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types([SynTypeDefnSig.SynTypeDefnSig(range=mSynTypeDefnSig)], mTypes)]) ])) ->
+            assertRange (2, 0) (4, 30) mTypes
+            assertRange (2, 5) (4, 30) mSynTypeDefnSig
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -1154,8 +1155,9 @@ type MyRecord =
 
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
-            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [SynTypeDefnSig.SynTypeDefnSig(range = r)])]) ])) ->
-            assertRange (2, 0) (5, 30) r
+            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types([SynTypeDefnSig.SynTypeDefnSig(range=mSynTypeDefnSig)], mTypes)]) ])) ->
+            assertRange (2, 0) (5, 30) mTypes
+            assertRange (2, 5) (5, 30) mSynTypeDefnSig
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -1168,8 +1170,9 @@ type MyFunction =
 
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
-            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [SynTypeDefnSig.SynTypeDefnSig(range = r)])]) ])) ->
-            assertRange (2, 0) (3, 29) r
+            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types([SynTypeDefnSig.SynTypeDefnSig(range=mSynTypeDefnSig)], mTypes) ]) ])) ->
+            assertRange (2, 0) (3, 29) mTypes
+            assertRange (2, 5) (3, 29) mSynTypeDefnSig
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -1183,8 +1186,9 @@ type SomeCollection with
 
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
-            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [SynTypeDefnSig.SynTypeDefnSig(range = r)])]) ])) ->
-            assertRange (2, 0) (4, 37) r
+            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types([SynTypeDefnSig.SynTypeDefnSig(range=mSynTypeDefnSig)], mTypes)]) ])) ->
+            assertRange (2, 0) (4, 37) mTypes
+            assertRange (2, 5) (4, 37) mSynTypeDefnSig
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -1227,13 +1231,13 @@ and [<CustomEquality>] Bang =
 
         match parseResults with
         | ParsedInput.SigFile (ParsedSigFileInput (modules = [
-            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types(types = [
+            SynModuleOrNamespaceSig(decls = [SynModuleSigDecl.Types([
                 SynTypeDefnSig.SynTypeDefnSig(range = r1)
                 SynTypeDefnSig.SynTypeDefnSig(range = r2)
-            ]) as t]) ])) ->
-            assertRange (4, 0) (5, 9) r1
+            ], mTypes)]) ])) ->
+            assertRange (4, 5) (5, 9) r1
             assertRange (7, 4) (12, 42) r2
-            assertRange (4, 0) (12, 42) t.Range
+            assertRange (4, 0) (12, 42) mTypes
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
@@ -1715,6 +1719,98 @@ module X =
             SynModuleSigDecl.NestedModule(equalsRange = Some equalsM)
         ]) ])) ->
             assertRange (4, 9) (4, 10) equalsM
+        | _ -> Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``Range of nested module in signature file should end at the last SynModuleSigDecl`` () =
+        let parseResults =
+            getParseResultsOfSignatureFile
+                """namespace Microsoft.FSharp.Core
+
+open System
+open System.Collections.Generic
+open Microsoft.FSharp.Core
+open Microsoft.FSharp.Collections
+open System.Collections
+
+
+module Tuple =
+
+    type Tuple<'T1,'T2,'T3,'T4> =
+        interface IStructuralEquatable
+        interface IStructuralComparable
+        interface IComparable
+        new : 'T1 * 'T2 * 'T3 * 'T4 -> Tuple<'T1,'T2,'T3,'T4>
+        member Item1 : 'T1 with get
+        member Item2 : 'T2 with get
+        member Item3 : 'T3 with get
+        member Item4 : 'T4 with get
+
+
+module Choice =
+
+    /// <summary>Helper types for active patterns with 6 choices.</summary>
+    [<StructuralEquality; StructuralComparison>]
+    [<CompiledName("FSharpChoice`6")>]
+    type Choice<'T1,'T2,'T3,'T4,'T5,'T6> =
+      /// <summary>Choice 1 of 6 choices</summary>
+      | Choice1Of6 of 'T1
+      /// <summary>Choice 2 of 6 choices</summary>
+      | Choice2Of6 of 'T2
+      /// <summary>Choice 3 of 6 choices</summary>
+      | Choice3Of6 of 'T3
+      /// <summary>Choice 4 of 6 choices</summary>
+      | Choice4Of6 of 'T4
+      /// <summary>Choice 5 of 6 choices</summary>
+      | Choice5Of6 of 'T5
+      /// <summary>Choice 6 of 6 choices</summary>
+      | Choice6Of6 of 'T6
+
+
+
+/// <summary>Basic F# Operators. This module is automatically opened in all F# code.</summary>
+[<AutoOpen>]
+module Operators =
+
+    type ``[,]``<'T> with
+        [<CompiledName("Length1")>]
+        /// <summary>Get the length of an array in the first dimension  </summary>
+        member Length1 : int
+        [<CompiledName("Length2")>]
+        /// <summary>Get the length of the array in the second dimension  </summary>
+        member Length2 : int
+        [<CompiledName("Base1")>]
+        /// <summary>Get the lower bound of the array in the first dimension  </summary>
+        member Base1 : int
+        [<CompiledName("Base2")>]
+        /// <summary>Get the lower bound of the array in the second dimension  </summary>
+        member Base2 : int
+"""
+
+        match parseResults with
+        | ParsedInput.SigFile (ParsedSigFileInput (modules = [ SynModuleOrNamespaceSig(decls = [
+              SynModuleSigDecl.Open _
+              SynModuleSigDecl.Open _
+              SynModuleSigDecl.Open _
+              SynModuleSigDecl.Open _
+              SynModuleSigDecl.Open _
+              SynModuleSigDecl.NestedModule(range=mTupleModule; moduleDecls=[ SynModuleSigDecl.Types([
+                  SynTypeDefnSig(typeRepr=SynTypeDefnSigRepr.ObjectModel(range=mTupleObjectModel); range=mTupleType)
+              ], mTupleTypes) ])
+              SynModuleSigDecl.NestedModule(range=mChoiceModule)
+              SynModuleSigDecl.NestedModule(range=mOperatorsModule; moduleDecls=[ SynModuleSigDecl.Types([
+                  SynTypeDefnSig(typeRepr=SynTypeDefnSigRepr.Simple(range=mAugmentationSimple); range=mAugmentation)
+              ], mOperatorsTypes) ])
+          ]) ])) ->
+            assertRange (10, 0) (20, 35) mTupleModule
+            assertRange (12, 4) (20, 35) mTupleTypes
+            assertRange (12, 9) (20, 35) mTupleType
+            assertRange (13, 8) (20, 35) mTupleObjectModel
+            assertRange (23, 0) (40, 25) mChoiceModule
+            assertRange (45, 0) (60, 26) mOperatorsModule
+            assertRange (48, 4) (60, 26) mOperatorsTypes
+            assertRange (48, 9) (60, 26) mAugmentation
+            assertRange (48, 9) (60, 26) mAugmentationSimple
         | _ -> Assert.Fail "Could not get valid AST"
 
 module SynBindings =


### PR DESCRIPTION
Fixes #2094.

The main problem was that the `lhs parseState` is unreliable if members are involved.
I tried to take a correct starting position and calculate the range by including all the member ranges.

While I was at it I noticed that there is a discrepancy between types in signature files and implementation files.
In signature files [SynTypeDefnSig](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-syntypedefnsig.html) did include the `type` keyword in its range. While the counterpart [SynTypeDefn](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-syntypedefn.html) does not.
The type keyword should (I think) only be included in [SynModuleDecl.Types](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-synmoduledecl.html#Types) and [SynModuleSigDecl.Types](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-syntax-synmodulesigdecl.html#Types)

//cc @dsyme 