### PR TITLE
Fix https://github.com/dotnet/fsharp/issues/13043

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -5850,13 +5850,14 @@ and TcNonControlFlowExpr (env: TcEnv) f =
         | NotedSourceConstruct.Combine
         | NotedSourceConstruct.With
         | NotedSourceConstruct.While
-        | NotedSourceConstruct.DelayOrQuoteOrRun -> 
+        | NotedSourceConstruct.DelayOrQuoteOrRun ->
             res, tpenv
         | NotedSourceConstruct.None ->
             // Skip outer debug point for "e1 && e2" and "e1 || e2"
             let res2 =
                 match res with
                 | IfThenElseExpr _ -> res
+                | FunctionMatchExpr _ -> res
                 | _ -> mkDebugPoint res.Range res
             res2, tpenv
     else

--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -5857,7 +5857,7 @@ and TcNonControlFlowExpr (env: TcEnv) f =
             let res2 =
                 match res with
                 | IfThenElseExpr _ -> res
-                | FunctionMatchExpr _ -> res
+                | MatchLambdaExpr _ -> res
                 | _ -> mkDebugPoint res.Range res
             res2, tpenv
     else

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -9760,6 +9760,18 @@ let (|IfThenElseExpr|_|) expr =
         Some (cond, thenExpr,  elseExpr)
     | _ -> None
 
+/// Match a functionmatch expression
+let (|FunctionMatchExpr|_|) expr =
+    match expr with
+    | Expr.Lambda(_a,_b,_c,_d,bodyExpr,_f,_g) ->
+        match bodyExpr with
+        | Expr.Let (_a, bodyExpr, _c, _d) ->
+            match bodyExpr with
+            | Expr.Match (_a, _b, _c, _d, _e, _f) -> Some(expr)
+            | _ -> None
+        | _ -> None
+    | _ -> None
+
 /// if __useResumableCode then ... else ...
 let (|IfUseResumableStateMachinesExpr|_|) g expr =
     match expr with

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -9761,7 +9761,7 @@ let (|IfThenElseExpr|_|) expr =
     | _ -> None
 
 /// Match a functionmatch expression
-let (|FunctionMatchExpr|_|) expr =
+let (|MatchLambdaExpr|_|) expr =
     match expr with
     | Expr.Lambda(_, _, _, _, bodyExpr, _ ,_) ->
         match bodyExpr with

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -9763,13 +9763,8 @@ let (|IfThenElseExpr|_|) expr =
 /// Match a functionmatch expression
 let (|MatchLambdaExpr|_|) expr =
     match expr with
-    | Expr.Lambda(_, _, _, _, bodyExpr, _ ,_) ->
-        match bodyExpr with
-        | Expr.Let (_, bodyExpr, _, _) ->
-            match bodyExpr with
-            | Expr.Match (_, _, _, _, _, _) -> Some(expr)
-            | _ -> None
-        | _ -> None
+    | Expr.Lambda(_, _, _, _, _, _ ,_) -> Some (expr)
+    | Expr.TyLambda(_, _, _, _, _) -> Some (expr)
     | _ -> None
 
 /// if __useResumableCode then ... else ...

--- a/src/fsharp/TypedTreeOps.fs
+++ b/src/fsharp/TypedTreeOps.fs
@@ -9763,11 +9763,11 @@ let (|IfThenElseExpr|_|) expr =
 /// Match a functionmatch expression
 let (|FunctionMatchExpr|_|) expr =
     match expr with
-    | Expr.Lambda(_a,_b,_c,_d,bodyExpr,_f,_g) ->
+    | Expr.Lambda(_, _, _, _, bodyExpr, _ ,_) ->
         match bodyExpr with
-        | Expr.Let (_a, bodyExpr, _c, _d) ->
+        | Expr.Let (_, bodyExpr, _, _) ->
             match bodyExpr with
-            | Expr.Match (_a, _b, _c, _d, _e, _f) -> Some(expr)
+            | Expr.Match (_, _, _, _, _, _) -> Some(expr)
             | _ -> None
         | _ -> None
     | _ -> None

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -2547,5 +2547,8 @@ val mkDebugPoint: m: range -> expr: Expr -> Expr
 /// Match an if...then...else expression or the result of "a && b" or "a || b"
 val (|IfThenElseExpr|_|): expr: Expr -> (Expr * Expr * Expr) option
 
+/// Match an if...then...else expression or the result of "a && b" or "a || b"
+val (|FunctionMatchExpr|_|): expr: Expr -> Expr option
+
 /// Determine if a value is a method implementing an interface dispatch slot using a private method impl
 val ComputeUseMethodImpl: g: TcGlobals -> v: Val -> bool

--- a/src/fsharp/TypedTreeOps.fsi
+++ b/src/fsharp/TypedTreeOps.fsi
@@ -2548,7 +2548,7 @@ val mkDebugPoint: m: range -> expr: Expr -> Expr
 val (|IfThenElseExpr|_|): expr: Expr -> (Expr * Expr * Expr) option
 
 /// Match an if...then...else expression or the result of "a && b" or "a || b"
-val (|FunctionMatchExpr|_|): expr: Expr -> Expr option
+val (|MatchLambdaExpr|_|): expr: Expr -> Expr option
 
 /// Determine if a value is a method implementing an interface dispatch slot using a private method impl
 val ComputeUseMethodImpl: g: TcGlobals -> v: Val -> bool

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
@@ -258,6 +258,7 @@ module TestFunctions =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"Verify13043.fs"|])>]
     let ``Verify13043_il`` compilation =
         compilation
+        |> withDebug
         |> verifyCompilation
 
     // Verify Execution 13043

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
@@ -261,11 +261,21 @@ module TestFunctions =
         |> withDebug
         |> verifyCompilation
 
-    // Verify Execution 13043
+    // Verify Execution 13043 run it built not optimized with debug
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"Verify13043.fs"|])>]
-    let ``Verify13043_execution`` compilation =
+    let ``Verify13043_execution_noopt`` compilation =
         compilation
         |> withDebug
         |> verifyCompileAndRun
         |> shouldSucceed
 
+    // Verify Execution 13043 --- run it built optimized no debug
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"Verify13043.fs"|])>]
+    let ``Verify13043_execution_opt`` compilation =
+        compilation
+        |> withOptions [ "--test:EmitFeeFeeAs100001"; "--nowarn:988"; "--nowarn:3370"]
+        |> withOptimize
+        |> withNoDebug
+        |> asExe
+        |> verifyCompileAndRun
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
@@ -273,9 +273,9 @@ module TestFunctions =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"Verify13043.fs"|])>]
     let ``Verify13043_execution_opt`` compilation =
         compilation
+        |> asExe
         |> withOptions [ "--test:EmitFeeFeeAs100001"; "--nowarn:988"; "--nowarn:3370"]
         |> withOptimize
         |> withNoDebug
-        |> asExe
-        |> verifyCompileAndRun
+        |> compileAndRun
         |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
@@ -264,5 +264,7 @@ module TestFunctions =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"Verify13043.fs"|])>]
     let ``Verify13043_execution`` compilation =
         compilation
-        |> verifyCompileAndRun 
+        |> withDebug
+        |> verifyCompileAndRun
+        |> shouldSucceed
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunctions.fs
@@ -7,14 +7,23 @@ open FSharp.Test.Compiler
 
 module TestFunctions =
 
-    let verifyCompilation compilation =
+    let verifyCore compilation =
         compilation
-        |> withOptions [ "--test:EmitFeeFeeAs100001" ]
+        |> withOptions [ "--test:EmitFeeFeeAs100001"; "--nowarn:988"; "--nowarn:3370"]
         |> asExe
         |> withNoOptimize
         |> withEmbeddedPdb
         |> withEmbedAllSource
         |> ignoreWarnings
+
+    let verifyCompileAndRun compilation =
+        compilation
+        |> verifyCore
+        |> compileAndRun
+
+    let verifyCompilation compilation =
+        compilation
+        |> verifyCore
         |> verifyILBaseline
 
     //SOURCE=TestFunction01.fs   SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd TestFunction01.exe"	# TestFunction01.fs
@@ -244,4 +253,16 @@ module TestFunctions =
     let ``TestFunction24_fs`` compilation =
         compilation
         |> verifyCompilation
+
+    // Verify IL 13043
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"Verify13043.fs"|])>]
+    let ``Verify13043_il`` compilation =
+        compilation
+        |> verifyCompilation
+
+    // Verify Execution 13043
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"Verify13043.fs"|])>]
+    let ``Verify13043_execution`` compilation =
+        compilation
+        |> verifyCompileAndRun 
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs
@@ -1,0 +1,48 @@
+module Verify13043
+
+let list = [1; 2; 3]
+let condition n = n < 3
+
+let dropWhileWithMatch condition list =
+  let rec f (l : List<int>) : List<int> =
+    match l with
+    | [] -> []
+    | head :: tail ->
+      match condition head with
+      | true -> f tail
+      | false -> head :: tail
+
+  f list
+
+(*
+  This function caused an Unhandled exception at execution time:
+
+  Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
+   at Program.f@14-1.Invoke(FSharpList`1 _arg1) in /workspaces/function-rec-fsharp-dotnet7-bug-demo/Program.fs:line 18
+   at Program.dropWhileWithFunction(FSharpFunc`2 condition, FSharpList`1 list) in /workspaces/function-rec-fsharp-dotnet7-bug-demo/Program.fs:line 21
+   at <StartupCode$function-rec-fsharp-dotnet7-bug-demo>.$Program.main@() in /workspaces/function-rec-fsharp-dotnet7-bug-demo/Program.fs:line 29
+*)
+let dropWhileWithFunction condition list =
+  let rec f : List<int> -> List<int> =
+    function
+    | [] -> []
+    | head :: tail ->
+      match condition head with
+      | true -> f tail
+      | false -> head :: tail
+
+  f list
+
+
+// this runs fine:
+let matchResult = dropWhileWithMatch condition list
+printfn "Match: %A" matchResult
+
+
+// and this results in a null reference exception
+let functionResult = dropWhileWithFunction condition list
+printfn "Function: %A" functionResult
+
+
+7 |> (fun x -> match x with | 6 -> printfn "6" | _ -> printfn "Not 6")
+

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs
@@ -42,7 +42,3 @@ printfn "Match: %A" matchResult
 // and this results in a null reference exception
 let functionResult = dropWhileWithFunction condition list
 printfn "Function: %A" functionResult
-
-
-7 |> (fun x -> match x with | 6 -> printfn "6" | _ -> printfn "Not 6")
-

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.il.debug.bsl
@@ -4,10 +4,10 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
@@ -21,7 +21,7 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
@@ -37,19 +37,19 @@
   // WARNING: managed resource file FSharpOptimizationData.Verify13043 created
 }
 .module Verify13043.exe
-// MVID: {626B09D1-A4BE-F155-A745-0383D1096B62}
+// MVID: {626B3FB3-9119-C695-A745-0383B33F6B62}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00000267ACA50000
+// Image base: 0x02D60000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed Verify13043
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class auto ansi serializable sealed nested assembly beforefieldinit f@8
@@ -59,8 +59,8 @@
     .method assembly specialname rtspecialname 
             instance void  .ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -127,8 +127,8 @@
     .method assembly specialname rtspecialname 
             instance void  .ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -194,8 +194,8 @@
     .method assembly specialname rtspecialname 
             instance void  .ctor() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -232,8 +232,8 @@
     .method assembly specialname rtspecialname 
             instance void  .ctor() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -357,28 +357,26 @@
 } // end of class Verify13043
 
 .class private abstract auto ansi sealed '<StartupCode$Verify13043>'.$Verify13043
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list@3
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> matchResult@38
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> functionResult@43
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly int32 init@
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       184 (0xb8)
+    // Code size       127 (0x7f)
     .maxstack  6
     .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
              class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
-             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2,
-             int32 V_3,
-             int32 V_4)
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2)
     IL_0000:  ldc.i4.1
     IL_0001:  ldc.i4.2
     IL_0002:  ldc.i4.3
@@ -400,8 +398,8 @@
     IL_002e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::matchResult@38
     IL_0033:  stloc.1
     IL_0034:  ldstr      "Match: %A"
-    IL_0039:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
-    IL_003e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0039:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
+    IL_003e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0043:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_matchResult()
     IL_0048:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
     IL_004d:  pop
@@ -413,36 +411,12 @@
     IL_005e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::functionResult@43
     IL_0063:  stloc.2
     IL_0064:  ldstr      "Function: %A"
-    IL_0069:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
-    IL_006e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0069:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
+    IL_006e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0073:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_functionResult()
     IL_0078:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
     IL_007d:  pop
-    IL_007e:  ldc.i4.7
-    IL_007f:  stloc.3
-    IL_0080:  ldloc.3
-    IL_0081:  stloc.s    V_4
-    IL_0083:  nop
-    IL_0084:  ldloc.s    V_4
-    IL_0086:  ldc.i4.6
-    IL_0087:  sub
-    IL_0088:  switch     ( 
-                          IL_0093)
-    IL_0091:  br.s       IL_00a6
-
-    IL_0093:  ldstr      "6"
-    IL_0098:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-    IL_009d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-    IL_00a2:  pop
-    IL_00a3:  nop
-    IL_00a4:  br.s       IL_00b7
-
-    IL_00a6:  ldstr      "Not 6"
-    IL_00ab:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-    IL_00b0:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-    IL_00b5:  pop
-    IL_00b6:  nop
-    IL_00b7:  ret
+    IL_007e:  ret
   } // end of method $Verify13043::main@
 
 } // end of class '<StartupCode$Verify13043>'.$Verify13043
@@ -451,4 +425,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\TestFunctions\Verify13043_il\Verify13043.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\TestFunctions\Verify13043_il\Verify13043.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.il.debug.bsl
@@ -1,0 +1,454 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0-preview.7.20364.11
+
+
+
+// Metadata version: v4.0.30319
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 6:0:0:0
+}
+.assembly extern FSharp.Core
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 6:0:0:0
+}
+.assembly Verify13043
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32,
+                                                                                                      int32,
+                                                                                                      int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.mresource public FSharpSignatureData.Verify13043
+{
+  // Offset: 0x00000000 Length: 0x0000036E
+  // WARNING: managed resource file FSharpSignatureData.Verify13043 created
+}
+.mresource public FSharpOptimizationData.Verify13043
+{
+  // Offset: 0x00000378 Length: 0x000000F1
+  // WARNING: managed resource file FSharpOptimizationData.Verify13043 created
+}
+.module Verify13043.exe
+// MVID: {626B09D1-A4BE-F155-A745-0383D1096B62}
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x00000267ACA50000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public abstract auto ansi sealed Verify13043
+       extends [System.Runtime]System.Object
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+  .class auto ansi serializable sealed nested assembly beforefieldinit f@8
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>
+  {
+    .field public class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition
+    .method assembly specialname rtspecialname 
+            instance void  .ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition) cil managed
+    {
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       14 (0xe)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor()
+      IL_0006:  ldarg.0
+      IL_0007:  ldarg.1
+      IL_0008:  stfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> Verify13043/f@8::condition
+      IL_000d:  ret
+    } // end of method f@8::.ctor
+
+    .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+            Invoke(class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> l) cil managed
+    {
+      // Code size       63 (0x3f)
+      .maxstack  6
+      .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2,
+               int32 V_3)
+      IL_0000:  nop
+      IL_0001:  ldarg.1
+      IL_0002:  stloc.0
+      IL_0003:  ldloc.0
+      IL_0004:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+      IL_0009:  brfalse.s  IL_000d
+
+      IL_000b:  br.s       IL_0013
+
+      IL_000d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+      IL_0012:  ret
+
+      IL_0013:  ldloc.0
+      IL_0014:  stloc.1
+      IL_0015:  ldloc.1
+      IL_0016:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+      IL_001b:  stloc.2
+      IL_001c:  ldloc.1
+      IL_001d:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
+      IL_0022:  stloc.3
+      IL_0023:  nop
+      IL_0024:  ldarg.0
+      IL_0025:  ldfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> Verify13043/f@8::condition
+      IL_002a:  ldloc.3
+      IL_002b:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
+      IL_0030:  brfalse.s  IL_0037
+
+      IL_0032:  ldloc.2
+      IL_0033:  starg.s    l
+      IL_0035:  br.s       IL_0000
+
+      IL_0037:  ldloc.3
+      IL_0038:  ldloc.2
+      IL_0039:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+      IL_003e:  ret
+    } // end of method f@8::Invoke
+
+  } // end of class f@8
+
+  .class auto ansi serializable sealed nested assembly beforefieldinit 'f@27-1'
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>
+  {
+    .field public class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition
+    .method assembly specialname rtspecialname 
+            instance void  .ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition) cil managed
+    {
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       14 (0xe)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor()
+      IL_0006:  ldarg.0
+      IL_0007:  ldarg.1
+      IL_0008:  stfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> Verify13043/'f@27-1'::condition
+      IL_000d:  ret
+    } // end of method 'f@27-1'::.ctor
+
+    .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+            Invoke(class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> _arg1) cil managed
+    {
+      // Code size       62 (0x3e)
+      .maxstack  6
+      .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2,
+               int32 V_3)
+      IL_0000:  ldarg.1
+      IL_0001:  stloc.0
+      IL_0002:  ldloc.0
+      IL_0003:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+      IL_0008:  brfalse.s  IL_000c
+
+      IL_000a:  br.s       IL_0012
+
+      IL_000c:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+      IL_0011:  ret
+
+      IL_0012:  ldloc.0
+      IL_0013:  stloc.1
+      IL_0014:  ldloc.1
+      IL_0015:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+      IL_001a:  stloc.2
+      IL_001b:  ldloc.1
+      IL_001c:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
+      IL_0021:  stloc.3
+      IL_0022:  nop
+      IL_0023:  ldarg.0
+      IL_0024:  ldfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> Verify13043/'f@27-1'::condition
+      IL_0029:  ldloc.3
+      IL_002a:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
+      IL_002f:  brfalse.s  IL_0036
+
+      IL_0031:  ldloc.2
+      IL_0032:  starg.s    _arg1
+      IL_0034:  br.s       IL_0000
+
+      IL_0036:  ldloc.3
+      IL_0037:  ldloc.2
+      IL_0038:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+      IL_003d:  ret
+    } // end of method 'f@27-1'::Invoke
+
+  } // end of class 'f@27-1'
+
+  .class auto ansi serializable sealed nested assembly beforefieldinit matchResult@38
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
+  {
+    .field static assembly initonly class Verify13043/matchResult@38 @_instance
+    .method assembly specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
+      IL_0006:  ret
+    } // end of method matchResult@38::.ctor
+
+    .method public strict virtual instance bool 
+            Invoke(int32 n) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  call       bool Verify13043::condition(int32)
+      IL_0006:  ret
+    } // end of method matchResult@38::Invoke
+
+    .method private specialname rtspecialname static 
+            void  .cctor() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  10
+      IL_0000:  newobj     instance void Verify13043/matchResult@38::.ctor()
+      IL_0005:  stsfld     class Verify13043/matchResult@38 Verify13043/matchResult@38::@_instance
+      IL_000a:  ret
+    } // end of method matchResult@38::.cctor
+
+  } // end of class matchResult@38
+
+  .class auto ansi serializable sealed nested assembly beforefieldinit functionResult@43
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
+  {
+    .field static assembly initonly class Verify13043/functionResult@43 @_instance
+    .method assembly specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
+      IL_0006:  ret
+    } // end of method functionResult@43::.ctor
+
+    .method public strict virtual instance bool 
+            Invoke(int32 n) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  call       bool Verify13043::condition(int32)
+      IL_0006:  ret
+    } // end of method functionResult@43::Invoke
+
+    .method private specialname rtspecialname static 
+            void  .cctor() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  10
+      IL_0000:  newobj     instance void Verify13043/functionResult@43::.ctor()
+      IL_0005:  stsfld     class Verify13043/functionResult@43 Verify13043/functionResult@43::@_instance
+      IL_000a:  ret
+    } // end of method functionResult@43::.cctor
+
+  } // end of class functionResult@43
+
+  .method public specialname static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          get_list() cil managed
+  {
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::list@3
+    IL_0005:  ret
+  } // end of method Verify13043::get_list
+
+  .method public static bool  condition(int32 n) cil managed
+  {
+    // Code size       5 (0x5)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldc.i4.3
+    IL_0002:  clt
+    IL_0004:  ret
+  } // end of method Verify13043::condition
+
+  .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          dropWhileWithMatch(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition,
+                             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list) cil managed
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
+    // Code size       17 (0x11)
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>> V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  newobj     instance void Verify13043/f@8::.ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>)
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldarg.1
+    IL_0009:  tail.
+    IL_000b:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::Invoke(!0)
+    IL_0010:  ret
+  } // end of method Verify13043::dropWhileWithMatch
+
+  .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          dropWhileWithFunction(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition,
+                                class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list) cil managed
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
+    // Code size       17 (0x11)
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>> V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  newobj     instance void Verify13043/'f@27-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>)
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldarg.1
+    IL_0009:  tail.
+    IL_000b:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::Invoke(!0)
+    IL_0010:  ret
+  } // end of method Verify13043::dropWhileWithFunction
+
+  .method public specialname static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          get_matchResult() cil managed
+  {
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::matchResult@38
+    IL_0005:  ret
+  } // end of method Verify13043::get_matchResult
+
+  .method public specialname static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          get_functionResult() cil managed
+  {
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::functionResult@43
+    IL_0005:  ret
+  } // end of method Verify13043::get_functionResult
+
+  .property class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>
+          list()
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
+    .get class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_list()
+  } // end of property Verify13043::list
+  .property class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>
+          matchResult()
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
+    .get class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_matchResult()
+  } // end of property Verify13043::matchResult
+  .property class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>
+          functionResult()
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
+    .get class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_functionResult()
+  } // end of property Verify13043::functionResult
+} // end of class Verify13043
+
+.class private abstract auto ansi sealed '<StartupCode$Verify13043>'.$Verify13043
+       extends [System.Runtime]System.Object
+{
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list@3
+  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> matchResult@38
+  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> functionResult@43
+  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .field static assembly int32 init@
+  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public static void  main@() cil managed
+  {
+    .entrypoint
+    // Code size       184 (0xb8)
+    .maxstack  6
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2,
+             int32 V_3,
+             int32 V_4)
+    IL_0000:  ldc.i4.1
+    IL_0001:  ldc.i4.2
+    IL_0002:  ldc.i4.3
+    IL_0003:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_0008:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_000d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_0012:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_0017:  dup
+    IL_0018:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::list@3
+    IL_001d:  stloc.0
+    IL_001e:  ldsfld     class Verify13043/matchResult@38 Verify13043/matchResult@38::@_instance
+    IL_0023:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_list()
+    IL_0028:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::dropWhileWithMatch(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>,
+                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>)
+    IL_002d:  dup
+    IL_002e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::matchResult@38
+    IL_0033:  stloc.1
+    IL_0034:  ldstr      "Match: %A"
+    IL_0039:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
+    IL_003e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0043:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_matchResult()
+    IL_0048:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
+    IL_004d:  pop
+    IL_004e:  ldsfld     class Verify13043/functionResult@43 Verify13043/functionResult@43::@_instance
+    IL_0053:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_list()
+    IL_0058:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::dropWhileWithFunction(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>,
+                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>)
+    IL_005d:  dup
+    IL_005e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::functionResult@43
+    IL_0063:  stloc.2
+    IL_0064:  ldstr      "Function: %A"
+    IL_0069:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
+    IL_006e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0073:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_functionResult()
+    IL_0078:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
+    IL_007d:  pop
+    IL_007e:  ldc.i4.7
+    IL_007f:  stloc.3
+    IL_0080:  ldloc.3
+    IL_0081:  stloc.s    V_4
+    IL_0083:  nop
+    IL_0084:  ldloc.s    V_4
+    IL_0086:  ldc.i4.6
+    IL_0087:  sub
+    IL_0088:  switch     ( 
+                          IL_0093)
+    IL_0091:  br.s       IL_00a6
+
+    IL_0093:  ldstr      "6"
+    IL_0098:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+    IL_009d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_00a2:  pop
+    IL_00a3:  nop
+    IL_00a4:  br.s       IL_00b7
+
+    IL_00a6:  ldstr      "Not 6"
+    IL_00ab:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+    IL_00b0:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_00b5:  pop
+    IL_00b6:  nop
+    IL_00b7:  ret
+  } // end of method $Verify13043::main@
+
+} // end of class '<StartupCode$Verify13043>'.$Verify13043
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\TestFunctions\Verify13043_il\Verify13043.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.il.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.il.release.bsl
@@ -37,13 +37,13 @@
   // WARNING: managed resource file FSharpOptimizationData.Verify13043 created
 }
 .module Verify13043.exe
-// MVID: {626B11CB-9119-C695-A745-0383CB116B62}
+// MVID: {626B3AAF-9119-C695-A745-0383AF3A6B62}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02F20000
+// Image base: 0x03AC0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -372,13 +372,11 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       184 (0xb8)
+    // Code size       127 (0x7f)
     .maxstack  6
     .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
              class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
-             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2,
-             int32 V_3,
-             int32 V_4)
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2)
     IL_0000:  ldc.i4.1
     IL_0001:  ldc.i4.2
     IL_0002:  ldc.i4.3
@@ -418,31 +416,7 @@
     IL_0073:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_functionResult()
     IL_0078:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
     IL_007d:  pop
-    IL_007e:  ldc.i4.7
-    IL_007f:  stloc.3
-    IL_0080:  ldloc.3
-    IL_0081:  stloc.s    V_4
-    IL_0083:  nop
-    IL_0084:  ldloc.s    V_4
-    IL_0086:  ldc.i4.6
-    IL_0087:  sub
-    IL_0088:  switch     ( 
-                          IL_0093)
-    IL_0091:  br.s       IL_00a6
-
-    IL_0093:  ldstr      "6"
-    IL_0098:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-    IL_009d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-    IL_00a2:  pop
-    IL_00a3:  nop
-    IL_00a4:  br.s       IL_00b7
-
-    IL_00a6:  ldstr      "Not 6"
-    IL_00ab:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-    IL_00b0:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-    IL_00b5:  pop
-    IL_00b6:  nop
-    IL_00b7:  ret
+    IL_007e:  ret
   } // end of method $Verify13043::main@
 
 } // end of class '<StartupCode$Verify13043>'.$Verify13043

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.il.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.il.release.bsl
@@ -1,0 +1,454 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0-preview.7.20364.11
+
+
+
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly extern FSharp.Core
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 6:0:0:0
+}
+.assembly Verify13043
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32,
+                                                                                                      int32,
+                                                                                                      int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.mresource public FSharpSignatureData.Verify13043
+{
+  // Offset: 0x00000000 Length: 0x00000372
+  // WARNING: managed resource file FSharpSignatureData.Verify13043 created
+}
+.mresource public FSharpOptimizationData.Verify13043
+{
+  // Offset: 0x00000378 Length: 0x000000F1
+  // WARNING: managed resource file FSharpOptimizationData.Verify13043 created
+}
+.module Verify13043.exe
+// MVID: {626B11CB-9119-C695-A745-0383CB116B62}
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x02F20000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public abstract auto ansi sealed Verify13043
+       extends [mscorlib]System.Object
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+  .class auto ansi serializable sealed nested assembly beforefieldinit f@8
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>
+  {
+    .field public class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition
+    .method assembly specialname rtspecialname 
+            instance void  .ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition) cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       14 (0xe)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor()
+      IL_0006:  ldarg.0
+      IL_0007:  ldarg.1
+      IL_0008:  stfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> Verify13043/f@8::condition
+      IL_000d:  ret
+    } // end of method f@8::.ctor
+
+    .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+            Invoke(class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> l) cil managed
+    {
+      // Code size       63 (0x3f)
+      .maxstack  6
+      .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2,
+               int32 V_3)
+      IL_0000:  nop
+      IL_0001:  ldarg.1
+      IL_0002:  stloc.0
+      IL_0003:  ldloc.0
+      IL_0004:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+      IL_0009:  brfalse.s  IL_000d
+
+      IL_000b:  br.s       IL_0013
+
+      IL_000d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+      IL_0012:  ret
+
+      IL_0013:  ldloc.0
+      IL_0014:  stloc.1
+      IL_0015:  ldloc.1
+      IL_0016:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+      IL_001b:  stloc.2
+      IL_001c:  ldloc.1
+      IL_001d:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
+      IL_0022:  stloc.3
+      IL_0023:  nop
+      IL_0024:  ldarg.0
+      IL_0025:  ldfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> Verify13043/f@8::condition
+      IL_002a:  ldloc.3
+      IL_002b:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
+      IL_0030:  brfalse.s  IL_0037
+
+      IL_0032:  ldloc.2
+      IL_0033:  starg.s    l
+      IL_0035:  br.s       IL_0000
+
+      IL_0037:  ldloc.3
+      IL_0038:  ldloc.2
+      IL_0039:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+      IL_003e:  ret
+    } // end of method f@8::Invoke
+
+  } // end of class f@8
+
+  .class auto ansi serializable sealed nested assembly beforefieldinit 'f@27-1'
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>
+  {
+    .field public class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition
+    .method assembly specialname rtspecialname 
+            instance void  .ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition) cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       14 (0xe)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor()
+      IL_0006:  ldarg.0
+      IL_0007:  ldarg.1
+      IL_0008:  stfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> Verify13043/'f@27-1'::condition
+      IL_000d:  ret
+    } // end of method 'f@27-1'::.ctor
+
+    .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+            Invoke(class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> _arg1) cil managed
+    {
+      // Code size       62 (0x3e)
+      .maxstack  6
+      .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2,
+               int32 V_3)
+      IL_0000:  ldarg.1
+      IL_0001:  stloc.0
+      IL_0002:  ldloc.0
+      IL_0003:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+      IL_0008:  brfalse.s  IL_000c
+
+      IL_000a:  br.s       IL_0012
+
+      IL_000c:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+      IL_0011:  ret
+
+      IL_0012:  ldloc.0
+      IL_0013:  stloc.1
+      IL_0014:  ldloc.1
+      IL_0015:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+      IL_001a:  stloc.2
+      IL_001b:  ldloc.1
+      IL_001c:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
+      IL_0021:  stloc.3
+      IL_0022:  nop
+      IL_0023:  ldarg.0
+      IL_0024:  ldfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> Verify13043/'f@27-1'::condition
+      IL_0029:  ldloc.3
+      IL_002a:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
+      IL_002f:  brfalse.s  IL_0036
+
+      IL_0031:  ldloc.2
+      IL_0032:  starg.s    _arg1
+      IL_0034:  br.s       IL_0000
+
+      IL_0036:  ldloc.3
+      IL_0037:  ldloc.2
+      IL_0038:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+      IL_003d:  ret
+    } // end of method 'f@27-1'::Invoke
+
+  } // end of class 'f@27-1'
+
+  .class auto ansi serializable sealed nested assembly beforefieldinit matchResult@38
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
+  {
+    .field static assembly initonly class Verify13043/matchResult@38 @_instance
+    .method assembly specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
+      IL_0006:  ret
+    } // end of method matchResult@38::.ctor
+
+    .method public strict virtual instance bool 
+            Invoke(int32 n) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  call       bool Verify13043::condition(int32)
+      IL_0006:  ret
+    } // end of method matchResult@38::Invoke
+
+    .method private specialname rtspecialname static 
+            void  .cctor() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  10
+      IL_0000:  newobj     instance void Verify13043/matchResult@38::.ctor()
+      IL_0005:  stsfld     class Verify13043/matchResult@38 Verify13043/matchResult@38::@_instance
+      IL_000a:  ret
+    } // end of method matchResult@38::.cctor
+
+  } // end of class matchResult@38
+
+  .class auto ansi serializable sealed nested assembly beforefieldinit functionResult@43
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
+  {
+    .field static assembly initonly class Verify13043/functionResult@43 @_instance
+    .method assembly specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
+      IL_0006:  ret
+    } // end of method functionResult@43::.ctor
+
+    .method public strict virtual instance bool 
+            Invoke(int32 n) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  call       bool Verify13043::condition(int32)
+      IL_0006:  ret
+    } // end of method functionResult@43::Invoke
+
+    .method private specialname rtspecialname static 
+            void  .cctor() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  10
+      IL_0000:  newobj     instance void Verify13043/functionResult@43::.ctor()
+      IL_0005:  stsfld     class Verify13043/functionResult@43 Verify13043/functionResult@43::@_instance
+      IL_000a:  ret
+    } // end of method functionResult@43::.cctor
+
+  } // end of class functionResult@43
+
+  .method public specialname static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          get_list() cil managed
+  {
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::list@3
+    IL_0005:  ret
+  } // end of method Verify13043::get_list
+
+  .method public static bool  condition(int32 n) cil managed
+  {
+    // Code size       5 (0x5)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldc.i4.3
+    IL_0002:  clt
+    IL_0004:  ret
+  } // end of method Verify13043::condition
+
+  .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          dropWhileWithMatch(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition,
+                             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list) cil managed
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
+    // Code size       17 (0x11)
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>> V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  newobj     instance void Verify13043/f@8::.ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>)
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldarg.1
+    IL_0009:  tail.
+    IL_000b:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::Invoke(!0)
+    IL_0010:  ret
+  } // end of method Verify13043::dropWhileWithMatch
+
+  .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          dropWhileWithFunction(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition,
+                                class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list) cil managed
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
+    // Code size       17 (0x11)
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>> V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  newobj     instance void Verify13043/'f@27-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>)
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldarg.1
+    IL_0009:  tail.
+    IL_000b:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::Invoke(!0)
+    IL_0010:  ret
+  } // end of method Verify13043::dropWhileWithFunction
+
+  .method public specialname static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          get_matchResult() cil managed
+  {
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::matchResult@38
+    IL_0005:  ret
+  } // end of method Verify13043::get_matchResult
+
+  .method public specialname static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 
+          get_functionResult() cil managed
+  {
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::functionResult@43
+    IL_0005:  ret
+  } // end of method Verify13043::get_functionResult
+
+  .property class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>
+          list()
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
+    .get class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_list()
+  } // end of property Verify13043::list
+  .property class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>
+          matchResult()
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
+    .get class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_matchResult()
+  } // end of property Verify13043::matchResult
+  .property class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>
+          functionResult()
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
+    .get class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_functionResult()
+  } // end of property Verify13043::functionResult
+} // end of class Verify13043
+
+.class private abstract auto ansi sealed '<StartupCode$Verify13043>'.$Verify13043
+       extends [mscorlib]System.Object
+{
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list@3
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> matchResult@38
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> functionResult@43
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .field static assembly int32 init@
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public static void  main@() cil managed
+  {
+    .entrypoint
+    // Code size       184 (0xb8)
+    .maxstack  6
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_2,
+             int32 V_3,
+             int32 V_4)
+    IL_0000:  ldc.i4.1
+    IL_0001:  ldc.i4.2
+    IL_0002:  ldc.i4.3
+    IL_0003:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_0008:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_000d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_0012:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_0017:  dup
+    IL_0018:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::list@3
+    IL_001d:  stloc.0
+    IL_001e:  ldsfld     class Verify13043/matchResult@38 Verify13043/matchResult@38::@_instance
+    IL_0023:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_list()
+    IL_0028:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::dropWhileWithMatch(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>,
+                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>)
+    IL_002d:  dup
+    IL_002e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::matchResult@38
+    IL_0033:  stloc.1
+    IL_0034:  ldstr      "Match: %A"
+    IL_0039:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
+    IL_003e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0043:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_matchResult()
+    IL_0048:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
+    IL_004d:  pop
+    IL_004e:  ldsfld     class Verify13043/functionResult@43 Verify13043/functionResult@43::@_instance
+    IL_0053:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_list()
+    IL_0058:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::dropWhileWithFunction(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>,
+                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>)
+    IL_005d:  dup
+    IL_005e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Verify13043>'.$Verify13043::functionResult@43
+    IL_0063:  stloc.2
+    IL_0064:  ldstr      "Function: %A"
+    IL_0069:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
+    IL_006e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0073:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Verify13043::get_functionResult()
+    IL_0078:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
+    IL_007d:  pop
+    IL_007e:  ldc.i4.7
+    IL_007f:  stloc.3
+    IL_0080:  ldloc.3
+    IL_0081:  stloc.s    V_4
+    IL_0083:  nop
+    IL_0084:  ldloc.s    V_4
+    IL_0086:  ldc.i4.6
+    IL_0087:  sub
+    IL_0088:  switch     ( 
+                          IL_0093)
+    IL_0091:  br.s       IL_00a6
+
+    IL_0093:  ldstr      "6"
+    IL_0098:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+    IL_009d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_00a2:  pop
+    IL_00a3:  nop
+    IL_00a4:  br.s       IL_00b7
+
+    IL_00a6:  ldstr      "Not 6"
+    IL_00ab:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+    IL_00b0:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_00b5:  pop
+    IL_00b6:  nop
+    IL_00b7:  ret
+  } // end of method $Verify13043::main@
+
+} // end of class '<StartupCode$Verify13043>'.$Verify13043
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Release\net472\tests\EmittedIL\TestFunctions\Verify13043_il\Verify13043.res

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -342,6 +342,12 @@ module rec Compiler =
         | FS fs -> FS { fs with Options = fs.Options @ options }
         | _ -> failwith message
 
+    let withDebug (cUnit: CompilationUnit) : CompilationUnit =
+        withOptionsHelper [ "--debug+" ] "debug+ is only supported on F#" cUnit
+
+    let withNoDebug (cUnit: CompilationUnit) : CompilationUnit =
+        withOptionsHelper [ "--debug-" ] "debug- is only supported on F#" cUnit
+
     let withOcamlCompat (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ "--mlcompatibility" ] "withOcamlCompat is only supported on F#" cUnit
 


### PR DESCRIPTION
@dsyme can you take a look at this.

WIP to check the results of the ci.

I think this is the fix.   The change doesn't emit a debug point when the body of the lambda is bind match.

I have manually verified the debugging experience of **function** with and without this change it is identical.

Todo: 
- [x] Add testing 