### PR TITLE
Fix XmlDocs for namespaces and secondary constructor definitions

### DIFF
--- a/src/fsharp/CheckFormatStrings.fs
+++ b/src/fsharp/CheckFormatStrings.fs
@@ -76,7 +76,7 @@ let parseFormatStringInternal (m: range) (fragRanges: range list) (g: TcGlobals)
     // Note this also means that when compiling (command-line or background IncrementalBuilder in the IDE
     // there are no accurate intra-string ranges available for exact error message locations within the string.
     // The 'm' range passed as an input is however accurate and covers the whole string.
-    ///
+    //
     let fmt, fragments = 
 
         //printfn "--------------------" 

--- a/src/fsharp/DependencyManager/DependencyProvider.fsi
+++ b/src/fsharp/DependencyManager/DependencyProvider.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-/// Helper members to integrate DependencyManagers into F# codebase
+// Helper members to integrate DependencyManagers into F# codebase
 namespace FSharp.Compiler.DependencyManager
 
 open System.Runtime.InteropServices

--- a/src/fsharp/FSharp.Core/SI.fs
+++ b/src/fsharp/FSharp.Core/SI.fs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// The International System of Units (SI)
+// The International System of Units (SI)
 namespace Microsoft.FSharp.Data.UnitSystems.SI.UnitNames
     open Microsoft.FSharp.Core
 
@@ -113,7 +113,7 @@ namespace Microsoft.FSharp.Data.UnitSystems.SI.UnitNames
     type katal = mole/second 
 
 
-/// Common abbreviations for the International System of Units (SI)
+// Common abbreviations for the International System of Units (SI)
 namespace Microsoft.FSharp.Data.UnitSystems.SI.UnitSymbols
     open Microsoft.FSharp.Core
     open Microsoft.FSharp.Data.UnitSystems.SI.UnitNames

--- a/src/fsharp/FSharp.Core/collections.fsi
+++ b/src/fsharp/FSharp.Core/collections.fsi
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// <summary>This namespace contains some common collections in a style primarily designed for use from F#.</summary>
-
+// This namespace contains some common collections in a style primarily designed for use from F#.
 namespace Microsoft.FSharp.Collections
 
 open Microsoft.FSharp.Core

--- a/src/fsharp/FSharp.Core/fslib-extra-pervasives.fsi
+++ b/src/fsharp/FSharp.Core/fslib-extra-pervasives.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// <summary>Pervasives: Additional bindings available at the top level</summary>
+// Pervasives: Additional bindings available at the top level
 namespace Microsoft.FSharp.Core
 
 /// <summary>A set of extra operators and functions. This module is automatically opened in all F# code.</summary>

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -17,7 +17,7 @@ module internal DetailedExceptions =
     val invalidArgDifferentArrayLength: arg1:string -> len1:int -> arg2:string -> len2:int -> _
     val invalidArg3ArraysDifferent: arg1:string -> arg2:string -> arg3:string -> len1:int -> len2:int -> len3:int -> _
 
-/// Definitions internal for this library.
+// Definitions internal for this library.
 namespace Microsoft.FSharp.Primitives.Basics 
 
 open Microsoft.FSharp.Core

--- a/src/fsharp/FSharp.Core/prim-types-prelude.fsi
+++ b/src/fsharp/FSharp.Core/prim-types-prelude.fsi
@@ -4,7 +4,7 @@
 #nowarn "61" // The containing type can use <c>null</c> as a representation value for its nullary union case. This member will be compiled as a static member.
 #nowarn "62" // This construct is for ML compatibility. The syntax <c>module ... : sig .. end</c> is deprecated unless OCaml compatibility is enabled. Consider using <c>module ... = begin .. end'.
 
-/// <summary>Basic F# type definitions, functions and operators.</summary> 
+// Basic F# type definitions, functions and operators.
 namespace Microsoft.FSharp.Core
 
     open System

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -2319,7 +2319,7 @@ namespace Microsoft.FSharp.Core
         //      0oOOOOOOO
         //      -0oOOOOOOO
         // without leading/trailing spaces.
-        ///
+        //
         // Note: Parse defaults to NumberStyles.Integer =  AllowLeadingWhite ||| AllowTrailingWhite ||| AllowLeadingSign
         // However, that is not the required behaviour of 'int32', 'int64' etc. when used on string
         // arguments: we explicitly disallow AllowLeadingWhite ||| AllowTrailingWhite 

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -3,7 +3,7 @@
 #nowarn "35" // This construct is deprecated: the treatment of this operator is now handled directly by the F# compiler and its meaning may not be redefined.
 #nowarn "61" // The containing type can use 'null' as a representation value for its nullary union case. This member will be compiled as a static member.
 
-/// <summary>Basic F# type definitions, functions and operators </summary>
+// Basic F# type definitions, functions and operators
 namespace Microsoft.FSharp.Core
 
     open System

--- a/src/fsharp/FSharp.Core/printf.fsi
+++ b/src/fsharp/FSharp.Core/printf.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// <summary>This namespace contains types and modules for generating and formatting text with F#</summary>
+// This namespace contains types and modules for generating and formatting text with F#
 namespace Microsoft.FSharp.Core
 
 open Microsoft.FSharp.Core

--- a/src/fsharp/FSharp.Core/quotations.fsi
+++ b/src/fsharp/FSharp.Core/quotations.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// <summary>Types and functions related to expression quotations</summary>
+// Types and functions related to expression quotations
 namespace Microsoft.FSharp.Quotations
 
 open Microsoft.FSharp.Core

--- a/src/fsharp/FSharp.Core/reflect.fsi
+++ b/src/fsharp/FSharp.Core/reflect.fsi
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// <summary>This namespace contains constructs for reflecting on the representation of
-/// F# values and types. It augments the design of System.Reflection.</summary>
+// This namespace contains constructs for reflecting on the representation of
+// F# values and types. It augments the design of System.Reflection.
 namespace Microsoft.FSharp.Reflection 
 
 open System

--- a/src/fsharp/FSharp.Core/tasks.fsi
+++ b/src/fsharp/FSharp.Core/tasks.fsi
@@ -164,7 +164,7 @@ namespace Microsoft.FSharp.Control
         val backgroundTask: BackgroundTaskBuilder
     
 
-/// Contains the `task` computation expression builder.
+// Contains the `task` computation expression builder.
 namespace Microsoft.FSharp.Control.TaskBuilderExtensions 
 
     open System

--- a/src/fsharp/TextLayoutRender.fsi
+++ b/src/fsharp/TextLayoutRender.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// DSL to create structured layout objects with optional breaks and render them
+// DSL to create structured layout objects with optional breaks and render them
 namespace FSharp.Compiler.Text
 
 open System.Text

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -680,7 +680,7 @@ let u_lazy u st =
     let res =
         lazy (let st = { st with is = st.is.CloneAndSeek idx1 }
               u st)
-    /// Force the reading of the data as a "tripwire" for each of the OSGN thunks
+    // Force the reading of the data as a "tripwire" for each of the OSGN thunks
     for i = otyconsIdx1 to otyconsIdx2-1 do wire (st.ientities.Get i) res done
     for i = ovalsIdx1   to ovalsIdx2-1   do wire (st.ivals.Get i)   res done
     for i = otyparsIdx1 to otyparsIdx2-1 do wire (st.itypars.Get i) res done

--- a/src/fsharp/fsiaux.fsi
+++ b/src/fsharp/fsiaux.fsi
@@ -19,8 +19,8 @@ namespace FSharp.Compiler.Interactive
         /// <summary>Schedule a restart for the event loop.</summary>
         abstract ScheduleRestart : unit -> unit
     
+    /// Operations supported by the currently executing F# Interactive session.
     [<Sealed>]
-    /// <summary>Operations supported by the currently executing F# Interactive session.</summary>
     type InteractiveSession =
 
         /// <summary>Get or set the floating point format used in the output of the interactive session.</summary>

--- a/src/fsharp/infos.fsi
+++ b/src/fsharp/infos.fsi
@@ -432,7 +432,7 @@ type MethInfo =
     member ImplementedSlotSignatures: SlotSig list
 
     // Is this particular MethInfo one that doesn't provide an implementation?
-    ///
+    //
     // For F# methods, this is 'true' for the MethInfos corresponding to 'abstract' declarations,
     // and false for the (potentially) matching 'default' implementation MethInfos that eventually
     // provide an implementation for the dispatch slot.

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -754,7 +754,8 @@ fileModuleSpec:
         | _ ->
             let lastDeclRange = List.tryLast $1 |> Option.map (fun decl -> decl.Range) |> Option.defaultValue (rhs parseState 1)
             let m = mkRange lastDeclRange.FileName (lhs parseState).Start lastDeclRange.End
-            ParsedSigFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, xml, [], m))  } 
+            xml.MarkAsInvalid()
+            ParsedSigFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m))  } 
 
 
 moduleSpfnsPossiblyEmptyBlock: 
@@ -1242,7 +1243,8 @@ fileModuleImpl:
         | _ ->
             let lastDeclRange = List.tryLast $1 |> Option.map (fun decl -> decl.Range) |> Option.defaultValue (rhs parseState 1)
             let m = mkRange lastDeclRange.FileName (lhs parseState).Start lastDeclRange.End
-            ParsedImplFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, xml, [], m)) } 
+            xml.MarkAsInvalid()
+            ParsedImplFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m)) } 
 
 
 /* A collection/block of definitions or expressions making up a module or namespace, possibly empty */
@@ -2120,7 +2122,8 @@ classDefnMember:
 
   | opt_attributes opt_declVisibility NEW  atomicPattern optAsSpec EQUALS typedSequentialExprBlock opt_ODECLEND
      {  let mWholeBindLhs = rhs2 parseState 1 (if Option.isSome $5 then 5 else 4)
-        let m = unionRanges mWholeBindLhs $7.Range 
+        let xmlDoc = grabXmlDoc(parseState, $1, 1)
+        let m = unionRanges mWholeBindLhs $7.Range |> unionRangeWithXmlDoc xmlDoc
         let mEquals = rhs parseState 6
         let expr = $7
         let valSynData = SynValData (Some (CtorMemberFlags SynMemberFlagsTrivia.Zero), SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), $5) 
@@ -2129,7 +2132,7 @@ classDefnMember:
         // Check that 'SynPatForConstructorDecl' matches this correctly
         assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
         let synBindingTrivia: SynBindingTrivia = { LetKeyword = None; EqualsRange = Some mEquals }
-        [ SynMemberDefn.Member(SynBinding (None, SynBindingKind.Normal, false, false, $1, grabXmlDoc(parseState, $1, 1), valSynData, declPat, None, expr, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, synBindingTrivia), m) ] }
+        [ SynMemberDefn.Member(SynBinding (None, SynBindingKind.Normal, false, false, $1, xmlDoc, valSynData, declPat, None, expr, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, synBindingTrivia), m) ] }
         
   | opt_attributes opt_declVisibility STATIC typeKeyword tyconDefn 
      {  if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))

--- a/src/fsharp/range.fs
+++ b/src/fsharp/range.fs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// Anything to do with special names of identifiers and other lexical rules
+// Anything to do with special names of identifiers and other lexical rules
 namespace FSharp.Compiler.Text
 
 open System

--- a/src/fsharp/range.fsi
+++ b/src/fsharp/range.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// The Range and Pos types form part of the public API of FSharp.Compiler.Service
+// The Range and Pos types form part of the public API of FSharp.Compiler.Service
 namespace FSharp.Compiler.Text
 
 open System.Collections.Generic

--- a/src/fsharp/service/ServiceDeclarationLists.fsi
+++ b/src/fsharp/service/ServiceDeclarationLists.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// API for declaration lists and method overload lists
+// API for declaration lists and method overload lists
 namespace FSharp.Compiler.EditorServices
 
 open FSharp.Compiler.NameResolution

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// SourceCodeServices API to the compiler as an incremental service for parsing,
-/// type checking and intellisense-like environment-reporting.
+// SourceCodeServices API to the compiler as an incremental service for parsing,
+// type checking and intellisense-like environment-reporting.
 namespace FSharp.Compiler.CodeAnalysis
 
 open System

--- a/src/fsharp/utils/PathMap.fs
+++ b/src/fsharp/utils/PathMap.fs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// Functions to map real paths to paths to be written to PDB/IL
+// Functions to map real paths to paths to be written to PDB/IL
 namespace Internal.Utilities
 
 open System

--- a/src/fsharp/utils/PathMap.fsi
+++ b/src/fsharp/utils/PathMap.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// Functions to map real paths to paths to be written to PDB/IL
+// Functions to map real paths to paths to be written to PDB/IL
 namespace Internal.Utilities
 
 type internal PathMap

--- a/src/fsharp/utils/TaggedCollections.fsi
+++ b/src/fsharp/utils/TaggedCollections.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-/// This namespace contains FSharp.PowerPack extensions for the F# collection types
+// This namespace contains FSharp.PowerPack extensions for the F# collection types
 namespace Internal.Utilities.Collections.Tagged
 
     open System

--- a/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
+++ b/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
@@ -40,7 +40,6 @@ module SignatureGenerationTests =
     [<Test>]
     let ``can generate sigs with comments`` () = 
         """
-/// namespace comments
 namespace Sample
 
 /// exception comments

--- a/tests/service/data/TestTP/ProvidedTypes.fsi
+++ b/tests/service/data/TestTP/ProvidedTypes.fsi
@@ -394,8 +394,8 @@ type ProvidedAssembly =
 
 #endif
 
-[<Class>]
 /// Represents the context for which code is to be generated. Normally you should not need to use this directly.
+[<Class>]
 type ProvidedTypesContext = 
         
     /// Try to find the given target assembly in the context


### PR DESCRIPTION
1. XmlDoc for namespaces are currently allowed, but they are not supported by either F# or C# tooltips, these comments wouldn't go to output xml files and there's no single namespace declaration to use for output. In line with C# implementation, we should not allow such doc comments
2. In implementation files, the XmlDoc range is not included in the secondary constructor range

This PR fixes range for secondary constructor with XmlDoc and adds warning about using XmlDoc for namespaces.