### PR TITLE
Fix typo in example of `lock` in `prim-types.fsi`

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -3737,7 +3737,7 @@ namespace Microsoft.FSharp.Core
         ///     .ForAll(fun _ -> counter2.IncrementWithLock())
         /// 
         /// //  Evaluates to 100000 deterministically because the increment to the counter object is locked
-        /// counter.Count
+        /// counter2.Count
         /// </code>
         /// </example>
         /// 


### PR DESCRIPTION
fix typo in `lock` example (one char that makes me think the `lock` function does not work!)