### PR TITLE
Capture single line comment at eof.

### DIFF
--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -1431,7 +1431,8 @@ and singleLineComment cargs skip = parse
            token args skip lexbuf }
 
  | eof
-     { let _, _n, _mStart, _mEnd, args = cargs
+     { let _, _n, mStart, mEnd, args = cargs
+       LexbufCommentStore.SaveSingleLineComment(lexbuf, mStart, mEnd)
        // NOTE: it is legal to end a file with this comment, so we'll return EOF as a token
        EOF (LexCont.Token(args.ifdefStack, args.stringNest)) }
 

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -1427,7 +1427,7 @@ and singleLineComment cargs skip = parse
        // Saves the documentation (if we're collecting any) into a buffer-local variable.
        if not skip then LINE_COMMENT (LexCont.Token(args.ifdefStack, args.stringNest))
        else
-           LexbufCommentStore.SaveSingleLineComment(lexbuf, mStart, mEnd)
+           if Option.isNone buff then LexbufCommentStore.SaveSingleLineComment(lexbuf, mStart, mEnd)
            token args skip lexbuf }
 
  | eof

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -3757,3 +3757,17 @@ val a (* b *) : int
             assertRange (1, 2) (1, 6) mComment
         | _ ->
             Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``triple slash comment should not be captured`` () =
+        let trivia =
+            getCommentTrivia false """
+/// Some great documentation comment
+let x = 0
+"""
+
+        match trivia with
+        | [] ->
+            Assert.Pass()
+        | _ ->
+            Assert.Fail "Could not get valid AST"

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -3746,3 +3746,14 @@ val a (* b *) : int
             assertRange (4, 6) (4, 13) mComment
         | _ ->
             Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``comment at end of file`` () =
+        let trivia =
+            getCommentTrivia false "x // y"
+
+        match trivia with
+        | [ CommentTrivia.LineComment mComment ] ->
+            assertRange (1, 2) (1, 6) mComment
+        | _ ->
+            Assert.Fail "Could not get valid AST"


### PR DESCRIPTION
A missed edge case of #12854.