### PR TITLE
SynLongIdent

### DIFF
--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -1237,7 +1237,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
 
         // 'use! pat = e1 in e2' --> build.Bind(e1, (function  _argN -> match _argN with pat -> build.Using(x, (fun _argN -> match _argN with pat -> e2))))
         | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.Named (ident=id; isThisVal=false) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp)
-        | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.LongIdent (longDotId=LongIdentWithDots(id=[id])) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp) ->
+        | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.LongIdent (longDotId=LongIdentWithDots([id], _)) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp) ->
 
             let mBind = match spBind with DebugPointAtBinding.Yes m -> m | _ -> rhsExpr.Range
             if isQuery then error(Error(FSComp.SR.tcBindMayNotBeUsedInQueries(), mBind))

--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -244,7 +244,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
             | args -> SynExpr.Paren (SynExpr.Tuple (false, args, [], m), range0, None, m)
                 
         let builderVal = mkSynIdGet m builderValName
-        mkSynApp1 (SynExpr.DotGet (builderVal, range0, LongIdentWithDots([mkSynId m nm], []), m)) args m
+        mkSynApp1 (SynExpr.DotGet (builderVal, range0, SynLongIdent([mkSynId m nm], [], [None]), m)) args m
 
     let hasMethInfo nm = TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env mBuilderVal ad nm builderTy |> isNil |> not
 

--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -243,7 +243,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
             | [arg] -> SynExpr.Paren (SynExpr.Paren (arg, range0, None, m), range0, None, m)
             | args -> SynExpr.Paren (SynExpr.Tuple (false, args, [], m), range0, None, m)
                 
-        let builderVal = mkSynIdGet m builderValName None
+        let builderVal = mkSynIdGet m builderValName
         mkSynApp1 (SynExpr.DotGet (builderVal, range0, LongIdentWithDots([mkSynId m nm], []), m)) args m
 
     let hasMethInfo nm = TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env mBuilderVal ad nm builderTy |> isNil |> not
@@ -689,8 +689,8 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
     let mkExprForVarSpace m (patvs: Val list) = 
         match patvs with 
         | [] -> SynExpr.Const (SynConst.Unit, m)
-        | [v] -> SynExpr.Ident (v.Id, None)
-        | vs -> SynExpr.Tuple (false, (vs |> List.map (fun v -> SynExpr.Ident (v.Id, None))), [], m)  
+        | [v] -> SynExpr.Ident v.Id
+        | vs -> SynExpr.Tuple (false, (vs |> List.map (fun v -> SynExpr.Ident(v.Id))), [], m)  
 
     let mkSimplePatForVarSpace m (patvs: Val list) = 
         let spats = 
@@ -1249,7 +1249,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
 
             let bindExpr =
                 let consumeExpr = SynExpr.MatchLambda(false, mBind, [SynMatchClause(pat, None, transNoQueryOps innerComp, innerComp.Range, DebugPointAtTarget.Yes, SynMatchClauseTrivia.Zero)], DebugPointAtBinding.NoneAtInvisible, mBind)
-                let consumeExpr = mkSynCall "Using" mBind [SynExpr.Ident(id, None); consumeExpr ]
+                let consumeExpr = mkSynCall "Using" mBind [SynExpr.Ident id; consumeExpr ]
                 let consumeExpr = SynExpr.MatchLambda(false, mBind, [SynMatchClause(pat, None, consumeExpr, id.idRange, DebugPointAtTarget.No, SynMatchClauseTrivia.Zero)], DebugPointAtBinding.NoneAtInvisible, mBind)
                 let rhsExpr = mkSourceExprConditional isFromSource rhsExpr
                 mkSynCall "Bind" mBind [rhsExpr; consumeExpr]
@@ -1775,7 +1775,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
     // Add a call to 'Quote' if the method is present
     let quotedSynExpr = 
         if isAutoQuote then 
-            SynExpr.Quote (mkSynIdGet mDelayOrQuoteOrRun (CompileOpName "<@ @>") None, (*isRaw=*)false, delayedExpr, (*isFromQueryExpression=*)true, mWhole) 
+            SynExpr.Quote (mkSynIdGet mDelayOrQuoteOrRun (CompileOpName "<@ @>"), (*isRaw=*)false, delayedExpr, (*isFromQueryExpression=*)true, mWhole) 
         else delayedExpr
             
     // Add a call to 'Run' if the method is present

--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -243,7 +243,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
             | [arg] -> SynExpr.Paren (SynExpr.Paren (arg, range0, None, m), range0, None, m)
             | args -> SynExpr.Paren (SynExpr.Tuple (false, args, [], m), range0, None, m)
                 
-        let builderVal = mkSynIdGet m builderValName
+        let builderVal = mkSynIdGet m builderValName None
         mkSynApp1 (SynExpr.DotGet (builderVal, range0, LongIdentWithDots([mkSynId m nm], []), m)) args m
 
     let hasMethInfo nm = TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env mBuilderVal ad nm builderTy |> isNil |> not
@@ -689,8 +689,8 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
     let mkExprForVarSpace m (patvs: Val list) = 
         match patvs with 
         | [] -> SynExpr.Const (SynConst.Unit, m)
-        | [v] -> SynExpr.Ident v.Id
-        | vs -> SynExpr.Tuple (false, (vs |> List.map (fun v -> SynExpr.Ident v.Id)), [], m)  
+        | [v] -> SynExpr.Ident (v.Id, None)
+        | vs -> SynExpr.Tuple (false, (vs |> List.map (fun v -> SynExpr.Ident (v.Id, None))), [], m)  
 
     let mkSimplePatForVarSpace m (patvs: Val list) = 
         let spats = 
@@ -1249,7 +1249,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
 
             let bindExpr =
                 let consumeExpr = SynExpr.MatchLambda(false, mBind, [SynMatchClause(pat, None, transNoQueryOps innerComp, innerComp.Range, DebugPointAtTarget.Yes, SynMatchClauseTrivia.Zero)], DebugPointAtBinding.NoneAtInvisible, mBind)
-                let consumeExpr = mkSynCall "Using" mBind [SynExpr.Ident(id); consumeExpr ]
+                let consumeExpr = mkSynCall "Using" mBind [SynExpr.Ident(id, None); consumeExpr ]
                 let consumeExpr = SynExpr.MatchLambda(false, mBind, [SynMatchClause(pat, None, consumeExpr, id.idRange, DebugPointAtTarget.No, SynMatchClauseTrivia.Zero)], DebugPointAtBinding.NoneAtInvisible, mBind)
                 let rhsExpr = mkSourceExprConditional isFromSource rhsExpr
                 mkSynCall "Bind" mBind [rhsExpr; consumeExpr]
@@ -1775,7 +1775,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
     // Add a call to 'Quote' if the method is present
     let quotedSynExpr = 
         if isAutoQuote then 
-            SynExpr.Quote (mkSynIdGet mDelayOrQuoteOrRun (CompileOpName "<@ @>"), (*isRaw=*)false, delayedExpr, (*isFromQueryExpression=*)true, mWhole) 
+            SynExpr.Quote (mkSynIdGet mDelayOrQuoteOrRun (CompileOpName "<@ @>") None, (*isRaw=*)false, delayedExpr, (*isFromQueryExpression=*)true, mWhole) 
         else delayedExpr
             
     // Add a call to 'Run' if the method is present

--- a/src/fsharp/CheckComputationExpressions.fs
+++ b/src/fsharp/CheckComputationExpressions.fs
@@ -1236,7 +1236,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
             Some (transBind q varSpace mBind (addBindDebugPoint spBind) "Bind" [rhsExpr] pat innerComp translatedCtxt)
 
         // 'use! pat = e1 in e2' --> build.Bind(e1, (function  _argN -> match _argN with pat -> build.Using(x, (fun _argN -> match _argN with pat -> e2))))
-        | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.Named (ident=id; isThisVal=false) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp)
+        | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.Named (ident=SynIdent(id,_); isThisVal=false) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp)
         | SynExpr.LetOrUseBang (bindDebugPoint=spBind; isUse=true; isFromSource=isFromSource; pat=SynPat.LongIdent (longDotId=LongIdentWithDots([id], _)) as pat; rhs=rhsExpr; andBangs=[]; body=innerComp) ->
 
             let mBind = match spBind with DebugPointAtBinding.Yes m -> m | _ -> rhsExpr.Range

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -4831,7 +4831,7 @@ module TcDeclarations =
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> true | _ -> false)
                         let mLetPortion = synExpr.Range
                         let fldId = ident (CompilerGeneratedName id.idText, mLetPortion)
-                        let headPat = SynPat.LongIdent (LongIdentWithDots([fldId], []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mLetPortion)
+                        let headPat = SynPat.LongIdent (SynLongIdent([fldId], [], [None]), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mLetPortion)
                         let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                         let isMutable = 
                             match propKind with 
@@ -4859,7 +4859,7 @@ module TcDeclarations =
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> false | _ -> true)
                         let fldId = ident (CompilerGeneratedName id.idText, mMemberPortion)
                         let headPatIds = if isStatic then [id] else [ident ("__", mMemberPortion);id]
-                        let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mMemberPortion)
+                        let headPat = SynPat.LongIdent (SynLongIdent(headPatIds, [], List.replicate headPatIds.Length None), None, None, Some noInferredTypars, SynArgPats.Pats [], None, mMemberPortion)
 
                         match propKind, mGetSetOpt with 
                         | SynMemberKind.PropertySet, Some m -> errorR(Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSetNotJustSet(), m))
@@ -4884,7 +4884,7 @@ module TcDeclarations =
                             | SynMemberKind.PropertyGetSet -> 
                                 let setter = 
                                     let vId = ident("v", mMemberPortion)
-                                    let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
+                                    let headPat = SynPat.LongIdent (SynLongIdent(headPatIds, [], List.replicate headPatIds.Length None), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
                                     let rhsExpr = mkSynAssign (SynExpr.Ident fldId) (SynExpr.Ident vId)
                                     //let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                                     let binding = mkSynBinding (xmlDoc, headPat) (access, false, false, mMemberPortion, DebugPointAtBinding.NoneAtInvisible, None, rhsExpr, rhsExpr.Range, [], [], Some (memberFlags SynMemberKind.PropertySet), SynBindingTrivia.Zero)

--- a/src/fsharp/CheckDeclarations.fs
+++ b/src/fsharp/CheckDeclarations.fs
@@ -476,7 +476,7 @@ module TcRecdUnionAndEnumDeclarations =
             | _ ->
                 seen.Add(f.LogicalName, sf))
                 
-    let TcUnionCaseDecl (cenv: cenv) env parent thisTy thisTyInst tpenv (SynUnionCase(Attributes synAttrs, (id, _), args, xmldoc, vis, m, _)) =
+    let TcUnionCaseDecl (cenv: cenv) env parent thisTy thisTyInst tpenv (SynUnionCase(Attributes synAttrs, SynIdent(id, _), args, xmldoc, vis, m, _)) =
         let g = cenv.g
         let attrs = TcAttributes cenv env AttributeTargets.UnionCaseDecl synAttrs // the attributes of a union case decl get attached to the generated "static factory" method
         let vis, _ = ComputeAccessAndCompPath env None m vis None parent
@@ -527,7 +527,7 @@ module TcRecdUnionAndEnumDeclarations =
         let unionCasesR = unionCases |> List.map (TcUnionCaseDecl cenv env parent thisTy thisTyInst tpenv) 
         unionCasesR |> CheckDuplicates (fun uc -> uc.Id) "union case" 
 
-    let TcEnumDecl cenv env parent thisTy fieldTy (SynEnumCase(attributes=Attributes synAttrs; ident=(id,_); value=v; xmlDoc=xmldoc; range=m)) =
+    let TcEnumDecl cenv env parent thisTy fieldTy (SynEnumCase(attributes=Attributes synAttrs; ident= SynIdent(id,_); value=v; xmlDoc=xmldoc; range=m)) =
         let attrs = TcAttributes cenv env AttributeTargets.Field synAttrs
         match v with 
         | SynConst.Bytes _
@@ -3001,7 +3001,7 @@ let CheckForDuplicateModule env nm m =
 /// Check 'exception' declarations in implementations and signatures
 module TcExceptionDeclarations = 
 
-    let TcExnDefnCore_Phase1A cenv env parent (SynExceptionDefnRepr(Attributes synAttrs, SynUnionCase(ident=(id,_)), _, doc, vis, m)) =
+    let TcExnDefnCore_Phase1A cenv env parent (SynExceptionDefnRepr(Attributes synAttrs, SynUnionCase(ident= SynIdent(id,_)), _, doc, vis, m)) =
         let attrs = TcAttributes cenv env AttributeTargets.ExnDecl synAttrs
         if not (String.isLeadingIdentifierCharacterUpperCase id.idText) then errorR(NotUpperCaseConstructor m)
         let vis, cpath = ComputeAccessAndCompPath env None m vis None parent
@@ -4871,7 +4871,7 @@ module TcDeclarations =
                             | SynMemberKind.PropertyGet 
                             | SynMemberKind.PropertyGetSet -> 
                                 let getter = 
-                                    let rhsExpr = SynExpr.Ident (fldId, None)
+                                    let rhsExpr = SynExpr.Ident fldId
                                     let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                                     let attribs = mkAttributeList attribs mMemberPortion
                                     let binding = mkSynBinding (xmlDoc, headPat) (access, false, false, mMemberPortion, DebugPointAtBinding.NoneAtInvisible, retInfo, rhsExpr, rhsExpr.Range, [], attribs, Some (memberFlags SynMemberKind.Member), SynBindingTrivia.Zero)
@@ -4885,7 +4885,7 @@ module TcDeclarations =
                                 let setter = 
                                     let vId = ident("v", mMemberPortion)
                                     let headPat = SynPat.LongIdent (LongIdentWithDots(headPatIds, []), None, None, Some noInferredTypars, SynArgPats.Pats [mkSynPatVar None vId], None, mMemberPortion)
-                                    let rhsExpr = mkSynAssign (SynExpr.Ident (fldId, None)) (SynExpr.Ident (vId, None))
+                                    let rhsExpr = mkSynAssign (SynExpr.Ident fldId) (SynExpr.Ident vId)
                                     //let retInfo = match tyOpt with None -> None | Some ty -> Some (SynReturnInfo((ty, SynInfo.unnamedRetVal), ty.Range))
                                     let binding = mkSynBinding (xmlDoc, headPat) (access, false, false, mMemberPortion, DebugPointAtBinding.NoneAtInvisible, None, rhsExpr, rhsExpr.Range, [], [], Some (memberFlags SynMemberKind.PropertySet), SynBindingTrivia.Zero)
                                     SynMemberDefn.Member (binding, mMemberPortion) 
@@ -5350,7 +5350,7 @@ and TcSignatureElementsMutRec cenv parent typeNames m mutRecNSInfo envInitial (d
                       decls, (openOk, moduleAbbrevOk)
 
                 | SynModuleSigDecl.Exception (exnSig=SynExceptionSig(exnRepr=exnRepr; withKeyword=withKeyword; members=members)) ->
-                      let ( SynExceptionDefnRepr(synAttrs, SynUnionCase(ident=(id,_)), _, doc, vis, m)) = exnRepr
+                      let ( SynExceptionDefnRepr(synAttrs, SynUnionCase(ident=SynIdent(id,_)), _, doc, vis, m)) = exnRepr
                       let compInfo = SynComponentInfo(synAttrs, None, [], [id], doc, false, vis, id.idRange)
                       let decls = [ MutRecShape.Tycon(SynTypeDefnSig.SynTypeDefnSig(compInfo, None, SynTypeDefnSigRepr.Exception exnRepr, withKeyword, members, m)) ]
                       decls, (false, false)
@@ -5688,7 +5688,7 @@ and TcModuleOrNamespaceElementsMutRec (cenv: cenv) parent typeNames m envInitial
                   decls, (openOk, moduleAbbrevOk, attrs)
 
               | SynModuleDecl.Exception (SynExceptionDefn(repr, _, members, _), _m) -> 
-                  let (SynExceptionDefnRepr(synAttrs, SynUnionCase(ident=(id,_)), _repr, doc, vis, m)) = repr
+                  let (SynExceptionDefnRepr(synAttrs, SynUnionCase(ident=SynIdent(id,_)), _repr, doc, vis, m)) = repr
                   let compInfo = SynComponentInfo(synAttrs, None, [], [id], doc, false, vis, id.idRange)
                   let decls = [ MutRecShape.Tycon(SynTypeDefn(compInfo, SynTypeDefnRepr.Exception repr, members, None, m, SynTypeDefnTrivia.Zero)) ]
                   decls, (false, false, attrs)

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -2599,7 +2599,7 @@ module EventDeclarationNormalization =
                    match rhsExpr with
                    // Detect 'fun () -> e' which results from the compilation of a property getter
                    | SynExpr.Lambda (args=SynSimplePats.SimplePats([], _); body=trueRhsExpr; range=m) ->
-                       let rhsExpr = mkSynApp1 (SynExpr.DotGet (SynExpr.Paren (trueRhsExpr, range0, None, m), range0, LongIdentWithDots([ident(target, m)], []), m)) (SynExpr.Ident (ident(argName, m), None)) m
+                       let rhsExpr = mkSynApp1 (SynExpr.DotGet (SynExpr.Paren (trueRhsExpr, range0, None, m), range0, LongIdentWithDots([ident(target, m)], []), m)) (SynExpr.Ident (ident(argName, m))) m
 
                        // reconstitute rhsExpr
                        let bindingRhs = NormalizedBindingRhs([], None, rhsExpr)
@@ -4093,7 +4093,7 @@ and TcPseudoMemberSpec cenv newOk env synTypes tpenv memSpfn m =
 /// Check a value specification, e.g. in a signature, interface declaration or a constraint
 and TcValSpec cenv env declKind newOk containerInfo memFlagsOpt thisTyOpt tpenv valSpfn attrs =
     let g = cenv.g
-    let (SynValSig(ident=(id,_); explicitValDecls=ValTyparDecls (synTypars, synTyparConstraints, _); synType=ty; arity=valSynInfo; range=m)) = valSpfn
+    let (SynValSig(ident=SynIdent(id,_); explicitValDecls=ValTyparDecls (synTypars, synTyparConstraints, _); synType=ty; arity=valSynInfo; range=m)) = valSpfn
     let declaredTypars = TcTyparDecls cenv env synTypars
     let (ContainerInfo(altActualParent, tcrefContainerInfo)) = containerInfo
 
@@ -5167,7 +5167,7 @@ and ConvSynPatToSynExpr x =
     match x with
     | SynPat.FromParseError(p, _) -> ConvSynPatToSynExpr p
     | SynPat.Const (c, m) -> SynExpr.Const (c, m)
-    | SynPat.Named (id, _, None, _) -> SynExpr.Ident (id,None)
+    | SynPat.Named (id, _, None, _) -> SynExpr.Ident id
     | SynPat.Typed (p, cty, m) -> SynExpr.Typed (ConvSynPatToSynExpr p, cty, m)
     | SynPat.LongIdent (longDotId=LongIdentWithDots(longId, dotms) as lidwd; argPats=args; accessibility=None; range=m) ->
         let args = match args with SynArgPats.Pats args -> args | _ -> failwith "impossible: active patterns can be used only with SynConstructorArgs.Pats"
@@ -5869,7 +5869,7 @@ and TcExprUndelayed cenv (overallTy: OverallTy) env tpenv (synExpr: SynExpr) =
     match synExpr with
     // ( * )
     | SynExpr.Paren(SynExpr.IndexRange (None, opm, None, _m1, _m2, _), _, _, _) ->
-        let replacementExpr = SynExpr.Ident(ident(CompileOpName "*", opm), None)
+        let replacementExpr = SynExpr.Ident(ident(CompileOpName "*", opm))
         TcExpr cenv overallTy env tpenv replacementExpr
 
     | SynExpr.Paren (expr2, _, _, mWholeExprIncludingParentheses) ->
@@ -6606,7 +6606,7 @@ and ExpandIndexArgs (synLeftExprOpt: SynExpr option) indexArgs =
         | None -> error(Error(FSComp.SR.tcInvalidUseOfReverseIndex(), range)) 
         | Some xsId -> 
             mkSynApp1
-                (mkSynDot range range xsId (mkSynId (range.MakeSynthetic()) "GetReverseIndex", None))
+                (mkSynDot range range xsId (SynIdent((mkSynId (range.MakeSynthetic()) "GetReverseIndex"), None)))
                 sliceArgs
                 range
 

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -2599,7 +2599,7 @@ module EventDeclarationNormalization =
                    match rhsExpr with
                    // Detect 'fun () -> e' which results from the compilation of a property getter
                    | SynExpr.Lambda (args=SynSimplePats.SimplePats([], _); body=trueRhsExpr; range=m) ->
-                       let rhsExpr = mkSynApp1 (SynExpr.DotGet (SynExpr.Paren (trueRhsExpr, range0, None, m), range0, LongIdentWithDots([ident(target, m)], []), m)) (SynExpr.Ident (ident(argName, m))) m
+                       let rhsExpr = mkSynApp1 (SynExpr.DotGet (SynExpr.Paren (trueRhsExpr, range0, None, m), range0, LongIdentWithDots([ident(target, m)], []), m)) (SynExpr.Ident (ident(argName, m), None)) m
 
                        // reconstitute rhsExpr
                        let bindingRhs = NormalizedBindingRhs([], None, rhsExpr)
@@ -4093,7 +4093,7 @@ and TcPseudoMemberSpec cenv newOk env synTypes tpenv memSpfn m =
 /// Check a value specification, e.g. in a signature, interface declaration or a constraint
 and TcValSpec cenv env declKind newOk containerInfo memFlagsOpt thisTyOpt tpenv valSpfn attrs =
     let g = cenv.g
-    let (SynValSig(ident=id; explicitValDecls=ValTyparDecls (synTypars, synTyparConstraints, _); synType=ty; arity=valSynInfo; range=m)) = valSpfn
+    let (SynValSig(ident=(id,_); explicitValDecls=ValTyparDecls (synTypars, synTyparConstraints, _); synType=ty; arity=valSynInfo; range=m)) = valSpfn
     let declaredTypars = TcTyparDecls cenv env synTypars
     let (ContainerInfo(altActualParent, tcrefContainerInfo)) = containerInfo
 
@@ -5167,7 +5167,7 @@ and ConvSynPatToSynExpr x =
     match x with
     | SynPat.FromParseError(p, _) -> ConvSynPatToSynExpr p
     | SynPat.Const (c, m) -> SynExpr.Const (c, m)
-    | SynPat.Named (id, _, None, _) -> SynExpr.Ident id
+    | SynPat.Named (id, _, None, _) -> SynExpr.Ident (id,None)
     | SynPat.Typed (p, cty, m) -> SynExpr.Typed (ConvSynPatToSynExpr p, cty, m)
     | SynPat.LongIdent (longDotId=LongIdentWithDots(longId, dotms) as lidwd; argPats=args; accessibility=None; range=m) ->
         let args = match args with SynArgPats.Pats args -> args | _ -> failwith "impossible: active patterns can be used only with SynConstructorArgs.Pats"
@@ -5869,7 +5869,7 @@ and TcExprUndelayed cenv (overallTy: OverallTy) env tpenv (synExpr: SynExpr) =
     match synExpr with
     // ( * )
     | SynExpr.Paren(SynExpr.IndexRange (None, opm, None, _m1, _m2, _), _, _, _) ->
-        let replacementExpr = SynExpr.Ident(ident(CompileOpName "*", opm))
+        let replacementExpr = SynExpr.Ident(ident(CompileOpName "*", opm), None)
         TcExpr cenv overallTy env tpenv replacementExpr
 
     | SynExpr.Paren (expr2, _, _, mWholeExprIncludingParentheses) ->
@@ -6606,7 +6606,7 @@ and ExpandIndexArgs (synLeftExprOpt: SynExpr option) indexArgs =
         | None -> error(Error(FSComp.SR.tcInvalidUseOfReverseIndex(), range)) 
         | Some xsId -> 
             mkSynApp1
-                (mkSynDot range range xsId (mkSynId (range.MakeSynthetic()) "GetReverseIndex"))
+                (mkSynDot range range xsId (mkSynId (range.MakeSynthetic()) "GetReverseIndex", None))
                 sliceArgs
                 range
 

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -7663,7 +7663,7 @@ and TcRecdExpr cenv (overallTy: TType) env tpenv (inherits, optOrigExpr, flds, m
                         // we assume that parse errors were already reported
                         raise (ReportedError None)
 
-                    yield (List.frontAndBack lidwd.Lid, v)
+                    yield (List.frontAndBack lidwd.LongIdent, v)
             ]
 
         match flds with

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -682,7 +682,7 @@ type SynExpr =
         trivia: SynExprIfThenElseTrivia
 
     | Ident of
-        ident: Ident
+        ident: IdentWithTrivia
 
     | LongIdent of
         isOptional: bool *
@@ -946,7 +946,7 @@ type SynExpr =
         | SynExpr.DoBang (range=m)
         | SynExpr.Fixed (range=m) 
         | SynExpr.InterpolatedString (range=m) -> m
-        | SynExpr.Ident id -> id.idRange
+        | SynExpr.Ident (id,_) -> id.idRange
         | SynExpr.DebugPoint (_, _, innerExpr) -> innerExpr.Range
 
     member e.RangeWithoutAnyExtraDot =
@@ -1453,7 +1453,7 @@ type SynEnumCase =
 
     | SynEnumCase of
         attributes: SynAttributes *
-        ident: Ident *
+        ident: IdentWithTrivia *
         value: SynConst *
         valueRange: range *
         xmlDoc: PreXmlDoc *
@@ -1469,7 +1469,7 @@ type SynUnionCase =
 
     | SynUnionCase of
         attributes: SynAttributes *
-        ident: Ident *
+        ident: IdentWithTrivia *
         caseType: SynUnionCaseKind *
         xmlDoc: PreXmlDoc *
         accessibility: SynAccess option *
@@ -1558,7 +1558,7 @@ type SynComponentInfo =
 type SynValSig =
     | SynValSig of
         attributes: SynAttributes *
-        ident: Ident *
+        ident: IdentWithTrivia *
         explicitValDecls: SynValTyparDecls *
         synType: SynType *
         arity: SynValInfo *
@@ -1570,7 +1570,7 @@ type SynValSig =
         withKeyword: range option *
         range: range
 
-    member x.RangeOfId  = let (SynValSig(ident=id)) = x in id.idRange
+    member x.RangeOfId  = let (SynValSig(ident=(id, _))) = x in id.idRange
 
     member x.SynInfo = let (SynValSig(arity=v)) = x in v
 

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -67,7 +67,7 @@ module SynLongIdentHelpers =
         | SynLongIdent(lid, dots, _) -> lid, dots
 
     [<Obsolete("Please use SynLongIdent")>]
-    let LongIdentWithDots (lid, dots) = SynLongIdent(lid, dots, []) 
+    let LongIdentWithDots (lid, dots) = SynLongIdent(lid, dots, List.replicate lid.Length None) 
 
 [<RequireQualifiedAccess>]
 type ParserDetail =

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -1098,7 +1098,7 @@ type SynPat =
         range: range
 
     | Named of
-        ident: Ident *
+        ident: SynIdent *
         isThisVal: bool *
         accessibility: SynAccess option *
         range: range

--- a/src/fsharp/SyntaxTree.fs
+++ b/src/fsharp/SyntaxTree.fs
@@ -33,6 +33,12 @@ type LongIdentWithTrivia =
        | LongIdentWithTrivia(h :: t, dotRanges, _) -> unionRanges h.idRange (List.last t).idRange |> unionRanges (List.last dotRanges)
 
     member this.LongIdent = match this with LongIdentWithTrivia(lid, _, _) -> lid
+    
+    member this.Dots = match this with LongIdentWithTrivia(dotRanges = dots) -> dots
+    
+    member this.Trivia =
+        match this with
+        | LongIdentWithTrivia(trivia = trivia) -> List.choose id trivia
 
     member this.IdentsWithTrivia =
         let (LongIdentWithTrivia(lid, _, trivia)) = this
@@ -53,11 +59,12 @@ type LongIdentWithTrivia =
 
 [<AutoOpen>]
 module LongIdentWithTriviaHelpers =
+    [<Obsolete("Please use LongIdentWithTrivia or define a custom active pattern")>]
     let (|LongIdentWithDots|) =
         function
         | LongIdentWithTrivia(lid, dots, _) -> lid, dots
 
-    [<Obsolete("Please use LongIDentWithTrivia")>]
+    [<Obsolete("Please use LongIdentWithTrivia")>]
     let LongIdentWithDots (lid, dots) = LongIdentWithTrivia(lid, dots, []) 
 
 [<RequireQualifiedAccess>]

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -1218,7 +1218,7 @@ type SynPat =
 
     /// A name pattern 'ident' 
     | Named of
-        ident: Ident *
+        ident: SynIdent *
         isThisVal: bool *
         accessibility: SynAccess option *
         range: range

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -2,6 +2,7 @@
 
 namespace rec FSharp.Compiler.Syntax
 
+open System
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Xml
@@ -13,7 +14,10 @@ type Ident =
      new: text: string * range: range -> Ident
      member idText: string
      member idRange: range
-       
+
+/// Represents an identifier with potentially additional trivia information.
+type IdentWithTrivia = Ident * IdentTrivia option
+
 /// Represents a long identifier e.g. 'A.B.C'
 type LongIdent = Ident list
 
@@ -24,21 +28,30 @@ type LongIdent = Ident list
 /// if dotRanges.Length = lid.Length, then the parser must have reported an error, so the typechecker is allowed
 /// more freedom about typechecking these expressions.
 /// LongIdent can be empty list - it is used to denote that name of some AST element is absent (i.e. empty type name in inherit)
-type LongIdentWithDots =
-    | //[<Experimental("This construct is subject to change in future versions of FSharp.Compiler.Service and should only be used if no adequate alternative is available.")>]
-      LongIdentWithDots of id: LongIdent * dotRanges: range list
+type LongIdentWithTrivia =
+    | LongIdentWithTrivia of id: LongIdent * dotRanges: range list * trivia: IdentTrivia option list
 
     /// Gets the syntax range of this construct
     member Range: range
 
     /// Get the long ident for this construct
-    member Lid: LongIdent
+    member LongIdent: LongIdent
+    
+    /// Get the idents with potential trivia attached
+    member IdentsWithTrivia: IdentWithTrivia list
 
     /// Indicates if the construct ends in '.' due to error recovery
     member ThereIsAnExtraDotAtTheEnd: bool
 
     /// Gets the syntax range for part of this construct
     member RangeWithoutAnyExtraDot: range
+
+[<AutoOpen>]
+module LongIdentWithTriviaHelpers =
+    val (|LongIdentWithDots|): LongIdentWithTrivia -> LongIdent * range list
+
+    [<Obsolete("Please use LongIDentWithTrivia")>]
+    val LongIdentWithDots: LongIdent * range list -> LongIdentWithTrivia 
 
 /// Indicates if the construct arises from error recovery
 [<RequireQualifiedAccess>]
@@ -323,7 +336,7 @@ type BlockSeparator = range * pos option
 
 /// Represents a record field name plus a flag indicating if given record field name is syntactically
 /// correct and can be used in name resolution.
-type RecordFieldName = LongIdentWithDots * bool
+type RecordFieldName = LongIdentWithTrivia * bool
 
 /// Indicates if an expression is an atomic expression.
 ///
@@ -437,7 +450,7 @@ type SynType =
     
     /// F# syntax: A.B.C
     | LongIdent of
-        longDotId: LongIdentWithDots
+        longDotId: LongIdentWithTrivia
 
     /// F# syntax: type<type, ..., type> or type type or (type, ..., type) type
     ///   isPostfix: indicates a postfix type application e.g. "int list" or "(int, string) dict"
@@ -453,7 +466,7 @@ type SynType =
     /// F# syntax: type.A.B.C<type, ..., type>
     | LongIdentApp of
         typeName: SynType *
-        longDotId: LongIdentWithDots *
+        longDotId: LongIdentWithTrivia *
         lessRange: range option *
         typeArgs: SynType list *
         commaRanges: range list * // interstitial commas
@@ -819,13 +832,13 @@ type SynExpr =
     /// variables in desugaring pattern matching. See SynSimplePat.Id
     | LongIdent of
         isOptional: bool *
-        longDotId: LongIdentWithDots *
+        longDotId: LongIdentWithTrivia *
         altNameRefCell: SynSimplePatAlternativeIdInfo ref option *
         range: range
 
     /// F# syntax: ident.ident...ident <- expr
     | LongIdentSet of
-        longDotId: LongIdentWithDots *
+        longDotId: LongIdentWithTrivia *
         expr: SynExpr *
         range: range
 
@@ -833,13 +846,13 @@ type SynExpr =
     | DotGet of
         expr: SynExpr *
         rangeOfDot: range *
-        longDotId: LongIdentWithDots *
+        longDotId: LongIdentWithTrivia *
         range: range
 
     /// F# syntax: expr.ident...ident <- expr
     | DotSet of
         targetExpr: SynExpr *
-        longDotId: LongIdentWithDots *
+        longDotId: LongIdentWithTrivia *
         rhsExpr: SynExpr *
         range: range
 
@@ -867,7 +880,7 @@ type SynExpr =
 
     /// F# syntax: Type.Items(e1) <- e2, rarely used named-property-setter notation, e.g. Foo.Bar.Chars(3) <- 'a'
     | NamedIndexedPropertySet of
-        longDotId: LongIdentWithDots *
+        longDotId: LongIdentWithTrivia *
         expr1: SynExpr *
         expr2: SynExpr *
         range: range
@@ -875,7 +888,7 @@ type SynExpr =
     /// F# syntax: expr.Items (e1) <- e2, rarely used named-property-setter notation, e.g. (stringExpr).Chars(3) <- 'a'
     | DotNamedIndexedPropertySet of
         targetExpr: SynExpr *
-        longDotId: LongIdentWithDots *
+        longDotId: LongIdentWithTrivia *
         argExpr: SynExpr *
         rhsExpr: SynExpr *
         range: range
@@ -1234,7 +1247,7 @@ type SynPat =
 
     /// A long identifier pattern possibly with argument patterns
     | LongIdent of
-        longDotId: LongIdentWithDots *
+        longDotId: LongIdentWithTrivia *
         propertyKeyword: PropertyKeyword option *
         extraId: Ident option * // holds additional ident for tooling
         typarDecls: SynValTyparDecls option * // usually None: temporary used to parse "f<'a> x = x"
@@ -1342,7 +1355,7 @@ type SynMatchClause =
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynAttribute =
     { /// The name of the type for the attribute
-      TypeName: LongIdentWithDots
+      TypeName: LongIdentWithTrivia
 
       /// The argument of the attribute, perhaps a tuple
       ArgExpr: SynExpr

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -37,6 +37,12 @@ type LongIdentWithTrivia =
     /// Get the long ident for this construct
     member LongIdent: LongIdent
     
+    /// Get the dot ranges
+    member Dots: range list
+    
+    /// Get the trivia of the idents
+    member Trivia: IdentTrivia list
+    
     /// Get the idents with potential trivia attached
     member IdentsWithTrivia: IdentWithTrivia list
 
@@ -48,9 +54,10 @@ type LongIdentWithTrivia =
 
 [<AutoOpen>]
 module LongIdentWithTriviaHelpers =
+    [<Obsolete("Please use LongIdentWithTrivia or define a custom active pattern")>]
     val (|LongIdentWithDots|): LongIdentWithTrivia -> LongIdent * range list
 
-    [<Obsolete("Please use LongIDentWithTrivia")>]
+    [<Obsolete("Please use LongIdentWithTrivia")>]
     val LongIdentWithDots: LongIdent * range list -> LongIdentWithTrivia 
 
 /// Indicates if the construct arises from error recovery

--- a/src/fsharp/SyntaxTree.fsi
+++ b/src/fsharp/SyntaxTree.fsi
@@ -823,7 +823,7 @@ type SynExpr =
     /// F# syntax: ident
     /// Optimized representation for SynExpr.LongIdent (false, [id], id.idRange)
     | Ident of
-        ident: Ident
+        ident: IdentWithTrivia
 
     /// F# syntax: ident.ident...ident
     ///
@@ -1588,7 +1588,7 @@ type SynEnumCase =
 
     | SynEnumCase of
         attributes: SynAttributes *
-        ident: Ident *
+        ident: IdentWithTrivia *
         value: SynConst *
         valueRange: range *
         xmlDoc: PreXmlDoc *
@@ -1604,7 +1604,7 @@ type SynUnionCase =
 
     | SynUnionCase of
         attributes: SynAttributes *
-        ident: Ident *
+        ident: IdentWithTrivia *
         caseType: SynUnionCaseKind *
         xmlDoc: PreXmlDoc *
         accessibility: SynAccess option *
@@ -1706,7 +1706,7 @@ type SynComponentInfo =
 type SynValSig =
     | SynValSig of
         attributes: SynAttributes *
-        ident: Ident *
+        ident: IdentWithTrivia *
         explicitValDecls: SynValTyparDecls *
         synType: SynType *
         arity: SynValInfo *

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -41,7 +41,7 @@ let mkSynId m s = Ident(s, m)
 
 let pathToSynLid m p = List.map (mkSynId m) p
 
-let mkSynIdGet m n trivia = SynExpr.Ident (mkSynId m n, trivia)
+let mkSynIdGet m n = SynExpr.Ident (mkSynId m n)
 
 let mkSynLidGet m path n =
     let lid = pathToSynLid m path @ [mkSynId m n]
@@ -50,7 +50,7 @@ let mkSynLidGet m path n =
 
 let mkSynIdGetWithAlt m id altInfo =
     match altInfo with
-    | None -> SynExpr.Ident (id, None)
+    | None -> SynExpr.Ident id
     | _ -> SynExpr.LongIdent (false, LongIdentWithDots([id], []), altInfo, m)
 
 let mkSynSimplePatVar isOpt id = SynSimplePat.Id (id, None, false, false, isOpt, id.idRange)
@@ -61,18 +61,18 @@ let mkSynCompGenSimplePatVar id = SynSimplePat.Id (id, None, true, false, false,
 let (|LongOrSingleIdent|_|) inp =
     match inp with
     | SynExpr.LongIdent (isOpt, lidwd, altId, _m) -> Some (isOpt, lidwd, altId, lidwd.RangeWithoutAnyExtraDot)
-    | SynExpr.Ident (id, _) -> Some (false, LongIdentWithDots([id], []), None, id.idRange)
+    | SynExpr.Ident id -> Some (false, LongIdentWithDots([id], []), None, id.idRange)
     | _ -> None
 
 let (|SingleIdent|_|) inp =
     match inp with
     | SynExpr.LongIdent (false, LongIdentWithDots([id], _), None, _) -> Some id
-    | SynExpr.Ident (id, _) -> Some id
+    | SynExpr.Ident id -> Some id
     | _ -> None
 
 let (|SynBinOp|_|) input =
     match input with
-    | SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.Ident (synId,_), x1, _m1), x2, _m2) ->
+    | SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent (longDotId = SynLongIdent(id = [synId])), x1, _m1), x2, _m2) ->
         Some (synId, x1, x2)
     | _ -> None
 
@@ -235,12 +235,12 @@ let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
             | SynPat.Named(ident, _, _, _)
             | SynPat.As(_, SynPat.Named(ident, _, _, _), _) ->
                 // named pats should be referred to as their name in docs, tooltips, etc.
-                let item = mkSynIdGet m ident.idText None
+                let item = mkSynIdGet m ident.idText
                 false, None, ident, item
             | _ ->
                 let nm = synArgNameGenerator.New()
                 let id = mkSynId m nm
-                let item = mkSynIdGet m nm None
+                let item = mkSynIdGet m nm
                 true, None, id, item
         let fn =
             match p with
@@ -331,7 +331,8 @@ let opNameParenGet  = CompileOpName parenGet
 
 let opNameQMark = CompileOpName qmark
 
-let mkSynOperator opm oper = mkSynIdGet opm (CompileOpName oper) (Some (IdentTrivia.OriginalNotation oper))
+let mkSynOperator opm oper =
+    SynExpr.LongIdent(false, SynLongIdent([ident(CompileOpName oper, opm)], [], [Some (IdentTrivia.OriginalNotation oper)]), None, opm)
 
 let mkSynInfix opm (l: SynExpr) oper (r: SynExpr) =
     let firstTwoRange = unionRanges l.Range opm
@@ -412,26 +413,26 @@ let mkSynAssign (l: SynExpr) (r: SynExpr) =
     | SynExpr.App (_, _, SynExpr.DotGet (e, _, v, _), x, _)  -> SynExpr.DotNamedIndexedPropertySet (e, v, x, r, m)
     | l  -> SynExpr.Set (l, r, m)
 
-let mkSynDot dotm m l (r, rTrivia) =
+let mkSynDot dotm m l (SynIdent(r, rTrivia)) =
     match l with
-    | SynExpr.LongIdent (isOpt, LongIdentWithTrivia(lid, dots, trivia), None, _) ->
+    | SynExpr.LongIdent (isOpt, SynLongIdent(lid, dots, trivia), None, _) ->
         // REVIEW: MEMORY PERFORMANCE: This list operation is memory intensive (we create a lot of these list nodes)
-        SynExpr.LongIdent (isOpt, LongIdentWithTrivia(lid@[r], dots@[dotm], trivia@[rTrivia]), None, m)
-    | SynExpr.Ident (id, idTrivia) ->
-        SynExpr.LongIdent (false, LongIdentWithTrivia([id;r], [dotm], [idTrivia;rTrivia]), None, m)
-    | SynExpr.DotGet (e, dm, LongIdentWithTrivia(lid, dots, trivia), _) ->
+        SynExpr.LongIdent (isOpt, SynLongIdent(lid@[r], dots@[dotm], trivia@[rTrivia]), None, m)
+    | SynExpr.Ident id ->
+        SynExpr.LongIdent (false, SynLongIdent([id;r], [dotm], [None; rTrivia]), None, m)
+    | SynExpr.DotGet (e, dm, SynLongIdent(lid, dots, trivia), _) ->
         // REVIEW: MEMORY PERFORMANCE: This is memory intensive (we create a lot of these list nodes)
-        SynExpr.DotGet (e, dm, LongIdentWithTrivia(lid@[r], dots@[dotm], trivia@[rTrivia]), m)
+        SynExpr.DotGet (e, dm, SynLongIdent(lid@[r], dots@[dotm], trivia@[rTrivia]), m)
     | expr ->
-        SynExpr.DotGet (expr, dotm, LongIdentWithTrivia([r], [], [rTrivia]), m)
+        SynExpr.DotGet (expr, dotm, SynLongIdent([r], [], [rTrivia]), m)
 
 let mkSynDotMissing dotm m l =
     match l with
     | SynExpr.LongIdent (isOpt, LongIdentWithDots(lid, dots), None, _) ->
          // REVIEW: MEMORY PERFORMANCE: This list operation is memory intensive (we create a lot of these list nodes)
          SynExpr.LongIdent (isOpt, LongIdentWithDots(lid, dots@[dotm]), None, m)
-    | SynExpr.Ident (id, trivia) ->
-        SynExpr.LongIdent (false, LongIdentWithTrivia([id], [dotm], [trivia]), None, m)
+    | SynExpr.Ident id ->
+        SynExpr.LongIdent (false, SynLongIdent([id], [dotm], []), None, m)
     | SynExpr.DotGet (e, dm, LongIdentWithDots(lid, dots), _) ->
         SynExpr.DotGet (e, dm, LongIdentWithDots(lid, dots@[dotm]), m)// REVIEW: MEMORY PERFORMANCE: This is memory intensive (we create a lot of these list nodes)
     | expr ->
@@ -889,7 +890,7 @@ let (|ParsedHashDirectiveArguments|) (input: ParsedHashDirectiveArgument list) =
         | ParsedHashDirectiveArgument.SourceIdentifier (_, v, _) -> v)
         input
 
-let prependIdentInLongIdentWithTrivia (ident, identTrivia) dotm lid =
+let prependIdentInLongIdentWithTrivia (SynIdent(ident, identTrivia)) dotm lid =
     match lid with
-    | LongIdentWithTrivia(lid, dots, trivia) ->
-        LongIdentWithTrivia(ident :: lid, dotm :: dots, identTrivia :: trivia)
+    | SynLongIdent(lid, dots, trivia) ->
+        SynLongIdent(ident :: lid, dotm :: dots, identTrivia :: trivia)

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -332,8 +332,15 @@ let opNameParenGet  = CompileOpName parenGet
 
 let opNameQMark = CompileOpName qmark
 
-let mkSynOperator opm oper =
-    SynExpr.LongIdent(false, SynLongIdent([ident(CompileOpName oper, opm)], [], [Some (IdentTrivia.OriginalNotation oper)]), None, opm)
+let mkSynOperator (opm:range) (oper:string) =
+    let trivia =
+        if oper.StartsWith("~") && ((opm.EndColumn - opm.StartColumn) = (oper.Length - 1)) then
+            // PREFIX_OP token where the ~ was actually absent
+            IdentTrivia.OriginalNotation (string(oper.[1..]))
+        else
+            IdentTrivia.OriginalNotation oper
+        
+    SynExpr.LongIdent(false, SynLongIdent([ident(CompileOpName oper, opm)], [], [Some trivia]), None, opm)
 
 let mkSynInfix opm (l: SynExpr) oper (r: SynExpr) =
     let firstTwoRange = unionRanges l.Range opm

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -161,9 +161,9 @@ let mkSynAnonField (ty: SynType, xmlDoc) = SynField([], false, None, ty, false, 
 
 let mkSynNamedField (ident, ty: SynType, xmlDoc, m) = SynField([], false, Some ident, ty, false, xmlDoc, None, m)
 
-let mkSynPatVar vis (id: Ident) = SynPat.Named (id, false, vis, id.idRange)
+let mkSynPatVar vis (id: Ident) = SynPat.Named (SynIdent(id, None), false, vis, id.idRange)
 
-let mkSynThisPatVar (id: Ident) = SynPat.Named (id, true, None, id.idRange)
+let mkSynThisPatVar (id: Ident) = SynPat.Named (SynIdent(id, None), true, None, id.idRange)
 
 let mkSynPatMaybeVar lidwd vis m =  SynPat.LongIdent (lidwd, None, None, None, SynArgPats.Pats [], vis, m)
 
@@ -208,7 +208,7 @@ let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
         SynSimplePat.Attrib(p2, attribs, m),
         laterF
 
-    | SynPat.Named (v, thisV, _, m) ->
+    | SynPat.Named (SynIdent(v,_), thisV, _, m) ->
         SynSimplePat.Id (v, None, false, thisV, false, m),
         None
 
@@ -232,8 +232,8 @@ let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
                 let altNameRefCell = Some (ref (SynSimplePatAlternativeIdInfo.Undecided (mkSynId m (synArgNameGenerator.New()))))
                 let item = mkSynIdGetWithAlt m id altNameRefCell
                 false, altNameRefCell, id, item
-            | SynPat.Named(ident, _, _, _)
-            | SynPat.As(_, SynPat.Named(ident, _, _, _), _) ->
+            | SynPat.Named(SynIdent(ident,_), _, _, _)
+            | SynPat.As(_, SynPat.Named(SynIdent(ident,_), _, _, _), _) ->
                 // named pats should be referred to as their name in docs, tooltips, etc.
                 let item = mkSynIdGet m ident.idText
                 false, None, ident, item

--- a/src/fsharp/SyntaxTreeOps.fs
+++ b/src/fsharp/SyntaxTreeOps.fs
@@ -888,3 +888,8 @@ let (|ParsedHashDirectiveArguments|) (input: ParsedHashDirectiveArgument list) =
         | ParsedHashDirectiveArgument.String (s, _, _) -> s
         | ParsedHashDirectiveArgument.SourceIdentifier (_, v, _) -> v)
         input
+
+let prependIdentInLongIdentWithTrivia (ident, identTrivia) dotm lid =
+    match lid with
+    | LongIdentWithTrivia(lid, dots, trivia) ->
+        LongIdentWithTrivia(ident :: lid, dotm :: dots, identTrivia :: trivia)

--- a/src/fsharp/SyntaxTreeOps.fsi
+++ b/src/fsharp/SyntaxTreeOps.fsi
@@ -42,7 +42,7 @@ val mkSynSimplePatVar: isOpt:bool -> id:Ident -> SynSimplePat
 val mkSynCompGenSimplePatVar: id:Ident -> SynSimplePat
 
 /// Match a long identifier, including the case for single identifiers which gets a more optimized node in the syntax tree.
-val (|LongOrSingleIdent|_|): inp:SynExpr -> (bool * LongIdentWithDots * SynSimplePatAlternativeIdInfo ref option * range) option
+val (|LongOrSingleIdent|_|): inp:SynExpr -> (bool * LongIdentWithTrivia * SynSimplePatAlternativeIdInfo ref option * range) option
 
 val (|SingleIdent|_|): inp:SynExpr -> Ident option
 
@@ -61,7 +61,7 @@ val mkSynPatVar: vis:SynAccess option -> id:Ident -> SynPat
 
 val mkSynThisPatVar: id:Ident -> SynPat
 
-val mkSynPatMaybeVar: lidwd:LongIdentWithDots -> vis:SynAccess option -> m:range -> SynPat
+val mkSynPatMaybeVar: lidwd:LongIdentWithTrivia -> vis:SynAccess option -> m:range -> SynPat
 
 val ( |SynPatForConstructorDecl|_| ): x:SynPat -> SynPat option
 
@@ -300,3 +300,5 @@ val (|SynPipeRight2|_|): SynExpr -> (SynExpr * SynExpr * SynExpr) option
 
 /// 'e1 |||> e2'
 val (|SynPipeRight3|_|): SynExpr -> (SynExpr * SynExpr * SynExpr * SynExpr) option
+
+val prependIdentInLongIdentWithTrivia: ident: IdentWithTrivia -> dotm: range -> lid: LongIdentWithTrivia -> LongIdentWithTrivia

--- a/src/fsharp/SyntaxTreeOps.fsi
+++ b/src/fsharp/SyntaxTreeOps.fsi
@@ -31,7 +31,7 @@ val mkSynId: m:range -> s:string -> Ident
 
 val pathToSynLid: m:range -> p:string list -> Ident list
 
-val mkSynIdGet: m:range -> n:string -> SynExpr
+val mkSynIdGet: m:range -> n:string -> IdentTrivia option -> SynExpr
 
 val mkSynLidGet: m:range -> path:string list -> n:string -> SynExpr
 
@@ -142,7 +142,7 @@ val mkSynDelay: m:range -> e:SynExpr -> SynExpr
 
 val mkSynAssign: l:SynExpr -> r:SynExpr -> SynExpr
 
-val mkSynDot: dotm:range -> m:range -> l:SynExpr -> r:Ident -> SynExpr
+val mkSynDot: dotm:range -> m:range -> l:SynExpr -> r:IdentWithTrivia -> SynExpr
 
 val mkSynDotMissing: dotm:range -> m:range -> l:SynExpr -> SynExpr
 

--- a/src/fsharp/SyntaxTreeOps.fsi
+++ b/src/fsharp/SyntaxTreeOps.fsi
@@ -31,7 +31,7 @@ val mkSynId: m:range -> s:string -> Ident
 
 val pathToSynLid: m:range -> p:string list -> Ident list
 
-val mkSynIdGet: m:range -> n:string -> IdentTrivia option -> SynExpr
+val mkSynIdGet: m:range -> n:string -> SynExpr
 
 val mkSynLidGet: m:range -> path:string list -> n:string -> SynExpr
 
@@ -42,7 +42,7 @@ val mkSynSimplePatVar: isOpt:bool -> id:Ident -> SynSimplePat
 val mkSynCompGenSimplePatVar: id:Ident -> SynSimplePat
 
 /// Match a long identifier, including the case for single identifiers which gets a more optimized node in the syntax tree.
-val (|LongOrSingleIdent|_|): inp:SynExpr -> (bool * LongIdentWithTrivia * SynSimplePatAlternativeIdInfo ref option * range) option
+val (|LongOrSingleIdent|_|): inp:SynExpr -> (bool * SynLongIdent * SynSimplePatAlternativeIdInfo ref option * range) option
 
 val (|SingleIdent|_|): inp:SynExpr -> Ident option
 
@@ -61,7 +61,7 @@ val mkSynPatVar: vis:SynAccess option -> id:Ident -> SynPat
 
 val mkSynThisPatVar: id:Ident -> SynPat
 
-val mkSynPatMaybeVar: lidwd:LongIdentWithTrivia -> vis:SynAccess option -> m:range -> SynPat
+val mkSynPatMaybeVar: lidwd:SynLongIdent -> vis:SynAccess option -> m:range -> SynPat
 
 val ( |SynPatForConstructorDecl|_| ): x:SynPat -> SynPat option
 
@@ -142,7 +142,7 @@ val mkSynDelay: m:range -> e:SynExpr -> SynExpr
 
 val mkSynAssign: l:SynExpr -> r:SynExpr -> SynExpr
 
-val mkSynDot: dotm:range -> m:range -> l:SynExpr -> r:IdentWithTrivia -> SynExpr
+val mkSynDot: dotm:range -> m:range -> l:SynExpr -> r:SynIdent -> SynExpr
 
 val mkSynDotMissing: dotm:range -> m:range -> l:SynExpr -> SynExpr
 
@@ -301,4 +301,4 @@ val (|SynPipeRight2|_|): SynExpr -> (SynExpr * SynExpr * SynExpr) option
 /// 'e1 |||> e2'
 val (|SynPipeRight3|_|): SynExpr -> (SynExpr * SynExpr * SynExpr * SynExpr) option
 
-val prependIdentInLongIdentWithTrivia: ident: IdentWithTrivia -> dotm: range -> lid: LongIdentWithTrivia -> LongIdentWithTrivia
+val prependIdentInLongIdentWithTrivia: ident: SynIdent -> dotm: range -> lid: SynLongIdent -> SynLongIdent

--- a/src/fsharp/SyntaxTrivia.fs
+++ b/src/fsharp/SyntaxTrivia.fs
@@ -5,6 +5,12 @@ namespace FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.Text
 
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
+type IdentTrivia =
+    | OriginalNotation of text: string
+    | OriginalNotationWithParen of lpr: range * text:string * rpr: range
+    | HasParenthesis of lpr: range * rpr: range
+
+[<RequireQualifiedAccess; NoEquality; NoComparison>]
 type ConditionalDirectiveTrivia =
     | If of expr:IfDirectiveExpression * range:range
     | Else of range:range

--- a/src/fsharp/SyntaxTrivia.fs
+++ b/src/fsharp/SyntaxTrivia.fs
@@ -7,8 +7,8 @@ open FSharp.Compiler.Text
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
 type IdentTrivia =
     | OriginalNotation of text: string
-    | OriginalNotationWithParen of lpr: range * text:string * rpr: range
-    | HasParenthesis of lpr: range * rpr: range
+    | OriginalNotationWithParen of leftParenRange: range * text:string * rightParenRange: range
+    | HasParenthesis of leftParenRange: range * rightParenRange: range
 
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
 type ConditionalDirectiveTrivia =

--- a/src/fsharp/SyntaxTrivia.fsi
+++ b/src/fsharp/SyntaxTrivia.fsi
@@ -6,12 +6,18 @@ open FSharp.Compiler.Text
 
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
 type IdentTrivia =
-    /// The ident originally had a different notation
+    /// The ident originally had a different notation.
+    /// Example: a + b
+    /// The operator ident will be compiled into "op_Addition", while the original notation was "+"
     | OriginalNotation of text: string
     /// The ident originally had a different notation and parenthesis
-    | OriginalNotationWithParen of lpr: range * text:string * rpr: range
+    /// Example: let (>=>) a b = ...
+    /// The operator ident will be compiled into "op_GreaterEqualsGreater", while the original notation was ">=>" and had parenthesis
+    | OriginalNotationWithParen of leftParenRange: range * text:string * rightParenRange: range
     /// The ident had parenthesis
-    | HasParenthesis of lpr: range * rpr: range
+    /// Example: let (|Odd|Even|) = ...
+    /// The active pattern ident will be "|Odd|Even|", while originally there were parenthesis.
+    | HasParenthesis of leftParenRange: range * rightParenRange: range
 
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
 type ConditionalDirectiveTrivia =

--- a/src/fsharp/SyntaxTrivia.fsi
+++ b/src/fsharp/SyntaxTrivia.fsi
@@ -5,6 +5,15 @@ namespace rec FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.Text
 
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
+type IdentTrivia =
+    /// The ident originally had a different notation
+    | OriginalNotation of text: string
+    /// The ident originally had a different notation and parenthesis
+    | OriginalNotationWithParen of lpr: range * text:string * rpr: range
+    /// The ident had parenthesis
+    | HasParenthesis of lpr: range * rpr: range
+
+[<RequireQualifiedAccess; NoEquality; NoComparison>]
 type ConditionalDirectiveTrivia =
     | If of expr:IfDirectiveExpression * range:range
     | Else of range:range

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1840,7 +1840,7 @@ type internal FsiDynamicCompiler
     member _.CreateDebuggerBreak (m: range) =
         let breakPath = ["System";"Diagnostics";"Debugger";"Break"]
         let dots = List.replicate (breakPath.Length - 1) m
-        let methCall = SynExpr.LongIdent (false, LongIdentWithDots(List.map (mkSynId m) breakPath, dots), None, m)
+        let methCall = SynExpr.LongIdent (false, SynLongIdent(List.map (mkSynId m) breakPath, dots, List.replicate breakPath.Length None), None, m)
         let args = SynExpr.Const (SynConst.Unit, m)
         let breakStatement = SynExpr.App (ExprAtomicFlag.Atomic, false, methCall, args, m)
         SynModuleDecl.Expr(breakStatement, m)

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -188,7 +188,7 @@ let idOfPat (parseState:IParseState) m p =
     match p with
     | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop ->
         mkSynId r "_"
-    | SynPat.Named (id, false, _, _) -> id
+    | SynPat.Named (SynIdent(id,_), false, _, _) -> id
     | SynPat.LongIdent(longDotId=SynLongIdent([id], _, _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier())
 
@@ -1882,7 +1882,7 @@ memberCore:
                              let rec go p = 
                                  match p with 
                                  | SynPat.LongIdent (longDotId=SynLongIdent([id], _, _)) -> id.idText
-                                 | SynPat.Named (nm, _, _, _) | SynPat.As (_, SynPat.Named (nm, _, _, _), _) -> nm.idText
+                                 | SynPat.Named (SynIdent(nm, _), _, _, _) | SynPat.As (_, SynPat.Named (SynIdent(nm, _), _, _, _), _) -> nm.idText
                                  | SynPat.Typed (p, _, _) -> go p
                                  | SynPat.Attrib (p, _, _) -> go p
                                  | _ -> raiseParseErrorAt mBindLhs (FSComp.SR.parsInvalidDeclarationSyntax()) 
@@ -1993,7 +1993,7 @@ memberCore:
                      let lidOuter, lidVisOuter = 
                          match bindingPatOuter with 
                          | SynPat.LongIdent (lid, _, None, None, SynArgPats.Pats [], lidVisOuter, m) ->  lid, lidVisOuter
-                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> SynLongIdent([id], [], [None]), visOuter
+                         | SynPat.Named (SynIdent(id, _), _, visOuter, m) | SynPat.As(_, SynPat.Named (SynIdent(id, _), _, visOuter, m), _) -> SynLongIdent([id], [], [None]), visOuter
                          | p -> raiseParseErrorAt mWholeBindLhs (FSComp.SR.parsInvalidDeclarationSyntax()) 
   
                      // Merge the visibility from the outer point with the inner point, e.g.
@@ -2027,8 +2027,8 @@ memberCore:
                                  else 
                                      args
                              SynPat.LongIdent (lidOuter, withPropertyKeyword, Some(id), tyargs, SynArgPats.Pats args, mergeLidVisOuter lidVisInner, m)
-                         | SynPat.Named (nm, _, lidVisInner, m)
-                         | SynPat.As (_, SynPat.Named (nm, _, lidVisInner, m), _) -> SynPat.LongIdent (lidOuter, None, None, None, SynArgPats.Pats [], mergeLidVisOuter lidVisInner, m)
+                         | SynPat.Named (_, _, lidVisInner, m)
+                         | SynPat.As (_, SynPat.Named (_, _, lidVisInner, m), _) -> SynPat.LongIdent (lidOuter, None, None, None, SynArgPats.Pats [], mergeLidVisOuter lidVisInner, m)
                          | SynPat.Typed (p, ty, m) ->  SynPat.Typed(go p, ty, m)
                          | SynPat.Attrib (p, attribs, m) ->  SynPat.Attrib(go p, attribs, m)
                          | SynPat.Wild(m) ->  SynPat.Wild(m)
@@ -2927,7 +2927,7 @@ externArg:
      { let m = lhs parseState in SynPat.Typed(SynPat.Wild m, $2, m) |> addAttribs $1 }
 
   | opt_attributes cType ident 
-     { let m = lhs parseState in SynPat.Typed(SynPat.Named ($3, false, None, m), $2, m) |> addAttribs $1 }
+     { let m = lhs parseState in SynPat.Typed(SynPat.Named (SynIdent($3, None), false, None, m), $2, m) |> addAttribs $1 }
 
 /* An type in an 'extern' DllImport function definition */
 cType: 
@@ -3206,7 +3206,7 @@ bindingPattern:
 simplePattern:
   | ident
       { let m = rhs parseState 1 
-        SynPat.Named($1, false, None, m) }
+        SynPat.Named(SynIdent($1, None), false, None, m) }
 
   | QMARK ident
       { SynPat.OptionalVal($2, rhs parseState 2) }
@@ -3397,9 +3397,12 @@ atomicPattern:
 
   | atomicPatternLongIdent %prec prec_atompat_pathop 
       { let vis, lidwd = $1 
-        if not (isNilOrSingleton lidwd.LongIdent) || String.isLeadingIdentifierCharacterUpperCase (List.head lidwd.LongIdent).idText
-        then mkSynPatMaybeVar lidwd vis (lhs parseState)
-        else mkSynPatVar vis (List.head lidwd.LongIdent) }
+        if not (isNilOrSingleton lidwd.LongIdent) || String.isLeadingIdentifierCharacterUpperCase (List.head lidwd.LongIdent).idText then 
+            mkSynPatMaybeVar lidwd vis (lhs parseState)
+        else 
+           let synIdent = List.head lidwd.IdentsWithTrivia
+           let (SynIdent(id, _)) = synIdent
+           SynPat.Named (synIdent, false, vis, id.idRange) }
 
   | constant 
       { SynPat.Const (fst $1, snd $1) }
@@ -5597,7 +5600,7 @@ path:
        let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid, dotms @ [rhs parseState 2], trivia)  } 
 
 
-/* An operator name, with surrounnding parentheses */
+/* An operator name, with surrounding parentheses */
 opName: 
   | LPAREN operatorName rparen  
      { let lpr = rhs parseState 1

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -52,7 +52,7 @@ let rebindRanges first fields lastSep =
         | (f, m) :: xs -> run f xs (SynExprRecordField(name, mEquals, value, m) :: acc)
     run first fields []
 
-let mkUnderscoreRecdField m = LongIdentWithTrivia([ident("_", m)], [], [None]), false
+let mkUnderscoreRecdField m = SynLongIdent([ident("_", m)], [], [None]), false
 
 let mkRecdField lidwd = lidwd, true
 
@@ -189,7 +189,7 @@ let idOfPat (parseState:IParseState) m p =
     | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop ->
         mkSynId r "_"
     | SynPat.Named (id, false, _, _) -> id
-    | SynPat.LongIdent(longDotId=LongIdentWithTrivia([id], _, _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
+    | SynPat.LongIdent(longDotId=SynLongIdent([id], _, _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier())
 
 let checkForMultipleAugmentations m a1 a2 = 
@@ -345,8 +345,8 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <SynExceptionDefn> exconDefn
 %type <SynExceptionDefnRepr> exconCore
 %type <SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
-%type <LongIdentWithTrivia> path
-%type <LongIdentWithTrivia> pathOp
+%type <SynLongIdent> path
+%type <SynLongIdent> pathOp
 /*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
 %type <range * range option * bool     * SynType list * range list * range> typeArgsActual
 /*     LESS    GREATER        typeArgs           m for each   mWhole  */
@@ -983,7 +983,7 @@ tyconSpfnRhs:
   | DELEGATE OF topType
      { let m = lhs parseState 
        let ty, arity = $3
-       let invoke = SynMemberSig.Member(SynValSig([], (mkSynId m "Invoke", None), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m), AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
+       let invoke = SynMemberSig.Member(SynValSig([], (SynIdent(mkSynId m "Invoke", None)), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m), AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
        (fun nameRange nameInfo mEquals augmentation -> 
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
            let mWhole = unionRanges nameRange m
@@ -1099,7 +1099,7 @@ classMemberSpfn:
      { let vis, doc, (ty, valSynInfo) = $2, grabXmlDoc(parseState, $1, 1), $5
        let m = unionRanges (rhs parseState 1) ty.Range |> unionRangeWithXmlDoc doc
        let isInline = false 
-       let valSpfn = SynValSig ($1, (mkSynId (rhs parseState 3) "new", None), noInferredTypars, ty, valSynInfo, isInline, false, doc, vis, None, None, m)
+       let valSpfn = SynValSig ($1, (SynIdent(mkSynId (rhs parseState 3) "new", None)), noInferredTypars, ty, valSynInfo, isInline, false, doc, vis, None, None, m)
        SynMemberSig.Member(valSpfn, CtorMemberFlags SynMemberFlagsTrivia.Zero, m) }
 
 
@@ -1125,14 +1125,14 @@ classMemberSpfnGetSet:
 /* The "get, set" on a property member in a signature */
 classMemberSpfnGetSetElements:
   | nameop 
-    { (let (id:Ident, _) = $1 
+    { (let (SynIdent(id:Ident, _)) = $1 
        if id.idText = "get" then SynMemberKind.PropertyGet 
        else if id.idText = "set" then SynMemberKind.PropertySet 
        else raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired())) }
 
   | nameop COMMA nameop
-    { let (id:Ident, _) = $1 
-      let (id2, _) = $3
+    { let (SynIdent(id, _)) = $1 
+      let (SynIdent(id2, _)) = $3
       if not ((id.idText = "get" && id2.idText = "set") ||
               (id.idText = "set" && id2.idText = "get")) then 
          raiseParseErrorAt (rhs2 parseState 1 3) (FSComp.SR.parsGetOrSetRequired())
@@ -1459,7 +1459,7 @@ namedModuleDefnBlock:
          // However in that case we do use type name lookup to make the resolution.
 
          match $2 with 
-         | [ SynModuleDecl.Expr (LongOrSingleIdent(false, LongIdentWithTrivia(path, _, _), None, _), _) ] -> 
+         | [ SynModuleDecl.Expr (LongOrSingleIdent(false, SynLongIdent(path, _, _), None, _), _) ] -> 
              Choice1Of2  path
          | _ -> 
              Choice2Of2 $2 
@@ -1723,7 +1723,7 @@ tyconDefnRhs:
      { let m = lhs parseState 
        let ty, arity = $3
        (fun nameRange augmentation -> 
-           let valSpfn = SynValSig([], (mkSynId m "Invoke", None), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m) 
+           let valSpfn = SynValSig([], (SynIdent(mkSynId m "Invoke", None)), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m) 
            let invoke = SynMemberDefn.AbstractSlot(valSpfn, AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
            SynTypeDefnRepr.ObjectModel (SynTypeDefnKind.Delegate (ty, arity), [invoke], m), []) }
@@ -1881,7 +1881,7 @@ memberCore:
                        let getset = 
                              let rec go p = 
                                  match p with 
-                                 | SynPat.LongIdent (longDotId=LongIdentWithTrivia([id], _, _)) -> id.idText
+                                 | SynPat.LongIdent (longDotId=SynLongIdent([id], _, _)) -> id.idText
                                  | SynPat.Named (nm, _, _, _) | SynPat.As (_, SynPat.Named (nm, _, _, _), _) -> nm.idText
                                  | SynPat.Typed (p, _, _) -> go p
                                  | SynPat.Attrib (p, _, _) -> go p
@@ -1993,7 +1993,7 @@ memberCore:
                      let lidOuter, lidVisOuter = 
                          match bindingPatOuter with 
                          | SynPat.LongIdent (lid, _, None, None, SynArgPats.Pats [], lidVisOuter, m) ->  lid, lidVisOuter
-                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> LongIdentWithTrivia([id], [], [None]), visOuter
+                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> SynLongIdent([id], [], [None]), visOuter
                          | p -> raiseParseErrorAt mWholeBindLhs (FSComp.SR.parsInvalidDeclarationSyntax()) 
   
                      // Merge the visibility from the outer point with the inner point, e.g.
@@ -2010,7 +2010,7 @@ memberCore:
                      // Replace the "get" or the "set" with the right name
                      let rec go p = 
                          match p with 
-                         | SynPat.LongIdent (longDotId=LongIdentWithTrivia([id], _, _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
+                         | SynPat.LongIdent (longDotId=SynLongIdent([id], _, _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
                              // Setters have all arguments tupled in their internal form, though they don't 
                              // appear to be tupled from the syntax. Somewhat unfortunate
                              let args = 
@@ -2129,7 +2129,7 @@ classDefnMember:
         let expr = $7
         let valSynData = SynValData (Some (CtorMemberFlags SynMemberFlagsTrivia.Zero), SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), $5) 
         let vis = $2 
-        let declPat = SynPat.LongIdent (LongIdentWithTrivia([mkSynId (rhs parseState 3) "new"], [], [None]), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
+        let declPat = SynPat.LongIdent (SynLongIdent([mkSynId (rhs parseState 3) "new"], [], [None]), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
         // Check that 'SynPatForConstructorDecl' matches this correctly
         assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
         let synBindingTrivia: SynBindingTrivia = { LetKeyword = None; EqualsRange = Some mEquals }
@@ -2178,12 +2178,12 @@ atomicPatternLongIdent:
 
        let underscore = ident("_", rhs parseState 1)
        let dotm = rhs parseState 2
-       None, prependIdentInLongIdentWithTrivia (underscore, None) dotm $3 }
+       None, prependIdentInLongIdentWithTrivia (SynIdent(underscore, None)) dotm $3 }
 
   | GLOBAL DOT pathOp
      { let globalIdent = ident(MangledGlobalName, rhs parseState 1)
        let dotm = rhs parseState 2
-       None, prependIdentInLongIdentWithTrivia (globalIdent, None) dotm $3 }
+       None, prependIdentInLongIdentWithTrivia (SynIdent(globalIdent, None)) dotm $3 }
 
   | pathOp
      { (None, $1) }
@@ -2194,7 +2194,7 @@ atomicPatternLongIdent:
 
        let underscore = ident("_", rhs parseState 2)
        let dotm = rhs parseState 3
-       Some($1), prependIdentInLongIdentWithTrivia (underscore, None) dotm $4 } 
+       Some($1), prependIdentInLongIdentWithTrivia (SynIdent(underscore, None)) dotm $4 } 
 
   | access pathOp
      { (Some($1), $2) }
@@ -2264,7 +2264,7 @@ inheritsDefn:
   | INHERIT ends_coming_soon_or_recover
      { let mDecl = (rhs parseState 1)
        if not $2 then errorR(Error(FSComp.SR.parsTypeNameCannotBeEmpty(), mDecl))
-       SynMemberDefn.Inherit(SynType.LongIdent(LongIdentWithTrivia([], [], [])), None, mDecl) }
+       SynMemberDefn.Inherit(SynType.LongIdent(SynLongIdent([], [], [])), None, mDecl) }
 
 optAsSpec: 
   | asSpec
@@ -2641,26 +2641,26 @@ unionCaseName:
   | LPAREN COLON_COLON rparen  
       { let lpr = rhs parseState 1
         let rpr = rhs parseState 3 
-        ident(opNameCons, rhs parseState 2), Some(IdentTrivia.OriginalNotationWithParen(lpr, "::", rpr)) }  
+        SynIdent(ident(opNameCons, rhs parseState 2), Some(IdentTrivia.OriginalNotationWithParen(lpr, "::", rpr))) }  
 
   | LPAREN LBRACK RBRACK  rparen  
       { let lpr = rhs parseState 1
         let rpr = rhs parseState 3
-        ident(opNameNil, rhs2 parseState 2 3), Some(IdentTrivia.OriginalNotationWithParen(lpr, "[]", rpr)) }  
+        SynIdent(ident(opNameNil, rhs2 parseState 2 3), Some(IdentTrivia.OriginalNotationWithParen(lpr, "[]", rpr))) }  
 
 firstUnionCaseDeclOfMany: 
   | ident opt_OBLOCKSEP
       { let trivia: SynUnionCaseTrivia = { BarRange = None }
         let xmlDoc = grabXmlDoc(parseState, [], 1)
         let mDecl = (rhs parseState 1) |> unionRangeWithXmlDoc xmlDoc
-        Choice2Of2 (SynUnionCase ( [], ($1, None), SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia)) }
+        Choice2Of2 (SynUnionCase ( [], (SynIdent($1, None)), SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia)) }
 
   | ident EQUALS constant opt_OBLOCKSEP
       { let mEquals = rhs parseState 2
         let trivia: SynEnumCaseTrivia = { BarRange = None; EqualsRange = mEquals }
         let xmlDoc = grabXmlDoc(parseState, [], 1)
         let mDecl = (rhs2 parseState 1 3) |> unionRangeWithXmlDoc xmlDoc
-        Choice1Of2 (SynEnumCase ([], ($1, None), fst $3, snd $3, xmlDoc, mDecl, trivia)) }
+        Choice1Of2 (SynEnumCase ([], SynIdent($1, None), fst $3, snd $3, xmlDoc, mDecl, trivia)) }
 
   | firstUnionCaseDecl opt_OBLOCKSEP
       { $1 }
@@ -2670,14 +2670,14 @@ firstUnionCaseDecl:
      { let trivia: SynUnionCaseTrivia = { BarRange = None }
        let xmlDoc = grabXmlDoc(parseState, [], 1)
        let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-       Choice2Of2 (SynUnionCase ( [], ($1, None), SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
+       Choice2Of2 (SynUnionCase ( [], SynIdent($1, None), SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
 
   | ident EQUALS constant opt_OBLOCKSEP
       { let mEquals = rhs parseState 2
         let trivia: SynEnumCaseTrivia = { BarRange = None; EqualsRange = mEquals }
         let xmlDoc = grabXmlDoc(parseState, [], 1)
         let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-        Choice1Of2 (SynEnumCase ([], ($1, None), fst $3, snd $3, xmlDoc, mDecl, trivia))  }
+        Choice1Of2 (SynEnumCase ([], SynIdent($1, None), fst $3, snd $3, xmlDoc, mDecl, trivia))  }
 
 unionCaseReprElements:
   | unionCaseReprElement STAR unionCaseReprElements
@@ -2743,13 +2743,13 @@ exconCore:
 /* Part of an exception definition */
 exconIntro:
   | ident
-      { SynUnionCase([], ($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
+      { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
   | ident OF unionCaseRepr
-      { SynUnionCase([], ($1,None), SynUnionCaseKind.Fields $3, PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
+      { SynUnionCase([], SynIdent($1,None), SynUnionCaseKind.Fields $3, PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
   | ident OF recover
-      { SynUnionCase([], ($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
+      { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
 exconRepr: 
   | /* EMPTY */
@@ -2888,11 +2888,11 @@ cPrototype:
             SynExpr.App (
                 ExprAtomicFlag.NonAtomic,
                 false,
-                SynExpr.Ident (ident("failwith", rhs parseState 6), None),
+                SynExpr.Ident (ident("failwith", rhs parseState 6)),
                 SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
                 mRhs)
         (fun attrs _ ->
-            let bindingPat = SynPat.LongIdent (LongIdentWithTrivia([nm], [], [None]), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
+            let bindingPat = SynPat.LongIdent (SynLongIdent([nm], [], [None]), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
             let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let xmlDoc = grabXmlDoc(parseState, attrs, 1)
             let binding =
@@ -2937,19 +2937,19 @@ cType:
 
   | cType opt_HIGH_PRECEDENCE_APP LBRACK RBRACK 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("[]", m)], [], [None])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("[]", m)], [], [None])), None, [$1], [], None, true, m) } 
 
   | cType STAR 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("nativeptr", m)], [], [None])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeptr", m)], [], [None])), None, [$1], [], None, true, m) } 
 
   | cType AMP  
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("byref", m)], [], [None])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("byref", m)], [], [None])), None, [$1], [], None, true, m) } 
 
   | VOID STAR 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("nativeint", m)], [], [None])), None, [], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeint", m)], [], [None])), None, [], [], None, true, m) } 
 
 
 /* A return type in an 'extern' DllImport function definition */
@@ -2959,7 +2959,7 @@ cRetType:
 
   | opt_attributes VOID  
      { let m = rhs parseState 2 
-       SynReturnInfo((SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("unit", m)], [], [None])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
+       SynReturnInfo((SynType.App(SynType.LongIdent(SynLongIdent([ident("unit", m)], [], [None])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
 
 
 localBindings: 
@@ -3264,7 +3264,7 @@ headBindingPattern:
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
   | headBindingPattern COLON_COLON  headBindingPattern 
-      { SynPat.LongIdent (LongIdentWithTrivia(mkSynCaseName (rhs parseState 2) opNameCons, [], [None]), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
+      { SynPat.LongIdent (SynLongIdent(mkSynCaseName (rhs parseState 2) opNameCons, [], [None]), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
 
   | tuplePatternElements  %prec pat_tuple 
       { SynPat.Tuple(false, List.rev $1, lhs parseState) }
@@ -3503,7 +3503,7 @@ parenPattern:
         SynPat.Attrib($2, $1, lhsm) } 
 
   | parenPattern COLON_COLON  parenPattern 
-      { SynPat.LongIdent (LongIdentWithTrivia(mkSynCaseName (rhs parseState 2) opNameCons, [], [None]), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
+      { SynPat.LongIdent (SynLongIdent(mkSynCaseName (rhs parseState 2) opNameCons, [], [None]), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
 
   | constrPattern { $1 }
 
@@ -4054,7 +4054,7 @@ declExpr:
 
   | declExpr COLON_COLON declExpr
      { let tupExpr = SynExpr.Tuple (false, [$1;$3], [rhs parseState 2], unionRanges $1.Range $3.Range)
-       let identExpr = mkSynIdGet (rhs parseState 2) opNameCons (Some (IdentTrivia.OriginalNotation "::"))
+       let identExpr = mkSynOperator (rhs parseState 2) "::"
        SynExpr.App (ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range $3.Range) }
 
   | declExpr PLUS_MINUS_OP declExpr
@@ -4130,7 +4130,7 @@ declExpr:
 
   | declExpr COLON_COLON OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("::"))
-       let identExpr = mkSynIdGet (rhs parseState 2) opNameCons (Some (IdentTrivia.OriginalNotation "::"))
+       let identExpr = mkSynOperator (rhs parseState 2) "::"
        let tupExpr = SynExpr.Tuple (false, [$1;(arbExpr("declExprInfix", (rhs parseState 3).StartRange))], [rhs parseState 2], unionRanges $1.Range (rhs parseState 3).StartRange)
        SynExpr.App (ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range (rhs parseState 3).StartRange) }
 
@@ -4450,19 +4450,21 @@ atomicExpr:
         $3 arg1 (lhs parseState) (rhs parseState 2), hpa1 }
 
   | BASE DOT atomicExprQualification 
-      { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1), None)
+      { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1))
         $3 arg1 (lhs parseState) (rhs parseState 2), false }
 
   | QMARK nameop 
-      { let ident, trivia = $2
-        SynExpr.LongIdent (true, LongIdentWithTrivia([ident], [], [trivia]), None, rhs parseState 2), false }
+      { let (SynIdent(ident, trivia)) = $2
+        SynExpr.LongIdent (true, SynLongIdent([ident], [], [trivia]), None, rhs parseState 2), false }
 
   | atomicExpr QMARK dynamicArg
       { let arg1, hpa1 = $1
         mkSynInfix (rhs parseState 2) arg1 "?" $3, hpa1 }
 
   | GLOBAL
-      { SynExpr.Ident (ident(MangledGlobalName, rhs parseState 1), Some (IdentTrivia.OriginalNotation "global")), false }
+      { let m = rhs parseState 1
+        let ident = ident(MangledGlobalName, m)
+        SynExpr.LongIdent(false, SynLongIdent([ident], [], [Some (IdentTrivia.OriginalNotation "global")]), None, m), false }
 
   | identExpr
       { $1, false }
@@ -4532,7 +4534,7 @@ atomicExprQualification:
             // Note that "*" is parsed as an expression (it is allowed in "foo.[3,*]")
             match $2 with
             | SynExpr.IndexRange (None, opm, None, _m1, _m2, _) ->
-                mkSynDot dotm lhsm e (ident(CompileOpName "*", opm), Some(IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr)))
+                mkSynDot dotm lhsm e (SynIdent(ident(CompileOpName "*", opm), Some(IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr))))
             | _ ->
                 if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
                     mlCompatError (FSComp.SR.mlCompatMultiPrefixTyparsNoLongerSupported()) (lhs parseState) 
@@ -4608,19 +4610,19 @@ beginEndExpr:
 quoteExpr:
   | LQUOTE typedSequentialExpr RQUOTE 
       { if $1 <> $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsMismatchedQuote(fst $1))
-        (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)) None, snd $1, $2, false, lhs parseState)) } 
+        (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, lhs parseState)) } 
 
   | LQUOTE typedSequentialExpr recover 
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))  
         let mExpr = rhs2 parseState 1 2
-        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)) None, snd $1, $2, false, mExpr))  } 
+        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, mExpr))  } 
 
   | LQUOTE error RQUOTE 
-      { (* silent recovery *) SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)) None, snd $1, arbExpr("quoteExpr", (rhs parseState 2)), false, lhs parseState)  }  
+      { (* silent recovery *) SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr", (rhs parseState 2)), false, lhs parseState)  }  
 
   | LQUOTE recover 
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))
-        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)) None, snd $1, arbExpr("quoteExpr2", (rhs parseState 1).EndRange), false, rhs parseState 1))  }  
+        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr2", (rhs parseState 1).EndRange), false, rhs parseState 1))  }  
 
 arrayExpr:
   | LBRACK_BAR arrayExprElements BAR_RBRACK 
@@ -4831,7 +4833,7 @@ recdExpr:
   | INHERIT atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType recdExprBindings opt_seps_recd
      { let arg = match $4 with None -> mkSynUnit (lhs parseState) | Some e -> e 
        let l = List.rev $5
-       let dummyField = mkRecdField (LongIdentWithTrivia([], [], [])) // dummy identifier, it will be discarded
+       let dummyField = mkRecdField (SynLongIdent([], [], [])) // dummy identifier, it will be discarded
        let l = rebindRanges (dummyField, None, None) l $6 
        let (SynExprRecordField(_, _, _, inheritsSep)) = List.head l
        let bindings = List.tail l
@@ -4843,7 +4845,7 @@ recdExpr:
 recdExprCore:
   | appExpr EQUALS declExprBlock recdExprBindings opt_seps_recd
      { match $1 with 
-       | LongOrSingleIdent(false, (LongIdentWithTrivia _ as f), None, m) ->  
+       | LongOrSingleIdent(false, (SynLongIdent _ as f), None, m) ->  
             let f = mkRecdField f
             let mEquals = rhs parseState 2
             let l = List.rev $4
@@ -5046,8 +5048,8 @@ braceBarExprCore:
      { let orig, flds = $2
        let flds = 
            flds |> List.choose (function 
-             | SynExprRecordField((LongIdentWithTrivia([id], _, _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
-             | SynExprRecordField((LongIdentWithTrivia([id], _, _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
+             | SynExprRecordField((SynLongIdent([id], _, _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
+             | SynExprRecordField((SynLongIdent([id], _, _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 3
        (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
@@ -5057,8 +5059,8 @@ braceBarExprCore:
        let orig, flds = $2 
        let flds = 
            flds |> List.choose (function 
-             | SynExprRecordField((LongIdentWithTrivia([id], _, _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
-             | SynExprRecordField((LongIdentWithTrivia([id], _, _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
+             | SynExprRecordField((SynLongIdent([id], _, _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
+             | SynExprRecordField((SynLongIdent([id], _, _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 2
        (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
@@ -5183,7 +5185,7 @@ topTupleTypeElements:
 topAppType:
   | attributes appType COLON appType 
      { match $2 with 
-       | SynType.LongIdent(LongIdentWithTrivia([id], _, _)) -> $4, SynArgInfo($1, false, Some id)
+       | SynType.LongIdent(SynLongIdent([id], _, _)) -> $4, SynArgInfo($1, false, Some id)
        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType())  }
 
   | attributes QMARK ident COLON appType 
@@ -5194,7 +5196,7 @@ topAppType:
 
   | appType COLON appType 
      { match $1 with 
-       | SynType.LongIdent(LongIdentWithTrivia([id], _, _)) -> $3, SynArgInfo([], false, Some id)
+       | SynType.LongIdent(SynLongIdent([id], _, _)) -> $3, SynArgInfo([], false, Some id)
        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType())  }
 
   | QMARK ident COLON appType 
@@ -5504,7 +5506,7 @@ dummyTypeArg:
   |  /* EMPTY */
      { let m = rhs parseState 1
        let dummyStatVal = SynType.StaticConstant(SynConst.Int32(0), m)
-       let dummyName = SynType.LongIdent(LongIdentWithTrivia([ident("", m)], [], [None]))
+       let dummyName = SynType.LongIdent(SynLongIdent([ident("", m)], [], [None]))
        let dummyTypeArg = SynType.StaticConstantNamed(dummyName, dummyStatVal, m)
        dummyTypeArg }
 
@@ -5582,17 +5584,17 @@ ident:
 /* A A.B.C path used to an identifier */
 path: 
   | GLOBAL
-      { LongIdentWithTrivia([ident(MangledGlobalName, rhs parseState 1)], [], [None]) }
+      { SynLongIdent([ident(MangledGlobalName, rhs parseState 1)], [], [None]) }
 
   | ident  
-     { LongIdentWithTrivia([$1], [], [None]) }
+     { SynLongIdent([$1], [], [None]) }
 
   | path DOT ident  
-     { let (LongIdentWithTrivia(lid, dotms, trivia)) = $1 in LongIdentWithTrivia(lid @ [$3], dotms @ [rhs parseState 2], trivia @ [None]) } 
+     { let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid @ [$3], dotms @ [rhs parseState 2], trivia @ [None]) } 
 
   | path DOT ends_coming_soon_or_recover  
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedNameAfterToken())
-       let (LongIdentWithTrivia(lid, dotms, trivia)) = $1 in LongIdentWithTrivia(lid, dotms @ [rhs parseState 2], trivia)  } 
+       let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid, dotms @ [rhs parseState 2], trivia)  } 
 
 
 /* An operator name, with surrounnding parentheses */
@@ -5731,27 +5733,27 @@ activePatternCaseNames:
 /* A single item that is an identifier or operator name */
 identOrOp: 
   | ident  
-     { $1, None } 
+     { SynIdent($1, None) } 
 
   | opName 
      { let ident, trivia = $1
-       ident, Some trivia }
+       SynIdent(ident, Some trivia) }
 
 /* An A.B.C path ending in an identifier or operator name */
 /* Note, only used in atomicPatternLongIdent */
 pathOp: 
   | ident  
-     { LongIdentWithTrivia([$1], [], [None]) }
+     { SynLongIdent([$1], [], [None]) }
 
   | opName 
      { let ident, trivia = $1
-       LongIdentWithTrivia([ident], [], [Some trivia]) }
+       SynLongIdent([ident], [], [Some trivia]) }
 
   | ident DOT pathOp 
-     { prependIdentInLongIdentWithTrivia ($1, None) (rhs parseState 2) $3 }
+     { prependIdentInLongIdentWithTrivia (SynIdent($1, None)) (rhs parseState 2) $3 }
 
   | ident DOT error
-     { (* silent recovery *) LongIdentWithTrivia([$1], [rhs parseState 2], [None]) }  
+     { (* silent recovery *) SynLongIdent([$1], [rhs parseState 2], [None]) }  
 
 
 /* nameop is identOrOp not used as part of a path */
@@ -5760,7 +5762,7 @@ nameop:
 
 identExpr:
   | ident
-     { SynExpr.Ident($1, None) }
+     { SynExpr.Ident($1) }
 
   | opName
      { let m = lhs parseState
@@ -5776,7 +5778,16 @@ identExpr:
            | IdentTrivia.HasParenthesis(lpr, rpr) ->
                lpr, rpr, None
 
-       SynExpr.Paren(SynExpr.Ident(ident, trivia), mLparen, Some mRparen, m) }
+       match trivia with
+       | None -> 
+           SynExpr.Paren(SynExpr.Ident(ident), mLparen, Some mRparen, m)
+       | Some trivia ->
+           SynExpr.Paren(
+               SynExpr.LongIdent(false, SynLongIdent([ident], [], [Some trivia]), None, m),
+               mLparen, 
+               Some mRparen, 
+               m
+           ) }
 
 topSeparator: 
   | SEMICOLON { } 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -983,7 +983,7 @@ tyconSpfnRhs:
   | DELEGATE OF topType
      { let m = lhs parseState 
        let ty, arity = $3
-       let invoke = SynMemberSig.Member(SynValSig([], mkSynId m "Invoke", inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m), AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
+       let invoke = SynMemberSig.Member(SynValSig([], (mkSynId m "Invoke", None), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m), AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
        (fun nameRange nameInfo mEquals augmentation -> 
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
            let mWhole = unionRanges nameRange m
@@ -1099,7 +1099,7 @@ classMemberSpfn:
      { let vis, doc, (ty, valSynInfo) = $2, grabXmlDoc(parseState, $1, 1), $5
        let m = unionRanges (rhs parseState 1) ty.Range |> unionRangeWithXmlDoc doc
        let isInline = false 
-       let valSpfn = SynValSig ($1, mkSynId (rhs parseState 3) "new", noInferredTypars, ty, valSynInfo, isInline, false, doc, vis, None, None, m)
+       let valSpfn = SynValSig ($1, (mkSynId (rhs parseState 3) "new", None), noInferredTypars, ty, valSynInfo, isInline, false, doc, vis, None, None, m)
        SynMemberSig.Member(valSpfn, CtorMemberFlags SynMemberFlagsTrivia.Zero, m) }
 
 
@@ -1125,15 +1125,16 @@ classMemberSpfnGetSet:
 /* The "get, set" on a property member in a signature */
 classMemberSpfnGetSetElements:
   | nameop 
-    { (let (id:Ident) = $1 
+    { (let (id:Ident, _) = $1 
        if id.idText = "get" then SynMemberKind.PropertyGet 
        else if id.idText = "set" then SynMemberKind.PropertySet 
        else raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired())) }
 
   | nameop COMMA nameop
-    { let (id:Ident) = $1 
-      if not ((id.idText = "get" && $3.idText = "set") ||
-              (id.idText = "set" && $3.idText = "get")) then 
+    { let (id:Ident, _) = $1 
+      let (id2, _) = $3
+      if not ((id.idText = "get" && id2.idText = "set") ||
+              (id.idText = "set" && id2.idText = "get")) then 
          raiseParseErrorAt (rhs2 parseState 1 3) (FSComp.SR.parsGetOrSetRequired())
       SynMemberKind.PropertyGetSet }
 
@@ -1722,7 +1723,7 @@ tyconDefnRhs:
      { let m = lhs parseState 
        let ty, arity = $3
        (fun nameRange augmentation -> 
-           let valSpfn = SynValSig([], mkSynId m "Invoke", inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m) 
+           let valSpfn = SynValSig([], (mkSynId m "Invoke", None), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, None, m) 
            let invoke = SynMemberDefn.AbstractSlot(valSpfn, AbstractMemberFlags SynMemberFlagsTrivia.Zero SynMemberKind.Member, m) 
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
            SynTypeDefnRepr.ObjectModel (SynTypeDefnKind.Delegate (ty, arity), [invoke], m), []) }
@@ -2638,24 +2639,28 @@ unionCaseName:
       { $1 } 
 
   | LPAREN COLON_COLON rparen  
-      {  ident(opNameCons, rhs parseState 2) }  
+      { let lpr = rhs parseState 1
+        let rpr = rhs parseState 3 
+        ident(opNameCons, rhs parseState 2), Some(IdentTrivia.OriginalNotationWithParen(lpr, "::", rpr)) }  
 
   | LPAREN LBRACK RBRACK  rparen  
-      {  ident(opNameNil, rhs2 parseState 2 3) }  
+      { let lpr = rhs parseState 1
+        let rpr = rhs parseState 3
+        ident(opNameNil, rhs2 parseState 2 3), Some(IdentTrivia.OriginalNotationWithParen(lpr, "[]", rpr)) }  
 
 firstUnionCaseDeclOfMany: 
   | ident opt_OBLOCKSEP
       { let trivia: SynUnionCaseTrivia = { BarRange = None }
         let xmlDoc = grabXmlDoc(parseState, [], 1)
         let mDecl = (rhs parseState 1) |> unionRangeWithXmlDoc xmlDoc
-        Choice2Of2 (SynUnionCase ( [], $1, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia)) }
+        Choice2Of2 (SynUnionCase ( [], ($1, None), SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia)) }
 
   | ident EQUALS constant opt_OBLOCKSEP
       { let mEquals = rhs parseState 2
         let trivia: SynEnumCaseTrivia = { BarRange = None; EqualsRange = mEquals }
         let xmlDoc = grabXmlDoc(parseState, [], 1)
         let mDecl = (rhs2 parseState 1 3) |> unionRangeWithXmlDoc xmlDoc
-        Choice1Of2 (SynEnumCase ([], $1, fst $3, snd $3, xmlDoc, mDecl, trivia)) }
+        Choice1Of2 (SynEnumCase ([], ($1, None), fst $3, snd $3, xmlDoc, mDecl, trivia)) }
 
   | firstUnionCaseDecl opt_OBLOCKSEP
       { $1 }
@@ -2665,14 +2670,14 @@ firstUnionCaseDecl:
      { let trivia: SynUnionCaseTrivia = { BarRange = None }
        let xmlDoc = grabXmlDoc(parseState, [], 1)
        let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-       Choice2Of2 (SynUnionCase ( [], $1, SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
+       Choice2Of2 (SynUnionCase ( [], ($1, None), SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
 
   | ident EQUALS constant opt_OBLOCKSEP
       { let mEquals = rhs parseState 2
         let trivia: SynEnumCaseTrivia = { BarRange = None; EqualsRange = mEquals }
         let xmlDoc = grabXmlDoc(parseState, [], 1)
         let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-        Choice1Of2 (SynEnumCase ([], $1, fst $3, snd $3, xmlDoc, mDecl, trivia))  }
+        Choice1Of2 (SynEnumCase ([], ($1, None), fst $3, snd $3, xmlDoc, mDecl, trivia))  }
 
 unionCaseReprElements:
   | unionCaseReprElement STAR unionCaseReprElements
@@ -2738,13 +2743,13 @@ exconCore:
 /* Part of an exception definition */
 exconIntro:
   | ident
-      { SynUnionCase([], $1, SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
+      { SynUnionCase([], ($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
   | ident OF unionCaseRepr
-      { SynUnionCase([], $1, SynUnionCaseKind.Fields $3, PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
+      { SynUnionCase([], ($1,None), SynUnionCaseKind.Fields $3, PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
   | ident OF recover
-      { SynUnionCase([], $1, SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
+      { SynUnionCase([], ($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
 exconRepr: 
   | /* EMPTY */
@@ -2883,7 +2888,7 @@ cPrototype:
             SynExpr.App (
                 ExprAtomicFlag.NonAtomic,
                 false,
-                SynExpr.Ident (ident("failwith", rhs parseState 6)),
+                SynExpr.Ident (ident("failwith", rhs parseState 6), None),
                 SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
                 mRhs)
         (fun attrs _ ->
@@ -4049,7 +4054,8 @@ declExpr:
 
   | declExpr COLON_COLON declExpr
      { let tupExpr = SynExpr.Tuple (false, [$1;$3], [rhs parseState 2], unionRanges $1.Range $3.Range)
-       SynExpr.App (ExprAtomicFlag.NonAtomic, true, mkSynIdGet (rhs parseState 2) opNameCons, tupExpr, unionRanges $1.Range $3.Range) }
+       let identExpr = mkSynIdGet (rhs parseState 2) opNameCons (Some (IdentTrivia.OriginalNotation "::"))
+       SynExpr.App (ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range $3.Range) }
 
   | declExpr PLUS_MINUS_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4123,9 +4129,10 @@ declExpr:
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr COLON_COLON OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("::")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("::"))
+       let identExpr = mkSynIdGet (rhs parseState 2) opNameCons (Some (IdentTrivia.OriginalNotation "::"))
        let tupExpr = SynExpr.Tuple (false, [$1;(arbExpr("declExprInfix", (rhs parseState 3).StartRange))], [rhs parseState 2], unionRanges $1.Range (rhs parseState 3).StartRange)
-       SynExpr.App (ExprAtomicFlag.NonAtomic, true, mkSynIdGet (rhs parseState 2) opNameCons, tupExpr, unionRanges $1.Range (rhs parseState 3).StartRange) }
+       SynExpr.App (ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range (rhs parseState 3).StartRange) }
 
   | declExpr PLUS_MINUS_OP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
@@ -4443,18 +4450,19 @@ atomicExpr:
         $3 arg1 (lhs parseState) (rhs parseState 2), hpa1 }
 
   | BASE DOT atomicExprQualification 
-      { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1))
+      { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1), None)
         $3 arg1 (lhs parseState) (rhs parseState 2), false }
 
   | QMARK nameop 
-      { SynExpr.LongIdent (true, LongIdentWithTrivia([$2], [], [None]), None, rhs parseState 2), false }
+      { let ident, trivia = $2
+        SynExpr.LongIdent (true, LongIdentWithTrivia([ident], [], [trivia]), None, rhs parseState 2), false }
 
   | atomicExpr QMARK dynamicArg
       { let arg1, hpa1 = $1
         mkSynInfix (rhs parseState 2) arg1 "?" $3, hpa1 }
 
   | GLOBAL
-      { SynExpr.Ident (ident(MangledGlobalName, rhs parseState 1)), false }
+      { SynExpr.Ident (ident(MangledGlobalName, rhs parseState 1), Some (IdentTrivia.OriginalNotation "global")), false }
 
   | identExpr
       { $1, false }
@@ -4517,12 +4525,14 @@ atomicExprQualification:
             SynExpr.LibraryOnlyUnionCaseFieldGet (e, mkSynCaseName lhsm opNameCons, (fst $5), lhsm)) }
 
   | LPAREN  typedSequentialExpr rparen  
-      { (fun e lhsm dotm -> 
+      { let lpr = rhs parseState 1
+        let rpr = rhs parseState 3
+        (fun e lhsm dotm -> 
             // Check for expr.( * )
             // Note that "*" is parsed as an expression (it is allowed in "foo.[3,*]")
             match $2 with
             | SynExpr.IndexRange (None, opm, None, _m1, _m2, _) ->
-                mkSynDot dotm lhsm e (ident(CompileOpName "*", opm))
+                mkSynDot dotm lhsm e (ident(CompileOpName "*", opm), Some(IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr)))
             | _ ->
                 if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
                     mlCompatError (FSComp.SR.mlCompatMultiPrefixTyparsNoLongerSupported()) (lhs parseState) 
@@ -4598,19 +4608,19 @@ beginEndExpr:
 quoteExpr:
   | LQUOTE typedSequentialExpr RQUOTE 
       { if $1 <> $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsMismatchedQuote(fst $1))
-        (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, lhs parseState)) } 
+        (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)) None, snd $1, $2, false, lhs parseState)) } 
 
   | LQUOTE typedSequentialExpr recover 
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))  
         let mExpr = rhs2 parseState 1 2
-        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, mExpr))  } 
+        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)) None, snd $1, $2, false, mExpr))  } 
 
   | LQUOTE error RQUOTE 
-      { (* silent recovery *) SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr", (rhs parseState 2)), false, lhs parseState)  }  
+      { (* silent recovery *) SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)) None, snd $1, arbExpr("quoteExpr", (rhs parseState 2)), false, lhs parseState)  }  
 
   | LQUOTE recover 
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))
-        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr2", (rhs parseState 1).EndRange), false, rhs parseState 1))  }  
+        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)) None, snd $1, arbExpr("quoteExpr2", (rhs parseState 1).EndRange), false, rhs parseState 1))  }  
 
 arrayExpr:
   | LBRACK_BAR arrayExprElements BAR_RBRACK 
@@ -5588,23 +5598,35 @@ path:
 /* An operator name, with surrounnding parentheses */
 opName: 
   | LPAREN operatorName rparen  
-     {  ident(CompileOpName $2, rhs parseState 2) }
+     { let lpr = rhs parseState 1
+       let rpr = rhs parseState 3
+       ident(CompileOpName $2, rhs parseState 2), IdentTrivia.OriginalNotationWithParen(lpr, $2, rpr) }
 
   | LPAREN error rparen  
-     {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName()); ident(CompileOpName "****", rhs parseState 2) }
+     {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName())
+        let lpr = rhs parseState 1
+        let rpr = rhs parseState 3
+        ident(CompileOpName "****", rhs parseState 2), IdentTrivia.HasParenthesis(lpr, rpr) }
 
   | LPAREN_STAR_RPAREN
-     {  ident(CompileOpName "*", rhs parseState 1) }
+     { let m = rhs parseState 1
+       let lpr = mkFileIndexRange m.FileIndex m.Start m.Start
+       let rpr = mkFileIndexRange m.FileIndex m.End m.End
+       ident(CompileOpName "*", rhs parseState 1), IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr) }
 
   /* active pattern name */
   | LPAREN activePatternCaseNames BAR rparen 
-     { let text = ("|" + String.concat "|" (List.rev $2) + "|")
-       ident(text, rhs2 parseState 2 3) }
+     { let lpr = rhs parseState 1
+       let text = ("|" + String.concat "|" (List.rev $2) + "|")
+       let rpr = rhs parseState 4
+       ident(text, rhs2 parseState 2 3), IdentTrivia.HasParenthesis(lpr, rpr) }
                          
   /* partial active pattern name */
   | LPAREN activePatternCaseNames BAR UNDERSCORE BAR rparen 
-     { let text = ("|" + String.concat "|" (List.rev $2) + "|_|" )
-       ident(text, rhs2 parseState 2 5) }
+     { let lpr = rhs parseState 1
+       let text = ("|" + String.concat "|" (List.rev $2) + "|_|" )
+       let rpr = rhs parseState 6
+       ident(text, rhs2 parseState 2 5), IdentTrivia.HasParenthesis(lpr, rpr) }
 
 /* An operator name, without surrounding parentheses */
 operatorName: 
@@ -5709,10 +5731,11 @@ activePatternCaseNames:
 /* A single item that is an identifier or operator name */
 identOrOp: 
   | ident  
-     { $1 } 
+     { $1, None } 
 
   | opName 
-     { $1 }
+     { let ident, trivia = $1
+       ident, Some trivia }
 
 /* An A.B.C path ending in an identifier or operator name */
 /* Note, only used in atomicPatternLongIdent */
@@ -5721,7 +5744,8 @@ pathOp:
      { LongIdentWithTrivia([$1], [], [None]) }
 
   | opName 
-     { LongIdentWithTrivia([$1], [], [None]) }
+     { let ident, trivia = $1
+       LongIdentWithTrivia([ident], [], [Some trivia]) }
 
   | ident DOT pathOp 
      { prependIdentInLongIdentWithTrivia ($1, None) (rhs parseState 2) $3 }
@@ -5736,13 +5760,23 @@ nameop:
 
 identExpr:
   | ident
-     { SynExpr.Ident($1) }
+     { SynExpr.Ident($1, None) }
 
   | opName
      { let m = lhs parseState
-       let mLparen = mkFileIndexRange m.FileIndex m.Start (mkPos m.StartLine (m.StartColumn + 1))
-       let mRparen = mkFileIndexRange m.FileIndex (mkPos m.EndLine (m.EndColumn - 1)) m.End
-       SynExpr.Paren(SynExpr.Ident($1), mLparen, Some mRparen, m) }
+       let ident, trivia = $1
+       let mLparen, mRparen, trivia =
+           match trivia with
+           | IdentTrivia.OriginalNotation text -> 
+               let mLparen = mkFileIndexRange m.FileIndex m.Start (mkPos m.StartLine (m.StartColumn + 1))
+               let mRparen = mkFileIndexRange m.FileIndex (mkPos m.EndLine (m.EndColumn - 1)) m.End
+               mLparen, mRparen, Some trivia
+           | IdentTrivia.OriginalNotationWithParen(lpr, text, rpr) ->
+               lpr, rpr, Some(IdentTrivia.OriginalNotation(text))
+           | IdentTrivia.HasParenthesis(lpr, rpr) ->
+               lpr, rpr, None
+
+       SynExpr.Paren(SynExpr.Ident(ident, trivia), mLparen, Some mRparen, m) }
 
 topSeparator: 
   | SEMICOLON { } 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -52,7 +52,7 @@ let rebindRanges first fields lastSep =
         | (f, m) :: xs -> run f xs (SynExprRecordField(name, mEquals, value, m) :: acc)
     run first fields []
 
-let mkUnderscoreRecdField m = LongIdentWithDots([ident("_", m)], []), false
+let mkUnderscoreRecdField m = LongIdentWithTrivia([ident("_", m)], [], [None]), false
 
 let mkRecdField lidwd = lidwd, true
 
@@ -189,7 +189,7 @@ let idOfPat (parseState:IParseState) m p =
     | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop ->
         mkSynId r "_"
     | SynPat.Named (id, false, _, _) -> id
-    | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
+    | SynPat.LongIdent(longDotId=LongIdentWithTrivia([id], _, _); typarDecls=None; argPats=SynArgPats.Pats []; accessibility=None) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier())
 
 let checkForMultipleAugmentations m a1 a2 = 
@@ -345,8 +345,8 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <SynExceptionDefn> exconDefn
 %type <SynExceptionDefnRepr> exconCore
 %type <SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
-%type <LongIdentWithDots> path
-%type <LongIdentWithDots> pathOp
+%type <LongIdentWithTrivia> path
+%type <LongIdentWithTrivia> pathOp
 /*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
 %type <range * range option * bool     * SynType list * range list * range> typeArgsActual
 /*     LESS    GREATER        typeArgs           m for each   mWhole  */
@@ -689,13 +689,13 @@ moduleIntro:
       { if not (isNil $2) then
             parseState.LexBuffer.CheckLanguageFeatureErrorRecover LanguageFeature.AttributesToRightOfModuleKeyword <| rhs parseState 4
         let mModule = rhs parseState 1
-        mModule, $4, $5.Lid, $3, $2 }
+        mModule, $4, $5.LongIdent, $3, $2 }
 
 
 /* The start of a namespace declaration */
 namespaceIntro: 
   | NAMESPACE opt_rec path 
-      { $2, $3.Lid, grabXmlDoc(parseState, [], 1)  }
+      { $2, $3.LongIdent, grabXmlDoc(parseState, [], 1)  }
 
 
 /* The contents of a signature file */
@@ -1413,7 +1413,7 @@ moduleDefn:
 openDecl:
   /* 'open' declarations */
   | OPEN path
-      { SynOpenDeclTarget.ModuleOrNamespace($2.Lid, (rhs parseState 2)) }
+      { SynOpenDeclTarget.ModuleOrNamespace($2.LongIdent, (rhs parseState 2)) }
 
   | OPEN typeKeyword appType
       { SynOpenDeclTarget.Type($3, (rhs parseState 3)) }
@@ -1423,10 +1423,10 @@ openDecl:
 /* We don't use it in signature files */
 namedModuleAbbrevBlock:
   | OBLOCKBEGIN path oblockend 
-     { $2.Lid }
+     { $2.LongIdent }
 
   | path 
-     { $1.Lid  }
+     { $1.LongIdent  }
        
 
 /* The right-hand-side of a module definition */ 
@@ -1458,7 +1458,7 @@ namedModuleDefnBlock:
          // However in that case we do use type name lookup to make the resolution.
 
          match $2 with 
-         | [ SynModuleDecl.Expr (LongOrSingleIdent(false, LongIdentWithDots(path, _), None, _), _) ] -> 
+         | [ SynModuleDecl.Expr (LongOrSingleIdent(false, LongIdentWithTrivia(path, _, _), None, _), _) ] -> 
              Choice1Of2  path
          | _ -> 
              Choice2Of2 $2 
@@ -1476,7 +1476,7 @@ namedModuleDefnBlock:
      { Choice2Of2 $1 }
 
   | path 
-     { Choice1Of2 $1.Lid }
+     { Choice1Of2 $1.LongIdent }
 
 
 /* A module definition that inccludes a 'begin'...'end' (rarely used in F# with #light syntax) */ 
@@ -1880,7 +1880,7 @@ memberCore:
                        let getset = 
                              let rec go p = 
                                  match p with 
-                                 | SynPat.LongIdent (longDotId=LongIdentWithDots([id], _)) -> id.idText
+                                 | SynPat.LongIdent (longDotId=LongIdentWithTrivia([id], _, _)) -> id.idText
                                  | SynPat.Named (nm, _, _, _) | SynPat.As (_, SynPat.Named (nm, _, _, _), _) -> nm.idText
                                  | SynPat.Typed (p, _, _) -> go p
                                  | SynPat.Attrib (p, _, _) -> go p
@@ -1992,7 +1992,7 @@ memberCore:
                      let lidOuter, lidVisOuter = 
                          match bindingPatOuter with 
                          | SynPat.LongIdent (lid, _, None, None, SynArgPats.Pats [], lidVisOuter, m) ->  lid, lidVisOuter
-                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> LongIdentWithDots([id], []), visOuter
+                         | SynPat.Named (id, _, visOuter, m) | SynPat.As(_, SynPat.Named (id, _, visOuter, m), _) -> LongIdentWithTrivia([id], [], [None]), visOuter
                          | p -> raiseParseErrorAt mWholeBindLhs (FSComp.SR.parsInvalidDeclarationSyntax()) 
   
                      // Merge the visibility from the outer point with the inner point, e.g.
@@ -2009,7 +2009,7 @@ memberCore:
                      // Replace the "get" or the "set" with the right name
                      let rec go p = 
                          match p with 
-                         | SynPat.LongIdent (longDotId=LongIdentWithDots([id], _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
+                         | SynPat.LongIdent (longDotId=LongIdentWithTrivia([id], _, _); typarDecls=tyargs; argPats=SynArgPats.Pats args; accessibility=lidVisInner; range=m) ->  
                              // Setters have all arguments tupled in their internal form, though they don't 
                              // appear to be tupled from the syntax. Somewhat unfortunate
                              let args = 
@@ -2128,7 +2128,7 @@ classDefnMember:
         let expr = $7
         let valSynData = SynValData (Some (CtorMemberFlags SynMemberFlagsTrivia.Zero), SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), $5) 
         let vis = $2 
-        let declPat = SynPat.LongIdent (LongIdentWithDots([mkSynId (rhs parseState 3) "new"], []), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
+        let declPat = SynPat.LongIdent (LongIdentWithTrivia([mkSynId (rhs parseState 3) "new"], [], [None]), None, None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
         // Check that 'SynPatForConstructorDecl' matches this correctly
         assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
         let synBindingTrivia: SynBindingTrivia = { LetKeyword = None; EqualsRange = Some mEquals }
@@ -2174,12 +2174,15 @@ atomicPatternLongIdent:
   | UNDERSCORE DOT pathOp
      { if not (parseState.LexBuffer.SupportsFeature LanguageFeature.SingleUnderscorePattern) then
           raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedSymbolDot())
-       let (LongIdentWithDots(lid, dotms)) = $3
-       (None, LongIdentWithDots(ident("_", rhs parseState 1)::lid, rhs parseState 2::dotms)) }
+
+       let underscore = ident("_", rhs parseState 1)
+       let dotm = rhs parseState 2
+       None, prependIdentInLongIdentWithTrivia (underscore, None) dotm $3 }
 
   | GLOBAL DOT pathOp
-     { let (LongIdentWithDots(lid, dotms)) = $3
-       (None, LongIdentWithDots(ident(MangledGlobalName, rhs parseState 1) :: lid, rhs parseState 2 :: dotms)) }
+     { let globalIdent = ident(MangledGlobalName, rhs parseState 1)
+       let dotm = rhs parseState 2
+       None, prependIdentInLongIdentWithTrivia (globalIdent, None) dotm $3 }
 
   | pathOp
      { (None, $1) }
@@ -2187,8 +2190,10 @@ atomicPatternLongIdent:
   | access UNDERSCORE DOT pathOp
      { if not (parseState.LexBuffer.SupportsFeature LanguageFeature.SingleUnderscorePattern) then
           raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedSymbolDot())
-       let (LongIdentWithDots(lid, dotms)) = $4
-       (Some($1), LongIdentWithDots(ident("_", rhs parseState 2)::lid, rhs parseState 3::dotms)) }  
+
+       let underscore = ident("_", rhs parseState 2)
+       let dotm = rhs parseState 3
+       Some($1), prependIdentInLongIdentWithTrivia (underscore, None) dotm $4 } 
 
   | access pathOp
      { (Some($1), $2) }
@@ -2258,7 +2263,7 @@ inheritsDefn:
   | INHERIT ends_coming_soon_or_recover
      { let mDecl = (rhs parseState 1)
        if not $2 then errorR(Error(FSComp.SR.parsTypeNameCannotBeEmpty(), mDecl))
-       SynMemberDefn.Inherit(SynType.LongIdent(LongIdentWithDots([], [])), None, mDecl) }
+       SynMemberDefn.Inherit(SynType.LongIdent(LongIdentWithTrivia([], [], [])), None, mDecl) }
 
 optAsSpec: 
   | asSpec
@@ -2431,13 +2436,13 @@ interfaceMember:
 
 tyconNameAndTyparDecls:  
   | opt_access path 
-      { None, $2.Lid, false, $1 }
+      { None, $2.LongIdent, false, $1 }
 
   | opt_access prefixTyparDecls  path
-      { Some $2, $3.Lid, false, $1 }
+      { Some $2, $3.LongIdent, false, $1 }
 
   | opt_access path postfixTyparDecls 
-      { Some $3, $2.Lid, true, $1 }
+      { Some $3, $2.LongIdent, true, $1 }
 
 prefixTyparDecls:
   | typar
@@ -2746,7 +2751,7 @@ exconRepr:
      { None }
 
   | EQUALS path
-     { Some ($2.Lid) }
+     { Some ($2.LongIdent) }
 
 /*-------------------------------------------------------------------------*/
 /* F# Definitions, Types, Patterns and Expressions  */
@@ -2882,7 +2887,7 @@ cPrototype:
                 SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
                 mRhs)
         (fun attrs _ ->
-            let bindingPat = SynPat.LongIdent (LongIdentWithDots([nm], []), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
+            let bindingPat = SynPat.LongIdent (LongIdentWithTrivia([nm], [], [None]), None, None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
             let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let xmlDoc = grabXmlDoc(parseState, attrs, 1)
             let binding =
@@ -2927,19 +2932,19 @@ cType:
 
   | cType opt_HIGH_PRECEDENCE_APP LBRACK RBRACK 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("[]", m)], [])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("[]", m)], [], [None])), None, [$1], [], None, true, m) } 
 
   | cType STAR 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("nativeptr", m)], [])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("nativeptr", m)], [], [None])), None, [$1], [], None, true, m) } 
 
   | cType AMP  
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("byref", m)], [])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("byref", m)], [], [None])), None, [$1], [], None, true, m) } 
 
   | VOID STAR 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(LongIdentWithDots([ident("nativeint", m)], [])), None, [], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("nativeint", m)], [], [None])), None, [], [], None, true, m) } 
 
 
 /* A return type in an 'extern' DllImport function definition */
@@ -2949,7 +2954,7 @@ cRetType:
 
   | opt_attributes VOID  
      { let m = rhs parseState 2 
-       SynReturnInfo((SynType.App(SynType.LongIdent(LongIdentWithDots([ident("unit", m)], [])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
+       SynReturnInfo((SynType.App(SynType.LongIdent(LongIdentWithTrivia([ident("unit", m)], [], [None])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
 
 
 localBindings: 
@@ -3254,7 +3259,7 @@ headBindingPattern:
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
   | headBindingPattern COLON_COLON  headBindingPattern 
-      { SynPat.LongIdent (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
+      { SynPat.LongIdent (LongIdentWithTrivia(mkSynCaseName (rhs parseState 2) opNameCons, [], [None]), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
 
   | tuplePatternElements  %prec pat_tuple 
       { SynPat.Tuple(false, List.rev $1, lhs parseState) }
@@ -3387,9 +3392,9 @@ atomicPattern:
 
   | atomicPatternLongIdent %prec prec_atompat_pathop 
       { let vis, lidwd = $1 
-        if not (isNilOrSingleton lidwd.Lid) || String.isLeadingIdentifierCharacterUpperCase (List.head lidwd.Lid).idText
+        if not (isNilOrSingleton lidwd.LongIdent) || String.isLeadingIdentifierCharacterUpperCase (List.head lidwd.LongIdent).idText
         then mkSynPatMaybeVar lidwd vis (lhs parseState)
-        else mkSynPatVar vis (List.head lidwd.Lid) }
+        else mkSynPatVar vis (List.head lidwd.LongIdent) }
 
   | constant 
       { SynPat.Const (fst $1, snd $1) }
@@ -3493,7 +3498,7 @@ parenPattern:
         SynPat.Attrib($2, $1, lhsm) } 
 
   | parenPattern COLON_COLON  parenPattern 
-      { SynPat.LongIdent (LongIdentWithDots(mkSynCaseName (rhs parseState 2) opNameCons, []), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
+      { SynPat.LongIdent (LongIdentWithTrivia(mkSynCaseName (rhs parseState 2) opNameCons, [], [None]), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
 
   | constrPattern { $1 }
 
@@ -3521,7 +3526,7 @@ recordPatternElementsAux: /* Fix 1190 */
 recordPatternElement:  
   | path EQUALS parenPattern 
     { let mEquals = rhs parseState 2
-      (List.frontAndBack $1.Lid, mEquals, $3) }
+      (List.frontAndBack $1.LongIdent, mEquals, $3) }
 
 listPatternElements:
   | /* EMPTY */                                      
@@ -4442,7 +4447,7 @@ atomicExpr:
         $3 arg1 (lhs parseState) (rhs parseState 2), false }
 
   | QMARK nameop 
-      { SynExpr.LongIdent (true, LongIdentWithDots([$2], []), None, rhs parseState 2), false }
+      { SynExpr.LongIdent (true, LongIdentWithTrivia([$2], [], [None]), None, rhs parseState 2), false }
 
   | atomicExpr QMARK dynamicArg
       { let arg1, hpa1 = $1
@@ -4816,7 +4821,7 @@ recdExpr:
   | INHERIT atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType recdExprBindings opt_seps_recd
      { let arg = match $4 with None -> mkSynUnit (lhs parseState) | Some e -> e 
        let l = List.rev $5
-       let dummyField = mkRecdField (LongIdentWithDots([], [])) // dummy identifier, it will be discarded
+       let dummyField = mkRecdField (LongIdentWithTrivia([], [], [])) // dummy identifier, it will be discarded
        let l = rebindRanges (dummyField, None, None) l $6 
        let (SynExprRecordField(_, _, _, inheritsSep)) = List.head l
        let bindings = List.tail l
@@ -4828,7 +4833,7 @@ recdExpr:
 recdExprCore:
   | appExpr EQUALS declExprBlock recdExprBindings opt_seps_recd
      { match $1 with 
-       | LongOrSingleIdent(false, (LongIdentWithDots(_, _) as f), None, m) ->  
+       | LongOrSingleIdent(false, (LongIdentWithTrivia _ as f), None, m) ->  
             let f = mkRecdField f
             let mEquals = rhs parseState 2
             let l = List.rev $4
@@ -5031,8 +5036,8 @@ braceBarExprCore:
      { let orig, flds = $2
        let flds = 
            flds |> List.choose (function 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
+             | SynExprRecordField((LongIdentWithTrivia([id], _, _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
+             | SynExprRecordField((LongIdentWithTrivia([id], _, _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 3
        (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
@@ -5042,8 +5047,8 @@ braceBarExprCore:
        let orig, flds = $2 
        let flds = 
            flds |> List.choose (function 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
-             | SynExprRecordField((LongIdentWithDots([id], _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
+             | SynExprRecordField((LongIdentWithTrivia([id], _, _), _), mEquals, Some e, _) -> Some (id, mEquals, e) 
+             | SynExprRecordField((LongIdentWithTrivia([id], _, _), _), mEquals, None, _) -> Some (id, mEquals, arbExpr("anonField", id.idRange)) 
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None) 
        let m = rhs2 parseState 1 2
        (fun isStruct -> SynExpr.AnonRecd (isStruct, orig, flds, m)) }
@@ -5168,7 +5173,7 @@ topTupleTypeElements:
 topAppType:
   | attributes appType COLON appType 
      { match $2 with 
-       | SynType.LongIdent(LongIdentWithDots([id], _)) -> $4, SynArgInfo($1, false, Some id)
+       | SynType.LongIdent(LongIdentWithTrivia([id], _, _)) -> $4, SynArgInfo($1, false, Some id)
        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType())  }
 
   | attributes QMARK ident COLON appType 
@@ -5179,7 +5184,7 @@ topAppType:
 
   | appType COLON appType 
      { match $1 with 
-       | SynType.LongIdent(LongIdentWithDots([id], _)) -> $3, SynArgInfo([], false, Some id)
+       | SynType.LongIdent(LongIdentWithTrivia([id], _, _)) -> $3, SynArgInfo([], false, Some id)
        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType())  }
 
   | QMARK ident COLON appType 
@@ -5489,7 +5494,7 @@ dummyTypeArg:
   |  /* EMPTY */
      { let m = rhs parseState 1
        let dummyStatVal = SynType.StaticConstant(SynConst.Int32(0), m)
-       let dummyName = SynType.LongIdent(LongIdentWithDots([ident("", m)], []))
+       let dummyName = SynType.LongIdent(LongIdentWithTrivia([ident("", m)], [], [None]))
        let dummyTypeArg = SynType.StaticConstantNamed(dummyName, dummyStatVal, m)
        dummyTypeArg }
 
@@ -5502,7 +5507,7 @@ measureTypeArg:
 
 measureTypeAtom:
   | path 
-     { SynMeasure.Named($1.Lid, $1.Range) }
+     { SynMeasure.Named($1.LongIdent, $1.Range) }
 
   | typar 
      { SynMeasure.Var($1, lhs parseState) }
@@ -5567,17 +5572,17 @@ ident:
 /* A A.B.C path used to an identifier */
 path: 
   | GLOBAL
-      { LongIdentWithDots([ident(MangledGlobalName, rhs parseState 1)], []) }
+      { LongIdentWithTrivia([ident(MangledGlobalName, rhs parseState 1)], [], [None]) }
 
   | ident  
-     { LongIdentWithDots([$1], []) }
+     { LongIdentWithTrivia([$1], [], [None]) }
 
   | path DOT ident  
-     { let (LongIdentWithDots(lid, dotms)) = $1 in LongIdentWithDots(lid @ [$3], dotms @ [rhs parseState 2]) } 
+     { let (LongIdentWithTrivia(lid, dotms, trivia)) = $1 in LongIdentWithTrivia(lid @ [$3], dotms @ [rhs parseState 2], trivia @ [None]) } 
 
   | path DOT ends_coming_soon_or_recover  
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedNameAfterToken())
-       let (LongIdentWithDots(lid, dotms)) = $1 in LongIdentWithDots(lid, dotms @ [rhs parseState 2])  } 
+       let (LongIdentWithTrivia(lid, dotms, trivia)) = $1 in LongIdentWithTrivia(lid, dotms @ [rhs parseState 2], trivia)  } 
 
 
 /* An operator name, with surrounnding parentheses */
@@ -5713,16 +5718,16 @@ identOrOp:
 /* Note, only used in atomicPatternLongIdent */
 pathOp: 
   | ident  
-     { LongIdentWithDots([$1], []) }
+     { LongIdentWithTrivia([$1], [], [None]) }
 
   | opName 
-     { LongIdentWithDots([$1], []) }
+     { LongIdentWithTrivia([$1], [], [None]) }
 
   | ident DOT pathOp 
-     { let (LongIdentWithDots(lid, dotms)) = $3 in LongIdentWithDots($1 :: lid, rhs parseState 2 :: dotms) } 
+     { prependIdentInLongIdentWithTrivia ($1, None) (rhs parseState 2) $3 }
 
-  | ident DOT error  
-     { (* silent recovery *) LongIdentWithDots([$1], [rhs parseState 2]) }  
+  | ident DOT error
+     { (* silent recovery *) LongIdentWithTrivia([$1], [rhs parseState 2], [None]) }  
 
 
 /* nameop is identOrOp not used as part of a path */

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -2941,15 +2941,15 @@ cType:
 
   | cType STAR 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeptr", m)], [], [None])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeptr", m)], [], [ Some (IdentTrivia.OriginalNotation "*") ])), None, [$1], [], None, true, m) } 
 
   | cType AMP  
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("byref", m)], [], [None])), None, [$1], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("byref", m)], [], [ Some (IdentTrivia.OriginalNotation "&") ])), None, [$1], [], None, true, m) } 
 
   | VOID STAR 
      { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeint", m)], [], [None])), None, [], [], None, true, m) } 
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeint", m)], [], [ Some (IdentTrivia.OriginalNotation "void*") ])), None, [], [], None, true, m) } 
 
 
 /* A return type in an 'extern' DllImport function definition */
@@ -2959,7 +2959,7 @@ cRetType:
 
   | opt_attributes VOID  
      { let m = rhs parseState 2 
-       SynReturnInfo((SynType.App(SynType.LongIdent(SynLongIdent([ident("unit", m)], [], [None])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
+       SynReturnInfo((SynType.App(SynType.LongIdent(SynLongIdent([ident("unit", m)], [], [ Some (IdentTrivia.OriginalNotation "void") ])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
 
 
 localBindings: 
@@ -3264,7 +3264,7 @@ headBindingPattern:
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
   | headBindingPattern COLON_COLON  headBindingPattern 
-      { SynPat.LongIdent (SynLongIdent(mkSynCaseName (rhs parseState 2) opNameCons, [], [None]), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
+      { SynPat.LongIdent (SynLongIdent(mkSynCaseName (rhs parseState 2) opNameCons, [], [ Some (IdentTrivia.OriginalNotation "::") ]), None, None, None, SynArgPats.Pats [SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3)], None, lhs parseState) }
 
   | tuplePatternElements  %prec pat_tuple 
       { SynPat.Tuple(false, List.rev $1, lhs parseState) }
@@ -3503,7 +3503,7 @@ parenPattern:
         SynPat.Attrib($2, $1, lhsm) } 
 
   | parenPattern COLON_COLON  parenPattern 
-      { SynPat.LongIdent (SynLongIdent(mkSynCaseName (rhs parseState 2) opNameCons, [], [None]), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
+      { SynPat.LongIdent (SynLongIdent(mkSynCaseName (rhs parseState 2) opNameCons, [], [ Some (IdentTrivia.OriginalNotation "::") ]), None, None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
 
   | constrPattern { $1 }
 

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -137,7 +137,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         SyntaxTraversal.Traverse(pos, input, { new SyntaxVisitorBase<_>() with
             member _.VisitExpr(_, _, defaultTraverse, expr) =
                 match expr with
-                | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.Ident (ident, _), _, _), argExpr, _) when rangeContainsPos argExpr.Range pos ->
+                | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ident])), _, _), argExpr, _) when rangeContainsPos argExpr.Range pos ->
                     match argExpr with
                     | SynExpr.App(_, _, _, SynExpr.Paren(expr, _, _, _), _) when rangeContainsPos expr.Range pos ->
                         None
@@ -171,7 +171,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
     member _.TryRangeOfFunctionOrMethodBeingApplied pos =
         let rec getIdentRangeForFuncExprInApp traverseSynExpr expr pos =
             match expr with
-            | SynExpr.Ident (ident,_) -> Some ident.idRange
+            | SynExpr.Ident ident -> Some ident.idRange
         
             | SynExpr.LongIdent (_, _, _, range) -> Some range
 
@@ -308,7 +308,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
 
     member _.TryRangeOfParenEnclosingOpEqualsGreaterUsage opGreaterEqualPos =
         let (|Ident|_|) ofName =
-            function | SynExpr.Ident (ident,_) when ident.idText = ofName -> Some ()
+            function | SynExpr.LongIdent(longDotId = SynLongIdent(id = [ident])) when ident.idText = ofName -> Some ()
                      | _ -> None
         let (|InfixAppOfOpEqualsGreater|_|) =
           function | SynExpr.App(ExprAtomicFlag.NonAtomic, false, SynExpr.App(ExprAtomicFlag.NonAtomic, true, Ident "op_EqualsGreater", actualParamListExpr, _), actualLambdaBodyExpr, _) ->
@@ -357,7 +357,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         SyntaxTraversal.Traverse(expressionPos, input, { new SyntaxVisitorBase<_>() with 
             member _.VisitExpr(_, _, defaultTraverse, expr) =
                 match expr with
-                | SynExpr.App(_, false, SynExpr.Ident (funcIdent,_), expr, _) ->
+                | SynExpr.App(_, false, SynExpr.LongIdent(longDotId = SynLongIdent(id = [funcIdent])), expr, _) ->
                     if funcIdent.idText = "op_Dereference" && rangeContainsPos expr.Range expressionPos then
                         Some funcIdent.idRange
                     else
@@ -368,7 +368,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         SyntaxTraversal.Traverse(expressionPos, input, { new SyntaxVisitorBase<_>() with 
             member _.VisitExpr(_, _, defaultTraverse, expr) =
                 match expr with
-                | SynExpr.App(_, false, SynExpr.Ident (funcIdent, _), expr, _) ->
+                | SynExpr.App(_, false, SynExpr.LongIdent(longDotId = SynLongIdent(id = [funcIdent])), expr, _) ->
                     if funcIdent.idText = "op_Dereference" && rangeContainsPos expr.Range expressionPos then
                         Some expr.Range
                     else

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -89,8 +89,8 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                 match headPat with
                 | SynPat.LongIdent (longDotId=longIdentWithDots) ->
                     Some longIdentWithDots.Range
-                | SynPat.As (rhsPat=SynPat.Named (ident=ident; isThisVal=false))
-                | SynPat.Named (ident, false, _, _) ->
+                | SynPat.As (rhsPat=SynPat.Named (ident=SynIdent(ident,_); isThisVal=false))
+                | SynPat.Named (SynIdent(ident,_), false, _, _) ->
                     Some ident.idRange
                 | _ ->
                     None

--- a/src/fsharp/service/FSharpParseFileResults.fs
+++ b/src/fsharp/service/FSharpParseFileResults.fs
@@ -137,7 +137,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         SyntaxTraversal.Traverse(pos, input, { new SyntaxVisitorBase<_>() with
             member _.VisitExpr(_, _, defaultTraverse, expr) =
                 match expr with
-                | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.Ident ident, _, _), argExpr, _) when rangeContainsPos argExpr.Range pos ->
+                | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.Ident (ident, _), _, _), argExpr, _) when rangeContainsPos argExpr.Range pos ->
                     match argExpr with
                     | SynExpr.App(_, _, _, SynExpr.Paren(expr, _, _, _), _) when rangeContainsPos expr.Range pos ->
                         None
@@ -171,7 +171,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
     member _.TryRangeOfFunctionOrMethodBeingApplied pos =
         let rec getIdentRangeForFuncExprInApp traverseSynExpr expr pos =
             match expr with
-            | SynExpr.Ident ident -> Some ident.idRange
+            | SynExpr.Ident (ident,_) -> Some ident.idRange
         
             | SynExpr.LongIdent (_, _, _, range) -> Some range
 
@@ -308,7 +308,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
 
     member _.TryRangeOfParenEnclosingOpEqualsGreaterUsage opGreaterEqualPos =
         let (|Ident|_|) ofName =
-            function | SynExpr.Ident ident when ident.idText = ofName -> Some ()
+            function | SynExpr.Ident (ident,_) when ident.idText = ofName -> Some ()
                      | _ -> None
         let (|InfixAppOfOpEqualsGreater|_|) =
           function | SynExpr.App(ExprAtomicFlag.NonAtomic, false, SynExpr.App(ExprAtomicFlag.NonAtomic, true, Ident "op_EqualsGreater", actualParamListExpr, _), actualLambdaBodyExpr, _) ->
@@ -357,7 +357,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         SyntaxTraversal.Traverse(expressionPos, input, { new SyntaxVisitorBase<_>() with 
             member _.VisitExpr(_, _, defaultTraverse, expr) =
                 match expr with
-                | SynExpr.App(_, false, SynExpr.Ident funcIdent, expr, _) ->
+                | SynExpr.App(_, false, SynExpr.Ident (funcIdent,_), expr, _) ->
                     if funcIdent.idText = "op_Dereference" && rangeContainsPos expr.Range expressionPos then
                         Some funcIdent.idRange
                     else
@@ -368,7 +368,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         SyntaxTraversal.Traverse(expressionPos, input, { new SyntaxVisitorBase<_>() with 
             member _.VisitExpr(_, _, defaultTraverse, expr) =
                 match expr with
-                | SynExpr.App(_, false, SynExpr.Ident funcIdent, expr, _) ->
+                | SynExpr.App(_, false, SynExpr.Ident (funcIdent, _), expr, _) ->
                     if funcIdent.idText = "op_Dereference" && rangeContainsPos expr.Range expressionPos then
                         Some expr.Range
                     else

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -166,7 +166,7 @@ module NavigationImpl =
             | _ -> []
         
         // Process a class declaration or F# type declaration
-        let rec processExnDefnRepr baseName nested (SynExceptionDefnRepr(_, SynUnionCase(ident=(id,_); caseType=fldspec), _, _, access, m)) =
+        let rec processExnDefnRepr baseName nested (SynExceptionDefnRepr(_, SynUnionCase(ident=SynIdent(id,_); caseType=fldspec), _, _, access, m)) =
             // Exception declaration
             [ createDecl(baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, fldspecRange fldspec, nested, NavigationEntityKind.Exception, false, access) ] 
 
@@ -189,13 +189,13 @@ module NavigationImpl =
                 match simple with
                 | SynTypeDefnSimpleRepr.Union(_, cases, mb) ->
                     let cases = 
-                        [ for SynUnionCase(ident=(id,_); caseType=fldspec) in cases -> 
+                        [ for SynUnionCase(ident=SynIdent(id,_); caseType=fldspec) in cases -> 
                             createMember(id, NavigationItemKind.Other, FSharpGlyph.Struct, unionRanges (fldspecRange fldspec) id.idRange, NavigationEntityKind.Union, false, access) ]
                     let nested = cases@topMembers              
                     [ createDeclLid(baseName, lid, NavigationItemKind.Type, FSharpGlyph.Union, m, bodyRange mb nested, nested, NavigationEntityKind.Union, false, access) ]
                 | SynTypeDefnSimpleRepr.Enum(cases, mb) -> 
                     let cases = 
-                        [ for SynEnumCase(ident=(id,_); range=m) in cases ->
+                        [ for SynEnumCase(ident=SynIdent(id,_); range=m) in cases ->
                             createMember(id, NavigationItemKind.Field, FSharpGlyph.EnumMember, m, NavigationEntityKind.Enum, false, access) ]
                     let nested = cases@topMembers
                     [ createDeclLid(baseName, lid, NavigationItemKind.Type, FSharpGlyph.Enum, m, bodyRange mb nested, nested, NavigationEntityKind.Enum, false, access) ]
@@ -233,7 +233,7 @@ module NavigationImpl =
                              [ createMember(rcid, NavigationItemKind.Field, FSharpGlyph.Field, range, enclosingEntityKind, false, access) ]
                          | SynMemberDefn.AutoProperty(ident=id; accessibility=access) -> 
                              [ createMember(id, NavigationItemKind.Field, FSharpGlyph.Field, id.idRange, enclosingEntityKind, false, access) ]
-                         | SynMemberDefn.AbstractSlot(SynValSig(ident=(id,_); synType=ty; accessibility=access), _, _) ->
+                         | SynMemberDefn.AbstractSlot(SynValSig(ident=SynIdent(id,_); synType=ty; accessibility=access), _, _) ->
                              [ createMember(id, NavigationItemKind.Method, FSharpGlyph.OverridenMethod, ty.Range, enclosingEntityKind, true, access) ]
                          | SynMemberDefn.NestedType _ -> failwith "tycon as member????" //processTycon tycon                
                          | SynMemberDefn.Interface(members=Some(membs)) ->
@@ -339,7 +339,7 @@ module NavigationImpl =
         let createMember(id:Ident, kind, baseGlyph, m, enclosingEntityKind, isAbstract, access) =
             NavigationItem.Create(id.idText, kind, baseGlyph, m, m, false, enclosingEntityKind, isAbstract, access), (addItemName(id.idText))
 
-        let rec processExnRepr baseName nested (SynExceptionDefnRepr(_, SynUnionCase(ident=(id,_); caseType=fldspec), _, _, access, m)) =
+        let rec processExnRepr baseName nested (SynExceptionDefnRepr(_, SynUnionCase(ident=SynIdent(id,_); caseType=fldspec), _, _, access, m)) =
             // Exception declaration
             [ createDecl(baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, fldspecRange fldspec, nested, NavigationEntityKind.Exception, false, access) ] 
         
@@ -361,13 +361,13 @@ module NavigationImpl =
                 match simple with
                 | SynTypeDefnSimpleRepr.Union(_, cases, mb) ->
                     let cases = 
-                        [ for SynUnionCase(ident=(id,_); caseType=fldspec) in cases -> 
+                        [ for SynUnionCase(ident=SynIdent(id,_); caseType=fldspec) in cases -> 
                             createMember(id, NavigationItemKind.Other, FSharpGlyph.Struct, unionRanges (fldspecRange fldspec) id.idRange, NavigationEntityKind.Union, false, access) ]
                     let nested = cases@topMembers              
                     [ createDeclLid(baseName, lid, NavigationItemKind.Type, FSharpGlyph.Union, m, bodyRange mb nested, nested, NavigationEntityKind.Union, false, access) ]
                 | SynTypeDefnSimpleRepr.Enum(cases, mb) -> 
                     let cases = 
-                        [ for SynEnumCase(ident = (id,_); range = m) in cases ->
+                        [ for SynEnumCase(ident = SynIdent(id,_); range = m) in cases ->
                             createMember(id, NavigationItemKind.Field, FSharpGlyph.EnumMember, m, NavigationEntityKind.Enum, false, access) ]
                     let nested = cases@topMembers
                     [ createDeclLid(baseName, lid, NavigationItemKind.Type, FSharpGlyph.Enum, m, bodyRange mb nested, nested, NavigationEntityKind.Enum, false, access) ]
@@ -392,7 +392,7 @@ module NavigationImpl =
         and processSigMembers (members: SynMemberSig list): list<NavigationItem * int> = 
             [ for memb in members do
                  match memb with
-                 | SynMemberSig.Member(SynValSig.SynValSig(ident=(id,_); accessibility=access; range=m), _, _) ->
+                 | SynMemberSig.Member(SynValSig.SynValSig(ident=SynIdent(id,_); accessibility=access; range=m), _, _) ->
                      yield createMember(id, NavigationItemKind.Method, FSharpGlyph.Method, m, NavigationEntityKind.Class, false, access)
                  | SynMemberSig.ValField(SynField(_, _, Some(rcid), ty, _, _, access, _), _) ->
                      yield createMember(rcid, NavigationItemKind.Field, FSharpGlyph.Field, ty.Range, NavigationEntityKind.Class, false, access)
@@ -400,7 +400,7 @@ module NavigationImpl =
 
         // Process declarations in a module that belong to the right drop-down (let bindings)
         let processNestedSigDeclarations decls = decls |> List.collect (function
-            | SynModuleSigDecl.Val(SynValSig.SynValSig(ident=(id,_); accessibility=access; range=m), _) ->
+            | SynModuleSigDecl.Val(SynValSig.SynValSig(ident=SynIdent(id,_); accessibility=access; range=m), _) ->
                 [ createMember(id, NavigationItemKind.Method, FSharpGlyph.Method, m, NavigationEntityKind.Module, false, access) ]
             | _ -> [] )        
 
@@ -530,7 +530,7 @@ module NavigateTo =
         let addModuleAbbreviation (id: Ident) isSig container =
             addIdent NavigableItemKind.ModuleAbbreviation id isSig container
         
-        let addExceptionRepr (SynExceptionDefnRepr(_, SynUnionCase(ident=(id,_)), _, _, _, _)) isSig container = 
+        let addExceptionRepr (SynExceptionDefnRepr(_, SynUnionCase(ident=SynIdent(id,_)), _, _, _, _)) isSig container = 
             addIdent NavigableItemKind.Exception id isSig container
             { Type = NavigableContainerType.Exception; Name = id.idText }
     
@@ -540,7 +540,7 @@ module NavigateTo =
             | _ -> ()
             { Type = containerType; Name = formatLongIdent lid }
     
-        let addValSig kind (SynValSig(ident=(id,_))) isSig container = 
+        let addValSig kind (SynValSig(ident=SynIdent(id,_))) isSig container = 
             addIdent kind id isSig container
         
         let addField(SynField(_, _, id, _, _, _, _, _)) isSig container = 
@@ -548,10 +548,10 @@ module NavigateTo =
             | Some id -> addIdent NavigableItemKind.Field id isSig container
             | _ -> ()
         
-        let addEnumCase(SynEnumCase(ident=(id,_))) isSig = 
+        let addEnumCase(SynEnumCase(ident=SynIdent(id,_))) isSig = 
             addIdent NavigableItemKind.EnumCase id isSig
         
-        let addUnionCase(SynUnionCase(ident=(id,_))) isSig container = 
+        let addUnionCase(SynUnionCase(ident=SynIdent(id,_))) isSig container = 
             addIdent NavigableItemKind.UnionCase id isSig container
     
         let mapMemberKind mk = 

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -160,7 +160,7 @@ module NavigationImpl =
                 [ createMemberLid(lidShow, kind, icon, unionRanges rangeMerge m, enclosingEntityKind, isAbstract, access) ]
             | SynPat.LongIdent(longDotId=LongIdentWithDots(lid,_); accessibility=access), _ -> 
                 [ createMemberLid(lid, NavigationItemKind.Field, FSharpGlyph.Field, unionRanges (List.head lid).idRange m, enclosingEntityKind, isAbstract, access) ]
-            | SynPat.Named (id, _, access, _), _ | SynPat.As(_, SynPat.Named (id, _, access, _), _), _ -> 
+            | SynPat.Named (SynIdent(id,_), _, access, _), _ | SynPat.As(_, SynPat.Named (SynIdent(id,_), _, access, _), _), _ -> 
                 let glyph = if isMember then FSharpGlyph.Method else FSharpGlyph.Field
                 [ createMember(id, NavigationItemKind.Field, glyph, unionRanges id.idRange m, enclosingEntityKind, isAbstract, access) ]
             | _ -> []
@@ -580,7 +580,7 @@ module NavigateTo =
             | SynPat.LongIdent(longDotId=LongIdentWithDots([id], _)) ->
                 // functions
                 addIdent kind id false container
-            | SynPat.Named (id, _, _, _) | SynPat.As(_, SynPat.Named (id, _, _, _), _) ->
+            | SynPat.Named (SynIdent(id,_), _, _, _) | SynPat.As(_, SynPat.Named (SynIdent(id,_), _, _, _), _) ->
                 // values
                 addIdent kind id false container
             | _ -> ()

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -243,7 +243,7 @@ module NavigationImpl =
                      | [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(longDotId=lid1; extraId=Some(info1))) as binding1)
                         SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(longDotId=lid2; extraId=Some(info2))) as binding2)] ->
                          // ensure same long id
-                         assert((lid1.Lid,lid2.Lid) ||> List.forall2 (fun x y -> x.idText = y.idText))
+                         assert((lid1.LongIdent,lid2.LongIdent) ||> List.forall2 (fun x y -> x.idText = y.idText))
                          // ensure one is getter, other is setter
                          assert((info1.idText = "set" && info2.idText = "get") ||
                                 (info2.idText = "set" && info1.idText = "get"))

--- a/src/fsharp/service/ServiceNavigation.fs
+++ b/src/fsharp/service/ServiceNavigation.fs
@@ -166,7 +166,7 @@ module NavigationImpl =
             | _ -> []
         
         // Process a class declaration or F# type declaration
-        let rec processExnDefnRepr baseName nested (SynExceptionDefnRepr(_, SynUnionCase(ident=id; caseType=fldspec), _, _, access, m)) =
+        let rec processExnDefnRepr baseName nested (SynExceptionDefnRepr(_, SynUnionCase(ident=(id,_); caseType=fldspec), _, _, access, m)) =
             // Exception declaration
             [ createDecl(baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, fldspecRange fldspec, nested, NavigationEntityKind.Exception, false, access) ] 
 
@@ -189,13 +189,13 @@ module NavigationImpl =
                 match simple with
                 | SynTypeDefnSimpleRepr.Union(_, cases, mb) ->
                     let cases = 
-                        [ for SynUnionCase(ident=id; caseType=fldspec) in cases -> 
+                        [ for SynUnionCase(ident=(id,_); caseType=fldspec) in cases -> 
                             createMember(id, NavigationItemKind.Other, FSharpGlyph.Struct, unionRanges (fldspecRange fldspec) id.idRange, NavigationEntityKind.Union, false, access) ]
                     let nested = cases@topMembers              
                     [ createDeclLid(baseName, lid, NavigationItemKind.Type, FSharpGlyph.Union, m, bodyRange mb nested, nested, NavigationEntityKind.Union, false, access) ]
                 | SynTypeDefnSimpleRepr.Enum(cases, mb) -> 
                     let cases = 
-                        [ for SynEnumCase(ident=id; range=m) in cases ->
+                        [ for SynEnumCase(ident=(id,_); range=m) in cases ->
                             createMember(id, NavigationItemKind.Field, FSharpGlyph.EnumMember, m, NavigationEntityKind.Enum, false, access) ]
                     let nested = cases@topMembers
                     [ createDeclLid(baseName, lid, NavigationItemKind.Type, FSharpGlyph.Enum, m, bodyRange mb nested, nested, NavigationEntityKind.Enum, false, access) ]
@@ -233,7 +233,7 @@ module NavigationImpl =
                              [ createMember(rcid, NavigationItemKind.Field, FSharpGlyph.Field, range, enclosingEntityKind, false, access) ]
                          | SynMemberDefn.AutoProperty(ident=id; accessibility=access) -> 
                              [ createMember(id, NavigationItemKind.Field, FSharpGlyph.Field, id.idRange, enclosingEntityKind, false, access) ]
-                         | SynMemberDefn.AbstractSlot(SynValSig(ident=id; synType=ty; accessibility=access), _, _) ->
+                         | SynMemberDefn.AbstractSlot(SynValSig(ident=(id,_); synType=ty; accessibility=access), _, _) ->
                              [ createMember(id, NavigationItemKind.Method, FSharpGlyph.OverridenMethod, ty.Range, enclosingEntityKind, true, access) ]
                          | SynMemberDefn.NestedType _ -> failwith "tycon as member????" //processTycon tycon                
                          | SynMemberDefn.Interface(members=Some(membs)) ->
@@ -339,7 +339,7 @@ module NavigationImpl =
         let createMember(id:Ident, kind, baseGlyph, m, enclosingEntityKind, isAbstract, access) =
             NavigationItem.Create(id.idText, kind, baseGlyph, m, m, false, enclosingEntityKind, isAbstract, access), (addItemName(id.idText))
 
-        let rec processExnRepr baseName nested (SynExceptionDefnRepr(_, SynUnionCase(ident=id; caseType=fldspec), _, _, access, m)) =
+        let rec processExnRepr baseName nested (SynExceptionDefnRepr(_, SynUnionCase(ident=(id,_); caseType=fldspec), _, _, access, m)) =
             // Exception declaration
             [ createDecl(baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, fldspecRange fldspec, nested, NavigationEntityKind.Exception, false, access) ] 
         
@@ -361,13 +361,13 @@ module NavigationImpl =
                 match simple with
                 | SynTypeDefnSimpleRepr.Union(_, cases, mb) ->
                     let cases = 
-                        [ for SynUnionCase(ident=id; caseType=fldspec) in cases -> 
+                        [ for SynUnionCase(ident=(id,_); caseType=fldspec) in cases -> 
                             createMember(id, NavigationItemKind.Other, FSharpGlyph.Struct, unionRanges (fldspecRange fldspec) id.idRange, NavigationEntityKind.Union, false, access) ]
                     let nested = cases@topMembers              
                     [ createDeclLid(baseName, lid, NavigationItemKind.Type, FSharpGlyph.Union, m, bodyRange mb nested, nested, NavigationEntityKind.Union, false, access) ]
                 | SynTypeDefnSimpleRepr.Enum(cases, mb) -> 
                     let cases = 
-                        [ for SynEnumCase(ident = id; range = m) in cases ->
+                        [ for SynEnumCase(ident = (id,_); range = m) in cases ->
                             createMember(id, NavigationItemKind.Field, FSharpGlyph.EnumMember, m, NavigationEntityKind.Enum, false, access) ]
                     let nested = cases@topMembers
                     [ createDeclLid(baseName, lid, NavigationItemKind.Type, FSharpGlyph.Enum, m, bodyRange mb nested, nested, NavigationEntityKind.Enum, false, access) ]
@@ -392,7 +392,7 @@ module NavigationImpl =
         and processSigMembers (members: SynMemberSig list): list<NavigationItem * int> = 
             [ for memb in members do
                  match memb with
-                 | SynMemberSig.Member(SynValSig.SynValSig(ident=id; accessibility=access; range=m), _, _) ->
+                 | SynMemberSig.Member(SynValSig.SynValSig(ident=(id,_); accessibility=access; range=m), _, _) ->
                      yield createMember(id, NavigationItemKind.Method, FSharpGlyph.Method, m, NavigationEntityKind.Class, false, access)
                  | SynMemberSig.ValField(SynField(_, _, Some(rcid), ty, _, _, access, _), _) ->
                      yield createMember(rcid, NavigationItemKind.Field, FSharpGlyph.Field, ty.Range, NavigationEntityKind.Class, false, access)
@@ -400,7 +400,7 @@ module NavigationImpl =
 
         // Process declarations in a module that belong to the right drop-down (let bindings)
         let processNestedSigDeclarations decls = decls |> List.collect (function
-            | SynModuleSigDecl.Val(SynValSig.SynValSig(ident=id; accessibility=access; range=m), _) ->
+            | SynModuleSigDecl.Val(SynValSig.SynValSig(ident=(id,_); accessibility=access; range=m), _) ->
                 [ createMember(id, NavigationItemKind.Method, FSharpGlyph.Method, m, NavigationEntityKind.Module, false, access) ]
             | _ -> [] )        
 
@@ -530,7 +530,7 @@ module NavigateTo =
         let addModuleAbbreviation (id: Ident) isSig container =
             addIdent NavigableItemKind.ModuleAbbreviation id isSig container
         
-        let addExceptionRepr (SynExceptionDefnRepr(_, SynUnionCase(ident=id), _, _, _, _)) isSig container = 
+        let addExceptionRepr (SynExceptionDefnRepr(_, SynUnionCase(ident=(id,_)), _, _, _, _)) isSig container = 
             addIdent NavigableItemKind.Exception id isSig container
             { Type = NavigableContainerType.Exception; Name = id.idText }
     
@@ -540,7 +540,7 @@ module NavigateTo =
             | _ -> ()
             { Type = containerType; Name = formatLongIdent lid }
     
-        let addValSig kind (SynValSig(ident=id)) isSig container = 
+        let addValSig kind (SynValSig(ident=(id,_))) isSig container = 
             addIdent kind id isSig container
         
         let addField(SynField(_, _, id, _, _, _, _, _)) isSig container = 
@@ -548,10 +548,10 @@ module NavigateTo =
             | Some id -> addIdent NavigableItemKind.Field id isSig container
             | _ -> ()
         
-        let addEnumCase(SynEnumCase(ident=id)) isSig = 
+        let addEnumCase(SynEnumCase(ident=(id,_))) isSig = 
             addIdent NavigableItemKind.EnumCase id isSig
         
-        let addUnionCase(SynUnionCase(ident=id)) isSig container = 
+        let addUnionCase(SynUnionCase(ident=(id,_))) isSig container = 
             addIdent NavigableItemKind.UnionCase id isSig container
     
         let mapMemberKind mk = 

--- a/src/fsharp/service/ServiceParamInfoLocations.fs
+++ b/src/fsharp/service/ServiceParamInfoLocations.fs
@@ -58,7 +58,7 @@ module internal ParameterLocationsImpl =
     let rec digOutIdentFromFuncExpr synExpr =
         // we found it, dig out ident
         match synExpr with
-        | SynExpr.Ident (id,_) -> Some ([id.idText], id.idRange)
+        | SynExpr.Ident id -> Some ([id.idText], id.idRange)
         | SynExpr.LongIdent (_, LongIdentWithDots(lid, _), _, lidRange) 
         | SynExpr.DotGet (_, _, LongIdentWithDots(lid, _), lidRange) -> Some (pathOfLid lid, lidRange)
         | SynExpr.TypeApp (synExpr, _, _synTypeList, _commas, _, _, _range) -> digOutIdentFromFuncExpr synExpr 
@@ -79,15 +79,15 @@ module internal ParameterLocationsImpl =
         match e with
         // f(x=4)
         | SynExpr.App (ExprAtomicFlag.NonAtomic, _, 
-                        SynExpr.App (ExprAtomicFlag.NonAtomic, true, 
-                                    SynExpr.Ident (op,_), 
-                                    SynExpr.Ident (n,_), 
-                                    _range), 
+                        SynExpr.App (ExprAtomicFlag.NonAtomic, true,
+                                     SynExpr.LongIdent(longDotId = SynLongIdent(id = [op])),
+                                     SynExpr.Ident n, 
+                                     _range), 
                         _, _) when op.idText="op_Equality" -> Some n.idText
         // f(?x=4)
         | SynExpr.App (ExprAtomicFlag.NonAtomic, _, 
                         SynExpr.App (ExprAtomicFlag.NonAtomic, true, 
-                                    SynExpr.Ident (op,_), 
+                                    SynExpr.LongIdent(longDotId = SynLongIdent(id = [op])),
                                     SynExpr.LongIdent (true(*isOptional*), LongIdentWithDots([n], _), _ref, _lidrange), _range), 
                         _, _) when op.idText="op_Equality" -> Some n.idText
         | _ -> None
@@ -201,7 +201,7 @@ module internal ParameterLocationsImpl =
                     | _ -> traverseSynExpr synExpr
 
             // EXPR<  = error recovery of a form of half-written TypeApp
-            | SynExpr.App (_, _, SynExpr.App (_, true, SynExpr.Ident (op,_), synExpr, openm), SynExpr.ArbitraryAfterError _, wholem) when op.idText = "op_LessThan" ->
+            | SynExpr.App (_, _, SynExpr.App (_, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [op])), synExpr, openm), SynExpr.ArbitraryAfterError _, wholem) when op.idText = "op_LessThan" ->
                 // Look in the function expression
                 let fResult = traverseSynExpr synExpr
                 match fResult with

--- a/src/fsharp/service/ServiceParamInfoLocations.fs
+++ b/src/fsharp/service/ServiceParamInfoLocations.fs
@@ -6,6 +6,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.SyntaxTreeOps
 
 type TupledArgumentLocation = { IsNamedArgument: bool; ArgumentRange: range }
@@ -59,6 +60,7 @@ module internal ParameterLocationsImpl =
         // we found it, dig out ident
         match synExpr with
         | SynExpr.Ident id -> Some ([id.idText], id.idRange)
+        | SynExpr.LongIdent(_, SynLongIdent([id], [], [ Some _ ]), _, _) -> Some ([id.idText], id.idRange)
         | SynExpr.LongIdent (_, LongIdentWithDots(lid, _), _, lidRange) 
         | SynExpr.DotGet (_, _, LongIdentWithDots(lid, _), lidRange) -> Some (pathOfLid lid, lidRange)
         | SynExpr.TypeApp (synExpr, _, _synTypeList, _commas, _, _, _range) -> digOutIdentFromFuncExpr synExpr 

--- a/src/fsharp/service/ServiceParamInfoLocations.fs
+++ b/src/fsharp/service/ServiceParamInfoLocations.fs
@@ -58,7 +58,7 @@ module internal ParameterLocationsImpl =
     let rec digOutIdentFromFuncExpr synExpr =
         // we found it, dig out ident
         match synExpr with
-        | SynExpr.Ident id -> Some ([id.idText], id.idRange)
+        | SynExpr.Ident (id,_) -> Some ([id.idText], id.idRange)
         | SynExpr.LongIdent (_, LongIdentWithDots(lid, _), _, lidRange) 
         | SynExpr.DotGet (_, _, LongIdentWithDots(lid, _), lidRange) -> Some (pathOfLid lid, lidRange)
         | SynExpr.TypeApp (synExpr, _, _synTypeList, _commas, _, _, _range) -> digOutIdentFromFuncExpr synExpr 
@@ -80,14 +80,14 @@ module internal ParameterLocationsImpl =
         // f(x=4)
         | SynExpr.App (ExprAtomicFlag.NonAtomic, _, 
                         SynExpr.App (ExprAtomicFlag.NonAtomic, true, 
-                                    SynExpr.Ident op, 
-                                    SynExpr.Ident n, 
+                                    SynExpr.Ident (op,_), 
+                                    SynExpr.Ident (n,_), 
                                     _range), 
                         _, _) when op.idText="op_Equality" -> Some n.idText
         // f(?x=4)
         | SynExpr.App (ExprAtomicFlag.NonAtomic, _, 
                         SynExpr.App (ExprAtomicFlag.NonAtomic, true, 
-                                    SynExpr.Ident op, 
+                                    SynExpr.Ident (op,_), 
                                     SynExpr.LongIdent (true(*isOptional*), LongIdentWithDots([n], _), _ref, _lidrange), _range), 
                         _, _) when op.idText="op_Equality" -> Some n.idText
         | _ -> None
@@ -201,7 +201,7 @@ module internal ParameterLocationsImpl =
                     | _ -> traverseSynExpr synExpr
 
             // EXPR<  = error recovery of a form of half-written TypeApp
-            | SynExpr.App (_, _, SynExpr.App (_, true, SynExpr.Ident op, synExpr, openm), SynExpr.ArbitraryAfterError _, wholem) when op.idText = "op_LessThan" ->
+            | SynExpr.App (_, _, SynExpr.App (_, true, SynExpr.Ident (op,_), synExpr, openm), SynExpr.ArbitraryAfterError _, wholem) when op.idText = "op_LessThan" ->
                 // Look in the function expression
                 let fResult = traverseSynExpr synExpr
                 match fResult with

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -439,7 +439,7 @@ module SyntaxTraversal =
                         | _ -> false
                     let ok = 
                         match isPartOfArrayOrList, synExpr with
-                        | false, SynExpr.Ident ident -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [])))
+                        | false, SynExpr.Ident (ident,_) -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [])))
                         | false, SynExpr.LongIdent (false, lidwd, _, _) -> visitor.VisitRecordField(path, None, Some lidwd)
                         | _ -> None
                     if ok.IsSome then ok

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -96,7 +96,7 @@ type SyntaxVisitorBase<'T>() =
         None
 
     /// VisitRecordField allows overriding behavior when visiting l.h.s. of constructed record instances
-    abstract VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithDots option -> 'T option
+    abstract VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithTrivia option -> 'T option
     default _.VisitRecordField (path, copyOpt, recordField) =
         ignore (path, copyOpt, recordField)
         None
@@ -686,7 +686,7 @@ module SyntaxTraversal =
                         |  [SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(longDotId=lid1; extraId=Some(info1)))) as mem1
                             SynMemberDefn.Member(memberDefn=SynBinding(headPat=SynPat.LongIdent(longDotId=lid2; extraId=Some(info2)))) as mem2] -> // can happen if one is a getter and one is a setter
                             // ensure same long id
-                            assert( (lid1.Lid,lid2.Lid) ||> List.forall2 (fun x y -> x.idText = y.idText) )
+                            assert( (lid1.LongIdent,lid2.LongIdent) ||> List.forall2 (fun x y -> x.idText = y.idText) )
                             // ensure one is getter, other is setter
                             assert( (info1.idText="set" && info2.idText="get") ||
                                     (info2.idText="set" && info1.idText="get") )

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -439,7 +439,7 @@ module SyntaxTraversal =
                         | _ -> false
                     let ok = 
                         match isPartOfArrayOrList, synExpr with
-                        | false, SynExpr.Ident ident -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [])))
+                        | false, SynExpr.Ident ident -> visitor.VisitRecordField(path, None, Some (SynLongIdent([ident], [], [None])))
                         | false, SynExpr.LongIdent (false, lidwd, _, _) -> visitor.VisitRecordField(path, None, Some lidwd)
                         | _ -> None
                     if ok.IsSome then ok

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -96,7 +96,7 @@ type SyntaxVisitorBase<'T>() =
         None
 
     /// VisitRecordField allows overriding behavior when visiting l.h.s. of constructed record instances
-    abstract VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithTrivia option -> 'T option
+    abstract VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: SynLongIdent option -> 'T option
     default _.VisitRecordField (path, copyOpt, recordField) =
         ignore (path, copyOpt, recordField)
         None
@@ -439,7 +439,7 @@ module SyntaxTraversal =
                         | _ -> false
                     let ok = 
                         match isPartOfArrayOrList, synExpr with
-                        | false, SynExpr.Ident (ident,_) -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [])))
+                        | false, SynExpr.Ident ident -> visitor.VisitRecordField(path, None, Some (LongIdentWithDots([ident], [])))
                         | false, SynExpr.LongIdent (false, lidwd, _, _) -> visitor.VisitRecordField(path, None, Some lidwd)
                         | _ -> None
                     if ok.IsSome then ok

--- a/src/fsharp/service/ServiceParseTreeWalk.fsi
+++ b/src/fsharp/service/ServiceParseTreeWalk.fsi
@@ -74,8 +74,8 @@ type SyntaxVisitorBase<'T> =
       abstract VisitPat: path: SyntaxVisitorPath * defaultTraverse: (SynPat -> 'T option) * synPat: SynPat -> 'T option
       default VisitPat: path: SyntaxVisitorPath * defaultTraverse: (SynPat -> 'T option) * synPat: SynPat -> 'T option
 
-      abstract VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithDots option -> 'T option
-      default VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithDots option -> 'T option
+      abstract VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithTrivia option -> 'T option
+      default VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithTrivia option -> 'T option
 
       abstract VisitSimplePats: path: SyntaxVisitorPath * synPats: SynSimplePat list -> 'T option
       default VisitSimplePats: path: SyntaxVisitorPath * synPats: SynSimplePat list -> 'T option

--- a/src/fsharp/service/ServiceParseTreeWalk.fsi
+++ b/src/fsharp/service/ServiceParseTreeWalk.fsi
@@ -74,8 +74,8 @@ type SyntaxVisitorBase<'T> =
       abstract VisitPat: path: SyntaxVisitorPath * defaultTraverse: (SynPat -> 'T option) * synPat: SynPat -> 'T option
       default VisitPat: path: SyntaxVisitorPath * defaultTraverse: (SynPat -> 'T option) * synPat: SynPat -> 'T option
 
-      abstract VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithTrivia option -> 'T option
-      default VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: LongIdentWithTrivia option -> 'T option
+      abstract VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: SynLongIdent option -> 'T option
+      default VisitRecordField: path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: SynLongIdent option -> 'T option
 
       abstract VisitSimplePats: path: SyntaxVisitorPath * synPats: SynSimplePat list -> 'T option
       default VisitSimplePats: path: SyntaxVisitorPath * synPats: SynSimplePat list -> 'T option

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -852,11 +852,11 @@ module ParsedInput =
                 setters
             | _ -> emptyStringSet
 
-        let endOfLastIdent (lid: LongIdentWithDots) = 
-            let last = List.last lid.Lid
+        let endOfLastIdent (lid: LongIdentWithTrivia) = 
+            let last = List.last lid.LongIdent
             last.idRange.End
 
-        let endOfClosingTokenOrLastIdent (mClosing: range option) (lid : LongIdentWithDots) =
+        let endOfClosingTokenOrLastIdent (mClosing: range option) (lid : LongIdentWithTrivia) =
             match mClosing with
             | Some m -> m.End
             | None -> endOfLastIdent lid

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -280,7 +280,7 @@ module ParsedInput =
                     traverseSynExpr synExpr
                 else
                     Some range 
-            | SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.Ident ident, rhs, _) 
+            | SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.Ident (ident, _), rhs, _) 
                 when ident.idText = "op_ArrayLookup" 
                      && not(SyntaxTraversal.rangeContainsPosLeftEdgeInclusive rhs.Range pos) ->
                 match defaultTraverse expr with
@@ -429,7 +429,7 @@ module ParsedInput =
                                     // the cursor is left of the dot
                                     None
                             | r -> r
-                        | SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.Ident ident, lhs, _m) 
+                        | SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.Ident (ident, _), lhs, _m) 
                             when ident.idText = "op_ArrayLookup" 
                                  && not(SyntaxTraversal.rangeContainsPosLeftEdgeInclusive lhs.Range pos) ->
                             match defaultTraverse expr with
@@ -594,7 +594,7 @@ module ParsedInput =
             | Sequentials es -> List.tryPick (walkExprWithKind parentKind) es
             | SynExpr.IfThenElse (ifExpr=e1; thenExpr=e2; elseExpr=e3) -> 
                 List.tryPick (walkExprWithKind parentKind) [e1; e2] |> Option.orElseWith (fun () -> match e3 with None -> None | Some e -> walkExprWithKind parentKind e)
-            | SynExpr.Ident ident -> ifPosInRange ident.idRange (fun _ -> Some (EntityKind.FunctionOrValue false))
+            | SynExpr.Ident (ident,_) -> ifPosInRange ident.idRange (fun _ -> Some (EntityKind.FunctionOrValue false))
             | SynExpr.LongIdentSet (_, e, _) -> walkExprWithKind parentKind e
             | SynExpr.DotGet (e, _, _, _) -> walkExprWithKind parentKind e
             | SynExpr.DotSet (e, _, _, _) -> walkExprWithKind parentKind e
@@ -826,7 +826,7 @@ module ParsedInput =
 
         let (|Operator|_|) name e = 
             match e with
-            | SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.Ident ident, lhs, _), rhs, _) 
+            | SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.Ident (ident, _), lhs, _), rhs, _) 
                 when ident.idText = name -> Some (lhs, rhs)
             | _ -> None
 
@@ -838,7 +838,7 @@ module ParsedInput =
 
         let (|Setter|_|) e =
             match e with
-            | Operator "op_Equality" (SynExpr.Ident id, _) -> Some id
+            | Operator "op_Equality" (SynExpr.Ident (id,_) , _) -> Some id
             | _ -> None
 
         let findSetters argList =
@@ -874,10 +874,10 @@ module ParsedInput =
             | SynExpr.New (_, SynType.App(StripParenTypes (SynType.LongIdent typeName), _, _, _, mGreaterThan, _, _), arg, _) -> 
                 // new A<_>()
                 Some (endOfClosingTokenOrLastIdent mGreaterThan typeName, findSetters arg)
-            | SynExpr.App (_, false, SynExpr.Ident id, arg, _) -> 
+            | SynExpr.App (_, false, SynExpr.Ident (id, _), arg, _) -> 
                 // A()
                 Some (id.idRange.End, findSetters arg)
-            | SynExpr.App (_, false, SynExpr.TypeApp (SynExpr.Ident id, _, _, _, mGreaterThan, _, _), arg, _) -> 
+            | SynExpr.App (_, false, SynExpr.TypeApp (SynExpr.Ident (id, _), _, _, _, mGreaterThan, _, _), arg, _) -> 
                 // A<_>()
                 Some (endOfClosingTokenOrIdent mGreaterThan id, findSetters arg)
             | SynExpr.App (_, false, SynExpr.LongIdent (_, lid, _, _), arg, _) -> 
@@ -941,7 +941,7 @@ module ParsedInput =
                                 | _ -> 
                                     defaultTraverse expr
                             // new (... A$)
-                            | SynExpr.Ident id when id.idRange.End = pos ->
+                            | SynExpr.Ident (id,_) when id.idRange.End = pos ->
                                 match path with
                                 | PartOfParameterList None args -> 
                                     Some (CompletionContext.ParameterList args)
@@ -1110,7 +1110,7 @@ module ParsedInput =
                             | _ -> None)
 
                     member _.VisitUnionDefn(_path, cases, _range) =
-                        cases |> List.tryPick (fun (SynUnionCase (ident = id; caseType = caseType)) ->
+                        cases |> List.tryPick (fun (SynUnionCase (ident = (id,_); caseType = caseType)) ->
                             if rangeContainsPos id.idRange pos then
                                 // No completions in a union case identifier
                                 Some CompletionContext.Invalid
@@ -1344,7 +1344,7 @@ module ParsedInput =
                 fields |> List.iter (fun (SynExprRecordField(fieldName=(ident, _); expr=e)) ->
                             addLongIdentWithDots ident
                             e |> Option.iter walkExpr)
-            | SynExpr.Ident ident -> addIdent ident
+            | SynExpr.Ident (ident,_) -> addIdent ident
             | SynExpr.ObjExpr (objType=ty; argOptions=argOpt; bindings=bindings; members=ms; extraImpls=ifaces) ->
                 let bindings = unionBindingAndMembers bindings ms
                 argOpt |> Option.iter (fun (e, ident) ->

--- a/src/fsharp/service/ServiceParsedInputOps.fs
+++ b/src/fsharp/service/ServiceParsedInputOps.fs
@@ -1262,7 +1262,7 @@ module ParsedInput =
             | SynPat.Tuple (_,pats, _)
             | SynPat.ArrayOrList (_, pats, _)
             | SynPat.Ands (pats, _) -> List.iter walkPat pats
-            | SynPat.Named (ident, _, _, _) -> addIdent ident
+            | SynPat.Named (SynIdent(ident,_), _, _, _) -> addIdent ident
             | SynPat.Typed (pat, t, _) ->
                 walkPat pat
                 walkType t

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -829,7 +829,7 @@ module Structure =
 
         let rec parseModuleSigDeclaration (decl: SynModuleSigDecl) =
             match decl with
-            | SynModuleSigDecl.Val (SynValSig(attributes=attrs; ident=ident; range=valrange), r) ->
+            | SynModuleSigDecl.Val (SynValSig(attributes=attrs; ident=(ident,_); range=valrange), r) ->
                 let collapse = Range.endToEnd ident.idRange valrange
                 rcheck Scope.Val Collapse.Below r collapse
                 parseAttributes attrs

--- a/src/fsharp/service/ServiceStructure.fs
+++ b/src/fsharp/service/ServiceStructure.fs
@@ -829,7 +829,7 @@ module Structure =
 
         let rec parseModuleSigDeclaration (decl: SynModuleSigDecl) =
             match decl with
-            | SynModuleSigDecl.Val (SynValSig(attributes=attrs; ident=(ident,_); range=valrange), r) ->
+            | SynModuleSigDecl.Val (SynValSig(attributes=attrs; ident=SynIdent(ident,_); range=valrange), r) ->
                 let collapse = Range.endToEnd ident.idRange valrange
                 rcheck Scope.Val Collapse.Below r collapse
                 parseAttributes attrs

--- a/src/fsharp/service/ServiceUntypedParse.fs
+++ b/src/fsharp/service/ServiceUntypedParse.fs
@@ -600,7 +600,7 @@ module UntypedParseImpl =
                     traverseSynExpr synExpr
                 else
                     Some range 
-            | SynExpr.App (ExprAtomicFlag.NonAtomic, true, (SynExpr.Ident ident), rhs, _) 
+            | SynExpr.App (ExprAtomicFlag.NonAtomic, true, (SynExpr.LongIdent(longDotId = SynLongIdent([ident], _, _))), rhs, _) 
                 when ident.idText = "op_ArrayLookup" 
                      && not(AstTraversal.rangeContainsPosLeftEdgeInclusive rhs.Range pos) ->
                 match defaultTraverse expr with
@@ -755,7 +755,7 @@ module UntypedParseImpl =
                                     // the cursor is left of the dot
                                     None
                             | r -> r
-                        | SynExpr.App (ExprAtomicFlag.NonAtomic, true, (SynExpr.Ident ident), lhs, _m) 
+                        | SynExpr.App (ExprAtomicFlag.NonAtomic, true, (SynExpr.LongIdent(longDotId = SynLongIdent([ident], _, _))), lhs, _m) 
                             when ident.idText = "op_ArrayLookup" 
                                  && not(AstTraversal.rangeContainsPosLeftEdgeInclusive lhs.Range pos) ->
                             match defaultTraverse expr with

--- a/src/fsharp/service/ServiceXmlDocParser.fs
+++ b/src/fsharp/service/ServiceXmlDocParser.fs
@@ -20,8 +20,8 @@ module XmlDocParsing =
 
     let rec digNamesFrom pat =
         match pat with
-        | SynPat.As (_, SynPat.Named(id,_isTheThisVar,_access,_range), _)
-        | SynPat.Named (id,_isTheThisVar,_access,_range) -> [id.idText]
+        | SynPat.As (_, SynPat.Named(SynIdent(id,_),_isTheThisVar,_access,_range), _)
+        | SynPat.Named (SynIdent(id,_),_isTheThisVar,_access,_range) -> [id.idText]
         | SynPat.Typed(pat,_type,_range) -> digNamesFrom pat
         | SynPat.Attrib(pat,_attrs,_range) -> digNamesFrom pat
         | SynPat.LongIdent(argPats=ConstructorPats pats) -> 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -1455,12 +1455,12 @@ FSharp.Compiler.AbstractIL.IL+ILType: System.String get_BasicQualifiedName()
 FSharp.Compiler.AbstractIL.IL+ILType: System.String get_QualifiedName()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean HasSecurity
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsAbstract
-FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsKnownToBeAttribute
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsClass
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsComInterop
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsDelegate
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsEnum
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsInterface
+FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsKnownToBeAttribute
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsSealed
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsSerializable
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsSpecialName
@@ -1468,12 +1468,12 @@ FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsStruct
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean IsStructOrEnum
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_HasSecurity()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsAbstract()
-FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsKnownToBeAttribute()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsClass()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsComInterop()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsDelegate()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsEnum()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsInterface()
+FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsKnownToBeAttribute()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsSealed()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsSerializable()
 FSharp.Compiler.AbstractIL.IL+ILTypeDef: Boolean get_IsSpecialName()
@@ -5416,23 +5416,30 @@ FSharp.Compiler.Syntax.Ident: System.String ToString()
 FSharp.Compiler.Syntax.Ident: System.String get_idText()
 FSharp.Compiler.Syntax.Ident: System.String idText
 FSharp.Compiler.Syntax.Ident: Void .ctor(System.String, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.LongIdentWithDots
-FSharp.Compiler.Syntax.LongIdentWithDots: Boolean ThereIsAnExtraDotAtTheEnd
-FSharp.Compiler.Syntax.LongIdentWithDots: Boolean get_ThereIsAnExtraDotAtTheEnd()
-FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Syntax.LongIdentWithDots NewLongIdentWithDots(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
-FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range Range
-FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range RangeWithoutAnyExtraDot
-FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range get_Range()
-FSharp.Compiler.Syntax.LongIdentWithDots: FSharp.Compiler.Text.Range get_RangeWithoutAnyExtraDot()
-FSharp.Compiler.Syntax.LongIdentWithDots: Int32 Tag
-FSharp.Compiler.Syntax.LongIdentWithDots: Int32 get_Tag()
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] Lid
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_Lid()
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_id()
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] id
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] dotRanges
-FSharp.Compiler.Syntax.LongIdentWithDots: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_dotRanges()
-FSharp.Compiler.Syntax.LongIdentWithDots: System.String ToString()
+FSharp.Compiler.Syntax.LongIdentWithTrivia
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Boolean ThereIsAnExtraDotAtTheEnd
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Boolean get_ThereIsAnExtraDotAtTheEnd()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Syntax.LongIdentWithTrivia NewLongIdentWithTrivia(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]])
+FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Text.Range RangeWithoutAnyExtraDot
+FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Text.Range get_RangeWithoutAnyExtraDot()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Int32 Tag
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Int32 get_Tag()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] LongIdent
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_LongIdent()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_id()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] id
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] dotRanges
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_dotRanges()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_trivia()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] trivia
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]]] IdentsWithTrivia
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]]] get_IdentsWithTrivia()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: System.String ToString()
+FSharp.Compiler.Syntax.LongIdentWithTriviaHelpers
+FSharp.Compiler.Syntax.LongIdentWithTriviaHelpers: FSharp.Compiler.Syntax.LongIdentWithTrivia LongIdentWithDots(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.Syntax.LongIdentWithTriviaHelpers: System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident],Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range]] |LongIdentWithDots|(FSharp.Compiler.Syntax.LongIdentWithTrivia)
 FSharp.Compiler.Syntax.ParsedHashDirective
 FSharp.Compiler.Syntax.ParsedHashDirective: FSharp.Compiler.Syntax.ParsedHashDirective NewParsedHashDirective(System.String, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.ParsedHashDirectiveArgument], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedHashDirective: FSharp.Compiler.Text.Range get_range()
@@ -5831,8 +5838,8 @@ FSharp.Compiler.Syntax.SynArgPats: System.String ToString()
 FSharp.Compiler.Syntax.SynAttribute
 FSharp.Compiler.Syntax.SynAttribute: Boolean AppliesToGetterAndSetter
 FSharp.Compiler.Syntax.SynAttribute: Boolean get_AppliesToGetterAndSetter()
-FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.LongIdentWithDots TypeName
-FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.LongIdentWithDots get_TypeName()
+FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.LongIdentWithTrivia TypeName
+FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.LongIdentWithTrivia get_TypeName()
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.SynExpr ArgExpr
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.SynExpr get_ArgExpr()
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Text.Range Range
@@ -5840,7 +5847,7 @@ FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynAttribute: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] Target
 FSharp.Compiler.Syntax.SynAttribute: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_Target()
 FSharp.Compiler.Syntax.SynAttribute: System.String ToString()
-FSharp.Compiler.Syntax.SynAttribute: Void .ctor(FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynAttribute: Void .ctor(FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynAttributeList
 FSharp.Compiler.Syntax.SynAttributeList: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynAttributeList: FSharp.Compiler.Text.Range get_Range()
@@ -6289,8 +6296,8 @@ FSharp.Compiler.Syntax.SynExpr+DoBang: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+DoBang: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+DoBang: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+DoBang: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Text.Range get_range()
@@ -6317,8 +6324,8 @@ FSharp.Compiler.Syntax.SynExpr+DotIndexedSet: FSharp.Compiler.Text.Range get_lef
 FSharp.Compiler.Syntax.SynExpr+DotIndexedSet: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+DotIndexedSet: FSharp.Compiler.Text.Range leftOfSetRange
 FSharp.Compiler.Syntax.SynExpr+DotIndexedSet: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr argExpr
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr get_argExpr()
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr get_rhsExpr()
@@ -6327,8 +6334,8 @@ FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Synta
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr targetExpr
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynExpr get_rhsExpr()
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynExpr get_targetExpr()
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynExpr rhsExpr
@@ -6525,14 +6532,14 @@ FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Microsoft.FSharp.Co
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Boolean get_isOptional()
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Boolean isOptional
-FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]] altNameRefCell
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]] get_altNameRefCell()
-FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Text.Range get_range()
@@ -6567,8 +6574,8 @@ FSharp.Compiler.Syntax.SynExpr+MatchLambda: FSharp.Compiler.Text.Range keywordRa
 FSharp.Compiler.Syntax.SynExpr+MatchLambda: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+MatchLambda: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause] get_matchClauses()
 FSharp.Compiler.Syntax.SynExpr+MatchLambda: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause] matchClauses
-FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr expr1
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr expr2
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr get_expr1()
@@ -6958,11 +6965,11 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDebugPoint(FSh
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDiscardAfterMissingQualificationAfterDot(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDo(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDoBang(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotGet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotGet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotIndexedGet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotIndexedSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotNamedIndexedPropertySet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotNamedIndexedPropertySet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDowncast(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFixed(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFor(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
@@ -6985,12 +6992,12 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyILA
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyStaticOptimization(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynStaticOptimizationConstraint], FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyUnionCaseFieldGet(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Int32, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyUnionCaseFieldSet(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Int32, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdent(Boolean, FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdentSet(FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdent(Boolean, FSharp.Compiler.Syntax.LongIdentWithTrivia, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdentSet(FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewMatch(FSharp.Compiler.Syntax.DebugPointAtBinding, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprMatchTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewMatchBang(FSharp.Compiler.Syntax.DebugPointAtBinding, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprMatchBangTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewMatchLambda(Boolean, FSharp.Compiler.Text.Range, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause], FSharp.Compiler.Syntax.DebugPointAtBinding, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNamedIndexedPropertySet(FSharp.Compiler.Syntax.LongIdentWithDots, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNamedIndexedPropertySet(FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNew(Boolean, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewObjExpr(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynInterfaceImpl], FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
@@ -7107,7 +7114,7 @@ FSharp.Compiler.Syntax.SynExprAndBang: Int32 Tag
 FSharp.Compiler.Syntax.SynExprAndBang: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynExprAndBang: System.String ToString()
 FSharp.Compiler.Syntax.SynExprRecordField
-FSharp.Compiler.Syntax.SynExprRecordField: FSharp.Compiler.Syntax.SynExprRecordField NewSynExprRecordField(System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithDots,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]])
+FSharp.Compiler.Syntax.SynExprRecordField: FSharp.Compiler.Syntax.SynExprRecordField NewSynExprRecordField(System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithTrivia,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]])
 FSharp.Compiler.Syntax.SynExprRecordField: Int32 Tag
 FSharp.Compiler.Syntax.SynExprRecordField: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr] expr
@@ -7117,8 +7124,8 @@ FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]] blockSeparator
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]] get_blockSeparator()
 FSharp.Compiler.Syntax.SynExprRecordField: System.String ToString()
-FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithDots,System.Boolean] fieldName
-FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithDots,System.Boolean] get_fieldName()
+FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithTrivia,System.Boolean] fieldName
+FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithTrivia,System.Boolean] get_fieldName()
 FSharp.Compiler.Syntax.SynField
 FSharp.Compiler.Syntax.SynField: Boolean get_isMutable()
 FSharp.Compiler.Syntax.SynField: Boolean get_isStatic()
@@ -7890,8 +7897,8 @@ FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType get_pat()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType pat
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynArgPats argPats
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynArgPats get_argPats()
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range get_range()
@@ -8021,7 +8028,7 @@ FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewDeprecatedCharRa
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewFromParseError(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewInstanceMember(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewIsInst(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithTrivia, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNamed(FSharp.Compiler.Syntax.Ident, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOptionalVal(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
@@ -8343,10 +8350,10 @@ FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType ge
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType innerType
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
-FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.LongIdentWithDots get_longDotId()
-FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.LongIdentWithDots longDotId
+FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
+FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
+FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.SynType get_typeName()
 FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.SynType typeName
 FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Text.Range get_range()
@@ -8462,8 +8469,8 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewApp(FSharp.Com
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewArray(Int32, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFun(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewHashConstraint(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithDots)
-FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdentApp(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.LongIdentWithDots, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithTrivia)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdentApp(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.LongIdentWithTrivia, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewMeasureDivide(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewMeasurePower(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynRationalConst, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewParen(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
@@ -9074,7 +9081,7 @@ FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOptio
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynModuleOrNamespace)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitPat(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynPat,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynPat)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordDefn(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.LongIdentWithDots])
+FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.LongIdentWithTrivia])
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitSimplePats(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynSimplePat])
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitType(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynType,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynType)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitTypeAbbrev(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
@@ -9150,6 +9157,38 @@ FSharp.Compiler.SyntaxTrivia.ConditionalDirectiveTrivia: FSharp.Compiler.SyntaxT
 FSharp.Compiler.SyntaxTrivia.ConditionalDirectiveTrivia: Int32 Tag
 FSharp.Compiler.SyntaxTrivia.ConditionalDirectiveTrivia: Int32 get_Tag()
 FSharp.Compiler.SyntaxTrivia.ConditionalDirectiveTrivia: System.String ToString()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range get_lpr()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range get_rpr()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range lpr
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotation: System.String get_text()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotation: System.String text
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range get_lpr()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range get_rpr()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range lpr
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: System.String get_text()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: System.String text
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+Tags: Int32 HasParenthesis
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+Tags: Int32 OriginalNotation
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+Tags: Int32 OriginalNotationWithParen
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: Boolean IsHasParenthesis
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: Boolean IsOriginalNotation
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: Boolean IsOriginalNotationWithParen
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: Boolean get_IsHasParenthesis()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: Boolean get_IsOriginalNotation()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: Boolean get_IsOriginalNotationWithParen()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: FSharp.Compiler.SyntaxTrivia.IdentTrivia NewHasParenthesis(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: FSharp.Compiler.SyntaxTrivia.IdentTrivia NewOriginalNotation(System.String)
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: FSharp.Compiler.SyntaxTrivia.IdentTrivia NewOriginalNotationWithParen(FSharp.Compiler.Text.Range, System.String, FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotation
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: FSharp.Compiler.SyntaxTrivia.IdentTrivia+Tags
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: Int32 Tag
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: Int32 get_Tag()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.IfDirectiveExpression
 FSharp.Compiler.SyntaxTrivia.IfDirectiveExpression+And: FSharp.Compiler.SyntaxTrivia.IfDirectiveExpression Item1
 FSharp.Compiler.SyntaxTrivia.IfDirectiveExpression+And: FSharp.Compiler.SyntaxTrivia.IfDirectiveExpression Item2

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -5416,34 +5416,6 @@ FSharp.Compiler.Syntax.Ident: System.String ToString()
 FSharp.Compiler.Syntax.Ident: System.String get_idText()
 FSharp.Compiler.Syntax.Ident: System.String idText
 FSharp.Compiler.Syntax.Ident: Void .ctor(System.String, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.LongIdentWithTrivia
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Boolean ThereIsAnExtraDotAtTheEnd
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Boolean get_ThereIsAnExtraDotAtTheEnd()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Syntax.LongIdentWithTrivia NewLongIdentWithTrivia(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]])
-FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Text.Range Range
-FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Text.Range RangeWithoutAnyExtraDot
-FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Text.Range get_Range()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: FSharp.Compiler.Text.Range get_RangeWithoutAnyExtraDot()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Int32 Tag
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Int32 get_Tag()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] LongIdent
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_LongIdent()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_id()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] id
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia] Trivia
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia] get_Trivia()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] Dots
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] dotRanges
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_Dots()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_dotRanges()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_trivia()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] trivia
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]]] IdentsWithTrivia
-FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]]] get_IdentsWithTrivia()
-FSharp.Compiler.Syntax.LongIdentWithTrivia: System.String ToString()
-FSharp.Compiler.Syntax.LongIdentWithTriviaHelpers
-FSharp.Compiler.Syntax.LongIdentWithTriviaHelpers: FSharp.Compiler.Syntax.LongIdentWithTrivia LongIdentWithDots(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
-FSharp.Compiler.Syntax.LongIdentWithTriviaHelpers: System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident],Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range]] |LongIdentWithDots|(FSharp.Compiler.Syntax.LongIdentWithTrivia)
 FSharp.Compiler.Syntax.ParsedHashDirective
 FSharp.Compiler.Syntax.ParsedHashDirective: FSharp.Compiler.Syntax.ParsedHashDirective NewParsedHashDirective(System.String, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.ParsedHashDirectiveArgument], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedHashDirective: FSharp.Compiler.Text.Range get_range()
@@ -5842,16 +5814,16 @@ FSharp.Compiler.Syntax.SynArgPats: System.String ToString()
 FSharp.Compiler.Syntax.SynAttribute
 FSharp.Compiler.Syntax.SynAttribute: Boolean AppliesToGetterAndSetter
 FSharp.Compiler.Syntax.SynAttribute: Boolean get_AppliesToGetterAndSetter()
-FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.LongIdentWithTrivia TypeName
-FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.LongIdentWithTrivia get_TypeName()
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.SynExpr ArgExpr
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.SynExpr get_ArgExpr()
+FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.SynLongIdent TypeName
+FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Syntax.SynLongIdent get_TypeName()
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynAttribute: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynAttribute: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] Target
 FSharp.Compiler.Syntax.SynAttribute: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] get_Target()
 FSharp.Compiler.Syntax.SynAttribute: System.String ToString()
-FSharp.Compiler.Syntax.SynAttribute: Void .ctor(FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynAttribute: Void .ctor(FSharp.Compiler.Syntax.SynLongIdent, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynAttributeList
 FSharp.Compiler.Syntax.SynAttributeList: FSharp.Compiler.Text.Range Range
 FSharp.Compiler.Syntax.SynAttributeList: FSharp.Compiler.Text.Range get_Range()
@@ -6160,7 +6132,9 @@ FSharp.Compiler.Syntax.SynConst: System.String ToString()
 FSharp.Compiler.Syntax.SynEnumCase
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynConst get_value()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynConst value
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynEnumCase NewSynEnumCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]], FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range, FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia)
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynEnumCase NewSynEnumCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynIdent, FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range, FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia)
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynIdent get_ident()
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynIdent ident
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia get_trivia()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia trivia
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range Range
@@ -6176,8 +6150,6 @@ FSharp.Compiler.Syntax.SynEnumCase: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynEnumCase: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynEnumCase: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
 FSharp.Compiler.Syntax.SynEnumCase: System.String ToString()
-FSharp.Compiler.Syntax.SynEnumCase: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_ident()
-FSharp.Compiler.Syntax.SynEnumCase: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] ident
 FSharp.Compiler.Syntax.SynExceptionDefn
 FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Syntax.SynExceptionDefn NewSynExceptionDefn(FSharp.Compiler.Syntax.SynExceptionDefnRepr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Syntax.SynExceptionDefnRepr exnRepr
@@ -6300,10 +6272,10 @@ FSharp.Compiler.Syntax.SynExpr+DoBang: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+DoBang: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+DoBang: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+DoBang: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.SynExpr get_expr()
+FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Text.Range get_rangeOfDot()
 FSharp.Compiler.Syntax.SynExpr+DotGet: FSharp.Compiler.Text.Range range
@@ -6328,22 +6300,22 @@ FSharp.Compiler.Syntax.SynExpr+DotIndexedSet: FSharp.Compiler.Text.Range get_lef
 FSharp.Compiler.Syntax.SynExpr+DotIndexedSet: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+DotIndexedSet: FSharp.Compiler.Text.Range leftOfSetRange
 FSharp.Compiler.Syntax.SynExpr+DotIndexedSet: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr argExpr
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr get_argExpr()
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr get_rhsExpr()
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr get_targetExpr()
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr rhsExpr
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr targetExpr
+FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynExpr get_rhsExpr()
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynExpr get_targetExpr()
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynExpr rhsExpr
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynExpr targetExpr
+FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+DotSet: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Syntax.SynExpr expr
@@ -6394,8 +6366,8 @@ FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Syntax.SynExpr ex
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+Ident: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_ident()
-FSharp.Compiler.Syntax.SynExpr+Ident: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] ident
+FSharp.Compiler.Syntax.SynExpr+Ident: FSharp.Compiler.Syntax.Ident get_ident()
+FSharp.Compiler.Syntax.SynExpr+Ident: FSharp.Compiler.Syntax.Ident ident
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean get_isFromErrorRecovery()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean isFromErrorRecovery
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.DebugPointAtBinding get_spIfToThen()
@@ -6536,16 +6508,16 @@ FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Microsoft.FSharp.Co
 FSharp.Compiler.Syntax.SynExpr+LibraryOnlyUnionCaseFieldSet: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] longId
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Boolean get_isOptional()
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Boolean isOptional
-FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
+FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+LongIdent: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]] altNameRefCell
 FSharp.Compiler.Syntax.SynExpr+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]] get_altNameRefCell()
-FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.SynExpr get_expr()
+FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+LongIdentSet: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+Match: FSharp.Compiler.Syntax.DebugPointAtBinding get_matchDebugPoint()
@@ -6578,12 +6550,12 @@ FSharp.Compiler.Syntax.SynExpr+MatchLambda: FSharp.Compiler.Text.Range keywordRa
 FSharp.Compiler.Syntax.SynExpr+MatchLambda: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+MatchLambda: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause] get_matchClauses()
 FSharp.Compiler.Syntax.SynExpr+MatchLambda: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause] matchClauses
-FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr expr1
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr expr2
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr get_expr1()
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynExpr get_expr2()
+FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+NamedIndexedPropertySet: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+New: Boolean get_isProtected()
@@ -6969,17 +6941,17 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDebugPoint(FSh
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDiscardAfterMissingQualificationAfterDot(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDo(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDoBang(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotGet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotGet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynLongIdent, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotIndexedGet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotIndexedSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotNamedIndexedPropertySet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotNamedIndexedPropertySet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynLongIdent, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynLongIdent, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDowncast(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFixed(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFor(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewForEach(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.SeqExprOnly, Boolean, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFromParseError(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIdent(System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]])
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIdent(FSharp.Compiler.Syntax.Ident)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIfThenElse(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Syntax.DebugPointAtBinding, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprIfThenElseTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewImplicitZero(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIndexFromEnd(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
@@ -6996,12 +6968,12 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyILA
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyStaticOptimization(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynStaticOptimizationConstraint], FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyUnionCaseFieldGet(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Int32, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLibraryOnlyUnionCaseFieldSet(FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Int32, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdent(Boolean, FSharp.Compiler.Syntax.LongIdentWithTrivia, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdentSet(FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdent(Boolean, FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpRef`1[FSharp.Compiler.Syntax.SynSimplePatAlternativeIdInfo]], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewLongIdentSet(FSharp.Compiler.Syntax.SynLongIdent, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewMatch(FSharp.Compiler.Syntax.DebugPointAtBinding, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprMatchTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewMatchBang(FSharp.Compiler.Syntax.DebugPointAtBinding, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprMatchBangTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewMatchLambda(Boolean, FSharp.Compiler.Text.Range, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMatchClause], FSharp.Compiler.Syntax.DebugPointAtBinding, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNamedIndexedPropertySet(FSharp.Compiler.Syntax.LongIdentWithTrivia, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNamedIndexedPropertySet(FSharp.Compiler.Syntax.SynLongIdent, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNew(Boolean, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewObjExpr(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynInterfaceImpl], FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
@@ -7118,7 +7090,7 @@ FSharp.Compiler.Syntax.SynExprAndBang: Int32 Tag
 FSharp.Compiler.Syntax.SynExprAndBang: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynExprAndBang: System.String ToString()
 FSharp.Compiler.Syntax.SynExprRecordField
-FSharp.Compiler.Syntax.SynExprRecordField: FSharp.Compiler.Syntax.SynExprRecordField NewSynExprRecordField(System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithTrivia,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]])
+FSharp.Compiler.Syntax.SynExprRecordField: FSharp.Compiler.Syntax.SynExprRecordField NewSynExprRecordField(System.Tuple`2[FSharp.Compiler.Syntax.SynLongIdent,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]])
 FSharp.Compiler.Syntax.SynExprRecordField: Int32 Tag
 FSharp.Compiler.Syntax.SynExprRecordField: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr] expr
@@ -7128,8 +7100,8 @@ FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]] blockSeparator
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]] get_blockSeparator()
 FSharp.Compiler.Syntax.SynExprRecordField: System.String ToString()
-FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithTrivia,System.Boolean] fieldName
-FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.LongIdentWithTrivia,System.Boolean] get_fieldName()
+FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.SynLongIdent,System.Boolean] fieldName
+FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.SynLongIdent,System.Boolean] get_fieldName()
 FSharp.Compiler.Syntax.SynField
 FSharp.Compiler.Syntax.SynField: Boolean get_isMutable()
 FSharp.Compiler.Syntax.SynField: Boolean get_isStatic()
@@ -7151,6 +7123,15 @@ FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Com
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
 FSharp.Compiler.Syntax.SynField: System.String ToString()
+FSharp.Compiler.Syntax.SynIdent
+FSharp.Compiler.Syntax.SynIdent: FSharp.Compiler.Syntax.Ident get_ident()
+FSharp.Compiler.Syntax.SynIdent: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynIdent: FSharp.Compiler.Syntax.SynIdent NewSynIdent(FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia])
+FSharp.Compiler.Syntax.SynIdent: Int32 Tag
+FSharp.Compiler.Syntax.SynIdent: Int32 get_Tag()
+FSharp.Compiler.Syntax.SynIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia] get_trivia()
+FSharp.Compiler.Syntax.SynIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia] trivia
+FSharp.Compiler.Syntax.SynIdent: System.String ToString()
 FSharp.Compiler.Syntax.SynInterfaceImpl
 FSharp.Compiler.Syntax.SynInterfaceImpl: FSharp.Compiler.Syntax.SynInterfaceImpl NewSynInterfaceImpl(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynInterfaceImpl: FSharp.Compiler.Syntax.SynType get_interfaceTy()
@@ -7189,6 +7170,34 @@ FSharp.Compiler.Syntax.SynInterpolatedStringPart: FSharp.Compiler.Syntax.SynInte
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: Int32 Tag
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynInterpolatedStringPart: System.String ToString()
+FSharp.Compiler.Syntax.SynLongIdent
+FSharp.Compiler.Syntax.SynLongIdent: Boolean ThereIsAnExtraDotAtTheEnd
+FSharp.Compiler.Syntax.SynLongIdent: Boolean get_ThereIsAnExtraDotAtTheEnd()
+FSharp.Compiler.Syntax.SynLongIdent: FSharp.Compiler.Syntax.SynLongIdent NewSynLongIdent(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]])
+FSharp.Compiler.Syntax.SynLongIdent: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynLongIdent: FSharp.Compiler.Text.Range RangeWithoutAnyExtraDot
+FSharp.Compiler.Syntax.SynLongIdent: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.Syntax.SynLongIdent: FSharp.Compiler.Text.Range get_RangeWithoutAnyExtraDot()
+FSharp.Compiler.Syntax.SynLongIdent: Int32 Tag
+FSharp.Compiler.Syntax.SynLongIdent: Int32 get_Tag()
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] LongIdent
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_LongIdent()
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_id()
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] id
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdent] IdentsWithTrivia
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynIdent] get_IdentsWithTrivia()
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia] Trivia
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia] get_Trivia()
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] Dots
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] dotRanges
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_Dots()
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_dotRanges()
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_trivia()
+FSharp.Compiler.Syntax.SynLongIdent: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] trivia
+FSharp.Compiler.Syntax.SynLongIdent: System.String ToString()
+FSharp.Compiler.Syntax.SynLongIdentHelpers
+FSharp.Compiler.Syntax.SynLongIdentHelpers: FSharp.Compiler.Syntax.SynLongIdent LongIdentWithDots(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.Syntax.SynLongIdentHelpers: System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident],Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range]] |LongIdentWithDots|(FSharp.Compiler.Syntax.SynLongIdent)
 FSharp.Compiler.Syntax.SynMatchClause
 FSharp.Compiler.Syntax.SynMatchClause: FSharp.Compiler.Syntax.DebugPointAtTarget debugPoint
 FSharp.Compiler.Syntax.SynMatchClause: FSharp.Compiler.Syntax.DebugPointAtTarget get_debugPoint()
@@ -7901,10 +7910,10 @@ FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType get_pat()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Syntax.SynType pat
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+IsInst: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynArgPats argPats
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynArgPats get_argPats()
+FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+LongIdent: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident] extraId
@@ -8032,7 +8041,7 @@ FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewDeprecatedCharRa
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewFromParseError(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewInstanceMember(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewIsInst(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithTrivia, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNamed(FSharp.Compiler.Syntax.Ident, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOptionalVal(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
@@ -8354,10 +8363,10 @@ FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType ge
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType innerType
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
-FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.LongIdentWithTrivia get_longDotId()
-FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.LongIdentWithTrivia longDotId
+FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.SynLongIdent longDotId
+FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
+FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.SynType get_typeName()
 FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.SynType typeName
 FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Text.Range get_range()
@@ -8473,8 +8482,8 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewApp(FSharp.Com
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewArray(Int32, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFun(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewHashConstraint(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdent(FSharp.Compiler.Syntax.LongIdentWithTrivia)
-FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdentApp(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.LongIdentWithTrivia, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdent(FSharp.Compiler.Syntax.SynLongIdent)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdentApp(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewMeasureDivide(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewMeasurePower(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynRationalConst, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewParen(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
@@ -8889,7 +8898,9 @@ FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: Int32 Tag
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: System.String ToString()
 FSharp.Compiler.Syntax.SynUnionCase
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCase NewSynUnionCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]], FSharp.Compiler.Syntax.SynUnionCaseKind, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia)
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynIdent get_ident()
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynIdent ident
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCase NewSynUnionCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynIdent, FSharp.Compiler.Syntax.SynUnionCaseKind, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia)
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCaseKind caseType
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCaseKind get_caseType()
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia get_trivia()
@@ -8907,8 +8918,6 @@ FSharp.Compiler.Syntax.SynUnionCase: Microsoft.FSharp.Collections.FSharpList`1[F
 FSharp.Compiler.Syntax.SynUnionCase: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynUnionCase: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
 FSharp.Compiler.Syntax.SynUnionCase: System.String ToString()
-FSharp.Compiler.Syntax.SynUnionCase: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_ident()
-FSharp.Compiler.Syntax.SynUnionCase: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] ident
 FSharp.Compiler.Syntax.SynUnionCaseKind
 FSharp.Compiler.Syntax.SynUnionCaseKind+Fields: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField] cases
 FSharp.Compiler.Syntax.SynUnionCaseKind+Fields: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField] get_cases()
@@ -8961,6 +8970,8 @@ FSharp.Compiler.Syntax.SynValSig: Boolean get_isInline()
 FSharp.Compiler.Syntax.SynValSig: Boolean get_isMutable()
 FSharp.Compiler.Syntax.SynValSig: Boolean isInline
 FSharp.Compiler.Syntax.SynValSig: Boolean isMutable
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynIdent get_ident()
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynIdent ident
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType SynType
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType get_SynType()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType get_synType()
@@ -8969,7 +8980,7 @@ FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo SynInfo
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo arity
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_SynInfo()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_arity()
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]], FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynIdent, FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls explicitValDecls
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls get_explicitValDecls()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Text.Range RangeOfId
@@ -8989,8 +9000,6 @@ FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Co
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_withKeyword()
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] withKeyword
 FSharp.Compiler.Syntax.SynValSig: System.String ToString()
-FSharp.Compiler.Syntax.SynValSig: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_ident()
-FSharp.Compiler.Syntax.SynValSig: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] ident
 FSharp.Compiler.Syntax.SynValTyparDecls
 FSharp.Compiler.Syntax.SynValTyparDecls: Boolean canInfer
 FSharp.Compiler.Syntax.SynValTyparDecls: Boolean get_canInfer()
@@ -9085,7 +9094,7 @@ FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOptio
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynModuleOrNamespace)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitPat(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynPat,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynPat)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordDefn(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.LongIdentWithTrivia])
+FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynLongIdent])
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitSimplePats(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynSimplePat])
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitType(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynType,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynType)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitTypeAbbrev(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
@@ -10931,6 +10940,21 @@ FSharp.Compiler.Xml.PreXmlDoc: FSharp.Compiler.Xml.XmlDoc ToXmlDoc(Boolean, Micr
 FSharp.Compiler.Xml.PreXmlDoc: Int32 GetHashCode()
 FSharp.Compiler.Xml.PreXmlDoc: Int32 GetHashCode(System.Collections.IEqualityComparer)
 FSharp.Compiler.Xml.PreXmlDoc: System.String ToString()
+FSharp.Compiler.Xml.XmlDoc
+FSharp.Compiler.Xml.XmlDoc: Boolean IsEmpty
+FSharp.Compiler.Xml.XmlDoc: Boolean NonEmpty
+FSharp.Compiler.Xml.XmlDoc: Boolean get_IsEmpty()
+FSharp.Compiler.Xml.XmlDoc: Boolean get_NonEmpty()
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Text.Range get_Range()
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc Empty
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc Merge(FSharp.Compiler.Xml.XmlDoc, FSharp.Compiler.Xml.XmlDoc)
+FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc get_Empty()
+FSharp.Compiler.Xml.XmlDoc: System.String GetXmlText()
+FSharp.Compiler.Xml.XmlDoc: System.String[] GetElaboratedXmlLines()
+FSharp.Compiler.Xml.XmlDoc: System.String[] UnprocessedLines
+FSharp.Compiler.Xml.XmlDoc: System.String[] get_UnprocessedLines()
+FSharp.Compiler.Xml.XmlDoc: Void .ctor(System.String[], FSharp.Compiler.Text.Range)FSharp.Compiler.Xml.PreXmlDoc: System.String ToString()
 FSharp.Compiler.Xml.XmlDoc
 FSharp.Compiler.Xml.XmlDoc: Boolean IsEmpty
 FSharp.Compiler.Xml.XmlDoc: Boolean NonEmpty

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -10954,19 +10954,4 @@ FSharp.Compiler.Xml.XmlDoc: System.String GetXmlText()
 FSharp.Compiler.Xml.XmlDoc: System.String[] GetElaboratedXmlLines()
 FSharp.Compiler.Xml.XmlDoc: System.String[] UnprocessedLines
 FSharp.Compiler.Xml.XmlDoc: System.String[] get_UnprocessedLines()
-FSharp.Compiler.Xml.XmlDoc: Void .ctor(System.String[], FSharp.Compiler.Text.Range)FSharp.Compiler.Xml.PreXmlDoc: System.String ToString()
-FSharp.Compiler.Xml.XmlDoc
-FSharp.Compiler.Xml.XmlDoc: Boolean IsEmpty
-FSharp.Compiler.Xml.XmlDoc: Boolean NonEmpty
-FSharp.Compiler.Xml.XmlDoc: Boolean get_IsEmpty()
-FSharp.Compiler.Xml.XmlDoc: Boolean get_NonEmpty()
-FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Text.Range Range
-FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Text.Range get_Range()
-FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc Empty
-FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc Merge(FSharp.Compiler.Xml.XmlDoc, FSharp.Compiler.Xml.XmlDoc)
-FSharp.Compiler.Xml.XmlDoc: FSharp.Compiler.Xml.XmlDoc get_Empty()
-FSharp.Compiler.Xml.XmlDoc: System.String GetXmlText()
-FSharp.Compiler.Xml.XmlDoc: System.String[] GetElaboratedXmlLines()
-FSharp.Compiler.Xml.XmlDoc: System.String[] UnprocessedLines
-FSharp.Compiler.Xml.XmlDoc: System.String[] get_UnprocessedLines()
 FSharp.Compiler.Xml.XmlDoc: Void .ctor(System.String[], FSharp.Compiler.Text.Range)

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -5430,7 +5430,11 @@ FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpL
 FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_LongIdent()
 FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] get_id()
 FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.Ident] id
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia] Trivia
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia] get_Trivia()
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] Dots
 FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] dotRanges
+FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_Dots()
 FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_dotRanges()
 FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_trivia()
 FSharp.Compiler.Syntax.LongIdentWithTrivia: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] trivia
@@ -9158,16 +9162,16 @@ FSharp.Compiler.SyntaxTrivia.ConditionalDirectiveTrivia: Int32 Tag
 FSharp.Compiler.SyntaxTrivia.ConditionalDirectiveTrivia: Int32 get_Tag()
 FSharp.Compiler.SyntaxTrivia.ConditionalDirectiveTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.IdentTrivia
-FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range get_lpr()
-FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range get_rpr()
-FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range lpr
-FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range get_leftParenRange()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range get_rightParenRange()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range leftParenRange
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+HasParenthesis: FSharp.Compiler.Text.Range rightParenRange
 FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotation: System.String get_text()
 FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotation: System.String text
-FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range get_lpr()
-FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range get_rpr()
-FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range lpr
-FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range rpr
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range get_leftParenRange()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range get_rightParenRange()
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range leftParenRange
+FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: FSharp.Compiler.Text.Range rightParenRange
 FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: System.String get_text()
 FSharp.Compiler.SyntaxTrivia.IdentTrivia+OriginalNotationWithParen: System.String text
 FSharp.Compiler.SyntaxTrivia.IdentTrivia+Tags: Int32 HasParenthesis

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -7926,8 +7926,8 @@ FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FS
 FSharp.Compiler.Syntax.SynPat+LongIdent: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls] typarDecls
 FSharp.Compiler.Syntax.SynPat+Named: Boolean get_isThisVal()
 FSharp.Compiler.Syntax.SynPat+Named: Boolean isThisVal
-FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.SynIdent get_ident()
+FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Syntax.SynIdent ident
 FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynPat+Named: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynPat+Named: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
@@ -8042,7 +8042,7 @@ FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewFromParseError(F
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewInstanceMember(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewIsInst(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewLongIdent(FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.PropertyKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynValTyparDecls], FSharp.Compiler.Syntax.SynArgPats, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNamed(FSharp.Compiler.Syntax.Ident, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNamed(FSharp.Compiler.Syntax.SynIdent, Boolean, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewNull(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOptionalVal(FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynPat: FSharp.Compiler.Syntax.SynPat NewOr(FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia)

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -6154,11 +6154,9 @@ FSharp.Compiler.Syntax.SynConst: Int32 Tag
 FSharp.Compiler.Syntax.SynConst: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynConst: System.String ToString()
 FSharp.Compiler.Syntax.SynEnumCase
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.Ident ident
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynConst get_value()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynConst value
-FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynEnumCase NewSynEnumCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range, FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia)
+FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Syntax.SynEnumCase NewSynEnumCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]], FSharp.Compiler.Syntax.SynConst, FSharp.Compiler.Text.Range, FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia)
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia get_trivia()
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.SyntaxTrivia.SynEnumCaseTrivia trivia
 FSharp.Compiler.Syntax.SynEnumCase: FSharp.Compiler.Text.Range Range
@@ -6174,6 +6172,8 @@ FSharp.Compiler.Syntax.SynEnumCase: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynEnumCase: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] attributes
 FSharp.Compiler.Syntax.SynEnumCase: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList] get_attributes()
 FSharp.Compiler.Syntax.SynEnumCase: System.String ToString()
+FSharp.Compiler.Syntax.SynEnumCase: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_ident()
+FSharp.Compiler.Syntax.SynEnumCase: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] ident
 FSharp.Compiler.Syntax.SynExceptionDefn
 FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Syntax.SynExceptionDefn NewSynExceptionDefn(FSharp.Compiler.Syntax.SynExceptionDefnRepr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExceptionDefn: FSharp.Compiler.Syntax.SynExceptionDefnRepr exnRepr
@@ -6390,8 +6390,8 @@ FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Syntax.SynExpr ex
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+FromParseError: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+Ident: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynExpr+Ident: FSharp.Compiler.Syntax.Ident ident
+FSharp.Compiler.Syntax.SynExpr+Ident: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_ident()
+FSharp.Compiler.Syntax.SynExpr+Ident: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] ident
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean get_isFromErrorRecovery()
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: Boolean isFromErrorRecovery
 FSharp.Compiler.Syntax.SynExpr+IfThenElse: FSharp.Compiler.Syntax.DebugPointAtBinding get_spIfToThen()
@@ -6975,7 +6975,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFixed(FSharp.C
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFor(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewForEach(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.SeqExprOnly, Boolean, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFromParseError(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIdent(FSharp.Compiler.Syntax.Ident)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIdent(System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]])
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIfThenElse(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Syntax.DebugPointAtBinding, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprIfThenElseTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewImplicitZero(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewIndexFromEnd(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
@@ -8885,9 +8885,7 @@ FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: Int32 Tag
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynTypeDefnSimpleRepr: System.String ToString()
 FSharp.Compiler.Syntax.SynUnionCase
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.Ident ident
-FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCase NewSynUnionCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynUnionCaseKind, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia)
+FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCase NewSynUnionCase(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]], FSharp.Compiler.Syntax.SynUnionCaseKind, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia)
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCaseKind caseType
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.Syntax.SynUnionCaseKind get_caseType()
 FSharp.Compiler.Syntax.SynUnionCase: FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia get_trivia()
@@ -8905,6 +8903,8 @@ FSharp.Compiler.Syntax.SynUnionCase: Microsoft.FSharp.Collections.FSharpList`1[F
 FSharp.Compiler.Syntax.SynUnionCase: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] accessibility
 FSharp.Compiler.Syntax.SynUnionCase: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess] get_accessibility()
 FSharp.Compiler.Syntax.SynUnionCase: System.String ToString()
+FSharp.Compiler.Syntax.SynUnionCase: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_ident()
+FSharp.Compiler.Syntax.SynUnionCase: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] ident
 FSharp.Compiler.Syntax.SynUnionCaseKind
 FSharp.Compiler.Syntax.SynUnionCaseKind+Fields: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField] cases
 FSharp.Compiler.Syntax.SynUnionCaseKind+Fields: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField] get_cases()
@@ -8957,8 +8957,6 @@ FSharp.Compiler.Syntax.SynValSig: Boolean get_isInline()
 FSharp.Compiler.Syntax.SynValSig: Boolean get_isMutable()
 FSharp.Compiler.Syntax.SynValSig: Boolean isInline
 FSharp.Compiler.Syntax.SynValSig: Boolean isMutable
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.Ident get_ident()
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.Ident ident
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType SynType
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType get_SynType()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynType get_synType()
@@ -8967,7 +8965,7 @@ FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo SynInfo
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo arity
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_SynInfo()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValInfo get_arity()
-FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.Ident, FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValSig NewSynValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]], FSharp.Compiler.Syntax.SynValTyparDecls, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynValInfo, Boolean, Boolean, FSharp.Compiler.Xml.PreXmlDoc, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls explicitValDecls
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Syntax.SynValTyparDecls get_explicitValDecls()
 FSharp.Compiler.Syntax.SynValSig: FSharp.Compiler.Text.Range RangeOfId
@@ -8987,6 +8985,8 @@ FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Co
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_withKeyword()
 FSharp.Compiler.Syntax.SynValSig: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] withKeyword
 FSharp.Compiler.Syntax.SynValSig: System.String ToString()
+FSharp.Compiler.Syntax.SynValSig: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] get_ident()
+FSharp.Compiler.Syntax.SynValSig: System.Tuple`2[FSharp.Compiler.Syntax.Ident,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.IdentTrivia]] ident
 FSharp.Compiler.Syntax.SynValTyparDecls
 FSharp.Compiler.Syntax.SynValTyparDecls: Boolean canInfer
 FSharp.Compiler.Syntax.SynValTyparDecls: Boolean get_canInfer()

--- a/tests/service/InteractiveCheckerTests.fs
+++ b/tests/service/InteractiveCheckerTests.fs
@@ -18,7 +18,7 @@ open FSharp.Compiler.Text.Range
 
 let internal longIdentToString (longIdent: LongIdent) =
     String.Join(".", longIdent |> List.map (fun ident -> ident.ToString()))
-let internal longIdentWithDotsToString (LongIdentWithDots (longIdent, _)) = longIdentToString longIdent
+let internal longIdentWithDotsToString (SynLongIdent (longIdent, _, _)) = longIdentToString longIdent
 
 let internal posToTuple (pos: pos) = (pos.Line, pos.Column)
 let internal rangeToTuple (range: range) = (posToTuple range.Start, posToTuple range.End)

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -35,7 +35,7 @@ let x = ()
     let (|UnionWithCases|_|) typeDefn =
         match typeDefn with
         | SynTypeDefn (typeRepr = SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Union (unionCases = cases), _)) ->
-            cases |> List.map (fun (SynUnionCase (ident = ident)) -> ident.idText) |> Some
+            cases |> List.map (fun (SynUnionCase (ident = (ident,_))) -> ident.idText) |> Some
         | _ -> None
 
     match getSingleModuleMemberDecls parseResults with

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -35,7 +35,7 @@ let x = ()
     let (|UnionWithCases|_|) typeDefn =
         match typeDefn with
         | SynTypeDefn (typeRepr = SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.Union (unionCases = cases), _)) ->
-            cases |> List.map (fun (SynUnionCase (ident = (ident,_))) -> ident.idText) |> Some
+            cases |> List.map (fun (SynUnionCase (ident = SynIdent(ident,_))) -> ident.idText) |> Some
         | _ -> None
 
     match getSingleModuleMemberDecls parseResults with

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1139,6 +1139,31 @@ global
             Assert.Pass()
         | _ -> Assert.Fail "Could not get valid AST"
 
+    [<Test>]
+    let ``SynExprRecordFields contain correct amount of trivia`` () =
+        let ast =
+            getParseResults """
+        { JobType = EsriBoundaryImport
+          FileToImport = filePath
+          State = state
+          DryRun = args.DryRun }
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+                    SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                        SynModuleDecl.Expr(expr =
+                            SynExpr.Record(recordFields = [
+                                SynExprRecordField(fieldName = (synLongIdent, _))
+                                _; _; _
+                            ]))
+                    ])
+                ])) ->
+            match synLongIdent.IdentsWithTrivia with
+            | [ _ ] -> Assert.Pass()
+            | idents -> Assert.Fail $"Expected a single SynIdent, got {idents}"
+        | _ -> Assert.Fail $"Could not get valid AST, got {ast}"
+
 module Strings =
     let getBindingExpressionValue (parseResults: ParsedInput) =
         match parseResults with

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -2517,7 +2517,7 @@ module Lambdas =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Named _], SynExpr.Ident(ident,_)))
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Named _], SynExpr.Ident ident))
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
@@ -2532,7 +2532,7 @@ module Lambdas =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Wild _; SynPat.Named _], SynExpr.Ident(ident,_)))
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Wild _; SynPat.Named _], SynExpr.Ident ident))
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
@@ -2547,7 +2547,7 @@ module Lambdas =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Paren(SynPat.Tuple _,_); SynPat.Named _], SynExpr.Ident(ident,_)))
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Paren(SynPat.Tuple _,_); SynPat.Named _], SynExpr.Ident ident))
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
@@ -2562,7 +2562,7 @@ module Lambdas =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Ident(ident,_)))))
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Ident ident))))
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
@@ -3808,7 +3808,7 @@ module OperatorName =
         | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Expr (expr = SynExpr.App(funcExpr = SynExpr.App(funcExpr =
-                    SynExpr.Paren(SynExpr.Ident(ident, Some (IdentTrivia.OriginalNotation("+"))), lpr, Some rpr, pr))))
+                    SynExpr.Paren(SynExpr.LongIdent(longDotId = SynLongIdent([ident], _, [Some (IdentTrivia.OriginalNotation "+")])), lpr, Some rpr, pr))))
                 ])
             ])) ->
             assertRange (2, 0) (2, 1) lpr
@@ -3829,7 +3829,7 @@ module OperatorName =
         | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Expr (expr = SynExpr.App(funcExpr =
-                    SynExpr.Paren(SynExpr.Ident(ident, None), lpr, Some rpr, pr)))
+                    SynExpr.Paren(SynExpr.Ident ident, lpr, Some rpr, pr)))
                 ])
             ])) ->
             assertRange (2, 0) (2, 1) lpr
@@ -3850,7 +3850,7 @@ module OperatorName =
         | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Expr (expr = SynExpr.App(funcExpr =
-                    SynExpr.Paren(SynExpr.Ident(ident, None), lpr, Some rpr, pr)))
+                    SynExpr.Paren(SynExpr.Ident ident, lpr, Some rpr, pr)))
                 ])
             ])) ->
             assertRange (2, 0) (2, 1) lpr
@@ -3871,7 +3871,7 @@ let (+) a b = a + b
         | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Let(bindings = [SynBinding(headPat=
-                    SynPat.LongIdent(longDotId = LongIdentWithTrivia([ ident ],_, [ Some (IdentTrivia.OriginalNotationWithParen(lpr, "+", rpr)) ])))
+                    SynPat.LongIdent(longDotId = SynLongIdent([ ident ],_, [ Some (IdentTrivia.OriginalNotationWithParen(lpr, "+", rpr)) ])))
                 ])
             ])])) ->
             assertRange (2, 4) (2,5) lpr
@@ -3891,7 +3891,7 @@ let (|Odd|Even|) (a: int) = if a % 2 = 0 then Even else Odd
         | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Let(bindings = [SynBinding(headPat=
-                    SynPat.LongIdent(longDotId = LongIdentWithTrivia([ident], _, [Some (IdentTrivia.HasParenthesis(lpr, rpr))])))
+                    SynPat.LongIdent(longDotId = SynLongIdent([ident], _, [Some (IdentTrivia.HasParenthesis(lpr, rpr))])))
                 ])
             ])])) ->
             assertRange (2, 4) (2, 5) lpr
@@ -3911,7 +3911,7 @@ let (|Int32Const|_|) (a: SynConst) = match a with SynConst.Int32 _ -> Some a | _
         | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Let(bindings = [SynBinding(headPat=
-                    SynPat.LongIdent(longDotId = LongIdentWithTrivia([ident], _, [Some (IdentTrivia.HasParenthesis(lpr, rpr))])))
+                    SynPat.LongIdent(longDotId = SynLongIdent([ident], _, [Some (IdentTrivia.HasParenthesis(lpr, rpr))])))
                 ])
             ])])) ->
              assertRange (2, 4) (2, 5) lpr
@@ -3931,7 +3931,7 @@ val (&): e1: bool -> e2: bool -> bool
         match ast with
         | ParsedInput.SigFile(ParsedSigFileInput(modules = [
             SynModuleOrNamespaceSig(decls = [
-                SynModuleSigDecl.Val(valSig = SynValSig(ident = (ident, Some (IdentTrivia.OriginalNotationWithParen(lpr, "&", rpr)))
+                SynModuleSigDecl.Val(valSig = SynValSig(ident = SynIdent(ident, Some (IdentTrivia.OriginalNotationWithParen(lpr, "&", rpr)))
                 ))])
             ])) ->
             assertRange (3, 4) (3, 5) lpr
@@ -3962,7 +3962,7 @@ val (&): e1: bool -> e2: bool -> bool
             SynModuleOrNamespaceSig(decls = [
                 SynModuleSigDecl.Val(valSig = SynValSig(synType=SynType.WithGlobalConstraints(constraints=[
                     SynTypeConstraint.WhereTyparSupportsMember(memberSig=SynMemberSig.Member(memberSig=SynValSig(ident =
-                        (ident, Some (IdentTrivia.OriginalNotationWithParen(lpr, "~-", rpr))))))
+                        SynIdent(ident, Some (IdentTrivia.OriginalNotationWithParen(lpr, "~-", rpr))))))
                     SynTypeConstraint.WhereTyparDefaultsToType _
                 ])))
                 ])
@@ -3983,7 +3983,7 @@ f(x=4)
         | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Expr(expr = SynExpr.App(argExpr = SynExpr.Paren(expr = SynExpr.App(funcExpr=
-                    SynExpr.App(funcExpr= SynExpr.Ident(ident, Some(IdentTrivia.OriginalNotation "=")))))))
+                    SynExpr.App(funcExpr= SynExpr.LongIdent(longDotId = SynLongIdent([ident], _, [Some (IdentTrivia.OriginalNotation "=")])))))))
                 ])
             ])) ->
             Assert.AreEqual("op_Equality", ident.idText)
@@ -4002,7 +4002,7 @@ f(x=4)
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Expr(expr =
                     SynExpr.App(funcExpr = SynExpr.App(isInfix = true
-                                                       funcExpr = SynExpr.Ident(ident, Some (IdentTrivia.OriginalNotation "+"))
+                                                       funcExpr = SynExpr.LongIdent(longDotId = SynLongIdent([ident], _, [Some (IdentTrivia.OriginalNotation "+")]))
                                                        argExpr = SynExpr.Const(SynConst.Int32(1), _))
                                 argExpr = SynExpr.Const(SynConst.Int32(1), _)))
                 ])
@@ -4024,14 +4024,14 @@ op_Addition a b
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Expr(expr =
                     SynExpr.App(funcExpr = SynExpr.App(isInfix = false
-                                                       funcExpr = SynExpr.Paren(SynExpr.Ident(ident, Some (IdentTrivia.OriginalNotation "+")), lpr, Some rpr, pr)
-                                                       argExpr = SynExpr.Ident (a1, None))
-                                argExpr = SynExpr.Ident (b1, None)))
+                                                       funcExpr = SynExpr.Paren(SynExpr.LongIdent(longDotId = SynLongIdent([ident], _, [Some (IdentTrivia.OriginalNotation "+")])), lpr, Some rpr, pr)
+                                                       argExpr = SynExpr.Ident a1)
+                                argExpr = SynExpr.Ident b1))
                 SynModuleDecl.Expr(expr =
                     SynExpr.App(funcExpr = SynExpr.App(isInfix = false
-                                                       funcExpr = SynExpr.Ident (op_Addition, None)
-                                                       argExpr = SynExpr.Ident (a2, None))
-                                argExpr = SynExpr.Ident (b2, None))
+                                                       funcExpr = SynExpr.Ident op_Addition
+                                                       argExpr = SynExpr.Ident a2)
+                                argExpr = SynExpr.Ident b2)
                     )
                 ])
             ])) ->
@@ -4061,7 +4061,7 @@ type X with
                 SynModuleDecl.Types(typeDefns = [
                     SynTypeDefn(members = [
                         SynMemberDefn.Member(memberDefn = SynBinding(headPat = SynPat.LongIdent(longDotId =
-                            LongIdentWithTrivia([ _; operatorIdent ], [ mDot ], [ None; Some (IdentTrivia.OriginalNotationWithParen(lpr, "+", rpr)) ]) as lid)))
+                            SynLongIdent([ _; operatorIdent ], [ mDot ], [ None; Some (IdentTrivia.OriginalNotationWithParen(lpr, "+", rpr)) ]) as lid)))
                     ])
                     ]
                 )
@@ -4086,8 +4086,15 @@ nameof(+)
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Expr(expr =
                                     SynExpr.App(isInfix = false
-                                                funcExpr = SynExpr.Ident (nameofIdent, None)
-                                                argExpr = SynExpr.Paren(SynExpr.Ident(operatorIdent, Some (IdentTrivia.OriginalNotation "+")), lpr, Some rpr, pr)))
+                                                funcExpr = SynExpr.Ident nameofIdent
+                                                argExpr = SynExpr.Paren(
+                                                    SynExpr.LongIdent(longDotId = SynLongIdent([operatorIdent], _, [Some (IdentTrivia.OriginalNotation "+")])),
+                                                    lpr,
+                                                    Some rpr,
+                                                    pr
+                                                )
+                                    )
+                    )
                 ])
             ])) ->
             Assert.AreEqual("nameof", nameofIdent.idText)
@@ -4109,12 +4116,12 @@ f(?x = 7)
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Expr(expr =
                                     SynExpr.App(isInfix = false
-                                                funcExpr = SynExpr.Ident (f, None)
+                                                funcExpr = SynExpr.Ident f
                                                 argExpr = SynExpr.Paren(
                                                     SynExpr.App(funcExpr = SynExpr.App(
                                                                     isInfix = true
-                                                                    funcExpr = SynExpr.Ident(eqIdent, Some (IdentTrivia.OriginalNotation "="))
-                                                                    argExpr = SynExpr.LongIdent(true, LongIdentWithTrivia([x], [], [None]), _, mOptional)
+                                                                    funcExpr = SynExpr.LongIdent(longDotId = SynLongIdent([eqIdent], _, [Some (IdentTrivia.OriginalNotation "=")]))
+                                                                    argExpr = SynExpr.LongIdent(true, SynLongIdent([x], [], [None]), _, mOptional)
                                                                 )
                                                                 argExpr = SynExpr.Const(SynConst.Int32 7, _)), lpr, Some rpr, pr)))
                 ])
@@ -4144,9 +4151,9 @@ type X() =
                     SynTypeDefn.SynTypeDefn(typeRepr = SynTypeDefnRepr.ObjectModel(members =[
                         SynMemberDefn.ImplicitCtor _
                         SynMemberDefn.LetBindings _
-                        SynMemberDefn.Member(memberDefn = SynBinding(headPat = SynPat.LongIdent(longDotId = LongIdentWithTrivia(id = [ _ ; allowIntoPatternGet ])
+                        SynMemberDefn.Member(memberDefn = SynBinding(headPat = SynPat.LongIdent(longDotId = SynLongIdent(id = [ _ ; allowIntoPatternGet ])
                                                                                                 propertyKeyword = Some (PropertyKeyword.With mWith))))
-                        SynMemberDefn.Member(memberDefn = SynBinding(headPat = SynPat.LongIdent(longDotId = LongIdentWithTrivia(id = [ _ ; allowIntoPatternSet ])
+                        SynMemberDefn.Member(memberDefn = SynBinding(headPat = SynPat.LongIdent(longDotId = SynLongIdent(id = [ _ ; allowIntoPatternSet ])
                                                                                                 propertyKeyword = Some (PropertyKeyword.And mAnd))))
                     ]))
                 ])
@@ -4170,7 +4177,7 @@ let PowByte (x:byte) n = Checked.( * ) x
             SynModuleOrNamespace.SynModuleOrNamespace(decls = [
                 SynModuleDecl.Let(bindings = [
                     SynBinding(expr = SynExpr.App(funcExpr =
-                        SynExpr.LongIdent(longDotId = LongIdentWithTrivia([checkedIdent; operatorIdent], [mDot], [None; Some (IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr))]))))
+                        SynExpr.LongIdent(longDotId = SynLongIdent([checkedIdent; operatorIdent], [mDot], [None; Some (IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr))]))))
                 ])
             ])
             ])) ->
@@ -4200,7 +4207,7 @@ type A() =
                     SynTypeDefn(typeRepr = SynTypeDefnRepr.ObjectModel(members = [
                         SynMemberDefn.ImplicitCtor _
                         SynMemberDefn.Member(memberDefn = SynBinding(
-                            headPat = SynPat.LongIdent(longDotId = LongIdentWithTrivia([underscoreIdent; aQuoteIdent], [ mDot ], [ None; Some (IdentTrivia.HasParenthesis(lpr, rpr)) ]))
+                            headPat = SynPat.LongIdent(longDotId = SynLongIdent([underscoreIdent; aQuoteIdent], [ mDot ], [ None; Some (IdentTrivia.HasParenthesis(lpr, rpr)) ]))
                         ))
                     ]))
                 ])
@@ -4218,3 +4225,5 @@ type A() =
 
 // TODO:
 // add test for global (SynExpr.Ident mangledGlobalName)
+
+// todo add test for a.(0) // op_ArrayLookup

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -4206,6 +4206,47 @@ f(x=4)
             Assert.Fail $"Could not get valid AST, got {ast}"
 
     [<Test>]
+    let ``prefix operation`` () =
+        let ast = getParseResults """
++ -86
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr(expr =
+                    SynExpr.App(isInfix = false
+                                funcExpr = SynExpr.LongIdent(longDotId = SynLongIdent([ident], _, [Some (IdentTrivia.OriginalNotation "+")]))
+                                argExpr = SynExpr.Const(SynConst.Int32(-86), _)))
+                ])
+            ])) ->
+            Assert.AreEqual("op_UnaryPlus", ident.idText)
+            assertRange (2,0) (2,1) ident.idRange
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``prefix operation with two characters`` () =
+        let ast = getParseResults """
+%%arg
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr(expr =
+                    SynExpr.App(isInfix = false
+                                funcExpr = SynExpr.LongIdent(longDotId = SynLongIdent([ident], _, [Some (IdentTrivia.OriginalNotation "%%")]))
+                                argExpr = SynExpr.Ident argIdent))
+                ])
+            ])) ->
+            Assert.AreEqual("op_SpliceUntyped", ident.idText)
+            assertRange (2,0) (2,2) ident.idRange
+            Assert.AreEqual("arg", argIdent.idText)
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"    
+
+    [<Test>]
     let ``detect difference between compiled operators`` () =
         let ast = getParseResults """
 (+) a b

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -2517,7 +2517,7 @@ module Lambdas =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Named _], SynExpr.Ident(ident)))
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Named _], SynExpr.Ident(ident,_)))
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
@@ -2532,7 +2532,7 @@ module Lambdas =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Wild _; SynPat.Named _], SynExpr.Ident(ident)))
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Wild _; SynPat.Named _], SynExpr.Ident(ident,_)))
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
@@ -2547,7 +2547,7 @@ module Lambdas =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Paren(SynPat.Tuple _,_); SynPat.Named _], SynExpr.Ident(ident)))
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Named _; SynPat.Paren(SynPat.Tuple _,_); SynPat.Named _], SynExpr.Ident(ident,_)))
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
@@ -2562,7 +2562,7 @@ module Lambdas =
         match parseResults with
         | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
             SynModuleDecl.Expr(
-                expr = SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Ident(ident)))))
+                expr = SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Lambda(parsedData = Some([SynPat.Wild _], SynExpr.Ident(ident,_)))))
             )
         ]) ])) ->
             Assert.AreEqual("x", ident.idText)
@@ -3795,3 +3795,426 @@ let x =
             assertRange (7, 4) (7, 27) m3
         | _ ->
             Assert.Fail "Could not get valid AST"
+
+module OperatorName =
+    [<Test>]
+    let ``operator as function`` () =
+        let ast = """
+(+) 3 4
+"""
+                        |> getParseResults
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr (expr = SynExpr.App(funcExpr = SynExpr.App(funcExpr =
+                    SynExpr.Paren(SynExpr.Ident(ident, Some (IdentTrivia.OriginalNotation("+"))), lpr, Some rpr, pr))))
+                ])
+            ])) ->
+            assertRange (2, 0) (2, 1) lpr
+            Assert.AreEqual("op_Addition", ident.idText)
+            assertRange (2, 2) (2, 3) rpr
+            assertRange (2, 0) (2, 3) pr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``active pattern as function `` () =
+        let ast = """
+(|Odd|Even|) 4
+"""
+                        |> getParseResults
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr (expr = SynExpr.App(funcExpr =
+                    SynExpr.Paren(SynExpr.Ident(ident, None), lpr, Some rpr, pr)))
+                ])
+            ])) ->
+            assertRange (2, 0) (2, 1) lpr
+            Assert.AreEqual("|Odd|Even|", ident.idText)
+            assertRange (2, 11) (2, 12) rpr
+            assertRange (2, 0) (2, 12) pr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``partial active pattern as function `` () =
+        let ast = """
+(|Odd|_|) 4
+"""
+                        |> getParseResults
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr (expr = SynExpr.App(funcExpr =
+                    SynExpr.Paren(SynExpr.Ident(ident, None), lpr, Some rpr, pr)))
+                ])
+            ])) ->
+            assertRange (2, 0) (2, 1) lpr
+            Assert.AreEqual("|Odd|_|", ident.idText)
+            assertRange (2, 8) (2, 9) rpr
+            assertRange (2, 0) (2, 9) pr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``custom operator definition`` () =
+        let ast = """
+let (+) a b = a + b
+"""
+                        |> getParseResults
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Let(bindings = [SynBinding(headPat=
+                    SynPat.LongIdent(longDotId = LongIdentWithTrivia([ ident ],_, [ Some (IdentTrivia.OriginalNotationWithParen(lpr, "+", rpr)) ])))
+                ])
+            ])])) ->
+            assertRange (2, 4) (2,5) lpr
+            Assert.AreEqual("op_Addition", ident.idText)
+            assertRange (2, 6) (2, 7) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``active pattern definition`` () =
+        let ast = """
+let (|Odd|Even|) (a: int) = if a % 2 = 0 then Even else Odd
+"""
+                        |> getParseResults
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Let(bindings = [SynBinding(headPat=
+                    SynPat.LongIdent(longDotId = LongIdentWithTrivia([ident], _, [Some (IdentTrivia.HasParenthesis(lpr, rpr))])))
+                ])
+            ])])) ->
+            assertRange (2, 4) (2, 5) lpr
+            Assert.AreEqual("|Odd|Even|", ident.idText)
+            assertRange (2, 15) (2, 16) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``partial active pattern definition`` () =
+        let ast = """
+let (|Int32Const|_|) (a: SynConst) = match a with SynConst.Int32 _ -> Some a | _ -> None
+"""
+                        |> getParseResults
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Let(bindings = [SynBinding(headPat=
+                    SynPat.LongIdent(longDotId = LongIdentWithTrivia([ident], _, [Some (IdentTrivia.HasParenthesis(lpr, rpr))])))
+                ])
+            ])])) ->
+             assertRange (2, 4) (2, 5) lpr
+             Assert.AreEqual("|Int32Const|_|", ident.idText)
+             assertRange (2, 19) (2, 20) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``operator name in SynValSig`` () =
+        let ast = """
+module IntrinsicOperators
+val (&): e1: bool -> e2: bool -> bool
+"""
+                        |> getParseResultsOfSignatureFile
+
+        match ast with
+        | ParsedInput.SigFile(ParsedSigFileInput(modules = [
+            SynModuleOrNamespaceSig(decls = [
+                SynModuleSigDecl.Val(valSig = SynValSig(ident = (ident, Some (IdentTrivia.OriginalNotationWithParen(lpr, "&", rpr)))
+                ))])
+            ])) ->
+            assertRange (3, 4) (3, 5) lpr
+            Assert.AreEqual("op_Amp", ident.idText)
+            assertRange (3, 6) (3, 7) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``operator name in val constraint`` () =
+        let ast =
+            getParseResultsOfSignatureFile """
+    [<AutoOpen>]
+    module Operators
+    /// <summary>Overloaded unary negation.</summary>
+    ///
+    /// <param name="n">The value to negate.</param>
+    ///
+    /// <returns>The result of the operation.</returns>
+    /// 
+    /// <example-tbd></example-tbd>
+    /// 
+    val inline (~-): n: ^T -> ^T when ^T: (static member ( ~- ): ^T -> ^T) and default ^T: int
+"""
+
+        match ast with
+        | ParsedInput.SigFile(ParsedSigFileInput(modules = [
+            SynModuleOrNamespaceSig(decls = [
+                SynModuleSigDecl.Val(valSig = SynValSig(synType=SynType.WithGlobalConstraints(constraints=[
+                    SynTypeConstraint.WhereTyparSupportsMember(memberSig=SynMemberSig.Member(memberSig=SynValSig(ident =
+                        (ident, Some (IdentTrivia.OriginalNotationWithParen(lpr, "~-", rpr))))))
+                    SynTypeConstraint.WhereTyparDefaultsToType _
+                ])))
+                ])
+            ])) ->
+            assertRange (12, 57) (12, 58) lpr
+            Assert.AreEqual("op_UnaryNegation", ident.idText)
+            assertRange (12, 62) (12, 63) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``named parameter`` () =
+        let ast = getParseResults """
+f(x=4)
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr(expr = SynExpr.App(argExpr = SynExpr.Paren(expr = SynExpr.App(funcExpr=
+                    SynExpr.App(funcExpr= SynExpr.Ident(ident, Some(IdentTrivia.OriginalNotation "=")))))))
+                ])
+            ])) ->
+            Assert.AreEqual("op_Equality", ident.idText)
+            assertRange (2,3) (2,4) ident.idRange
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``infix operation`` () =
+        let ast = getParseResults """
+1 + 1
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr(expr =
+                    SynExpr.App(funcExpr = SynExpr.App(isInfix = true
+                                                       funcExpr = SynExpr.Ident(ident, Some (IdentTrivia.OriginalNotation "+"))
+                                                       argExpr = SynExpr.Const(SynConst.Int32(1), _))
+                                argExpr = SynExpr.Const(SynConst.Int32(1), _)))
+                ])
+            ])) ->
+            Assert.AreEqual("op_Addition", ident.idText)
+            assertRange (2,2) (2,3) ident.idRange
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``detect difference between compiled operators`` () =
+        let ast = getParseResults """
+(+) a b
+op_Addition a b
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr(expr =
+                    SynExpr.App(funcExpr = SynExpr.App(isInfix = false
+                                                       funcExpr = SynExpr.Paren(SynExpr.Ident(ident, Some (IdentTrivia.OriginalNotation "+")), lpr, Some rpr, pr)
+                                                       argExpr = SynExpr.Ident (a1, None))
+                                argExpr = SynExpr.Ident (b1, None)))
+                SynModuleDecl.Expr(expr =
+                    SynExpr.App(funcExpr = SynExpr.App(isInfix = false
+                                                       funcExpr = SynExpr.Ident (op_Addition, None)
+                                                       argExpr = SynExpr.Ident (a2, None))
+                                argExpr = SynExpr.Ident (b2, None))
+                    )
+                ])
+            ])) ->
+            assertRange (2,0) (2,1) lpr
+            Assert.AreEqual("op_Addition", ident.idText)
+            assertRange (2,2) (2,3) rpr
+            assertRange (2,0) (2,3) pr
+            Assert.AreEqual("a", a1.idText)
+            Assert.AreEqual("b", b1.idText)
+
+            Assert.AreEqual("op_Addition", op_Addition.idText)
+            Assert.AreEqual("a", a2.idText)
+            Assert.AreEqual("b", b2.idText)
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``operator in member definition`` () =
+        let ast = getParseResults """
+type X with
+    member _.(+) a b = a + b
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Types(typeDefns = [
+                    SynTypeDefn(members = [
+                        SynMemberDefn.Member(memberDefn = SynBinding(headPat = SynPat.LongIdent(longDotId =
+                            LongIdentWithTrivia([ _; operatorIdent ], [ mDot ], [ None; Some (IdentTrivia.OriginalNotationWithParen(lpr, "+", rpr)) ]) as lid)))
+                    ])
+                    ]
+                )
+                ])
+            ])) ->
+            assertRange (3,12) (3,13) mDot
+            assertRange (3,13) (3,14) lpr
+            Assert.AreEqual("op_Addition", operatorIdent.idText)
+            assertRange (3,15) (3,16) rpr
+            assertRange (3,11) (3,15) lid.Range
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``nameof operator`` () =
+        let ast = getParseResults """
+nameof(+)
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr(expr =
+                                    SynExpr.App(isInfix = false
+                                                funcExpr = SynExpr.Ident (nameofIdent, None)
+                                                argExpr = SynExpr.Paren(SynExpr.Ident(operatorIdent, Some (IdentTrivia.OriginalNotation "+")), lpr, Some rpr, pr)))
+                ])
+            ])) ->
+            Assert.AreEqual("nameof", nameofIdent.idText)
+            assertRange (2,6) (2,7) lpr
+            Assert.AreEqual("op_Addition", operatorIdent.idText)
+            assertRange (2,8) (2,9) rpr
+            assertRange (2,6) (2,9) pr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``optional expression`` () =
+        let ast = getParseResults """
+f(?x = 7)
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Expr(expr =
+                                    SynExpr.App(isInfix = false
+                                                funcExpr = SynExpr.Ident (f, None)
+                                                argExpr = SynExpr.Paren(
+                                                    SynExpr.App(funcExpr = SynExpr.App(
+                                                                    isInfix = true
+                                                                    funcExpr = SynExpr.Ident(eqIdent, Some (IdentTrivia.OriginalNotation "="))
+                                                                    argExpr = SynExpr.LongIdent(true, LongIdentWithTrivia([x], [], [None]), _, mOptional)
+                                                                )
+                                                                argExpr = SynExpr.Const(SynConst.Int32 7, _)), lpr, Some rpr, pr)))
+                ])
+            ])) ->
+            Assert.AreEqual("f", f.idText)
+            assertRange (2,1) (2,2) lpr
+            Assert.AreEqual("x", x.idText)
+            assertRange (2,3) (2, 4) mOptional
+            Assert.AreEqual("op_Equality", eqIdent.idText)
+            assertRange (2,8) (2,9) rpr
+            assertRange (2,1) (2,9) pr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``object model with two members`` () =
+        let ast = getParseResults """
+type X() =
+    let mutable allowInto = 0
+    member _.AllowIntoPattern with get() = allowInto and set v = allowInto <- v
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Types(typeDefns = [
+                    SynTypeDefn.SynTypeDefn(typeRepr = SynTypeDefnRepr.ObjectModel(members =[
+                        SynMemberDefn.ImplicitCtor _
+                        SynMemberDefn.LetBindings _
+                        SynMemberDefn.Member(memberDefn = SynBinding(headPat = SynPat.LongIdent(longDotId = LongIdentWithTrivia(id = [ _ ; allowIntoPatternGet ])
+                                                                                                propertyKeyword = Some (PropertyKeyword.With mWith))))
+                        SynMemberDefn.Member(memberDefn = SynBinding(headPat = SynPat.LongIdent(longDotId = LongIdentWithTrivia(id = [ _ ; allowIntoPatternSet ])
+                                                                                                propertyKeyword = Some (PropertyKeyword.And mAnd))))
+                    ]))
+                ])
+            ])
+            ])) ->
+            Assert.AreEqual("AllowIntoPattern", allowIntoPatternGet.idText)
+            assertRange (4, 30) (4, 34) mWith
+            Assert.AreEqual("AllowIntoPattern", allowIntoPatternSet.idText)
+            assertRange (4, 53) (4, 56) mAnd
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``qualified operator expression`` () =
+        let ast = getParseResults """
+let PowByte (x:byte) n = Checked.( * ) x
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Let(bindings = [
+                    SynBinding(expr = SynExpr.App(funcExpr =
+                        SynExpr.LongIdent(longDotId = LongIdentWithTrivia([checkedIdent; operatorIdent], [mDot], [None; Some (IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr))]))))
+                ])
+            ])
+            ])) ->
+            Assert.AreEqual("Checked", checkedIdent.idText)
+            assertRange (2, 32) (2, 33) mDot
+            assertRange (2, 33) (2, 34) lpr
+            Assert.AreEqual("op_Multiply", operatorIdent.idText)
+            assertRange (2, 37) (2, 38) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    [<Test>]
+    let ``active pattern identifier in private member`` () =
+        let ast = getParseResults """
+type A() =
+    member private _.(|
+        A'
+    |) = (|
+        Lazy
+    |)
+"""
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Types(typeDefns = [
+                    SynTypeDefn(typeRepr = SynTypeDefnRepr.ObjectModel(members = [
+                        SynMemberDefn.ImplicitCtor _
+                        SynMemberDefn.Member(memberDefn = SynBinding(
+                            headPat = SynPat.LongIdent(longDotId = LongIdentWithTrivia([underscoreIdent; aQuoteIdent], [ mDot ], [ None; Some (IdentTrivia.HasParenthesis(lpr, rpr)) ]))
+                        ))
+                    ]))
+                ])
+            ])
+            ])) ->
+            ()
+            Assert.AreEqual("_", underscoreIdent.idText)
+            Assert.AreEqual("|A'|", aQuoteIdent.idText)
+            assertRange (3, 21) (3, 22) lpr
+            assertRange (5, 5) (5, 6) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+
+
+// TODO:
+// add test for global (SynExpr.Ident mangledGlobalName)

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -4068,6 +4068,27 @@ let (|Int32Const|_|) (a: SynConst) = match a with SynConst.Int32 _ -> Some a | _
             Assert.Fail $"Could not get valid AST, got {ast}"
 
     [<Test>]
+    let ``partial active pattern definition without parameters`` () =
+        let ast = """
+let (|Boolean|_|) = Boolean.parse
+"""
+                        |> getParseResults
+
+        match ast with
+        | ParsedInput.ImplFile(ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Let(bindings = [SynBinding(headPat=
+                    SynPat.Named(ident = SynIdent(ident, Some (IdentTrivia.HasParenthesis(lpr, rpr)))))
+                ])
+            ])])) ->
+             assertRange (2, 4) (2, 5) lpr
+             Assert.AreEqual("|Boolean|_|", ident.idText)
+             assertRange (2, 16) (2, 17) rpr
+        | _ ->
+            Assert.Fail $"Could not get valid AST, got {ast}"
+
+    
+    [<Test>]
     let ``operator name in SynValSig`` () =
         let ast = """
 module IntrinsicOperators

--- a/tests/service/TreeVisitorTests.fs
+++ b/tests/service/TreeVisitorTests.fs
@@ -44,7 +44,7 @@ let ``Visit union definition test`` () =
     let parseTree = parseSourceCode("C:\\test.fs", source)
 
     match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
-    | Some [ SynUnionCase (ident=id1); SynUnionCase (ident=id2) ] when id1.idText = "A" && id2.idText = "B" -> ()
+    | Some [ SynUnionCase (ident=(id1,_)); SynUnionCase (ident=(id2,_)) ] when id1.idText = "A" && id2.idText = "B" -> ()
     | _ -> failwith "Did not visit union definition"
 
 [<Test>]
@@ -57,5 +57,5 @@ let ``Visit enum definition test`` () =
     let parseTree = parseSourceCode("C:\\test.fs", source)
 
     match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
-    | Some [ SynEnumCase (_, id1, _, _, _, _, _); SynEnumCase (_, id2, _, _, _, _, _) ] when id1.idText = "A" && id2.idText = "B" -> ()
+    | Some [ SynEnumCase (_, (id1,_), _, _, _, _, _); SynEnumCase (_, (id2,_), _, _, _, _, _) ] when id1.idText = "A" && id2.idText = "B" -> ()
     | _ -> failwith "Did not visit enum definition"

--- a/tests/service/TreeVisitorTests.fs
+++ b/tests/service/TreeVisitorTests.fs
@@ -44,7 +44,7 @@ let ``Visit union definition test`` () =
     let parseTree = parseSourceCode("C:\\test.fs", source)
 
     match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
-    | Some [ SynUnionCase (ident=(id1,_)); SynUnionCase (ident=(id2,_)) ] when id1.idText = "A" && id2.idText = "B" -> ()
+    | Some [ SynUnionCase (ident = SynIdent(id1,_)); SynUnionCase (ident = SynIdent(id2,_)) ] when id1.idText = "A" && id2.idText = "B" -> ()
     | _ -> failwith "Did not visit union definition"
 
 [<Test>]
@@ -57,5 +57,5 @@ let ``Visit enum definition test`` () =
     let parseTree = parseSourceCode("C:\\test.fs", source)
 
     match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
-    | Some [ SynEnumCase (_, (id1,_), _, _, _, _, _); SynEnumCase (_, (id2,_), _, _, _, _, _) ] when id1.idText = "A" && id2.idText = "B" -> ()
+    | Some [ SynEnumCase (_, SynIdent(id1,_), _, _, _, _, _); SynEnumCase (_, SynIdent(id2,_), _, _, _, _, _) ] when id1.idText = "A" && id2.idText = "B" -> ()
     | _ -> failwith "Did not visit enum definition"

--- a/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
@@ -35,7 +35,7 @@ type FSharpParseFileResults with
                 match expr with
                 | SynExpr.DotGet(expr, _, _, range) ->
                     match expr with
-                    | SynExpr.TypeApp(SynExpr.Ident(ident, _), _, typeArgs, _, _, _, _) ->
+                    | SynExpr.TypeApp(SynExpr.Ident ident, _, typeArgs, _, _, _, _) ->
                         let onlyOneTypeArg =
                             match typeArgs with
                             | [] -> false

--- a/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
@@ -35,7 +35,7 @@ type FSharpParseFileResults with
                 match expr with
                 | SynExpr.DotGet(expr, _, _, range) ->
                     match expr with
-                    | SynExpr.TypeApp(SynExpr.Ident(ident), _, typeArgs, _, _, _, _) ->
+                    | SynExpr.TypeApp(SynExpr.Ident(ident, _), _, typeArgs, _, _, _, _) ->
                         let onlyOneTypeArg =
                             match typeArgs with
                             | [] -> false


### PR DESCRIPTION
In this PR, I'd like to address https://github.com/dotnet/fsharp/issues/11893.
The key concept is that the `Ident`s are enriched with additional information where applicable.
@dsyme I must say this approach is growing on me.
I've addressed all the review remarks and would happily address any other feedback.

The build is green I believe, there is one error about `[error]Publishing build artifacts failed with an error: Not found PathtoPublish: D:\a\_work\1\s\artifacts\log\Release` which looks unrelated.