### PR TITLE
Update version of NUnit related packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -210,10 +210,9 @@
     <MicrosoftNETTestSdkVersion>16.6.1</MicrosoftNETTestSdkVersion>
     <MicrosoftWin32RegistryVersion>4.3.0</MicrosoftWin32RegistryVersion>
     <NewtonsoftJsonVersion>12.0.2</NewtonsoftJsonVersion>
-    <NUnitVersion>3.11.0</NUnitVersion>
-    <NUnit3TestAdapterVersion>3.11.2</NUnit3TestAdapterVersion>
-    <NUnitLiteVersion>3.11.0</NUnitLiteVersion>
-    <NunitXmlTestLoggerVersion>2.1.41</NunitXmlTestLoggerVersion>
+    <NUnitVersion>3.13.2</NUnitVersion>
+    <NUnit3TestAdapterVersion>4.1.0</NUnit3TestAdapterVersion>
+    <NunitXmlTestLoggerVersion>2.1.80</NunitXmlTestLoggerVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
     <StrawberryPerlVersion>5.28.0.1</StrawberryPerlVersion>
     <StreamJsonRpcVersion>2.8.3-alpha</StreamJsonRpcVersion>


### PR DESCRIPTION
I hitting bunch of exceptions during execution of `dotnet test tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj` on Linux with only .NET 6 installed.
```
System.ArgumentException: Unknown framework version 6.5 (Parameter 'version')
   at NUnit.Framework.Internal.RuntimeFramework.ThrowInvalidFrameworkVersion(Version version)
   at NUnit.Framework.Internal.RuntimeFramework.InitFromFrameworkVersion(Version version)
   at NUnit.Framework.Internal.RuntimeFramework..ctor(RuntimeType runtime, Version version)
   at NUnit.Framework.Internal.RuntimeFramework.<>c.<.cctor>b__33_0()
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.get_Value()
   at NUnit.Framework.Internal.RuntimeFramework.get_CurrentFramework()
   at NUnit.Framework.Internal.PlatformHelper..ctor()
   at NUnit.Framework.TestCaseAttribute.BuildFrom(IMethodInfo method, Test suite)+MoveNext()
   at NUnit.Framework.Internal.Builders.DefaultTestCaseBuilder.BuildFrom(IMethodInfo method, Test parentSuite)
   at NUnit.Framework.Internal.Builders.NUnitTestFixtureBuilder.AddTestCasesToFixture(TestFixture fixture, IPreFilter filter)
   at NUnit.Framework.Internal.Builders.NUnitTestFixtureBuilder.BuildFrom(ITypeInfo typeInfo, IPreFilter filter)
   at NUnit.Framework.Internal.Builders.DefaultSuiteBuilder.BuildFrom(ITypeInfo typeInfo, IPreFilter filter)
```

In spirit of https://github.com/dotnet/fsharp/issues/9947 maybe would be better to migrate these tests to XUnit