### PR TITLE
NuGet warning NU1604 when restoring an F# project for net4.6.1

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -73,8 +73,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </ItemGroup>
 
   <PropertyGroup>
-    <DefaultValueTuplePackageVersion>4.4.0</DefaultValueTuplePackageVersion>
-    <ValueTupleImplicitPackageVersion>$(DefaultValueTuplePackageVersionValue)</ValueTupleImplicitPackageVersion>
+    <ValueTupleImplicitPackageVersion>4.4.0</ValueTupleImplicitPackageVersion>
     <FSCorePackageVersion>{{FSCorePackageVersionValue}}</FSCorePackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes: #12778

A renaming from a while ago wasn't fully implemented.  This fix merely simplifies the whole thing.