### PR TITLE
Collect triple slash comments as trivia.

### DIFF
--- a/src/fsharp/ParseHelpers.fsi
+++ b/src/fsharp/ParseHelpers.fsi
@@ -52,7 +52,7 @@ module LexbufLocalXmlDocStore =
 
     val AddGrabPointDelayed: lexbuf:UnicodeLexing.Lexbuf -> unit
 
-    val ReportInvalidXmlDocPositions: lexbuf:UnicodeLexing.Lexbuf -> unit
+    val ReportInvalidXmlDocPositions: lexbuf:UnicodeLexing.Lexbuf -> range list
 
 type LexerIfdefStackEntry =
     | IfDefIf

--- a/src/fsharp/XmlDoc.fsi
+++ b/src/fsharp/XmlDoc.fsi
@@ -49,7 +49,7 @@ type internal XmlDocCollector =
 
     member HasComments: grabPointPos: pos -> bool
 
-    member CheckInvalidXmlDocPositions: unit -> unit
+    member CheckInvalidXmlDocPositions: unit -> range list
 
 /// Represents the XmlDoc fragments as collected from the lexer during parsing
 [<Sealed>]

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -3771,3 +3771,27 @@ let x = 0
             Assert.Pass()
         | _ ->
             Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``triple slash comment should be captured, if used in an invalid location`` () =
+        let trivia =
+            getCommentTrivia false """
+/// Valid xml doc
+let x =
+    /// Some great documentation comment
+
+    /// With a blank line in between
+    /// but on a while loop
+    while true do ()
+    a + 1
+"""
+
+        match trivia with
+        | [ CommentTrivia.LineComment m1
+            CommentTrivia.LineComment m2
+            CommentTrivia.LineComment m3 ] ->
+            assertRange (4, 4) (4, 40) m1
+            assertRange (6, 4) (6, 36) m2
+            assertRange (7, 4) (7, 27) m3
+        | _ ->
+            Assert.Fail "Could not get valid AST"


### PR DESCRIPTION
If a user placed a `///` comment in a location where it is not being collected as PreXmlDoc, that information would be lost.
This PR tries to deal with this by storing the invalid XML doc lines as CommentTrivia.

Related: https://github.com/fsprojects/fantomas/issues/2186