### PR TITLE
XmlDoc fixes

### DIFF
--- a/src/fsharp/XmlDoc.fs
+++ b/src/fsharp/XmlDoc.fs
@@ -51,8 +51,12 @@ type XmlDoc(unprocessedLines: string[], range: range) =
     member doc.NonEmpty = not doc.IsEmpty
 
     static member Merge (doc1: XmlDoc) (doc2: XmlDoc) =
-        XmlDoc(Array.append doc1.UnprocessedLines doc2.UnprocessedLines,
-               unionRanges doc1.Range doc2.Range)
+        let range = 
+            if doc1.IsEmpty then doc2.Range
+            elif doc2.IsEmpty then doc1.Range
+            else unionRanges doc1.Range doc2.Range
+
+        XmlDoc(Array.append doc1.UnprocessedLines doc2.UnprocessedLines, range)
 
     member doc.GetXmlText() =
         if doc.IsEmpty then ""

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -919,15 +919,15 @@ tyconSpfn:
         $3 lhsm $1 (Some mEquals) }
   | typeNameInfo  opt_classSpfn       
       { let mWithKwd, members = $2
+        let (SynComponentInfo(range=range)) = $1
         let m =
             match members with
             | [] ->
                 match mWithKwd with
-                | None -> rhs parseState 1
-                | Some mWithKwd -> unionRanges (rhs parseState 1) mWithKwd
+                | None -> range
+                | Some mWithKwd -> unionRanges range mWithKwd
             | decls ->
-                let (SynComponentInfo(range=start)) = $1
-                (start, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
+                (range, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
         SynTypeDefnSig($1, None, SynTypeDefnSigRepr.Simple (SynTypeDefnSimpleRepr.None m, m), mWithKwd, members, m) }
 
 
@@ -1096,7 +1096,7 @@ classMemberSpfn:
 
   | opt_attributes opt_declVisibility NEW COLON topTypeWithTypeConstraints  
      { let vis, doc, (ty, valSynInfo) = $2, grabXmlDoc(parseState, $1, 1), $5
-       let m = unionRanges (rhs parseState 1) ty.Range 
+       let m = unionRanges (rhs parseState 1) ty.Range |> unionRangeWithXmlDoc doc
        let isInline = false 
        let valSpfn = SynValSig ($1, mkSynId (rhs parseState 3) "new", noInferredTypars, ty, valSynInfo, isInline, false, doc, vis, None, None, m)
        SynMemberSig.Member(valSpfn, CtorMemberFlags SynMemberFlagsTrivia.Zero, m) }

--- a/tests/service/XmlDocTests.fs
+++ b/tests/service/XmlDocTests.fs
@@ -349,13 +349,10 @@ type
             |]
 
             match parseResults.ParseTree with
-            | Types(range, [TypeRange(typeRange, synComponentRange)]) ->
+            | Types(range, [TypeRange(typeRange, synComponentRange)])
+            | TypeSigs(range, [TypeSigRange(typeRange, synComponentRange)]) ->
                 assertRange (4, 0) (10, 14) range
                 assertRange (4, 0) (10, 14) typeRange
-                assertRange (10, 13) (10, 14) synComponentRange
-            | TypeSigs(range, [TypeSigRange(typeRange, synComponentRange)]) ->
-                assertRange (4, 0) (11, 0) range
-                assertRange (4, 0) (11, 0) typeRange
                 assertRange (10, 13) (10, 14) synComponentRange
             | x ->
                 failwith $"Unexpected ParsedInput %A{x}")
@@ -1057,7 +1054,7 @@ module M2 = type A
     match parseResults.ParseTree with
     | NestedModulesSigs(range1, range2) ->
         assertRange (2, 0) (6, 30) range1
-        assertRange (8, 0) (11, 0) range2
+        assertRange (8, 0) (10, 18) range2
     | x ->
         failwith $"Unexpected ParsedInput: %A{x}"
 


### PR DESCRIPTION
Several bugs were found in XmlDocs:

1. In signature files, for 'new' type members xmldoc is not in member range
```F#
/// :( -- not in range
new: unit -> T
```

2. In signature files, for types without members everything is included in the range up to the next declaration
```F#
type A

///B -- in 'A' declaration range :(
type B = ...
```

3. For properties with explicit accessors XmlDoc range was incorrectly calculated in XmlDoc.Merge, 
when one of the xml docs is empty

This PR fixes them