### PR TITLE
Filter type test completion list

### DIFF
--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -459,7 +459,7 @@ module SyntaxTraversal =
 
                 | SynExpr.Match (expr=synExpr; clauses=synMatchClauseList) -> 
                     [yield dive synExpr synExpr.Range traverseSynExpr
-                     yield! synMatchClauseList |> List.map (fun x -> dive x x.RangeOfGuardAndRhs (traverseSynMatchClause path))]
+                     yield! synMatchClauseList |> List.map (fun x -> dive x x.Range (traverseSynMatchClause path))]
                     |> pick expr
 
                 | SynExpr.Do (synExpr, _range) -> traverseSynExpr synExpr
@@ -632,7 +632,8 @@ module SyntaxTraversal =
                 let path = SyntaxNode.SynPat p :: origPath
                 match p with
                 | SynPat.Paren (p, _) -> traversePat path p
-                | SynPat.Or (p1, p2, _, _) -> [ p1; p2] |> List.tryPick (traversePat path)
+                | SynPat.As (p1, p2, _)
+                | SynPat.Or (p1, p2, _, _) -> [ p1; p2 ] |> List.tryPick (traversePat path)
                 | SynPat.Ands (ps, _)
                 | SynPat.Tuple (_, ps, _)
                 | SynPat.ArrayOrList (_, ps, _) -> ps |> List.tryPick (traversePat path)

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -1076,6 +1076,12 @@ module ParsedInput =
                                     None
                             | _ -> None)
 
+                    member _.VisitPat (_, defaultTraverse, pat) =
+                        match pat with
+                        | SynPat.IsInst (_, range) when rangeContainsPos range pos ->
+                            Some CompletionContext.PatternType
+                        | _ -> defaultTraverse pat
+
                     member _.VisitModuleDecl(_path, defaultTraverse, decl) =
                         match decl with
                         | SynModuleDecl.Open(target, m) -> 

--- a/vsintegration/tests/UnitTests/CompletionProviderTests.fs
+++ b/vsintegration/tests/UnitTests/CompletionProviderTests.fs
@@ -648,6 +648,25 @@ let _ = fun (p:l) -> ()
     VerifyCompletionList(fileContents, "let _ = fun (p:l", ["LanguagePrimitives"; "List"], ["let"; "log"])
 
 [<Test>]
+let ``Completions in match clause type test contain modules and types but not keywords or functions``() =
+    let fileContents = """
+match box 5 with
+| :? l as x -> ()
+| _ -> ()
+"""
+    VerifyCompletionList(fileContents, ":? l", ["LanguagePrimitives"; "List"], ["let"; "log"])
+
+[<Test>]
+let ``Completions in catch clause type test contain modules and types but not keywords or functions``() =
+    let fileContents = """
+try
+    ()
+with :? l as x ->
+    ()
+"""
+    VerifyCompletionList(fileContents, ":? l", ["LanguagePrimitives"; "List"], ["let"; "log"])
+
+[<Test>]
 let ``Extensions.Bug5162``() =
     let fileContents = """
 module Extensions =


### PR DESCRIPTION
Given

```fsharp
try
    match box 5 with
    | :? str as x -> printfn "%s" x
    | _ -> raise (ArgumentException ())
with :? Arg ->
    ()
```

pressing Ctrl-space on `str` or `Arg` will now only show type-like completions. Currently the list also contains keywords and functions.