### PR TITLE
Reduce default pickled data metadata size to below LOH threshold

### DIFF
--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -783,7 +783,7 @@ let p_simpletyp x st = p_int (encode_simpletyp st.occus st.ostrings st.onlerefs 
 
 /// Arbitrary value
 [<Literal>]
-let PickleBufferCapacity = 100000
+let PickleBufferCapacity = 50000
 
 let pickleObjWithDanglingCcus inMem file g scope p x =
   let st1 =


### PR DESCRIPTION

Further mitigation for https://github.com/dotnet/fsharp/issues/5933

When pickling F# metadata we create pooled buffers.  The default size is 100000 but this is above the LOH threshold.  This simply moves to a lower default size below the LOH threshold, and will improve IDE performance in inter-project working where metadata is smaller than 50K, which is fairly common.