### PR TITLE
Introduce SynPat.ParametersOwner.

### DIFF
--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -1237,7 +1237,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
 
         // 'use! pat = e1 in e2' --> build.Bind(e1, (function  _argN -> match _argN with pat -> build.Using(x, (fun _argN -> match _argN with pat -> e2))))
         | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.Named (ident=id; isThisVal=false) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp)
-        | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.LongIdent (longDotId=LongIdentWithDots(id=[id])) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp) ->
+        | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.ParametersOwner (longDotId=LongIdentWithDots(id=[id])) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp) ->
 
             let mBind = match spBind with DebugPointAtBinding.Yes m -> m | _ -> rhsExpr.Range
             if isQuery then error(Error(FSComp.SR.tcBindMayNotBeUsedInQueries(), mBind))

--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -1237,7 +1237,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
 
         // 'use! pat = e1 in e2' --> build.Bind(e1, (function  _argN -> match _argN with pat -> build.Using(x, (fun _argN -> match _argN with pat -> e2))))
         | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.Named (ident=id; isThisVal=false) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp)
-        | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.ParametersOwner (longDotId=LongIdentWithDots(id=[id])) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp) ->
+        | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.ParametersOwner (namePat = SingleIdentInParametersOwnerNamePat id) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp) ->
 
             let mBind = match spBind with DebugPointAtBinding.Yes m -> m | _ -> rhsExpr.Range
             if isQuery then error(Error(FSComp.SR.tcBindMayNotBeUsedInQueries(), mBind))

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -4831,7 +4831,7 @@ module TcDeclarations =
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> true | _ -> false)
                         let mLetPortion = synExpr.Range
                         let fldId = ident (CompilerGeneratedName id.idText, mLetPortion)
-                        let headPat = SynPat.ParametersOwner (LongIdentWithDots([fldId], []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mLetPortion)
+                        let headPat = SynPat.ParametersOwner (SynPat.Ident(fldId, fldId.idRange), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mLetPortion)
                         let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                         let isMutable = 
                             match propKind with 
@@ -4859,7 +4859,8 @@ module TcDeclarations =
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> false | _ -> true)
                         let fldId = ident (CompilerGeneratedName id.idText, mMemberPortion)
                         let headPatIds = if isStatic then [id] else [ident ("__", mMemberPortion);id]
-                        let headPat = SynPat.ParametersOwner (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mMemberPortion)
+                        let headPatLid = LongIdentWithDots(headPatIds, [])
+                        let headPat = SynPat.ParametersOwner (SynPat.LongIdent(headPatLid, headPatLid.Range), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mMemberPortion)
 
                         match propKind, mGetSetOpt with 
                         | SynMemberKind.PropertySet, Some m -> errorR(Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSetNotJustSet(), m))
@@ -4884,7 +4885,7 @@ module TcDeclarations =
                             | SynMemberKind.PropertyGetSet -> 
                                 let setter = 
                                     let vId = ident("v", mMemberPortion)
-                                    let headPat = SynPat.ParametersOwner (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
+                                    let headPat = SynPat.ParametersOwner (SynPat.LongIdent(headPatLid, headPatLid.Range), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
                                     let rhsExpr = mkSynAssign (SynExpr.Ident fldId) (SynExpr.Ident vId)
                                     //let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                                     let binding = mkSynBinding (xmlDoc, headPat) (access, false, false, mMemberPortion, DebugPointAtBinding.NoneAtInvisible, None, rhsExpr, rhsExpr.Range, [], [], Some (memberFlags SynMemberKind.PropertySet), SynBindingTrivia.Zero)

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -4831,7 +4831,7 @@ module TcDeclarations =
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> true | _ -> false)
                         let mLetPortion = synExpr.Range
                         let fldId = ident (CompilerGeneratedName id.idText, mLetPortion)
-                        let headPat = SynPat.LongIdent (LongIdentWithDots([fldId], []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mLetPortion)
+                        let headPat = SynPat.ParametersOwner (LongIdentWithDots([fldId], []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mLetPortion)
                         let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                         let isMutable = 
                             match propKind with 
@@ -4859,7 +4859,7 @@ module TcDeclarations =
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> false | _ -> true)
                         let fldId = ident (CompilerGeneratedName id.idText, mMemberPortion)
                         let headPatIds = if isStatic then [id] else [ident ("__", mMemberPortion);id]
-                        let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mMemberPortion)
+                        let headPat = SynPat.ParametersOwner (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mMemberPortion)
 
                         match propKind, mGetSetOpt with 
                         | SynMemberKind.PropertySet, Some m -> errorR(Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSetNotJustSet(), m))
@@ -4884,7 +4884,7 @@ module TcDeclarations =
                             | SynMemberKind.PropertyGetSet -> 
                                 let setter = 
                                     let vId = ident("v", mMemberPortion)
-                                    let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
+                                    let headPat = SynPat.ParametersOwner (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
                                     let rhsExpr = mkSynAssign (SynExpr.Ident fldId) (SynExpr.Ident vId)
                                     //let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                                     let binding = mkSynBinding (xmlDoc, headPat) (access, false, false, mMemberPortion, DebugPointAtBinding.NoneAtInvisible, None, rhsExpr, rhsExpr.Range, [], [], Some (memberFlags SynMemberKind.PropertySet), SynBindingTrivia.Zero)

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -2474,7 +2474,7 @@ module BindingNormalization =
             // of available items, to the point that you can't even define a function with the same name as an existing union case.
             match pat with
             | SynPat.FromParseError(p, _) -> normPattern p
-            | SynPat.ParametersOwner (LongIdentWithDots(longId, _), _, toolId, tyargs, SynArgPats.Pats args, vis, m) ->
+            | SynPat.ParametersOwner (LongIdentInParametersOwnerNamePat longId, _, toolId, tyargs, SynArgPats.Pats args, vis, m) ->
                 let typars = match tyargs with None -> inferredTyparDecls | Some typars -> typars
                 match memberFlagsOpt with
                 | None ->
@@ -5079,7 +5079,7 @@ and TcPat warnOnUpper cenv env topValInfo vFlags (tpenv, names, takenNames) ty p
         let pats', acc = TcPatterns warnOnUpper cenv env vFlags (tpenv, names, takenNames) (List.map (fun _ -> ty) pats) pats
         (fun values -> TPat_conjs(List.map (fun f -> f values) pats', m)), acc
 
-    | SynPat.ParametersOwner (longDotId=longDotId; typarDecls=tyargs; argPats=args; accessibility=vis; range=m) ->
+    | SynPat.ParametersOwner (namePat = LongIdentWithDotsInParametersOwnerNamePat longDotId; typarDecls=tyargs; argPats=args; accessibility=vis; range=m) ->
         TcPatLongIdent warnOnUpper cenv env ad topValInfo vFlags (tpenv, names, takenNames) ty (longDotId, tyargs, args, vis, m)
 
     | SynPat.QuoteExpr(_, m) ->
@@ -5142,6 +5142,11 @@ and TcPat warnOnUpper cenv env topValInfo vFlags (tpenv, names, takenNames) ty p
     | SynPat.FromParseError (pat, _) ->
         suppressErrorReporting (fun () -> TcPatAndRecover warnOnUpper cenv env topValInfo vFlags (tpenv, names, takenNames) (NewErrorType()) pat)
 
+    | SynPat.Ident (range = m)
+    | SynPat.LongIdent (range = m) ->
+        // TODO: this probably is a bad way of dealing with this...
+        error(Error((9002,"Unexpected patterns to be typed checked"), m))
+
 and CheckNoArgsForLiteral args m =
     match args with
     | SynArgPats.Pats []
@@ -5169,7 +5174,8 @@ and ConvSynPatToSynExpr x =
     | SynPat.Const (c, m) -> SynExpr.Const (c, m)
     | SynPat.Named (id, _, None, _) -> SynExpr.Ident id
     | SynPat.Typed (p, cty, m) -> SynExpr.Typed (ConvSynPatToSynExpr p, cty, m)
-    | SynPat.ParametersOwner (longDotId=LongIdentWithDots(longId, dotms) as lidwd; argPats=args; accessibility=None; range=m) ->
+    | SynPat.ParametersOwner (namePat = LongIdentWithDotsInParametersOwnerNamePat lidwd; argPats=args; accessibility=None; range=m) ->
+        let (LongIdentWithDots(longId, dotms)) = lidwd
         let args = match args with SynArgPats.Pats args -> args | _ -> failwith "impossible: active patterns can be used only with SynConstructorArgs.Pats"
         let e =
             if dotms.Length = longId.Length then
@@ -10099,7 +10105,7 @@ and CheckRecursiveBindingIds binds =
             match b with
             | SynPat.Named(id, _, _, _)
             | SynPat.As(_, SynPat.Named(id, _, _, _), _)
-            | SynPat.ParametersOwner(longDotId=LongIdentWithDots([id], _)) -> id.idText
+            | SynPat.ParametersOwner(namePat=SingleIdentInParametersOwnerNamePat id) -> id.idText
             | _ -> ""
         if nm <> "" && not (hashOfBinds.Add nm) then
             error(Duplicate("value", nm, m))

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1100,8 +1100,16 @@ type SynPat =
         rhsPat: SynPat *
         range: range
 
-    | ParametersOwner of
+    | Ident of
+        ident: Ident *
+        range: range
+
+    | LongIdent of
         longDotId: LongIdentWithDots *
+        range: range
+    
+    | ParametersOwner of
+        namePat: SynPat *
         propertyKeyword: PropertyKeyword option *
         extraId: Ident option * // holds additional ident for tooling
         typarDecls: SynValTyparDecls option * // usually None: temporary used to parse "f<'a> x = x"
@@ -1166,6 +1174,8 @@ type SynPat =
       | SynPat.Or (range=m)
       | SynPat.Ands (range=m)
       | SynPat.As (range=m)
+      | SynPat.Ident(range=m)
+      | SynPat.LongIdent(range=m)
       | SynPat.ParametersOwner (range=m)
       | SynPat.ArrayOrList (range=m)
       | SynPat.Tuple (range=m)

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1100,7 +1100,7 @@ type SynPat =
         rhsPat: SynPat *
         range: range
 
-    | LongIdent of
+    | ParametersOwner of
         longDotId: LongIdentWithDots *
         propertyKeyword: PropertyKeyword option *
         extraId: Ident option * // holds additional ident for tooling
@@ -1166,7 +1166,7 @@ type SynPat =
       | SynPat.Or (range=m)
       | SynPat.Ands (range=m)
       | SynPat.As (range=m)
-      | SynPat.LongIdent (range=m)
+      | SynPat.ParametersOwner (range=m)
       | SynPat.ArrayOrList (range=m)
       | SynPat.Tuple (range=m)
       | SynPat.Typed (range=m)

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -1232,9 +1232,20 @@ type SynPat =
         rhsPat: SynPat *
         range: range
 
+    /// Used as namePat in ParametersOwner
+    | Ident of
+        ident: Ident *
+        range: range
+
+    /// Used as namePat in ParametersOwner
+    | LongIdent of
+        longDotId: LongIdentWithDots *
+        range: range
+    
     /// A long identifier pattern possibly with argument patterns
     | ParametersOwner of
-        longDotId: LongIdentWithDots *
+        /// Can be SynPat.Ident or SynPat.LongIdent
+        namePat: SynPat *
         propertyKeyword: PropertyKeyword option *
         extraId: Ident option * // holds additional ident for tooling
         typarDecls: SynValTyparDecls option * // usually None: temporary used to parse "f<'a> x = x"

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -1233,7 +1233,7 @@ type SynPat =
         range: range
 
     /// A long identifier pattern possibly with argument patterns
-    | LongIdent of
+    | ParametersOwner of
         longDotId: LongIdentWithDots *
         propertyKeyword: PropertyKeyword option *
         extraId: Ident option * // holds additional ident for tooling

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -137,7 +137,7 @@ let rec IsControlFlowExpression e =
 //
 // For example
 //    let x = 1 + 1
-// gets extended to inludde the 'let x'.
+// gets extended to include the 'let x'.
 //
 // A corner case: some things that look like simple value bindings get generalized, e.g.
 //    let empty = []
@@ -150,7 +150,7 @@ let IsDebugPointBinding synPat synExpr =
     // Don't yield the binding sequence point if there are any arguments, i.e. we're defining a function or a method
     let isFunction = 
         match synPat with 
-        | SynPat.LongIdent (argPats=SynArgPats.Pats args; typarDecls=typarDecls) when not args.IsEmpty || typarDecls.IsSome -> true
+        | SynPat.ParametersOwner (argPats=SynArgPats.Pats args; typarDecls=typarDecls) when not args.IsEmpty || typarDecls.IsSome -> true
         | _ -> false
     not isFunction
 
@@ -165,12 +165,12 @@ let mkSynPatVar vis (id: Ident) = SynPat.Named (id, false, vis, id.idRange)
 
 let mkSynThisPatVar (id: Ident) = SynPat.Named (id, true, None, id.idRange)
 
-let mkSynPatMaybeVar lidwd vis m =  SynPat.LongIdent (lidwd, None, None, None, SynArgPats.Pats [], vis, m)
+let mkSynPatMaybeVar lidwd vis m =  SynPat.ParametersOwner (lidwd, None, None, None, SynArgPats.Pats [], vis, m)
 
 /// Extract the argument for patterns corresponding to the declaration of 'new ... = ...'
 let (|SynPatForConstructorDecl|_|) x =
     match x with
-    | SynPat.LongIdent (longDotId=LongIdentWithDots([_], _); argPats=SynArgPats.Pats [arg]) -> Some arg
+    | SynPat.ParametersOwner (longDotId=LongIdentWithDots([_], _); argPats=SynArgPats.Pats [arg]) -> Some arg
     | _ -> None
 
 /// Recognize the '()' in 'new()'
@@ -224,7 +224,7 @@ let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
         let m = p.Range
         let isCompGen, altNameRefCell, id, item =
             match p with
-            | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) ->
+            | SynPat.ParametersOwner(longDotId=LongIdentWithDots([id], _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) ->
                 // The pattern is 'V' or some other capitalized identifier.
                 // It may be a real variable, in which case we want to maintain its name.
                 // But it may also be a nullary union case or some other identifier.
@@ -599,12 +599,12 @@ module SynInfo =
 
         let infosForExplicitArgs =
             match pat with
-            | Some(SynPat.LongIdent(argPats=SynArgPats.Pats curriedArgs)) -> List.map InferSynArgInfoFromPat curriedArgs
+            | Some(SynPat.ParametersOwner(argPats=SynArgPats.Pats curriedArgs)) -> List.map InferSynArgInfoFromPat curriedArgs
             | _ -> []
 
         let explicitArgsAreSimple =
             match pat with
-            | Some(SynPat.LongIdent(argPats=SynArgPats.Pats curriedArgs)) -> List.forall isSimplePattern curriedArgs
+            | Some(SynPat.ParametersOwner(argPats=SynArgPats.Pats curriedArgs)) -> List.forall isSimplePattern curriedArgs
             | _ -> true
 
         let retInfo = InferSynReturnData retInfo

--- a/src/fsharp/SyntaxTreeOps.fsi
+++ b/src/fsharp/SyntaxTreeOps.fsi
@@ -46,6 +46,12 @@ val (|LongOrSingleIdent|_|): inp:SynExpr -> (bool * LongIdentWithDots * SynSimpl
 
 val (|SingleIdent|_|): inp:SynExpr -> Ident option
 
+val (|SingleIdentInParametersOwnerNamePat|_|): namePat:SynPat -> Ident option
+
+val (|LongIdentInParametersOwnerNamePat|): namePat:SynPat -> LongIdent
+
+val (|LongIdentWithDotsInParametersOwnerNamePat|): namePat: SynPat -> LongIdentWithDots
+
 /// This affects placement of debug points
 val IsControlFlowExpression: e:SynExpr -> bool
 
@@ -61,7 +67,7 @@ val mkSynPatVar: vis:SynAccess option -> id:Ident -> SynPat
 
 val mkSynThisPatVar: id:Ident -> SynPat
 
-val mkSynPatMaybeVar: lidwd:LongIdentWithDots -> vis:SynAccess option -> m:range -> SynPat
+val mkSynPatMaybeVar: namePat: SynPat -> vis:SynAccess option -> m:range -> SynPat
 
 val ( |SynPatForConstructorDecl|_| ): x:SynPat -> SynPat option
 
@@ -300,3 +306,5 @@ val (|SynPipeRight2|_|): SynExpr -> (SynExpr * SynExpr * SynExpr) option
 
 /// 'e1 |||> e2'
 val (|SynPipeRight3|_|): SynExpr -> (SynExpr * SynExpr * SynExpr * SynExpr) option
+
+val prependIdentInPattern: ident: Ident -> dotm: range -> pat: SynPat -> SynPat

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -189,7 +189,7 @@ let idOfPat (parseState:IParseState) m p =
     | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop ->
         mkSynId r "_"
     | SynPat.Named (id, false, _, _) -> id
-    | SynPat.ParametersOwner(longDotId=LongIdentWithDots([id], _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
+    | SynPat.ParametersOwner(namePat=SingleIdentInParametersOwnerNamePat id; typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier())
 
 let checkForMultipleAugmentations m a1 a2 = 
@@ -346,7 +346,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <SynExceptionDefnRepr> exconCore
 %type <SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
 %type <LongIdentWithDots> path
-%type <LongIdentWithDots> pathOp
+%type <SynPat> pathOp
 /*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
 %type <range * range option * bool     * SynType list * range list * range> typeArgsActual
 /*     LESS    GREATER        typeArgs           m for each   mWhole  */
@@ -1880,7 +1880,7 @@ memberCore:
                        let getset = 
                              let rec go p = 
                                  match p with 
-                                 | SynPat.ParametersOwner (longDotId=LongIdentWithDots([id], _)) -> id.idText
+                                 | SynPat.ParametersOwner (namePat=SingleIdentInParametersOwnerNamePat id) -> id.idText
                                  | SynPat.Named (nm, _, _, _) | SynPat.As (_, SynPat.Named (nm, _, _, _), _) -> nm.idText
                                  | SynPat.Typed (p, _, _) -> go p
                                  | SynPat.Attrib (p, _, _) -> go p
@@ -1989,10 +1989,10 @@ memberCore:
   
                      let (SynBinding (_, _, _, _, _, doc2, _, bindingPatOuter, _, _, _, _, _)) = bindingOuter 
                  
-                     let lidOuter, lidVisOuter = 
+                     let namePatOuter, lidVisOuter = 
                          match bindingPatOuter with 
-                         | SynPat.ParametersOwner (lid, _, None, None, SynArgPats.Pats [], lidVisOuter, m) ->  lid, lidVisOuter
-                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> LongIdentWithDots([id], []), visOuter
+                         | SynPat.ParametersOwner (namePat, _, None, None, SynArgPats.Pats [], lidVisOuter, m) ->  namePat, lidVisOuter
+                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> SynPat.Ident(id, m), visOuter
                          | p -> raiseParseErrorAt mWholeBindLhs (FSComp.SR.parsInvalidDeclarationSyntax()) 
   
                      // Merge the visibility from the outer point with the inner point, e.g.
@@ -2009,7 +2009,7 @@ memberCore:
                      // Replace the "get" or the "set" with the right name
                      let rec go p = 
                          match p with 
-                         | SynPat.ParametersOwner (longDotId=LongIdentWithDots([id], _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
+                         | SynPat.ParametersOwner (namePat=SingleIdentInParametersOwnerNamePat id; typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
                              // Setters have all arguments tupled in their internal form, though they don't 
                              // appear to be tupled from the syntax. Somewhat unfortunate
                              let args = 
@@ -2025,9 +2025,9 @@ memberCore:
                                          raiseParseErrorAt m (FSComp.SR.parsSetSyntax())
                                  else 
                                      args
-                             SynPat.ParametersOwner (lidOuter, withPropertyKeyword, Some(id), tyargs, SynArgPats.Pats args, mergeLidVisOuter lidVisInner, m)
+                             SynPat.ParametersOwner (namePatOuter, withPropertyKeyword, Some(id), tyargs, SynArgPats.Pats args, mergeLidVisOuter lidVisInner, m)
                          | SynPat.Named (nm, _, lidVisInner, m)
-                         | SynPat.As (_, SynPat.Named (nm, _, lidVisInner, m), _) -> SynPat.ParametersOwner (lidOuter, None, None, None, SynArgPats.Pats [], mergeLidVisOuter lidVisInner, m)
+                         | SynPat.As (_, SynPat.Named (nm, _, lidVisInner, m), _) -> SynPat.ParametersOwner (namePatOuter, None, None, None, SynArgPats.Pats [], mergeLidVisOuter lidVisInner, m)
                          | SynPat.Typed (p, ty, m) ->  SynPat.Typed(go p, ty, m)
                          | SynPat.Attrib (p, attribs, m) ->  SynPat.Attrib(go p, attribs, m)
                          | SynPat.Wild(m) ->  SynPat.Wild(m)
@@ -2128,7 +2128,8 @@ classDefnMember:
         let expr = $7
         let valSynData = SynValData (Some (CtorMemberFlags SynMemberFlagsTrivia.Zero), SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), $5) 
         let vis = $2 
-        let declPat = SynPat.ParametersOwner (LongIdentWithDots([mkSynId (rhs parseState 3) "new"], []), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
+        let mNew = rhs parseState 3
+        let declPat = SynPat.ParametersOwner (SynPat.Ident(mkSynId mNew "new", mNew), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
         // Check that 'SynPatForConstructorDecl' matches this correctly
         assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
         let synBindingTrivia: SynBindingTrivia = { LetKeyword = None; EqualsRange = Some mEquals }
@@ -2174,12 +2175,15 @@ atomicPatternLongIdent:
   | UNDERSCORE DOT pathOp
      { if not (parseState.LexBuffer.SupportsFeature LanguageFeature.SingleUnderscorePattern) then
           raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedSymbolDot())
-       let (LongIdentWithDots(lid, dotms)) = $3
-       (None, LongIdentWithDots(ident("_", rhs parseState 1)::lid, rhs parseState 2::dotms)) }
+
+       let underscore = ident("_", rhs parseState 1)
+       let dotm = rhs parseState 2
+       None, prependIdentInPattern underscore dotm $3 }
 
   | GLOBAL DOT pathOp
-     { let (LongIdentWithDots(lid, dotms)) = $3
-       (None, LongIdentWithDots(ident(MangledGlobalName, rhs parseState 1) :: lid, rhs parseState 2 :: dotms)) }
+     { let globalIdent = ident(MangledGlobalName, rhs parseState 1)
+       let dotm = rhs parseState 2
+       None, prependIdentInPattern globalIdent dotm $3 }
 
   | pathOp
      { (None, $1) }
@@ -2187,8 +2191,10 @@ atomicPatternLongIdent:
   | access UNDERSCORE DOT pathOp
      { if not (parseState.LexBuffer.SupportsFeature LanguageFeature.SingleUnderscorePattern) then
           raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedSymbolDot())
-       let (LongIdentWithDots(lid, dotms)) = $4
-       (Some($1), LongIdentWithDots(ident("_", rhs parseState 2)::lid, rhs parseState 3::dotms)) }  
+
+       let underscore = ident("_", rhs parseState 2)
+       let dotm = rhs parseState 3
+       Some($1), prependIdentInPattern underscore dotm $4 }  
 
   | access pathOp
      { (Some($1), $2) }
@@ -2882,7 +2888,7 @@ cPrototype:
                 SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
                 mRhs)
         (fun attrs _ ->
-            let bindingPat = SynPat.ParametersOwner (LongIdentWithDots([nm], []), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
+            let bindingPat = SynPat.ParametersOwner (SynPat.Ident(nm, nm.idRange), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
             let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let xmlDoc = grabXmlDoc(parseState, attrs, 1)
             let binding =
@@ -3254,7 +3260,8 @@ headBindingPattern:
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
   | headBindingPattern COLON_COLON  headBindingPattern 
-      { SynPat.ParametersOwner (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
+      { let mColonColon = rhs parseState 2
+        SynPat.ParametersOwner (SynPat.Ident(ident(opNameCons, mColonColon), mColonColon), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
 
   | tuplePatternElements  %prec pat_tuple 
       { SynPat.Tuple(false, List.rev $1, lhs parseState) }
@@ -3386,10 +3393,16 @@ atomicPattern:
       { SynPat.OptionalVal($2, lhs parseState) } 
 
   | atomicPatternLongIdent %prec prec_atompat_pathop 
-      { let vis, lidwd = $1 
-        if not (isNilOrSingleton lidwd.Lid) || String.isLeadingIdentifierCharacterUpperCase (List.head lidwd.Lid).idText
-        then mkSynPatMaybeVar lidwd vis (lhs parseState)
-        else mkSynPatVar vis (List.head lidwd.Lid) }
+      { let vis, pat = $1
+        let isSingle, headIdent =
+            match pat with
+            | SynPat.Ident(id, _) -> true, id
+            | SynPat.LongIdent(LongIdentWithDots(id = idents), _) -> isNilOrSingleton idents, idents.[0]
+            | _ -> true, ident("", rhs parseState 1)
+
+        if not isSingle || String.isLeadingIdentifierCharacterUpperCase headIdent.idText
+        then mkSynPatMaybeVar pat vis (lhs parseState)
+        else mkSynPatVar vis headIdent }
 
   | constant 
       { SynPat.Const (fst $1, snd $1) }
@@ -3493,7 +3506,8 @@ parenPattern:
         SynPat.Attrib($2, $1, lhsm) } 
 
   | parenPattern COLON_COLON  parenPattern 
-      { SynPat.ParametersOwner (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
+      { let mColonColon = rhs parseState 2
+        SynPat.ParametersOwner (SynPat.Ident(ident(opNameCons,mColonColon), mColonColon), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
 
   | constrPattern { $1 }
 
@@ -5713,16 +5727,18 @@ identOrOp:
 /* Note, only used in atomicPatternLongIdent */
 pathOp: 
   | ident  
-     { LongIdentWithDots([$1], []) }
+     { SynPat.Ident($1, $1.idRange) }
 
   | opName 
-     { LongIdentWithDots([$1], []) }
+     { SynPat.Ident($1, $1.idRange) }
 
   | ident DOT pathOp 
-     { let (LongIdentWithDots(lid, dotms)) = $3 in LongIdentWithDots($1 :: lid, rhs parseState 2 :: dotms) } 
+     { prependIdentInPattern $1 (rhs parseState 2) $3 } 
 
   | ident DOT error  
-     { (* silent recovery *) LongIdentWithDots([$1], [rhs parseState 2]) }  
+     { (* silent recovery *) 
+       let m = rhs2 parseState 1 2
+       SynPat.LongIdent(LongIdentWithDots([$1], [rhs parseState 2]), m) }  
 
 
 /* nameop is identOrOp not used as part of a path */

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -189,7 +189,7 @@ let idOfPat (parseState:IParseState) m p =
     | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop ->
         mkSynId r "_"
     | SynPat.Named (id, false, _, _) -> id
-    | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
+    | SynPat.ParametersOwner(longDotId=LongIdentWithDots([id], _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier())
 
 let checkForMultipleAugmentations m a1 a2 = 
@@ -1880,7 +1880,7 @@ memberCore:
                        let getset = 
                              let rec go p = 
                                  match p with 
-                                 | SynPat.LongIdent (longDotId=LongIdentWithDots([id], _)) -> id.idText
+                                 | SynPat.ParametersOwner (longDotId=LongIdentWithDots([id], _)) -> id.idText
                                  | SynPat.Named (nm, _, _, _) | SynPat.As (_, SynPat.Named (nm, _, _, _), _) -> nm.idText
                                  | SynPat.Typed (p, _, _) -> go p
                                  | SynPat.Attrib (p, _, _) -> go p
@@ -1991,7 +1991,7 @@ memberCore:
                  
                      let lidOuter, lidVisOuter = 
                          match bindingPatOuter with 
-                         | SynPat.LongIdent (lid, _, None, None, SynArgPats.Pats [], lidVisOuter, m) ->  lid, lidVisOuter
+                         | SynPat.ParametersOwner (lid, _, None, None, SynArgPats.Pats [], lidVisOuter, m) ->  lid, lidVisOuter
                          | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> LongIdentWithDots([id], []), visOuter
                          | p -> raiseParseErrorAt mWholeBindLhs (FSComp.SR.parsInvalidDeclarationSyntax()) 
   
@@ -2009,7 +2009,7 @@ memberCore:
                      // Replace the "get" or the "set" with the right name
                      let rec go p = 
                          match p with 
-                         | SynPat.LongIdent (longDotId=LongIdentWithDots([id], _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
+                         | SynPat.ParametersOwner (longDotId=LongIdentWithDots([id], _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
                              // Setters have all arguments tupled in their internal form, though they don't 
                              // appear to be tupled from the syntax. Somewhat unfortunate
                              let args = 
@@ -2025,9 +2025,9 @@ memberCore:
                                          raiseParseErrorAt m (FSComp.SR.parsSetSyntax())
                                  else 
                                      args
-                             SynPat.LongIdent (lidOuter, withPropertyKeyword, Some(id), tyargs, SynArgPats.Pats args, mergeLidVisOuter lidVisInner, m)
+                             SynPat.ParametersOwner (lidOuter, withPropertyKeyword, Some(id), tyargs, SynArgPats.Pats args, mergeLidVisOuter lidVisInner, m)
                          | SynPat.Named (nm, _, lidVisInner, m)
-                         | SynPat.As (_, SynPat.Named (nm, _, lidVisInner, m), _) -> SynPat.LongIdent (lidOuter, None, None, None, SynArgPats.Pats [], mergeLidVisOuter lidVisInner, m)
+                         | SynPat.As (_, SynPat.Named (nm, _, lidVisInner, m), _) -> SynPat.ParametersOwner (lidOuter, None, None, None, SynArgPats.Pats [], mergeLidVisOuter lidVisInner, m)
                          | SynPat.Typed (p, ty, m) ->  SynPat.Typed(go p, ty, m)
                          | SynPat.Attrib (p, attribs, m) ->  SynPat.Attrib(go p, attribs, m)
                          | SynPat.Wild(m) ->  SynPat.Wild(m)
@@ -2128,7 +2128,7 @@ classDefnMember:
         let expr = $7
         let valSynData = SynValData (Some (CtorMemberFlags SynMemberFlagsTrivia.Zero), SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), $5) 
         let vis = $2 
-        let declPat = SynPat.LongIdent (LongIdentWithDots([mkSynId (rhs parseState 3) "new"], []), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
+        let declPat = SynPat.ParametersOwner (LongIdentWithDots([mkSynId (rhs parseState 3) "new"], []), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
         // Check that 'SynPatForConstructorDecl' matches this correctly
         assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
         let synBindingTrivia: SynBindingTrivia = { LetKeyword = None; EqualsRange = Some mEquals }
@@ -2882,7 +2882,7 @@ cPrototype:
                 SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
                 mRhs)
         (fun attrs _ ->
-            let bindingPat = SynPat.LongIdent (LongIdentWithDots([nm], []), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
+            let bindingPat = SynPat.ParametersOwner (LongIdentWithDots([nm], []), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
             let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let xmlDoc = grabXmlDoc(parseState, attrs, 1)
             let binding =
@@ -3254,7 +3254,7 @@ headBindingPattern:
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
   | headBindingPattern COLON_COLON  headBindingPattern 
-      { SynPat.LongIdent (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
+      { SynPat.ParametersOwner (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
 
   | tuplePatternElements  %prec pat_tuple 
       { SynPat.Tuple(false, List.rev $1, lhs parseState) }
@@ -3294,43 +3294,43 @@ namePatPair:
 constrPattern:
   | atomicPatternLongIdent explicitValTyparDecls
       { let vis, lid = $1
-        SynPat.LongIdent (lid, None, None, Some $2, SynArgPats.Pats [], vis, lhs parseState) }
+        SynPat.ParametersOwner (lid, None, None, Some $2, SynArgPats.Pats [], vis, lhs parseState) }
 
   | atomicPatternLongIdent explicitValTyparDecls atomicPatsOrNamePatPairs %prec pat_app
       { let vis, lid = $1
         let args, argsM = $3
         let m = unionRanges (rhs2 parseState 1 2) argsM
-        SynPat.LongIdent (lid, None, None, Some $2, args, vis, m) }
+        SynPat.ParametersOwner (lid, None, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
         let args, argsM = $4
         let m = unionRanges (rhs2 parseState 1 2) argsM
-        SynPat.LongIdent (lid, None, None, Some $2, args, vis, m) }
+        SynPat.ParametersOwner (lid, None, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
         let args, argsM = $4
         let m = unionRanges (rhs2 parseState 1 2) argsM
-        SynPat.LongIdent (lid, None, None, Some $2, args, vis, m) }
+        SynPat.ParametersOwner (lid, None, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent atomicPatsOrNamePatPairs %prec pat_app
       { let vis, lid = $1
         let args, argsM = $2
         let m = unionRanges (rhs parseState 1) argsM
-        SynPat.LongIdent (lid, None, None, None, args, vis, m) }
+        SynPat.ParametersOwner (lid, None, None, None, args, vis, m) }
 
   | atomicPatternLongIdent HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
         let args, argsM = $3
         let m = unionRanges (rhs parseState 1) argsM
-        SynPat.LongIdent (lid, None, None, None, args, vis, m) }
+        SynPat.ParametersOwner (lid, None, None, None, args, vis, m) }
 
   | atomicPatternLongIdent HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
         let args, argsM = $3
         let m = unionRanges (rhs parseState 1) argsM
-        SynPat.LongIdent (lid, None, None, None, args, vis, m) }
+        SynPat.ParametersOwner (lid, None, None, None, args, vis, m) }
 
   | COLON_QMARK atomTypeOrAnonRecdType  %prec pat_isinst 
       { SynPat.IsInst($2, lhs parseState) }
@@ -3493,7 +3493,7 @@ parenPattern:
         SynPat.Attrib($2, $1, lhsm) } 
 
   | parenPattern COLON_COLON  parenPattern 
-      { SynPat.LongIdent (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
+      { SynPat.ParametersOwner (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
 
   | constrPattern { $1 }
 

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -87,8 +87,8 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
             match binding with
             | SynBinding(headPat=headPat) ->
                 match headPat with
-                | SynPat.ParametersOwner (longDotId=longIdentWithDots) ->
-                    Some longIdentWithDots.Range
+                | SynPat.ParametersOwner (namePat = pat) ->
+                    Some pat.Range
                 | SynPat.As (rhsPat=SynPat.Named (ident=ident; isThisVal=false))
                 | SynPat.Named (ident, false, _, _) ->
                     Some ident.idRange

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -87,7 +87,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
             match binding with
             | SynBinding(headPat=headPat) ->
                 match headPat with
-                | SynPat.LongIdent (longDotId=longIdentWithDots) ->
+                | SynPat.ParametersOwner (longDotId=longIdentWithDots) ->
                     Some longIdentWithDots.Range
                 | SynPat.As (rhsPat=SynPat.Named (ident=ident; isThisVal=false))
                 | SynPat.Named (ident, false, _, _) ->

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -503,7 +503,7 @@ module InterfaceStubGenerator =
         GetInterfaceMembers entity |> Seq.isEmpty
 
     let internal (|LongIdentPattern|_|) = function
-        | SynPat.LongIdent(longDotId=LongIdentWithDots(xs, _)) ->
+        | SynPat.ParametersOwner(longDotId=LongIdentWithDots(xs, _)) ->
 //            let (name, range) = xs |> List.map (fun x -> x.idText, x.idRange) |> List.last
             let last = List.last xs
             Some(last.idText, last.idRange)

--- a/src/fsharp/service/ServiceInterfaceStubGenerator.fs
+++ b/src/fsharp/service/ServiceInterfaceStubGenerator.fs
@@ -503,7 +503,7 @@ module InterfaceStubGenerator =
         GetInterfaceMembers entity |> Seq.isEmpty
 
     let internal (|LongIdentPattern|_|) = function
-        | SynPat.ParametersOwner(longDotId=LongIdentWithDots(xs, _)) ->
+        | SynPat.ParametersOwner(namePat = LongIdentInParametersOwnerNamePat xs) ->
 //            let (name, range) = xs |> List.map (fun x -> x.idText, x.idRange) |> List.last
             let last = List.last xs
             Some(last.idText, last.idRange)

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -142,7 +142,7 @@ module NavigationImpl =
                 | _ -> synExpr.Range
 
             match synPat, memberOpt with
-            | SynPat.LongIdent(longDotId=LongIdentWithDots(lid,_); accessibility=access), Some(flags) when isMember -> 
+            | SynPat.ParametersOwner(longDotId=LongIdentWithDots(lid,_); accessibility=access), Some(flags) when isMember -> 
                 let icon, kind =
                   match flags.MemberKind with
                   | SynMemberKind.ClassConstructor
@@ -158,7 +158,7 @@ module NavigationImpl =
                   | hd :: _ -> (lid, hd.idRange) 
                   | _ -> (lid, m)
                 [ createMemberLid(lidShow, kind, icon, unionRanges rangeMerge m, enclosingEntityKind, isAbstract, access) ]
-            | SynPat.LongIdent(longDotId=LongIdentWithDots(lid,_); accessibility=access), _ -> 
+            | SynPat.ParametersOwner(longDotId=LongIdentWithDots(lid,_); accessibility=access), _ -> 
                 [ createMemberLid(lid, NavigationItemKind.Field, FSharpGlyph.Field, unionRanges (List.head lid).idRange m, enclosingEntityKind, isAbstract, access) ]
             | SynPat.Named (id, _, access, _), _ | SynPat.As(_, SynPat.Named (id, _, access, _), _), _ -> 
                 let glyph = if isMember then FSharpGlyph.Method else FSharpGlyph.Field
@@ -240,8 +240,8 @@ module NavigationImpl =
                              processMembers membs enclosingEntityKind |> snd
                          | _ -> [] 
                      // can happen if one is a getter and one is a setter
-                     | [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(longDotId=lid1; extraId=Some(info1))) as binding1)
-                        SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(longDotId=lid2; extraId=Some(info2))) as binding2)] ->
+                     | [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(longDotId=lid1; extraId=Some(info1))) as binding1)
+                        SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(longDotId=lid2; extraId=Some(info2))) as binding2)] ->
                          // ensure same long id
                          assert((lid1.Lid,lid2.Lid) ||> List.forall2 (fun x y -> x.idText = y.idText))
                          // ensure one is getter, other is setter
@@ -574,10 +574,10 @@ module NavigateTo =
                     | _ -> NavigableItemKind.ModuleValue
     
             match headPat with
-            | SynPat.LongIdent(longDotId=LongIdentWithDots([_; id], _)) ->
+            | SynPat.ParametersOwner(longDotId=LongIdentWithDots([_; id], _)) ->
                 // instance members
                 addIdent kind id false container
-            | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _)) ->
+            | SynPat.ParametersOwner(longDotId=LongIdentWithDots([id], _)) ->
                 // functions
                 addIdent kind id false container
             | SynPat.Named (id, _, _, _) | SynPat.As(_, SynPat.Named (id, _, _, _), _) ->

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -142,7 +142,7 @@ module NavigationImpl =
                 | _ -> synExpr.Range
 
             match synPat, memberOpt with
-            | SynPat.ParametersOwner(longDotId=LongIdentWithDots(lid,_); accessibility=access), Some(flags) when isMember -> 
+            | SynPat.ParametersOwner(namePat = LongIdentInParametersOwnerNamePat lid; accessibility=access), Some(flags) when isMember -> 
                 let icon, kind =
                   match flags.MemberKind with
                   | SynMemberKind.ClassConstructor
@@ -158,7 +158,7 @@ module NavigationImpl =
                   | hd :: _ -> (lid, hd.idRange) 
                   | _ -> (lid, m)
                 [ createMemberLid(lidShow, kind, icon, unionRanges rangeMerge m, enclosingEntityKind, isAbstract, access) ]
-            | SynPat.ParametersOwner(longDotId=LongIdentWithDots(lid,_); accessibility=access), _ -> 
+            | SynPat.ParametersOwner(namePat = LongIdentInParametersOwnerNamePat lid; accessibility=access), _ -> 
                 [ createMemberLid(lid, NavigationItemKind.Field, FSharpGlyph.Field, unionRanges (List.head lid).idRange m, enclosingEntityKind, isAbstract, access) ]
             | SynPat.Named (id, _, access, _), _ | SynPat.As(_, SynPat.Named (id, _, access, _), _), _ -> 
                 let glyph = if isMember then FSharpGlyph.Method else FSharpGlyph.Field
@@ -240,10 +240,10 @@ module NavigationImpl =
                              processMembers membs enclosingEntityKind |> snd
                          | _ -> [] 
                      // can happen if one is a getter and one is a setter
-                     | [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(longDotId=lid1; extraId=Some(info1))) as binding1)
-                        SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(longDotId=lid2; extraId=Some(info2))) as binding2)] ->
+                     | [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(namePat = LongIdentInParametersOwnerNamePat lid1; extraId=Some(info1))) as binding1)
+                        SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(namePat = LongIdentInParametersOwnerNamePat lid2; extraId=Some(info2))) as binding2)] ->
                          // ensure same long id
-                         assert((lid1.Lid,lid2.Lid) ||> List.forall2 (fun x y -> x.idText = y.idText))
+                         assert((lid1,lid2) ||> List.forall2 (fun x y -> x.idText = y.idText))
                          // ensure one is getter, other is setter
                          assert((info1.idText = "set" && info2.idText = "get") ||
                                 (info2.idText = "set" && info1.idText = "get"))
@@ -574,10 +574,10 @@ module NavigateTo =
                     | _ -> NavigableItemKind.ModuleValue
     
             match headPat with
-            | SynPat.ParametersOwner(longDotId=LongIdentWithDots([_; id], _)) ->
+            | SynPat.ParametersOwner(namePat = LongIdentInParametersOwnerNamePat [_; id]) ->
                 // instance members
                 addIdent kind id false container
-            | SynPat.ParametersOwner(longDotId=LongIdentWithDots([id], _)) ->
+            | SynPat.ParametersOwner(namePat = SingleIdentInParametersOwnerNamePat id) ->
                 // functions
                 addIdent kind id false container
             | SynPat.Named (id, _, _, _) | SynPat.As(_, SynPat.Named (id, _, _, _), _) ->

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -683,10 +683,10 @@ module SyntaxTraversal =
                         match mems |> Seq.toList with
                         | [mem] -> // the typical case, a single member has this range 'r'
                             Some (dive mem r (traverseSynMemberDefn path  traverseInherit))
-                        |  [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(longDotId=lid1; extraId=Some(info1)))) as mem1
-                            SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(longDotId=lid2; extraId=Some(info2)))) as mem2] -> // can happen if one is a getter and one is a setter
+                        |  [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(namePat = LongIdentInParametersOwnerNamePat lid1; extraId=Some(info1)))) as mem1
+                            SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(namePat = LongIdentInParametersOwnerNamePat lid2; extraId=Some(info2)))) as mem2] -> // can happen if one is a getter and one is a setter
                             // ensure same long id
-                            assert( (lid1.Lid,lid2.Lid) ||> List.forall2 (fun x y -> x.idText = y.idText) )
+                            assert( (lid1,lid2) ||> List.forall2 (fun x y -> x.idText = y.idText) )
                             // ensure one is getter, other is setter
                             assert( (info1.idText="set" && info2.idText="get") ||
                                     (info2.idText="set" && info1.idText="get") )

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -639,7 +639,7 @@ module SyntaxTraversal =
                 | SynPat.Tuple (_, ps, _)
                 | SynPat.ArrayOrList (_, ps, _) -> ps |> List.tryPick (traversePat path)
                 | SynPat.Attrib (p, _, _) -> traversePat path p
-                | SynPat.LongIdent(argPats=args) ->
+                | SynPat.ParametersOwner(argPats=args) ->
                     match args with
                     | SynArgPats.Pats ps -> ps |> List.tryPick (traversePat path)
                     | SynArgPats.NamePatPairs (ps, _) ->
@@ -683,8 +683,8 @@ module SyntaxTraversal =
                         match mems |> Seq.toList with
                         | [mem] -> // the typical case, a single member has this range 'r'
                             Some (dive mem r (traverseSynMemberDefn path  traverseInherit))
-                        |  [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(longDotId=lid1; extraId=Some(info1)))) as mem1
-                            SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(longDotId=lid2; extraId=Some(info2)))) as mem2] -> // can happen if one is a getter and one is a setter
+                        |  [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(longDotId=lid1; extraId=Some(info1)))) as mem1
+                            SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(longDotId=lid2; extraId=Some(info2)))) as mem2] -> // can happen if one is a getter and one is a setter
                             // ensure same long id
                             assert( (lid1.Lid,lid2.Lid) ||> List.forall2 (fun x y -> x.idText = y.idText) )
                             // ensure one is getter, other is setter

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -1006,7 +1006,7 @@ module ParsedInput =
                             | _ -> defaultTraverse synBinding
 
                         match headPat with
-                        | SynPat.ParametersOwner(longDotId = lidwd) when rangeContainsPos lidwd.Range pos ->
+                        | SynPat.ParametersOwner(namePat = pat) when rangeContainsPos pat.Range pos ->
                             // let fo|o x = ()
                             Some CompletionContext.Invalid
                         | SynPat.ParametersOwner(argPats=ctorArgs) ->
@@ -1264,7 +1264,7 @@ module ParsedInput =
                 List.iter walkAttribute attrs
             | SynPat.As (pat1, pat2, _)
             | SynPat.Or (pat1, pat2, _, _) -> List.iter walkPat [pat1; pat2]
-            | SynPat.ParametersOwner (longDotId=ident; typarDecls=typars; argPats=ConstructorPats pats) ->
+            | SynPat.ParametersOwner (namePat = LongIdentWithDotsInParametersOwnerNamePat ident; typarDecls=typars; argPats=ConstructorPats pats) ->
                 addLongIdentWithDots ident
                 typars
                 |> Option.iter (fun (ValTyparDecls (typars, constraints, _)) ->

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -495,7 +495,7 @@ module ParsedInput =
             | SynPat.Typed(pat, t, _) -> walkPat pat |> Option.orElseWith (fun () -> walkType t)
             | SynPat.Attrib(pat, Attributes attrs, _) -> walkPat pat |> Option.orElseWith (fun () -> List.tryPick walkAttribute attrs)
             | SynPat.Or(pat1, pat2, _, _) -> List.tryPick walkPat [pat1; pat2]
-            | SynPat.LongIdent(typarDecls=typars; argPats=ConstructorPats pats; range=r) -> 
+            | SynPat.ParametersOwner(typarDecls=typars; argPats=ConstructorPats pats; range=r) -> 
                 ifPosInRange r (fun _ -> kind)
                 |> Option.orElseWith (fun () -> 
                     typars 
@@ -1006,10 +1006,10 @@ module ParsedInput =
                             | _ -> defaultTraverse synBinding
 
                         match headPat with
-                        | SynPat.LongIdent(longDotId = lidwd) when rangeContainsPos lidwd.Range pos ->
+                        | SynPat.ParametersOwner(longDotId = lidwd) when rangeContainsPos lidwd.Range pos ->
                             // let fo|o x = ()
                             Some CompletionContext.Invalid
-                        | SynPat.LongIdent(argPats=ctorArgs) ->
+                        | SynPat.ParametersOwner(argPats=ctorArgs) ->
                             match ctorArgs with
                             | SynArgPats.Pats pats ->
                                 pats |> List.tryPick (fun (SkipFromParseErrorPat pat) ->
@@ -1264,7 +1264,7 @@ module ParsedInput =
                 List.iter walkAttribute attrs
             | SynPat.As (pat1, pat2, _)
             | SynPat.Or (pat1, pat2, _, _) -> List.iter walkPat [pat1; pat2]
-            | SynPat.LongIdent (longDotId=ident; typarDecls=typars; argPats=ConstructorPats pats) ->
+            | SynPat.ParametersOwner (longDotId=ident; typarDecls=typars; argPats=ConstructorPats pats) ->
                 addLongIdentWithDots ident
                 typars
                 |> Option.iter (fun (ValTyparDecls (typars, constraints, _)) ->

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -480,7 +480,7 @@ module Structure =
               
                   let collapse =
                     match synPat with
-                    | SynPat.LongIdent(longDotId=longIdent) ->
+                    | SynPat.ParametersOwner(longDotId=longIdent) ->
                        Range.endToEnd longIdent.Range d.Range
                     | _ -> Range.endToEnd bindingRange d.Range
 

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -480,8 +480,8 @@ module Structure =
               
                   let collapse =
                     match synPat with
-                    | SynPat.ParametersOwner(longDotId=longIdent) ->
-                       Range.endToEnd longIdent.Range d.Range
+                    | SynPat.ParametersOwner(namePat = pat) ->
+                       Range.endToEnd pat.Range d.Range
                     | _ -> Range.endToEnd bindingRange d.Range
 
                   rcheck Scope.Member Collapse.Below range collapse

--- a/src/fsharp/service/ServiceXmlDocParser.fs
+++ b/src/fsharp/service/ServiceXmlDocParser.fs
@@ -41,7 +41,9 @@ module XmlDocParsing =
         | SynPat.QuoteExpr _
         | SynPat.DeprecatedCharRange _
         | SynPat.InstanceMember _
-        | SynPat.FromParseError _ -> []
+        | SynPat.FromParseError _
+        | SynPat.Ident _
+        | SynPat.LongIdent _ -> []
 
     let getXmlDocablesImpl(sourceText: ISourceText, input: ParsedInput) =
         let indentOf (lineNum: int) =

--- a/src/fsharp/service/ServiceXmlDocParser.fs
+++ b/src/fsharp/service/ServiceXmlDocParser.fs
@@ -24,7 +24,7 @@ module XmlDocParsing =
         | SynPat.Named (id,_isTheThisVar,_access,_range) -> [id.idText]
         | SynPat.Typed(pat,_type,_range) -> digNamesFrom pat
         | SynPat.Attrib(pat,_attrs,_range) -> digNamesFrom pat
-        | SynPat.LongIdent(argPats=ConstructorPats pats) -> 
+        | SynPat.ParametersOwner(argPats=ConstructorPats pats) -> 
             pats |> List.collect digNamesFrom 
         | SynPat.Tuple(_,pats,_range) -> pats |> List.collect digNamesFrom 
         | SynPat.Paren(pat,_range) -> digNamesFrom pat

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -43,9 +43,6 @@
     <Compile Include="..\service\PerfTests.fs">
       <Link>PerfTests.fs</Link>
     </Compile>
-    <Compile Include="..\service\NojafTests.fs">
-      <Link>NojafTests.fs</Link>
-    </Compile>
     <Compile Include="..\service\InteractiveCheckerTests.fs">
       <Link>InteractiveCheckerTests.fs</Link>
     </Compile>

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -43,6 +43,9 @@
     <Compile Include="..\service\PerfTests.fs">
       <Link>PerfTests.fs</Link>
     </Compile>
+    <Compile Include="..\service\NojafTests.fs">
+      <Link>NojafTests.fs</Link>
+    </Compile>
     <Compile Include="..\service\InteractiveCheckerTests.fs">
       <Link>InteractiveCheckerTests.fs</Link>
     </Compile>

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -7876,6 +7876,10 @@ FSharp.Compiler.Syntax.SynPat+FromParseError: FSharp.Compiler.Syntax.SynPat get_
 FSharp.Compiler.Syntax.SynPat+FromParseError: FSharp.Compiler.Syntax.SynPat pat
 FSharp.Compiler.Syntax.SynPat+FromParseError: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+FromParseError: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynPat+Ident: FSharp.Compiler.Syntax.Ident get_ident()
+FSharp.Compiler.Syntax.SynPat+Ident: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynPat+Ident: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynPat+Ident: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.Ident get_memberId()
 FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.Ident get_thisId()
 FSharp.Compiler.Syntax.SynPat+InstanceMember: FSharp.Compiler.Syntax.Ident memberId
@@ -7890,6 +7894,10 @@ FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType get_pat()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType pat
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
+FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynPat+Named: Boolean get_isThisVal()
 FSharp.Compiler.Syntax.SynPat+Named: Boolean isThisVal
 FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.Ident get_ident()
@@ -7912,10 +7920,10 @@ FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia ge
 FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia trivia
 FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
 FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.SynArgPats argPats
 FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.SynArgPats get_argPats()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.SynPat get_namePat()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.SynPat namePat
 FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] extraId
@@ -7945,8 +7953,10 @@ FSharp.Compiler.Syntax.SynPat+Tags: Int32 Attrib
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Const
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 DeprecatedCharRange
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 FromParseError
+FSharp.Compiler.Syntax.SynPat+Tags: Int32 Ident
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 InstanceMember
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 IsInst
+FSharp.Compiler.Syntax.SynPat+Tags: Int32 LongIdent
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Named
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Null
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 OptionalVal
@@ -7979,8 +7989,10 @@ FSharp.Compiler.Syntax.SynPat: Boolean IsAttrib
 FSharp.Compiler.Syntax.SynPat: Boolean IsConst
 FSharp.Compiler.Syntax.SynPat: Boolean IsDeprecatedCharRange
 FSharp.Compiler.Syntax.SynPat: Boolean IsFromParseError
+FSharp.Compiler.Syntax.SynPat: Boolean IsIdent
 FSharp.Compiler.Syntax.SynPat: Boolean IsInstanceMember
 FSharp.Compiler.Syntax.SynPat: Boolean IsIsInst
+FSharp.Compiler.Syntax.SynPat: Boolean IsLongIdent
 FSharp.Compiler.Syntax.SynPat: Boolean IsNamed
 FSharp.Compiler.Syntax.SynPat: Boolean IsNull
 FSharp.Compiler.Syntax.SynPat: Boolean IsOptionalVal
@@ -7999,8 +8011,10 @@ FSharp.Compiler.Syntax.SynPat: Boolean get_IsAttrib()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsConst()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsDeprecatedCharRange()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsFromParseError()
+FSharp.Compiler.Syntax.SynPat: Boolean get_IsIdent()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsInstanceMember()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsIsInst()
+FSharp.Compiler.Syntax.SynPat: Boolean get_IsLongIdent()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsNamed()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsNull()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsOptionalVal()
@@ -8019,13 +8033,15 @@ FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewAttrib(FSharp.Co
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewConst(FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewDeprecatedCharRange(Char, Char, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewFromParseError(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewIdent(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewInstanceMember(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewIsInst(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNamed(FSharp.Compiler.Syntax.Ident, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOptionalVal(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOr(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewParametersOwner(FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewParametersOwner(FSharp.Compiler.Syntax.SynPat, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewParen(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewQuoteExpr(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewRecord(Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]], FSharp.Compiler.Text.Range)
@@ -8039,8 +8055,10 @@ FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Attrib
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Const
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+DeprecatedCharRange
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+FromParseError
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Ident
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+InstanceMember
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+IsInst
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+LongIdent
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Named
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Null
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+OptionalVal

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -1455,12 +1455,12 @@ FSharp.Compiler.AbstractIL.IL+ILType: System.String get_BasicQualifiedName()
 FSharp.Compiler.AbstractIL.IL+ILType: System.String get_QualifiedName()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean HasSecurity
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsAbstract
-FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsKnownToBeAttribute
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsClass
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsComInterop
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsDelegate
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsEnum
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsInterface
+FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsKnownToBeAttribute
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsSealed
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsSerializable
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsSpecialName
@@ -1468,12 +1468,12 @@ FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsStruct
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsStructOrEnum
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_HasSecurity()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsAbstract()
-FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsKnownToBeAttribute()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsClass()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsComInterop()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsDelegate()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsEnum()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsInterface()
+FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsKnownToBeAttribute()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsSealed()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsSerializable()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsSpecialName()
@@ -7890,20 +7890,6 @@ FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType get_pat()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType pat
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynArgPats argPats
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynArgPats get_argPats()
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range get_range()
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] extraId
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_extraId()
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword] get_propertyKeyword()
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword] propertyKeyword
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls] get_typarDecls()
-FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls] typarDecls
 FSharp.Compiler.Syntax.SynPat+Named: Boolean get_isThisVal()
 FSharp.Compiler.Syntax.SynPat+Named: Boolean isThisVal
 FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.Ident get_ident()
@@ -7926,6 +7912,20 @@ FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia ge
 FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia trivia
 FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+Or: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.SynArgPats argPats
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Syntax.SynArgPats get_argPats()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] extraId
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_extraId()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword] get_propertyKeyword()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword] propertyKeyword
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls] get_typarDecls()
+FSharp.Compiler.Syntax.SynPat+ParametersOwner: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls] typarDecls
 FSharp.Compiler.Syntax.SynPat+Paren: FSharp.Compiler.Syntax.SynPat get_pat()
 FSharp.Compiler.Syntax.SynPat+Paren: FSharp.Compiler.Syntax.SynPat pat
 FSharp.Compiler.Syntax.SynPat+Paren: FSharp.Compiler.Text.Range get_range()
@@ -7947,11 +7947,11 @@ FSharp.Compiler.Syntax.SynPat+Tags: Int32 DeprecatedCharRange
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 FromParseError
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 InstanceMember
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 IsInst
-FSharp.Compiler.Syntax.SynPat+Tags: Int32 LongIdent
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Named
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Null
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 OptionalVal
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Or
+FSharp.Compiler.Syntax.SynPat+Tags: Int32 ParametersOwner
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Paren
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 QuoteExpr
 FSharp.Compiler.Syntax.SynPat+Tags: Int32 Record
@@ -7981,11 +7981,11 @@ FSharp.Compiler.Syntax.SynPat: Boolean IsDeprecatedCharRange
 FSharp.Compiler.Syntax.SynPat: Boolean IsFromParseError
 FSharp.Compiler.Syntax.SynPat: Boolean IsInstanceMember
 FSharp.Compiler.Syntax.SynPat: Boolean IsIsInst
-FSharp.Compiler.Syntax.SynPat: Boolean IsLongIdent
 FSharp.Compiler.Syntax.SynPat: Boolean IsNamed
 FSharp.Compiler.Syntax.SynPat: Boolean IsNull
 FSharp.Compiler.Syntax.SynPat: Boolean IsOptionalVal
 FSharp.Compiler.Syntax.SynPat: Boolean IsOr
+FSharp.Compiler.Syntax.SynPat: Boolean IsParametersOwner
 FSharp.Compiler.Syntax.SynPat: Boolean IsParen
 FSharp.Compiler.Syntax.SynPat: Boolean IsQuoteExpr
 FSharp.Compiler.Syntax.SynPat: Boolean IsRecord
@@ -8001,11 +8001,11 @@ FSharp.Compiler.Syntax.SynPat: Boolean get_IsDeprecatedCharRange()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsFromParseError()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsInstanceMember()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsIsInst()
-FSharp.Compiler.Syntax.SynPat: Boolean get_IsLongIdent()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsNamed()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsNull()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsOptionalVal()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsOr()
+FSharp.Compiler.Syntax.SynPat: Boolean get_IsParametersOwner()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsParen()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsQuoteExpr()
 FSharp.Compiler.Syntax.SynPat: Boolean get_IsRecord()
@@ -8021,11 +8021,11 @@ FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewDeprecatedCharRa
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewFromParseError(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewInstanceMember(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewIsInst(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNamed(FSharp.Compiler.Syntax.Ident, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOptionalVal(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOr(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewParametersOwner(FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewParen(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewQuoteExpr(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewRecord(Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Syntax.Ident],FSharp.Compiler.Text.Range,FSharp.Compiler.Syntax.SynPat]], FSharp.Compiler.Text.Range)
@@ -8041,11 +8041,11 @@ FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+DeprecatedCharRange
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+FromParseError
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+InstanceMember
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+IsInst
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+LongIdent
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Named
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Null
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+OptionalVal
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Or
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+ParametersOwner
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Paren
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+QuoteExpr
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat+Record

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -158,7 +158,7 @@ let f (x
     match getSingleDeclInModule parseResults with
     | SynModuleDecl.Let (_, [ SynBinding (headPat = headPat) ], _) ->
         match headPat with
-        | SynPat.LongIdent (argPats=SynArgPats.Pats [ SynPat.FromParseError (SynPat.Paren (SynPat.Named _, _), _) ]) -> ()
+        | SynPat.ParametersOwner (argPats=SynArgPats.Pats [ SynPat.FromParseError (SynPat.Paren (SynPat.Named _, _), _) ]) -> ()
         | _ -> failwith "Unexpected tree"
     | _ -> failwith "Unexpected tree"
 
@@ -171,7 +171,7 @@ let f (x, y
     match getSingleDeclInModule parseResults with
     | SynModuleDecl.Let (_, [ SynBinding (headPat = headPat) ], _) ->
         match headPat with
-        | SynPat.LongIdent (argPats=SynArgPats.Pats [ SynPat.FromParseError (SynPat.Paren (SynPat.Tuple _, _), _) ]) -> ()
+        | SynPat.ParametersOwner (argPats=SynArgPats.Pats [ SynPat.FromParseError (SynPat.Paren (SynPat.Tuple _, _), _) ]) -> ()
         | _ -> failwith "Unexpected tree"
     | _ -> failwith "Unexpected tree"
 
@@ -182,7 +182,7 @@ let f (x,
 """
 
     match getSingleDeclInModule parseResults with
-    | SynModuleDecl.Let (_, [ SynBinding (headPat = SynPat.LongIdent (argPats = SynArgPats.Pats [ pat ])) ], _) ->
+    | SynModuleDecl.Let (_, [ SynBinding (headPat = SynPat.ParametersOwner (argPats = SynArgPats.Pats [ pat ])) ], _) ->
         match pat with
         | SynPat.FromParseError (SynPat.Paren (SynPat.FromParseError (SynPat.Wild _, _), _), _) -> ()
         | _ -> failwith "Unexpected tree"

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -570,7 +570,7 @@ type Foo() =
             SynModuleDecl.Types(
                 typeDefns = [ SynTypeDefn(typeRepr =
                     SynTypeDefnRepr.ObjectModel(members=[ _
-                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(propertyKeyword=Some(PropertyKeyword.With mWith)))) ])
+                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(propertyKeyword=Some(PropertyKeyword.With mWith)))) ])
                     ) ])
              ]) ])) ->
             assertRange (4, 31) (4, 35) mWith
@@ -591,7 +591,7 @@ type Foo() =
             SynModuleDecl.Types(
                 typeDefns = [ SynTypeDefn(typeRepr =
                     SynTypeDefnRepr.ObjectModel(members=[ _
-                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(propertyKeyword=Some(PropertyKeyword.With mWith)))) ])
+                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(propertyKeyword=Some(PropertyKeyword.With mWith)))) ])
                     ) ])
              ]) ])) ->
             assertRange (4, 36) (4, 40) mWith
@@ -614,8 +614,8 @@ type Foo() =
             SynModuleDecl.Types(
                 typeDefns = [ SynTypeDefn(typeRepr =
                     SynTypeDefnRepr.ObjectModel(members=[ _
-                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(propertyKeyword=Some(PropertyKeyword.With mWith))))
-                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(propertyKeyword=Some(PropertyKeyword.And mAnd)))) ])
+                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(propertyKeyword=Some(PropertyKeyword.With mWith))))
+                                                          SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.ParametersOwner(propertyKeyword=Some(PropertyKeyword.And mAnd)))) ])
                     ) ])
              ]) ])) ->
             assertRange (5, 8) (5, 12) mWith
@@ -3030,7 +3030,7 @@ match x with
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Match(clauses = [ SynMatchClause(pat = SynPat.LongIdent(argPats = SynArgPats.NamePatPairs(pats = [ _, mEquals ,_ ])))])
+                expr = SynExpr.Match(clauses = [ SynMatchClause(pat = SynPat.ParametersOwner(argPats = SynArgPats.NamePatPairs(pats = [ _, mEquals ,_ ])))])
             )
         ]) ])) ->
             assertRange (3, 7) (3, 8) mEquals

--- a/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
@@ -20,7 +20,7 @@ type FSharpParseFileResults with
                     else
                         // Check if it's an operator
                         match pat with
-                        | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _)) when id.idText.StartsWith("op_") ->
+                        | SynPat.ParametersOwner(longDotId=LongIdentWithDots([id], _)) when id.idText.StartsWith("op_") ->
                             if Position.posEq id.idRange.Start pos then
                                 Some binding.RangeOfBindingWithRhs
                             else

--- a/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
@@ -20,7 +20,7 @@ type FSharpParseFileResults with
                     else
                         // Check if it's an operator
                         match pat with
-                        | SynPat.ParametersOwner(longDotId=LongIdentWithDots([id], _)) when id.idText.StartsWith("op_") ->
+                        | SynPat.ParametersOwner(namePat = SynPat.Ident(id,_) | SynPat.LongIdent(LongIdentWithDots([id], _), _)) when id.idText.StartsWith("op_") ->
                             if Position.posEq id.idRange.Start pos then
                                 Some binding.RangeOfBindingWithRhs
                             else


### PR DESCRIPTION
This is a subset, the first step if you will, from https://github.com/dotnet/fsharp/pull/12989.
In 12989 I tried to do too much at the same time and I would like to cut it up into multiple PRs.

This first one refactors `SynPat.LongIdent` to `SynPat.ParameterOwners` and take a `SynPat` as the name identifier.
In practise, this can be `SynPat.LongIdent` or `SynPat.Ident`. 

Later this could be extended to include `SynPat.Operator` and `SynPat.DotGetOperator`.
And after that, the captured `SynOperatorName` could also be introduced into `SynExpr`.

@dsyme, @vzarytovskii please let me know your thoughts on this.
I do believe this proposed route should be favoured over the alternative in https://github.com/dotnet/fsharp/pull/13023.
Replacing `Ident` with `SynIdentOrOperatorName` takes a performance hit and it is used in a lot of places where operator names will never be valid. So, I would abandon that idea altogether.

//cc @auduchinok