### PR TITLE
Compiler config: use lazy sequence for resolution paths 

### DIFF
--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -56,7 +56,7 @@ exception FileNameNotResolved of (*filename*) string * (*description of searched
 exception LoadedSourceNotFoundIgnoring of (*filename*) string * range
 
 /// Will return None if the filename is not found.
-let TryResolveFileUsingPaths(paths: string seq, m, name) =
+let TryResolveFileUsingPaths(paths, m, name) =
     let () =
         try FileSystem.IsPathRootedShim name |> ignore
         with :? ArgumentException as e -> error(Error(FSComp.SR.buildProblemWithFilename(name, e.Message), m))
@@ -66,9 +66,11 @@ let TryResolveFileUsingPaths(paths: string seq, m, name) =
         else
             None
     else
-        paths |> Seq.tryFind (fun path ->
+        let res = paths |> Seq.tryPick (fun path ->
             let n = Path.Combine(path, name)
-            FileSystem.FileExistsShim n)
+            if FileSystem.FileExistsShim n then Some n
+            else None)
+        res
 
 /// Will raise FileNameNotResolved if the filename was not found
 let ResolveFileUsingPaths(paths, m, name) =

--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -66,11 +66,9 @@ let TryResolveFileUsingPaths(paths: string seq, m, name) =
         else
             None
     else
-        let res = paths |> Seq.tryPick (fun path ->
+        paths |> Seq.tryFind (fun path ->
             let n = Path.Combine(path, name)
-            if FileSystem.FileExistsShim n then Some n
-            else None)
-        res
+            FileSystem.FileExistsShim n)
 
 /// Will raise FileNameNotResolved if the filename was not found
 let ResolveFileUsingPaths(paths, m, name) =

--- a/src/fsharp/CompilerConfig.fs
+++ b/src/fsharp/CompilerConfig.fs
@@ -60,8 +60,11 @@ let TryResolveFileUsingPaths(paths: string seq, m, name) =
     let () =
         try FileSystem.IsPathRootedShim name |> ignore
         with :? ArgumentException as e -> error(Error(FSComp.SR.buildProblemWithFilename(name, e.Message), m))
-    if FileSystem.IsPathRootedShim name && FileSystem.FileExistsShim name
-    then Some name
+    if FileSystem.IsPathRootedShim name then
+        if FileSystem.FileExistsShim name then
+            Some name
+        else
+            None
     else
         let res = paths |> Seq.tryPick (fun path ->
             let n = Path.Combine(path, name)

--- a/src/fsharp/CompilerConfig.fsi
+++ b/src/fsharp/CompilerConfig.fsi
@@ -561,9 +561,9 @@ type TcConfigProvider =
     /// TcConfigBuilder rather than delivering snapshots.
     static member BasedOnMutableBuilder: TcConfigBuilder -> TcConfigProvider
 
-val TryResolveFileUsingPaths: paths: string list * m: range * name: string -> string option
+val TryResolveFileUsingPaths: paths: string seq * m: range * name: string -> string option
 
-val ResolveFileUsingPaths: paths: string list * m: range * name: string -> string
+val ResolveFileUsingPaths: paths: string seq * m: range * name: string -> string
 
 val GetWarningNumber: m: range * warningNumber: string -> int option
 

--- a/src/fsharp/CompilerImports.fs
+++ b/src/fsharp/CompilerImports.fs
@@ -319,6 +319,8 @@ type TcConfig with
 
             let searchPaths =
                 seq {
+                    yield! tcConfig.GetSearchPathsForLibraryFiles()
+
                     // if this is a #r reference (not from dummy range), make sure the directory of the declaring
                     // file is included in the search path. This should ideally already be one of the search paths, but
                     // during some global checks it won't be. We append to the end of the search list so that this is the last
@@ -328,8 +330,6 @@ type TcConfig with
                         not (equals r rangeStartup) &&
                         not (equals r rangeCmdArgs) &&
                         FileSystem.IsPathRootedShim r.FileName
-
-                    yield! tcConfig.GetSearchPathsForLibraryFiles()
 
                     if isPoundRReference m then
                         yield Path.GetDirectoryName(m.FileName)

--- a/src/fsharp/CompilerImports.fs
+++ b/src/fsharp/CompilerImports.fs
@@ -318,20 +318,22 @@ type TcConfig with
            || isNetModule then
 
             let searchPaths =
-                // if this is a #r reference (not from dummy range), make sure the directory of the declaring
-                // file is included in the search path. This should ideally already be one of the search paths, but
-                // during some global checks it won't be. We append to the end of the search list so that this is the last
-                // place that is checked.
-                let isPoundRReference (r: range) =
-                    not (equals r range0) &&
-                    not (equals r rangeStartup) &&
-                    not (equals r rangeCmdArgs) &&
-                    FileSystem.IsPathRootedShim r.FileName
+                seq {
+                    // if this is a #r reference (not from dummy range), make sure the directory of the declaring
+                    // file is included in the search path. This should ideally already be one of the search paths, but
+                    // during some global checks it won't be. We append to the end of the search list so that this is the last
+                    // place that is checked.
+                    let isPoundRReference (r: range) =
+                        not (equals r range0) &&
+                        not (equals r rangeStartup) &&
+                        not (equals r rangeCmdArgs) &&
+                        FileSystem.IsPathRootedShim r.FileName
 
-                if isPoundRReference m then
-                    tcConfig.GetSearchPathsForLibraryFiles() @ [Path.GetDirectoryName(m.FileName)]
-                else
-                    tcConfig.GetSearchPathsForLibraryFiles()
+                    yield! tcConfig.GetSearchPathsForLibraryFiles()
+
+                    if isPoundRReference m then
+                        yield Path.GetDirectoryName(m.FileName)
+                }
 
             let resolved = TryResolveFileUsingPaths(searchPaths, m, nm)
             match resolved with


### PR DESCRIPTION
The directory paths aren't required for resolving absolute file paths, so don't calc them in advance.
Also, don't enumerate directory paths for absolute file paths, since combining them doesn't produce a new path and it just checks existence for the same path many times.