### PR TITLE
Fix Unicode characters being entered via console

### DIFF
--- a/src/fsharp/fsi/console.fs
+++ b/src/fsharp/fsi/console.fs
@@ -6,26 +6,6 @@ open System
 open System.Text
 open System.Collections.Generic
 
-/// System.Console.ReadKey appears to return an ANSI character (not the expected the unicode character).
-/// When this fix flag is true, this byte is converted to a char using the System.Console.InputEncoding.
-/// This is a code-around for bug://1345.
-/// Fixes to System.Console.ReadKey may break this code around, hence the option here.
-module internal ConsoleOptions =
-
-  let readKeyFixup (c:char) =
-      // Assumes the c:char is actually a byte in the System.Console.InputEncoding.
-      // Convert it to a Unicode char through the encoding.
-      if 0 <= int c && int c <= 255 then
-          let chars = System.Console.InputEncoding.GetChars [| byte c |]
-          if chars.Length = 1 then
-              chars.[0] // fixed up char
-          else
-              assert("readKeyFixHook: InputEncoding.GetChars(single-byte) returned multiple chars" = "")
-              c // no fix up
-      else
-          assert("readKeyFixHook: given char is outside the 0..255 byte range" = "")
-          c
-
 type internal Style = Prompt | Out | Error
 
 /// Class managing the command History.
@@ -367,7 +347,6 @@ type internal ReadLineConsole() =
             // REVIEW: the Ctrl-Z code is not recognised as EOF by the lexer.
             // REVIEW: looks like a relic of the port of readline, which is currently removable.
             let c = if (key.Key = ConsoleKey.F6) then '\x1A' else key.KeyChar
-            let c = ConsoleOptions.readKeyFixup c
             insertChar(c)
             
         let backspace() =


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/7733

I finally looked into this long standing regression.

[This change between F# 4.5 and F# 4.7](https://github.com/dotnet/fsharp/compare/Visual-Studio-2019-Version-16.0..Visual-Studio-2019-Version-16.3#diff-12467ce4bfeeafc44e30497d5660154b11cb2b13a9a29d29bd3fa24fe33706a9L27) was incorrect - `fixNonUnicodeSystemConsoleReadKey` is considered false in the change, but it appears someone falsely read `!a` as `not a`.  A good example of why it was good to deprecate `!expr` in F# 6.0

I don't actually know how to test console key input within our automated testing, I'm not totally sure it can be done.  None of console.fs is under automated test AFAIK.  If anyone has good ideas we could add testing.

