### PR TITLE
Ignore directives inside multiline strings and block comments.

### DIFF
--- a/src/fsharp/ParseHelpers.fsi
+++ b/src/fsharp/ParseHelpers.fsi
@@ -83,6 +83,16 @@ module LexbufIfdefStore =
     val SaveEndIfHash: lexbuf:UnicodeLexing.Lexbuf * lexed:string * range: range -> unit
 
     val GetTrivia: lexbuf:UnicodeLexing.Lexbuf -> SyntaxTrivia.ConditionalDirectiveTrivia list
+    
+    val SetLexingString: lexbuf:UnicodeLexing.Lexbuf -> unit
+    
+    val ClearLexingString: lexbuf:UnicodeLexing.Lexbuf -> unit
+
+    val SetLexingBlockComment: lexbuf:UnicodeLexing.Lexbuf -> unit
+    
+    val ClearLexingBlockComment: lexbuf:UnicodeLexing.Lexbuf -> unit
+    
+    val ClearTrivia: lexbuf:UnicodeLexing.Lexbuf -> unit
 
 [<RequireQualifiedAccess>]
 type LexerStringStyle =

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -136,8 +136,11 @@ let startString args (lexbuf: UnicodeLexing.Lexbuf) =
     let buf = ByteBuffer.Create StringCapacity
     let m = lexbuf.LexemeRange
     let startp = lexbuf.StartPos
+    LexbufIfdefStore.SetLexingString(lexbuf)
     let fin =
         LexerStringFinisher (fun buf kind context cont ->
+            LexbufIfdefStore.ClearLexingString(lexbuf)
+        
             // Adjust the start-of-token mark back to the true start of the token
             lexbuf.StartPos <- startp
             let isPart = context.HasFlag(LexerStringFinisherContext.InterpolatedPart)
@@ -588,7 +591,9 @@ rule token args skip = parse
  | "(*"
      { let m = lexbuf.LexemeRange
        if not skip then COMMENT (LexCont.Comment(args.ifdefStack, args.stringNest, 1, m))
-       else comment (1,m,args) skip lexbuf }
+       else
+           LexbufIfdefStore.SetLexingBlockComment(lexbuf)
+           comment (1,m,args) skip lexbuf }
 
  | "(*IF-CAML*)" |  "(*IF-OCAML*)"
      { let m = lexbuf.LexemeRange
@@ -1073,6 +1078,30 @@ and ifdefSkip n m args skip = parse
   | newline
     { newline lexbuf; ifdefSkip n m args skip lexbuf }
 
+  | '"' '"' '"'
+    { // Even though this string isn't active, capture it anyway to avoid that any #if directives inside the string
+      // are mistaken for actual directives
+      let buf, fin, m = startString args lexbuf
+
+      // Single quote in triple quote ok, others disallowed
+      match args.stringNest with
+      | _ :: _ -> errorR(Error(FSComp.SR.lexTripleQuoteInTripleQuote(), m))
+      | _ -> ()
+
+      if skip then
+          tripleQuoteString (buf, fin, m, LexerStringKind.String, args) skip lexbuf
+      else
+          INACTIVECODE (LexCont.IfDefSkip(args.ifdefStack, args.stringNest, n, m)) }
+
+  | "(*"
+    { // Similar to multiline string, #if directives inside code comments are to be avoided
+      let m = lexbuf.LexemeRange
+      if skip then
+          LexbufIfdefStore.SetLexingBlockComment(lexbuf)
+          comment (1,m,args) skip lexbuf
+      else
+          INACTIVECODE (LexCont.IfDefSkip(args.ifdefStack, args.stringNest, n, m)) }
+
   | [^ ' ' '\n' '\r' ]+
 
   | anywhite+
@@ -1493,7 +1522,9 @@ and comment cargs skip = parse
       else
           LexbufLocalXmlDocStore.AddGrabPointDelayed(lexbuf)
           if not skip then COMMENT (LexCont.Token(args.ifdefStack, args.stringNest))
-          else token args skip lexbuf }
+          else
+              LexbufIfdefStore.ClearLexingBlockComment(lexbuf)
+              token args skip lexbuf }
 
  | anywhite+
  | [^ '\'' '(' '*' '\n' '\r' '"' ')' '@' ' ' '\t' ]+

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -83,6 +83,7 @@ let mkLexargs (defines, lightStatus, resourceManager, ifdefStack, errorLogger, p
 let reusingLexbufForParsing lexbuf f = 
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parse
     LexbufLocalXmlDocStore.ClearXmlDoc lexbuf
+    LexbufIfdefStore.ClearTrivia lexbuf
     try
       f () 
     with e ->


### PR DESCRIPTION
Hello @dsyme, in light of https://github.com/dotnet/fsharp/issues/12815 I found two edge cases where there still were `#if` lines reported that aren't actually shouldn't be.

Scenario's like:
```fsharp
#if FOO
    """
    #if BAR
    #endif
    """
#else
    """
    #if BAR
    #endif
    """
#endif
```

and

```fsharp
#if FOO
    (*
        #if BAR
        #endif
    *)
    ()
#else
    (*
        #if MEH
        #endif
    *)
#endif
```

In this PR, I did an attempt to fix this. This won't work for all string types yet and I would like to hear your thoughts on the proposed fix. Does this look feaseable to you?