### PR TITLE
[WIP] sig data trim 

### DIFF
--- a/src/fsharp/TypedTreeBasics.fs
+++ b/src/fsharp/TypedTreeBasics.fs
@@ -445,7 +445,14 @@ let canAccessFrom (TAccess x) cpath =
     x |> List.forall (fun cpath1 -> canAccessCompPathFrom cpath1 cpath)
 
 let canAccessFromEverywhere (TAccess x) = x.IsEmpty
+
 let canAccessFromSomewhere (TAccess _) = true
+
+let hasInternalsVisibleToAttribute _ivts = false // TBD
+
+let canAccessFromSomewhereOutside ivts access = 
+    canAccessFromEverywhere access || hasInternalsVisibleToAttribute ivts
+
 let isLessAccessible (TAccess aa) (TAccess bb) = 
     not (aa |> List.forall(fun a -> bb |> List.exists (fun b -> canAccessCompPathFrom a b)))
 

--- a/src/fsharp/TypedTreeBasics.fsi
+++ b/src/fsharp/TypedTreeBasics.fsi
@@ -207,6 +207,8 @@ val canAccessFromEverywhere: Accessibility -> bool
 
 val canAccessFromSomewhere: Accessibility -> bool
 
+val canAccessFromSomewhereOutside: 'T -> Accessibility -> bool
+
 val isLessAccessible: Accessibility -> Accessibility -> bool
 
 /// Given (newPath, oldPath) replace oldPath by newPath in the TAccess.

--- a/src/fsharp/absil/illib.fs
+++ b/src/fsharp/absil/illib.fs
@@ -1100,6 +1100,13 @@ module NameMultiMap =
     
     let chooseRange f (m: NameMultiMap<'T>) = Map.foldBack (fun _ x sofar -> List.choose f x @ sofar) m []
 
+    let filterRange (f: 'T -> bool) (m: NameMultiMap<'T>) : NameMultiMap<'T> =
+        m 
+        // Filter all the entries for each key
+        |> Map.map (fun _ l -> List.filter f l) 
+        // Remove the empty entries
+        |> Map.filter (fun _ l -> not (List.isEmpty l))
+
     let map f (m: NameMultiMap<'T>) = NameMap.map (List.map f) m 
 
     let empty : NameMultiMap<'T> = Map.empty

--- a/src/fsharp/absil/illib.fsi
+++ b/src/fsharp/absil/illib.fsi
@@ -566,6 +566,8 @@ module internal NameMultiMap =
 
     val chooseRange: f:('T -> 'a option) -> m:NameMultiMap<'T> -> 'a list
 
+    val filterRange: f:('T -> bool) -> m:NameMultiMap<'T> -> NameMultiMap<'T>
+
     val map: f:('T -> 'a) -> m:NameMultiMap<'T> -> Map<string,'a list>
 
     val empty: NameMultiMap<'T>

--- a/tests/fsharp/new.fs
+++ b/tests/fsharp/new.fs
@@ -1,0 +1,169 @@
+
+
+
+
+open System
+
+module M
+
+type ClassPublic() = class end
+
+type private ClassPrivate() =   // CUT
+   static member ClassPrivateProperty = 1   // CUT
+
+type InterfacePublic = interface end
+
+type private InterfacePrivate = interface end
+
+// Val 
+let private PrivateFunction() = 0xabba    // CUT
+
+
+//
+// type GenericClass<'T when 'T :> InterfacePrivate >() = // NOTE: This is not allowed   
+//    class end
+
+
+[<AttributeUsage(AttributeTargets.All)>]
+type PublicAttribute () =
+    inherit Attribute()
+
+[<AttributeUsage(AttributeTargets.All)>]
+type private PrivateAttribute () =
+    inherit Attribute()
+
+[<AttributeUsage(AttributeTargets.All)>]
+type PublicWithPrivateConstructorAttribute internal () =
+    inherit Attribute()
+
+[<AttributeUsage(AttributeTargets.All)>]
+type PublicWithPrivateSetterPropertyAttribute() =
+    inherit Attribute()
+    member val internal Prop1 : int = 0 with get, set
+
+// [<AttributeUsage(AttributeTargets.All)>]
+// type PublicAttrributeWithPrivateSetterField() =
+//     inherit Attribute()
+//     member val private Prop1 : int = 0 with get, set
+
+[<PublicAttribute()>] // KEEP
+[<PrivateAttribute()>] // note: this is allowed! accessibility of attributes is implied by structure of attribute! CUT
+[<PublicWithPrivateConstructor()>] // note: this is allowed!  accessibility of attributes is implied by structure of attribute! CUT
+[<PublicWithPrivateSetterProperty(Prop1=4)>]  // note: this is allowed!  accessibility of attributes is implied by structure of attribute! CUT
+type ClassPublicWithPrivateAttributes() = class end
+
+type ClassPublicWithPrivateInterface() =
+    interface InterfacePrivate
+    static member MPublic1() = 1
+    static member private MPrivate1() = ClassPublic()   // CUT
+    static member private MPrivate2() = ClassPrivate()  // CUT
+
+type private InterfacePrivateInheritingInterfacePublic = 
+   interface
+     inherit InterfacePublic
+   end
+
+type ClassPublicWithPrivateInterface() =
+    interface InterfacePrivateInheritingInterfacePublic
+    // TODO: note, restriction should not cut this fully, but rather reduce it to
+    //  to InterfacePrivateInheritingInterfacePublic
+    // Question: What does C# do here, e.g.
+    //    - internal interface extends a public interface
+    //    - a public class implements this interface
+    //    - what ends up in the reference assembly? 
+
+type RecordPublic =
+    { FPublic: ClassPublic() }   
+
+type RecordPublicPrivate =                         // CUT
+    private { FRecordPublicPrivate: ClassPrivate() }   // CUT
+
+type private RecordPrivate =              // CUT
+    { FRecordPrivate: ClassPrivate() }        // CUT
+
+[<Struct>]
+type StructRecordPublic =
+    { FStructRecordPublic: ClassPublic() }   
+
+[<Struct>]
+type StructRecordPublicPrivate =
+    private { FStructRecordPublicPrivate: ClassPrivate() }    // CUT
+
+[<Struct>]
+type private StructRecordPrivate =                // CUT
+    { FStructRecordPrivate: ClassPrivate() }          // CUT
+
+type UnionPublic =
+    | UnionPublicCase1 of ClassPublic
+    | UnionPublicCase2 of ClassPublic
+
+type UnionPublicPrivate =
+    private                                           // CUT
+    | UnionPublicPrivateCase1 of ClassPrivate             // CUT
+    | UnionPublicPrivateCase2 of ClassPrivate             // CUT
+
+type private UnionPrivate =                           // CUT
+    | UnionPrivateCase1 of ClassPrivate                   // CUT
+    | UnionPrivateCase2 of ClassPrivate                   // CUT
+
+[<Struct>]
+type StructUnionPublic =
+    | StructUnionPublicCase1 of ClassPublic
+    | StructUnionPublicCase2 of ClassPublic
+
+[<Struct>]
+type StructUnionPublicInternal =
+    private                                            // CUT
+    | StructUnionPublicInternalCase1 of ClassPrivate       // CUT
+    | StructUnionPublicInternalCase2 of ClassPrivate       // CUT
+
+[<Struct>]
+type private StructUnionPrivate =                     // CUT
+    | StructUnionPrivateCase1 of ClassPrivate             // CUT
+    | StructUnionPrivateCase2 of ClassPrivate            // CUT
+
+type private InterfacePrivate = 
+   interface
+       abstract M: int -> int
+   end
+
+type GenericInterfacePublic<'T> = 
+   interface
+       abstract M: int -> int
+   end
+
+type ClassPublicImplementingPrivateInterface() =
+    interface InterfacePrivate with // allowed, must be trimmed
+        member _.M(x:int) = x
+    interface GenericInterfacePublic<InterfacePrivate> with // allowed, must be trimmed
+        member _.M(x:int) = x
+
+// type private BaseClassPrivate() = 
+//     class
+//     end
+// type ClassPublicWithPrivateBaseClass() =
+//     inherit BaseClassPrivate()  // not allowed
+
+
+exception ExceptionPublic of ClassPublic
+exception ExceptionAbbrevPublic =  ExceptionPublic
+
+// Note, existing checks disallow this, for no good reason
+//exception private ExceptionPrivate of ClassPrivate // Trimmed
+exception private ExceptionPrivate of int // CUT!
+exception private ExceptionAbbrevPrivate = ExceptionPrivate // CUT!
+
+// Implied private
+module private ModulePrivate =
+    type CImplicitlyPrivate() = class end // CUT
+     // + duplicate out all of the above
+     
+
+
+
+let test1() = PrivateFunction()
+
+let test2() = C() |> ignore
+
+let test3() = C.P
+

--- a/tests/fsharp/new.fs
+++ b/tests/fsharp/new.fs
@@ -1,9 +1,3 @@
-
-
-
-
-open System
-
 module M
 
 type ClassPublic() = class end
@@ -33,23 +27,18 @@ type private PrivateAttribute () =
     inherit Attribute()
 
 [<AttributeUsage(AttributeTargets.All)>]
-type PublicWithPrivateConstructorAttribute internal () =
+type PublicWithInternalConstructorAttribute internal () =
     inherit Attribute()
 
 [<AttributeUsage(AttributeTargets.All)>]
-type PublicWithPrivateSetterPropertyAttribute() =
+type PublicWithInternalSetterPropertyAttribute() =
     inherit Attribute()
     member val internal Prop1 : int = 0 with get, set
 
-// [<AttributeUsage(AttributeTargets.All)>]
-// type PublicAttrributeWithPrivateSetterField() =
-//     inherit Attribute()
-//     member val private Prop1 : int = 0 with get, set
-
 [<PublicAttribute()>] // KEEP
 [<PrivateAttribute()>] // note: this is allowed! accessibility of attributes is implied by structure of attribute! CUT
-[<PublicWithPrivateConstructor()>] // note: this is allowed!  accessibility of attributes is implied by structure of attribute! CUT
-[<PublicWithPrivateSetterProperty(Prop1=4)>]  // note: this is allowed!  accessibility of attributes is implied by structure of attribute! CUT
+[<PublicWithInternalConstructorAttribute()>] // note: this is allowed!  accessibility of attributes is implied by structure of attribute! CUT
+[<PublicWithInternalSetterPropertyAttribute(Prop1=4)>]  // note: this is allowed!  accessibility of attributes is implied by structure of attribute! CUT
 type ClassPublicWithPrivateAttributes() = class end
 
 type ClassPublicWithPrivateInterface() =
@@ -72,11 +61,27 @@ type ClassPublicWithPrivateInterface() =
     //    - a public class implements this interface
     //    - what ends up in the reference assembly? 
 
+
+
+type private ClassPrivateUsedInPrivateFieldOfPublicStruct = // This must be kept!
+  member private x.P = 1
+
+[<Struct>]
+type private StructPrivateUsedInPrivateFieldOfPublicStruct = // This must be kept!
+  val private X: int   // This must be kept!  Computation of "has default value" and "unmanaged" depend on this!
+
+[<Struct>]
+type S = 
+   val private X1: ClassPrivateUsedInPrivateFieldOfPublicStruct
+   val private X2: StructPrivateUsedInPrivateFieldOfPublicStruct
+
+
+
 type RecordPublic =
-    { FPublic: ClassPublic() }   
+    { FPublic: ClassPublic }   
 
 type RecordPublicPrivate =                         // CUT
-    private { FRecordPublicPrivate: ClassPrivate() }   // CUT
+    private { FRecordPublicPrivate: ClassPrivate }   // CUT
 
 type private RecordPrivate =              // CUT
     { FRecordPrivate: ClassPrivate() }        // CUT
@@ -109,18 +114,15 @@ type private UnionPrivate =                           // CUT
 [<Struct>]
 type StructUnionPublic =
     | StructUnionPublicCase1 of ClassPublic
-    | StructUnionPublicCase2 of ClassPublic
 
 [<Struct>]
-type StructUnionPublicInternal =
+type StructUnionPublicPrivate =
     private                                            // CUT
-    | StructUnionPublicInternalCase1 of ClassPrivate       // CUT
-    | StructUnionPublicInternalCase2 of ClassPrivate       // CUT
+    | StructUnionPublicPrivateCase1 of ClassPrivate       // CUT
 
 [<Struct>]
 type private StructUnionPrivate =                     // CUT
     | StructUnionPrivateCase1 of ClassPrivate             // CUT
-    | StructUnionPrivateCase2 of ClassPrivate            // CUT
 
 type private InterfacePrivate = 
    interface


### PR DESCRIPTION
While working on #11521 with @vzarytovskii we've identified that the F# signature data metadata resource blob contains Too Much Information.  

In particular it contains 

1. the metadata for "private" declarations in implementation files that don't have signature files
2. the metadata for "internal" declarations when there are no InternalsVisibleTo in the assembly

This means the reference assembly feature will not be quite as effective as we would like , as reference assemblies will get updated even when private implementation details change.  

However, this fix to reduce the information on the signature bloc is of a different nature to the rest of the work on reference assemblies and is in a sense completely independent from a logical/correctness point of view.  It also has some subtle edge cases, and thus we think this fix is best made separately, and perhaps released under preview or else have a command line option to disable it.

The reference assembly feature is still highly useful without this fix as there are plenty of cases where it's still useful without this.


