### PR TITLE
fix  4461

### DIFF
--- a/src/fsharp/autobox.fs
+++ b/src/fsharp/autobox.fs
@@ -193,7 +193,7 @@ let TransformImplFile g amap implFile =
               { PreIntercept = Some(TransformExpr g nvs)
                 PreInterceptBinding = Some(TransformBinding g nvs)
                 PostTransform = (fun _ -> None)
-                RewriteQuotations = false
+                RewriteQuotations = true
                 StackGuard = StackGuard(AutoboxRewriteStackGuardDepth) } 
 
 

--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -4158,6 +4158,19 @@ module TestTaskQuotationExecution =
 
     check "vewhwveh" task.Result "bar"
 
+module QuotationCapturingMutableThatGetsBoxed =
+
+    // Debug compilation failed
+    type Test () =
+        static member g ([< ReflectedDefinition>] f : Quotations.Expr<unit -> unit>) = printfn "%A" f
+
+    let f () =
+        let mutable x = 0
+        fun _ ->
+            Test.g (fun _ -> x |> ignore)
+
+    f () ()
+
 #if TESTS_AS_APP
 let RUN() = !failures
 #else


### PR DESCRIPTION
Fix https://github.com/dotnet/fsharp/issues/4461

The problem was that the code implementing the executable version of the quotation had an AutoBox optimization applied for the `let mutable`.  This optimization should thus be rewriting the expressions in the quotation (though that doesn't effect the quotation, but rather the code generated for the ValueWithName node that accompanies the quotation when using ReflectedDefinition attribute). 

  