### PR TITLE
[WIP] Fix cross-file navigation features when #line is used

### DIFF
--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -500,6 +500,8 @@ type TcConfigBuilder =
 
       mutable noConditionalErasure: bool
 
+      mutable applyLineDirectives: bool
+
       mutable pathMap: PathMap
 
       mutable langVersion: LanguageVersion
@@ -672,6 +674,7 @@ type TcConfigBuilder =
           fsiMultiAssemblyEmit = true
           internalTestSpanStackReferring = false
           noConditionalErasure = false
+          applyLineDirectives = true
           pathMap = PathMap.empty
           langVersion = LanguageVersion.Default
           implicitIncludeDir = implicitIncludeDir
@@ -1062,6 +1065,7 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
     member x.tryGetMetadataSnapshot = data.tryGetMetadataSnapshot
     member x.internalTestSpanStackReferring = data.internalTestSpanStackReferring
     member x.noConditionalErasure = data.noConditionalErasure
+    member _.applyLineDirectives = data.applyLineDirectives
     member x.xmlDocInfoLoader = data.xmlDocInfoLoader
 
     static member Create(builder, validate) =

--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -293,6 +293,9 @@ type TcConfigBuilder =
       /// Prevent erasure of conditional attributes and methods so tooling is able analyse them.
       mutable noConditionalErasure: bool
 
+      /// Take '#line' into account? Defaults to true
+      mutable applyLineDirectives: bool
+
       mutable pathMap : PathMap
 
       mutable langVersion : LanguageVersion
@@ -523,6 +526,9 @@ type TcConfig =
 
     /// Prevent erasure of conditional attributes and methods so tooling is able analyse them.
     member noConditionalErasure: bool
+
+    /// Take '#line' into account? Defaults to true
+    member applyLineDirectives: bool
 
     /// if true - 'let mutable x = Span.Empty', the value 'x' is a stack referring span. Used for internal testing purposes only until we get true stack spans.
     member internalTestSpanStackReferring : bool

--- a/src/fsharp/CompilerOptions.fs
+++ b/src/fsharp/CompilerOptions.fs
@@ -1059,6 +1059,7 @@ let editorSpecificFlags (tcConfigB: TcConfigBuilder) =
     CompilerOption("exename", tagNone, OptionString (fun s -> tcConfigB.exename <- Some s), None, None)
     CompilerOption("maxerrors", tagInt, OptionInt (fun n -> tcConfigB.maxErrors <- n), None, None)
     CompilerOption("noconditionalerasure", tagNone, OptionUnit (fun () -> tcConfigB.noConditionalErasure <- true), None, None)
+    CompilerOption("ignorelinedirectives", tagNone, OptionUnit (fun () -> tcConfigB.applyLineDirectives <- false), None, None)
   ]
 
 let internalFlags (tcConfigB:TcConfigBuilder) =

--- a/src/fsharp/ParseAndCheckInputs.fs
+++ b/src/fsharp/ParseAndCheckInputs.fs
@@ -388,7 +388,7 @@ let ParseOneInputLexbuf (tcConfig: TcConfig, lexResourceManager, lexbuf, filenam
         let lightStatus = LightSyntaxStatus (tcConfig.ComputeLightSyntaxInitialStatus filename, true)
 
         // Set up the initial lexer arguments
-        let lexargs = mkLexargs (tcConfig.conditionalDefines, lightStatus, lexResourceManager, [], errorLogger, tcConfig.pathMap)
+        let lexargs = mkLexargs (tcConfig.conditionalDefines, lightStatus, lexResourceManager, [], errorLogger, tcConfig.pathMap, tcConfig.applyLineDirectives)
 
         // Set up the initial lexer arguments
         let shortFilename = SanitizeFileName filename tcConfig.implicitIncludeDir

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2403,7 +2403,7 @@ type FsiStdinLexerProvider
     ) =
 
     // #light is the default for FSI
-    let interactiveInputLightSyntaxStatus =
+    let lightStatus =
         let initialLightSyntaxStatus = tcConfigB.light <> Some false
         LightSyntaxStatus (initialLightSyntaxStatus, false (* no warnings *))
 
@@ -2442,8 +2442,9 @@ type FsiStdinLexerProvider
         resetLexbufPos sourceFileName lexbuf
         let skip = true  // don't report whitespace from lexer
         let defines = tcConfigB.conditionalDefines
-        let lexargs = mkLexargs (defines, interactiveInputLightSyntaxStatus, lexResourceManager, [], errorLogger, PathMap.empty)
-        let tokenizer = LexFilter.LexFilter(interactiveInputLightSyntaxStatus, tcConfigB.compilingFslib, Lexer.token lexargs skip, lexbuf)
+        let applyLineDirectives = true
+        let lexargs = mkLexargs (defines, lightStatus, lexResourceManager, [], errorLogger, PathMap.empty, applyLineDirectives)
+        let tokenizer = LexFilter.LexFilter(lightStatus, tcConfigB.compilingFslib, Lexer.token lexargs skip, lexbuf)
         tokenizer
 
     // Create a new lexer to read stdin

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -949,7 +949,7 @@ rule token args skip = parse
 
  | anywhite* "#if" anywhite+ anystring
    { let m = lexbuf.LexemeRange
-     let lookup id = List.contains id args.defines
+     let lookup id = List.contains id args.conditionalDefines
      let lexed = lexeme lexbuf
      let isTrue, expr = evalIfDefExpression lexbuf.StartPos lexbuf.ReportLibraryOnlyFeatures lexbuf.LanguageVersion args lookup lexed
      args.ifdefStack <- (IfDefIf,m) :: args.ifdefStack
@@ -1027,7 +1027,7 @@ and ifdefSkip n m args skip = parse
        else ifdefSkip n m args skip lexbuf
      else
        let lexed = lexeme lexbuf
-       let lookup id = List.contains id args.defines
+       let lookup id = List.contains id args.conditionalDefines
        let _, expr = evalIfDefExpression lexbuf.StartPos lexbuf.ReportLibraryOnlyFeatures lexbuf.LanguageVersion args lookup lexed
        LexbufIfdefStore.SaveIfHash(lexbuf, lexed, expr, m)
        let tok = INACTIVECODE(LexCont.EndLine(args.ifdefStack, args.stringNest, LexerEndlineContinuation.Skip(n+1, m)))

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -50,7 +50,7 @@ type LexResourceManager(?capacity: int) =
 /// Lexer parameters 
 type LexArgs =  
     {
-      defines: string list
+      conditionalDefines: string list
       resourceManager: LexResourceManager
       errorLogger: ErrorLogger
       applyLineDirectives: bool
@@ -67,14 +67,14 @@ type LongUnicodeLexResult =
     | SingleChar of uint16
     | Invalid
 
-let mkLexargs (defines, lightStatus, resourceManager, ifdefStack, errorLogger, pathMap:PathMap) =
+let mkLexargs (conditionalDefines, lightStatus, resourceManager, ifdefStack, errorLogger, pathMap:PathMap, applyLineDirectives) =
     { 
-      defines = defines
+      conditionalDefines = conditionalDefines
       ifdefStack = ifdefStack
       lightStatus = lightStatus
       resourceManager = resourceManager
       errorLogger = errorLogger
-      applyLineDirectives = true
+      applyLineDirectives = applyLineDirectives
       stringNest = []
       pathMap = pathMap
     }

--- a/src/fsharp/lexhelp.fsi
+++ b/src/fsharp/lexhelp.fsi
@@ -31,7 +31,7 @@ type LexResourceManager =
 /// The context applicable to all lexing functions (tokens, strings etc.)
 type LexArgs =
     {
-      defines: string list
+      conditionalDefines: string list
       resourceManager: LexResourceManager
       errorLogger: ErrorLogger
       applyLineDirectives: bool
@@ -48,7 +48,15 @@ type LongUnicodeLexResult =
 
 val resetLexbufPos: string -> Lexbuf -> unit
 
-val mkLexargs: string list * LightSyntaxStatus * LexResourceManager * LexerIfdefStack * ErrorLogger * PathMap -> LexArgs
+val mkLexargs:
+    conditionalDefines: string list *
+    lightStatus: LightSyntaxStatus *
+    resourceManager: LexResourceManager *
+    ifdefStack: LexerIfdefStack *
+    errorLogger: ErrorLogger *
+    pathMap: PathMap *
+    applyLineDirectives: bool
+        -> LexArgs
 
 val reusingLexbufForParsing: Lexbuf -> (unit -> 'a) -> 'a
 

--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -193,12 +193,26 @@ type public FSharpProjectContext =
 type public FSharpParsingOptions =
     { 
       SourceFiles: string[]
+      
+      /// Indicates if the ranges returned by parsing should have '#line' directives applied to them.
+      /// When compiling code, this should usually be 'true'.  For editing tools, this is usually 'false.
+      /// The default for FSharpParsingOptions.ApplyLineDirectives is 'false'.  The default for 
+      /// FSharpParsingOptions arising from FSharpProjectOptions will be 'true' unless '--ignorelinedirectives' is used in the
+      /// parameters from which these are derived.
+      ApplyLineDirectives: bool
+
       ConditionalDefines: string list
+
       ErrorSeverityOptions: FSharpDiagnosticOptions
+
       LangVersionText: string
+
       IsInteractive: bool
+
       LightSyntax: bool option
+
       CompilingFsLib: bool
+
       IsExe: bool
     }
     static member Default: FSharpParsingOptions

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -926,7 +926,9 @@ type FSharpSourceTokenizer(conditionalDefines: string list, filename: string opt
 
     let lexResourceManager = LexResourceManager()
 
-    let lexargs = mkLexargs(conditionalDefines, LightSyntaxStatus(true, false), lexResourceManager, [], DiscardErrorsLogger, PathMap.empty)
+    let applyLineDirectives = false
+    let lightStatus = LightSyntaxStatus(true, false)
+    let lexargs = mkLexargs(conditionalDefines, lightStatus, lexResourceManager, [], DiscardErrorsLogger, PathMap.empty, applyLineDirectives)
 
     member _.CreateLineTokenizer(lineText: string) =
         let lexbuf = UnicodeLexing.StringAsLexbuf(reportLibraryOnlyFeatures, langVersion, lineText)
@@ -1520,8 +1522,8 @@ module FSharpLexerImpl =
 
         let lexbuf = UnicodeLexing.SourceTextAsLexbuf(reportLibraryOnlyFeatures, langVersion, text)
         let lightStatus = LightSyntaxStatus(isLightSyntaxOn, true)
-        let lexargs = mkLexargs (conditionalDefines, lightStatus, LexResourceManager(0), [], errorLogger, pathMap)
-        let lexargs = { lexargs with applyLineDirectives = isCompiling }
+        let applyLineDirectives = isCompiling
+        let lexargs = mkLexargs (conditionalDefines, lightStatus, LexResourceManager(0), [], errorLogger, pathMap, applyLineDirectives)
 
         let getNextToken =
             let lexer = Lexer.token lexargs canSkipTrivia

--- a/tests/FSharp.Compiler.UnitTests/HashIfExpression.fs
+++ b/tests/FSharp.Compiler.UnitTests/HashIfExpression.fs
@@ -62,9 +62,10 @@ type public HashIfExpression() =
 
         let lightSyntax = LightSyntaxStatus(true, false)
         let resourceManager = LexResourceManager ()
-        let defines= []
+        let defines = []
+        let applyLineDirectives = true
         let startPos = Position.Empty
-        let args = mkLexargs (defines, lightSyntax, resourceManager, [], errorLogger, PathMap.empty)
+        let args = mkLexargs (defines, lightSyntax, resourceManager, [], errorLogger, PathMap.empty, applyLineDirectives)
 
         CompileThreadStatic.ErrorLogger <- errorLogger
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -289,6 +289,11 @@ type private FSharpProjectOptionsReactor (checker: FSharpChecker) =
                         for x in project.ProjectReferences do
                             "-r:" + project.Solution.GetProject(x.ProjectId).OutputFilePath
 
+                        // In the IDE we always ignore all #line directives for all purposes.  This means
+                        // IDE features work correctly within generated source files, but diagnostics are
+                        // reported in the IDE with respect to the generated source, and will not unify with
+                        // diagnostics from the build.
+                        "--ignorelinedirectives"
                     |]
 
                 let! ver = project.GetDependentVersionAsync(ct) |> Async.AwaitTask
@@ -509,6 +514,7 @@ type internal FSharpProjectOptionsManager
             | Some (_, parsingOptions, _) -> parsingOptions
             | _ ->
                 { FSharpParsingOptions.Default with
+                    ApplyLineDirectives = false
                     IsInteractive = CompilerEnvironment.IsScriptFile document.Name
                 }
         CompilerEnvironment.GetConditionalDefinesForEditing parsingOptions     


### PR DESCRIPTION
Builds on https://github.com/dotnet/fsharp/pull/12962

This fixes

* https://github.com/dotnet/fsharp/issues/9928

Some testing will need to be added.

Background: I've been looking into how VS and FCS behave when `#line` is used.

### Desired specification

In general, the IDE should ignore `#line`. The current status for F# before this PR is
* GOOD: colorization  works
* GOOD: brace matching works
* GOOD: diagnostics-from-build are reported and take `#line` into account
* GOOD: diagnostics-from-intellisense are reported and do not take `#line` into account
* GOOD: `#nowarn` works in generated source
* GOOD: autocomplete works at all in generated source
* GOOD: tooltips work in generated source
* GOOD: goto-definition works in generated source
* BAD: goto-definition doesn't work across files
* BAD: find-all-references doesn't work at all
* BAD: bug https://github.com/dotnet/fsharp/issues/9796

Essentially any features relying on source locations coming from the "IncrementalBuild" are broken

This PR makes sure no line directives are applied for the incremental build, for the VS IDE.  The same technique as https://github.com/dotnet/fsharp/pull/6004 is used - that is, the IDE directs the background build not to take line directives into account.  Like there it is important to use a switch because some clients of FCS (e.g. Fable) definitely *do* want to take `#line` into account (because they are implementing a compiler).

  