### PR TITLE
Fix tests

### DIFF
--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -331,22 +331,22 @@ let rec allSymbolsInEntities compGen (entities: IList<FSharpEntity>) =
 
 
 let getParseResults (source: string) =
-    parseSourceCode("/home/user/Test.fsx", source)
+    parseSourceCode("Test.fsx", source)
 
 let getParseResultsOfSignatureFile (source: string) =
-    parseSourceCode("/home/user/Test.fsi", source)
+    parseSourceCode("Test.fsi", source)
 
 let getParseAndCheckResults (source: string) =
-    parseAndCheckScript("/home/user/Test.fsx", source)
+    parseAndCheckScript("Test.fsx", source)
 
 let getParseAndCheckResultsOfSignatureFile (source: string) =
-    parseAndCheckScript("/home/user/Test.fsi", source)
+    parseAndCheckScript("Test.fsi", source)
 
 let getParseAndCheckResultsPreview (source: string) =
-    parseAndCheckScriptPreview("/home/user/Test.fsx", source)
+    parseAndCheckScriptPreview("Test.fsx", source)
 
 let getParseAndCheckResults50 (source: string) =
-    parseAndCheckScript50("/home/user/Test.fsx", source)
+    parseAndCheckScript50("Test.fsx", source)
 
 
 let inline dumpErrors results =


### PR DESCRIPTION
It seems that in
https://github.com/dotnet/fsharp/blob/12c8309f7621c7e7833d561bebb4e573c1dd249f/src/fsharp/symbols/SymbolHelpers.fs#L196
check ```fileName = mainInputFileName``` is not passing 
since one of them has the form `/home/user/Test.fsx` and the other one is normalized to the form `C:/home/user/Test.fsx`

due to which some diagnostics may not be reported (like here https://github.com/dotnet/fsharp/pull/12865#issuecomment-1077454811)