### PR TITLE
Filter lambda variable type completion list

### DIFF
--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -956,7 +956,7 @@ module ParsedInput =
                                     Some (CompletionContext.ParameterList args)
                                 | _ -> 
                                     defaultTraverse expr
-                            
+
                             | _ -> defaultTraverse expr
 
                     member _.VisitRecordField(path, copyOpt, field) = 
@@ -1060,13 +1060,20 @@ module ParsedInput =
 
                     member _.VisitSimplePats (_path, pats) =
                         pats |> List.tryPick (fun pat ->
-                            // No completions in an identifier or type in a pattern
+                            // No completions in an identifier in a pattern
                             match pat with
                             // fun x| ->
-                            | SynSimplePat.Id(range = range)
-                            // fun (x: int|) ->
-                            | SynSimplePat.Typed(SynSimplePat.Id(range = range), _, _) when rangeContainsPos range pos ->
+                            | SynSimplePat.Id(range = range) when rangeContainsPos range pos ->
                                 Some CompletionContext.Invalid
+                            | SynSimplePat.Typed(SynSimplePat.Id(range = idRange), synType, _) ->
+                                // fun (x|: int) ->
+                                if rangeContainsPos idRange pos then
+                                    Some CompletionContext.Invalid
+                                // fun (x: int|) ->
+                                elif rangeContainsPos synType.Range pos then
+                                    Some CompletionContext.PatternType
+                                else
+                                    None
                             | _ -> None)
 
                     member _.VisitModuleDecl(_path, defaultTraverse, decl) =

--- a/vsintegration/tests/UnitTests/CompletionProviderTests.fs
+++ b/vsintegration/tests/UnitTests/CompletionProviderTests.fs
@@ -634,11 +634,18 @@ let _ = fun (p) -> ()
     VerifyNoCompletionList(fileContents, "let _ = fun (p")
 
 [<Test>]
-let ``Provide completion on lambda argument type hint``() =
+let ``No completion on lambda argument name2``() =
     let fileContents = """
-let _ = fun (p:i) -> ()
+let _ = fun (p: int) -> ()
 """
-    VerifyCompletionList(fileContents, "let _ = fun (p:i", ["int"], [])
+    VerifyNoCompletionList(fileContents, "let _ = fun (p")
+
+[<Test>]
+let ``Completions on lambda argument type hint contain modules and types but not keywords or functions``() =
+    let fileContents = """
+let _ = fun (p:l) -> ()
+"""
+    VerifyCompletionList(fileContents, "let _ = fun (p:l", ["LanguagePrimitives"; "List"], ["let"; "log"])
 
 [<Test>]
 let ``Extensions.Bug5162``() =


### PR DESCRIPTION
Given

```fsharp
fun (x: str) -> ()
```

pressing Ctrl-space on `str` will now only show type-like completions. Currently the list also contains keywords and functions.

This worked correctly for let-bound functions (`let x (y: str|)`), but was not implemented for patterns in lambdas (`SynSimplePat`).