### PR TITLE
Remove Strawberry perl

### DIFF
--- a/TESTGUIDE.md
+++ b/TESTGUIDE.md
@@ -143,7 +143,7 @@ There are also negative tests checking code expected to fail compilation. See no
 
 ### FSharpQA Suite
 
-The FSharpQA suite relies on [Perl](http://www.perl.org/get.html), StrawberryPerl package from nuget is used automatically by the test suite.
+The FSharpQA suite relies on [Perl](http://www.perl.org/get.html), StrawberryPerl package from https://strawberryperl.com.
 
 These tests use the `RunAll.pl` framework to execute, however the easiest way to run them is via the `.\build` script, see [usage examples](#quick-start-running-tests).
 

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -443,6 +443,11 @@ try {
     $toolsetBuildProj = InitializeToolset
     TryDownloadDotnetFrameworkSdk
 
+    $nativeToolsDir = InitializeNativeTools
+    write-host "Native tools: $nativeToolsDir"
+    $env:PERL5Path = Join-Path "$nativeToolsDir" "perl\5.32.1.1\perl\bin\perl.exe"
+    $env:PERL5LIB = Join-Path "$nativeToolsDir" "perl\5.32.1.1\perl\vendor\lib"
+
     $dotnetPath = InitializeDotNetCli
     $env:DOTNET_ROOT = "$dotnetPath"
     Get-Item -Path Env:
@@ -501,8 +506,6 @@ try {
         $resultsLog = "test-net40-fsharpqa-results.log"
         $errorLog = "test-net40-fsharpqa-errors.log"
         $failLog = "test-net40-fsharpqa-errors"
-        $perlPackageRoot = "$nugetPackages\StrawberryPerl\5.28.0.1";
-        $perlExe = "$perlPackageRoot\bin\perl.exe"
         Create-Directory $resultsRoot
         UpdatePath
         $env:HOSTED_COMPILER = 1
@@ -510,8 +513,7 @@ try {
         $env:FSCOREDLLPATH = "$ArtifactsDir\bin\fsc\$configuration\net472\FSharp.Core.dll"
         $env:LINK_EXE = "$RepoRoot\tests\fsharpqa\testenv\bin\link\link.exe"
         $env:OSARCH = $env:PROCESSOR_ARCHITECTURE
-        $env:PERL5LIB = "$perlPackageRoot\vendor\lib"
-        Exec-Console $perlExe """$RepoRoot\tests\fsharpqa\testenv\bin\runall.pl"" -resultsroot ""$resultsRoot"" -results $resultsLog -log $errorLog -fail $failLog -cleanup:no -procs:$env:NUMBER_OF_PROCESSORS"
+        Exec-Console $env:PERL5Path """$RepoRoot\tests\fsharpqa\testenv\bin\runall.pl"" -resultsroot ""$resultsRoot"" -results $resultsLog -log $errorLog -fail $failLog -cleanup:no -procs:$env:NUMBER_OF_PROCESSORS"
         Pop-Location
     }
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -215,7 +215,6 @@
     <NUnitLiteVersion>3.11.0</NUnitLiteVersion>
     <NunitXmlTestLoggerVersion>2.1.41</NunitXmlTestLoggerVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
-    <StrawberryPerlVersion>5.28.0.1</StrawberryPerlVersion>
     <StreamJsonRpcVersion>2.8.3-alpha</StreamJsonRpcVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>

--- a/global.json
+++ b/global.json
@@ -13,6 +13,9 @@
       ]
     }
   },
+  "native-tools": {
+    "perl": "5.32.1.1"
+  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22071.6",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19069.2"

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -111,7 +111,6 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
     <PackageReference Include="Microsoft.NETCore.ILDAsm" Version="$(MicrosoftNETCoreILDAsmVersion)" />
     <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)" />
-    <PackageReference Include="StrawberryPerl" Version="$(StrawberryPerlVersion)" ExcludeAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />

--- a/tests/fsharpqa/Source/test.lst
+++ b/tests/fsharpqa/Source/test.lst
@@ -98,7 +98,6 @@ Conformance02			Conformance\DeclarationElements\FieldMembers
 Conformance02			Conformance\DeclarationElements\ImportDeclarations
 Conformance02			Conformance\DeclarationElements\InterfaceSpecificationsAndImplementations
 Conformance02			Conformance\DeclarationElements\LetBindings\ActivePatternBindings
-Conformance02			Conformance\DeclarationElements\LetBindings\ArityInference
 Conformance02			Conformance\DeclarationElements\LetBindings\Basic
 Conformance02			Conformance\DeclarationElements\LetBindings\ExplicitTypeParameters
 Conformance02			Conformance\DeclarationElements\LetBindings\TypeFunctions

--- a/tests/fsharpqa/run.fsharpqa.test.fsx
+++ b/tests/fsharpqa/run.fsharpqa.test.fsx
@@ -15,6 +15,8 @@ let addToPath path =
     if not(Array.contains path splits) then
         setEnvVar "PATH" (path + (string Path.PathSeparator) + currentPath)
 
+let perl5Path = System.Environment.GetEnvironmentVariable "PERL5PATH"
+
 let nugetCache = 
     match System.Environment.GetEnvironmentVariable("NUGET_PACKAGES") with
     | null -> Path.Combine(System.Environment.GetEnvironmentVariable "USERPROFILE", ".nuget", "packages")
@@ -39,7 +41,7 @@ let runPerl arguments =
 
     use perlProcess =
         ProcessStartInfo(
-            FileName = Path.Combine(nugetCache, "StrawberryPerl", "5.28.0.1", "bin", "perl.exe"),
+            FileName = perl5Path,
             Arguments = (arguments |> Array.map(fun a -> @"""" + a + @"""") |> String.concat " "),
             WorkingDirectory = Path.Combine(rootFolder, "tests", "fsharpqa", "source"),
             RedirectStandardOutput = true,


### PR DESCRIPTION
The Strawberry perl nuget package is pretty old and there are some security bulletins against it.  So moving over to the latest download from strawberry perl.com