### PR TITLE
improve default exception printing

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -7709,8 +7709,10 @@ and GenAbstractBinding cenv eenv tref (vref: ValRef) =
     else
         [], [], []
 
-/// Generate a ToString method that calls 'sprintf "%A"'
-and GenToStringMethod cenv eenv ilThisTy m =
+and GenToStringMethod cenv eenv ilThisTy m = GenPrintingMethod cenv eenv "ToString" ilThisTy m
+
+/// Generate a ToString/get_Message method that calls 'sprintf "%A"'
+and GenPrintingMethod cenv eenv methName ilThisTy m =
     let g = cenv.g
     [ match (eenv.valsInScope.TryFind g.sprintf_vref.Deref,
              eenv.valsInScope.TryFind g.new_format_vref.Deref) with
@@ -7750,7 +7752,7 @@ and GenToStringMethod cenv eenv ilThisTy m =
 
                let ilMethodBody = mkMethodBody (true, [], 2, nonBranchingInstrsToCode ilInstrs, None, eenv.imports)
                
-               let mdef = mkILNonGenericVirtualMethod ("ToString", ILMemberAccess.Public, [], mkILReturn g.ilg.typ_String, ilMethodBody)
+               let mdef = mkILNonGenericVirtualMethod (methName, ILMemberAccess.Public, [], mkILReturn g.ilg.typ_String, ilMethodBody)
                let mdef = mdef.With(customAttrs = mkILCustomAttrs [ g.CompilerGeneratedAttribute ])
                yield mdef
       | _ -> () ]
@@ -8433,12 +8435,21 @@ and GenExnDef cenv mgbuf eenv m (exnc: Tycon) =
 
         let ilTypeName = tref.Name
 
+        let ilMethodDefs =
+            [ ilCtorDef
+              yield! ilCtorDefNoArgs
+              yield! serializationRelatedMembers
+              yield! ilMethodDefsForProperties
+
+              if not (exnc.HasMember g "get_Message" []) && not (exnc.HasMember g "Message" [])  then
+                  yield! GenPrintingMethod cenv eenv "get_Message" ilThisTy m ]
+
         let interfaces = exnc.ImmediateInterfaceTypesOfFSharpTycon |> List.map (GenType cenv.amap m eenv.tyenv)
         let tdef =
           mkILGenericClass
             (ilTypeName, access, [], g.iltyp_Exception,
              interfaces,
-             mkILMethods ([ilCtorDef] @ ilCtorDefNoArgs @ serializationRelatedMembers @ ilMethodDefsForProperties),
+             mkILMethods ilMethodDefs,
              mkILFields ilFieldDefs,
              emptyILTypeDefs,
              mkILProperties ilPropertyDefs,

--- a/src/fsharp/utils/FileSystem.fsi
+++ b/src/fsharp/utils/FileSystem.fsi
@@ -9,7 +9,7 @@ open System.Reflection
 open System.Text
 open System.Runtime.CompilerServices
 
-exception IllegalFileNameChar of string * char
+exception internal IllegalFileNameChar of string * char
 
 module internal Bytes =
     /// returned int will be 0 <= x <= 255

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -4087,17 +4087,6 @@ FSharp.Compiler.IO.IFileSystem: System.String NormalizePathShim(System.String)
 FSharp.Compiler.IO.IFileSystem: Void CopyShim(System.String, System.String, Boolean)
 FSharp.Compiler.IO.IFileSystem: Void DirectoryDeleteShim(System.String)
 FSharp.Compiler.IO.IFileSystem: Void FileDeleteShim(System.String)
-FSharp.Compiler.IO.IllegalFileNameChar
-FSharp.Compiler.IO.IllegalFileNameChar: Boolean Equals(System.Object)
-FSharp.Compiler.IO.IllegalFileNameChar: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
-FSharp.Compiler.IO.IllegalFileNameChar: Char Data1
-FSharp.Compiler.IO.IllegalFileNameChar: Char get_Data1()
-FSharp.Compiler.IO.IllegalFileNameChar: Int32 GetHashCode()
-FSharp.Compiler.IO.IllegalFileNameChar: Int32 GetHashCode(System.Collections.IEqualityComparer)
-FSharp.Compiler.IO.IllegalFileNameChar: System.String Data0
-FSharp.Compiler.IO.IllegalFileNameChar: System.String get_Data0()
-FSharp.Compiler.IO.IllegalFileNameChar: Void .ctor()
-FSharp.Compiler.IO.IllegalFileNameChar: Void .ctor(System.String, Char)
 FSharp.Compiler.IO.StreamExtensions
 FSharp.Compiler.IO.StreamExtensions: Byte[] Stream.ReadAllBytes(System.IO.Stream)
 FSharp.Compiler.IO.StreamExtensions: Byte[] Stream.ReadBytes(System.IO.Stream, Int32, Int32)

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelModule.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelModule.il.bsl
@@ -36,13 +36,13 @@
   // Offset: 0x00001148 Length: 0x000003FD
 }
 .module TopLevelModule.dll
-// MVID: {61F2D6CA-37F5-C118-A745-0383CAD6F261}
+// MVID: {620E3D71-37F5-C118-A745-0383713D0E62}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x07430000
+// Image base: 0x07130000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -579,6 +579,20 @@
       IL_0001:  ldfld      int32 ABC/MyExn::Data0@
       IL_0006:  ret
     } // end of method MyExn::get_Data0
+
+    .method public strict virtual instance string 
+            get_Message() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       22 (0x16)
+      .maxstack  8
+      IL_0000:  ldstr      "%+A"
+      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class ABC/MyExn,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class ABC/MyExn>::.ctor(string)
+      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class ABC/MyExn,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+      IL_000f:  ldarg.0
+      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class ABC/MyExn,string>::Invoke(!0)
+      IL_0015:  ret
+    } // end of method MyExn::get_Message
 
     .method public hidebysig virtual instance int32 
             GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
@@ -1351,6 +1365,20 @@
         IL_0001:  ldfld      int32 ABC/ABC/MyExn::Data0@
         IL_0006:  ret
       } // end of method MyExn::get_Data0
+
+      .method public strict virtual instance string 
+              get_Message() cil managed
+      {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        // Code size       22 (0x16)
+        .maxstack  8
+        IL_0000:  ldstr      "%+A"
+        IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class ABC/ABC/MyExn,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class ABC/ABC/MyExn>::.ctor(string)
+        IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class ABC/ABC/MyExn,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+        IL_000f:  ldarg.0
+        IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class ABC/ABC/MyExn,string>::Invoke(!0)
+        IL_0015:  ret
+      } // end of method MyExn::get_Message
 
       .method public hidebysig virtual instance int32 
               GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelNamespace.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelNamespace.il.bsl
@@ -36,13 +36,13 @@
   // Offset: 0x00001850 Length: 0x0000055C
 }
 .module ToplevelNamespace.dll
-// MVID: {61F2D6CC-218B-729A-A745-0383CCD6F261}
+// MVID: {620E3D73-218B-729A-A745-0383733D0E62}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x07080000
+// Image base: 0x06D00000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -574,6 +574,20 @@
     IL_0001:  ldfld      int32 XYZ.MyExn::Data0@
     IL_0006:  ret
   } // end of method MyExn::get_Data0
+
+  .method public strict virtual instance string 
+          get_Message() cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       22 (0x16)
+    .maxstack  8
+    IL_0000:  ldstr      "%+A"
+    IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.MyExn,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class XYZ.MyExn>::.ctor(string)
+    IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.MyExn,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+    IL_000f:  ldarg.0
+    IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.MyExn,string>::Invoke(!0)
+    IL_0015:  ret
+  } // end of method MyExn::get_Message
 
   .method public hidebysig virtual instance int32 
           GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
@@ -1347,6 +1361,20 @@
       IL_0006:  ret
     } // end of method MyExn::get_Data0
 
+    .method public strict virtual instance string 
+            get_Message() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       22 (0x16)
+      .maxstack  8
+      IL_0000:  ldstr      "%+A"
+      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.ABC/MyExn,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class XYZ.ABC/MyExn>::.ctor(string)
+      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.ABC/MyExn,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+      IL_000f:  ldarg.0
+      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.ABC/MyExn,string>::Invoke(!0)
+      IL_0015:  ret
+    } // end of method MyExn::get_Message
+
     .method public hidebysig virtual instance int32 
             GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
@@ -2118,6 +2146,20 @@
         IL_0001:  ldfld      int32 XYZ.ABC/ABC/MyExn::Data0@
         IL_0006:  ret
       } // end of method MyExn::get_Data0
+
+      .method public strict virtual instance string 
+              get_Message() cil managed
+      {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        // Code size       22 (0x16)
+        .maxstack  8
+        IL_0000:  ldstr      "%+A"
+        IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.ABC/ABC/MyExn,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class XYZ.ABC/ABC/MyExn>::.ctor(string)
+        IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.ABC/ABC/MyExn,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+        IL_000f:  ldarg.0
+        IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class XYZ.ABC/ABC/MyExn,string>::Invoke(!0)
+        IL_0015:  ret
+      } // end of method MyExn::get_Message
 
       .method public hidebysig virtual instance int32 
               GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed


### PR DESCRIPTION
This fixes the original problem reported here is in #3327. It adds a Message override if none has been provided, using %A to format all the data in the exception object. This seems reasonable.  You could imagine refinements like "use a single string as the message" but I don't think that's appropriate because any particular refinement may lose information.  ​If the user wants this customized they 
should override the `Message` property.

We should gate this by language version since it could be a breaking change (because of people doing silly things like searching inside the text of an exception message