### PR TITLE
Revert arcade sdk

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "7.0.100-preview.2.22153.17",
+    "version": "6.0.200",
     "allowPrerelease": true,
     "rollForward": "minor"
   },
   "tools": {
-    "dotnet": "7.0.100-preview.2.22153.17",
+    "dotnet": "6.0.200",
     "vs": {
       "version": "16.8",
       "components": [


### PR DESCRIPTION
The recent Arcade update made it trickier to use the repo from VS.  For now reverting back to the shipped dotnet sdk.

/cc @brettfo, @vzarytovskii 