### PR TITLE
Enable go to source for tests

### DIFF
--- a/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
+++ b/src/buildtools/AssemblyCheck/AssemblyCheck.fsproj
@@ -9,6 +9,9 @@
 
   <ItemGroup>
     <Compile Include="AssemblyCheck.fs" />
+    <Content Include="SkipVerifyEmbeddedPdb.txt">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/buildtools/AssemblyCheck/SkipVerifyEmbeddedPdb.txt
+++ b/src/buildtools/AssemblyCheck/SkipVerifyEmbeddedPdb.txt
@@ -1,0 +1,9 @@
+FSharp.Build.UnitTests.dll
+FSharp.Compiler.Benchmarks.dll
+FSharp.Compiler.ComponentTests.dll
+FSharp.Test.Utilities.dll
+FSharp.Compiler.Private.Scripting.UnitTests.dll
+FSharp.Compiler.Service.Tests.dll
+FSharp.Compiler.UnitTests.dll
+FSharp.Core.UnitTests.dll
+FSharpSuite.Tests.dll

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The go to test source option in the test explorer wasn't working for the unit tests in this repo.  This is because test explorer requires a separate pdb file and we embed them by default in this repo.

The fix was merely to ensure that test assemblies are not built with embedded pdb files.