### PR TITLE
WIP: Syntax for creating ImmutableArrays

### DIFF
--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -2221,7 +2221,7 @@ let TcArrayOrListComputedExpression (cenv: cenv) env (overallTy: OverallTy) tpen
         | _ -> ()
 
         let replacementExpr =
-            let ConcreteCollection = if isArray then ConcreteCollection.Array else ConcreteCollection.List
+            let cc = if isArray then ConcreteCollection.Array else ConcreteCollection.List
             if isArray then 
                 // This are to improve parsing/processing speed for parser tables by converting to an array blob ASAP 
                 let nelems = elems.Length 
@@ -2229,11 +2229,11 @@ let TcArrayOrListComputedExpression (cenv: cenv) env (overallTy: OverallTy) tpen
                 then SynExpr.Const (SynConst.UInt16s (Array.ofList (List.map (function SynExpr.Const (SynConst.UInt16 x, _) -> x | _ -> failwith "unreachable") elems)), m)
                 elif nelems > 0 && List.forall (function SynExpr.Const (SynConst.Byte _, _) -> true | _ -> false) elems 
                 then SynExpr.Const (SynConst.Bytes (Array.ofList (List.map (function SynExpr.Const (SynConst.Byte x, _) -> x | _ -> failwith "unreachable") elems), SynByteStringKind.Regular, m), m)
-                else SynExpr.ArrayOrList (ConcreteCollection, elems, m)
+                else SynExpr.ArrayOrList (cc, elems, m)
             else 
                 if elems.Length > 500 then 
                     error(Error(FSComp.SR.tcListLiteralMaxSize(), m))
-                SynExpr.ArrayOrList (ConcreteCollection, elems, m)
+                SynExpr.ArrayOrList (cc, elems, m)
 
         TcExprUndelayed cenv overallTy env tpenv replacementExpr
     | _ -> 

--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -2220,7 +2220,8 @@ let TcArrayOrListComputedExpression (cenv: cenv) env (overallTy: OverallTy) tpen
         | _ when validateExpressionWithIfRequiresParenthesis -> errorR(Deprecated(FSComp.SR.tcExpressionWithIfRequiresParenthesis(), m))
         | _ -> ()
 
-        let replacementExpr = 
+        let replacementExpr =
+            let ConcreteCollection = if isArray then ConcreteCollection.Array else ConcreteCollection.List
             if isArray then 
                 // This are to improve parsing/processing speed for parser tables by converting to an array blob ASAP 
                 let nelems = elems.Length 
@@ -2228,11 +2229,11 @@ let TcArrayOrListComputedExpression (cenv: cenv) env (overallTy: OverallTy) tpen
                 then SynExpr.Const (SynConst.UInt16s (Array.ofList (List.map (function SynExpr.Const (SynConst.UInt16 x, _) -> x | _ -> failwith "unreachable") elems)), m)
                 elif nelems > 0 && List.forall (function SynExpr.Const (SynConst.Byte _, _) -> true | _ -> false) elems 
                 then SynExpr.Const (SynConst.Bytes (Array.ofList (List.map (function SynExpr.Const (SynConst.Byte x, _) -> x | _ -> failwith "unreachable") elems), SynByteStringKind.Regular, m), m)
-                else SynExpr.ArrayOrList (isArray, elems, m)
+                else SynExpr.ArrayOrList (ConcreteCollection, elems, m)
             else 
                 if elems.Length > 500 then 
                     error(Error(FSComp.SR.tcListLiteralMaxSize(), m))
-                SynExpr.ArrayOrList (isArray, elems, m)
+                SynExpr.ArrayOrList (ConcreteCollection, elems, m)
 
         TcExprUndelayed cenv overallTy env tpenv replacementExpr
     | _ -> 

--- a/src/fsharp/CheckComputationExpressions.fsi
+++ b/src/fsharp/CheckComputationExpressions.fsi
@@ -10,7 +10,7 @@ open FSharp.Compiler.TypedTree
 
 val TcSequenceExpressionEntry: cenv:TcFileState -> env:TcEnv -> overallTy:OverallTy -> tpenv:UnscopedTyparEnv -> hasBuilder:bool * comp:SynExpr -> m:range -> Expr * UnscopedTyparEnv    
 
-val TcArrayOrListComputedExpression: cenv:TcFileState -> env:TcEnv -> overallTy:OverallTy -> tpenv:UnscopedTyparEnv -> isArray:bool * comp:SynExpr -> m:range -> Expr * UnscopedTyparEnv    
+val TcArrayOrListComputedExpression: cenv:TcFileState -> env:TcEnv -> overallTy:OverallTy -> tpenv:UnscopedTyparEnv -> cc:ConcreteCollection * comp:SynExpr -> m:range -> Expr * UnscopedTyparEnv    
 
 val TcComputationExpression: cenv:TcFileState -> env:TcEnv -> overallTy:OverallTy -> tpenv:UnscopedTyparEnv -> mWhole:range * interpExpr:Expr * builderTy:TType * comp:SynExpr -> Expr * UnscopedTyparEnv    
 

--- a/src/fsharp/CheckExpressions.fsi
+++ b/src/fsharp/CheckExpressions.fsi
@@ -237,7 +237,7 @@ type TcFileState =
       TcSequenceExpressionEntry: TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv
 
       // forward call 
-      TcArrayOrListComputedExpression: TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv
+      TcArrayOrListComputedExpression: TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> ConcreteCollection * SynExpr -> range -> Expr * UnscopedTyparEnv
 
       // forward call 
       TcComputationExpression: TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> range * Expr * TType * SynExpr -> Expr * UnscopedTyparEnv
@@ -257,7 +257,7 @@ type TcFileState =
         // forward call to CheckComputationExpressions.fs
         tcSequenceExpressionEntry: (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv) *
         // forward call to CheckComputationExpressions.fs 
-        tcArrayOrListSequenceExpression: (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv) *
+        tcArrayOrListSequenceExpression: (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> ConcreteCollection * SynExpr -> range -> Expr * UnscopedTyparEnv) *
         // forward call to CheckComputationExpressions.fs
         tcComputationExpression: (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> range * Expr * TType * SynExpr -> Expr * UnscopedTyparEnv) 
          -> TcFileState

--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -1034,9 +1034,11 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
               | Parser.TOKEN_LBRACK -> getErrorString("Parser.TOKEN.LBRACK")
               | Parser.TOKEN_LBRACE_BAR -> getErrorString("Parser.TOKEN.LBRACE.BAR")
               | Parser.TOKEN_LBRACK_BAR -> getErrorString("Parser.TOKEN.LBRACK.BAR")
+              | Parser.TOKEN_LBRACK_COLON -> getErrorString("Parser.TOKEN.LBRACK.COLON")
               | Parser.TOKEN_LBRACK_LESS -> getErrorString("Parser.TOKEN.LBRACK.LESS")
               | Parser.TOKEN_LBRACE -> getErrorString("Parser.TOKEN.LBRACE")
               | Parser.TOKEN_BAR_RBRACK -> getErrorString("Parser.TOKEN.BAR.RBRACK")
+              | Parser.TOKEN_COLON_RBRACK -> getErrorString("Parser.TOKEN.COLON.RBRACK")
               | Parser.TOKEN_BAR_RBRACE -> getErrorString("Parser.TOKEN.BAR.RBRACE")
               | Parser.TOKEN_GREATER_RBRACK -> getErrorString("Parser.TOKEN.GREATER.RBRACK")
               | Parser.TOKEN_RQUOTE_DOT _

--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -637,11 +637,14 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
 
           match contextInfo with
           | ContextInfo.IfExpression range when equals range m -> os.Append(FSComp.SR.ifExpression(t1, t2)) |> ignore
-          | ContextInfo.CollectionElement (isArray, range) when equals range m ->
-            if isArray then
+          | ContextInfo.CollectionElement (cc, range) when equals range m ->
+            match cc with
+            | ConcreteCollection.Array ->
                 os.Append(FSComp.SR.arrayElementHasWrongType(t1, t2)) |> ignore
-            else
+            | ConcreteCollection.List ->
                 os.Append(FSComp.SR.listElementHasWrongType(t1, t2)) |> ignore
+            | ConcreteCollection.ImmutableArray ->
+                failwith "not implemented"
           | ContextInfo.OmittedElseBranch range when equals range m -> os.Append(FSComp.SR.missingElseBranch(t2)) |> ignore
           | ContextInfo.ElseBranchResult range when equals range m -> os.Append(FSComp.SR.elseBranchHasWrongType(t1, t2)) |> ignore
           | ContextInfo.FollowingPatternMatchClause range when equals range m -> os.Append(FSComp.SR.followingPatternMatchClauseHasWrongType(t1, t2)) |> ignore
@@ -668,11 +671,14 @@ let OutputPhasedErrorR (os: StringBuilder) (err: PhasedDiagnostic) (canSuggestNa
           let t1, t2, tpcs = NicePrint.minimalStringsOfTwoTypes denv t1 t2
           match contextInfo with
           | ContextInfo.IfExpression range when equals range m -> os.Append(FSComp.SR.ifExpression(t1, t2)) |> ignore
-          | ContextInfo.CollectionElement (isArray, range) when equals range m ->
-            if isArray then
+          | ContextInfo.CollectionElement (cc, range) when equals range m ->
+            match cc with
+            | ConcreteCollection.Array ->
                 os.Append(FSComp.SR.arrayElementHasWrongType(t1, t2)) |> ignore
-            else
+            | ConcreteCollection.List ->
                 os.Append(FSComp.SR.listElementHasWrongType(t1, t2)) |> ignore
+            | ConcreteCollection.ImmutableArray ->
+                failwith "not implemented"
           | ContextInfo.OmittedElseBranch range when equals range m -> os.Append(FSComp.SR.missingElseBranch(t2)) |> ignore
           | ContextInfo.ElseBranchResult range when equals range m -> os.Append(FSComp.SR.elseBranchHasWrongType(t1, t2)) |> ignore
           | ContextInfo.FollowingPatternMatchClause range when equals range m -> os.Append(FSComp.SR.followingPatternMatchClauseHasWrongType(t1, t2)) |> ignore

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -170,7 +170,7 @@ type ContextInfo =
     | TupleInRecordFields
 
     /// The type equation comes from a list or array constructor
-    | CollectionElement of bool * range
+    | CollectionElement of ConcreteCollection * range
 
     /// The type equation comes from a return in a computation expression.
 

--- a/src/fsharp/ConstraintSolver.fsi
+++ b/src/fsharp/ConstraintSolver.fsi
@@ -66,7 +66,7 @@ type ContextInfo =
     | TupleInRecordFields
 
     /// The type equation comes from a list or array constructor
-    | CollectionElement of bool * range
+    | CollectionElement of ConcreteCollection * range
 
     /// The type equation comes from a return in a computation expression.
     | ReturnInComputationExpression

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -41,6 +41,12 @@ type LongIdentWithDots =
            let nonExtraDots = if dotRanges.Length = t.Length then dotRanges else List.truncate t.Length dotRanges
            unionRanges h.idRange (List.last t).idRange |> unionRanges (List.last nonExtraDots)
 
+[<Struct; RequireQualifiedAccess>]
+type ConcreteSequence =
+    | List
+    | Array
+    | ImmutableArray
+
 [<RequireQualifiedAccess>]
 type ParserDetail =
     | Ok
@@ -490,7 +496,7 @@ type SynExpr =
         range: range
 
     | ArrayOrList of
-        isArray: bool *
+        sequenceType: ConcreteSequence *
         exprs: SynExpr list *
         range: range
 

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -42,7 +42,7 @@ type LongIdentWithDots =
            unionRanges h.idRange (List.last t).idRange |> unionRanges (List.last nonExtraDots)
 
 [<Struct; RequireQualifiedAccess>]
-type ConcreteSequence =
+type ConcreteCollection =
     | List
     | Array
     | ImmutableArray
@@ -496,7 +496,7 @@ type SynExpr =
         range: range
 
     | ArrayOrList of
-        sequenceType: ConcreteSequence *
+        sequenceType: ConcreteCollection *
         exprs: SynExpr list *
         range: range
 
@@ -1121,7 +1121,7 @@ type SynPat =
         range: range
 
     | ArrayOrList of
-        isArray: bool *
+        ConcreteCollection:ConcreteCollection *
         elementPats: SynPat list *
         range: range
 

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -550,7 +550,7 @@ type SynExpr =
         range: range
 
     | ArrayOrListComputed of
-        isArray: bool *
+        cc:ConcreteCollection *
         expr: SynExpr *
         range: range
 

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -49,6 +49,12 @@ type ParserDetail =
     /// The construct arises from error recovery
     | ErrorRecovery
 
+[<Struct; RequireQualifiedAccess>]
+type ConcreteSequence =
+    | List
+    | Array
+    | ImmutableArray
+
 /// Represents whether a type parameter has a static requirement or not (^T or 'T)
 [<RequireQualifiedAccess>]
 type TyparStaticReq =
@@ -594,7 +600,7 @@ type SynExpr =
 
     /// F# syntax: [ e1; ...; en ], [| e1; ...; en |]
     | ArrayOrList of
-        isArray: bool *
+        sequenceType: ConcreteSequence *
         exprs: SynExpr list *
         range: range
 

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -50,7 +50,7 @@ type ParserDetail =
     | ErrorRecovery
 
 [<Struct; RequireQualifiedAccess>]
-type ConcreteSequence =
+type ConcreteCollection =
     | List
     | Array
     | ImmutableArray
@@ -600,7 +600,7 @@ type SynExpr =
 
     /// F# syntax: [ e1; ...; en ], [| e1; ...; en |]
     | ArrayOrList of
-        sequenceType: ConcreteSequence *
+        sequenceType: ConcreteCollection *
         exprs: SynExpr list *
         range: range
 
@@ -1263,7 +1263,7 @@ type SynPat =
 
     /// An array or a list as a pattern
     | ArrayOrList of
-        isArray: bool *
+        ConcreteCollection: ConcreteCollection *
         elementPats: SynPat list *
         range: range
 

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -665,7 +665,7 @@ type SynExpr =
 
     /// F# syntax: [ expr ], [| expr |]
     | ArrayOrListComputed of
-        isArray: bool *
+        cc:ConcreteCollection *
         expr: SynExpr *
         range: range
 

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -821,6 +821,8 @@ rule token args skip = parse
 
  | "[|" { LBRACK_BAR }
 
+ | "[:" { LBRACK_COLON }
+
  | "{|" { LBRACE_BAR }
 
  | "<" { LESS false }
@@ -832,6 +834,8 @@ rule token args skip = parse
  | "]" { RBRACK }
 
  | "|]" { BAR_RBRACK }
+
+ | "[:" { COLON_RBRACK }
 
  | "|}" { BAR_RBRACE }
 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -4621,19 +4621,19 @@ arrayExpr:
         (* silent recovery *) 
         exprFromParseError (SynExpr.ArrayOrList (ConcreteCollection.Array, [ ], rhs parseState 1)) }  
 
-immutablearrayExpr:
+immarrayExpr:
   | LBRACK_COLON immarrayExprElements COLON_RBRACK
       {  $2 (lhs parseState) }
 
   | LBRACK_COLON immarrayExprElements recover
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedColonBar())
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar()) // Don't know where this is, can't change to BracketColon
         exprFromParseError ($2 (rhs2 parseState 1 2)) }
 
   | LBRACK_COLON error COLON_RBRACK
       {  (* silent recovery *) SynExpr.ArrayOrList (ConcreteCollection.ImmutableArray, [ ], lhs parseState) }
 
   | LBRACK_COLON recover
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedColonBar())
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar()) // Don't know where this is, can't change to BracketColon
         (* silent recovery *)
         exprFromParseError (SynExpr.ArrayOrList (ConcreteCollection.ImmutableArray, [ ], rhs parseState 1)) }
 
@@ -4744,17 +4744,24 @@ braceExprBody:
 
 listExprElements: 
   | sequentialExpr
-     { (fun lhsm -> SynExpr.ArrayOrListComputed (false, $1, lhsm)) }
+     { (fun lhsm -> SynExpr.ArrayOrListComputed (ConcreteCollection.List, $1, lhsm)) }
 
   | 
      { (fun lhsm -> SynExpr.ArrayOrList (ConcreteCollection.List, [ ], lhsm)) }
 
 arrayExprElements: 
   | sequentialExpr
-     { (fun lhsm -> SynExpr.ArrayOrListComputed (true, $1, lhsm)) }
+     { (fun lhsm -> SynExpr.ArrayOrListComputed (ConcreteCollection.Array, $1, lhsm)) }
 
   | 
      { (fun lhsm -> SynExpr.ArrayOrList (ConcreteCollection.Array, [ ], lhsm)) }
+
+immarrayExprElements: 
+  | sequentialExpr
+     { (fun lhsm -> SynExpr.ArrayOrListComputed (ConcreteCollection.ImmutableArray, $1, lhsm)) }
+
+  | 
+     { (fun lhsm -> SynExpr.ArrayOrList (ConcreteCollection.ImmutableArray, [ ], lhsm)) }
 
 computationExpr: 
   | sequentialExpr

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -252,8 +252,8 @@ let rangeOfLongIdent(lid:LongIdent) =
 %token OPEN OR REC THEN TO TRUE TRY TYPE VAL INLINE INTERFACE INSTANCE CONST
 %token WHEN WHILE WITH HASH AMP AMP_AMP QUOTE LPAREN RPAREN RPAREN_COMING_SOON RPAREN_IS_HERE STAR COMMA RARROW GREATER_BAR_RBRACK LPAREN_STAR_RPAREN
 %token QMARK QMARK_QMARK DOT COLON COLON_COLON COLON_GREATER  COLON_QMARK_GREATER COLON_QMARK COLON_EQUALS SEMICOLON 
-%token SEMICOLON_SEMICOLON LARROW EQUALS  LBRACK  LBRACK_BAR  LBRACE_BAR  LBRACK_LESS 
-%token BAR_RBRACK BAR_RBRACE UNDERSCORE
+%token SEMICOLON_SEMICOLON LARROW EQUALS  LBRACK  LBRACK_BAR LBRACK_COLON LBRACE_BAR  LBRACK_LESS 
+%token BAR_RBRACK COLON_RBRACK BAR_RBRACE UNDERSCORE
 %token BAR RBRACK RBRACE_COMING_SOON RBRACE_IS_HERE MINUS DOLLAR
 %token GREATER_RBRACK STRUCT SIG 
 %token STATIC MEMBER CLASS ABSTRACT OVERRIDE DEFAULT CONSTRUCTOR INHERIT 
@@ -438,7 +438,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %nonassoc prec_atompat_pathop
 %nonassoc INT8 UINT8 INT16 UINT16 INT32 UINT32 INT64 UINT64 NATIVEINT UNATIVEINT IEEE32 IEEE64 CHAR KEYWORD_STRING STRING BYTEARRAY BIGNUM DECIMAL
 %nonassoc INTERP_STRING_BEGIN INTERP_STRING_PART INTERP_STRING_END
-%nonassoc LPAREN LBRACE LBRACK_BAR 
+%nonassoc LPAREN LBRACE LBRACK_BAR LBRACK_COLON
 %nonassoc TRUE FALSE UNDERSCORE NULL
 
 
@@ -3373,8 +3373,11 @@ atomicPattern:
   | LBRACK listPatternElements RBRACK
       { SynPat.ArrayOrList(ConcreteCollection.List, $2, lhs parseState) }
 
-  | LBRACK_BAR listPatternElements  BAR_RBRACK
+  | LBRACK_BAR listPatternElements BAR_RBRACK
       { SynPat.ArrayOrList(ConcreteCollection.Array, $2, lhs parseState) }
+
+  | LBRACK_COLON listPatternElements COLON_RBRACK
+      { SynPat.ArrayOrList(ConcreteCollection.ImmutableArray, $2, lhs parseState) }
 
   | UNDERSCORE 
       { SynPat.Wild (lhs parseState) }
@@ -4617,6 +4620,22 @@ arrayExpr:
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar())  
         (* silent recovery *) 
         exprFromParseError (SynExpr.ArrayOrList (ConcreteCollection.Array, [ ], rhs parseState 1)) }  
+
+immutablearrayExpr:
+  | LBRACK_COLON immarrayExprElements COLON_RBRACK
+      {  $2 (lhs parseState) }
+
+  | LBRACK_COLON immarrayExprElements recover
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedColonBar())
+        exprFromParseError ($2 (rhs2 parseState 1 2)) }
+
+  | LBRACK_COLON error COLON_RBRACK
+      {  (* silent recovery *) SynExpr.ArrayOrList (ConcreteCollection.ImmutableArray, [ ], lhs parseState) }
+
+  | LBRACK_COLON recover
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedColonBar())
+        (* silent recovery *)
+        exprFromParseError (SynExpr.ArrayOrList (ConcreteCollection.ImmutableArray, [ ], rhs parseState 1)) }
 
 parenExpr:
   | LPAREN rparen 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -3371,10 +3371,10 @@ atomicPattern:
       { let rs, m = $2 in SynPat.Record (rs, rhs2 parseState 1 3) }
 
   | LBRACK listPatternElements RBRACK
-      { SynPat.ArrayOrList(false, $2, lhs parseState) }
+      { SynPat.ArrayOrList(ConcreteCollection.List, $2, lhs parseState) }
 
   | LBRACK_BAR listPatternElements  BAR_RBRACK
-      { SynPat.ArrayOrList(true, $2, lhs parseState) }
+      { SynPat.ArrayOrList(ConcreteCollection.Array, $2, lhs parseState) }
 
   | UNDERSCORE 
       { SynPat.Wild (lhs parseState) }
@@ -4458,12 +4458,12 @@ atomicExpr:
 
   | LBRACK error RBRACK 
       { // silent recovery 
-        SynExpr.ArrayOrList (false, [ ], lhs parseState), false  } 
+        SynExpr.ArrayOrList (ConcreteCollection.List, [ ], lhs parseState), false  } 
 
   | LBRACK recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
         // silent recovery 
-        exprFromParseError (SynExpr.ArrayOrList (false, [ ], rhs parseState 1)), false  } 
+        exprFromParseError (SynExpr.ArrayOrList (ConcreteCollection.List, [ ], rhs parseState 1)), false  } 
 
   | STRUCT LPAREN tupleExpr rparen
       { let exprs, commas = $3
@@ -4611,12 +4611,12 @@ arrayExpr:
         exprFromParseError ($2 (rhs2 parseState 1 2)) }
 
   | LBRACK_BAR error BAR_RBRACK 
-      {  (* silent recovery *) SynExpr.ArrayOrList (true, [ ], lhs parseState) }  
+      {  (* silent recovery *) SynExpr.ArrayOrList (ConcreteCollection.Array, [ ], lhs parseState) }  
 
   | LBRACK_BAR recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar())  
         (* silent recovery *) 
-        exprFromParseError (SynExpr.ArrayOrList (true, [ ], rhs parseState 1)) }  
+        exprFromParseError (SynExpr.ArrayOrList (ConcreteCollection.Array, [ ], rhs parseState 1)) }  
 
 parenExpr:
   | LPAREN rparen 
@@ -4728,14 +4728,14 @@ listExprElements:
      { (fun lhsm -> SynExpr.ArrayOrListComputed (false, $1, lhsm)) }
 
   | 
-     { (fun lhsm -> SynExpr.ArrayOrList (false, [ ], lhsm)) }
+     { (fun lhsm -> SynExpr.ArrayOrList (ConcreteCollection.List, [ ], lhsm)) }
 
 arrayExprElements: 
   | sequentialExpr
      { (fun lhsm -> SynExpr.ArrayOrListComputed (true, $1, lhsm)) }
 
   | 
-     { (fun lhsm -> SynExpr.ArrayOrList (true, [ ], lhsm)) }
+     { (fun lhsm -> SynExpr.ArrayOrList (ConcreteCollection.Array, [ ], lhsm)) }
 
 computationExpr: 
   | sequentialExpr

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -252,13 +252,13 @@ module internal TokenClassifications =
         | LBRACK_LESS ->
             (FSharpTokenColorKind.Punctuation, FSharpTokenCharKind.Delimiter, FSharpTokenTriggerClass.None )
 
-        | LQUOTE _  | LBRACK  | LBRACE _ | LBRACK_BAR | LBRACE_BAR ->
+        | LQUOTE _  | LBRACK  | LBRACE _ | LBRACK_BAR | LBRACK_COLON | LBRACE_BAR ->
             (FSharpTokenColorKind.Punctuation, FSharpTokenCharKind.Delimiter, FSharpTokenTriggerClass.MatchBraces )
 
         | GREATER_RBRACK  | GREATER_BAR_RBRACK ->
             (FSharpTokenColorKind.Punctuation, FSharpTokenCharKind.Delimiter, FSharpTokenTriggerClass.None )
 
-        | RQUOTE _  | RBRACK  | RBRACE _ | RBRACE_COMING_SOON | RBRACE_IS_HERE | BAR_RBRACK | BAR_RBRACE ->
+        | RQUOTE _  | RBRACK  | RBRACE _ | RBRACE_COMING_SOON | RBRACE_IS_HERE | BAR_RBRACK | COLON_RBRACK | BAR_RBRACE ->
             (FSharpTokenColorKind.Punctuation, FSharpTokenCharKind.Delimiter, FSharpTokenTriggerClass.MatchBraces )
 
         | PUBLIC | PRIVATE | INTERNAL | BASE | GLOBAL

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -304,8 +304,9 @@ module Structure =
             | SynExpr.Sequential (_, _, e1, e2, _) ->
                 parseExpr e1
                 parseExpr e2
-            | SynExpr.ArrayOrListComputed (isArray, e, r) ->
-                rcheck  Scope.ArrayOrList Collapse.Same r <| Range.modBoth (if isArray then 2 else 1) (if isArray then 2 else 1) r
+            | SynExpr.ArrayOrListComputed (cc, e, r) ->
+                let pos = match cc with ConcreteCollection.Array | ConcreteCollection.ImmutableArray -> 2 | ConcreteCollection.List -> 1
+                rcheck  Scope.ArrayOrList Collapse.Same r <| Range.modBoth pos pos r
                 parseExpr e
             | SynExpr.ComputationExpr (_, e, _r) as _c ->
                 parseExpr e


### PR DESCRIPTION
Allow creating an ImmutableArray using `[: :]`.
https://github.com/fsharp/fslang-design/blob/main/RFCs/FS-1094-block.md

Module functions done in https://github.com/dotnet/fsharp/pull/11750