### PR TITLE
Add with keyword to SynTypeDefn and SynExceptionDefn.

### DIFF
--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -3004,7 +3004,7 @@ module TcExceptionDeclarations =
         binds, exnc
 
 
-    let TcExnDefn cenv envInitial parent (SynExceptionDefn(core, aug, m), scopem) = 
+    let TcExnDefn cenv envInitial parent (SynExceptionDefn(core, _, aug, m), scopem) = 
         let binds1, exnc = TcExnDefnCore cenv envInitial parent core
         let envMutRec = AddLocalExnDefnAndReport cenv.tcSink scopem (AddLocalTycons cenv.g cenv.amap scopem [exnc] envInitial) exnc 
 
@@ -5561,7 +5561,7 @@ and TcModuleOrNamespaceElementsMutRec (cenv: cenv) parent typeNames m envInitial
                   let decls = [ MutRecShape.Open (MutRecDataForOpen(target, m, moduleRange, ref [])) ]
                   decls, (openOk, moduleAbbrevOk, attrs)
 
-              | SynModuleDecl.Exception (SynExceptionDefn(repr, members, _), _m) -> 
+              | SynModuleDecl.Exception (SynExceptionDefn(repr, _, members, _), _m) -> 
                   let (SynExceptionDefnRepr(synAttrs, SynUnionCase(_, id, _args, _, _, _), _repr, doc, vis, m)) = repr
                   let compInfo = SynComponentInfo(synAttrs, None, [], [id], doc, false, vis, id.idRange)
                   let decls = [ MutRecShape.Tycon(SynTypeDefn(compInfo, None, SynTypeDefnRepr.Exception repr, None, members, None, m)) ]

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -5564,7 +5564,7 @@ and TcModuleOrNamespaceElementsMutRec (cenv: cenv) parent typeNames m envInitial
               | SynModuleDecl.Exception (SynExceptionDefn(repr, members, _), _m) -> 
                   let (SynExceptionDefnRepr(synAttrs, SynUnionCase(_, id, _args, _, _, _), _repr, doc, vis, m)) = repr
                   let compInfo = SynComponentInfo(synAttrs, None, [], [id], doc, false, vis, id.idRange)
-                  let decls = [ MutRecShape.Tycon(SynTypeDefn(compInfo, None, SynTypeDefnRepr.Exception repr, members, None, m)) ]
+                  let decls = [ MutRecShape.Tycon(SynTypeDefn(compInfo, None, SynTypeDefnRepr.Exception repr, None, members, None, m)) ]
                   decls, (false, false, attrs)
 
               | SynModuleDecl.HashDirective _ -> 

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1578,6 +1578,7 @@ type SynExceptionDefn =
 
     | SynExceptionDefn of
         exnRepr: SynExceptionDefnRepr *
+        withKeyword: range option *
         members: SynMemberDefns *
         range: range
 

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1612,6 +1612,7 @@ type SynTypeDefn =
         typeInfo: SynComponentInfo *
         equalsRange: range option *
         typeRepr: SynTypeDefnRepr *
+        withKeyword: range option *
         members: SynMemberDefns *
         implicitConstructor: SynMemberDefn option *
         range: range

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -1796,6 +1796,7 @@ type SynTypeDefn =
         typeInfo: SynComponentInfo *
         equalsRange: range option *
         typeRepr: SynTypeDefnRepr *
+        withKeyword: range option *
         members: SynMemberDefns *
         implicitConstructor: SynMemberDefn option *
         range: range

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -1759,6 +1759,7 @@ type SynExceptionDefn =
 
     | SynExceptionDefn of
         exnRepr: SynExceptionDefnRepr *
+        withKeyword: range option *
         members: SynMemberDefns *
         range: range
 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1323,11 +1323,11 @@ moduleDefn:
   | opt_attributes opt_declVisibility typeKeyword tyconDefn tyconDefnList
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
-        let (SynTypeDefn(SynComponentInfo(cas, a, cs, b, _xmlDoc, d, d2, d3), mEquals, e, f, g, h)) = $4
+        let (SynTypeDefn(SynComponentInfo(cas, a, cs, b, _xmlDoc, d, d2, d3), mEquals, e, mWith, f, g, h)) = $4
         _xmlDoc.MarkAsInvalid()
         let attrs = $1@cas
         let mTc = (h, attrs)  ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
-        let tc = (SynTypeDefn(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), mEquals, e, f, g, mTc))
+        let tc = (SynTypeDefn(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), mEquals, e, mWith, f, g, mTc))
         let types = tc :: $5
         [ SynModuleDecl.Types(types, (rhs parseState 3, types) ||> unionRangeWithListBy (fun t -> t.Range) ) ] }
 
@@ -1555,9 +1555,9 @@ tyconDefnList:
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        let tyconDefn =
            if xmlDoc.IsEmpty then $2 else
-           let (SynTypeDefn(SynComponentInfo (a, typars, c, lid, _xmlDoc, fixity, vis, rangeOfLid), mEquals, typeRepr, members, implicitConstructor, range)) = $2
+           let (SynTypeDefn(SynComponentInfo (a, typars, c, lid, _xmlDoc, fixity, vis, rangeOfLid), mEquals, typeRepr, mWith, members, implicitConstructor, range)) = $2
            _xmlDoc.MarkAsInvalid()
-           SynTypeDefn(SynComponentInfo (a, typars, c, lid, xmlDoc, fixity, vis, rangeOfLid), mEquals, typeRepr, members, implicitConstructor, range)
+           SynTypeDefn(SynComponentInfo (a, typars, c, lid, xmlDoc, fixity, vis, rangeOfLid), mEquals, typeRepr, mWith, members, implicitConstructor, range)
        tyconDefn :: $3 }
   |                             
      { [] }
@@ -1565,7 +1565,7 @@ tyconDefnList:
 /* A type definition */
 tyconDefn: 
   | typeNameInfo 
-     { SynTypeDefn($1, None, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range), $1.Range), [], None, $1.Range) }
+     { SynTypeDefn($1, None, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range), $1.Range), None, [], None, $1.Range) }
 
   | typeNameInfo opt_equals tyconDefnRhsBlock 
      { match $2 with
@@ -1577,20 +1577,20 @@ tyconDefn:
             raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsEqualsMissingInTypeDefinition(typeNameId.ToString()))
        
        let nameRange = rhs parseState 1
-       let (tcDefRepr:SynTypeDefnRepr), members = $3 nameRange
+       let (tcDefRepr:SynTypeDefnRepr), mWith ,members = $3 nameRange
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
        let mWhole = (declRange, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)    
-       SynTypeDefn($1, $2, tcDefRepr, members, None, mWhole) }
+       SynTypeDefn($1, $2, tcDefRepr, mWith, members, None, mWhole) }
 
   | typeNameInfo tyconDefnAugmentation
      { let mWithKwd, classDefns = $2
        let m = (rhs parseState 1, classDefns) ||> unionRangeWithListBy (fun mem -> mem.Range)
-       SynTypeDefn($1, None, SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Augmentation mWithKwd, [], m), classDefns, None, m) }
+       SynTypeDefn($1, None, SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Augmentation mWithKwd, [], m), None, classDefns, None, m) }
 
   | typeNameInfo opt_attributes opt_declVisibility opt_HIGH_PRECEDENCE_APP  simplePatterns optAsSpec EQUALS tyconDefnRhsBlock
      { let vis, spats, az = $3, $5, $6
        let nameRange = rhs parseState 1
-       let (tcDefRepr, members) = $8 nameRange
+       let (tcDefRepr, mWith, members) = $8 nameRange
        let (SynComponentInfo(_, _, _, lid, _, _, _, _)) = $1
        let mEquals = rhs parseState 7
        // Gets the XML doc comments prior to the implicit constructor
@@ -1603,7 +1603,7 @@ tyconDefn:
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
        let mWhole = (declRange, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
        
-       SynTypeDefn($1, Some mEquals, tcDefRepr, members, Some memberCtorPattern, mWhole) }
+       SynTypeDefn($1, Some mEquals, tcDefRepr, mWith, members, Some memberCtorPattern, mWhole) }
 
 
 /* The right-hand-side of a type definition */
@@ -1617,17 +1617,28 @@ tyconDefnRhsBlock:
   /* block still needs to be considered and may occur indented or undented from the core type */
   /* representation. */
   | OBLOCKBEGIN  tyconDefnRhs opt_OBLOCKSEP classDefnMembers opt_classDefn oblockend opt_classDefn  
-     { let m = unionRanges (rhs parseState 1) (match $7 with [] -> (match $5 with [] -> (rhs parseState 4) | _ -> (rhs parseState 5)) | _ -> (rhs parseState 7))
-       (fun nameRange -> $2 nameRange (checkForMultipleAugmentations m ($4 @ $5) $7)) }
+     { let mWith, optClassDefn = $5
+       let mWith2, optClassDefn2 = $7
+       let m = unionRanges (rhs parseState 1) (match optClassDefn2 with [] -> (match optClassDefn with [] -> (rhs parseState 4) | _ -> (rhs parseState 5)) | _ -> (rhs parseState 7))
+       (fun nameRange ->
+           let tcDefRepr, members = $2 nameRange (checkForMultipleAugmentations m ($4 @ optClassDefn) optClassDefn2)
+           let mWith = Option.orElse mWith2 mWith
+           tcDefRepr, mWith, members) }
 
   | OBLOCKBEGIN  tyconDefnRhs opt_OBLOCKSEP classDefnMembers opt_classDefn recover
      { if not $6 then reportParseErrorAt (rhs parseState 6) (FSComp.SR.parsUnexpectedEndOfFileTypeDefinition())
-       let m = unionRanges (rhs parseState 1) (match $5 with [] -> (rhs parseState 4) | _ -> (rhs parseState 5))
-       (fun nameRange -> $2 nameRange (checkForMultipleAugmentations m ($4 @ $5) [])) }
+       let mWith, optClassDefn = $5
+       let m = unionRanges (rhs parseState 1) (match optClassDefn with [] -> (rhs parseState 4) | _ -> (rhs parseState 5))
+       (fun nameRange -> 
+           let tcDefRepr, members = $2 nameRange (checkForMultipleAugmentations m ($4 @ optClassDefn) [])
+           tcDefRepr, mWith, members) }
 
   | tyconDefnRhs opt_classDefn
      { let m = rhs parseState 1
-       (fun nameRange -> $1 nameRange $2) }
+       let mWith, optClassDefn = $2
+       (fun nameRange -> 
+           let tcDefRepr, members = $1 nameRange optClassDefn
+           tcDefRepr, mWith, members) }
 
 
 /* The right-hand-side of a type definition */
@@ -2157,10 +2168,11 @@ opt_interfaceImplDefn:
 
 opt_classDefn: 
   | WITH classDefnBlock declEnd
-     { $2 } 
+     { let mWithKwd = rhs parseState 1
+       (Some mWithKwd), $2 } 
 
   | /* EMPTY */
-     { [] }
+     { None, [] }
 
 
 /* An 'inherits' definition in an object type definition */
@@ -2607,7 +2619,8 @@ fieldDecl:
 /* An exception definition */
 exconDefn: 
   | exconCore opt_classDefn 
-     { SynExceptionDefn($1, $2, ($1.Range, $2) ||> unionRangeWithListBy (fun cd -> cd.Range) ) }
+     { let _mWith, optClassDefn = $2
+       SynExceptionDefn($1, optClassDefn, ($1.Range, optClassDefn) ||> unionRangeWithListBy (fun cd -> cd.Range) ) }
   
 /* Part of an exception definition */
 exconCore: 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1334,10 +1334,10 @@ moduleDefn:
   /* 'exception' definitions */
   | opt_attributes opt_declVisibility exconDefn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let (SynExceptionDefn(SynExceptionDefnRepr(cas, a, b, c, d, d2), e, f)) = $3 
+        let (SynExceptionDefn(SynExceptionDefnRepr(cas, a, b, c, d, d2), withKeyword, e, f)) = $3 
         let f = (f, $1) ||> unionRangeWithListBy (fun a -> a.Range)
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
-        let ec = (SynExceptionDefn(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, d2), e, f))
+        let ec = (SynExceptionDefn(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, d2), withKeyword, e, f))
         [ SynModuleDecl.Exception(ec, f) ] }
 
   /* 'module' definitions */
@@ -2619,8 +2619,8 @@ fieldDecl:
 /* An exception definition */
 exconDefn: 
   | exconCore opt_classDefn 
-     { let _mWith, optClassDefn = $2
-       SynExceptionDefn($1, optClassDefn, ($1.Range, optClassDefn) ||> unionRangeWithListBy (fun cd -> cd.Range) ) }
+     { let mWith, optClassDefn = $2
+       SynExceptionDefn($1, mWith, optClassDefn, ($1.Range, optClassDefn) ||> unionRangeWithListBy (fun cd -> cd.Range) ) }
   
 /* Part of an exception definition */
 exconCore: 

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -737,7 +737,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                       for d in decls do yield! walkDecl d
                   | SynModuleDecl.Types(tydefs, m) when isMatchRange m -> 
                       for d in tydefs do yield! walkTycon d
-                  | SynModuleDecl.Exception(SynExceptionDefn(SynExceptionDefnRepr _, membDefns, _), m) 
+                  | SynModuleDecl.Exception(SynExceptionDefn(SynExceptionDefnRepr _, _, membDefns, _), m) 
                         when isMatchRange m ->
                       for m in membDefns do yield! walkMember m
                   | _ -> () ] 

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -683,7 +683,7 @@ module InterfaceStubGenerator =
                 None
             else
                 match decl with
-                | SynModuleDecl.Exception(SynExceptionDefn(_, synMembers, _), _) -> 
+                | SynModuleDecl.Exception(SynExceptionDefn(_, _, synMembers, _), _) -> 
                     List.tryPick walkSynMemberDefn synMembers
                 | SynModuleDecl.Let(_isRecursive, bindings, _range) ->
                     List.tryPick walkBinding bindings

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -171,7 +171,7 @@ module NavigationImpl =
             [ createDecl(baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, fldspecRange fldspec, nested, NavigationEntityKind.Exception, false, access) ] 
 
         // Process a class declaration or F# type declaration
-        and processExnDefn baseName (SynExceptionDefn(repr, membDefns, _)) =  
+        and processExnDefn baseName (SynExceptionDefn(repr, _, membDefns, _)) =  
             let nested = processMembers membDefns NavigationEntityKind.Exception |> snd
             processExnDefnRepr baseName nested repr
 
@@ -663,7 +663,7 @@ module NavigateTo =
     
         and walkSynModuleDecl(decl: SynModuleDecl) container =
             match decl with
-            | SynModuleDecl.Exception(SynExceptionDefn(repr, synMembers, _), _) -> 
+            | SynModuleDecl.Exception(SynExceptionDefn(repr, _, synMembers, _), _) -> 
                 let container = addExceptionRepr repr false container
                 for m in synMembers do
                     walkSynMemberDefn m container

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -708,7 +708,7 @@ module SyntaxTraversal =
 #endif
                         )
 
-        and traverseSynTypeDefn origPath (SynTypeDefn(synComponentInfo, _, synTypeDefnRepr, synMemberDefns, _, tRange) as tydef) =
+        and traverseSynTypeDefn origPath (SynTypeDefn(synComponentInfo, _, synTypeDefnRepr, _, synMemberDefns, _, tRange) as tydef) =
             let path = SyntaxNode.SynTypeDefn tydef :: origPath
             
             match visitor.VisitComponentInfo (origPath, synComponentInfo) with

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -8576,7 +8576,7 @@ FSharp.Compiler.Syntax.SynTypeConstraint: System.String ToString()
 FSharp.Compiler.Syntax.SynTypeDefn
 FSharp.Compiler.Syntax.SynTypeDefn: FSharp.Compiler.Syntax.SynComponentInfo get_typeInfo()
 FSharp.Compiler.Syntax.SynTypeDefn: FSharp.Compiler.Syntax.SynComponentInfo typeInfo
-FSharp.Compiler.Syntax.SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn NewSynTypeDefn(FSharp.Compiler.Syntax.SynComponentInfo, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Syntax.SynTypeDefnRepr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynMemberDefn], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn NewSynTypeDefn(FSharp.Compiler.Syntax.SynComponentInfo, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Syntax.SynTypeDefnRepr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynMemberDefn], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefnRepr get_typeRepr()
 FSharp.Compiler.Syntax.SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefnRepr typeRepr
 FSharp.Compiler.Syntax.SynTypeDefn: FSharp.Compiler.Text.Range Range
@@ -8591,6 +8591,8 @@ FSharp.Compiler.Syntax.SynTypeDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.
 FSharp.Compiler.Syntax.SynTypeDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynMemberDefn] implicitConstructor
 FSharp.Compiler.Syntax.SynTypeDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] equalsRange
 FSharp.Compiler.Syntax.SynTypeDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_equalsRange()
+FSharp.Compiler.Syntax.SynTypeDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_withKeyword()
+FSharp.Compiler.Syntax.SynTypeDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] withKeyword
 FSharp.Compiler.Syntax.SynTypeDefn: System.String ToString()
 FSharp.Compiler.Syntax.SynTypeDefnKind
 FSharp.Compiler.Syntax.SynTypeDefnKind+Augmentation: FSharp.Compiler.Text.Range get_withKeyword()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -6135,7 +6135,7 @@ FSharp.Compiler.Syntax.SynEnumCase: Microsoft.FSharp.Collections.FSharpList`1[FS
 FSharp.Compiler.Syntax.SynEnumCase: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
 FSharp.Compiler.Syntax.SynEnumCase: System.String ToString()
 FSharp.Compiler.Syntax.SynExceptionDefn
-FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Syntax.SynExceptionDefn NewSynExceptionDefn(FSharp.Compiler.Syntax.SynExceptionDefnRepr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Syntax.SynExceptionDefn NewSynExceptionDefn(FSharp.Compiler.Syntax.SynExceptionDefnRepr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Syntax.SynExceptionDefnRepr exnRepr
 FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Syntax.SynExceptionDefnRepr get_exnRepr()
 FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Text.Range Range
@@ -6146,6 +6146,8 @@ FSharp.Compiler.Syntax.SynExceptionDefn: Int32 Tag
 FSharp.Compiler.Syntax.SynExceptionDefn: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynExceptionDefn: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn] get_members()
 FSharp.Compiler.Syntax.SynExceptionDefn: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn] members
+FSharp.Compiler.Syntax.SynExceptionDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_withKeyword()
+FSharp.Compiler.Syntax.SynExceptionDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] withKeyword
 FSharp.Compiler.Syntax.SynExceptionDefn: System.String ToString()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynExceptionDefnRepr NewSynExceptionDefnRepr(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynUnionCase, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident]], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -454,6 +454,26 @@ type Person(name : string, age : int) =
         | _ -> Assert.Fail "Could not get valid AST"
 
     [<Test>]
+    let ``SynTypeDefn with Record contains the range of the with keyword`` () =
+        let parseResults = 
+            getParseResults
+                """
+type Foo =
+    { Bar : int }
+    with
+        member this.Meh (v:int) = this.Bar + v
+"""
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+            SynModuleDecl.Types(
+                typeDefns = [ SynTypeDefn(typeRepr=SynTypeDefnRepr.Simple(simpleRepr= SynTypeDefnSimpleRepr.Record _); withKeyword= Some mWithKeyword) ]
+            )
+        ]) ])) ->
+            assertRange (4, 4) (4, 8) mWithKeyword
+        | _ -> Assert.Fail "Could not get valid AST"
+    
+    [<Test>]
     let ``SynTypeDefn with Augmentation contains the range of the with keyword`` () =
         let parseResults = 
             getParseResults

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -2616,3 +2616,24 @@ match x with
         ]) ])) ->
             assertRange (3, 7) (3, 8) mEquals
         | _ -> Assert.Fail "Could not get valid AST"
+
+module Exceptions =
+    [<Test>]
+    let ``SynExceptionDefn should contains the range of the with keyword`` () =
+        let parseResults = 
+            getParseResults
+                """
+namespace X
+
+exception Foo with
+    member Meh () = ()
+"""
+
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace(decls = [
+            SynModuleDecl.Exception(
+                exnDefn=SynExceptionDefn(withKeyword = Some mWithKeyword)
+            )
+        ]) ])) ->
+            assertRange (4, 14) (4, 18) mWithKeyword
+        | _ -> Assert.Fail "Could not get valid AST"


### PR DESCRIPTION
In https://github.com/dotnet/fsharp/pull/12400 the `with` keyword was added to `SynTypeDefnSig` and `SynExceptionSig`.
But not to `SynTypeDefn` and `SynExceptionDefn`.

The goal of this PR is to align both.
In a later stage I do intend to revisit this in regards to https://github.com/dotnet/fsharp/issues/12418