### PR TITLE
Invalidate typecheck cache when invalidating a configuration

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -928,6 +928,10 @@ type BackgroundCompiler(
             
     member bc.InvalidateConfiguration(options: FSharpProjectOptions, userOpName) =
         if incrementalBuildersCache.ContainsSimilarKey (AnyCallerThread, options) then
+            parseCacheLock.AcquireLock(fun ltok -> 
+                for sourceFile in options.SourceFiles do
+                    checkFileInProjectCache.RemoveAnySimilar(ltok, (sourceFile, 0L, options))
+            )
             let _ = createBuilderNode (options, userOpName, CancellationToken.None)
             ()
 


### PR DESCRIPTION
At the moment, `FSharpChecker.InvalidateConfiguration` does not invalidate the typecheck cache (`checkFileInProjectCache`), which can lead to the use of outdated typecheck results for script files.


This PR adds `checkFileInProjectCache` invalidation when invalidating a configuration.

Part of the discussion https://github.com/dotnet/fsharp/pull/12848