### PR TITLE
Cherry pick PR13065 --- release/dev17.2

### DIFF
--- a/src/fsharp/CheckExpressions.fs
+++ b/src/fsharp/CheckExpressions.fs
@@ -5786,7 +5786,7 @@ and TcNonControlFlowExpr (env: TcEnv) f =
         | NotedSourceConstruct.Combine
         | NotedSourceConstruct.With
         | NotedSourceConstruct.While
-        | NotedSourceConstruct.DelayOrQuoteOrRun -> 
+        | NotedSourceConstruct.DelayOrQuoteOrRun ->
             res, tpenv
         | NotedSourceConstruct.None ->
             // Skip outer debug point for "e1 && e2" and "e1 || e2"
@@ -5865,7 +5865,6 @@ and TcExprUndelayed cenv (overallTy: OverallTy) env tpenv (synExpr: SynExpr) =
 
     // e: ty
     | SynExpr.Typed (synBodyExpr, synType, m) ->
-        TcNonControlFlowExpr env <| fun env ->
         TcExprTypeAnnotated cenv overallTy env tpenv (synBodyExpr, synType, m)
 
     // e :? ty


### PR DESCRIPTION
Fixes: #13043 - Codegen Regression - function within recursive function results in null reference exception

This issue was reported last week by an F# Customer

The scenario is an important one it occurs when a function returns a lambda and has type annotation.  It impacts developers who use this style of functional programming.  In Don's words " If they use this .... they will use it a lot and will be affected by this bug"

---

The bug was added to the project in this release of Visual Studio, we added a feature that vastly improved the debugging experience of F# ... the word vastly underestimates the improvement it is great.   However, we were over eager adding debug breakpoints.  The bug is that the compiler emits a debug point for the type annotation portion of the code, obviously that is nonsense, this debug point was then used in further code generation creating code that will generate System.NullReferenceException at runtime.

It is embarrassing that we had no tests that provoked this error, neither don nor I routinely write code this way.  In main we have added test cases that verify the fix, validate the IL and verify the optimized and non optimized code gen.

This cherry-pick doesn't contain the test cases because they rely on test framework features that have been added since this branch was closed to insertions.

Risk:  very low ... the fix is to remove the single line of code that causes the problem and was added when the improved debugging feature was added.

Testing:   we have added additional automated testing.

Reviews: @KevinRansom , @dsyme , @vzarytovskii 

/cc @brettfo 