### PR TITLE
Add GetCachedProjectOptions

### DIFF
--- a/src/fsharp/InternalCollections.fs
+++ b/src/fsharp/InternalCollections.fs
@@ -142,7 +142,10 @@ type internal AgedLookup<'Token, 'Key, 'Value when 'Value : not struct>(keepStro
        let keep = FilterAndHold(tok)
        AssignWithStrength(tok,keep)
 
-        
+    member al.Keys(tok) =
+        FilterAndHold(tok) |> List.map fst
+
+
 
 type internal MruCache<'Token, 'Key,'Value when 'Value : not struct>(keepStrongly, areSame, ?isStillValid : 'Key*'Value->bool, ?areSimilar, ?requiredToKeep, ?keepMax) =
         
@@ -199,4 +202,5 @@ type internal MruCache<'Token, 'Key,'Value when 'Value : not struct>(keepStrongl
         
     member bc.Resize(tok, newKeepStrongly, ?newKeepMax) =
         cache.Resize(tok, newKeepStrongly, ?newKeepMax=newKeepMax)
-        
+
+    member bc.Keys(tok) = cache.Keys(tok)

--- a/src/fsharp/InternalCollections.fsi
+++ b/src/fsharp/InternalCollections.fsi
@@ -38,7 +38,10 @@ type internal AgedLookup<'Token, 'Key, 'Value when 'Value : not struct> =
 
     /// Resize
     member Resize : 'Token * newKeepStrongly: int * ?newKeepMax : int -> unit
-    
+
+    /// Keys
+    member Keys : 'Token -> 'Key list
+
 /// Simple priority caching for a small number of key/value associations.
 /// This cache may age-out results that have been Set by the caller.
 /// Because of this, the caller must be able to tolerate values 
@@ -84,3 +87,5 @@ type internal MruCache<'Token, 'Key,'Value when 'Value : not struct> =
     /// Resize
     member Resize : 'Token * newKeepStrongly: int * ?newKeepMax : int -> unit
 
+    /// Keys
+    member Keys : 'Token -> 'Key list

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -184,6 +184,12 @@ type public FSharpChecker =
         ?userOpName: string
             -> Async<FSharpProjectOptions * FSharpDiagnostic list>
 
+    /// <summary>Get the list of FSharpProjectOptions for the project/script if they exist in the FCS cache.</summary>
+    ///
+    /// <param name="projectOrScriptFileName">The project or script filename.</param>
+    /// <param name="isScript">Is the passed <paramref name="projectOrScriptFileName"/> the path to the script file.</param>
+    member GetCachedProjectOptions: projectOrScriptFileName: string * isScript: bool -> FSharpProjectOptions list
+
     /// <summary>Get the FSharpProjectOptions implied by a set of command line arguments.</summary>
     ///
     /// <param name="projectFileName">Used to differentiate between projects and for the base directory of the project.</param>

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -2015,6 +2015,7 @@ FSharp.Compiler.CodeAnalysis.FSharpChecker: Int32 ActualCheckFileCount
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Int32 ActualParseFileCount
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Int32 get_ActualCheckFileCount()
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Int32 get_ActualParseFileCount()
+FSharp.Compiler.CodeAnalysis.FSharpChecker: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.CodeAnalysis.FSharpProjectOptions] GetCachedProjectOptions(System.String, Boolean)
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[FSharp.Compiler.CodeAnalysis.FSharpCheckFileAnswer] CheckFileInProject(FSharp.Compiler.CodeAnalysis.FSharpParseFileResults, System.String, Int32, FSharp.Compiler.Text.ISourceText, FSharp.Compiler.CodeAnalysis.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[FSharp.Compiler.CodeAnalysis.FSharpCheckProjectResults] ParseAndCheckProject(FSharp.Compiler.CodeAnalysis.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Microsoft.FSharp.Control.FSharpAsync`1[FSharp.Compiler.CodeAnalysis.FSharpParseFileResults] GetBackgroundParseResultsForFileInProject(System.String, FSharp.Compiler.CodeAnalysis.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])


### PR DESCRIPTION
We need to be able to quickly get project/script options from the FCS cache. 
This PR adds ``GetCachedProjectOptions(projectOrScriptFileName, isScript)`` method.