### PR TITLE
Add and keyword range to read-write property.

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1751,9 +1751,10 @@ classDefnMemberGetSet:
 /* The "get, set" part of a member definition */
 classDefnMemberGetSetElements: 
   | classDefnMemberGetSetElement 
-     { [$1]  }
+     { [$1], None  }
   | classDefnMemberGetSetElement AND classDefnMemberGetSetElement
-     { [$1;$3] }
+     { let mAnd = rhs parseState 2
+       [$1;$3], Some mAnd }
 
 classDefnMemberGetSetElement: 
   | opt_inline opt_attributes bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS typedSequentialExprBlock 
@@ -1780,7 +1781,7 @@ memberCore:
 
   /* Properties with explicit get/set, also indexer properties */
   | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints classDefnMemberGetSet  
-     { let mWith, classDefnMemberGetSetElements = $4
+     { let mWith, (classDefnMemberGetSetElements, mAnd) = $4
        let mWhole = (rhs parseState 2, classDefnMemberGetSetElements) ||> unionRangeWithListBy (fun (_, _, _, _, _, _, m2) -> m2) 
        let propertyNameBindingBuilder, _ = $2 
        let optPropertyType = $3 
@@ -1969,7 +1970,7 @@ memberCore:
              // Iterate over 1 or 2 'get'/'set' entries
              match classDefnMemberGetSetElements with
              | [ h ] -> List.choose id [ tryMkSynMemberDefnMember (Some (PropertyKeyword.With mWith)) h ]
-             | [ g ; s ] -> List.choose id [ tryMkSynMemberDefnMember (Some (PropertyKeyword.With mWith)) g ; tryMkSynMemberDefnMember None s ]
+             | [ g ; s ] -> List.choose id [ tryMkSynMemberDefnMember (Some (PropertyKeyword.With mWith)) g ; tryMkSynMemberDefnMember (Option.map PropertyKeyword.And mAnd) s ]
              | _ -> [])
        }
 

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -593,10 +593,11 @@ type Foo() =
                 typeDefns = [ SynTypeDefn(typeRepr =
                     SynTypeDefnRepr.ObjectModel(members=[ _
                                                           SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(propertyKeyword=Some(PropertyKeyword.With mWith))))
-                                                          SynMemberDefn.Member _ ])
+                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(propertyKeyword=Some(PropertyKeyword.And mAnd)))) ])
                     ) ])
              ]) ])) ->
             assertRange (5, 8) (5, 12) mWith
+            assertRange (6, 8) (6, 11) mAnd
         | _ -> Assert.Fail "Could not get valid AST"
 
 module SyntaxExpressions =


### PR DESCRIPTION
This is a small thing I forgot in #12400.
It surfaced while implementing the nightly FCS changes into Fantomas.