### PR TITLE
fix for net7 regression for UMX

### DIFF
--- a/tests/fsharp/core/unitsOfMeasure/test.fs
+++ b/tests/fsharp/core/unitsOfMeasure/test.fs
@@ -128,6 +128,41 @@ module TestLibrary =
     printfn "test 7: %i" (test7 1000)
     printfn "test 8: %i" (test8 1000)
 
+module InterfacesOfMeasureAnnotatedTypes =
+    open System
+    type IDerivedComparable<'T> =
+        inherit IComparable<'T>
+
+    type IRandomOtherInterface<'T> =
+        abstract M: 'T -> 'T
+
+    type IDerivedEquatable<'T> =
+        inherit IEquatable<'T>
+
+    type Prim() =
+        interface IComparable with 
+            member x.CompareTo(y) = 0
+        interface IDerivedComparable<Prim> with 
+            member x.CompareTo(y) = 0
+        interface IDerivedEquatable<Prim> with 
+            member x.Equals(y) = true
+        interface IRandomOtherInterface<Prim> with 
+            member x.M(y) = y
+        override x.Equals(y) = true
+        override x.GetHashCode() = 0
+
+    [<MeasureAnnotatedAbbreviation>]
+    type Prim<[<Measure>] 'm> = Prim
+
+    // Check that Prim<'m> supports the unit-annotated IComparable interface
+    let f1 (x: Prim<'m>) = (x :> IComparable<Prim<'m>>)
+    let f2 (x: Prim<'m>) = (x :> IDerivedComparable<Prim<'m>>)
+    let f3 (x: Prim<'m>) = (x :> IEquatable<Prim<'m>>)
+    let f4 (x: Prim<'m>) = (x :> IDerivedEquatable<Prim<'m>>)
+    let f5 (x: Prim<'m>) = (x :> IComparable)
+    // Does not apply to other interfaces
+    let f6 (x: Prim<'m>) = (x :> IRandomOtherInterface<Prim>)
+
 
 [<EntryPoint>]
 let main argv = 

--- a/tests/fsharp/core/unitsOfMeasure/test.fs
+++ b/tests/fsharp/core/unitsOfMeasure/test.fs
@@ -156,9 +156,7 @@ module InterfacesOfMeasureAnnotatedTypes =
 
     // Check that Prim<'m> supports the unit-annotated IComparable interface
     let f1 (x: Prim<'m>) = (x :> IComparable<Prim<'m>>)
-    let f2 (x: Prim<'m>) = (x :> IDerivedComparable<Prim<'m>>)
     let f3 (x: Prim<'m>) = (x :> IEquatable<Prim<'m>>)
-    let f4 (x: Prim<'m>) = (x :> IDerivedEquatable<Prim<'m>>)
     let f5 (x: Prim<'m>) = (x :> IComparable)
     // Does not apply to other interfaces
     let f6 (x: Prim<'m>) = (x :> IRandomOtherInterface<Prim>)

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -377,3 +377,15 @@ neg20.fs(448,30,448,33): typecheck error FS0001: This expression was expected to
     'string option'    
 but here has type
     'string'    
+
+neg20.fs(477,29,477,62): typecheck error FS0193: Type constraint mismatch. The type 
+    'Prim<'m>'    
+is not compatible with type
+    'IDerivedComparable<Prim<'m>>'    
+
+
+neg20.fs(478,29,478,61): typecheck error FS0193: Type constraint mismatch. The type 
+    'Prim<'m>'    
+is not compatible with type
+    'IDerivedEquatable<Prim<'m>>'    
+

--- a/tests/fsharp/typecheck/sigs/neg20.fs
+++ b/tests/fsharp/typecheck/sigs/neg20.fs
@@ -447,3 +447,32 @@ module OptionTypeOpImplicitsIgnored =
     let x1 : int option = 3
     let x2 : string option = "a"
 
+module InterfacesOfMeasureAnnotatedTypes =
+    open System
+    type IDerivedComparable<'T> =
+        inherit IComparable<'T>
+
+    type IRandomOtherInterface<'T> =
+        abstract M: 'T -> 'T
+
+    type IDerivedEquatable<'T> =
+        inherit IEquatable<'T>
+
+    type Prim() =
+        interface IComparable with 
+            member x.CompareTo(y) = 0
+        interface IDerivedComparable<Prim> with 
+            member x.CompareTo(y) = 0
+        interface IDerivedEquatable<Prim> with 
+            member x.Equals(y) = true
+        interface IRandomOtherInterface<Prim> with 
+            member x.M(y) = y
+        override x.Equals(y) = true
+        override x.GetHashCode() = 0
+
+    [<MeasureAnnotatedAbbreviation>]
+    type Prim<[<Measure>] 'm> = Prim
+
+    // Check that Prim<'m> does not suppor interfaces in any way derived from IComparable and IEquatable
+    let f2 (x: Prim<'m>) = (x :> IDerivedComparable<Prim<'m>>)
+    let f4 (x: Prim<'m>) = (x :> IDerivedEquatable<Prim<'m>>)


### PR DESCRIPTION
Fix the core problem with https://github.com/dotnet/fsharp/issues/12881

As background, unit-annotated versions of primitive types are defined by:

```fsharp
    [<MeasureAnnotatedAbbreviation>]
    type SomeType<[<Measure>] 'm> = SomeType
```

This is primarily used on FSharp.Core to define `float<'m>`, `int64<'m>` and so on, but can also be used for unit-annotated versions of primitives like GUID - this is done in the UMX library.

For these types, the logic of the F# compiler must report which interfaces are implemented by the unitized versions of this type. 
 In general we preserve the interfaces of the underlying representation type unchanged, however there is an exception: we want the unitized types to support comparison and equality with corresponding unitized values.

So the unitized version of the type is considered to support the following interfaces. The adjustment in this PR is shown in **bold**

1. `IComparable<SomeType<'m>>`
1. `IEquatable<SomeType<'m>>`
1. All other interfaces supported by the underlying representation `SomeType` except those **derived from**  `IComparable<_>` or `IEquatable<_>`

This fixes #12881.  

