### PR TITLE
Improve record completions

### DIFF
--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -1095,12 +1095,15 @@ module ParsedInput =
                             Some CompletionContext.PatternType
                         | _ -> defaultTraverse ty
 
-                    member _.VisitRecordDefn(_path, fields, _range) =
-                        fields |> List.tryPick (fun (SynField (idOpt = idOpt; range = fieldRange)) ->
+                    member _.VisitRecordDefn(_path, fields, range) =
+                        fields
+                        |> List.tryPick (fun (SynField (idOpt = idOpt; range = fieldRange)) ->
                             match idOpt with
                             | Some id when rangeContainsPos id.idRange pos -> Some(CompletionContext.RecordField(RecordContext.Declaration true))
                             | _ when rangeContainsPos fieldRange pos -> Some(CompletionContext.RecordField(RecordContext.Declaration false))
                             | _ -> None)
+                        // No completions in a record outside of all fields
+                        |> Option.orElseWith (fun () -> if rangeContainsPos range pos then Some CompletionContext.Invalid else None)
 
                     member _.VisitUnionDefn(_path, cases, _range) =
                         cases |> List.tryPick (fun (SynUnionCase (ident = id; caseType = caseType)) ->

--- a/vsintegration/tests/UnitTests/CompletionProviderTests.fs
+++ b/vsintegration/tests/UnitTests/CompletionProviderTests.fs
@@ -751,6 +751,20 @@ type A = { Field: l }
     VerifyCompletionList(fileContents, "Field: l", ["LanguagePrimitives"; "List"], ["let"; "log"])
 
 [<Test>]
+let ``No completion on record stub with no fields at declaration site``() =
+    let fileContents = """
+type A = {  }
+"""
+    VerifyNoCompletionList(fileContents, "{ ")
+
+[<Test>]
+let ``No completion on record outside of all fields at declaration site``() =
+    let fileContents = """
+type A = { Field: string; }
+"""
+    VerifyNoCompletionList(fileContents, "; ")
+
+[<Test>]
 let ``No completion on union case identifier at declaration site``() =
     let fileContents = """
 type A =


### PR DESCRIPTION
Continuation of https://github.com/dotnet/fsharp/pull/12351, deals with 2 specific cases, which should now fully cover https://github.com/dotnet/fsharp/issues/5519.

No completions in an incomplete record declaration stub.

```fsharp
type A = {
    $
}
```

No completions when the caret is within a record declaration, but outside of all fields.

```fsharp
type A = {
    Field: string
    $
}
```