### PR TITLE
Added ignoring of nu1504 for vsintegration until fixed in sdk/vs

### DIFF
--- a/vsintegration/Directory.Build.props
+++ b/vsintegration/Directory.Build.props
@@ -9,6 +9,12 @@
     <BypassVsixValidation>true</BypassVsixValidation>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- NU1504 reports duplicate package download for various packages.
+          Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
+    <NoWarn>$(NoWarn);NU1504</NoWarn>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
 </Project>


### PR DESCRIPTION
Adding another `NoWarn` for 1504, otherwise repo is not buildable in latest dev17.3