### PR TITLE
fix delegate name resolution

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1249,6 +1249,7 @@ featureNonVariablePatternsToRightOfAsPatterns,"non-variable patterns to the righ
 featureAttributesToRightOfModuleKeyword,"attributes to the right of the 'module' keyword"
 featureMLCompatRevisions,"ML compatibility revisions"
 featureBetterExceptionPrinting,"automatic generation of 'Message' property for 'exception' declarations"
+featureDelegateTypeNameResolutionFix,"fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228"
 3090,tcIfThenElseMayNotBeUsedWithinQueries,"An if/then/else expression may not be used within queries. Consider using either an if/then expression, or use a sequence expression instead."
 3091,ilxgenUnexpectedArgumentToMethodHandleOfDuringCodegen,"Invalid argument to 'methodhandleof' during codegen"
 3092,etProvidedTypeReferenceMissingArgument,"A reference to a provided type was missing a value for the static parameter '%s'. You may need to recompile one or more referenced assemblies."

--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -46,6 +46,7 @@ type LanguageFeature =
     | AttributesToRightOfModuleKeyword
     | MLCompatRevisions
     | BetterExceptionPrinting
+    | DelegateTypeNameResolutionFix
 
 /// LanguageVersion management
 type LanguageVersion (versionText) =
@@ -102,6 +103,7 @@ type LanguageVersion (versionText) =
             LanguageFeature.FromEndSlicing, previewVersion
             LanguageFeature.MLCompatRevisions,previewVersion
             LanguageFeature.BetterExceptionPrinting,previewVersion
+            LanguageFeature.DelegateTypeNameResolutionFix,previewVersion
         ]
 
     static let defaultLanguageVersion = LanguageVersion("default")
@@ -199,6 +201,7 @@ type LanguageVersion (versionText) =
         | LanguageFeature.AttributesToRightOfModuleKeyword -> FSComp.SR.featureAttributesToRightOfModuleKeyword()
         | LanguageFeature.MLCompatRevisions -> FSComp.SR.featureMLCompatRevisions()
         | LanguageFeature.BetterExceptionPrinting -> FSComp.SR.featureBetterExceptionPrinting()
+        | LanguageFeature.DelegateTypeNameResolutionFix -> FSComp.SR.featureDelegateTypeNameResolutionFix()
 
     /// Get a version string associated with the given feature.
     member _.GetFeatureVersionString feature =

--- a/src/fsharp/LanguageFeatures.fs
+++ b/src/fsharp/LanguageFeatures.fs
@@ -98,12 +98,12 @@ type LanguageVersion (versionText) =
             LanguageFeature.UseBindingValueDiscard, languageVersion60
             LanguageFeature.NonVariablePatternsToRightOfAsPatterns, languageVersion60
             LanguageFeature.AttributesToRightOfModuleKeyword, languageVersion60
+            LanguageFeature.DelegateTypeNameResolutionFix,languageVersion60
 
             // F# preview
             LanguageFeature.FromEndSlicing, previewVersion
             LanguageFeature.MLCompatRevisions,previewVersion
             LanguageFeature.BetterExceptionPrinting,previewVersion
-            LanguageFeature.DelegateTypeNameResolutionFix,previewVersion
         ]
 
     static let defaultLanguageVersion = LanguageVersion("default")

--- a/src/fsharp/LanguageFeatures.fsi
+++ b/src/fsharp/LanguageFeatures.fsi
@@ -36,6 +36,7 @@ type LanguageFeature =
     | AttributesToRightOfModuleKeyword
     | MLCompatRevisions
     | BetterExceptionPrinting
+    | DelegateTypeNameResolutionFix
 
 /// LanguageVersion management
 type LanguageVersion =

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1266,7 +1266,9 @@ and private AddPartsOfTyconRefToNameEnv bulkAddMode ownDefinition (g: TcGlobals)
                     false
                     (fun () ->
                         let ty = generalizedTyconRef g tcref
-                        isClassTy g ty || isStructTy g ty)
+                        isClassTy g ty ||
+                        isStructTy g ty ||
+                        (g.langVersion.SupportsFeature LanguageFeature.DelegateTypeNameResolutionFix && isDelegateTy g ty))
 
             if mayHaveConstruction then
                 tab.AddOrModify (tcref.DisplayName, (fun prev ->

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -142,6 +142,11 @@
         <target state="translated">využití člena výchozího rozhraní</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">vzor discard ve vazbě použití</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -142,6 +142,11 @@
         <target state="translated">standardmäßige Schnittstellenmembernutzung</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">Das Verwerfen des verwendeten Musters ist verbindlich.</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -142,6 +142,11 @@
         <target state="translated">consumo de miembros de interfaz predeterminados</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">descartar enlace de patrón en uso</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">consommation par défaut des membres d'interface</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">annuler le modèle dans la liaison d’utilisation</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -142,6 +142,11 @@
         <target state="translated">utilizzo predefinito dei membri di interfaccia</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">rimuovi criterio nell'utilizzo dell'associazione</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -142,6 +142,11 @@
         <target state="translated">既定のインターフェイス メンバーの消費</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">使用バインドでパターンを破棄する</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -142,6 +142,11 @@
         <target state="translated">기본 인터페이스 멤버 사용</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">사용 중인 패턴 바인딩 무시</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -142,6 +142,11 @@
         <target state="translated">domyślne użycie składowej interfejsu</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">odrzuć wzorzec w powiązaniu użycia</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="translated">consumo de membro da interface padrão</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">descartar o padrão em uso de associação</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -142,6 +142,11 @@
         <target state="translated">использование элемента интерфейса по умолчанию</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">шаблон отмены в привязке использования</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">varsayılan arabirim üyesi tüketimi</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">kullanım bağlamasında deseni at</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="translated">默认接口成员消耗</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">放弃使用绑定模式</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="translated">預設介面成員使用</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureDelegateTypeNameResolutionFix">
+        <source>fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</source>
+        <target state="new">fix to resolution of delegate type names, see https://github.com/dotnet/fsharp/issues/10228</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDiscardUseValue">
         <source>discard pattern in use binding</source>
         <target state="translated">捨棄使用繫結中的模式</target>

--- a/tests/fsharp/core/auto-widen/preview/test.fsx
+++ b/tests/fsharp/core/auto-widen/preview/test.fsx
@@ -638,7 +638,7 @@ module DelegateNameFix =
     open System
 
     type Delegate = delegate of int -> int
-    Delegate(fun _ -> 1)
+    Delegate(fun _ -> 1) |> ignore
 
 let aa =
   match failures with 

--- a/tests/fsharp/core/auto-widen/preview/test.fsx
+++ b/tests/fsharp/core/auto-widen/preview/test.fsx
@@ -634,6 +634,12 @@ module MoreTests4 =
 
 printfn "test done"
 
+module DelegateNameFix =
+    open System
+
+    type Delegate = delegate of int -> int
+    Delegate(fun _ -> 1)
+
 let aa =
   match failures with 
   | [] -> 


### PR DESCRIPTION

This fixes https://github.com/dotnet/fsharp/issues/10228

It implements the fix as a language feature initially in preview

* In theory it can change name resolution for some existing code - a delegate type would have to shadow an existing type of the same name that has accessible constructors, and code would actually have to make use of this. 
* However this will be exceedingly rare

The problem is certainly a bug and I think it could have been addressed as such and so using a language feature is just being conservative in case someone needs to unapply this fix.

@KevinRansom @vzarytovskii Please  check if you agree with this resolution.