### PR TITLE
Verify the IN keyword is not the start of the body expression.

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -157,13 +157,21 @@ let mkClassMemberLocalBindings(isStatic, initialRangeOpt, attrs, vis, BindingSet
    if isUse then errorR(Error(FSComp.SR.parsUseBindingsIllegalInImplicitClassConstructors(), wholeRange))
    SynMemberDefn.LetBindings (decls, isStatic, isRec, wholeRange)
 
-let mkLocalBindings (mWhole, BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, _), mIn, body) = 
+let mkLocalBindings (mWhole, BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, _), mIn, body: SynExpr) = 
    let ignoredFreeAttrs, decls = declsPreAttrs [] None
    let mWhole =
        match decls with
        | SynBinding(xmlDoc = xmlDoc) :: _ -> unionRangeWithXmlDoc xmlDoc mWhole
        | _ -> mWhole
    if not (isNil ignoredFreeAttrs) then warning(Error(FSComp.SR.parsAttributesIgnored(), mWhole))
+   let mIn =
+       mIn
+       |> Option.bind (fun (mIn: range) -> 
+           if Position.posEq mIn.Start body.Range.Start then
+              None
+           else
+              Some mIn)
+
    SynExpr.LetOrUse (isRec, isUse, decls, body, mWhole, { InKeyword = mIn }) 
 
 let mkDefnBindings (mWhole, BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, _bindingSetRange), attrs, vis, attrsm) = 

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -968,6 +968,25 @@ do
             Assert.Pass()
         | _ -> Assert.Fail "Could not get valid AST"
 
+    [<Test>]
+    let ``SynExpr.LetOrUse where body expr starts with token of two characters does not contain the range of in keyword`` () =
+        let ast =
+            getParseResults """
+do
+    let e1 = e :?> Collections.DictionaryEntry
+    e1.Key, e1.Value
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+                    SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                        SynModuleDecl.DoExpr(expr =
+                            SynExpr.Do(expr = SynExpr.LetOrUse(trivia={ InKeyword = None })))
+                    ])
+                ])) ->
+            Assert.Pass()
+        | _ -> Assert.Fail "Could not get valid AST"
+
 module Strings =
     let getBindingExpressionValue (parseResults: ParsedInput) =
         match parseResults with


### PR DESCRIPTION
Following up upon: https://github.com/dotnet/fsharp/pull/12673/files#r797440462
This verifies that the `IN` really is a separate range.
@dsyme let me know if this could be improved somehow.