### PR TITLE
Report invalidXmlDocPosition warning for xmldoc at the eof

### DIFF
--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -1431,7 +1431,8 @@ and singleLineComment cargs skip = parse
            token args skip lexbuf }
 
  | eof
-     { let _, _n, mStart, mEnd, args = cargs
+     { let buff, _n, mStart, mEnd, args = cargs
+       trySaveXmlDoc lexbuf buff
        LexbufCommentStore.SaveSingleLineComment(lexbuf, mStart, mEnd)
        // NOTE: it is legal to end a file with this comment, so we'll return EOF as a token
        EOF (LexCont.Token(args.ifdefStack, args.stringNest)) }

--- a/tests/service/XmlDocTests.fs
+++ b/tests/service/XmlDocTests.fs
@@ -200,6 +200,17 @@ let checkParsingErrors expected (parseResults: FSharpParseFileResults) =
     |> shouldEqual expected
 
 [<Test>]
+let ``xml-doc eof``(): unit =
+    checkSignatureAndImplementation """
+module Test
+
+/// a"""
+        (fun _ -> ())
+        (fun parseResults ->
+            parseResults |>
+            checkParsingErrors [|(Information 3520, Line 4, Col 0, Line 4, Col 5, "XML comment is not placed on a valid language element.")|])
+
+[<Test>]
 let ``comments after xml-doc``(): unit =
     checkSignatureAndImplementation """
 module Test


### PR DESCRIPTION
XmlDoc at the end of the file is not marked as invalid because such an XmlDoc is not added to the `LexbufLocalXmlDocStore`

![image](https://user-images.githubusercontent.com/26364714/161786089-66530f0f-cb09-4ef9-89c2-19a407d71c40.png)

This PR fixes this bug.