### PR TITLE
Change dive of match clauses to use the outer range, including the match head pattern

### DIFF
--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -458,7 +458,7 @@ module SyntaxTraversal =
 
                 | SynExpr.Match (expr=synExpr; clauses=synMatchClauseList) -> 
                     [yield dive synExpr synExpr.Range traverseSynExpr
-                     yield! synMatchClauseList |> List.map (fun x -> dive x x.RangeOfGuardAndRhs (traverseSynMatchClause path))]
+                     yield! synMatchClauseList |> List.map (fun x -> dive x x.Range (traverseSynMatchClause path))]
                     |> pick expr
 
                 | SynExpr.Do (synExpr, _range) -> traverseSynExpr synExpr
@@ -603,7 +603,7 @@ module SyntaxTraversal =
 
                 | SynExpr.MatchBang (expr=synExpr; clauses=synMatchClauseList) -> 
                     [yield dive synExpr synExpr.Range traverseSynExpr
-                     yield! synMatchClauseList |> List.map (fun x -> dive x x.RangeOfGuardAndRhs (traverseSynMatchClause path))]
+                     yield! synMatchClauseList |> List.map (fun x -> dive x x.Range (traverseSynMatchClause path))]
                     |> pick expr
 
                 | SynExpr.DoBang (synExpr, _range) -> traverseSynExpr synExpr


### PR DESCRIPTION
When working on [a new codefix](https://github.com/baronfel/FsAutoComplete/pull/3/files#diff-6a91d85b8b08d051480e489e80aba3c5a70665bf5d404c1f0e2ce250ad78e644R48-R79) I discovered that syntax tree walks of match clauses don't seem to be triggering calls to VisitMatchClause. This seems to be because the range passed into the `dive` is the range of the guard expression + right hand side of the clause, when I believe it should be the overall range of the match clause.  Because of this inconsistency, I think no range matches the range checks in `pick`, and so the VisitMatchClause member is never called.