### PR TITLE
CheckDeclarations: don't report environment for checked top-level module

### DIFF
--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -233,13 +233,16 @@ let AddLocalSubModule g amap m env (modul: ModuleOrNamespace) =
                     eNameResEnv = AddModuleOrNamespaceRefToNameEnv g amap m false env.eAccessRights env.eNameResEnv (mkLocalModRef modul)
                     eUngeneralizableItems = addFreeItemOfModuleTy modul.ModuleOrNamespaceType env.eUngeneralizableItems }
     env
- 
+
 /// Add a "module X = ..." definition to the TcEnv and report it to the sink
 let AddLocalSubModuleAndReport tcSink scopem g amap m env (modul: ModuleOrNamespace) =
-    let env = AddLocalSubModule g amap m env modul 
-    CallEnvSink tcSink (scopem, env.NameEnv, env.eAccessRights)
+    let env = AddLocalSubModule g amap m env modul
+    if not (equals scopem m) then
+        // Don't report another environment for top-level module at its own range,
+        // so it doesn't overwrite inner environment used by features like code completion. 
+        CallEnvSink tcSink (scopem, env.NameEnv, env.eAccessRights)
     env
- 
+
 /// Given an inferred module type, place that inside a namespace path implied by a "namespace X.Y.Z" definition
 let BuildRootModuleType enclosingNamespacePath (cpath: CompilationPath) mtyp = 
     (enclosingNamespacePath, (cpath, (mtyp, []))) 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -67,6 +67,9 @@
     <Compile Include="..\service\PatternMatchCompilationTests.fs">
       <Link>PatternMatchCompilationTests.fs</Link>
     </Compile>
+    <Compile Include="..\service\CompletionTests.fs">
+      <Link>CompletionTests.fs</Link>
+    </Compile>
     <Compile Include="..\service\ScriptOptionsTests.fs">
       <Link>ScriptOptionsTests.fs</Link>
     </Compile>

--- a/tests/service/CompletionTests.fs
+++ b/tests/service/CompletionTests.fs
@@ -1,0 +1,18 @@
+﻿module FSharp.Compiler.Service.Tests.CompletionTests
+
+open FSharp.Compiler.EditorServices
+open FsUnit
+open NUnit.Framework
+
+[<Test>]
+let ``Expr - record - field 01 - anon module`` () =
+    let parseResults, checkResults = getParseAndCheckResults """
+type Record = { Field: int}
+
+{ Fi }
+"""
+    let lineText = "{ Fi }"
+    let plid = QuickParse.GetPartialLongNameEx(lineText, 3)
+    let info = checkResults.GetDeclarationListInfo(Some parseResults, 4, lineText, plid)
+
+    info.Items |> Array.exists (fun item -> item.Name = "Field") |> shouldEqual true

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
@@ -980,48 +980,6 @@ for i in 0..a."]
 
     [<Test>]
     [<Category("Records")>]
-    member public this.``Records.WRONG.MissingBindings``() = 
-        // this test should be removed after fixing 279738
-        let prologue = 
-            [
-                "type R = {AAA : int; BBB : bool}"
-            ]
-        let useCases =
-            [
-                ["let _ = {A = 1; _;  }"], "; _;", ["AAA"; "BBB"]
-                ["let _ = {A = 1; _=; }"], " _=;", ["AAA"; "BBB"]
-            ]
-
-        for (code, marker, shouldNot) in useCases do
-            let code = prologue @ code
-            printfn "running:"
-            printfn "%s" (String.concat "\r\n" code)
-            AssertCtrlSpaceCompleteContains code marker [] shouldNot
-
-
-
-    [<Test>]
-    [<Category("Records")>]
-    member public this.``Records.WRONG.IncorrectNameResEnv``() = 
-        // this test should be removed after fixing 279738
-        let prologue = 
-            [
-                "type R = {AAA : int; BBB : bool; CCC : int}"
-            ]
-        let useCases =
-            [
-                ["let _ = {A}"], "_ = {A", ["AAA"; "BBB"; "CCC"]
-                ["let _ = {AAA = 1; }"], "_ = {AAA = 1;", ["AAA"; "BBB"; "CCC"]
-            ]
-
-        for (code, marker, shouldNot) in useCases do
-            let code = prologue @ code
-            printfn "running:"
-            printfn "%s" (String.concat "\r\n" code)
-            AssertCtrlSpaceCompleteContains code marker [] shouldNot
-
-    [<Test>]
-    [<Category("Records")>]
     member public this.``Records.WRONG.ErrorsInFirstBinding``() =
         // errors in the first binding are critical now
         let prologue = 


### PR DESCRIPTION
Fixes completion for `Field` field at the caret position:

```fsharp
type Record =
    { Field: int }

{ Fie{caret} }
```

Prior to this change, another name environment for the anon module is reported after it's been checked, and this environment overwrites an environment that should've been used inside the module. Reporting such an environment is needed for analysis of subsequent module declarations in the outer scope but breaks editor features inside top-level modules when reported for its own range.