### PR TITLE
Checker: clear IL module readers cache in InvalidateAll

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1186,11 +1186,12 @@ type FSharpChecker(legacyReferenceResolver,
     /// For example, the type provider approvals file may have changed.
     member ic.InvalidateAll() =
         ic.ClearCaches()
-            
+
     member ic.ClearCaches() =
         let utok = AnyCallerThread
         braceMatchCache.Clear(utok)
-        backgroundCompiler.ClearCaches() 
+        backgroundCompiler.ClearCaches()
+        ClearAllILModuleReaderCache()
 
     // This is for unit testing only
     member ic.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients() =


### PR DESCRIPTION
Fixes IL module reader cache is not cleared on solution close.