### PR TITLE
TcMethodApplication: get param attributes at most once

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -9492,19 +9492,23 @@ and TcMethodApplication
 
             let MakeUnnamedCallerArgInfo x = (x, GetNewInferenceTypeForMethodArg cenv env tpenv x, x.Range)
 
+            let singleMethodCurriedArgs =
+                match candidates with
+                | [calledMeth] when List.forall isNil namedCurriedCallerArgs  ->
+                    let curriedCalledArgs = calledMeth.GetParamAttribs(cenv.amap, mItem)
+                    match curriedCalledArgs with
+                    | [arg :: _] when isSimpleFormalArg arg -> Some(curriedCalledArgs)
+                    | _ -> None
+                | _ -> None
+
             // "single named item" rule. This is where we have a single accessible method
             //      member x.M(arg1)
             // being used with
             //      x.M (x, y)
             // Without this rule this requires
             //      x.M ((x, y))
-            match candidates with
-            | [calledMeth]
-                  when (namedCurriedCallerArgs |> List.forall isNil &&
-                        let curriedCalledArgs = calledMeth.GetParamAttribs(cenv.amap, mItem)
-                        curriedCalledArgs.Length = 1 &&
-                        curriedCalledArgs.Head.Length = 1 &&
-                        curriedCalledArgs.Head.Head |> isSimpleFormalArg) ->
+            match singleMethodCurriedArgs, unnamedCurriedCallerArgs with
+            | Some [[_]], _ ->
                 let unnamedCurriedCallerArgs = curriedCallerArgs |> List.map (MakeUnnamedCallerArgInfo >> List.singleton)
                 let namedCurriedCallerArgs = namedCurriedCallerArgs |> List.map (fun _ -> [])
                 (Some (unnamedCurriedCallerArgs, namedCurriedCallerArgs), None, exprTy)
@@ -9516,15 +9520,7 @@ and TcMethodApplication
             // We typecheck this as if it has been written "(fun (v1, v2) -> x.M(v1, v2)) p"
             // Without this rule this requires
             //      x.M (fst p, snd p)
-            | [calledMeth]
-                  when (namedCurriedCallerArgs |> List.forall isNil &&
-                        unnamedCurriedCallerArgs.Length = 1 &&
-                        unnamedCurriedCallerArgs.Head.Length = 1 &&
-                        let curriedCalledArgs = calledMeth.GetParamAttribs(cenv.amap, mItem)
-                        curriedCalledArgs.Length = 1 &&
-                        curriedCalledArgs.Head.Length > 1 &&
-                        curriedCalledArgs.Head |> List.forall isSimpleFormalArg) ->
-
+            | Some [_ :: args], [[_]] when List.forall isSimpleFormalArg args ->
                 // The call lambda has function type
                 let exprTy = mkFunTy g (NewInferenceType g) exprTy.Commit
 

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -9540,9 +9540,9 @@ and TcMethodApplication
                 (Some (unnamedCurriedCallerArgs, namedCurriedCallerArgs), None, exprTy)
 
     let CalledMethHasSingleArgumentGroupOfThisLength n (calledMeth: MethInfo) =
-       let curriedMethodArgAttribs = calledMeth.GetParamAttribs(cenv.amap, mItem)
-       curriedMethodArgAttribs.Length = 1 &&
-       curriedMethodArgAttribs.Head.Length = n
+       match calledMeth.GetParamAttribs(cenv.amap, mItem) with
+       | [argAttribs] -> argAttribs.Length = n
+       | _ -> false
 
     let GenerateMatchingSimpleArgumentTypes (calledMeth: MethInfo) =
         let curriedMethodArgAttribs = calledMeth.GetParamAttribs(cenv.amap, mItem)

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -9540,8 +9540,8 @@ and TcMethodApplication
                 (Some (unnamedCurriedCallerArgs, namedCurriedCallerArgs), None, exprTy)
 
     let CalledMethHasSingleArgumentGroupOfThisLength n (calledMeth: MethInfo) =
-       match calledMeth.GetParamAttribs(cenv.amap, mItem) with
-       | [argAttribs] -> argAttribs.Length = n
+       match calledMeth.NumArgs with
+       | [argAttribs] -> argAttribs = n
        | _ -> false
 
     let GenerateMatchingSimpleArgumentTypes (calledMeth: MethInfo) =


### PR DESCRIPTION
Prevents expensive `MethInfo.GetParamAttribs` might be called twice; optimizes checking param list lengths.