### PR TITLE
support simple let bindings with types in the type-annotation-given walker

### DIFF
--- a/tests/service/ServiceUntypedParseTests.fs
+++ b/tests/service/ServiceUntypedParseTests.fs
@@ -1506,6 +1506,15 @@ let (x, y: string) = (12, "hello")
         Assert.IsFalse(parseFileResults.IsTypeAnnotationGivenAtPosition (mkPos 2 5), "Expected no annotation for argument 'x'")
         Assert.IsTrue(parseFileResults.IsTypeAnnotationGivenAtPosition (mkPos 2 8), "Expected annotation for argument 'y'")
 
+    [<Test>]
+    let ``IsTypeAnnotationGivenAtPosition - binding - second value annotated``() =
+        let source = """
+let x: int = 12
+"""
+        let parseFileResults, _ = getParseAndCheckResults source
+        Assert.IsTrue(parseFileResults.IsTypeAnnotationGivenAtPosition (mkPos 2 5), "Expected annotation for argument 'x'")
+
+
 module LambdaRecognition =
     [<Test>]
     let ``IsBindingALambdaAtPosition - recognize a lambda``() =


### PR DESCRIPTION
This is the fix to https://github.com/fsharp/FsAutoComplete/issues/921, where a binding of the form `let x: int = 12` wouldn't be recognized as a 'typed' thing and so would cause a type annotation inlay hint to be generated.

This is caused because of a difference in the AST shapes of the simple-let-binding case, which is easily added to the walker.