### PR TITLE
Operator syntax tree three

### DIFF
--- a/src/fsharp/CheckExpressions.fsi
+++ b/src/fsharp/CheckExpressions.fsi
@@ -74,7 +74,7 @@ type TcEnv =
       // 
       // Of the two, 'ePath' is the one that's barely used. It's only 
       // used by UpdateAccModuleOrNamespaceType to modify the CCU while compiling FSharp.Core
-      ePath: Ident list 
+      ePath: SynIdentOrOperatorName list 
 
       eCompPath: CompilationPath 
 
@@ -120,7 +120,7 @@ exception BakedInMemberConstraintName of string * range
 exception FunctionExpected of DisplayEnv * TType * range
 exception NotAFunction of DisplayEnv * TType * range * range
 exception NotAFunctionButIndexer of DisplayEnv * TType * string option * range * range * bool
-exception Recursion of DisplayEnv * Ident * TType * TType * range
+exception Recursion of DisplayEnv * SynIdentOrOperatorName * TType * TType * range
 exception RecursiveUseCheckedAtRuntime of DisplayEnv * ValRef * range
 exception LetRecEvaluatedOutOfOrder of DisplayEnv * ValRef * ValRef * range
 exception LetRecCheckedAtRuntime of range
@@ -137,7 +137,7 @@ exception UnitTypeExpectedWithPossiblePropertySetter of DisplayEnv * TType * str
 exception UnitTypeExpectedWithPossibleAssignment of DisplayEnv * TType * bool * string * range
 exception FunctionValueUnexpected of DisplayEnv * TType * range
 exception UnionPatternsBindDifferentNames of range
-exception VarBoundTwice of Ident
+exception VarBoundTwice of SynIdentOrOperatorName
 exception ValueRestriction of DisplayEnv * InfoReader * bool * Val * Typar * range
 exception ValNotMutable of DisplayEnv * ValRef * range
 exception ValNotLocal of DisplayEnv * ValRef * range
@@ -373,7 +373,7 @@ type ValSpecResult =
     | ValSpecResult of
         altActualParent: ParentRef *
         memberInfoOpt: PreValMemberInfo option *
-        id: Ident *
+        id: SynIdentOrOperatorName *
         enclosingDeclaredTypars: Typars *
         declaredTypars: Typars *
         ty: TType *
@@ -442,7 +442,7 @@ type RecursiveBindingInfo =
 /// Represents the results of the first phase of preparing simple values from a pattern
 [<Sealed>]
 type PrelimValScheme1 =
-    member Ident: Ident
+    member SynIdentOrOperatorName: SynIdentOrOperatorName
     member Type: TType
 
 /// Represents the results of the first phase of preparing bindings
@@ -452,7 +452,7 @@ type CheckedBindingInfo
 /// Represnts the results of the second phase of checking simple values
 type ValScheme = 
     | ValScheme of 
-        id: Ident * 
+        id: SynIdentOrOperatorName * 
         typeScheme: TypeScheme * 
         topValInfo: ValReprInfo option * 
         memberInfo: PreValMemberInfo option * 
@@ -597,7 +597,7 @@ val InferGenericArityFromTyScheme: TypeScheme -> partialValReprInfo: PartialValR
 
 /// Locate the environment within a particular namespace path, used to process a
 /// 'namespace' declaration.
-val LocateEnv: ccu: CcuThunk -> env: TcEnv -> enclosingNamespacePath: Ident list -> TcEnv
+val LocateEnv: ccu: CcuThunk -> env: TcEnv -> enclosingNamespacePath: SynIdentOrOperatorName list -> TcEnv
 
 /// Make the check for safe initialization of a member
 val MakeCheckSafeInit: g: TcGlobals -> tinst: TypeInst -> safeInitInfo: SafeInitData -> reqExpr: Expr -> expr: Expr -> Expr
@@ -606,27 +606,27 @@ val MakeCheckSafeInit: g: TcGlobals -> tinst: TypeInst -> safeInitInfo: SafeInit
 val MakeAndPublishVal: cenv: TcFileState -> env: TcEnv -> altActualParent: ParentRef * inSig: bool * declKind: DeclKind * vrec: ValRecursiveScopeInfo * vscheme: ValScheme * attrs: Attribs * doc: XmlDoc * konst: Const option * isGeneratedEventVal: bool -> Val
 
 /// Make an initial 'base' value
-val MakeAndPublishBaseVal: cenv: TcFileState -> env: TcEnv -> Ident option -> TType -> Val option
+val MakeAndPublishBaseVal: cenv: TcFileState -> env: TcEnv -> SynIdentOrOperatorName option -> TType -> Val option
 
 /// Make simple values (which are not recursive nor members)
 val MakeAndPublishSimpleVals: cenv: TcFileState -> env: TcEnv -> names: NameMap<PrelimValScheme1> -> NameMap<Val * TypeScheme> * NameMap<Val>
 
 /// Make an initial implicit safe initialization value
-val MakeAndPublishSafeThisVal: cenv: TcFileState -> env: TcEnv -> thisIdOpt: Ident option -> thisTy: TType -> Val option
+val MakeAndPublishSafeThisVal: cenv: TcFileState -> env: TcEnv -> thisIdOpt: SynIdentOrOperatorName option -> thisTy: TType -> Val option
 
 /// Make initial information for a member value
-val MakeMemberDataAndMangledNameForMemberVal: g: TcGlobals * tcref: TyconRef * isExtrinsic: bool * attrs: Attribs * optImplSlotTys: TType list * memberFlags: SynMemberFlags * valSynData: SynValInfo * id: Ident * isCompGen: bool -> PreValMemberInfo
+val MakeMemberDataAndMangledNameForMemberVal: g: TcGlobals * tcref: TyconRef * isExtrinsic: bool * attrs: Attribs * optImplSlotTys: TType list * memberFlags: SynMemberFlags * valSynData: SynValInfo * id: SynIdentOrOperatorName * isCompGen: bool -> PreValMemberInfo
 
 /// Return a new environment suitable for processing declarations in the interior of a type definition
 val MakeInnerEnvForTyconRef: env: TcEnv -> tcref: TyconRef -> isExtrinsicExtension: bool -> TcEnv
 
 /// Return a new environment suitable for processing declarations in the interior of a module definition
 /// including creating an accumulator for the module type.
-val MakeInnerEnv: addOpenToNameEnv: bool -> env: TcEnv -> nm: Ident -> modKind: ModuleOrNamespaceKind -> TcEnv * ModuleOrNamespaceType ref
+val MakeInnerEnv: addOpenToNameEnv: bool -> env: TcEnv -> nm: SynIdentOrOperatorName -> modKind: ModuleOrNamespaceKind -> TcEnv * ModuleOrNamespaceType ref
 
 /// Return a new environment suitable for processing declarations in the interior of a module definition
 /// given that the accumulator for the module type already exisits.
-val MakeInnerEnvWithAcc: addOpenToNameEnv: bool -> env: TcEnv -> nm: Ident -> mtypeAcc: ModuleOrNamespaceType ref -> modKind: ModuleOrNamespaceKind -> TcEnv
+val MakeInnerEnvWithAcc: addOpenToNameEnv: bool -> env: TcEnv -> nm: SynIdentOrOperatorName -> mtypeAcc: ModuleOrNamespaceType ref -> modKind: ModuleOrNamespaceKind -> TcEnv
 
 /// Produce a post-generalization type scheme for a simple type where no type inference generalization
 /// is appplied.
@@ -699,7 +699,7 @@ val TryTcStmt: cenv:TcFileState -> env:TcEnv -> tpenv:UnscopedTyparEnv -> synExp
 /// Check a pattern being used as a pattern match
 val TcMatchPattern: cenv:TcFileState -> inputTy:TType -> env:TcEnv -> tpenv:UnscopedTyparEnv -> pat:SynPat * optWhenExpr:SynExpr option -> Pattern * Expr option * Val list * TcEnv * UnscopedTyparEnv    
 
-val (|BinOpExpr|_|): SynExpr -> (Ident * SynExpr * SynExpr) option
+val (|BinOpExpr|_|): SynExpr -> (SynIdentOrOperatorName * SynExpr * SynExpr) option
 
 /// Check a set of let bindings
 val TcLetBindings: cenv:TcFileState -> env:TcEnv -> containerInfo:ContainerInfo -> declKind:DeclKind -> tpenv:UnscopedTyparEnv -> binds:SynBinding list * bindsm:range * scopem:range -> ModuleOrNamespaceExpr list * TcEnv * UnscopedTyparEnv

--- a/src/fsharp/CompilerDiagnostics.fs
+++ b/src/fsharp/CompilerDiagnostics.fs
@@ -155,12 +155,12 @@ let GetRangeOfDiagnostic(err: PhasedDiagnostic) =
 
       | FieldNotContained(_, _, _, arf, _, _) -> Some arf.Range
       | ValueNotContained(_, _, _, aval, _, _) -> Some aval.Range
-      | ConstrNotContained(_, _, _, aval, _, _) -> Some aval.Id.idRange
+      | ConstrNotContained(_, _, _, aval, _, _) -> Some aval.Id.Range
       | ExnconstrNotContained(_, _, aexnc, _, _) -> Some aexnc.Range
 
       | VarBoundTwice id
       | UndefinedName(_, _, id, _) ->
-          Some id.idRange
+          Some id.Range
 
       | Duplicate(_, _, m)
       | NameClash(_, _, _, m, _, _, _)

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -2710,9 +2710,9 @@ and ReportNoCandidatesError (csenv: ConstraintSolverEnv) (nUnnamedCallerArgs, nN
                     for p in minfo.DeclaringTyconRef.AllInstanceFieldsAsList do
                         addToBuffer(p.LogicalName.Replace("@", ""))
 
-                ErrorWithSuggestions((msgNum, FSComp.SR.csCtorHasNoArgumentOrReturnProperty(methodName, id.idText, msgText)), id.idRange, id.idText, suggestFields)
+                ErrorWithSuggestions((msgNum, FSComp.SR.csCtorHasNoArgumentOrReturnProperty(methodName, id.idText, msgText)), id.Range, id.idText, suggestFields)
             else
-                Error((msgNum, FSComp.SR.csMemberHasNoArgumentOrReturnProperty(methodName, id.idText, msgText)), id.idRange)
+                Error((msgNum, FSComp.SR.csMemberHasNoArgumentOrReturnProperty(methodName, id.idText, msgText)), id.Range)
         | [] -> Error((msgNum, msgText), m)
 
     // One method, incorrect number of arguments provided by the user

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6520,7 +6520,7 @@ and GenParams (cenv: cenv) eenv m (mspec: ILMethodSpec) witnessInfos (argInfos: 
                         if takenNames.Contains(id.idText) then
                             // Ensure that we have an g.CompilerGlobalState
                             assert(g.CompilerGlobalState |> Option.isSome)
-                            g.CompilerGlobalState.Value.NiceNameGenerator.FreshCompilerGeneratedName (id.idText, id.idRange)
+                            g.CompilerGlobalState.Value.NiceNameGenerator.FreshCompilerGeneratedName (id.idText, id.Range)
                         else
                             id.idText
                     Some nm, takenNames.Add(nm)

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -69,7 +69,7 @@ type CalledArg =
       IsInArg: bool
       IsOutArg: bool
       ReflArgInfo: ReflectedArgInfo
-      NameOpt: Ident option
+      NameOpt: SynIdentOrOperatorName option
       CalledArgumentType : TType }
 
 let CalledArg (pos, isParamArray, optArgInfo, callerInfo, isInArg, isOutArg, nameOpt, reflArgInfo, calledArgTy) =
@@ -88,7 +88,7 @@ let CalledArg (pos, isParamArray, optArgInfo, callerInfo, isInArg, isOutArg, nam
 type AssignedCalledArg<'T> = 
 
     { /// The identifier for a named argument, if any
-      NamedArgIdOpt : Ident option
+      NamedArgIdOpt : SynIdentOrOperatorName option
 
       /// The called argument in the method
       CalledArg: CalledArg 
@@ -105,14 +105,14 @@ type AssignedItemSetterTarget =
     | AssignedRecdFieldSetter of RecdFieldInfo 
 
 /// Represents the resolution of a caller argument as a named-setter argument
-type AssignedItemSetter<'T> = AssignedItemSetter of Ident * AssignedItemSetterTarget * CallerArg<'T> 
+type AssignedItemSetter<'T> = AssignedItemSetter of SynIdentOrOperatorName * AssignedItemSetterTarget * CallerArg<'T> 
 
 type CallerNamedArg<'T> = 
-    | CallerNamedArg of Ident * CallerArg<'T>  
+    | CallerNamedArg of SynIdentOrOperatorName * CallerArg<'T>  
 
-    member x.Ident = (let (CallerNamedArg(id, _)) = x in id)
+    member x.SynIdentOrOperatorName = (let (CallerNamedArg(id, _)) = x in id)
 
-    member x.Name = x.Ident.idText
+    member x.Name = x.SynIdentOrOperatorName.idText
 
     member x.CallerArg = (let (CallerNamedArg(_, a)) = x in a)
 
@@ -610,7 +610,7 @@ type CalledMeth<'T>
                 let returnedObjTy = methodRetTy
                 unassignedNamedItems |> List.splitChoose (fun (CallerNamedArg(id, e) as arg) -> 
                     let nm = id.idText
-                    let pinfos = GetIntrinsicPropInfoSetsOfType infoReader (Some nm) ad AllowMultiIntfInstantiations.Yes IgnoreOverrides id.idRange returnedObjTy
+                    let pinfos = GetIntrinsicPropInfoSetsOfType infoReader (Some nm) ad AllowMultiIntfInstantiations.Yes IgnoreOverrides id.Range returnedObjTy
                     let pinfos = pinfos |> ExcludeHiddenOfPropInfos g infoReader.amap m 
                     match pinfos with 
                     | [pinfo] when pinfo.HasSetter && not pinfo.IsIndexer -> 

--- a/src/fsharp/MethodCalls.fsi
+++ b/src/fsharp/MethodCalls.fsi
@@ -50,16 +50,16 @@ type CalledArg =
       IsInArg: bool
       IsOutArg: bool
       ReflArgInfo: ReflectedArgInfo
-      NameOpt: Ident option
+      NameOpt: SynIdentOrOperatorName option
       CalledArgumentType: TType }
 
-val CalledArg: pos:struct (int * int) * isParamArray:bool * optArgInfo:OptionalArgInfo * callerInfo:CallerInfo * isInArg:bool * isOutArg:bool * nameOpt:Ident option * reflArgInfo:ReflectedArgInfo * calledArgTy:TType -> CalledArg
+val CalledArg: pos:struct (int * int) * isParamArray:bool * optArgInfo:OptionalArgInfo * callerInfo:CallerInfo * isInArg:bool * isOutArg:bool * nameOpt:SynIdentOrOperatorName option * reflArgInfo:ReflectedArgInfo * calledArgTy:TType -> CalledArg
 
 /// Represents a match between a caller argument and a called argument, arising from either
 /// a named argument or an unnamed argument.
 type AssignedCalledArg<'T> =
     { /// The identifier for a named argument, if any
-      NamedArgIdOpt : Ident option
+      NamedArgIdOpt : SynIdentOrOperatorName option
 
       /// The called argument in the method
       CalledArg: CalledArg 
@@ -77,14 +77,14 @@ type AssignedItemSetterTarget =
 /// Represents the resolution of a caller argument as a named-setter argument
 type AssignedItemSetter<'T> =
     | AssignedItemSetter of
-      Ident * AssignedItemSetterTarget * CallerArg<'T>
+      SynIdentOrOperatorName * AssignedItemSetterTarget * CallerArg<'T>
 
 type CallerNamedArg<'T> =
-    | CallerNamedArg of Ident * CallerArg<'T>
+    | CallerNamedArg of SynIdentOrOperatorName * CallerArg<'T>
 
     member CallerArg: CallerArg<'T>
 
-    member Ident: Ident
+    member SynIdentOrOperatorName: SynIdentOrOperatorName
 
     member Name: string
   
@@ -283,7 +283,7 @@ type CalledMeth<'T> =
 
     member infoReader: InfoReader
   
-val NamesOfCalledArgs: calledArgs:CalledArg list -> Ident list
+val NamesOfCalledArgs: calledArgs:CalledArg list -> SynIdentOrOperatorName list
 
 type ArgumentAnalysis =
     | NoInfo
@@ -291,7 +291,7 @@ type ArgumentAnalysis =
     | CallerLambdaHasArgTypes of TType list
     | CalledArgMatchesType of adjustedCalledArgTy: TType * noEagerConstraintApplication: bool
 
-val ExamineMethodForLambdaPropagation: g: TcGlobals -> m: range -> meth:CalledMeth<SynExpr> -> ad:AccessorDomain -> (ArgumentAnalysis list list * (Ident * ArgumentAnalysis) list list) option
+val ExamineMethodForLambdaPropagation: g: TcGlobals -> m: range -> meth:CalledMeth<SynExpr> -> ad:AccessorDomain -> (ArgumentAnalysis list list * (SynIdentOrOperatorName * ArgumentAnalysis) list list) option
 
 /// Is this a 'base' call
 val IsBaseCall: objArgs:Expr list -> bool

--- a/src/fsharp/MethodOverrides.fsi
+++ b/src/fsharp/MethodOverrides.fsi
@@ -23,7 +23,7 @@ type OverrideCanImplement =
 
 /// The overall information about a method implementation in a class or object expression 
 type OverrideInfo =
-    | Override of OverrideCanImplement * TyconRef * Ident * (Typars * TyparInst) * TType list list * TType option * bool * bool
+    | Override of OverrideCanImplement * TyconRef * SynIdentOrOperatorName * (Typars * TyparInst) * TType list list * TType option * bool * bool
     
     member ArgTypes: TType list list
     
@@ -72,7 +72,7 @@ module DispatchSlotChecking =
     val FormatMethInfoSig: g:TcGlobals -> amap:ImportMap -> m:range -> denv:DisplayEnv -> d:MethInfo -> string
 
     /// Get the override information for an object expression method being used to implement dispatch slots
-    val GetObjectExprOverrideInfo: g:TcGlobals -> amap:ImportMap -> implty:TType * id:Ident * memberFlags:SynMemberFlags * ty:TType * arityInfo:ValReprInfo * bindingAttribs:Attribs * rhsExpr:Expr -> OverrideInfo * (Val option * Val * Val list list * Attribs * Expr)
+    val GetObjectExprOverrideInfo: g:TcGlobals -> amap:ImportMap -> implty:TType * id:SynIdentOrOperatorName * memberFlags:SynMemberFlags * ty:TType * arityInfo:ValReprInfo * bindingAttribs:Attribs * rhsExpr:Expr -> OverrideInfo * (Val option * Val * Val list list * Attribs * Expr)
 
     /// Check if an override exactly matches the requirements for a dispatch slot.
     val IsExactMatch: g:TcGlobals -> amap:ImportMap -> m:range -> dispatchSlot:MethInfo -> overrideBy:OverrideInfo -> bool
@@ -91,9 +91,9 @@ val FinalTypeDefinitionChecksAtEndOfInferenceScope: infoReader:InfoReader * nenv
 
 /// Get the methods relevant to determining if a uniquely-identified-override exists based on the syntactic information 
 /// at the member signature prior to type inference. This is used to pre-assign type information if it does 
-val GetAbstractMethInfosForSynMethodDecl: infoReader:InfoReader * ad:AccessorDomain * memberName:Ident * bindm:range * typToSearchForAbstractMembers:(TType * SlotImplSet option) * valSynData:SynValInfo -> MethInfo list * MethInfo list
+val GetAbstractMethInfosForSynMethodDecl: infoReader:InfoReader * ad:AccessorDomain * memberName:SynIdentOrOperatorName * bindm:range * typToSearchForAbstractMembers:(TType * SlotImplSet option) * valSynData:SynValInfo -> MethInfo list * MethInfo list
 
 /// Get the properties relevant to determining if a uniquely-identified-override exists based on the syntactic information 
 /// at the member signature prior to type inference. This is used to pre-assign type information if it does 
-val GetAbstractPropInfosForSynPropertyDecl: infoReader:InfoReader * ad:AccessorDomain * memberName:Ident * bindm:range * typToSearchForAbstractMembers:(TType * SlotImplSet option) * _k:'a * _valSynData:'b -> PropInfo list
+val GetAbstractPropInfosForSynPropertyDecl: infoReader:InfoReader * ad:AccessorDomain * memberName:SynIdentOrOperatorName * bindm:range * typToSearchForAbstractMembers:(TType * SlotImplSet option) * _k:'a * _valSynData:'b -> PropInfo list
 

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -76,7 +76,7 @@ type Item =
     // an identifier in different circumstances. 
 
     /// Represents the resolution of a name at the point of its own definition.
-    | NewDef of Ident
+    | NewDef of SynIdentOrOperatorName
 
     /// Represents the resolution of a name to a .NET field 
     | ILField of ILFieldInfo
@@ -117,13 +117,13 @@ type Item =
     | ModuleOrNamespaces of ModuleOrNamespaceRef list
 
     /// Represents the resolution of a name to an operator
-    | ImplicitOp of Ident * TraitConstraintSln option ref
+    | ImplicitOp of SynIdentOrOperatorName * TraitConstraintSln option ref
 
     /// Represents the resolution of a name to a named argument
-    | ArgName of Ident * TType * ArgumentContainer option
+    | ArgName of SynIdentOrOperatorName * TType * ArgumentContainer option
 
     /// Represents the resolution of a name to a named property setter
-    | SetterArg of Ident * Item 
+    | SetterArg of SynIdentOrOperatorName * Item 
 
     /// Represents the potential resolution of an unqualified name to a type.
     | UnqualifiedType of TyconRef list
@@ -254,7 +254,7 @@ val internal AddTyconRefsToNameEnv            : BulkAdd -> bool -> TcGlobals -> 
 val internal AddExceptionDeclsToNameEnv       : BulkAdd -> NameResolutionEnv -> TyconRef -> NameResolutionEnv
 
 /// Add a module abbreviation to the name resolution environment 
-val internal AddModuleAbbrevToNameEnv         : Ident -> NameResolutionEnv -> ModuleOrNamespaceRef list -> NameResolutionEnv
+val internal AddModuleAbbrevToNameEnv         : SynIdentOrOperatorName -> NameResolutionEnv -> ModuleOrNamespaceRef list -> NameResolutionEnv
 
 /// Add a list of module or namespace to the name resolution environment, including any sub-modules marked 'AutoOpen'
 val internal AddModuleOrNamespaceRefsToNameEnv              : TcGlobals -> ImportMap -> range -> bool -> AccessorDomain -> NameResolutionEnv -> ModuleOrNamespaceRef list -> NameResolutionEnv
@@ -534,28 +534,28 @@ type PermitDirectReferenceToGeneratedType =
     | No
 
 /// Resolve a long identifier to a namespace, module.
-val internal ResolveLongIdentAsModuleOrNamespace: TcResultsSink -> ResultCollectionSettings -> ImportMap -> range -> first: bool -> FullyQualifiedFlag -> NameResolutionEnv -> AccessorDomain -> Ident -> Ident list -> isOpenDecl: bool -> ResultOrException<(int * ModuleOrNamespaceRef * ModuleOrNamespaceType) list >
+val internal ResolveLongIdentAsModuleOrNamespace: TcResultsSink -> ResultCollectionSettings -> ImportMap -> range -> first: bool -> FullyQualifiedFlag -> NameResolutionEnv -> AccessorDomain -> SynIdentOrOperatorName -> SynIdentOrOperatorName list -> isOpenDecl: bool -> ResultOrException<(int * ModuleOrNamespaceRef * ModuleOrNamespaceType) list >
 
 /// Resolve a long identifier to an object constructor.
 val internal ResolveObjectConstructor          : NameResolver -> DisplayEnv -> range -> AccessorDomain -> TType -> ResultOrException<Item>
 
 /// Resolve a long identifier using type-qualified name resolution.
-val internal ResolveLongIdentInType            : TcResultsSink -> NameResolver -> NameResolutionEnv -> LookupKind -> range -> AccessorDomain -> Ident -> FindMemberFlag -> TypeNameResolutionInfo -> TType -> Item * Ident list
+val internal ResolveLongIdentInType            : TcResultsSink -> NameResolver -> NameResolutionEnv -> LookupKind -> range -> AccessorDomain -> SynIdentOrOperatorName -> FindMemberFlag -> TypeNameResolutionInfo -> TType -> Item * SynIdentOrOperatorName list
 
 /// Resolve a long identifier when used in a pattern.
-val internal ResolvePatternLongIdent           : TcResultsSink -> NameResolver -> WarnOnUpperFlag -> bool -> range -> AccessorDomain -> NameResolutionEnv -> TypeNameResolutionInfo -> Ident list -> Item
+val internal ResolvePatternLongIdent           : TcResultsSink -> NameResolver -> WarnOnUpperFlag -> bool -> range -> AccessorDomain -> NameResolutionEnv -> TypeNameResolutionInfo -> SynIdentOrOperatorName list -> Item
 
 /// Resolve a long identifier representing a type name 
-val internal ResolveTypeLongIdentInTyconRef    : TcResultsSink -> NameResolver -> NameResolutionEnv -> TypeNameResolutionInfo -> AccessorDomain -> range -> ModuleOrNamespaceRef -> Ident list -> TyconRef 
+val internal ResolveTypeLongIdentInTyconRef    : TcResultsSink -> NameResolver -> NameResolutionEnv -> TypeNameResolutionInfo -> AccessorDomain -> range -> ModuleOrNamespaceRef -> SynIdentOrOperatorName list -> TyconRef 
 
 /// Resolve a long identifier to a type definition
-val internal ResolveTypeLongIdent              : TcResultsSink -> NameResolver -> ItemOccurence -> FullyQualifiedFlag -> NameResolutionEnv -> AccessorDomain -> Ident list -> TypeNameResolutionStaticArgsInfo -> PermitDirectReferenceToGeneratedType -> ResultOrException<EnclosingTypeInst * TyconRef>
+val internal ResolveTypeLongIdent              : TcResultsSink -> NameResolver -> ItemOccurence -> FullyQualifiedFlag -> NameResolutionEnv -> AccessorDomain -> SynIdentOrOperatorName list -> TypeNameResolutionStaticArgsInfo -> PermitDirectReferenceToGeneratedType -> ResultOrException<EnclosingTypeInst * TyconRef>
 
 /// Resolve a long identifier to a field
-val internal ResolveField                      : TcResultsSink -> NameResolver -> NameResolutionEnv -> AccessorDomain -> TType -> Ident list * Ident -> Ident list -> FieldResolution list
+val internal ResolveField                      : TcResultsSink -> NameResolver -> NameResolutionEnv -> AccessorDomain -> TType -> SynIdentOrOperatorName list * SynIdentOrOperatorName -> SynIdentOrOperatorName list -> FieldResolution list
 
 /// Resolve a long identifier occurring in an expression position
-val internal ResolveExprLongIdent              : TcResultsSink -> NameResolver -> range -> AccessorDomain -> NameResolutionEnv -> TypeNameResolutionInfo -> Ident list -> ResultOrException<EnclosingTypeInst * Item * Ident list>
+val internal ResolveExprLongIdent              : TcResultsSink -> NameResolver -> range -> AccessorDomain -> NameResolutionEnv -> TypeNameResolutionInfo -> SynIdentOrOperatorName list -> ResultOrException<EnclosingTypeInst * Item * SynIdentOrOperatorName list>
 
 /// Resolve a (possibly incomplete) long identifier to a loist of possible class or record fields
 val internal ResolvePartialLongIdentToClassOrRecdFields: NameResolver -> NameResolutionEnv -> range -> AccessorDomain -> string list -> bool -> Item list
@@ -581,10 +581,10 @@ type AfterResolution =
     | RecordResolution of Item option * (TyparInst -> unit) * (MethInfo * PropInfo option * TyparInst -> unit) * (unit -> unit)
 
 /// Resolve a long identifier occurring in an expression position.
-val internal ResolveLongIdentAsExprAndComputeRange: TcResultsSink -> NameResolver -> range -> AccessorDomain -> NameResolutionEnv -> TypeNameResolutionInfo -> Ident list -> ResultOrException<EnclosingTypeInst * Item * range * Ident list * AfterResolution>
+val internal ResolveLongIdentAsExprAndComputeRange: TcResultsSink -> NameResolver -> range -> AccessorDomain -> NameResolutionEnv -> TypeNameResolutionInfo -> SynIdentOrOperatorName list -> ResultOrException<EnclosingTypeInst * Item * range * SynIdentOrOperatorName list * AfterResolution>
 
 /// Resolve a long identifier occurring in an expression position, qualified by a type.
-val internal ResolveExprDotLongIdentAndComputeRange: TcResultsSink -> NameResolver -> range -> AccessorDomain -> NameResolutionEnv -> TType -> Ident list -> TypeNameResolutionInfo -> FindMemberFlag -> bool -> Item * range * Ident list * AfterResolution
+val internal ResolveExprDotLongIdentAndComputeRange: TcResultsSink -> NameResolver -> range -> AccessorDomain -> NameResolutionEnv -> TType -> SynIdentOrOperatorName list -> TypeNameResolutionInfo -> FindMemberFlag -> bool -> Item * range * SynIdentOrOperatorName list * AfterResolution
 
 /// A generator of type instantiations used when no more specific type instantiation is known.
 val FakeInstantiationGenerator: range -> Typar list -> TType list

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1182,7 +1182,7 @@ module PrintTastMemberOrVals =
             | SynMemberKind.PropertyGet ->
                 if isNil argInfos then
                     // use error recovery because intellisense on an incomplete file will show this
-                    errorR(Error(FSComp.SR.tastInvalidFormForPropertyGetter(), v.Id.idRange))
+                    errorR(Error(FSComp.SR.tastInvalidFormForPropertyGetter(), v.Id.Range))
                     let nameL = layoutMemberName denv v [] tagProperty v.DisplayNameCoreMangled
                     let resL =
                         if short then nameL --- (WordL.keywordWith ^^ WordL.keywordGet)
@@ -1206,7 +1206,7 @@ module PrintTastMemberOrVals =
             | SynMemberKind.PropertySet ->
                 if argInfos.Length <> 1 || isNil argInfos.Head then
                     // use error recovery because intellisense on an incomplete file will show this
-                    errorR(Error(FSComp.SR.tastInvalidFormForPropertySetter(), v.Id.idRange))
+                    errorR(Error(FSComp.SR.tastInvalidFormForPropertySetter(), v.Id.Range))
                     let nameL = layoutMemberName denv v [] tagProperty v.DisplayNameCoreMangled
                     let resL = stat --- nameL --- (WordL.keywordWith ^^ WordL.keywordSet)
                     emptyTyparInst, resL

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -444,7 +444,7 @@ type MethodEnv =
 
 type IncrementalOptimizationEnv =
     { /// An identifier to help with name generation
-      latestBoundId: Ident option
+      latestBoundId: SynIdentOrOperatorName option
 
       /// The set of lambda IDs we've inlined to reach this point. Helps to prevent recursive inlining 
       dontInline: Zset<Unique>  

--- a/src/fsharp/ParseAndCheckInputs.fs
+++ b/src/fsharp/ParseAndCheckInputs.fs
@@ -70,7 +70,7 @@ let QualFileNameOfImpls filename specs =
     | _ -> QualFileNameOfFilename (mkRange filename pos0 pos0) filename
 
 let PrependPathToQualFileName x (QualifiedNameOfFile q) =
-    ComputeQualifiedNameOfFileFromUniquePath (q.idRange, pathOfLid x@[q.idText])
+    ComputeQualifiedNameOfFileFromUniquePath (q.Range, pathOfLid x@[q.idText])
 
 let PrependPathToImpl x (SynModuleOrNamespace(p, b, c, d, e, f, g, h)) =
     SynModuleOrNamespace(x@p, b, c, d, e, f, g, h)
@@ -107,7 +107,7 @@ let PostParseModuleImpl (_i, defaultNamespace, isLastCompiland, filename, impl) 
         let lid =
             match lid with
             | [id] when kind.IsModule && id.idText = MangledGlobalName ->
-                error(Error(FSComp.SR.buildInvalidModuleOrNamespaceName(), id.idRange))
+                error(Error(FSComp.SR.buildInvalidModuleOrNamespaceName(), id.Range))
             | id :: rest when id.idText = MangledGlobalName -> rest
             | _ -> lid
         SynModuleOrNamespace(lid, isRec, kind, decls, xmlDoc, attribs, access, m)
@@ -136,7 +136,7 @@ let PostParseModuleSpec (_i, defaultNamespace, isLastCompiland, filename, intf) 
         let lid =
             match lid with
             | [id] when kind.IsModule && id.idText = MangledGlobalName ->
-                error(Error(FSComp.SR.buildInvalidModuleOrNamespaceName(), id.idRange))
+                error(Error(FSComp.SR.buildInvalidModuleOrNamespaceName(), id.Range))
             | id :: rest when id.idText = MangledGlobalName -> rest
             | _ -> lid
         SynModuleOrNamespaceSig(lid, isRec, SynModuleOrNamespaceKind.NamedModule, decls, xmlDoc, attribs, access, m)
@@ -244,7 +244,7 @@ let DeduplicateModuleName (moduleNamesDict: ModuleNamesDict) fileName (qualNameO
         else
             let count = paths.Count + 1
             let id = qualNameOfFile.Id
-            let qualNameOfFileT = if count = 1 then qualNameOfFile else QualifiedNameOfFile(Ident(id.idText + "___" + count.ToString(), id.idRange))
+            let qualNameOfFileT = if count = 1 then qualNameOfFile else QualifiedNameOfFile(Ident(id.idText + "___" + count.ToString(), id.Range))
             let moduleNamesDictT = moduleNamesDict.Add(qualNameOfFile.Text, paths.Add(path, qualNameOfFileT))
             qualNameOfFileT, moduleNamesDictT
     | _ ->

--- a/src/fsharp/ParseAndCheckInputs.fsi
+++ b/src/fsharp/ParseAndCheckInputs.fsi
@@ -23,7 +23,7 @@ val IsScript: string -> bool
 
 val ComputeQualifiedNameOfFileFromUniquePath: range * string list -> QualifiedNameOfFile
 
-val PrependPathToInput: Ident list -> ParsedInput -> ParsedInput
+val PrependPathToInput: SynIdentOrOperatorName list -> ParsedInput -> ParsedInput
 
 /// State used to de-deduplicate module names along a list of file names
 type ModuleNamesDict = Map<string,Map<string,QualifiedNameOfFile>>

--- a/src/fsharp/SignatureConformance.fs
+++ b/src/fsharp/SignatureConformance.fs
@@ -287,14 +287,14 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                           checkAttribs aenv implArgInfo.Attribs sigArgInfo.Attribs (fun attribs -> 
                               match implArgInfo.Name, sigArgInfo.Name with 
                               | Some iname, Some sname when sname.idText <> iname.idText -> 
-                                   warning(Error (FSComp.SR.ArgumentsInSigAndImplMismatch(sname.idText, iname.idText), iname.idRange))
+                                   warning(Error (FSComp.SR.ArgumentsInSigAndImplMismatch(sname.idText, iname.idText), iname.Range))
                               | _ -> ()
                               
                               let sigHasInlineIfLambda = HasFSharpAttribute g g.attrib_InlineIfLambdaAttribute sigArgInfo.Attribs
                               let implHasInlineIfLambda = HasFSharpAttribute g g.attrib_InlineIfLambdaAttribute implArgInfo.Attribs
                               let m = 
                                   match implArgInfo.Name with 
-                                  | Some iname-> iname.idRange
+                                  | Some iname-> iname.Range
                                   | None -> implVal.Range
                               if sigHasInlineIfLambda && not implHasInlineIfLambda then 
                                   errorR(Error (FSComp.SR.implMissingInlineIfLambda(), m))

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -24,10 +24,9 @@ type SynIdentOrOperatorName =
          | SynIdentOrOperatorName.Operator(text=text) -> text
      member this.Range =
          match this with
-         | Ident (range = m) -> m
-         | ActivePattern(lpr, _, _, rpr)
-         | PartialActivePattern(lpr, _, _, rpr)
-         | Operator(Some lpr, _, _, Some rpr) -> unionRanges lpr rpr
+         | Ident (range = m)
+         | ActivePattern(textRange = m)
+         | PartialActivePattern(textRange = m)
          | Operator(textRange = m) -> m
          
      override this.ToString() = this.idText

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -26,7 +26,8 @@ type SynIdentOrOperatorName =
          match this with
          | Ident (range = m)
          | ActivePattern(textRange = m)
-         | PartialActivePattern(textRange = m)
+         | PartialActivePattern(textRange = m) -> m
+         | Operator(Some lpr, _, _, Some rpr) -> unionRanges lpr rpr
          | Operator(textRange = m) -> m
          
      override this.ToString() = this.idText

--- a/src/fsharp/SyntaxTreeOps.fsi
+++ b/src/fsharp/SyntaxTreeOps.fsi
@@ -13,38 +13,38 @@ type SynArgNameGenerator =
     member New: unit -> string
     member Reset: unit -> unit
     
-val ident: s:string * r:range -> Ident
+val ident: s:string * r:range -> SynIdentOrOperatorName
 
-val textOfId: id:Ident -> string
+val textOfId: id:SynIdentOrOperatorName -> string
 
-val pathOfLid: lid:Ident list -> string list
+val pathOfLid: lid:SynIdentOrOperatorName list -> string list
 
-val arrPathOfLid: lid:Ident list -> string []
+val arrPathOfLid: lid:SynIdentOrOperatorName list -> string []
 
 val textOfPath: path:seq<string> -> string
 
-val textOfLid: lid:Ident list -> string
+val textOfLid: lid:SynIdentOrOperatorName list -> string
 
-val rangeOfLid: lid:Ident list -> range
+val rangeOfLid: lid:SynIdentOrOperatorName list -> range
 
-val mkSynId: m:range -> s:string -> Ident
+val mkSynId: m:range -> s:string -> SynIdentOrOperatorName
 
-val pathToSynLid: m:range -> p:string list -> Ident list
+val pathToSynLid: m:range -> p:string list -> SynIdentOrOperatorName list
 
 val mkSynIdGet: m:range -> n:string -> SynExpr
 
 val mkSynLidGet: m:range -> path:string list -> n:string -> SynExpr
 
-val mkSynIdGetWithAlt: m:range -> id:Ident -> altInfo:SynSimplePatAlternativeIdInfo ref option -> SynExpr
+val mkSynIdGetWithAlt: m:range -> id:SynIdentOrOperatorName -> altInfo:SynSimplePatAlternativeIdInfo ref option -> SynExpr
 
-val mkSynSimplePatVar: isOpt:bool -> id:Ident -> SynSimplePat
+val mkSynSimplePatVar: isOpt:bool -> id:SynIdentOrOperatorName -> SynSimplePat
 
-val mkSynCompGenSimplePatVar: id:Ident -> SynSimplePat
+val mkSynCompGenSimplePatVar: id:SynIdentOrOperatorName -> SynSimplePat
 
 /// Match a long identifier, including the case for single identifiers which gets a more optimized node in the syntax tree.
 val (|LongOrSingleIdent|_|): inp:SynExpr -> (bool * LongIdentWithDots * SynSimplePatAlternativeIdInfo ref option * range) option
 
-val (|SingleIdent|_|): inp:SynExpr -> Ident option
+val (|SingleIdent|_|): inp:SynExpr -> SynIdentOrOperatorName option
 
 /// This affects placement of debug points
 val IsControlFlowExpression: e:SynExpr -> bool
@@ -55,11 +55,11 @@ val IsDebugPointBinding: synPat: SynPat -> synExpr: SynExpr -> bool
 
 val mkSynAnonField: ty:SynType * xmlDoc:PreXmlDoc -> SynField
 
-val mkSynNamedField: ident:Ident * ty:SynType * xmlDoc:PreXmlDoc * m:range -> SynField
+val mkSynNamedField: ident:SynIdentOrOperatorName * ty:SynType * xmlDoc:PreXmlDoc * m:range -> SynField
 
-val mkSynPatVar: vis:SynAccess option -> id:Ident -> SynPat
+val mkSynPatVar: vis:SynAccess option -> id:SynIdentOrOperatorName -> SynPat
 
-val mkSynThisPatVar: id:Ident -> SynPat
+val mkSynThisPatVar: id:SynIdentOrOperatorName -> SynPat
 
 val mkSynPatMaybeVar: lidwd:LongIdentWithDots -> vis:SynAccess option -> m:range -> SynPat
 
@@ -110,7 +110,7 @@ val mkSynPrefixPrim: opm:range -> m:range -> oper:string -> x:SynExpr -> SynExpr
 
 val mkSynPrefix: opm:range -> m:range -> oper:string -> x:SynExpr -> SynExpr
 
-val mkSynCaseName: m:range -> n:string -> Ident list
+val mkSynCaseName: m:range -> n:string -> SynIdentOrOperatorName list
 
 val mkSynApp1: f:SynExpr -> x1:SynExpr -> m:range -> SynExpr
 
@@ -142,7 +142,7 @@ val mkSynDelay: m:range -> e:SynExpr -> SynExpr
 
 val mkSynAssign: l:SynExpr -> r:SynExpr -> SynExpr
 
-val mkSynDot: dotm:range -> m:range -> l:SynExpr -> r:Ident -> SynExpr
+val mkSynDot: dotm:range -> m:range -> l:SynExpr -> r:SynIdentOrOperatorName -> SynExpr
 
 val mkSynDotMissing: dotm:range -> m:range -> l:SynExpr -> SynExpr
 

--- a/src/fsharp/TypedTree.fs
+++ b/src/fsharp/TypedTree.fs
@@ -2213,7 +2213,7 @@ type Typar =
 
     /// Creates a type variable that contains empty data, and is not yet linked. Only used during unpickling of F# metadata.
     static member NewUnlinked() : Typar = 
-        { typar_id = Unchecked.defaultof<_>
+        { typar_id = SynIdentOrOperatorName.Ident(String.Empty, Range.Zero)
           typar_flags = Unchecked.defaultof<_>
           typar_stamp = -1L
           typar_solution = Unchecked.defaultof<_>

--- a/src/fsharp/TypedTreeBasics.fs
+++ b/src/fsharp/TypedTreeBasics.fs
@@ -152,7 +152,7 @@ type EntityRef with
         | ERefLocal _ -> mkLocalTyconRef x
         | ERefNonLocal nlr -> mkNonLocalTyconRefPreResolved x nlr x.LogicalName
 
-    member tcref.RecdFieldRefInNestedTycon tycon (id: Ident) = RecdFieldRef (tcref.NestedTyconRef tycon, id.idText)
+    member tcref.RecdFieldRefInNestedTycon tycon (id: SynIdentOrOperatorName) = RecdFieldRef (tcref.NestedTyconRef tycon, id.idText)
 
 /// Make a reference to a union case for type in a module or namespace
 let mkModuleUnionCaseRef (modref: ModuleOrNamespaceRef) tycon uc = 

--- a/src/fsharp/TypedTreeBasics.fsi
+++ b/src/fsharp/TypedTreeBasics.fsi
@@ -101,7 +101,7 @@ val mkNonLocalTyconRefPreResolved: x:NonNullSlot<Entity> -> nleref:NonLocalEntit
 
 type EntityRef with
     member NestedTyconRef: x:Entity -> EntityRef
-    member RecdFieldRefInNestedTycon: tycon:Entity -> id:Ident -> RecdFieldRef
+    member RecdFieldRefInNestedTycon: tycon:Entity -> id:SynIdentOrOperatorName -> RecdFieldRef
 
 /// Make a reference to a union case for type in a module or namespace
 val mkModuleUnionCaseRef: modref:ModuleOrNamespaceRef -> tycon:Entity -> uc:UnionCase -> UnionCaseRef val VRefLocal: x:NonNullSlot<Val> -> ValRef

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -1200,7 +1200,7 @@ let mkMultiLambdaTy g m vs rty = mkFunTy g (typeOfLambdaArg m vs) rty
 /// particular point in order to do this.
 let ensureCcuHasModuleOrNamespaceAtPath (ccu: CcuThunk) path (CompPath(_, cpath)) xml =
     let scoref = ccu.ILScopeRef 
-    let rec loop prior_cpath (path: Ident list) cpath (modul: ModuleOrNamespace) =
+    let rec loop prior_cpath (path: SynIdentOrOperatorName list) cpath (modul: ModuleOrNamespace) =
         let mtype = modul.ModuleOrNamespaceType 
         match path, cpath with 
         | hpath :: tpath, (_, mkind) :: tcpath -> 
@@ -3941,7 +3941,7 @@ module DebugPrint =
 
     let recdFieldRefL (rfref: RecdFieldRef) = wordL (tagText rfref.FieldName)
 
-    let identL (id: Ident) = wordL (tagText id.idText)
+    let identL (id: SynIdentOrOperatorName) = wordL (tagText id.idText)
 
     // Note: We need nice printing of constants in order to print literals and attributes 
     let constL c =
@@ -4345,9 +4345,9 @@ let wrapModuleOrNamespaceTypeInNamespace id cpath mtyp =
     let mspec = wrapModuleOrNamespaceType id cpath mtyp
     Construct.NewModuleOrNamespaceType Namespace [ mspec ] [], mspec
 
-let wrapModuleOrNamespaceExprInNamespace (id: Ident) cpath mexpr = 
+let wrapModuleOrNamespaceExprInNamespace (id: SynIdentOrOperatorName) cpath mexpr = 
     let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType Namespace)
-    TMDefRec (false, [], [], [ModuleOrNamespaceBinding.Module(mspec, mexpr)], id.idRange)
+    TMDefRec (false, [], [], [ModuleOrNamespaceBinding.Module(mspec, mexpr)], id.Range)
 
 // cleanup: make this a property
 let SigTypeOfImplFile (TImplFile (implExprWithSig=mexpr)) = mexpr.Type 
@@ -7224,7 +7224,7 @@ let mkRecordExpr g (lnk, tcref, tinst, unsortedRecdFields: RecdFieldRef list, un
     let core = Expr.Op (TOp.Recd (lnk, tcref), tinst, sortedArgExprs, m)
     mkLetsBind m unsortedArgBinds core
 
-let mkAnonRecd (_g: TcGlobals) m (anonInfo: AnonRecdTypeInfo) (unsortedIds: Ident[]) (unsortedFieldExprs: Expr list) unsortedArgTys =
+let mkAnonRecd (_g: TcGlobals) m (anonInfo: AnonRecdTypeInfo) (unsortedIds: SynIdentOrOperatorName[]) (unsortedFieldExprs: Expr list) unsortedArgTys =
     let sortedRecdFields = unsortedFieldExprs |> List.indexed |> Array.ofList |> Array.sortBy (fun (i,_) -> unsortedIds[i].idText)
     let sortedArgTys = unsortedArgTys |> List.indexed |> List.sortBy (fun (i,_) -> unsortedIds[i].idText) |> List.map snd
 

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -55,7 +55,7 @@ val mkLambdaTy: TcGlobals -> Typars -> TTypes -> TType -> TType
 val mkMultiLambdaTy: TcGlobals -> range -> Val list -> TType -> TType
 
 /// Module publication, used while compiling fslib.
-val ensureCcuHasModuleOrNamespaceAtPath: CcuThunk -> Ident list -> CompilationPath -> XmlDoc -> unit 
+val ensureCcuHasModuleOrNamespaceAtPath: CcuThunk -> SynIdentOrOperatorName list -> CompilationPath -> XmlDoc -> unit 
 
 /// Ignore 'Expr.Link' in an expression
 val stripExpr: Expr -> Expr
@@ -1220,13 +1220,13 @@ val ComputeImplementationHidingInfoAtAssemblyBoundary: ModuleOrNamespaceExpr -> 
 val mkRepackageRemapping: SignatureRepackageInfo -> Remap 
 
 /// Wrap one module or namespace implementation in a 'namespace N' outer wrapper
-val wrapModuleOrNamespaceExprInNamespace: Ident -> CompilationPath -> ModuleOrNamespaceExpr -> ModuleOrNamespaceExpr
+val wrapModuleOrNamespaceExprInNamespace: SynIdentOrOperatorName -> CompilationPath -> ModuleOrNamespaceExpr -> ModuleOrNamespaceExpr
 
 /// Wrap one module or namespace definition in a 'namespace N' outer wrapper
-val wrapModuleOrNamespaceTypeInNamespace: Ident -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespaceType * ModuleOrNamespace  
+val wrapModuleOrNamespaceTypeInNamespace: SynIdentOrOperatorName -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespaceType * ModuleOrNamespace  
 
 /// Wrap one module or namespace definition in a 'module M = ..' outer wrapper
-val wrapModuleOrNamespaceType: Ident -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespace
+val wrapModuleOrNamespaceType: SynIdentOrOperatorName -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespace
 
 /// Given an implementation, fetch its recorded signature
 val SigTypeOfImplFile: TypedImplFile -> ModuleOrNamespaceType
@@ -2259,7 +2259,7 @@ val mkMethodTy: TcGlobals -> TType list list -> TType -> TType
 
 val mkAnyAnonRecdTy: TcGlobals -> AnonRecdTypeInfo -> TType list -> TType
 
-val mkAnonRecd: TcGlobals -> range -> AnonRecdTypeInfo -> Ident[] -> Exprs -> TType list -> Expr 
+val mkAnonRecd: TcGlobals -> range -> AnonRecdTypeInfo -> SynIdentOrOperatorName[] -> Exprs -> TType list -> Expr 
 
 val AdjustValForExpectedArity: TcGlobals -> range -> ValRef -> ValUseFlag -> ValReprInfo -> Expr * TType
 

--- a/src/fsharp/TypedTreePickle.fs
+++ b/src/fsharp/TypedTreePickle.fs
@@ -1359,7 +1359,7 @@ let p_range (x: range) st =
     p_tup3 p_string p_pos p_pos (fileName, x.Start, x.End) st
 
 let p_dummy_range : range pickler   = fun _x _st -> ()
-let p_ident (x: Ident) st = p_tup2 p_string p_range (x.idText, x.idRange) st
+let p_ident (x: SynIdentOrOperatorName) st = p_tup2 p_string p_range (x.idText, x.Range) st
 let p_xmldoc (doc: XmlDoc) st = p_array p_string doc.UnprocessedLines st
 
 let u_pos st = let a = u_int st in let b = u_int st in mkPos a b

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -640,7 +640,7 @@ type ReflectedArgInfo =
 /// Partial information about a parameter returned for use by the Language Service
 [<NoComparison; NoEquality>]
 type ParamNameAndType =
-    | ParamNameAndType of Ident option * TType
+    | ParamNameAndType of SynIdentOrOperatorName option * TType
 
     static member FromArgInfo (ty, argInfo : ArgReprInfo) = ParamNameAndType(argInfo.Name, ty)
     static member FromMember isCSharpExtMem g vref = GetArgInfosOfMember isCSharpExtMem g vref |> List.mapSquared ParamNameAndType.FromArgInfo
@@ -656,7 +656,7 @@ type ParamData =
         isOut: bool *
         optArgInfo: OptionalArgInfo *
         callerInfo: CallerInfo *
-        nameOpt: Ident option *
+        nameOpt: SynIdentOrOperatorName option *
         reflArgInfo: ReflectedArgInfo *
         ttype: TType
 

--- a/src/fsharp/infos.fsi
+++ b/src/fsharp/infos.fsi
@@ -190,7 +190,7 @@ type ReflectedArgInfo =
 /// Partial information about a parameter returned for use by the Language Service
 [<NoComparison; NoEquality>]
 type ParamNameAndType =
-    | ParamNameAndType of Ident option * TType
+    | ParamNameAndType of SynIdentOrOperatorName option * TType
 
     static member FromArgInfo: ty:TType * argInfo:ArgReprInfo -> ParamNameAndType
 
@@ -209,7 +209,7 @@ type ParamData =
       isOut: bool *
       optArgInfo: OptionalArgInfo * 
       callerInfo: CallerInfo *
-      nameOpt: Ident option * 
+      nameOpt: SynIdentOrOperatorName option * 
       reflArgInfo: ReflectedArgInfo *
       ttype: TType
 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -198,7 +198,7 @@ let checkForMultipleAugmentations m a1 a2 =
 
 let rangeOfLongIdent(lid:LongIdent) =
     System.Diagnostics.Debug.Assert(not lid.IsEmpty, "the parser should never produce a long-id that is the empty list") 
-    (lid.Head.idRange, lid) ||> unionRangeWithListBy (fun id -> id.idRange) 
+    (lid.Head.Range, lid) ||> unionRangeWithListBy (fun id -> id.Range) 
 
 %} 
 
@@ -324,7 +324,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <ParsedImplFile> implementationFile
 %type <ParsedSigFile> signatureFile
 %type <ParsedScriptInteraction> interaction
-%type <Ident> ident
+%type <SynIdentOrOperatorName> ident
 %type <SynType> typ typEOF
 %type <SynTypeDefnSig list> tyconSpfnList
 %type <SynArgPats * Range> atomicPatsOrNamePatPairs
@@ -1125,13 +1125,13 @@ classMemberSpfnGetSet:
 /* The "get, set" on a property member in a signature */
 classMemberSpfnGetSetElements:
   | nameop 
-    { (let (id:Ident) = $1 
+    { (let (id:SynIdentOrOperatorName) = $1 
        if id.idText = "get" then SynMemberKind.PropertyGet 
        else if id.idText = "set" then SynMemberKind.PropertySet 
        else raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired())) }
 
   | nameop COMMA nameop
-    { let (id:Ident) = $1 
+    { let (id:SynIdentOrOperatorName) = $1 
       if not ((id.idText = "get" && $3.idText = "set") ||
               (id.idText = "set" && $3.idText = "get")) then 
          raiseParseErrorAt (rhs2 parseState 1 3) (FSComp.SR.parsGetOrSetRequired())
@@ -1393,7 +1393,7 @@ moduleDefn:
             match vis with
             | Some vis -> raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsIgnoreAttributesOnModuleAbbreviationAlwaysPrivate(vis.ToString()))
             | None -> ()
-            [ SynModuleDecl.ModuleAbbrev(List.head path, eqn, (rhs parseState 3, eqn) ||> unionRangeWithListBy (fun id -> id.idRange) ) ]
+            [ SynModuleDecl.ModuleAbbrev(List.head path, eqn, (rhs parseState 3, eqn) ||> unionRangeWithListBy (fun id -> id.Range) ) ]
         | Choice2Of2 def -> 
             if not (isSingleton path) then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsModuleAbbreviationMustBeSimpleName())
             let info = SynComponentInfo(attribs @ attribs2, None, [], path, xmlDoc, false, vis, rhs parseState 3)
@@ -2878,7 +2878,7 @@ cPrototype:
             SynExpr.App (
                 ExprAtomicFlag.NonAtomic,
                 false,
-                SynExpr.Ident (ident("failwith", rhs parseState 6)),
+                SynExpr.IdentOrOperatorName (SynIdentOrOperatorName.Ident("failwith", rhs parseState 6)),
                 SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
                 mRhs)
         (fun attrs _ ->
@@ -4438,18 +4438,18 @@ atomicExpr:
         $3 arg1 (lhs parseState) (rhs parseState 2), hpa1 }
 
   | BASE DOT atomicExprQualification 
-      { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1))
+      { let arg1 = SynExpr.IdentOrOperatorName (SynIdentOrOperatorName.Ident("base", rhs parseState 1))
         $3 arg1 (lhs parseState) (rhs parseState 2), false }
 
   | QMARK nameop 
-      { SynExpr.LongIdent (true, LongIdentWithDots([$2], []), None, rhs parseState 2), false }
+      { SynExpr.LongIdent (true, LongIdentWithDots([$2], []), None, rhs2 parseState 1 2), false }
 
   | atomicExpr QMARK dynamicArg
       { let arg1, hpa1 = $1
         mkSynInfix (rhs parseState 2) arg1 "?" $3, hpa1 }
 
   | GLOBAL
-      { SynExpr.Ident (ident(MangledGlobalName, rhs parseState 1)), false }
+      { SynExpr.IdentOrOperatorName (SynIdentOrOperatorName.Ident(MangledGlobalName, rhs parseState 1)), false }
 
   | identExpr
       { $1, false }
@@ -4512,12 +4512,14 @@ atomicExprQualification:
             SynExpr.LibraryOnlyUnionCaseFieldGet (e, mkSynCaseName lhsm opNameCons, (fst $5), lhsm)) }
 
   | LPAREN  typedSequentialExpr rparen  
-      { (fun e lhsm dotm -> 
+      { let lpr = rhs parseState 1
+        let rpr = rhs parseState 3
+        (fun e lhsm dotm -> 
             // Check for expr.( * )
             // Note that "*" is parsed as an expression (it is allowed in "foo.[3,*]")
             match $2 with
             | SynExpr.IndexRange (None, opm, None, _m1, _m2, _) ->
-                mkSynDot dotm lhsm e (ident(CompileOpName "*", opm))
+                mkSynDot dotm lhsm e (SynIdentOrOperatorName.Operator(Some lpr, CompileOpName "*", opm, Some rpr))
             | _ ->
                 if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
                     mlCompatError (FSComp.SR.mlCompatMultiPrefixTyparsNoLongerSupported()) (lhs parseState) 
@@ -5032,7 +5034,7 @@ braceBarExprCore:
        let flds = 
            flds |> List.choose (function 
              | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
+             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.Range)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 3
        (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
@@ -5043,7 +5045,7 @@ braceBarExprCore:
        let flds = 
            flds |> List.choose (function 
              | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
+             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.Range)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 2
        (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
@@ -5562,7 +5564,7 @@ staticallyKnownHeadTypar:
 
 ident: 
   | IDENT 
-     { ident($1, rhs parseState 1) } 
+     { SynIdentOrOperatorName.Ident($1, rhs parseState 1) } 
 
 /* A A.B.C path used to an identifier */
 path: 
@@ -5580,26 +5582,37 @@ path:
        let (LongIdentWithDots(lid, dotms)) = $1 in LongIdentWithDots(lid, dotms @ [rhs parseState 2])  } 
 
 
-/* An operator name, with surrounnding parentheses */
-opName: 
-  | LPAREN operatorName rparen  
-     {  ident(CompileOpName $2, rhs parseState 2) }
+/* An operator name, with surrounding parentheses */
+opName:
+  | LPAREN operatorName rparen
+     { SynIdentOrOperatorName.Operator(Some (rhs parseState 1), CompileOpName $2, rhs parseState 2, Some (rhs parseState 3)) }
 
-  | LPAREN error rparen  
-     {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName()); ident(CompileOpName "****", rhs parseState 2) }
+  | LPAREN error rparen
+    {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName())
+       SynIdentOrOperatorName.Operator(Some (rhs parseState 1), CompileOpName "****", rhs parseState 2, Some (rhs parseState 3)) }
 
   | LPAREN_STAR_RPAREN
-     {  ident(CompileOpName "*", rhs parseState 1) }
+    { let m= rhs parseState 1
+      let lpr = mkFileIndexRange m.FileIndex m.Start m.Start
+      let mStar = mkFileIndexRange m.FileIndex (mkPos m.StartLine (m.StartColumn + 1)) (mkPos m.EndLine (m.EndColumn - 1))
+      let rpr = mkFileIndexRange m.FileIndex m.End m.End
+      SynIdentOrOperatorName.Operator(Some lpr, CompileOpName "*", mStar, Some rpr) }
 
   /* active pattern name */
-  | LPAREN activePatternCaseNames BAR rparen 
-     { let text = ("|" + String.concat "|" (List.rev $2) + "|")
-       ident(text, rhs2 parseState 2 3) }
-                         
+  | LPAREN activePatternCaseNames BAR rparen
+     { let lpr = rhs parseState 1
+       let text = ("|" + String.concat "|" (List.rev $2) + "|")
+       let mText = rhs2 parseState 2 3
+       let rpr = rhs parseState 4
+       SynIdentOrOperatorName.ActivePattern(lpr, text, mText, rpr) }
+
   /* partial active pattern name */
-  | LPAREN activePatternCaseNames BAR UNDERSCORE BAR rparen 
-     { let text = ("|" + String.concat "|" (List.rev $2) + "|_|" )
-       ident(text, rhs2 parseState 2 5) }
+  | LPAREN activePatternCaseNames BAR UNDERSCORE BAR rparen
+     { let lpr = rhs parseState 1
+       let text = ("|" + String.concat "|" (List.rev $2) + "|_|" )
+       let mText = rhs2 parseState 2 5
+       let rpr = rhs parseState 6
+       SynIdentOrOperatorName.PartialActivePattern(lpr, text, mText, rpr) }
 
 /* An operator name, without surrounding parentheses */
 operatorName: 
@@ -5731,13 +5744,10 @@ nameop:
 
 identExpr:
   | ident
-     { SynExpr.Ident($1) }
+     { SynExpr.IdentOrOperatorName($1) }
 
   | opName
-     { let m = lhs parseState
-       let mLparen = mkFileIndexRange m.FileIndex m.Start (mkPos m.StartLine (m.StartColumn + 1))
-       let mRparen = mkFileIndexRange m.FileIndex (mkPos m.EndLine (m.EndColumn - 1)) m.End
-       SynExpr.Paren(SynExpr.Ident($1), mLparen, Some mRparen, m) }
+     { SynExpr.IdentOrOperatorName($1) }
 
 topSeparator: 
   | SEMICOLON { } 

--- a/src/fsharp/service/FSharpParseFileResults.fsi
+++ b/src/fsharp/service/FSharpParseFileResults.fsi
@@ -31,7 +31,7 @@ type public FSharpParseFileResults =
 
     /// Attempts to find an Ident of a pipeline containing the given position, and the number of args already applied in that pipeline.
     /// For example, '[1..10] |> List.map ' would give back the ident of '|>' and 1, because it applied 1 arg (the list) to 'List.map'.
-    member TryIdentOfPipelineContainingPosAndNumArgsApplied: pos: pos -> (Ident * int) option
+    member TryIdentOfPipelineContainingPosAndNumArgsApplied: pos: pos -> (SynIdentOrOperatorName * int) option
 
     /// Determines if the given position is inside a function or method application.
     member IsPosContainedInApplication: pos: pos -> bool

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -506,7 +506,7 @@ module InterfaceStubGenerator =
         | SynPat.LongIdent(longDotId=LongIdentWithDots(xs, _)) ->
 //            let (name, range) = xs |> List.map (fun x -> x.idText, x.idRange) |> List.last
             let last = List.last xs
-            Some(last.idText, last.idRange)
+            Some(last.idText, last.Range)
         | _ -> 
             None
 
@@ -850,7 +850,7 @@ module InterfaceStubGenerator =
                     | None ->
                         List.tryPick walkExpr [synExpr1; synExpr2]
 
-                | SynExpr.Ident _ident ->
+                | SynExpr.IdentOrOperatorName _ident ->
                     None
 
                 | SynExpr.LongIdent (_, _longIdent, _altNameRefCell, _range) -> 

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -439,7 +439,7 @@ module SyntaxTraversal =
                         | _ -> false
                     let ok = 
                         match isPartOfArrayOrList, synExpr with
-                        | false, SynExpr.Ident ident -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [])))
+                        | false, SynExpr.IdentOrOperatorName ident -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [])))
                         | false, SynExpr.LongIdent (false, lidwd, _, _) -> visitor.VisitRecordField(path, None, Some lidwd)
                         | _ -> None
                     if ok.IsSome then ok
@@ -519,7 +519,7 @@ module SyntaxTraversal =
                      | Some x -> yield dive x x.Range traverseSynExpr]
                     |> pick expr
 
-                | SynExpr.Ident _ident -> None
+                | SynExpr.IdentOrOperatorName _ident -> None
 
                 | SynExpr.LongIdent (_, _longIdent, _altNameRefCell, _range) -> None
 

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -48,7 +48,7 @@ module Structure =
     let longIdentRange (longId:LongIdent) =
         match longId with 
         | [] -> range0
-        | head :: _ -> Range.startToEnd head.idRange (List.last longId).idRange
+        | head :: _ -> Range.startToEnd head.Range (List.last longId).Range
 
     /// Calculate the range of the provided type arguments (<'a, ..., 'z>) 
     /// or return the range `other` when `typeArgs` = []
@@ -289,7 +289,7 @@ module Structure =
             | SynExpr.App (atomicFlag, isInfix, funcExpr, argExpr, r) ->
                 // seq exprs, custom operators, etc
                 if ExprAtomicFlag.NonAtomic=atomicFlag && (not isInfix)
-                   && (function SynExpr.Ident _    -> true  | _ -> false) funcExpr
+                   && (function SynExpr.IdentOrOperatorName _    -> true  | _ -> false) funcExpr
                    && (function SynExpr.ComputationExpr _ -> false | _ -> true ) argExpr then
                    // if the argExpr is a computation expression another match will handle the outlining
                    // these cases must be removed to prevent creating unnecessary tags for the same scope
@@ -830,7 +830,7 @@ module Structure =
         let rec parseModuleSigDeclaration (decl: SynModuleSigDecl) =
             match decl with
             | SynModuleSigDecl.Val (SynValSig(attributes=attrs; ident=ident; range=valrange), r) ->
-                let collapse = Range.endToEnd ident.idRange valrange
+                let collapse = Range.endToEnd ident.Range valrange
                 rcheck Scope.Val Collapse.Below r collapse
                 parseAttributes attrs
             | SynModuleSigDecl.Types (typeSigs, _) ->

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -314,7 +314,7 @@ module internal SymbolHelpers =
         | Item.CtorGroup(_, minfos) -> minfos |> List.tryPick (rangeOfMethInfo g preferFlag)
         | Item.ActivePatternResult(APInfo _, _, _, m) -> Some m
         | Item.SetterArg (_, item) -> rangeOfItem g preferFlag item
-        | Item.ArgName (id, _, _) -> Some id.idRange
+        | Item.ArgName (id, _, _) -> Some id.Range
         | Item.CustomOperation (_, _, implOpt) -> implOpt |> Option.bind (rangeOfMethInfo g preferFlag)
         | Item.ImplicitOp (_, {contents = Some(TraitConstraintSln.FSMethSln(_, vref, _))}) -> Some vref.Range
         | Item.ImplicitOp _ -> None
@@ -592,7 +592,7 @@ module internal SymbolHelpers =
               | Item.TypeVar (nm1, tp1), Item.TypeVar (nm2, tp2) -> 
                     (nm1 = nm2) && typarRefEq tp1 tp2
               | Item.ModuleOrNamespaces(modref1 :: _), Item.ModuleOrNamespaces(modref2 :: _) -> fullDisplayTextOfModRef modref1 = fullDisplayTextOfModRef modref2
-              | Item.SetterArg(id1, _), Item.SetterArg(id2, _) -> Range.equals id1.idRange id2.idRange && id1.idText = id2.idText
+              | Item.SetterArg(id1, _), Item.SetterArg(id2, _) -> Range.equals id1.Range id2.Range && id1.idText = id2.idText
               | Item.MethodGroup(_, meths1, _), Item.MethodGroup(_, meths2, _) -> 
                   Seq.zip meths1 meths2 |> Seq.forall (fun (minfo1, minfo2) ->
                     MethInfo.MethInfosUseIdenticalDefinitions minfo1 minfo2)
@@ -635,7 +635,7 @@ module internal SymbolHelpers =
               | Item.CustomOperation (_, _, Some minfo) -> minfo.ComputeHashCode()
               | Item.CustomOperation (_, _, None) -> 1
               | Item.ModuleOrNamespaces(modref :: _) -> hash (fullDisplayTextOfModRef modref)          
-              | Item.SetterArg(id, _) -> hash (id.idRange, id.idText)
+              | Item.SetterArg(id, _) -> hash (id.Range, id.idText)
               | Item.MethodGroup(_, meths, _) -> meths |> List.fold (fun st a -> st + a.ComputeHashCode()) 0
               | Item.CtorGroup(name, meths) -> name.GetHashCode() + (meths |> List.fold (fun st a -> st + a.ComputeHashCode()) 0)
               | Item.Value vref | Item.CustomBuilder (_, vref) -> hash vref.LogicalName

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2657,7 +2657,7 @@ type FSharpParameter(cenv, paramTy: TType, topArgInfo: ArgReprInfo, ownerOpt, ow
 
     member _.DeclarationLocation =
         match topArgInfo.Name with
-        | Some v -> v.idRange
+        | Some v -> v.Range
         | None ->
 
         match ownerRangeOpt with

--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -1148,7 +1148,7 @@ type FSharpOpenDeclaration =
     internal new: target: SynOpenDeclTarget * range: range option * modules: FSharpEntity list * types: FSharpType list * appliedScope: range * isOwnNamespace: bool -> FSharpOpenDeclaration
 
     /// The syntactic target of the declaration
-    member LongId: Ident list
+    member LongId: SynIdentOrOperatorName list
 
     /// The syntactic target of the declaration
     member Target: SynOpenDeclTarget

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -2072,7 +2072,7 @@ FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Microsoft.FSharp.Core.FShar
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] TryRangeOfStringInterpolationContainingPos(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] ValidateBreakpointLocation(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range]] GetAllArgumentsForFunctionApplicationAtPostion(FSharp.Compiler.Text.Position)
-FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,System.Int32]] TryIdentOfPipelineContainingPosAndNumArgsApplied(FSharp.Compiler.Text.Position)
+FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynIdentOrOperatorName,System.Int32]] TryIdentOfPipelineContainingPosAndNumArgsApplied(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`3[FSharp.Compiler.Text.Range,FSharp.Compiler.Text.Range,FSharp.Compiler.Text.Range]] TryRangeOfParenEnclosingOpEqualsGreaterUsage(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: System.String FileName
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: System.String get_FileName()
@@ -3463,7 +3463,7 @@ FSharp.Compiler.EditorServices.ParsedInput: Microsoft.FSharp.Core.FSharpFunc`2[S
 FSharp.Compiler.EditorServices.ParsedInput: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.EditorServices.CompletionContext] TryGetCompletionContext(FSharp.Compiler.Text.Position, FSharp.Compiler.Syntax.ParsedInput, System.String)
 FSharp.Compiler.EditorServices.ParsedInput: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.EditorServices.EntityKind] GetEntityKind(FSharp.Compiler.Text.Position, FSharp.Compiler.Syntax.ParsedInput)
 FSharp.Compiler.EditorServices.ParsedInput: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] GetRangeOfExprLeftOfDot(FSharp.Compiler.Text.Position, FSharp.Compiler.Syntax.ParsedInput)
-FSharp.Compiler.EditorServices.ParsedInput: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident]] GetLongIdentAt(FSharp.Compiler.Syntax.ParsedInput, FSharp.Compiler.Text.Position)
+FSharp.Compiler.EditorServices.ParsedInput: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]] GetLongIdentAt(FSharp.Compiler.Syntax.ParsedInput, FSharp.Compiler.Text.Position)
 FSharp.Compiler.EditorServices.ParsedInput: Microsoft.FSharp.Core.FSharpOption`1[System.String] TryFindExpressionIslandInPosition(FSharp.Compiler.Text.Position, FSharp.Compiler.Syntax.ParsedInput)
 FSharp.Compiler.EditorServices.ParsedInput: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Position,System.Boolean]] TryFindExpressionASTLeftOfDotLeftOfCursor(FSharp.Compiler.Text.Position, FSharp.Compiler.Syntax.ParsedInput)
 FSharp.Compiler.EditorServices.ParsedInput: System.String[] GetFullNameOfSmallestModuleOrNamespaceAtPoint(FSharp.Compiler.Text.Position, FSharp.Compiler.Syntax.ParsedInput)
@@ -4955,8 +4955,8 @@ FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Collections.FSha
 FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Symbols.FSharpEntity] get_Modules()
 FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Symbols.FSharpType] Types
 FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Symbols.FSharpType] get_Types()
-FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] LongId
-FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_LongId()
+FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] LongId
+FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_LongId()
 FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] Range
 FSharp.Compiler.Symbols.FSharpOpenDeclaration: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_Range()
 FSharp.Compiler.Symbols.FSharpParameter
@@ -5407,27 +5407,20 @@ FSharp.Compiler.Syntax.ExprAtomicFlag
 FSharp.Compiler.Syntax.ExprAtomicFlag: FSharp.Compiler.Syntax.ExprAtomicFlag Atomic
 FSharp.Compiler.Syntax.ExprAtomicFlag: FSharp.Compiler.Syntax.ExprAtomicFlag NonAtomic
 FSharp.Compiler.Syntax.ExprAtomicFlag: Int32 value__
-FSharp.Compiler.Syntax.Ident
-FSharp.Compiler.Syntax.Ident: FSharp.Compiler.Text.Range get_idRange()
-FSharp.Compiler.Syntax.Ident: FSharp.Compiler.Text.Range idRange
-FSharp.Compiler.Syntax.Ident: System.String ToString()
-FSharp.Compiler.Syntax.Ident: System.String get_idText()
-FSharp.Compiler.Syntax.Ident: System.String idText
-FSharp.Compiler.Syntax.Ident: Void .ctor(System.String, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.LongIdentWithDots
 FSharp.Compiler.Syntax.LongIdentWithDots: Boolean ThereIsAnExtraDotAtTheEnd
 FSharp.Compiler.Syntax.LongIdentWithDots: Boolean get_ThereIsAnExtraDotAtTheEnd()
-FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Syntax.LongIdentWithDots NewLongIdentWithDots(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Syntax.LongIdentWithDots NewLongIdentWithDots(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
 FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range RangeWithoutAnyExtraDot
 FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range get_RangeWithoutAnyExtraDot()
 FSharp.Compiler.Syntax.LongIdentWithDots: Int32 Tag
 FSharp.Compiler.Syntax.LongIdentWithDots: Int32 get_Tag()
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] Lid
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_Lid()
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_id()
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] id
+FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] Lid
+FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_Lid()
+FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_id()
+FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] id
 FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] dotRanges
 FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_dotRanges()
 FSharp.Compiler.Syntax.LongIdentWithDots: System.String ToString()
@@ -5495,10 +5488,10 @@ FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
-FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
+FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl] decls
 FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl] get_decls()
 FSharp.Compiler.Syntax.ParsedImplFileFragment+Tags: Int32 AnonModule
@@ -5512,7 +5505,7 @@ FSharp.Compiler.Syntax.ParsedImplFileFragment: Boolean get_IsNamedModule()
 FSharp.Compiler.Syntax.ParsedImplFileFragment: Boolean get_IsNamespaceFragment()
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment NewAnonModule(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment NewNamedModule(FSharp.Compiler.Syntax.SynModuleOrNamespace)
-FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment NewNamespaceFragment(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment NewNamespaceFragment(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment+AnonModule
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment+NamedModule
 FSharp.Compiler.Syntax.ParsedImplFileFragment: FSharp.Compiler.Syntax.ParsedImplFileFragment+NamespaceFragment
@@ -5611,10 +5604,10 @@ FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
-FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
+FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl] decls
 FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl] get_decls()
 FSharp.Compiler.Syntax.ParsedSigFileFragment+Tags: Int32 AnonModule
@@ -5628,7 +5621,7 @@ FSharp.Compiler.Syntax.ParsedSigFileFragment: Boolean get_IsNamedModule()
 FSharp.Compiler.Syntax.ParsedSigFileFragment: Boolean get_IsNamespaceFragment()
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment NewAnonModule(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment NewNamedModule(FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
-FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment NewNamespaceFragment(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment NewNamespaceFragment(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment+AnonModule
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment+NamedModule
 FSharp.Compiler.Syntax.ParsedSigFileFragment: FSharp.Compiler.Syntax.ParsedSigFileFragment+NamespaceFragment
@@ -5719,11 +5712,11 @@ FSharp.Compiler.Syntax.PropertyKeyword: Int32 Tag
 FSharp.Compiler.Syntax.PropertyKeyword: Int32 get_Tag()
 FSharp.Compiler.Syntax.PropertyKeyword: System.String ToString()
 FSharp.Compiler.Syntax.QualifiedNameOfFile
-FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.Ident Id
-FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.Ident Item
-FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.Ident get_Id()
-FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.Ident get_Item()
-FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.QualifiedNameOfFile NewQualifiedNameOfFile(FSharp.Compiler.Syntax.Ident)
+FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.QualifiedNameOfFile NewQualifiedNameOfFile(FSharp.Compiler.Syntax.SynIdentOrOperatorName)
+FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.SynIdentOrOperatorName Id
+FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.SynIdentOrOperatorName Item
+FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_Id()
+FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_Item()
 FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.QualifiedNameOfFile: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.QualifiedNameOfFile: Int32 Tag
@@ -5791,23 +5784,23 @@ FSharp.Compiler.Syntax.SynAccess: System.String ToString()
 FSharp.Compiler.Syntax.SynArgInfo
 FSharp.Compiler.Syntax.SynArgInfo: Boolean get_optional()
 FSharp.Compiler.Syntax.SynArgInfo: Boolean optional
-FSharp.Compiler.Syntax.SynArgInfo: FSharp.Compiler.Syntax.SynArgInfo NewSynArgInfo(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident])
+FSharp.Compiler.Syntax.SynArgInfo: FSharp.Compiler.Syntax.SynArgInfo NewSynArgInfo(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName])
 FSharp.Compiler.Syntax.SynArgInfo: Int32 Tag
 FSharp.Compiler.Syntax.SynArgInfo: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] Attributes
 FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_Attributes()
 FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
-FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] Ident
-FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_Ident()
-FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_ident()
-FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] ident
+FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] Ident
+FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_Ident()
+FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_ident()
+FSharp.Compiler.Syntax.SynArgInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] ident
 FSharp.Compiler.Syntax.SynArgInfo: System.String ToString()
 FSharp.Compiler.Syntax.SynArgPats
 FSharp.Compiler.Syntax.SynArgPats+NamePatPairs: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynArgPats+NamePatPairs: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynArgPats+NamePatPairs: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.Ident,FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]] get_pats()
-FSharp.Compiler.Syntax.SynArgPats+NamePatPairs: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.Ident,FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]] pats
+FSharp.Compiler.Syntax.SynArgPats+NamePatPairs: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynIdentOrOperatorName,FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]] get_pats()
+FSharp.Compiler.Syntax.SynArgPats+NamePatPairs: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynIdentOrOperatorName,FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]] pats
 FSharp.Compiler.Syntax.SynArgPats+Pats: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynPat] get_pats()
 FSharp.Compiler.Syntax.SynArgPats+Pats: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynPat] pats
 FSharp.Compiler.Syntax.SynArgPats+Tags: Int32 NamePatPairs
@@ -5816,7 +5809,7 @@ FSharp.Compiler.Syntax.SynArgPats: Boolean IsNamePatPairs
 FSharp.Compiler.Syntax.SynArgPats: Boolean IsPats
 FSharp.Compiler.Syntax.SynArgPats: Boolean get_IsNamePatPairs()
 FSharp.Compiler.Syntax.SynArgPats: Boolean get_IsPats()
-FSharp.Compiler.Syntax.SynArgPats: FSharp.Compiler.Syntax.SynArgPats NewNamePatPairs(Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.Ident,FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynArgPats: FSharp.Compiler.Syntax.SynArgPats NewNamePatPairs(Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynIdentOrOperatorName,FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynArgPats: FSharp.Compiler.Syntax.SynArgPats NewPats(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynPat])
 FSharp.Compiler.Syntax.SynArgPats: FSharp.Compiler.Syntax.SynArgPats+NamePatPairs
 FSharp.Compiler.Syntax.SynArgPats: FSharp.Compiler.Syntax.SynArgPats+Pats
@@ -5835,10 +5828,10 @@ FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.SynExpr ArgExpr
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.SynExpr get_ArgExpr()
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Text.Range get_Range()
-FSharp.Compiler.Syntax.SynAttribute: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] Target
-FSharp.Compiler.Syntax.SynAttribute: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_Target()
+FSharp.Compiler.Syntax.SynAttribute: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] Target
+FSharp.Compiler.Syntax.SynAttribute: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_Target()
 FSharp.Compiler.Syntax.SynAttribute: System.String ToString()
-FSharp.Compiler.Syntax.SynAttribute: Void .ctor(FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynAttribute: Void .ctor(FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynAttributeList
 FSharp.Compiler.Syntax.SynAttributeList: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynAttributeList: FSharp.Compiler.Text.Range get_Range()
@@ -5948,7 +5941,7 @@ FSharp.Compiler.Syntax.SynByteStringKind: System.String ToString()
 FSharp.Compiler.Syntax.SynComponentInfo
 FSharp.Compiler.Syntax.SynComponentInfo: Boolean get_preferPostfix()
 FSharp.Compiler.Syntax.SynComponentInfo: Boolean preferPostfix
-FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Syntax.SynComponentInfo NewSynComponentInfo(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTyparDecls], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Xml.PreXmlDoc, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Syntax.SynComponentInfo NewSynComponentInfo(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTyparDecls], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Xml.PreXmlDoc, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Text.Range get_range()
@@ -5957,10 +5950,10 @@ FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Xml.PreXmlDoc get_xmlDo
 FSharp.Compiler.Syntax.SynComponentInfo: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynComponentInfo: Int32 Tag
 FSharp.Compiler.Syntax.SynComponentInfo: Int32 get_Tag()
-FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
+FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] constraints
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint] get_constraints()
 FSharp.Compiler.Syntax.SynComponentInfo: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
@@ -6145,11 +6138,11 @@ FSharp.Compiler.Syntax.SynConst: Int32 Tag
 FSharp.Compiler.Syntax.SynConst: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynConst: System.String ToString()
 FSharp.Compiler.Syntax.SynEnumCase
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.Ident ident
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynConst get_value()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynConst value
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynEnumCase NewSynEnumCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range, FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia)
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynEnumCase NewSynEnumCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynIdentOrOperatorName, FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range, FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia)
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia get_trivia()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia trivia
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range Range
@@ -6181,7 +6174,7 @@ FSharp.Compiler.Syntax.SynExceptionDefn: Microsoft.FSharp.Core.FSharpOption`1[FS
 FSharp.Compiler.Syntax.SynExceptionDefn: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] withKeyword
 FSharp.Compiler.Syntax.SynExceptionDefn: System.String ToString()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr
-FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynExceptionDefnRepr NewSynExceptionDefnRepr(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynUnionCase, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident]], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynExceptionDefnRepr NewSynExceptionDefnRepr(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynUnionCase, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynUnionCase caseName
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Syntax.SynUnionCase get_caseName()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: FSharp.Compiler.Text.Range Range
@@ -6196,8 +6189,8 @@ FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Collections.FSharp
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
-FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident]] get_longId()
-FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident]] longId
+FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]] get_longId()
+FSharp.Compiler.Syntax.SynExceptionDefnRepr: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]] longId
 FSharp.Compiler.Syntax.SynExceptionDefnRepr: System.String ToString()
 FSharp.Compiler.Syntax.SynExceptionSig
 FSharp.Compiler.Syntax.SynExceptionSig: FSharp.Compiler.Syntax.SynExceptionDefnRepr exnRepr
@@ -6225,8 +6218,8 @@ FSharp.Compiler.Syntax.SynExpr+AnonRecd: Boolean get_isStruct()
 FSharp.Compiler.Syntax.SynExpr+AnonRecd: Boolean isStruct
 FSharp.Compiler.Syntax.SynExpr+AnonRecd: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+AnonRecd: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]] get_recordFields()
-FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]] recordFields
+FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynIdentOrOperatorName,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]] get_recordFields()
+FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynIdentOrOperatorName,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]] recordFields
 FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]] copyInfo
 FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]] get_copyInfo()
 FSharp.Compiler.Syntax.SynExpr+App: Boolean get_isInfix()
@@ -6349,14 +6342,14 @@ FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.DebugPointAtFor forDe
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.DebugPointAtFor get_forDebugPoint()
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.DebugPointAtInOrTo get_toDebugPoint()
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.DebugPointAtInOrTo toDebugPoint
-FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.Ident ident
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.SynExpr doBody
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.SynExpr get_doBody()
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.SynExpr get_identBody()
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.SynExpr get_toBody()
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.SynExpr identBody
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.SynExpr toBody
+FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+For: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+For: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] equalsRange
@@ -6381,8 +6374,8 @@ FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Syntax.SynExpr ex
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+Ident: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynExpr+Ident: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynExpr+IdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_identOrOperatorName()
+FSharp.Compiler.Syntax.SynExpr+IdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName identOrOperatorName
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean get_isFromErrorRecovery()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean isFromErrorRecovery
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.DebugPointAtBinding get_spIfToThen()
@@ -6509,8 +6502,8 @@ FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldGet: FSharp.Compiler.Tex
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldGet: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldGet: Int32 fieldNum
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldGet: Int32 get_fieldNum()
-FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldGet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldGet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
+FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldGet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldGet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: FSharp.Compiler.Syntax.SynExpr get_rhsExpr()
@@ -6519,8 +6512,8 @@ FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: FSharp.Compiler.Tex
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Int32 fieldNum
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Int32 get_fieldNum()
-FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
+FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Boolean get_isOptional()
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Boolean isOptional
 FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
@@ -6597,8 +6590,8 @@ FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Collections.FSharpList`
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn] members
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_withKeyword()
 FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] withKeyword
-FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]] argOptions
-FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]] get_argOptions()
+FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]]] argOptions
+FSharp.Compiler.Syntax.SynExpr+ObjExpr: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]]] get_argOptions()
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+Paren: FSharp.Compiler.Text.Range get_leftParenRange()
@@ -6674,7 +6667,7 @@ FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Fixed
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 For
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 ForEach
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 FromParseError
-FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Ident
+FSharp.Compiler.Syntax.SynExpr+Tags: Int32 IdentOrOperatorName
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 IfThenElse
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 ImplicitZero
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 IndexFromEnd
@@ -6833,7 +6826,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean IsFixed
 FSharp.Compiler.Syntax.SynExpr: Boolean IsFor
 FSharp.Compiler.Syntax.SynExpr: Boolean IsForEach
 FSharp.Compiler.Syntax.SynExpr: Boolean IsFromParseError
-FSharp.Compiler.Syntax.SynExpr: Boolean IsIdent
+FSharp.Compiler.Syntax.SynExpr: Boolean IsIdentOrOperatorName
 FSharp.Compiler.Syntax.SynExpr: Boolean IsIfThenElse
 FSharp.Compiler.Syntax.SynExpr: Boolean IsImplicitZero
 FSharp.Compiler.Syntax.SynExpr: Boolean IsIndexFromEnd
@@ -6900,7 +6893,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean get_IsFixed()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsFor()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsForEach()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsFromParseError()
-FSharp.Compiler.Syntax.SynExpr: Boolean get_IsIdent()
+FSharp.Compiler.Syntax.SynExpr: Boolean get_IsIdentOrOperatorName()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsIfThenElse()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsImplicitZero()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsIndexFromEnd()
@@ -6944,7 +6937,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean get_IsWhile()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsYieldOrReturn()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsYieldOrReturnFrom()
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewAddressOf(Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewAnonRecd(Boolean, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewAnonRecd(Boolean, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynIdentOrOperatorName,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewApp(FSharp.Compiler.Syntax.ExprAtomicFlag, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewArbitraryAfterError(System.String, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewArrayOrList(Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Text.Range)
@@ -6963,10 +6956,10 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotNamedIndexe
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDowncast(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFixed(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFor(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFor(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.SynIdentOrOperatorName, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewForEach(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.SeqExprOnly, Boolean, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFromParseError(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIdent(FSharp.Compiler.Syntax.Ident)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIdentOrOperatorName(FSharp.Compiler.Syntax.SynIdentOrOperatorName)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIfThenElse(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Syntax.DebugPointAtBinding, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprIfThenElseTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewImplicitZero(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIndexFromEnd(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
@@ -6981,8 +6974,8 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLetOrUse(Boole
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLetOrUseBang(FSharp.Compiler.Syntax.DebugPointAtBinding, Boolean, Boolean, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExprAndBang], FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyILAssembly(System.Object, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyStaticOptimization(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynStaticOptimizationConstraint], FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyUnionCaseFieldGet(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Int32, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyUnionCaseFieldSet(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Int32, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyUnionCaseFieldGet(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Int32, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyUnionCaseFieldSet(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Int32, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdent(Boolean, FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdentSet(FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewMatch(FSharp.Compiler.Syntax.DebugPointAtBinding, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprMatchTrivia)
@@ -6991,7 +6984,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewMatchLambda(Bo
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNamedIndexedPropertySet(FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNew(Boolean, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNull(FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewObjExpr(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynInterfaceImpl], FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewObjExpr(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]]], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynInterfaceImpl], FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewParen(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewQuote(FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewRecord(Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]],FSharp.Compiler.Text.Range]], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExprRecordField], FSharp.Compiler.Text.Range)
@@ -7032,7 +7025,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Fixed
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+For
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+ForEach
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+FromParseError
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Ident
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+IdentOrOperatorName
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+IfThenElse
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+ImplicitZero
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+IndexFromEnd
@@ -7122,7 +7115,7 @@ FSharp.Compiler.Syntax.SynField: Boolean get_isMutable()
 FSharp.Compiler.Syntax.SynField: Boolean get_isStatic()
 FSharp.Compiler.Syntax.SynField: Boolean isMutable
 FSharp.Compiler.Syntax.SynField: Boolean isStatic
-FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynField NewSynField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Syntax.SynType, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynField NewSynField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Syntax.SynType, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynType fieldType
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynType get_fieldType()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range get_range()
@@ -7133,11 +7126,68 @@ FSharp.Compiler.Syntax.SynField: Int32 Tag
 FSharp.Compiler.Syntax.SynField: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
-FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_idOpt()
-FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] idOpt
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
+FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_idOpt()
+FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] idOpt
 FSharp.Compiler.Syntax.SynField: System.String ToString()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern: FSharp.Compiler.Text.Range get_lpr()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern: FSharp.Compiler.Text.Range get_rpr()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern: FSharp.Compiler.Text.Range get_textRange()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern: FSharp.Compiler.Text.Range lpr
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern: FSharp.Compiler.Text.Range textRange
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern: System.String get_text()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern: System.String text
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Ident: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Ident: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Ident: System.String get_text()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Ident: System.String text
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator: FSharp.Compiler.Text.Range get_textRange()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator: FSharp.Compiler.Text.Range textRange
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_lpr()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_rpr()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] lpr
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] rpr
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator: System.String get_text()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator: System.String text
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern: FSharp.Compiler.Text.Range get_lpr()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern: FSharp.Compiler.Text.Range get_rpr()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern: FSharp.Compiler.Text.Range get_textRange()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern: FSharp.Compiler.Text.Range lpr
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern: FSharp.Compiler.Text.Range textRange
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern: System.String get_text()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern: System.String text
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Tags: Int32 ActivePattern
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Tags: Int32 Ident
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Tags: Int32 Operator
+FSharp.Compiler.Syntax.SynIdentOrOperatorName+Tags: Int32 PartialActivePattern
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Boolean IsActivePattern
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Boolean IsIdent
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Boolean IsOperator
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Boolean IsPartialActivePattern
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Boolean get_IsActivePattern()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Boolean get_IsIdent()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Boolean get_IsOperator()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Boolean get_IsPartialActivePattern()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName NewActivePattern(FSharp.Compiler.Text.Range, System.String, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName NewIdent(System.String, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName NewOperator(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], System.String, FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName NewPartialActivePattern(FSharp.Compiler.Text.Range, System.String, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName+ActivePattern
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName+Ident
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName+Operator
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName+PartialActivePattern
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Syntax.SynIdentOrOperatorName+Tags
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Int32 Tag
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: Int32 get_Tag()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: System.String ToString()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: System.String get_idText()
+FSharp.Compiler.Syntax.SynIdentOrOperatorName: System.String idText
 FSharp.Compiler.Syntax.SynInterfaceImpl
 FSharp.Compiler.Syntax.SynInterfaceImpl: FSharp.Compiler.Syntax.SynInterfaceImpl NewSynInterfaceImpl(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynInterfaceImpl: FSharp.Compiler.Syntax.SynType get_interfaceTy()
@@ -7156,8 +7206,8 @@ FSharp.Compiler.Syntax.SynInterfaceImpl: System.String ToString()
 FSharp.Compiler.Syntax.SynInterpolatedStringPart
 FSharp.Compiler.Syntax.SynInterpolatedStringPart+FillExpr: FSharp.Compiler.Syntax.SynExpr fillExpr
 FSharp.Compiler.Syntax.SynInterpolatedStringPart+FillExpr: FSharp.Compiler.Syntax.SynExpr get_fillExpr()
-FSharp.Compiler.Syntax.SynInterpolatedStringPart+FillExpr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_qualifiers()
-FSharp.Compiler.Syntax.SynInterpolatedStringPart+FillExpr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] qualifiers
+FSharp.Compiler.Syntax.SynInterpolatedStringPart+FillExpr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_qualifiers()
+FSharp.Compiler.Syntax.SynInterpolatedStringPart+FillExpr: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] qualifiers
 FSharp.Compiler.Syntax.SynInterpolatedStringPart+String: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynInterpolatedStringPart+String: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynInterpolatedStringPart+String: System.String get_value()
@@ -7168,7 +7218,7 @@ FSharp.Compiler.Syntax.SynInterpolatedStringPart: Boolean IsFillExpr
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: Boolean IsString
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: Boolean get_IsFillExpr()
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: Boolean get_IsString()
-FSharp.Compiler.Syntax.SynInterpolatedStringPart: FSharp.Compiler.Syntax.SynInterpolatedStringPart NewFillExpr(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident])
+FSharp.Compiler.Syntax.SynInterpolatedStringPart: FSharp.Compiler.Syntax.SynInterpolatedStringPart NewFillExpr(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName])
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: FSharp.Compiler.Syntax.SynInterpolatedStringPart NewString(System.String, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: FSharp.Compiler.Syntax.SynInterpolatedStringPart+FillExpr
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: FSharp.Compiler.Syntax.SynInterpolatedStringPart+String
@@ -7208,8 +7258,8 @@ FSharp.Compiler.Syntax.SynMeasure+Divide: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynMeasure+Divide: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynMeasure+Named: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynMeasure+Named: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynMeasure+Named: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynMeasure+Named: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
+FSharp.Compiler.Syntax.SynMeasure+Named: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynMeasure+Named: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynMeasure+Power: FSharp.Compiler.Syntax.SynMeasure get_measure()
 FSharp.Compiler.Syntax.SynMeasure+Power: FSharp.Compiler.Syntax.SynMeasure measure
 FSharp.Compiler.Syntax.SynMeasure+Power: FSharp.Compiler.Syntax.SynRationalConst get_power()
@@ -7256,7 +7306,7 @@ FSharp.Compiler.Syntax.SynMeasure: Boolean get_IsSeq()
 FSharp.Compiler.Syntax.SynMeasure: Boolean get_IsVar()
 FSharp.Compiler.Syntax.SynMeasure: FSharp.Compiler.Syntax.SynMeasure NewAnon(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMeasure: FSharp.Compiler.Syntax.SynMeasure NewDivide(FSharp.Compiler.Syntax.SynMeasure, FSharp.Compiler.Syntax.SynMeasure, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMeasure: FSharp.Compiler.Syntax.SynMeasure NewNamed(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMeasure: FSharp.Compiler.Syntax.SynMeasure NewNamed(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMeasure: FSharp.Compiler.Syntax.SynMeasure NewPower(FSharp.Compiler.Syntax.SynMeasure, FSharp.Compiler.Syntax.SynRationalConst, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMeasure: FSharp.Compiler.Syntax.SynMeasure NewProduct(FSharp.Compiler.Syntax.SynMeasure, FSharp.Compiler.Syntax.SynMeasure, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMeasure: FSharp.Compiler.Syntax.SynMeasure NewSeq(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMeasure], FSharp.Compiler.Text.Range)
@@ -7283,10 +7333,10 @@ FSharp.Compiler.Syntax.SynMemberDefn+AbstractSlot: FSharp.Compiler.Text.Range ge
 FSharp.Compiler.Syntax.SynMemberDefn+AbstractSlot: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Boolean get_isStatic()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: Boolean isStatic
-FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.Ident ident
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynExpr get_synExpr()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynExpr synExpr
+FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynMemberKind get_propKind()
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Syntax.SynMemberKind propKind
 FSharp.Compiler.Syntax.SynMemberDefn+AutoProperty: FSharp.Compiler.Text.Range equalsRange
@@ -7315,24 +7365,24 @@ FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Xml.PreXmlDoc
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
-FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_selfIdentifier()
-FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] selfIdentifier
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
+FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_selfIdentifier()
+FSharp.Compiler.Syntax.SynMemberDefn+ImplicitCtor: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] selfIdentifier
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: FSharp.Compiler.Syntax.SynExpr get_inheritArgs()
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: FSharp.Compiler.Syntax.SynExpr inheritArgs
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: FSharp.Compiler.Syntax.SynType get_inheritType()
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: FSharp.Compiler.Syntax.SynType inheritType
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_inheritAlias()
-FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] inheritAlias
+FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_inheritAlias()
+FSharp.Compiler.Syntax.SynMemberDefn+ImplicitInherit: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] inheritAlias
 FSharp.Compiler.Syntax.SynMemberDefn+Inherit: FSharp.Compiler.Syntax.SynType baseType
 FSharp.Compiler.Syntax.SynMemberDefn+Inherit: FSharp.Compiler.Syntax.SynType get_baseType()
 FSharp.Compiler.Syntax.SynMemberDefn+Inherit: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynMemberDefn+Inherit: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynMemberDefn+Inherit: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] asIdent
-FSharp.Compiler.Syntax.SynMemberDefn+Inherit: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_asIdent()
+FSharp.Compiler.Syntax.SynMemberDefn+Inherit: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] asIdent
+FSharp.Compiler.Syntax.SynMemberDefn+Inherit: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_asIdent()
 FSharp.Compiler.Syntax.SynMemberDefn+Interface: FSharp.Compiler.Syntax.SynType get_interfaceType()
 FSharp.Compiler.Syntax.SynMemberDefn+Interface: FSharp.Compiler.Syntax.SynType interfaceType
 FSharp.Compiler.Syntax.SynMemberDefn+Interface: FSharp.Compiler.Text.Range get_range()
@@ -7401,10 +7451,10 @@ FSharp.Compiler.Syntax.SynMemberDefn: Boolean get_IsNestedType()
 FSharp.Compiler.Syntax.SynMemberDefn: Boolean get_IsOpen()
 FSharp.Compiler.Syntax.SynMemberDefn: Boolean get_IsValField()
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewAbstractSlot(FSharp.Compiler.Syntax.SynValSig, FSharp.Compiler.Syntax.SynMemberFlags, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewAutoProperty(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynType], FSharp.Compiler.Syntax.SynMemberKind, Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynMemberKind,FSharp.Compiler.Syntax.SynMemberFlags], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitCtor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynSimplePats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitInherit(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInherit(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewAutoProperty(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Boolean, FSharp.Compiler.Syntax.SynIdentOrOperatorName, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynType], FSharp.Compiler.Syntax.SynMemberKind, Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynMemberKind,FSharp.Compiler.Syntax.SynMemberFlags], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitCtor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynSimplePats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitInherit(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInherit(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInterface(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewLetBindings(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Boolean, Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewMember(FSharp.Compiler.Syntax.SynBinding, FSharp.Compiler.Text.Range)
@@ -7562,12 +7612,12 @@ FSharp.Compiler.Syntax.SynModuleDecl+Let: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynModuleDecl+Let: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynModuleDecl+Let: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding] bindings
 FSharp.Compiler.Syntax.SynModuleDecl+Let: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding] get_bindings()
-FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
+FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynModuleDecl+ModuleAbbrev: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynModuleDecl+NamespaceFragment: FSharp.Compiler.Syntax.SynModuleOrNamespace fragment
 FSharp.Compiler.Syntax.SynModuleDecl+NamespaceFragment: FSharp.Compiler.Syntax.SynModuleOrNamespace get_fragment()
 FSharp.Compiler.Syntax.SynModuleDecl+NestedModule: Boolean get_isContinuing()
@@ -7625,7 +7675,7 @@ FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewEx
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewExpr(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewHashDirective(FSharp.Compiler.Syntax.ParsedHashDirective, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewLet(Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewModuleAbbrev(FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewModuleAbbrev(FSharp.Compiler.Syntax.SynIdentOrOperatorName, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewNamespaceFragment(FSharp.Compiler.Syntax.SynModuleOrNamespace)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewNestedModule(FSharp.Compiler.Syntax.SynComponentInfo, Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynModuleDeclNestedModuleTrivia)
 FSharp.Compiler.Syntax.SynModuleDecl: FSharp.Compiler.Syntax.SynModuleDecl NewOpen(FSharp.Compiler.Syntax.SynOpenDeclTarget, FSharp.Compiler.Text.Range)
@@ -7649,7 +7699,7 @@ FSharp.Compiler.Syntax.SynModuleDecl: System.String ToString()
 FSharp.Compiler.Syntax.SynModuleOrNamespace
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Boolean get_isRecursive()
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Boolean isRecursive
-FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace NewSynModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace NewSynModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind get_kind()
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind kind
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Text.Range Range
@@ -7660,10 +7710,10 @@ FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Xml.PreXmlDoc get_x
 FSharp.Compiler.Syntax.SynModuleOrNamespace: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Int32 Tag
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Int32 get_Tag()
-FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attribs
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attribs()
+FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl] decls
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleDecl] get_decls()
 FSharp.Compiler.Syntax.SynModuleOrNamespace: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
@@ -7709,7 +7759,7 @@ FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Boolean get_isRecursive()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Boolean isRecursive
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind get_kind()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceKind kind
-FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig NewSynModuleOrNamespaceSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig NewSynModuleOrNamespaceSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Boolean, FSharp.Compiler.Syntax.SynModuleOrNamespaceKind, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Text.Range get_range()
@@ -7718,10 +7768,10 @@ FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Xml.PreXmlDoc ge
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: FSharp.Compiler.Xml.PreXmlDoc xmlDoc
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Int32 Tag
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Int32 get_Tag()
-FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attribs
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attribs()
+FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl] decls
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl] get_decls()
 FSharp.Compiler.Syntax.SynModuleOrNamespaceSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
@@ -7736,12 +7786,12 @@ FSharp.Compiler.Syntax.SynModuleSigDecl+HashDirective: FSharp.Compiler.Syntax.Pa
 FSharp.Compiler.Syntax.SynModuleSigDecl+HashDirective: FSharp.Compiler.Syntax.ParsedHashDirective hashDirective
 FSharp.Compiler.Syntax.SynModuleSigDecl+HashDirective: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynModuleSigDecl+HashDirective: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
+FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynModuleSigDecl+ModuleAbbrev: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynModuleSigDecl+NamespaceFragment: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig Item
 FSharp.Compiler.Syntax.SynModuleSigDecl+NamespaceFragment: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig get_Item()
 FSharp.Compiler.Syntax.SynModuleSigDecl+NestedModule: Boolean get_isRecursive()
@@ -7792,7 +7842,7 @@ FSharp.Compiler.Syntax.SynModuleSigDecl: Boolean get_IsTypes()
 FSharp.Compiler.Syntax.SynModuleSigDecl: Boolean get_IsVal()
 FSharp.Compiler.Syntax.SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl NewException(FSharp.Compiler.Syntax.SynExceptionSig, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl NewHashDirective(FSharp.Compiler.Syntax.ParsedHashDirective, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl NewModuleAbbrev(FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl NewModuleAbbrev(FSharp.Compiler.Syntax.SynIdentOrOperatorName, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl NewNamespaceFragment(FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
 FSharp.Compiler.Syntax.SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl NewNestedModule(FSharp.Compiler.Syntax.SynComponentInfo, Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynModuleSigDecl], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynModuleSigDeclNestedModuleTrivia)
 FSharp.Compiler.Syntax.SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl NewOpen(FSharp.Compiler.Syntax.SynOpenDeclTarget, FSharp.Compiler.Text.Range)
@@ -7815,8 +7865,8 @@ FSharp.Compiler.Syntax.SynModuleSigDecl: System.String ToString()
 FSharp.Compiler.Syntax.SynOpenDeclTarget
 FSharp.Compiler.Syntax.SynOpenDeclTarget+ModuleOrNamespace: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynOpenDeclTarget+ModuleOrNamespace: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynOpenDeclTarget+ModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_longId()
-FSharp.Compiler.Syntax.SynOpenDeclTarget+ModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
+FSharp.Compiler.Syntax.SynOpenDeclTarget+ModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_longId()
+FSharp.Compiler.Syntax.SynOpenDeclTarget+ModuleOrNamespace: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] longId
 FSharp.Compiler.Syntax.SynOpenDeclTarget+Tags: Int32 ModuleOrNamespace
 FSharp.Compiler.Syntax.SynOpenDeclTarget+Tags: Int32 Type
 FSharp.Compiler.Syntax.SynOpenDeclTarget+Type: FSharp.Compiler.Syntax.SynType get_typeName()
@@ -7827,7 +7877,7 @@ FSharp.Compiler.Syntax.SynOpenDeclTarget: Boolean IsModuleOrNamespace
 FSharp.Compiler.Syntax.SynOpenDeclTarget: Boolean IsType
 FSharp.Compiler.Syntax.SynOpenDeclTarget: Boolean get_IsModuleOrNamespace()
 FSharp.Compiler.Syntax.SynOpenDeclTarget: Boolean get_IsType()
-FSharp.Compiler.Syntax.SynOpenDeclTarget: FSharp.Compiler.Syntax.SynOpenDeclTarget NewModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynOpenDeclTarget: FSharp.Compiler.Syntax.SynOpenDeclTarget NewModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynOpenDeclTarget: FSharp.Compiler.Syntax.SynOpenDeclTarget NewType(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynOpenDeclTarget: FSharp.Compiler.Syntax.SynOpenDeclTarget+ModuleOrNamespace
 FSharp.Compiler.Syntax.SynOpenDeclTarget: FSharp.Compiler.Syntax.SynOpenDeclTarget+Tags
@@ -7874,16 +7924,16 @@ FSharp.Compiler.Syntax.SynPat+FromParseError: FSharp.Compiler.Syntax.SynPat get_
 FSharp.Compiler.Syntax.SynPat+FromParseError: FSharp.Compiler.Syntax.SynPat pat
 FSharp.Compiler.Syntax.SynPat+FromParseError: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+FromParseError: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.Ident get_memberId()
-FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.Ident get_thisId()
-FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.Ident memberId
-FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.Ident thisId
+FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_memberId()
+FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_thisId()
+FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.SynIdentOrOperatorName memberId
+FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.SynIdentOrOperatorName thisId
 FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+InstanceMember: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_toolingId()
-FSharp.Compiler.Syntax.SynPat+InstanceMember: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] toolingId
 FSharp.Compiler.Syntax.SynPat+InstanceMember: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynPat+InstanceMember: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
+FSharp.Compiler.Syntax.SynPat+InstanceMember: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_toolingId()
+FSharp.Compiler.Syntax.SynPat+InstanceMember: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] toolingId
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType get_pat()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType pat
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range get_range()
@@ -7894,26 +7944,26 @@ FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynArgPats argPa
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynArgPats get_argPats()
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] extraId
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_extraId()
 FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword] get_propertyKeyword()
 FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword] propertyKeyword
 FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
+FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] extraId
+FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_extraId()
 FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls] get_typarDecls()
 FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls] typarDecls
 FSharp.Compiler.Syntax.SynPat+Named: Boolean get_isThisVal()
 FSharp.Compiler.Syntax.SynPat+Named: Boolean isThisVal
-FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynPat+Named: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynPat+Named: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
 FSharp.Compiler.Syntax.SynPat+Null: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+Null: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+OptionalVal: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynPat+OptionalVal: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynPat+OptionalVal: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynPat+OptionalVal: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynPat+OptionalVal: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+OptionalVal: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.Syntax.SynPat get_lhsPat()
@@ -7934,8 +7984,8 @@ FSharp.Compiler.Syntax.SynPat+QuoteExpr: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+QuoteExpr: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynPat+Record: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+Record: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+Record: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]] fieldPats
-FSharp.Compiler.Syntax.SynPat+Record: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]] get_fieldPats()
+FSharp.Compiler.Syntax.SynPat+Record: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName],FSharp.Compiler.Syntax.SynIdentOrOperatorName],FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]] fieldPats
+FSharp.Compiler.Syntax.SynPat+Record: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName],FSharp.Compiler.Syntax.SynIdentOrOperatorName],FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]] get_fieldPats()
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Ands
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 ArrayOrList
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 As
@@ -8017,16 +8067,16 @@ FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewAttrib(FSharp.Co
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewConst(FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewDeprecatedCharRange(Char, Char, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewFromParseError(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewInstanceMember(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewInstanceMember(FSharp.Compiler.Syntax.SynIdentOrOperatorName, FSharp.Compiler.Syntax.SynIdentOrOperatorName, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewIsInst(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNamed(FSharp.Compiler.Syntax.Ident, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNamed(FSharp.Compiler.Syntax.SynIdentOrOperatorName, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNull(FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOptionalVal(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOptionalVal(FSharp.Compiler.Syntax.SynIdentOrOperatorName, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOr(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewParen(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewQuoteExpr(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewRecord(Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewRecord(Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName],FSharp.Compiler.Syntax.SynIdentOrOperatorName],FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewTuple(Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynPat], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewTyped(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewWild(FSharp.Compiler.Text.Range)
@@ -8108,8 +8158,8 @@ FSharp.Compiler.Syntax.SynSimplePat+Id: Boolean get_isThisVal()
 FSharp.Compiler.Syntax.SynSimplePat+Id: Boolean isCompilerGenerated
 FSharp.Compiler.Syntax.SynSimplePat+Id: Boolean isOptional
 FSharp.Compiler.Syntax.SynSimplePat+Id: Boolean isThisVal
-FSharp.Compiler.Syntax.SynSimplePat+Id: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynSimplePat+Id: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynSimplePat+Id: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynSimplePat+Id: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynSimplePat+Id: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynSimplePat+Id: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynSimplePat+Id: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]] altNameRefCell
@@ -8130,7 +8180,7 @@ FSharp.Compiler.Syntax.SynSimplePat: Boolean get_IsAttrib()
 FSharp.Compiler.Syntax.SynSimplePat: Boolean get_IsId()
 FSharp.Compiler.Syntax.SynSimplePat: Boolean get_IsTyped()
 FSharp.Compiler.Syntax.SynSimplePat: FSharp.Compiler.Syntax.SynSimplePat NewAttrib(FSharp.Compiler.Syntax.SynSimplePat, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynSimplePat: FSharp.Compiler.Syntax.SynSimplePat NewId(FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]], Boolean, Boolean, Boolean, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynSimplePat: FSharp.Compiler.Syntax.SynSimplePat NewId(FSharp.Compiler.Syntax.SynIdentOrOperatorName, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]], Boolean, Boolean, Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynSimplePat: FSharp.Compiler.Syntax.SynSimplePat NewTyped(FSharp.Compiler.Syntax.SynSimplePat, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynSimplePat: FSharp.Compiler.Syntax.SynSimplePat+Attrib
 FSharp.Compiler.Syntax.SynSimplePat: FSharp.Compiler.Syntax.SynSimplePat+Id
@@ -8142,18 +8192,18 @@ FSharp.Compiler.Syntax.SynSimplePat: Int32 Tag
 FSharp.Compiler.Syntax.SynSimplePat: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynSimplePat: System.String ToString()
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo
-FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Decided: FSharp.Compiler.Syntax.Ident Item
-FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Decided: FSharp.Compiler.Syntax.Ident get_Item()
+FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Decided: FSharp.Compiler.Syntax.SynIdentOrOperatorName Item
+FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Decided: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_Item()
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Tags: Int32 Decided
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Tags: Int32 Undecided
-FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Undecided: FSharp.Compiler.Syntax.Ident Item
-FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Undecided: FSharp.Compiler.Syntax.Ident get_Item()
+FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Undecided: FSharp.Compiler.Syntax.SynIdentOrOperatorName Item
+FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Undecided: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_Item()
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: Boolean IsDecided
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: Boolean IsUndecided
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: Boolean get_IsDecided()
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: Boolean get_IsUndecided()
-FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo NewDecided(FSharp.Compiler.Syntax.Ident)
-FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo NewUndecided(FSharp.Compiler.Syntax.Ident)
+FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo NewDecided(FSharp.Compiler.Syntax.SynIdentOrOperatorName)
+FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo NewUndecided(FSharp.Compiler.Syntax.SynIdentOrOperatorName)
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Decided
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Tags
 FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo: FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo+Undecided
@@ -8243,9 +8293,9 @@ FSharp.Compiler.Syntax.SynStringKind: System.String ToString()
 FSharp.Compiler.Syntax.SynTypar
 FSharp.Compiler.Syntax.SynTypar: Boolean get_isCompGen()
 FSharp.Compiler.Syntax.SynTypar: Boolean isCompGen
-FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Syntax.Ident ident
-FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Syntax.SynTypar NewSynTypar(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.TyparStaticReq, Boolean)
+FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
+FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Syntax.SynTypar NewSynTypar(FSharp.Compiler.Syntax.SynIdentOrOperatorName, FSharp.Compiler.Syntax.TyparStaticReq, Boolean)
 FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Syntax.TyparStaticReq get_staticReq()
 FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Syntax.TyparStaticReq staticReq
 FSharp.Compiler.Syntax.SynTypar: FSharp.Compiler.Text.Range Range
@@ -8309,8 +8359,8 @@ FSharp.Compiler.Syntax.SynType+AnonRecd: Boolean get_isStruct()
 FSharp.Compiler.Syntax.SynType+AnonRecd: Boolean isStruct
 FSharp.Compiler.Syntax.SynType+AnonRecd: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+AnonRecd: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynType+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,FSharp.Compiler.Syntax.SynType]] fields
-FSharp.Compiler.Syntax.SynType+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,FSharp.Compiler.Syntax.SynType]] get_fields()
+FSharp.Compiler.Syntax.SynType+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.SynIdentOrOperatorName,FSharp.Compiler.Syntax.SynType]] fields
+FSharp.Compiler.Syntax.SynType+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.SynIdentOrOperatorName,FSharp.Compiler.Syntax.SynType]] get_fields()
 FSharp.Compiler.Syntax.SynType+App: Boolean get_isPostfix()
 FSharp.Compiler.Syntax.SynType+App: Boolean isPostfix
 FSharp.Compiler.Syntax.SynType+App: FSharp.Compiler.Syntax.SynType get_typeName()
@@ -8455,7 +8505,7 @@ FSharp.Compiler.Syntax.SynType: Boolean get_IsTuple()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsVar()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsWithGlobalConstraints()
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewAnon(FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewAnonRecd(Boolean, Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,FSharp.Compiler.Syntax.SynType]], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewAnonRecd(Boolean, Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.SynIdentOrOperatorName,FSharp.Compiler.Syntax.SynType]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewApp(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewArray(Int32, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFun(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
@@ -8801,8 +8851,8 @@ FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Collectio
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField] get_fields()
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.SynValSig,FSharp.Compiler.Syntax.SynMemberFlags]] get_slotsigs()
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.SynValSig,FSharp.Compiler.Syntax.SynMemberFlags]] slotsigs
-FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]] get_inherits()
-FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]] inherits
+FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]]] get_inherits()
+FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]]] inherits
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynSimplePats] get_implicitCtorSynPats()
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+General: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynSimplePats] implicitCtorSynPats
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr+LibraryOnlyILAssembly: FSharp.Compiler.Text.Range get_range()
@@ -8855,7 +8905,7 @@ FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: Boolean get_IsTypeAbbrev()
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: Boolean get_IsUnion()
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr NewEnum(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynEnumCase], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr NewException(FSharp.Compiler.Syntax.SynExceptionDefnRepr)
-FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr NewGeneral(FSharp.Compiler.Syntax.SynTypeDefnKind, Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.SynValSig,FSharp.Compiler.Syntax.SynMemberFlags]], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField], Boolean, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynSimplePats], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr NewGeneral(FSharp.Compiler.Syntax.SynTypeDefnKind, Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName]]], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.SynValSig,FSharp.Compiler.Syntax.SynMemberFlags]], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField], Boolean, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynSimplePats], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr NewLibraryOnlyILAssembly(System.Object, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr NewNone(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr NewRecord(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField], FSharp.Compiler.Text.Range)
@@ -8876,9 +8926,9 @@ FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: Int32 Tag
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: System.String ToString()
 FSharp.Compiler.Syntax.SynUnionCase
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.Ident ident
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCase NewSynUnionCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynUnionCaseKind, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia)
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCase NewSynUnionCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynIdentOrOperatorName, FSharp.Compiler.Syntax.SynUnionCaseKind, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia)
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCaseKind caseType
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCaseKind get_caseType()
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia get_trivia()
@@ -8918,15 +8968,15 @@ FSharp.Compiler.Syntax.SynUnionCaseKind: Int32 Tag
 FSharp.Compiler.Syntax.SynUnionCaseKind: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynUnionCaseKind: System.String ToString()
 FSharp.Compiler.Syntax.SynValData
-FSharp.Compiler.Syntax.SynValData: FSharp.Compiler.Syntax.SynValData NewSynValData(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynMemberFlags], FSharp.Compiler.Syntax.SynValInfo, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident])
+FSharp.Compiler.Syntax.SynValData: FSharp.Compiler.Syntax.SynValData NewSynValData(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynMemberFlags], FSharp.Compiler.Syntax.SynValInfo, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName])
 FSharp.Compiler.Syntax.SynValData: FSharp.Compiler.Syntax.SynValInfo SynValInfo
 FSharp.Compiler.Syntax.SynValData: FSharp.Compiler.Syntax.SynValInfo get_SynValInfo()
 FSharp.Compiler.Syntax.SynValData: FSharp.Compiler.Syntax.SynValInfo get_valInfo()
 FSharp.Compiler.Syntax.SynValData: FSharp.Compiler.Syntax.SynValInfo valInfo
 FSharp.Compiler.Syntax.SynValData: Int32 Tag
 FSharp.Compiler.Syntax.SynValData: Int32 get_Tag()
-FSharp.Compiler.Syntax.SynValData: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_thisIdOpt()
-FSharp.Compiler.Syntax.SynValData: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] thisIdOpt
+FSharp.Compiler.Syntax.SynValData: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] get_thisIdOpt()
+FSharp.Compiler.Syntax.SynValData: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynIdentOrOperatorName] thisIdOpt
 FSharp.Compiler.Syntax.SynValData: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynMemberFlags] get_memberFlags()
 FSharp.Compiler.Syntax.SynValData: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynMemberFlags] memberFlags
 FSharp.Compiler.Syntax.SynValData: System.String ToString()
@@ -8948,8 +8998,8 @@ FSharp.Compiler.Syntax.SynValSig: Boolean get_isInline()
 FSharp.Compiler.Syntax.SynValSig: Boolean get_isMutable()
 FSharp.Compiler.Syntax.SynValSig: Boolean isInline
 FSharp.Compiler.Syntax.SynValSig: Boolean isMutable
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynIdentOrOperatorName get_ident()
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynIdentOrOperatorName ident
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType SynType
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType get_SynType()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType get_synType()
@@ -8958,7 +9008,7 @@ FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo SynInfo
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo arity
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_SynInfo()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_arity()
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynIdentOrOperatorName, FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls explicitValDecls
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls get_explicitValDecls()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Text.Range RangeOfId

--- a/tests/service/InteractiveCheckerTests.fs
+++ b/tests/service/InteractiveCheckerTests.fs
@@ -51,7 +51,7 @@ let internal identsAndRanges (input: ParsedInput) =
         let xs = moduleDecls |> List.collect extractFromModuleDecl
         if longIdent.IsEmpty then xs
         else
-            (identAndRange (longIdentToString longIdent) (longIdent |> List.map (fun id -> id.idRange) |> List.reduce unionRanges)) :: xs
+            (identAndRange (longIdentToString longIdent) (longIdent |> List.map (fun id -> id.Range) |> List.reduce unionRanges)) :: xs
 
     match input with
     | ParsedInput.ImplFile(ParsedImplFileInput(modules = modulesOrNamespaces)) ->

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -144,7 +144,7 @@ match () with
 b
 """
     match getSingleModuleMemberDecls parseResults with
-    | [ SynModuleDecl.Expr (expr=(SynExpr.Match _ as m)); SynModuleDecl.Expr (expr=(SynExpr.Ident _ as i)) ] ->
+    | [ SynModuleDecl.Expr (expr=(SynExpr.Match _ as m)); SynModuleDecl.Expr (expr=(SynExpr.IdentOrOperatorName _ as i)) ] ->
         Assert.True(Position.posLt m.Range.End i.Range.Start)
     | _ -> failwith "Unexpected tree"
 

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -206,7 +206,7 @@ let ``Test project1 all symbols`` () =
            ("val pair2", "file2", (24, 10), (24, 15), ["val"]);
            ("val pair1", "file2", (24, 4), (24, 9), ["val"]);
            ("val enumValue", "file2", (31, 4), (31, 13), ["val"]);
-           ("val op_PlusPlus", "file2", (33, 5), (33, 7), ["val"]);
+           ("val op_PlusPlus", "file2", (33, 4), (33, 8), ["val"]);
            ("val c1", "file2", (35, 4), (35, 6), ["val"]);
            ("val c2", "file2", (37, 4), (37, 6), ["val"]);
            ("val mmmm1", "file2", (39, 4), (39, 9), ["val"]);
@@ -257,7 +257,7 @@ let ``Test project1 all symbols`` () =
            ("val pair2", "file2", (24, 10), (24, 15), ["val"]);
            ("val pair1", "file2", (24, 4), (24, 9), ["val"]);
            ("val enumValue", "file2", (31, 4), (31, 13), ["val"]);
-           ("val op_PlusPlus", "file2", (33, 5), (33, 7), ["val"]);
+           ("val op_PlusPlus", "file2", (33, 4), (33, 8), ["val"]);
            ("val c1", "file2", (35, 4), (35, 6), ["val"]);
            ("val c2", "file2", (37, 4), (37, 6), ["val"]);
            ("val mmmm1", "file2", (39, 4), (39, 9), ["val"]);
@@ -362,7 +362,7 @@ let ``Test project1 all uses of all signature symbols`` () =
          ("val pair1", [("file2", ((23, 4), (23, 9)))]);
          ("val enumValue", [("file2", ((30, 4), (30, 13)))]);
          ("val op_PlusPlus",
-          [("file2", ((32, 5), (32, 7))); ("file2", ((34, 11), (34, 13)));
+          [("file2", ((32, 4), (32, 8))); ("file2", ((34, 11), (34, 13)));
            ("file2", ((36, 11), (36, 13)))]);
          ("val c1", [("file2", ((34, 4), (34, 6)))]);
          ("val c2", [("file2", ((36, 4), (36, 6)))]);
@@ -527,7 +527,7 @@ let ``Test project1 all uses of all symbols`` () =
                 ((32, 17), (32, 18)), ["val"]);
                ("x", "x", "file2", ((32, 15), (32, 16)), []);
                ("y", "y", "file2", ((32, 19), (32, 20)), []);
-               ("(++)", "N.(++)", "file2", ((32, 5), (32, 7)), ["val"]);
+               ("(++)", "N.(++)", "file2", ((32, 4), (32, 8)), ["val"]);
                ("(++)", "N.(++)", "file2", ((34, 11), (34, 13)), ["val"]);
                ("c1", "N.c1", "file2", ((34, 4), (34, 6)), ["val"]);
                ("(++)", "N.(++)", "file2", ((36, 11), (36, 13)), ["val"]);

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -3815,7 +3815,7 @@ module OperatorName =
             assertRange (2, 1) (2, 2) mText
             Assert.AreEqual("op_Addition", text)
             assertRange (2, 2) (2, 3) rpr
-            assertRange (2, 0) (2, 3) operator.Range
+            assertRange (2, 1) (2, 2) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3837,7 +3837,7 @@ module OperatorName =
             assertRange (2, 1) (2, 11) mText
             Assert.AreEqual("|Odd|Even|", text)
             assertRange (2, 11) (2, 12) rpr
-            assertRange (2, 0) (2, 12) activePattern.Range
+            assertRange (2, 1) (2, 11) activePattern.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3859,7 +3859,7 @@ module OperatorName =
             Assert.AreEqual("|Odd|_|", text)
             assertRange (2, 1) (2, 8) mText
             assertRange (2, 8) (2, 9) rpr
-            assertRange (2, 0) (2, 9) partialActivePattern.Range
+            assertRange (2, 1) (2, 8) partialActivePattern.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3880,7 +3880,7 @@ let (+) a b = a + b
             assertRange (2, 4) (2, 5) lpr
             Assert.AreEqual("op_Addition", text)
             assertRange (2, 5) (2, 6) mText
-            assertRange (2, 4) (2, 7) operator.Range
+            assertRange (2, 5) (2, 6) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3902,7 +3902,7 @@ let (|Odd|Even|) (a: int) = if a % 2 = 0 then Even else Odd
             Assert.AreEqual("|Odd|Even|", text)
             assertRange (2, 5) (2, 15) mText
             assertRange (2, 15) (2, 16) rpr
-            assertRange (2, 4) (2, 16) activePattern.Range
+            assertRange (2, 5) (2, 15) activePattern.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3924,7 +3924,7 @@ let (|Int32Const|_|) (a: SynConst) = match a with SynConst.Int32 _ -> Some a | _
             Assert.AreEqual("|Int32Const|_|", text)
             assertRange (2, 5) (2, 19) mText
             assertRange (2, 19) (2, 20) rpr
-            assertRange (2, 4) (2, 20) activePattern.Range
+            assertRange (2, 5) (2, 19) activePattern.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3947,7 +3947,7 @@ val (&): e1: bool -> e2: bool -> bool
             Assert.AreEqual("op_Amp", text)
             assertRange (3, 5) (3, 6) mText
             assertRange (3, 6) (3, 7) rpr
-            assertRange (3, 4) (3, 7) operator.Range
+            assertRange (3, 5) (3, 6) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3982,7 +3982,7 @@ val (&): e1: bool -> e2: bool -> bool
             Assert.AreEqual("op_UnaryNegation", text)
             assertRange (12, 59) (12, 61) mText
             assertRange (12, 62) (12, 63) rpr
-            assertRange (12, 57) (12, 63) operator.Range
+            assertRange (12, 59) (12, 61) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -4051,7 +4051,7 @@ op_Addition a b
             assertRange (2,0) (2,1) lpr
             Assert.AreEqual("op_Addition", text)
             assertRange (2,2) (2,3) rpr
-            assertRange (2,0) (2,3) operator.Range
+            assertRange (2,1) (2,2) operator.Range
             Assert.AreEqual("a", a1)
             Assert.AreEqual("b", b1)
 
@@ -4083,8 +4083,9 @@ type X with
             assertRange (3,12) (3,13) mDot
             assertRange (3,13) (3,14) lpr
             Assert.AreEqual("op_Addition", text)
+            assertRange (3, 14) (3, 15) mText
             assertRange (3,15) (3,16) rpr
-            assertRange (3,13) (3,16) operator.Range
+            assertRange (3, 14) (3, 15) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -4108,7 +4109,7 @@ nameof(+)
             Assert.AreEqual("op_Addition", text)
             assertRange (2,7) (2,8) mText
             assertRange (2,8) (2,9) rpr
-            assertRange (2,6) (2,9) operator.Range
+            assertRange (2,7) (2,8) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -3815,7 +3815,7 @@ module OperatorName =
             assertRange (2, 1) (2, 2) mText
             Assert.AreEqual("op_Addition", text)
             assertRange (2, 2) (2, 3) rpr
-            assertRange (2, 1) (2, 2) operator.Range
+            assertRange (2, 0) (2, 3) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3880,7 +3880,8 @@ let (+) a b = a + b
             assertRange (2, 4) (2, 5) lpr
             Assert.AreEqual("op_Addition", text)
             assertRange (2, 5) (2, 6) mText
-            assertRange (2, 5) (2, 6) operator.Range
+            assertRange (2, 6) (2, 7) rpr
+            assertRange (2, 4) (2, 7) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3947,7 +3948,7 @@ val (&): e1: bool -> e2: bool -> bool
             Assert.AreEqual("op_Amp", text)
             assertRange (3, 5) (3, 6) mText
             assertRange (3, 6) (3, 7) rpr
-            assertRange (3, 5) (3, 6) operator.Range
+            assertRange (3, 4) (3, 7) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -3982,7 +3983,7 @@ val (&): e1: bool -> e2: bool -> bool
             Assert.AreEqual("op_UnaryNegation", text)
             assertRange (12, 59) (12, 61) mText
             assertRange (12, 62) (12, 63) rpr
-            assertRange (12, 59) (12, 61) operator.Range
+            assertRange (12, 57) (12, 63) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -4051,7 +4052,7 @@ op_Addition a b
             assertRange (2,0) (2,1) lpr
             Assert.AreEqual("op_Addition", text)
             assertRange (2,2) (2,3) rpr
-            assertRange (2,1) (2,2) operator.Range
+            assertRange (2,0) (2,3) operator.Range
             Assert.AreEqual("a", a1)
             Assert.AreEqual("b", b1)
 
@@ -4085,7 +4086,7 @@ type X with
             Assert.AreEqual("op_Addition", text)
             assertRange (3, 14) (3, 15) mText
             assertRange (3,15) (3,16) rpr
-            assertRange (3, 14) (3, 15) operator.Range
+            assertRange (3, 13) (3, 16) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 
@@ -4109,7 +4110,7 @@ nameof(+)
             Assert.AreEqual("op_Addition", text)
             assertRange (2,7) (2,8) mText
             assertRange (2,8) (2,9) rpr
-            assertRange (2,7) (2,8) operator.Range
+            assertRange (2,6) (2,9) operator.Range
         | _ ->
             Assert.Fail $"Could not get valid AST, got {ast}"
 

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -94,7 +94,7 @@ type internal FSharpAddOpenCodeFixProvider
             let! symbol = 
                 maybe {
                     let! lexerSymbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, context.Span.End, document.FilePath, defines, SymbolLookupKind.Greedy, false, false)
-                    return checkResults.GetSymbolUseAtLocation(Line.fromZ linePos.Line, lexerSymbol.Ident.idRange.EndColumn, line.ToString(), lexerSymbol.FullIsland)
+                    return checkResults.GetSymbolUseAtLocation(Line.fromZ linePos.Line, lexerSymbol.Ident.Range.EndColumn, line.ToString(), lexerSymbol.FullIsland)
                 }
 
             do! Option.guard symbol.IsNone
@@ -130,7 +130,7 @@ type internal FSharpAddOpenCodeFixProvider
                     longIdent
                     |> List.map (fun ident ->
                         { Ident = ident.idText
-                          Resolved = not (ident.idRange = unresolvedIdentRange)})
+                          Resolved = not (ident.Range = unresolvedIdentRange)})
                     |> List.toArray)
                                                     
             let insertionPoint = 

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddTypeAnnotationToObjectOfIndeterminateType.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddTypeAnnotationToObjectOfIndeterminateType.fs
@@ -44,7 +44,7 @@ type internal FSharpAddTypeAnnotationToObjectOfIndeterminateTypeFixProvider
             let! lexerSymbol = document.TryFindFSharpLexerSymbolAsync(position, SymbolLookupKind.Greedy, false, false, nameof(FSharpAddTypeAnnotationToObjectOfIndeterminateTypeFixProvider))
 
             let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(FSharpAddTypeAnnotationToObjectOfIndeterminateTypeFixProvider)) |> liftAsync
-            let decl = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, false)
+            let decl = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, false)
 
             match decl with
             | FindDeclResult.DeclFound declRange when declRange.FileName = document.FilePath ->

--- a/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
@@ -174,7 +174,7 @@ type internal FSharpImplementInterfaceCodeFixProvider
             let lineContents = textLine.ToString()                            
             let! options = context.Document.GetOptionsAsync(cancellationToken)
             let tabSize = options.GetOption(FormattingOptions.TabSize, FSharpConstants.FSharpLanguageName)
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, lineContents, symbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.Range.EndColumn, lineContents, symbol.FullIsland)
             let! entity, displayContext = 
                 match symbolUse.Symbol with
                 | :? FSharpEntity as entity -> 

--- a/vsintegration/src/FSharp.Editor/CodeFix/MakeDeclarationMutable.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/MakeDeclarationMutable.fs
@@ -42,7 +42,7 @@ type internal FSharpMakeDeclarationMutableFixProvider
             let textLinePos = sourceText.Lines.GetLinePosition position
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let! parseFileResults, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(FSharpMakeDeclarationMutableFixProvider)) |> liftAsync
-            let decl = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, false)
+            let decl = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, false)
 
             match decl with
             // Only do this for symbols in the same file. That covers almost all cases anyways.

--- a/vsintegration/src/FSharp.Editor/CodeFix/UseMutationWhenValueIsMutable.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/UseMutationWhenValueIsMutable.fs
@@ -52,7 +52,7 @@ type internal FSharpUseMutationWhenValueIsMutableFixProvider
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let! lexerSymbol = document.TryFindFSharpLexerSymbolAsync(adjustedPosition, SymbolLookupKind.Greedy, false, false, nameof(FSharpUseMutationWhenValueIsMutableFixProvider))
             let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(FSharpUseMutationWhenValueIsMutableFixProvider)) |> liftAsync
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLine.ToString(), lexerSymbol.FullIsland)
 
             match symbolUse.Symbol with
             | :? FSharpMemberOrFunctionOrValue as mfv when mfv.IsMutable || mfv.HasSetterMethod ->

--- a/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
@@ -21,7 +21,7 @@ type FSharpParseFileResults with
                         // Check if it's an operator
                         match pat with
                         | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _)) when id.idText.StartsWith("op_") ->
-                            if Position.posEq id.idRange.Start pos then
+                            if Position.posEq id.Range.Start pos then
                                 Some binding.RangeOfBindingWithRhs
                             else
                                 defaultTraverse binding
@@ -35,7 +35,7 @@ type FSharpParseFileResults with
                 match expr with
                 | SynExpr.DotGet(expr, _, _, range) ->
                     match expr with
-                    | SynExpr.TypeApp(SynExpr.Ident(ident), _, typeArgs, _, _, _, _) ->
+                    | SynExpr.TypeApp(SynExpr.IdentOrOperatorName (ident), _, typeArgs, _, _, _, _) ->
                         let onlyOneTypeArg =
                             match typeArgs with
                             | [] -> false

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -256,7 +256,7 @@ type internal FSharpSignatureHelpProvider
                 }
 
             let! lexerSymbol = Tokenizer.getSymbolAtPosition(documentId, sourceText, possibleApplicableSymbolEndColumn, filePath, defines, SymbolLookupKind.Greedy, false, false)
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineText, lexerSymbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLineText, lexerSymbol.FullIsland)
 
             let isValid (mfv: FSharpMemberOrFunctionOrValue) =
                 not (PrettyNaming.IsOperatorDisplayName mfv.DisplayName) &&
@@ -265,7 +265,7 @@ type internal FSharpSignatureHelpProvider
 
             match symbolUse.Symbol with
             | :? FSharpMemberOrFunctionOrValue as mfv when isValid mfv ->
-                let tooltip = checkFileResults.GetToolTip(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineText, lexerSymbol.FullIsland, FSharpTokenTag.IDENT)
+                let tooltip = checkFileResults.GetToolTip(fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLineText, lexerSymbol.FullIsland, FSharpTokenTag.IDENT)
                 match tooltip with
                 | ToolTipText []
                 | ToolTipText [ToolTipElement.None] -> return! None

--- a/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
@@ -60,7 +60,7 @@ type internal FSharpDocumentHighlightsService [<ImportingConstructor>] () =
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
 
             let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(FSharpDocumentHighlightsService)) |> liftAsync
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.Range.EndColumn, textLine.ToString(), symbol.FullIsland)
             let symbolUses = checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol)
             return 
                 [| for symbolUse in symbolUses do

--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -152,7 +152,7 @@ type internal InlineRenameService
             let! symbol = document.TryFindFSharpLexerSymbolAsync(position, SymbolLookupKind.Greedy, false, false, nameof(InlineRenameService))
 
             let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(InlineRenameService)) |> liftAsync
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.Text.ToString(), symbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.Range.EndColumn, textLine.Text.ToString(), symbol.FullIsland)
             let! declLoc = symbolUse.GetDeclarationLocation(document)
 
             let! span = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, symbolUse.Range)

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -30,7 +30,7 @@ module internal SymbolHelpers =
             let textLinePos = sourceText.Lines.GetLinePosition(position)
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy, false, false)
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.Range.EndColumn, textLine.ToString(), symbol.FullIsland)
             let! ct = Async.CancellationToken |> liftAsync
             let symbolUses = checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol, cancellationToken=ct)
             return symbolUses
@@ -107,7 +107,7 @@ module internal SymbolHelpers =
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
 
             let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(userOpName) |> liftAsync
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.Range.EndColumn, textLine.ToString(), symbol.FullIsland)
             let! declLoc = symbolUse.GetDeclarationLocation(document)
             let newText = textChanger originalText
             // defer finding all symbol uses throughout the solution

--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -42,10 +42,10 @@ type internal LexerSymbolKind =
 type internal LexerSymbol =
     { Kind: LexerSymbolKind
       /// Last part of `LongIdent`
-      Ident: Ident
+      Ident: SynIdentOrOperatorName
       /// All parts of `LongIdent`
       FullIsland: string list }
-    member x.Range: Range = x.Ident.idRange
+    member x.Range: Range = x.Ident.Range
 
 [<RequireQualifiedAccess>]
 type internal SymbolLookupKind =
@@ -720,7 +720,8 @@ module internal Tokenizer =
             let identStr = lineStr.Substring(token.LeftColumn, token.MatchedLength)
             {   Kind = token.Kind
                 Ident = 
-                    Ident(identStr, 
+                    SynIdentOrOperatorName.Ident(
+                        identStr,
                         Range.mkRange 
                             fileName 
                             (Position.mkPos (linePos.Line + 1) token.LeftColumn)

--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -52,8 +52,8 @@ type internal FSharpFindUsagesService
             let! symbol = document.TryFindFSharpLexerSymbolAsync(position, SymbolLookupKind.Greedy, false, false, "findReferencedSymbolsAsync")
             
             let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(FSharpFindUsagesService)) |> liftAsync
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(lineNumber, symbol.Ident.idRange.EndColumn, textLine, symbol.FullIsland)
-            let declaration = checkFileResults.GetDeclarationLocation (lineNumber, symbol.Ident.idRange.EndColumn, textLine, symbol.FullIsland, false)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(lineNumber, symbol.Ident.Range.EndColumn, textLine, symbol.FullIsland)
+            let declaration = checkFileResults.GetDeclarationLocation (lineNumber, symbol.Ident.Range.EndColumn, textLine, symbol.FullIsland, false)
             let tags = FSharpGlyphTags.GetTags(Tokenizer.GetGlyphForSymbol (symbolUse.Symbol, symbol.Kind))
             
             let declarationRange = 

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -183,7 +183,7 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
             let textLinePos = sourceText.Lines.GetLinePosition position
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let lineText = (sourceText.Lines.GetLineFromPosition position).ToString()  
-            let idRange = lexerSymbol.Ident.idRange
+            let idRange = lexerSymbol.Ident.Range
 
             let! _, checkFileResults = originDocument.GetFSharpParseAndCheckResultsAsync(nameof(GoToDefinition)) |> liftAsync
             let! fsSymbolUse = checkFileResults.GetSymbolUseAtLocation (fcsTextLineNumber, idRange.EndColumn, lineText, lexerSymbol.FullIsland)
@@ -234,10 +234,10 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
             let preferSignature = isSignatureFile originDocument.FilePath
                 
             let! lexerSymbol = originDocument.TryFindFSharpLexerSymbolAsync(position, SymbolLookupKind.Greedy, false, false, userOpName)
-            let idRange = lexerSymbol.Ident.idRange
+            let idRange = lexerSymbol.Ident.Range
 
             let! _, checkFileResults = originDocument.GetFSharpParseAndCheckResultsAsync(userOpName) |> liftAsync
-            let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineString, lexerSymbol.FullIsland, preferSignature)
+            let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLineString, lexerSymbol.FullIsland, preferSignature)
             let! targetSymbolUse = checkFileResults.GetSymbolUseAtLocation (fcsTextLineNumber, idRange.EndColumn, lineText, lexerSymbol.FullIsland)
 
             match declarations with
@@ -286,7 +286,7 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                             let navItem = FSharpGoToDefinitionNavigableItem (implDocument, implTextSpan)
                             return (FSharpGoToDefinitionResult.NavigableItem(navItem), idRange)
                         else // jump from implementation to the corresponding signature
-                            let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLineString, lexerSymbol.FullIsland, true)
+                            let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLineString, lexerSymbol.FullIsland, true)
                             match declarations with
                             | FindDeclResult.DeclFound targetRange -> 
                                 let! sigDocument = originDocument.Project.Solution.TryGetDocumentFromPath targetRange.FileName
@@ -530,14 +530,14 @@ module internal FSharpQuickInfo =
 
             let extQuickInfoText = 
                 extCheckFileResults.GetToolTip
-                    (declRange.StartLine, extLexerSymbol.Ident.idRange.EndColumn, extLineText, extLexerSymbol.FullIsland, FSharpTokenTag.IDENT)
+                    (declRange.StartLine, extLexerSymbol.Ident.Range.EndColumn, extLineText, extLexerSymbol.FullIsland, FSharpTokenTag.IDENT)
 
             match extQuickInfoText with
             | ToolTipText []
             | ToolTipText [ToolTipElement.None] -> return! None
             | extQuickInfoText  ->
                 let! extSymbolUse =
-                    extCheckFileResults.GetSymbolUseAtLocation(declRange.StartLine, extLexerSymbol.Ident.idRange.EndColumn, extLineText, extLexerSymbol.FullIsland)
+                    extCheckFileResults.GetSymbolUseAtLocation(declRange.StartLine, extLexerSymbol.Ident.Range.EndColumn, extLineText, extLexerSymbol.FullIsland)
                 let! span = RoslynHelpers.TryFSharpRangeToTextSpan (extSourceText, extLexerSymbol.Range)
 
                 return { StructuredText = extQuickInfoText
@@ -560,7 +560,7 @@ module internal FSharpQuickInfo =
             let! lexerSymbol = document.TryFindFSharpLexerSymbolAsync(position, SymbolLookupKind.Greedy, true, true, userOpName)
             let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(userOpName) |> liftAsync
             let! sourceText = document.GetTextAsync cancellationToken
-            let idRange = lexerSymbol.Ident.idRange  
+            let idRange = lexerSymbol.Ident.Range  
             let textLinePos = sourceText.Lines.GetLinePosition position
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let lineText = (sourceText.Lines.GetLineFromPosition position).ToString()

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -43,12 +43,12 @@ type internal FSharpAsyncQuickInfoSource
             let! symbol = document.TryFindFSharpLexerSymbolAsync(position, SymbolLookupKind.Precise, true, true, nameof(FSharpAsyncQuickInfoSource))
 
             let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(FSharpAsyncQuickInfoSource)) |> liftAsync
-            let res = checkFileResults.GetToolTip (textLineNumber, symbol.Ident.idRange.EndColumn, textLineString, symbol.FullIsland, FSharpTokenTag.IDENT)
+            let res = checkFileResults.GetToolTip (textLineNumber, symbol.Ident.Range.EndColumn, textLineString, symbol.FullIsland, FSharpTokenTag.IDENT)
             match res with
             | ToolTipText []
             | ToolTipText [ToolTipElement.None] -> return! None
             | _ ->
-                let! symbolUse = checkFileResults.GetSymbolUseAtLocation (textLineNumber, symbol.Ident.idRange.EndColumn, textLineString, symbol.FullIsland)
+                let! symbolUse = checkFileResults.GetSymbolUseAtLocation (textLineNumber, symbol.Ident.Range.EndColumn, textLineString, symbol.FullIsland)
                 let! symbolSpan = RoslynHelpers.TryFSharpRangeToTextSpan (sourceText, symbol.Range)
                 return { StructuredText = res
                          Span = symbolSpan

--- a/vsintegration/src/FSharp.Editor/Refactor/AddExplicitTypeToParameter.fs
+++ b/vsintegration/src/FSharp.Editor/Refactor/AddExplicitTypeToParameter.fs
@@ -34,7 +34,7 @@ type internal FSharpAddExplicitTypeToParameterRefactoring
             let! lexerSymbol = document.TryFindFSharpLexerSymbolAsync(position, SymbolLookupKind.Greedy, false, false, nameof(FSharpAddExplicitTypeToParameterRefactoring))
 
             let! parseFileResults, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(FSharpAddExplicitTypeToParameterRefactoring)) |> liftAsync
-            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland)
+            let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLine.ToString(), lexerSymbol.FullIsland)
 
             let isValidParameterWithoutTypeAnnotation (funcOrValue: FSharpMemberOrFunctionOrValue) (symbolUse: FSharpSymbolUse) =
                 let isLambdaIfFunction =

--- a/vsintegration/tests/UnitTests/GoToDefinitionServiceTests.fs
+++ b/vsintegration/tests/UnitTests/GoToDefinitionServiceTests.fs
@@ -53,7 +53,7 @@ module GoToDefinitionServiceTests =
             let! lexerSymbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy, false, false)
             let _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(userOpName)) |> Async.RunSynchronously
 
-            let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.idRange.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, false)
+            let declarations = checkFileResults.GetDeclarationLocation (fcsTextLineNumber, lexerSymbol.Ident.Range.EndColumn, textLine.ToString(), lexerSymbol.FullIsland, false)
             
             match declarations with
             | FindDeclResult.DeclFound range -> return range


### PR DESCRIPTION
Another attempt to solve https://github.com/dotnet/fsharp/issues/11893.
This serves as an alternative to #12989.

One potential performance concern of this approach is changing the `Ident` struct to a Discriminated Union `SynIdentOrOperatorName`.
Besides that, the impact is a lot less as no SynPat shapes were altered.
This feels a lot safer but might also have drawbacks.

If anybody has any clues on how to verify the expected performance impact, I'm all ears.

//cc @dsyme, @auduchinok