### PR TITLE
Disallow intrinsic type extension mismatch type parameters count 

### DIFF
--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -4684,7 +4684,7 @@ module TcDeclarations =
             if isInSameModuleOrNamespace && not isInterfaceOrDelegateOrEnum then 
                 // For historical reasons we only give a warning for incorrect type parameters on intrinsic extensions
                 if nReqTypars <> synTypars.Length then 
-                    warning(Error(FSComp.SR.tcDeclaredTypeParametersForExtensionDoNotMatchOriginal(tcref.DisplayNameWithStaticParametersAndUnderscoreTypars), m))
+                    errorR(Error(FSComp.SR.tcDeclaredTypeParametersForExtensionDoNotMatchOriginal(tcref.DisplayNameWithStaticParametersAndUnderscoreTypars), m))
                 if not (typarsAEquiv g TypeEquivEnv.Empty reqTypars declaredTypars) then 
                     warning(Error(FSComp.SR.tcDeclaredTypeParametersForExtensionDoNotMatchOriginal(tcref.DisplayNameWithStaticParametersAndUnderscoreTypars), m))
                 // Note we return 'reqTypars' for intrinsic extensions since we may only have given warnings

--- a/tests/fsharp/typecheck/sigs/neg133.bsl
+++ b/tests/fsharp/typecheck/sigs/neg133.bsl
@@ -18,3 +18,7 @@ neg133.fs(57,7,57,19): typecheck error FS0026: This rule will never be matched
 neg133.fs(63,7,63,19): typecheck error FS0026: This rule will never be matched
 
 neg133.fs(69,7,69,21): typecheck error FS0026: This rule will never be matched
+
+neg133.fs(76,10,76,11): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'
+
+neg133.fs(76,10,76,11): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'

--- a/tests/fsharp/typecheck/sigs/neg133.fs
+++ b/tests/fsharp/typecheck/sigs/neg133.fs
@@ -69,3 +69,8 @@ let Misc_Redundant5(x: obj) =
     | :? string -> 2  // expect - never matched
     | g -> 3
 
+module AmbiguousIntrinsicExtension =
+    type A<'T1, 'T2> = class end
+    type A<'T1, 'T2, 'T3> = class end
+
+    type A<'T1> with member x.Foo = 123


### PR DESCRIPTION

This fixes https://github.com/dotnet/fsharp/issues/8300

We should raise an error, not a warning, when the type parameter count has a mismatch.  This handles the case of the ambiguity in the linked bug.