### PR TITLE
Inline Array.exists

### DIFF
--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -111,7 +111,7 @@ namespace Microsoft.FSharp.Collections
             arr
 
         [<CompiledName("Collect")>]
-        let collect (mapping: 'T -> 'U[])  (array: 'T[]) : 'U[]=
+        let collect (mapping: 'T -> 'U[]) (array: 'T[]) : 'U[]=
             checkNonNull "array" array
             let len = array.Length
             let result = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked<'U[]> len
@@ -362,11 +362,14 @@ namespace Microsoft.FSharp.Collections
             Microsoft.FSharp.Primitives.Basics.Array.mapFoldBack mapping array state
 
         [<CompiledName("Exists")>]
-        let exists (predicate: 'T -> bool) (array: 'T[]) =
+        let inline exists ([<InlineIfLambda>] predicate: 'T -> bool) (array: 'T[]) =
             checkNonNull "array" array
-            let len = array.Length
-            let rec loop i = i < len && (predicate array.[i] || loop (i+1))
-            len > 0 && loop 0
+            let mutable state = false
+            let mutable i = 0
+            while not state && i < array.Length do
+                state <- predicate array.[i]
+                i <- i + 1
+            state
 
         [<CompiledName("Contains")>]
         let inline contains value (array: 'T[]) =

--- a/src/fsharp/FSharp.Core/array.fsi
+++ b/src/fsharp/FSharp.Core/array.fsi
@@ -769,7 +769,7 @@ module Array =
     /// Evaluates to <c>false</c>
     /// </example>
     [<CompiledName("Exists")>]
-    val exists: predicate:('T -> bool) -> array:'T[] -> bool
+    val inline exists: predicate:('T -> bool) -> array:'T[] -> bool
 
     /// <summary>Tests if any pair of corresponding elements of the arrays satisfies the given predicate.</summary>
     ///


### PR DESCRIPTION
As follow-up on #12756, where I had not tried to inline any function which wasn't inlined before, in order to avoid controversy, this time I propose that we inline `Array.exists` and leverage `InlineIfLambda`. The rationale here is that this is a small function, and that we're already inlining `Array.contains`.
I've compared the existing implementation with the new one using Benchmark.NET, and even though small lambdas were already inlined and the performance benefit is not obvious in those cases, that's not true if the lambda is accessing scope and generating a closure. In this case, there is a significant performance benefit (30% in my benchmark) and more importantly, allocations are removed.

```
|        Method |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|-------------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|
|        Exists | 26.35 ns | 0.503 ns | 1.004 ns |  1.00 |    0.00 | 0.0057 |      24 B |
| InlinedExists | 18.38 ns | 0.231 ns | 0.216 ns |  0.68 |    0.03 |      - |         - |
```