### PR TITLE
Allow list literal of any size

### DIFF
--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -2236,8 +2236,6 @@ let TcArrayOrListComputedExpression (cenv: cenv) env (overallTy: OverallTy) tpen
                 then SynExpr.Const (SynConst.Bytes (Array.ofList (List.map (function SynExpr.Const (SynConst.Byte x, _) -> x | _ -> failwith "unreachable") elems), SynByteStringKind.Regular, m), m)
                 else SynExpr.ArrayOrList (isArray, elems, m)
             else 
-                if elems.Length > 500 then 
-                    error(Error(FSComp.SR.tcListLiteralMaxSize(), m))
                 SynExpr.ArrayOrList (isArray, elems, m)
 
         TcExprUndelayed cenv overallTy env tpenv replacementExpr


### PR DESCRIPTION
Fixes #10963 
when defining list literal with more that 500 elements

```fsharp
let ls = [ ... long list with more that 500 elements. .... ]
```
An error will occur a error:

FS0742: This list expression exceeds the maximum size of the list text. Use an Array for large text and call Array.toList.

Following Don's comment here  https://github.com/dotnet/fsharp/issues/10963#issuecomment-1103549462. I thought this my be a good first issue that I could contribute

This is my first time contributing to this repo and to a compiler ever.

Open questions :

-  Is there a way to test this to make sure the restriction is not longer visible. (I went through the unit tests and I could not find any for this 

