### PR TITLE
Operator syntax tree

### DIFF
--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -244,7 +244,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
             | args -> SynExpr.Paren (SynExpr.Tuple (false, args, [], m), range0, None, m)
                 
         let builderVal = mkSynIdGet m builderValName
-        mkSynApp1 (SynExpr.DotGet (builderVal, range0, LongIdentWithDots([mkSynId m nm], []), m)) args m
+        mkSynApp1 (SynExpr.DotGet (builderVal, range0, LongIdentWithDots([mkSynId m nm], [], None), m)) args m
 
     let hasMethInfo nm = TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env mBuilderVal ad nm builderTy |> isNil |> not
 

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -3182,7 +3182,7 @@ module EstablishTypeDefinitionCores =
 
     let private (|TyconCoreAbbrevThatIsReallyAUnion|_|) (hasMeasureAttr, envinner: TcEnv, id: Ident) synTyconRepr =
         match synTyconRepr with 
-        | SynTypeDefnSimpleRepr.TypeAbbrev(_, StripParenTypes (SynType.LongIdent(LongIdentWithDots([unionCaseName], _))), m) 
+        | SynTypeDefnSimpleRepr.TypeAbbrev(_, StripParenTypes (SynType.LongIdent(LongIdentWithDots([unionCaseName], _, _))), m) 
                               when 
                                 (not hasMeasureAttr && 
                                  (isNil (LookupTypeNameInEnvNoArity OpenQualified unionCaseName.idText envinner.NameEnv) || 
@@ -3531,9 +3531,9 @@ module EstablishTypeDefinitionCores =
     /// Get the items on the r.h.s. of a 'type X = ABC<...>' definition
     let private TcTyconDefnCore_GetGenerateDeclaration_Rhs (StripParenTypes rhsType) =
         match rhsType with 
-        | SynType.App (StripParenTypes (SynType.LongIdent(LongIdentWithDots(tc, _))), _, args, _commas, _, _postfix, m) -> Some(tc, args, m)
-        | SynType.LongIdent (LongIdentWithDots(tc, _) as lidwd) -> Some(tc, [], lidwd.Range)
-        | SynType.LongIdentApp (StripParenTypes (SynType.LongIdent (LongIdentWithDots(tc, _))), LongIdentWithDots(longId, _), _, args, _commas, _, m) -> Some(tc@longId, args, m)
+        | SynType.App (StripParenTypes (SynType.LongIdent(LongIdentWithDots(tc, _, _))), _, args, _commas, _, _postfix, m) -> Some(tc, args, m)
+        | SynType.LongIdent (LongIdentWithDots(tc, _, _) as lidwd) -> Some(tc, [], lidwd.Range)
+        | SynType.LongIdentApp (StripParenTypes (SynType.LongIdent (LongIdentWithDots(tc, _, _))), LongIdentWithDots(longId, _, _), _, args, _commas, _, m) -> Some(tc@longId, args, m)
         | _ -> None
 
     /// Check whether 'type X = ABC<...>' is a generative provided type definition
@@ -4831,7 +4831,7 @@ module TcDeclarations =
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> true | _ -> false)
                         let mLetPortion = synExpr.Range
                         let fldId = ident (CompilerGeneratedName id.idText, mLetPortion)
-                        let headPat = SynPat.LongIdent (LongIdentWithDots([fldId], []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mLetPortion)
+                        let headPat = SynPat.LongIdent (LongIdentWithDots([fldId], [], None), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mLetPortion)
                         let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                         let isMutable = 
                             match propKind with 
@@ -4859,7 +4859,7 @@ module TcDeclarations =
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> false | _ -> true)
                         let fldId = ident (CompilerGeneratedName id.idText, mMemberPortion)
                         let headPatIds = if isStatic then [id] else [ident ("__", mMemberPortion);id]
-                        let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mMemberPortion)
+                        let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, [], None), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mMemberPortion)
 
                         match propKind, mGetSetOpt with 
                         | SynMemberKind.PropertySet, Some m -> errorR(Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSetNotJustSet(), m))
@@ -4884,7 +4884,7 @@ module TcDeclarations =
                             | SynMemberKind.PropertyGetSet -> 
                                 let setter = 
                                     let vId = ident("v", mMemberPortion)
-                                    let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
+                                    let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, [], None), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
                                     let rhsExpr = mkSynAssign (SynExpr.Ident fldId) (SynExpr.Ident vId)
                                     //let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                                     let binding = mkSynBinding (xmlDoc, headPat) (access, false, false, mMemberPortion, DebugPointAtBinding.NoneAtInvisible, None, rhsExpr, rhsExpr.Range, [], [], Some (memberFlags SynMemberKind.PropertySet), SynBindingTrivia.Zero)
@@ -5069,7 +5069,7 @@ module TcDeclarations =
                         memberFlags.MemberKind=SynMemberKind.Constructor && 
                         // REVIEW: This is a syntactic approximation
                         (match valSpfn.SynType, valSpfn.SynInfo.CurriedArgInfos with 
-                         | StripParenTypes (SynType.Fun (StripParenTypes (SynType.LongIdent (LongIdentWithDots([id], _))), _, _)), [[_]] when id.idText = "unit" -> true
+                         | StripParenTypes (SynType.Fun (StripParenTypes (SynType.LongIdent (LongIdentWithDots([id], _, _))), _, _)), [[_]] when id.idText = "unit" -> true
                          | _ -> false) 
                     | _ -> false) 
 

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1563,6 +1563,7 @@ type SynValSig =
     | SynValSig of
         attributes: SynAttributes *
         ident: Ident *
+        operatorName: OperatorName option *
         explicitValDecls: SynValTyparDecls *
         synType: SynType *
         arity: SynValInfo *

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -13,7 +13,19 @@ type Ident =
      new: text: string * range: range -> Ident
      member idText: string
      member idRange: range
-       
+
+/// Represents an operator identifier in F# code
+[<RequireQualifiedAccess; NoEquality; NoComparison>]
+type OperatorName =
+    /// (|A|B|)
+    | ActivePattern of lpr: range * id: Ident * rpr: range
+    /// (|A|_|)
+    | PartialActivePattern of lpr: range * id: Ident * rpr: range
+    /// (>=>)
+    | Operator of lpr: range * id: Ident * rpr: range
+    member Range: range
+    member Ident: Ident
+
 /// Represents a long identifier e.g. 'A.B.C'
 type LongIdent = Ident list
 
@@ -26,7 +38,11 @@ type LongIdent = Ident list
 /// LongIdent can be empty list - it is used to denote that name of some AST element is absent (i.e. empty type name in inherit)
 type LongIdentWithDots =
     | //[<Experimental("This construct is subject to change in future versions of FSharp.Compiler.Service and should only be used if no adequate alternative is available.")>]
-      LongIdentWithDots of id: LongIdent * dotRanges: range list
+      LongIdentWithDots of
+        leadingId: LongIdent *
+        operatorName: OperatorName option *
+        trailingId: LongIdent *
+        dotRanges: range list
 
     /// Gets the syntax range of this construct
     member Range: range
@@ -1055,6 +1071,9 @@ type SynExpr =
         debugPoint: DebugPointAtLeafExpr *
         isControlFlow: bool *
         innerExpr: SynExpr
+
+    /// Operator, Active pattern or Partial Active pattern
+    | OperatorName of operatorName: OperatorName
 
     /// Gets the syntax range of this construct
     member Range: range

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -36,13 +36,11 @@ type LongIdent = Ident list
 /// if dotRanges.Length = lid.Length, then the parser must have reported an error, so the typechecker is allowed
 /// more freedom about typechecking these expressions.
 /// LongIdent can be empty list - it is used to denote that name of some AST element is absent (i.e. empty type name in inherit)
+/// 
+/// The `operatorName` is duplication information of one of the idents of id, if it indeed is an operator name.
 type LongIdentWithDots =
     | //[<Experimental("This construct is subject to change in future versions of FSharp.Compiler.Service and should only be used if no adequate alternative is available.")>]
-      LongIdentWithDots of
-        leadingId: LongIdent *
-        operatorName: OperatorName option *
-        trailingId: LongIdent *
-        dotRanges: range list
+      LongIdentWithDots of id: LongIdent * dotRanges: range list * operatorName: OperatorName option
 
     /// Gets the syntax range of this construct
     member Range: range

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -1713,6 +1713,7 @@ type SynValSig =
     | SynValSig of
         attributes: SynAttributes *
         ident: Ident *
+        operatorName: OperatorName option *
         explicitValDecls: SynValTyparDecls *
         synType: SynType *
         arity: SynValInfo *

--- a/src/fsharp/SyntaxTreeOps.fsi
+++ b/src/fsharp/SyntaxTreeOps.fsi
@@ -144,6 +144,8 @@ val mkSynAssign: l:SynExpr -> r:SynExpr -> SynExpr
 
 val mkSynDot: dotm:range -> m:range -> l:SynExpr -> r:Ident -> SynExpr
 
+val mkSynDotWithOperatorName: dotm:range -> m:range -> l:SynExpr -> operatorName:OperatorName -> SynExpr
+
 val mkSynDotMissing: dotm:range -> m:range -> l:SynExpr -> SynExpr
 
 val mkSynFunMatchLambdas: synArgNameGenerator:SynArgNameGenerator -> isMember:bool -> wholem:range -> ps:SynPat list -> arrow:Range option -> e:SynExpr -> SynExpr

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1838,7 +1838,7 @@ type internal FsiDynamicCompiler
     member _.CreateDebuggerBreak (m: range) =
         let breakPath = ["System";"Diagnostics";"Debugger";"Break"]
         let dots = List.replicate (breakPath.Length - 1) m
-        let methCall = SynExpr.LongIdent (false, LongIdentWithDots(List.map (mkSynId m) breakPath, dots), None, m)
+        let methCall = SynExpr.LongIdent (false, LongIdentWithDots(List.map (mkSynId m) breakPath, dots, None), None, m)
         let args = SynExpr.Const (SynConst.Unit, m)
         let breakStatement = SynExpr.App (ExprAtomicFlag.Atomic, false, methCall, args, m)
         SynModuleDecl.Expr(breakStatement, m)

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -860,7 +860,17 @@ valSpfn:
         let attr1, attr2, isInline, isMutable, vis2, id, doc, explicitValTyparDecls, (ty, arity), konst = ($1), ($4), ($5), ($6), ($7), ($8), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
         if not (isNil attr2) then errorR(Deprecated(FSComp.SR.parsAttributesMustComeBeforeVal(), rhs parseState 4))
         let m = rhs2 parseState 1 11 |> unionRangeWithXmlDoc doc
-        let valSpfn = SynValSig((attr1@attr2), id, explicitValTyparDecls, ty, arity, isInline, isMutable, doc, vis2, konst, None, m) 
+        let valSpfn = SynValSig((attr1@attr2), id, None, explicitValTyparDecls, ty, arity, isInline, isMutable, doc, vis2, konst, None, m) 
+        SynModuleSigDecl.Val(valSpfn, m)
+      }
+
+  | opt_attributes opt_declVisibility VAL opt_attributes opt_inline opt_mutable opt_access opName opt_explicitValTyparDecls COLON topTypeWithTypeConstraints optLiteralValueSpfn
+      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
+        let operatorName: OperatorName = $8
+        let attr1, attr2, isInline, isMutable, vis2, id, doc, explicitValTyparDecls, (ty, arity), konst = ($1), ($4), ($5), ($6), ($7), (operatorName.Ident), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
+        if not (isNil attr2) then errorR(Deprecated(FSComp.SR.parsAttributesMustComeBeforeVal(), rhs parseState 4))
+        let m = rhs2 parseState 1 11 |> unionRangeWithXmlDoc doc
+        let valSpfn = SynValSig((attr1@attr2), id, Some $8, explicitValTyparDecls, ty, arity, isInline, isMutable, doc, vis2, konst, None, m) 
         SynModuleSigDecl.Val(valSpfn, m)
       }
 
@@ -983,7 +993,7 @@ tyconSpfnRhs:
   | DELEGATE OF topType
      { let m = lhs parseState 
        let ty, arity = $3
-       let invoke = SynMemberSig.Member(SynValSig([], mkSynId m "Invoke", inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m), AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
+       let invoke = SynMemberSig.Member(SynValSig([], mkSynId m "Invoke", None, inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m), AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
        (fun nameRange nameInfo mEquals augmentation -> 
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
            let mWhole = unionRanges nameRange m
@@ -1065,7 +1075,7 @@ classMemberSpfn:
            | Some m2 -> unionRanges m m2
            |> fun m -> (m, $1) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
            |> unionRangeWithXmlDoc doc
-       let valSpfn = SynValSig($1, id, explicitValTyparDecls, ty, arity, isInline, false, doc, vis2, optLiteralValue, mWith, wholeRange)
+       let valSpfn = SynValSig($1, id, None, explicitValTyparDecls, ty, arity, isInline, false, doc, vis2, optLiteralValue, mWith, wholeRange)
        let _, flags = $3 
        SynMemberSig.Member(valSpfn, flags (getSetAdjuster arity), wholeRange) }
 
@@ -1099,7 +1109,7 @@ classMemberSpfn:
      { let vis, doc, (ty, valSynInfo) = $2, grabXmlDoc(parseState, $1, 1), $5
        let m = unionRanges (rhs parseState 1) ty.Range |> unionRangeWithXmlDoc doc
        let isInline = false 
-       let valSpfn = SynValSig ($1, mkSynId (rhs parseState 3) "new", noInferredTypars, ty, valSynInfo, isInline, false, doc, vis, None, None, m)
+       let valSpfn = SynValSig ($1, mkSynId (rhs parseState 3) "new", None, noInferredTypars, ty, valSynInfo, isInline, false, doc, vis, None, None, m)
        SynMemberSig.Member(valSpfn, CtorMemberFlags SynMemberFlagsTrivia.Zero, m) }
 
 
@@ -1720,7 +1730,7 @@ tyconDefnRhs:
      { let m = lhs parseState 
        let ty, arity = $3
        (fun nameRange augmentation -> 
-           let valSpfn = SynValSig([], mkSynId m "Invoke", inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m) 
+           let valSpfn = SynValSig([], mkSynId m "Invoke", None, inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m) 
            let invoke = SynMemberDefn.AbstractSlot(valSpfn, AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
            SynTypeDefnRepr.ObjectModel (SynTypeDefnKind.Delegate (ty, arity), [invoke], m), []) }
@@ -2093,7 +2103,7 @@ classDefnMember:
            | Some m2 -> unionRanges m m2
            |> unionRangeWithXmlDoc doc
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsAccessibilityModsIllegalForAbstract(), wholeRange))
-       let valSpfn = SynValSig($1, id, explicitValTyparDecls, ty, arity, isInline, false, doc, None, None, mWith, wholeRange)
+       let valSpfn = SynValSig($1, id, None, explicitValTyparDecls, ty, arity, isInline, false, doc, None, None, mWith, wholeRange)
        [ SynMemberDefn.AbstractSlot(valSpfn, AbstractMemberFlags $3 (getSetAdjuster arity), wholeRange) ] }
        
   | opt_attributes opt_declVisibility inheritsDefn

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -855,22 +855,12 @@ moduleSpfn:
       { SynModuleSigDecl.Open($1, (rhs parseState 1)) }
 
 valSpfn: 
-  | opt_attributes opt_declVisibility VAL opt_attributes opt_inline opt_mutable opt_access ident opt_explicitValTyparDecls COLON topTypeWithTypeConstraints optLiteralValueSpfn
+  | opt_attributes opt_declVisibility VAL opt_attributes opt_inline opt_mutable opt_access identOrOp opt_explicitValTyparDecls COLON topTypeWithTypeConstraints optLiteralValueSpfn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let attr1, attr2, isInline, isMutable, vis2, id, doc, explicitValTyparDecls, (ty, arity), konst = ($1), ($4), ($5), ($6), ($7), ($8), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
+        let attr1, attr2, isInline, isMutable, vis2, (id, operatorName), doc, explicitValTyparDecls, (ty, arity), konst = ($1), ($4), ($5), ($6), ($7), ($8), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
         if not (isNil attr2) then errorR(Deprecated(FSComp.SR.parsAttributesMustComeBeforeVal(), rhs parseState 4))
         let m = rhs2 parseState 1 11 |> unionRangeWithXmlDoc doc
-        let valSpfn = SynValSig((attr1@attr2), id, None, explicitValTyparDecls, ty, arity, isInline, isMutable, doc, vis2, konst, None, m) 
-        SynModuleSigDecl.Val(valSpfn, m)
-      }
-
-  | opt_attributes opt_declVisibility VAL opt_attributes opt_inline opt_mutable opt_access opName opt_explicitValTyparDecls COLON topTypeWithTypeConstraints optLiteralValueSpfn
-      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let operatorName: OperatorName = $8
-        let attr1, attr2, isInline, isMutable, vis2, id, doc, explicitValTyparDecls, (ty, arity), konst = ($1), ($4), ($5), ($6), ($7), (operatorName.Ident), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
-        if not (isNil attr2) then errorR(Deprecated(FSComp.SR.parsAttributesMustComeBeforeVal(), rhs parseState 4))
-        let m = rhs2 parseState 1 11 |> unionRangeWithXmlDoc doc
-        let valSpfn = SynValSig((attr1@attr2), id, Some $8, explicitValTyparDecls, ty, arity, isInline, isMutable, doc, vis2, konst, None, m) 
+        let valSpfn = SynValSig((attr1@attr2), id, operatorName, explicitValTyparDecls, ty, arity, isInline, isMutable, doc, vis2, konst, None, m) 
         SynModuleSigDecl.Val(valSpfn, m)
       }
 
@@ -1063,9 +1053,9 @@ classSpfnMembersAtLeastOne:
 
 /* A object member in a signature */
 classMemberSpfn:
-  | opt_attributes opt_declVisibility memberSpecFlags opt_inline opt_access ident opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet optLiteralValueSpfn
+  | opt_attributes opt_declVisibility memberSpecFlags opt_inline opt_access identOrOp opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet optLiteralValueSpfn
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-       let isInline, doc, vis2, id, explicitValTyparDecls, (ty, arity), optLiteralValue = $4, grabXmlDoc(parseState, $1, 1), $5, $6, $7, $9, $11
+       let isInline, doc, vis2, (id, operatorName), explicitValTyparDecls, (ty, arity), optLiteralValue = $4, grabXmlDoc(parseState, $1, 1), $5, $6, $7, $9, $11
        let mWith, getSetRangeOpt, getSet = $10 
        let getSetAdjuster arity = match arity, getSet with SynValInfo([], _), SynMemberKind.Member -> SynMemberKind.PropertyGet | _ -> getSet
        let wholeRange = 
@@ -1075,7 +1065,7 @@ classMemberSpfn:
            | Some m2 -> unionRanges m m2
            |> fun m -> (m, $1) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
            |> unionRangeWithXmlDoc doc
-       let valSpfn = SynValSig($1, id, None, explicitValTyparDecls, ty, arity, isInline, false, doc, vis2, optLiteralValue, mWith, wholeRange)
+       let valSpfn = SynValSig($1, id, operatorName, explicitValTyparDecls, ty, arity, isInline, false, doc, vis2, optLiteralValue, mWith, wholeRange)
        let _, flags = $3 
        SynMemberSig.Member(valSpfn, flags (getSetAdjuster arity), wholeRange) }
 
@@ -1135,13 +1125,16 @@ classMemberSpfnGetSet:
 /* The "get, set" on a property member in a signature */
 classMemberSpfnGetSetElements:
   | ident 
-    {  if $1.idText = "get" then SynMemberKind.PropertyGet 
-       elif $1.idText = "set" then SynMemberKind.PropertySet 
+    {  let (id:Ident) = $1
+       if id.idText = "get" then SynMemberKind.PropertyGet 
+       elif id.idText = "set" then SynMemberKind.PropertySet 
        else raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired()) }
 
   | ident COMMA ident
-    { if not (($1.idText = "get" && ($3.idText) = "set") ||
-              ($1.idText = "set" && ($3.idText) = "get")) then 
+    { let (id:Ident) = $1
+      let (id2:Ident) = $3
+      if not ((id.idText = "get" && (id2.idText) = "set") ||
+              (id.idText = "set" && (id2.idText) = "get")) then 
          raiseParseErrorAt (rhs2 parseState 1 3) (FSComp.SR.parsGetOrSetRequired())
       SynMemberKind.PropertyGetSet }
 
@@ -2091,9 +2084,9 @@ classDefnMember:
             | Some (mWithKwd, members, m) -> Some mWithKwd, Some members, unionRanges (rhs2 parseState 1 4) m
         [ SynMemberDefn.Interface ($4, mWithKwd, members, mWhole) ] }
         
-  | opt_attributes opt_declVisibility abstractMemberFlags opt_inline ident opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet  opt_ODECLEND
+  | opt_attributes opt_declVisibility abstractMemberFlags opt_inline identOrOp opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet  opt_ODECLEND
      { let ty, arity = $8
-       let isInline, doc, id, explicitValTyparDecls = $4, grabXmlDoc(parseState, $1, 1), $5, $6
+       let isInline, doc, (id, operatorName) , explicitValTyparDecls = $4, grabXmlDoc(parseState, $1, 1), $5, $6
        let mWith, getSetRangeOpt, getSet = $9
        let getSetAdjuster arity = match arity, getSet with SynValInfo([], _), SynMemberKind.Member -> SynMemberKind.PropertyGet | _ -> getSet
        let wholeRange = 
@@ -2103,7 +2096,7 @@ classDefnMember:
            | Some m2 -> unionRanges m m2
            |> unionRangeWithXmlDoc doc
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsAccessibilityModsIllegalForAbstract(), wholeRange))
-       let valSpfn = SynValSig($1, id, None, explicitValTyparDecls, ty, arity, isInline, false, doc, None, None, mWith, wholeRange)
+       let valSpfn = SynValSig($1, id, operatorName, explicitValTyparDecls, ty, arity, isInline, false, doc, None, None, mWith, wholeRange)
        [ SynMemberDefn.AbstractSlot(valSpfn, AbstractMemberFlags $3 (getSetAdjuster arity), wholeRange) ] }
        
   | opt_attributes opt_declVisibility inheritsDefn
@@ -4447,12 +4440,9 @@ atomicExpr:
       { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1))
         $3 arg1 (lhs parseState) (rhs parseState 2), false }
 
-  | QMARK opName 
-      { let operatorName: OperatorName = $2
-        SynExpr.LongIdent (true, LongIdentWithDots([operatorName.Ident], [], Some operatorName), None, rhs parseState 2), false }
-
-  | QMARK ident 
-      { SynExpr.LongIdent (true, LongIdentWithDots([$2], [], None), None, rhs parseState 2), false }
+  | QMARK identOrOp 
+      { let (ident, operatorName) = $2
+        SynExpr.LongIdent (true, LongIdentWithDots([ident], [], operatorName), None, rhs parseState 2), false }
 
   | atomicExpr QMARK dynamicArg
       { let arg1, hpa1 = $1
@@ -5725,6 +5715,15 @@ activePatternCaseNames:
 
   | activePatternCaseNames BAR activePatternCaseName
      { $3 :: $1 }
+
+/* A single item that is an identifier or operator name */
+identOrOp: 
+  | ident  
+     { $1, None } 
+
+  | opName 
+     { let operatorName: OperatorName = $1
+       operatorName.Ident, Some operatorName }
 
 /* An A.B.C path ending in an identifier or operator name */
 /* Note, only used in atomicPatternLongIdent */

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -52,7 +52,7 @@ let rebindRanges first fields lastSep =
         | (f, m) :: xs -> run f xs (SynExprRecordField(name, mEquals, value, m) :: acc)
     run first fields []
 
-let mkUnderscoreRecdField m = LongIdentWithDots([ident("_", m)], []), false
+let mkUnderscoreRecdField m = LongIdentWithDots([ident("_", m)], [], None), false
 
 let mkRecdField lidwd = lidwd, true
 
@@ -189,7 +189,7 @@ let idOfPat (parseState:IParseState) m p =
     | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop ->
         mkSynId r "_"
     | SynPat.Named (id, false, _, _) -> id
-    | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
+    | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _, _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier())
 
 let checkForMultipleAugmentations m a1 a2 = 
@@ -855,7 +855,7 @@ moduleSpfn:
       { SynModuleSigDecl.Open($1, (rhs parseState 1)) }
 
 valSpfn: 
-  | opt_attributes opt_declVisibility VAL opt_attributes opt_inline opt_mutable opt_access nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints optLiteralValueSpfn
+  | opt_attributes opt_declVisibility VAL opt_attributes opt_inline opt_mutable opt_access ident opt_explicitValTyparDecls COLON topTypeWithTypeConstraints optLiteralValueSpfn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let attr1, attr2, isInline, isMutable, vis2, id, doc, explicitValTyparDecls, (ty, arity), konst = ($1), ($4), ($5), ($6), ($7), ($8), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
         if not (isNil attr2) then errorR(Deprecated(FSComp.SR.parsAttributesMustComeBeforeVal(), rhs parseState 4))
@@ -1053,7 +1053,7 @@ classSpfnMembersAtLeastOne:
 
 /* A object member in a signature */
 classMemberSpfn:
-  | opt_attributes opt_declVisibility memberSpecFlags opt_inline opt_access nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet optLiteralValueSpfn
+  | opt_attributes opt_declVisibility memberSpecFlags opt_inline opt_access ident opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet optLiteralValueSpfn
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
        let isInline, doc, vis2, id, explicitValTyparDecls, (ty, arity), optLiteralValue = $4, grabXmlDoc(parseState, $1, 1), $5, $6, $7, $9, $11
        let mWith, getSetRangeOpt, getSet = $10 
@@ -1124,16 +1124,14 @@ classMemberSpfnGetSet:
 
 /* The "get, set" on a property member in a signature */
 classMemberSpfnGetSetElements:
-  | nameop 
-    { (let (id:Ident) = $1 
-       if id.idText = "get" then SynMemberKind.PropertyGet 
-       else if id.idText = "set" then SynMemberKind.PropertySet 
-       else raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired())) }
+  | ident 
+    {  if $1.idText = "get" then SynMemberKind.PropertyGet 
+       elif $1.idText = "set" then SynMemberKind.PropertySet 
+       else raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired()) }
 
-  | nameop COMMA nameop
-    { let (id:Ident) = $1 
-      if not ((id.idText = "get" && $3.idText = "set") ||
-              (id.idText = "set" && $3.idText = "get")) then 
+  | ident COMMA ident
+    { if not (($1.idText = "get" && ($3.idText) = "set") ||
+              ($1.idText = "set" && ($3.idText) = "get")) then 
          raiseParseErrorAt (rhs2 parseState 1 3) (FSComp.SR.parsGetOrSetRequired())
       SynMemberKind.PropertyGetSet }
 
@@ -1458,7 +1456,7 @@ namedModuleDefnBlock:
          // However in that case we do use type name lookup to make the resolution.
 
          match $2 with 
-         | [ SynModuleDecl.Expr (LongOrSingleIdent(false, LongIdentWithDots(path, _), None, _), _) ] -> 
+         | [ SynModuleDecl.Expr (LongOrSingleIdent(false, LongIdentWithDots(path, _, _), None, _), _) ] -> 
              Choice1Of2  path
          | _ -> 
              Choice2Of2 $2 
@@ -1880,7 +1878,7 @@ memberCore:
                        let getset = 
                              let rec go p = 
                                  match p with 
-                                 | SynPat.LongIdent (longDotId=LongIdentWithDots([id], _)) -> id.idText
+                                 | SynPat.LongIdent (longDotId=LongIdentWithDots([id], _, _)) -> id.idText
                                  | SynPat.Named (nm, _, _, _) | SynPat.As (_, SynPat.Named (nm, _, _, _), _) -> nm.idText
                                  | SynPat.Typed (p, _, _) -> go p
                                  | SynPat.Attrib (p, _, _) -> go p
@@ -1992,7 +1990,7 @@ memberCore:
                      let lidOuter, lidVisOuter = 
                          match bindingPatOuter with 
                          | SynPat.LongIdent (lid, _, None, None, SynArgPats.Pats [], lidVisOuter, m) ->  lid, lidVisOuter
-                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> LongIdentWithDots([id], []), visOuter
+                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> LongIdentWithDots([id], [], None), visOuter
                          | p -> raiseParseErrorAt mWholeBindLhs (FSComp.SR.parsInvalidDeclarationSyntax()) 
   
                      // Merge the visibility from the outer point with the inner point, e.g.
@@ -2009,7 +2007,7 @@ memberCore:
                      // Replace the "get" or the "set" with the right name
                      let rec go p = 
                          match p with 
-                         | SynPat.LongIdent (longDotId=LongIdentWithDots([id], _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
+                         | SynPat.LongIdent (longDotId=LongIdentWithDots([id], _, _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
                              // Setters have all arguments tupled in their internal form, though they don't 
                              // appear to be tupled from the syntax. Somewhat unfortunate
                              let args = 
@@ -2083,7 +2081,7 @@ classDefnMember:
             | Some (mWithKwd, members, m) -> Some mWithKwd, Some members, unionRanges (rhs2 parseState 1 4) m
         [ SynMemberDefn.Interface ($4, mWithKwd, members, mWhole) ] }
         
-  | opt_attributes opt_declVisibility abstractMemberFlags opt_inline nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet  opt_ODECLEND
+  | opt_attributes opt_declVisibility abstractMemberFlags opt_inline ident opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet  opt_ODECLEND
      { let ty, arity = $8
        let isInline, doc, id, explicitValTyparDecls = $4, grabXmlDoc(parseState, $1, 1), $5, $6
        let mWith, getSetRangeOpt, getSet = $9
@@ -2128,7 +2126,7 @@ classDefnMember:
         let expr = $7
         let valSynData = SynValData (Some (CtorMemberFlags SynMemberFlagsTrivia.Zero), SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), $5) 
         let vis = $2 
-        let declPat = SynPat.LongIdent (LongIdentWithDots([mkSynId (rhs parseState 3) "new"], []), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
+        let declPat = SynPat.LongIdent (LongIdentWithDots([mkSynId (rhs parseState 3) "new"], [], None), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
         // Check that 'SynPatForConstructorDecl' matches this correctly
         assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
         let synBindingTrivia: SynBindingTrivia = { LetKeyword = None; EqualsRange = Some mEquals }
@@ -2174,12 +2172,12 @@ atomicPatternLongIdent:
   | UNDERSCORE DOT pathOp
      { if not (parseState.LexBuffer.SupportsFeature LanguageFeature.SingleUnderscorePattern) then
           raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedSymbolDot())
-       let (LongIdentWithDots(lid, dotms)) = $3
-       (None, LongIdentWithDots(ident("_", rhs parseState 1)::lid, rhs parseState 2::dotms)) }
+       let (LongIdentWithDots(lid, dotms, operatorName)) = $3
+       (None, LongIdentWithDots(ident("_", rhs parseState 1)::lid, rhs parseState 2::dotms, operatorName)) }
 
   | GLOBAL DOT pathOp
-     { let (LongIdentWithDots(lid, dotms)) = $3
-       (None, LongIdentWithDots(ident(MangledGlobalName, rhs parseState 1) :: lid, rhs parseState 2 :: dotms)) }
+     { let (LongIdentWithDots(lid, dotms, operatorName)) = $3
+       (None, LongIdentWithDots(ident(MangledGlobalName, rhs parseState 1) :: lid, rhs parseState 2 :: dotms, operatorName)) }
 
   | pathOp
      { (None, $1) }
@@ -2187,8 +2185,8 @@ atomicPatternLongIdent:
   | access UNDERSCORE DOT pathOp
      { if not (parseState.LexBuffer.SupportsFeature LanguageFeature.SingleUnderscorePattern) then
           raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedSymbolDot())
-       let (LongIdentWithDots(lid, dotms)) = $4
-       (Some($1), LongIdentWithDots(ident("_", rhs parseState 2)::lid, rhs parseState 3::dotms)) }  
+       let (LongIdentWithDots(lid, dotms, operatorName)) = $4
+       (Some($1), LongIdentWithDots(ident("_", rhs parseState 2)::lid, rhs parseState 3::dotms, operatorName)) }  
 
   | access pathOp
      { (Some($1), $2) }
@@ -2258,7 +2256,7 @@ inheritsDefn:
   | INHERIT ends_coming_soon_or_recover
      { let mDecl = (rhs parseState 1)
        if not $2 then errorR(Error(FSComp.SR.parsTypeNameCannotBeEmpty(), mDecl))
-       SynMemberDefn.Inherit(SynType.LongIdent(LongIdentWithDots([], [])), None, mDecl) }
+       SynMemberDefn.Inherit(SynType.LongIdent(LongIdentWithDots([], [], None)), None, mDecl) }
 
 optAsSpec: 
   | asSpec
@@ -2629,7 +2627,7 @@ attrUnionCaseDecl:
 
 /* The name of a union case */
 unionCaseName: 
-  | nameop  
+  | ident  
       { $1 } 
 
   | LPAREN COLON_COLON rparen  
@@ -2882,7 +2880,7 @@ cPrototype:
                 SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
                 mRhs)
         (fun attrs _ ->
-            let bindingPat = SynPat.LongIdent (LongIdentWithDots([nm], []), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
+            let bindingPat = SynPat.LongIdent (LongIdentWithDots([nm], [], None), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
             let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let xmlDoc = grabXmlDoc(parseState, attrs, 1)
             let binding =
@@ -2927,19 +2925,19 @@ cType:
 
   | cType opt_HIGH_PRECEDENCE_APP LBRACK RBRACK 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("[]", m)], [])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("[]", m)], [], None)), None, [$1], [], None, true, m) } 
 
   | cType STAR 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("nativeptr", m)], [])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("nativeptr", m)], [], None)), None, [$1], [], None, true, m) } 
 
   | cType AMP  
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("byref", m)], [])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("byref", m)], [], None)), None, [$1], [], None, true, m) } 
 
   | VOID STAR 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("nativeint", m)], [])), None, [], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("nativeint", m)], [], None)), None, [], [], None, true, m) } 
 
 
 /* A return type in an 'extern' DllImport function definition */
@@ -2949,7 +2947,7 @@ cRetType:
 
   | opt_attributes VOID  
      { let m = rhs parseState 2 
-       SynReturnInfo((SynType.App(SynType.LongIdent(LongIdentWithDots([ident("unit", m)], [])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
+       SynReturnInfo((SynType.App(SynType.LongIdent(LongIdentWithDots([ident("unit", m)], [], None)), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
 
 
 localBindings: 
@@ -3254,7 +3252,7 @@ headBindingPattern:
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
   | headBindingPattern COLON_COLON  headBindingPattern 
-      { SynPat.LongIdent (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
+      { SynPat.LongIdent (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, [], None), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
 
   | tuplePatternElements  %prec pat_tuple 
       { SynPat.Tuple(false, List.rev $1, lhs parseState) }
@@ -3493,7 +3491,7 @@ parenPattern:
         SynPat.Attrib($2, $1, lhsm) } 
 
   | parenPattern COLON_COLON  parenPattern 
-      { SynPat.LongIdent (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
+      { SynPat.LongIdent (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, [], None), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
 
   | constrPattern { $1 }
 
@@ -4439,8 +4437,12 @@ atomicExpr:
       { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1))
         $3 arg1 (lhs parseState) (rhs parseState 2), false }
 
-  | QMARK nameop 
-      { SynExpr.LongIdent (true, LongIdentWithDots([$2], []), None, rhs parseState 2), false }
+  | QMARK opName 
+      { let operatorName: OperatorName = $2
+        SynExpr.LongIdent (true, LongIdentWithDots([operatorName.Ident], [], Some operatorName), None, rhs parseState 2), false }
+
+  | QMARK ident 
+      { SynExpr.LongIdent (true, LongIdentWithDots([$2], [], None), None, rhs parseState 2), false }
 
   | atomicExpr QMARK dynamicArg
       { let arg1, hpa1 = $1
@@ -4483,9 +4485,10 @@ atomicExpr:
       { $1, false }
 
 atomicExprQualification:
-  | identOrOp 
-      { let idm = rhs parseState 1 
-        (fun e lhsm dotm -> mkSynDot dotm lhsm e $1) }
+  | opName 
+      { fun e lhsm dotm -> mkSynDotWithOperatorName dotm lhsm e $1 }
+  | ident
+      { fun e lhsm dotm -> mkSynDot dotm lhsm e $1 }
 
   | GLOBAL
       { (fun e lhsm dotm -> 
@@ -4814,7 +4817,7 @@ recdExpr:
   | INHERIT atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType recdExprBindings opt_seps_recd
      { let arg = match $4 with None -> mkSynUnit (lhs parseState) | Some e -> e 
        let l = List.rev $5
-       let dummyField = mkRecdField (LongIdentWithDots([], [])) // dummy identifier, it will be discarded
+       let dummyField = mkRecdField (LongIdentWithDots([], [], None)) // dummy identifier, it will be discarded
        let l = rebindRanges (dummyField, None, None) l $6 
        let (SynExprRecordField(_, _, _, inheritsSep)) = List.head l
        let bindings = List.tail l
@@ -4826,7 +4829,7 @@ recdExpr:
 recdExprCore:
   | appExpr EQUALS declExprBlock recdExprBindings opt_seps_recd
      { match $1 with 
-       | LongOrSingleIdent(false, (LongIdentWithDots(_, _) as f), None, m) ->  
+       | LongOrSingleIdent(false, (LongIdentWithDots _ as f), None, m) ->  
             let f = mkRecdField f
             let mEquals = rhs parseState 2
             let l = List.rev $4
@@ -5029,8 +5032,8 @@ braceBarExprCore:
      { let orig, flds = $2
        let flds = 
            flds |> List.choose (function 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
+             | SynExprRecordField((LongIdentWithDots([id], _, _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
+             | SynExprRecordField((LongIdentWithDots([id], _, _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 3
        (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
@@ -5040,8 +5043,8 @@ braceBarExprCore:
        let orig, flds = $2 
        let flds = 
            flds |> List.choose (function 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
+             | SynExprRecordField((LongIdentWithDots([id], _, _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
+             | SynExprRecordField((LongIdentWithDots([id], _, _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 2
        (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
@@ -5166,7 +5169,7 @@ topTupleTypeElements:
 topAppType:
   | attributes appType COLON appType 
      { match $2 with 
-       | SynType.LongIdent(LongIdentWithDots([id], _)) -> $4, SynArgInfo($1, false, Some id)
+       | SynType.LongIdent(LongIdentWithDots([id], _, _)) -> $4, SynArgInfo($1, false, Some id)
        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType())  }
 
   | attributes QMARK ident COLON appType 
@@ -5177,7 +5180,7 @@ topAppType:
 
   | appType COLON appType 
      { match $1 with 
-       | SynType.LongIdent(LongIdentWithDots([id], _)) -> $3, SynArgInfo([], false, Some id)
+       | SynType.LongIdent(LongIdentWithDots([id], _, _)) -> $3, SynArgInfo([], false, Some id)
        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType())  }
 
   | QMARK ident COLON appType 
@@ -5487,7 +5490,7 @@ dummyTypeArg:
   |  /* EMPTY */
      { let m = rhs parseState 1
        let dummyStatVal = SynType.StaticConstant(SynConst.Int32(0), m)
-       let dummyName = SynType.LongIdent(LongIdentWithDots([ident("", m)], []))
+       let dummyName = SynType.LongIdent(LongIdentWithDots([ident("", m)], [], None))
        let dummyTypeArg = SynType.StaticConstantNamed(dummyName, dummyStatVal, m)
        dummyTypeArg }
 
@@ -5565,17 +5568,17 @@ ident:
 /* A A.B.C path used to an identifier */
 path: 
   | GLOBAL
-      { LongIdentWithDots([ident(MangledGlobalName, rhs parseState 1)], []) }
+      { LongIdentWithDots([ident(MangledGlobalName, rhs parseState 1)], [], None) }
 
   | ident  
-     { LongIdentWithDots([$1], []) }
+     { LongIdentWithDots([$1], [], None) }
 
   | path DOT ident  
-     { let (LongIdentWithDots(lid, dotms)) = $1 in LongIdentWithDots(lid @ [$3], dotms @ [rhs parseState 2]) } 
+     { let (LongIdentWithDots(lid, dotms, operatorName)) = $1 in LongIdentWithDots(lid @ [$3], dotms @ [rhs parseState 2], operatorName) } 
 
   | path DOT ends_coming_soon_or_recover  
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedNameAfterToken())
-       let (LongIdentWithDots(lid, dotms)) = $1 in LongIdentWithDots(lid, dotms @ [rhs parseState 2])  } 
+       let (LongIdentWithDots(lid, dotms, operatorName)) = $1 in LongIdentWithDots(lid, dotms @ [rhs parseState 2], operatorName)  } 
 
 
 /* An operator name, with surrounnding parentheses */
@@ -5610,7 +5613,7 @@ opName:
      { let lpr = rhs parseState 1
        let text = ("|" + String.concat "|" (List.rev $2) + "|_|" )
        let ident = ident(text, rhs2 parseState 2 5)
-       let lpr = rhs parseState 6
+       let rpr = rhs parseState 6
        OperatorName.PartialActivePattern(lpr, ident, rpr) }
 
 /* An operator name, without surrounding parentheses */
@@ -5713,38 +5716,20 @@ activePatternCaseNames:
   | activePatternCaseNames BAR activePatternCaseName
      { $3 :: $1 }
 
-/* A single item that is an identifier or operator name */
-identOrOp: 
-  | ident  
-     { $1 } 
-
-  | opName 
-     { $1 }
-
 /* An A.B.C path ending in an identifier or operator name */
 /* Note, only used in atomicPatternLongIdent */
 pathOp: 
   | ident  
-     { LongIdentWithDots([$1], None, []) }
+     { LongIdentWithDots([$1], [], None) }
 
   | opName 
-     { LongIdentWithDots([], Some $1, []) }
+     { LongIdentWithDots([$1.Ident], [], Some $1) }
 
   | ident DOT pathOp 
-     { match $3 with
-       | LongIdentWithDots(leading, None, trailing, dotms) ->
-           LongIdentWithDots($1 :: leading, None, rhs parseState 2 :: dotms)
-       | LongIdentWithDots(, Some _, [], dotms) ->
-     
-     let (LongIdentWithDots(lid, opName, dotms)) = $3 in LongIdentWithDots($1 :: lid, rhs parseState 2 :: dotms) } 
+     { let (LongIdentWithDots(lid, dotms, operatorName)) = $3 in LongIdentWithDots($1 :: lid, rhs parseState 2 :: dotms, operatorName) } 
 
   | ident DOT error  
-     { (* silent recovery *) LongIdentWithDots([$1], [rhs parseState 2]) }  
-
-
-/* nameop is identOrOp not used as part of a path */
-nameop: 
-  | identOrOp { $1 } 
+     { (* silent recovery *) LongIdentWithDots([$1], [rhs parseState 2], None) }   
 
 identExpr:
   | ident

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -5581,23 +5581,37 @@ path:
 /* An operator name, with surrounnding parentheses */
 opName: 
   | LPAREN operatorName rparen  
-     {  ident(CompileOpName $2, rhs parseState 2) }
+     {  let ident = ident(CompileOpName $2, rhs parseState 2)
+        OperatorName.Operator(rhs parseState 1, ident, rhs parseState 3) }
 
   | LPAREN error rparen  
-     {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName()); ident(CompileOpName "****", rhs parseState 2) }
+     {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName())
+        let ident = ident(CompileOpName "****", rhs parseState 2)
+        OperatorName.Operator(rhs parseState 1, ident, rhs parseState 3) }
 
   | LPAREN_STAR_RPAREN
-     {  ident(CompileOpName "*", rhs parseState 1) }
+     { let m= rhs parseState 1
+       let lpr = mkFileIndexRange m.FileIndex m.Start m.Start
+       let mStar = mkFileIndexRange m.FileIndex (mkPos m.StartLine (m.StartColumn + 1)) (mkPos m.EndLine (m.EndColumn - 1))
+       let ident = ident(CompileOpName "*", mStar)
+       let rpr = mkFileIndexRange m.FileIndex m.End m.End
+       OperatorName.Operator(lpr, ident, rpr) }
 
   /* active pattern name */
   | LPAREN activePatternCaseNames BAR rparen 
-     { let text = ("|" + String.concat "|" (List.rev $2) + "|")
-       ident(text, rhs2 parseState 2 3) }
+     { let lpr = rhs parseState 1
+       let text = ("|" + String.concat "|" (List.rev $2) + "|")
+       let ident = ident(text, rhs2 parseState 2 3)
+       let rpr = rhs parseState 4
+       OperatorName.ActivePattern(lpr, ident, rpr) }
                          
   /* partial active pattern name */
   | LPAREN activePatternCaseNames BAR UNDERSCORE BAR rparen 
-     { let text = ("|" + String.concat "|" (List.rev $2) + "|_|" )
-       ident(text, rhs2 parseState 2 5) }
+     { let lpr = rhs parseState 1
+       let text = ("|" + String.concat "|" (List.rev $2) + "|_|" )
+       let ident = ident(text, rhs2 parseState 2 5)
+       let lpr = rhs parseState 6
+       OperatorName.PartialActivePattern(lpr, ident, rpr) }
 
 /* An operator name, without surrounding parentheses */
 operatorName: 
@@ -5711,13 +5725,18 @@ identOrOp:
 /* Note, only used in atomicPatternLongIdent */
 pathOp: 
   | ident  
-     { LongIdentWithDots([$1], []) }
+     { LongIdentWithDots([$1], None, []) }
 
   | opName 
-     { LongIdentWithDots([$1], []) }
+     { LongIdentWithDots([], Some $1, []) }
 
   | ident DOT pathOp 
-     { let (LongIdentWithDots(lid, dotms)) = $3 in LongIdentWithDots($1 :: lid, rhs parseState 2 :: dotms) } 
+     { match $3 with
+       | LongIdentWithDots(leading, None, trailing, dotms) ->
+           LongIdentWithDots($1 :: leading, None, rhs parseState 2 :: dotms)
+       | LongIdentWithDots(, Some _, [], dotms) ->
+     
+     let (LongIdentWithDots(lid, opName, dotms)) = $3 in LongIdentWithDots($1 :: lid, rhs parseState 2 :: dotms) } 
 
   | ident DOT error  
      { (* silent recovery *) LongIdentWithDots([$1], [rhs parseState 2]) }  
@@ -5732,10 +5751,7 @@ identExpr:
      { SynExpr.Ident($1) }
 
   | opName
-     { let m = lhs parseState
-       let mLparen = mkFileIndexRange m.FileIndex m.Start (mkPos m.StartLine (m.StartColumn + 1))
-       let mRparen = mkFileIndexRange m.FileIndex (mkPos m.EndLine (m.EndColumn - 1)) m.End
-       SynExpr.Paren(SynExpr.Ident($1), mLparen, Some mRparen, m) }
+     { SynExpr.OperatorName($1) }
 
 topSeparator: 
   | SEMICOLON { } 

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -137,11 +137,12 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         SyntaxTraversal.Traverse(pos, input, { new SyntaxVisitorBase<_>() with
             member _.VisitExpr(_, _, defaultTraverse, expr) =
                 match expr with
-                | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.Ident ident, _, _), argExpr, _) when rangeContainsPos argExpr.Range pos ->
+                | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.OperatorName operatorName, _, _), argExpr, _) when rangeContainsPos argExpr.Range pos ->
                     match argExpr with
                     | SynExpr.App(_, _, _, SynExpr.Paren(expr, _, _, _), _) when rangeContainsPos expr.Range pos ->
                         None
                     | _ ->
+                        let ident = operatorName.Ident
                         if ident.idText = "op_PipeRight" then
                             Some (ident, 1)
                         elif ident.idText = "op_PipeRight2" then

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -172,6 +172,8 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         let rec getIdentRangeForFuncExprInApp traverseSynExpr expr pos =
             match expr with
             | SynExpr.Ident ident -> Some ident.idRange
+            
+            | SynExpr.OperatorName operatorName -> Some operatorName.Ident.idRange
         
             | SynExpr.LongIdent (_, _, _, range) -> Some range
 
@@ -497,6 +499,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                   | SynExpr.LibraryOnlyStaticOptimization _
                   | SynExpr.Null _
                   | SynExpr.Ident _
+                  | SynExpr.OperatorName _
                   | SynExpr.ImplicitZero _
                   | SynExpr.Const _ -> 
                      ()

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -125,7 +125,7 @@ type InterfaceData =
                         Some ("'" + s.idText)
                     | TyparStaticReq.HeadType -> 
                         Some ("^" + s.idText)
-                | SynType.LongIdent(LongIdentWithDots(xs, _)) ->
+                | SynType.LongIdent(LongIdentWithDots(xs, _, _)) ->
                     xs |> Seq.map (fun x -> x.idText) |> String.concat "." |> Some
                 | SynType.App(t, _, ts, _, _, isPostfix, _) ->
                     match t, ts with
@@ -503,7 +503,7 @@ module InterfaceStubGenerator =
         GetInterfaceMembers entity |> Seq.isEmpty
 
     let internal (|LongIdentPattern|_|) = function
-        | SynPat.LongIdent(longDotId=LongIdentWithDots(xs, _)) ->
+        | SynPat.LongIdent(longDotId=LongIdentWithDots(xs, _, _)) ->
 //            let (name, range) = xs |> List.map (fun x -> x.idText, x.idRange) |> List.last
             let last = List.last xs
             Some(last.idText, last.idRange)

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -853,6 +853,9 @@ module InterfaceStubGenerator =
                 | SynExpr.Ident _ident ->
                     None
 
+                | SynExpr.OperatorName _ ->
+                    None
+                
                 | SynExpr.LongIdent (_, _longIdent, _altNameRefCell, _range) -> 
                     None
 

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -142,7 +142,7 @@ module NavigationImpl =
                 | _ -> synExpr.Range
 
             match synPat, memberOpt with
-            | SynPat.LongIdent(longDotId=LongIdentWithDots(lid,_); accessibility=access), Some(flags) when isMember -> 
+            | SynPat.LongIdent(longDotId=LongIdentWithDots(lid,_, _); accessibility=access), Some(flags) when isMember -> 
                 let icon, kind =
                   match flags.MemberKind with
                   | SynMemberKind.ClassConstructor
@@ -158,7 +158,7 @@ module NavigationImpl =
                   | hd :: _ -> (lid, hd.idRange) 
                   | _ -> (lid, m)
                 [ createMemberLid(lidShow, kind, icon, unionRanges rangeMerge m, enclosingEntityKind, isAbstract, access) ]
-            | SynPat.LongIdent(longDotId=LongIdentWithDots(lid,_); accessibility=access), _ -> 
+            | SynPat.LongIdent(longDotId=LongIdentWithDots(lid,_, _); accessibility=access), _ -> 
                 [ createMemberLid(lid, NavigationItemKind.Field, FSharpGlyph.Field, unionRanges (List.head lid).idRange m, enclosingEntityKind, isAbstract, access) ]
             | SynPat.Named (id, _, access, _), _ | SynPat.As(_, SynPat.Named (id, _, access, _), _), _ -> 
                 let glyph = if isMember then FSharpGlyph.Method else FSharpGlyph.Field
@@ -574,10 +574,10 @@ module NavigateTo =
                     | _ -> NavigableItemKind.ModuleValue
     
             match headPat with
-            | SynPat.LongIdent(longDotId=LongIdentWithDots([_; id], _)) ->
+            | SynPat.LongIdent(longDotId=LongIdentWithDots([_; id], _, _)) ->
                 // instance members
                 addIdent kind id false container
-            | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _)) ->
+            | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _, _)) ->
                 // functions
                 addIdent kind id false container
             | SynPat.Named (id, _, _, _) | SynPat.As(_, SynPat.Named (id, _, _, _), _) ->

--- a/src/fsharp/service/ServiceParamInfoLocations.fs
+++ b/src/fsharp/service/ServiceParamInfoLocations.fs
@@ -59,8 +59,8 @@ module internal ParameterLocationsImpl =
         // we found it, dig out ident
         match synExpr with
         | SynExpr.Ident id -> Some ([id.idText], id.idRange)
-        | SynExpr.LongIdent (_, LongIdentWithDots(lid, _), _, lidRange) 
-        | SynExpr.DotGet (_, _, LongIdentWithDots(lid, _), lidRange) -> Some (pathOfLid lid, lidRange)
+        | SynExpr.LongIdent (_, LongIdentWithDots(lid, _, _), _, lidRange) 
+        | SynExpr.DotGet (_, _, LongIdentWithDots(lid, _, _), lidRange) -> Some (pathOfLid lid, lidRange)
         | SynExpr.TypeApp (synExpr, _, _synTypeList, _commas, _, _, _range) -> digOutIdentFromFuncExpr synExpr 
         | SynExpr.Paren(expr = expr) -> digOutIdentFromFuncExpr expr 
         | _ -> None
@@ -71,8 +71,8 @@ module internal ParameterLocationsImpl =
 
     let digOutIdentFromStaticArg (StripParenTypes synType) =
         match synType with 
-        | SynType.StaticConstantNamed(SynType.LongIdent(LongIdentWithDots([id], _)), _, _) -> Some id.idText 
-        | SynType.LongIdent(LongIdentWithDots([id], _)) -> Some id.idText // NOTE: again, not a static constant, but may be a prefix of a Named in incomplete code
+        | SynType.StaticConstantNamed(SynType.LongIdent(LongIdentWithDots([id], _, _)), _, _) -> Some id.idText 
+        | SynType.LongIdent(LongIdentWithDots([id], _, _)) -> Some id.idText // NOTE: again, not a static constant, but may be a prefix of a Named in incomplete code
         | _ -> None
 
     let getNamedParamName e =
@@ -88,13 +88,13 @@ module internal ParameterLocationsImpl =
         | SynExpr.App (ExprAtomicFlag.NonAtomic, _, 
                         SynExpr.App (ExprAtomicFlag.NonAtomic, true, 
                                     SynExpr.Ident op, 
-                                    SynExpr.LongIdent (true(*isOptional*), LongIdentWithDots([n], _), _ref, _lidrange), _range), 
+                                    SynExpr.LongIdent (true(*isOptional*), LongIdentWithDots([n], _, _), _ref, _lidrange), _range), 
                         _, _) when op.idText="op_Equality" -> Some n.idText
         | _ -> None
 
     let getTypeName synType =
         match synType with
-        | SynType.LongIdent(LongIdentWithDots(ids, _)) -> ids |> pathOfLid
+        | SynType.LongIdent(LongIdentWithDots(ids, _, _)) -> ids |> pathOfLid
         | _ -> [""] // TODO type name for other cases, see also unit test named "ParameterInfo.LocationOfParams.AfterQuicklyTyping.CallConstructorViaLongId.Bug94333"
 
     let handleSingleArg traverseSynExpr (pos, synExpr, parenRange, rpRangeOpt : _ option) =
@@ -169,7 +169,7 @@ module internal ParameterLocationsImpl =
 
     let (|StaticParameters|_|) pos (StripParenTypes synType) =
         match synType with
-        | SynType.App(StripParenTypes (SynType.LongIdent(LongIdentWithDots(lid, _) as lidwd)), Some(openm), args, commas, closemOpt, _pf, wholem) ->
+        | SynType.App(StripParenTypes (SynType.LongIdent(LongIdentWithDots(lid, _, _) as lidwd)), Some(openm), args, commas, closemOpt, _pf, wholem) ->
             let lidm = lidwd.Range
             let betweenTheBrackets = mkRange wholem.FileName openm.Start wholem.End
             if SyntaxTraversal.rangeContainsPosEdgesExclusive betweenTheBrackets pos && args |> List.forall isStaticArg then

--- a/src/fsharp/service/ServiceParamInfoLocations.fs
+++ b/src/fsharp/service/ServiceParamInfoLocations.fs
@@ -59,6 +59,7 @@ module internal ParameterLocationsImpl =
         // we found it, dig out ident
         match synExpr with
         | SynExpr.Ident id -> Some ([id.idText], id.idRange)
+        | SynExpr.OperatorName operatorName -> Some ([operatorName.Ident.idText], operatorName.Range)
         | SynExpr.LongIdent (_, LongIdentWithDots(lid, _, _), _, lidRange) 
         | SynExpr.DotGet (_, _, LongIdentWithDots(lid, _, _), lidRange) -> Some (pathOfLid lid, lidRange)
         | SynExpr.TypeApp (synExpr, _, _synTypeList, _commas, _, _, _range) -> digOutIdentFromFuncExpr synExpr 

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -437,7 +437,7 @@ module SyntaxTraversal =
                         | _ -> false
                     let ok = 
                         match isPartOfArrayOrList, synExpr with
-                        | false, SynExpr.Ident ident -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [])))
+                        | false, SynExpr.Ident ident -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [], None)))
                         | false, SynExpr.LongIdent (false, lidwd, _, _) -> visitor.VisitRecordField(path, None, Some lidwd)
                         | _ -> None
                     if ok.IsSome then ok
@@ -518,6 +518,8 @@ module SyntaxTraversal =
                     |> pick expr
 
                 | SynExpr.Ident _ident -> None
+
+                | SynExpr.OperatorName _ -> None
 
                 | SynExpr.LongIdent (_, _longIdent, _altNameRefCell, _range) -> None
 

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2794,7 +2794,7 @@ type FSharpOpenDeclaration(target: SynOpenDeclTarget, range: range option, modul
         | SynOpenDeclTarget.Type(synType, _) ->
             let rec get ty = 
                 match ty with 
-                | SynType.LongIdent (LongIdentWithDots(lid, _)) -> lid
+                | SynType.LongIdent (LongIdentWithDots(lid, _, _)) -> lid
                 | SynType.App (ty2, _, _, _, _, _, _) -> get ty2
                 | SynType.LongIdentApp (ty2, _, _, _, _, _, _) -> get ty2
                 | SynType.Paren (ty2, _) -> get ty2

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -9013,7 +9013,7 @@ FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo SynInfo
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo arity
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_SynInfo()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_arity()
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.OperatorName], FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls explicitValDecls
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls get_explicitValDecls()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Text.Range RangeOfId
@@ -9026,6 +9026,8 @@ FSharp.Compiler.Syntax.SynValSig: Int32 Tag
 FSharp.Compiler.Syntax.SynValSig: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
+FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.OperatorName] get_operatorName()
+FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.OperatorName] operatorName
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr] get_synExpr()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -3442,10 +3442,10 @@ FSharp.Compiler.EditorServices.ParameterLocations
 FSharp.Compiler.EditorServices.ParameterLocations: Boolean IsThereACloseParen
 FSharp.Compiler.EditorServices.ParameterLocations: Boolean get_IsThereACloseParen()
 FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.EditorServices.TupledArgumentLocation[] ArgumentLocations
+FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.EditorServices.TupledArgumentLocation[] get_ArgumentLocations()
 FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.Text.Position LongIdEndLocation
 FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.Text.Position LongIdStartLocation
 FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.Text.Position OpenParenLocation
-FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.EditorServices.TupledArgumentLocation[] get_ArgumentLocations()
 FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.Text.Position get_LongIdEndLocation()
 FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.Text.Position get_LongIdStartLocation()
 FSharp.Compiler.EditorServices.ParameterLocations: FSharp.Compiler.Text.Position get_OpenParenLocation()
@@ -4911,6 +4911,7 @@ FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSh
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue] get_EventForFSharpProperty()
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] FullTypeSafe
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] get_FullTypeSafe()
+FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.TaggedText[]] GetReturnTypeLayout(FSharp.Compiler.Symbols.FSharpDisplayContext)
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue]] GetOverloads(Boolean)
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[System.Object] LiteralValue
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[System.Object] get_LiteralValue()
@@ -4925,7 +4926,6 @@ FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: System.Collections.Generi
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpGenericParameter] get_GenericParameters()
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: System.Collections.Generic.IList`1[System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpParameter]] CurriedParameterGroups
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: System.Collections.Generic.IList`1[System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpParameter]] get_CurriedParameterGroups()
-FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.TaggedText[]] GetReturnTypeLayout(FSharp.Compiler.Symbols.FSharpDisplayContext)
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: System.String CompiledName
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: System.String DisplayName
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: System.String LogicalName
@@ -5417,7 +5417,7 @@ FSharp.Compiler.Syntax.Ident: Void .ctor(System.String, FSharp.Compiler.Text.Ran
 FSharp.Compiler.Syntax.LongIdentWithDots
 FSharp.Compiler.Syntax.LongIdentWithDots: Boolean ThereIsAnExtraDotAtTheEnd
 FSharp.Compiler.Syntax.LongIdentWithDots: Boolean get_ThereIsAnExtraDotAtTheEnd()
-FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Syntax.LongIdentWithDots NewLongIdentWithDots(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Syntax.LongIdentWithDots NewLongIdentWithDots(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.OperatorName])
 FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range RangeWithoutAnyExtraDot
 FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range get_Range()
@@ -5430,7 +5430,51 @@ FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpLis
 FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] id
 FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] dotRanges
 FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_dotRanges()
+FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.OperatorName] get_operatorName()
+FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.OperatorName] operatorName
 FSharp.Compiler.Syntax.LongIdentWithDots: System.String ToString()
+FSharp.Compiler.Syntax.OperatorName
+FSharp.Compiler.Syntax.OperatorName+ActivePattern: FSharp.Compiler.Syntax.Ident get_id()
+FSharp.Compiler.Syntax.OperatorName+ActivePattern: FSharp.Compiler.Syntax.Ident id
+FSharp.Compiler.Syntax.OperatorName+ActivePattern: FSharp.Compiler.Text.Range get_lpr()
+FSharp.Compiler.Syntax.OperatorName+ActivePattern: FSharp.Compiler.Text.Range get_rpr()
+FSharp.Compiler.Syntax.OperatorName+ActivePattern: FSharp.Compiler.Text.Range lpr
+FSharp.Compiler.Syntax.OperatorName+ActivePattern: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.Syntax.OperatorName+Operator: FSharp.Compiler.Syntax.Ident get_id()
+FSharp.Compiler.Syntax.OperatorName+Operator: FSharp.Compiler.Syntax.Ident id
+FSharp.Compiler.Syntax.OperatorName+Operator: FSharp.Compiler.Text.Range get_lpr()
+FSharp.Compiler.Syntax.OperatorName+Operator: FSharp.Compiler.Text.Range get_rpr()
+FSharp.Compiler.Syntax.OperatorName+Operator: FSharp.Compiler.Text.Range lpr
+FSharp.Compiler.Syntax.OperatorName+Operator: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.Syntax.OperatorName+PartialActivePattern: FSharp.Compiler.Syntax.Ident get_id()
+FSharp.Compiler.Syntax.OperatorName+PartialActivePattern: FSharp.Compiler.Syntax.Ident id
+FSharp.Compiler.Syntax.OperatorName+PartialActivePattern: FSharp.Compiler.Text.Range get_lpr()
+FSharp.Compiler.Syntax.OperatorName+PartialActivePattern: FSharp.Compiler.Text.Range get_rpr()
+FSharp.Compiler.Syntax.OperatorName+PartialActivePattern: FSharp.Compiler.Text.Range lpr
+FSharp.Compiler.Syntax.OperatorName+PartialActivePattern: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.Syntax.OperatorName+Tags: Int32 ActivePattern
+FSharp.Compiler.Syntax.OperatorName+Tags: Int32 Operator
+FSharp.Compiler.Syntax.OperatorName+Tags: Int32 PartialActivePattern
+FSharp.Compiler.Syntax.OperatorName: Boolean IsActivePattern
+FSharp.Compiler.Syntax.OperatorName: Boolean IsOperator
+FSharp.Compiler.Syntax.OperatorName: Boolean IsPartialActivePattern
+FSharp.Compiler.Syntax.OperatorName: Boolean get_IsActivePattern()
+FSharp.Compiler.Syntax.OperatorName: Boolean get_IsOperator()
+FSharp.Compiler.Syntax.OperatorName: Boolean get_IsPartialActivePattern()
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.Ident Ident
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.Ident get_Ident()
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.OperatorName NewActivePattern(FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.OperatorName NewOperator(FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.OperatorName NewPartialActivePattern(FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.OperatorName+ActivePattern
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.OperatorName+Operator
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.OperatorName+PartialActivePattern
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Syntax.OperatorName+Tags
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.OperatorName: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.Syntax.OperatorName: Int32 Tag
+FSharp.Compiler.Syntax.OperatorName: Int32 get_Tag()
+FSharp.Compiler.Syntax.OperatorName: System.String ToString()
 FSharp.Compiler.Syntax.ParsedHashDirective
 FSharp.Compiler.Syntax.ParsedHashDirective: FSharp.Compiler.Syntax.ParsedHashDirective NewParsedHashDirective(System.String, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.ParsedHashDirectiveArgument], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedHashDirective: FSharp.Compiler.Text.Range get_range()
@@ -6603,6 +6647,8 @@ FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[FSh
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] withKeyword
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]] argOptions
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]] get_argOptions()
+FSharp.Compiler.Syntax.SynExpr+OperatorName: FSharp.Compiler.Syntax.OperatorName get_operatorName()
+FSharp.Compiler.Syntax.SynExpr+OperatorName: FSharp.Compiler.Syntax.OperatorName operatorName
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Text.Range get_leftParenRange()
@@ -6704,6 +6750,7 @@ FSharp.Compiler.Syntax.SynExpr+Tags: Int32 NamedIndexedPropertySet
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 New
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Null
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 ObjExpr
+FSharp.Compiler.Syntax.SynExpr+Tags: Int32 OperatorName
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Paren
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Quote
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Record
@@ -6863,6 +6910,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean IsNamedIndexedPropertySet
 FSharp.Compiler.Syntax.SynExpr: Boolean IsNew
 FSharp.Compiler.Syntax.SynExpr: Boolean IsNull
 FSharp.Compiler.Syntax.SynExpr: Boolean IsObjExpr
+FSharp.Compiler.Syntax.SynExpr: Boolean IsOperatorName
 FSharp.Compiler.Syntax.SynExpr: Boolean IsParen
 FSharp.Compiler.Syntax.SynExpr: Boolean IsQuote
 FSharp.Compiler.Syntax.SynExpr: Boolean IsRecord
@@ -6930,6 +6978,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean get_IsNamedIndexedPropertySet()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsNew()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsNull()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsObjExpr()
+FSharp.Compiler.Syntax.SynExpr: Boolean get_IsOperatorName()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsParen()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsQuote()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsRecord()
@@ -6996,6 +7045,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNamedIndexedPr
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNew(Boolean, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewObjExpr(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynInterfaceImpl], FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewOperatorName(FSharp.Compiler.Syntax.OperatorName)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewParen(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewQuote(FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewRecord(Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]],FSharp.Compiler.Text.Range]], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExprRecordField], FSharp.Compiler.Text.Range)
@@ -7062,6 +7112,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+NamedIndexedPrope
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+New
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Null
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+ObjExpr
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+OperatorName
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Paren
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Quote
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Record
@@ -7548,14 +7599,14 @@ FSharp.Compiler.Syntax.SynModuleDecl+Attributes: FSharp.Compiler.Text.Range get_
 FSharp.Compiler.Syntax.SynModuleDecl+Attributes: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynModuleDecl+Attributes: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynModuleDecl+Attributes: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
-FSharp.Compiler.Syntax.SynModuleDecl+Expr: FSharp.Compiler.Syntax.SynExpr expr
-FSharp.Compiler.Syntax.SynModuleDecl+Expr: FSharp.Compiler.Syntax.SynExpr get_expr()
-FSharp.Compiler.Syntax.SynModuleDecl+Expr: FSharp.Compiler.Text.Range get_range()
-FSharp.Compiler.Syntax.SynModuleDecl+Expr: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynModuleDecl+Exception: FSharp.Compiler.Syntax.SynExceptionDefn exnDefn
 FSharp.Compiler.Syntax.SynModuleDecl+Exception: FSharp.Compiler.Syntax.SynExceptionDefn get_exnDefn()
 FSharp.Compiler.Syntax.SynModuleDecl+Exception: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynModuleDecl+Exception: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynModuleDecl+Expr: FSharp.Compiler.Syntax.SynExpr expr
+FSharp.Compiler.Syntax.SynModuleDecl+Expr: FSharp.Compiler.Syntax.SynExpr get_expr()
+FSharp.Compiler.Syntax.SynModuleDecl+Expr: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynModuleDecl+Expr: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynModuleDecl+HashDirective: FSharp.Compiler.Syntax.ParsedHashDirective get_hashDirective()
 FSharp.Compiler.Syntax.SynModuleDecl+HashDirective: FSharp.Compiler.Syntax.ParsedHashDirective hashDirective
 FSharp.Compiler.Syntax.SynModuleDecl+HashDirective: FSharp.Compiler.Text.Range get_range()
@@ -7591,8 +7642,8 @@ FSharp.Compiler.Syntax.SynModuleDecl+Open: FSharp.Compiler.Syntax.SynOpenDeclTar
 FSharp.Compiler.Syntax.SynModuleDecl+Open: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynModuleDecl+Open: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynModuleDecl+Tags: Int32 Attributes
-FSharp.Compiler.Syntax.SynModuleDecl+Tags: Int32 Expr
 FSharp.Compiler.Syntax.SynModuleDecl+Tags: Int32 Exception
+FSharp.Compiler.Syntax.SynModuleDecl+Tags: Int32 Expr
 FSharp.Compiler.Syntax.SynModuleDecl+Tags: Int32 HashDirective
 FSharp.Compiler.Syntax.SynModuleDecl+Tags: Int32 Let
 FSharp.Compiler.Syntax.SynModuleDecl+Tags: Int32 ModuleAbbrev
@@ -7605,8 +7656,8 @@ FSharp.Compiler.Syntax.SynModuleDecl+Types: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynModuleDecl+Types: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeDefn] get_typeDefns()
 FSharp.Compiler.Syntax.SynModuleDecl+Types: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeDefn] typeDefns
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsAttributes
-FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsExpr
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsException
+FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsExpr
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsHashDirective
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsLet
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsModuleAbbrev
@@ -7615,8 +7666,8 @@ FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsNestedModule
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsOpen
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean IsTypes
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsAttributes()
-FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsExpr()
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsException()
+FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsExpr()
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsHashDirective()
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsLet()
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsModuleAbbrev()
@@ -7625,8 +7676,8 @@ FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsNestedModule()
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsOpen()
 FSharp.Compiler.Syntax.SynModuleDecl: Boolean get_IsTypes()
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewAttributes(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewExpr(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewException(FSharp.Compiler.Syntax.SynExceptionDefn, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewExpr(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewHashDirective(FSharp.Compiler.Syntax.ParsedHashDirective, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewLet(Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewModuleAbbrev(FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
@@ -7635,8 +7686,8 @@ FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewNe
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewOpen(FSharp.Compiler.Syntax.SynOpenDeclTarget, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewTypes(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeDefn], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl+Attributes
-FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl+Expr
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl+Exception
+FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl+Expr
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl+HashDirective
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl+Let
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev

--- a/tests/service/InteractiveCheckerTests.fs
+++ b/tests/service/InteractiveCheckerTests.fs
@@ -18,7 +18,7 @@ open FSharp.Compiler.Text.Range
 
 let internal longIdentToString (longIdent: LongIdent) =
     String.Join(".", longIdent |> List.map (fun ident -> ident.ToString()))
-let internal longIdentWithDotsToString (LongIdentWithDots (longIdent, _)) = longIdentToString longIdent
+let internal longIdentWithDotsToString (LongIdentWithDots (longIdent, _, _)) = longIdentToString longIdent
 
 let internal posToTuple (pos: pos) = (pos.Line, pos.Column)
 let internal rangeToTuple (range: range) = (posToTuple range.Start, posToTuple range.End)

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -3967,3 +3967,26 @@ val (&): e1: bool -> e2: bool -> bool
             assertRange (13, 62) (13, 63) rpr
         | _ ->
             Assert.Fail "Could not get valid AST"
+
+    // TODO: should this also contain SynExpr.OperatorName
+    // Ident was compiled and this information is now lost
+    
+    [<Test>]
+    [<Ignore "AST is kept as it originally was">]
+    let ``named parameter`` () =
+        let ast = getParseResults """
+f(x=4)
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr(expr = SynExpr.App(argExpr = SynExpr.Paren(expr = SynExpr.App(funcExpr=
+                    SynExpr.App(funcExpr=SynExpr.OperatorName(OperatorName.Operator(lpr, ident, rpr)))))))
+                ])
+            ])) ->
+            assertRange (2, 1) (2, 2) lpr
+            Assert.AreEqual("op_Equality", ident.idText)
+            assertRange (2, 5) (2, 6) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -3913,3 +3913,24 @@ let (|Int32Const|_|) (a: SynConst) = match a with SynConst.Int32 _ -> Some a | _
             assertRange (2, 19) (2, 20) rpr
         | _ ->
             Assert.Fail "Could not get valid AST"
+
+    [<Test>]
+    let ``operator name in SynValSig`` () =
+        let ast = """
+module IntrinsicOperators
+
+val (&): e1: bool -> e2: bool -> bool
+"""
+                        |> getParseResultsOfSignatureFile
+
+        match ast with
+        | ParsedInput.SigFile(ParsedSigFileInput(modules = [
+            SynModuleOrNamespaceSig(decls = [
+                SynModuleSigDecl.Val(valSig = SynValSig(operatorName=Some(OperatorName.Operator(lpr, ident, rpr))))
+                ])
+            ])) ->
+            assertRange (4, 4) (4, 5) lpr
+            Assert.AreEqual("op_Amp", ident.idText)
+            assertRange (4, 6) (4, 7) rpr
+        | _ ->
+            Assert.Fail "Could not get valid AST"

--- a/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
@@ -20,7 +20,7 @@ type FSharpParseFileResults with
                     else
                         // Check if it's an operator
                         match pat with
-                        | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _)) when id.idText.StartsWith("op_") ->
+                        | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _, Some (OperatorName.Operator _))) ->
                             if Position.posEq id.idRange.Start pos then
                                 Some binding.RangeOfBindingWithRhs
                             else


### PR DESCRIPTION
This is an attempt at adding more information to the syntax tree for operators, active patterns and partial active patterns.
Related issue: https://github.com/dotnet/fsharp/issues/11893

The key concept is adding more information inside `LongIdentWithDots` when one of the Ident is indeed an operator, AP or PAP.

Pretty sure I didn't get everything right in the Typed AST so far.