### PR TITLE
Make Async.RunSynchronously more conservative about using current thread (reverting part of 11142)

### DIFF
--- a/src/fsharp/FSharp.Core/async.fs
+++ b/src/fsharp/FSharp.Core/async.fs
@@ -1066,8 +1066,8 @@ namespace Microsoft.FSharp.Control
         [<DebuggerHidden>]
         let RunSynchronously cancellationToken (computation: Async<'T>) timeout =
             // Reuse the current ThreadPool thread if possible.
-            match Thread.CurrentThread.IsThreadPoolThread, timeout with
-            | true, None -> RunImmediate cancellationToken computation
+            match SynchronizationContext.Current, Thread.CurrentThread.IsThreadPoolThread, timeout with
+            | null, true, None -> RunImmediate cancellationToken computation
             | _ -> QueueAsyncAndWaitForResultSynchronously cancellationToken computation timeout
 
         [<DebuggerHidden>]

--- a/src/fsharp/FSharp.Core/async.fsi
+++ b/src/fsharp/FSharp.Core/async.fsi
@@ -54,14 +54,19 @@ namespace Microsoft.FSharp.Control
         ///        
         /// If no cancellation token is provided then the default cancellation token is used.
         ///
+        /// The computation is started on the current thread if <see cref="P:System.Threading.SynchronizationContext.Current"/> is null,
+        /// <see cref="P:System.Threading.Thread.CurrentThread"/> has  <see cref="P:System.Threading.Thread.IsThreadPoolThread"/>
+        /// of <c>true</c>, and no timeout is specified. Otherwise the computation is started by queueing a new work item in the thread pool,
+        /// and the current thread is blocked awaiting the completion of the computation.
+        ///
         /// The timeout parameter is given in milliseconds.  A value of -1 is equivalent to
-        /// System.Threading.Timeout.Infinite.</remarks>
+        /// <see cref="F:System.Threading.Timeout.Infinite"/>.
+        /// </remarks>
         ///
         /// <param name="computation">The computation to run.</param>
         /// <param name="timeout">The amount of time in milliseconds to wait for the result of the
         /// computation before raising a <see cref="T:System.TimeoutException"/>.  If no value is provided
-        /// for timeout then a default of -1 is used to correspond to <see cref="F:System.Threading.Timeout.Infinite"/>.
-        /// If a cancellable cancellationToken is provided, timeout parameter will be ignored</param>
+        /// for timeout then a default of -1 is used to correspond to <see cref="F:System.Threading.Timeout.Infinite"/>.</param>
         /// <param name="cancellationToken">The cancellation token to be associated with the computation.
         /// If one is not supplied, the default cancellation token is used.</param>
         ///

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -409,8 +409,8 @@ type AsyncModule() =
     [<Fact>]
     member _.``RunSynchronously.NoThreadJumpsAndTimeout.DifferentSyncContexts``() = 
         let run syncContext =
-            let old = System.Threading.SynchronizationContext.Current
-            System.Threading.SynchronizationContext.SetSynchronizationContext(syncContext)
+            let old = SynchronizationContext.Current
+            SynchronizationContext.SetSynchronizationContext(syncContext)
             let longRunningTask = async { sleep(5000) }
             let mutable failed = false
             try
@@ -418,10 +418,30 @@ type AsyncModule() =
                 failed <- true
             with
                 :? System.TimeoutException -> ()
-            System.Threading.SynchronizationContext.SetSynchronizationContext(old)
+            SynchronizationContext.SetSynchronizationContext(old)
             if failed then Assert.Fail("TimeoutException expected")
         run null
         run (System.Threading.SynchronizationContext())
+
+    [<Fact>]
+    // See https://github.com/dotnet/fsharp/issues/12637#issuecomment-1020199383
+    member _.``RunSynchronously.ThreadJump.IfSyncCtxtNonNull``() = 
+        async {
+            do! Async.SwitchToThreadPool()
+            let old = SynchronizationContext.Current
+            SynchronizationContext.SetSynchronizationContext(SynchronizationContext())
+            Assert.NotNull(SynchronizationContext.Current)
+            Assert.True(Thread.CurrentThread.IsThreadPoolThread)
+            let computation =
+                async {
+                    let ctxt = SynchronizationContext.Current
+                    Assert.Null(ctxt)
+                    Assert.True(Thread.CurrentThread.IsThreadPoolThread)
+                }
+            Async.RunSynchronously(computation)
+            SynchronizationContext.SetSynchronizationContext(old)
+        }
+        |> Async.RunSynchronously
 
     [<Fact>]
     member _.``RaceBetweenCancellationAndError.AwaitWaitHandle``() = 


### PR DESCRIPTION
As described in https://github.com/dotnet/fsharp/issues/12637#issuecomment-1020199383, part of #11142 created a problematic change in behaviour about when `Async.RunSynchronously` uses the current thread.  Using the current thread is godo for performance and stacks but can cause deadlock if the current thread is relied on to process part of the async computation.

1. Prior to #11142 the current thread was used if  `SynchronizationContext` is null (and no timeout specified)

2. After #11142 the current thread is used if `Thread.CurrentThread.IsThreadPoolThread` is true (and no timeout specified).  

This change was not conservative - we now start on the current thread more often than we did before, specifically when we have non-null `SynchronizationContext`, yet `CurrentThread.IsThreadPoolThread` is true. 

The idea of #11142 was not bad - it tries to make sure the computation always runs in the thread pool.  However sometimes thread-pool threads have non-null  `SynchronizationContext.Current`, and this is an indication that starting the async computation on the current thread is not acceptable. 

As a conservative fix, we clarify the spec of `RunSynchronously` as follows:

> The computation is started on the current thread if and only if all of the following hold: `SynchronizationContext.Current` is null, `Thread.CurrentThread.IsThreadPoolThread` is true and no timeout is specified. If any of these conditions are false it is started by queueing a new work item in the thread pool.  This means that the computation will always be started on a thread-pool thread where the `SynchronizationContext.Current` is null.

This PR adjusts the code to match that.

### Testing 

Running without first adjusting tests to see if our existing tests clarify this.


