### PR TITLE
Add SynExpr.Dynamic to SyntaxTree.

### DIFF
--- a/src/Compiler/Service/FSharpParseFileResults.fs
+++ b/src/Compiler/Service/FSharpParseFileResults.fs
@@ -531,7 +531,8 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                   | SynExpr.Null _
                   | SynExpr.Ident _
                   | SynExpr.ImplicitZero _
-                  | SynExpr.Const _ -> 
+                  | SynExpr.Const _
+                  | SynExpr.Dynamic _ -> 
                      ()
 
                   | SynExpr.Quote (_, _, e, _, _)

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -472,6 +472,8 @@ module SyntaxTraversal =
 
                 | SynExpr.DebugPoint (_, _, synExpr) -> traverseSynExpr synExpr
 
+                | SynExpr.Dynamic _ -> None
+                
                 | SynExpr.App (_exprAtomicFlag, isInfix, synExpr, synExpr2, _range) ->
                     if isInfix then
                         [dive synExpr2 synExpr2.Range traverseSynExpr

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -888,7 +888,7 @@ type SynExpr =
         isControlFlow: bool *
         innerExpr: SynExpr
 
-    | Dynamic of expr: SynExpr * qmark: range * operation: SynExpr * range: range
+    | Dynamic of funcExpr: SynExpr * qmark: range * argExpr: SynExpr * range: range
     
     member e.Range =
         match e with

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -888,6 +888,8 @@ type SynExpr =
         isControlFlow: bool *
         innerExpr: SynExpr
 
+    | Dynamic of expr: SynExpr * qmark: range * operation: SynExpr * range: range
+    
     member e.Range =
         match e with
         | SynExpr.Paren (_, leftParenRange, rightParenRange, r) ->
@@ -956,7 +958,8 @@ type SynExpr =
         | SynExpr.MatchBang (range=m)
         | SynExpr.DoBang (range=m)
         | SynExpr.Fixed (range=m) 
-        | SynExpr.InterpolatedString (range=m) -> m
+        | SynExpr.InterpolatedString (range=m)
+        | SynExpr.Dynamic(range=m) -> m
         | SynExpr.Ident id -> id.idRange
         | SynExpr.DebugPoint (_, _, innerExpr) -> innerExpr.Range
 

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -896,6 +896,9 @@ type SynExpr =
     /// Debug points arising from computation expressions
     | DebugPoint of debugPoint: DebugPointAtLeafExpr * isControlFlow: bool * innerExpr: SynExpr
 
+    /// x?k
+    | Dynamic of expr: SynExpr * qmark: range * operation: SynExpr * range: range
+
     /// Gets the syntax range of this construct
     member Range: range
 

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -896,8 +896,8 @@ type SynExpr =
     /// Debug points arising from computation expressions
     | DebugPoint of debugPoint: DebugPointAtLeafExpr * isControlFlow: bool * innerExpr: SynExpr
 
-    /// x?k
-    | Dynamic of expr: SynExpr * qmark: range * operation: SynExpr * range: range
+    /// F# syntax: f?x
+    | Dynamic of funcExpr: SynExpr * qmark: range * argExpr: SynExpr * range: range
 
     /// Gets the syntax range of this construct
     member Range: range

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -903,3 +903,11 @@ let prependIdentInLongIdentWithTrivia (SynIdent(ident, identTrivia)) dotm lid =
     match lid with
     | SynLongIdent(lid, dots, trivia) ->
         SynLongIdent(ident :: lid, dotm :: dots, identTrivia :: trivia)
+
+let mkDynamicArgExpr expr =
+    match expr with
+    | SynExpr.Ident ident ->
+       let con = SynConst.String (ident.idText, SynStringKind.Regular, ident.idRange)
+       SynExpr.Const (con, con.Range ident.idRange)
+    | SynExpr.Paren(expr = e) -> e
+    | e -> e

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -773,7 +773,8 @@ let rec synExprContainsError inpExpr =
           | SynExpr.Null _
           | SynExpr.Ident _
           | SynExpr.ImplicitZero _
-          | SynExpr.Const _ -> false
+          | SynExpr.Const _
+          | SynExpr.Dynamic _ -> false
 
           | SynExpr.TypeTest (e, _, _)
           | SynExpr.Upcast (e, _, _)

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
@@ -338,3 +338,5 @@ val (|SynPipeRight2|_|): SynExpr -> (SynExpr * SynExpr * SynExpr) option
 val (|SynPipeRight3|_|): SynExpr -> (SynExpr * SynExpr * SynExpr * SynExpr) option
 
 val prependIdentInLongIdentWithTrivia: ident: SynIdent -> dotm: range -> lid: SynLongIdent -> SynLongIdent
+
+val mkDynamicArgExpr: expr: SynExpr -> SynExpr

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -4193,12 +4193,14 @@ declExpr:
 
 dynamicArg:
   | IDENT
-      { let con = SynConst.String ($1, SynStringKind.Regular, rhs parseState 1)
-        let arg2 = SynExpr.Const (con, con.Range (rhs parseState 1)) 
-        arg2 }
+      { let m = rhs parseState 1
+        SynExpr.Ident(Ident($1, m)) }
 
   | LPAREN typedSequentialExpr rparen
-      { $2 }
+      { let lpr = rhs parseState 1
+        let rpr = rhs parseState 3
+        let m = unionRanges lpr rpr
+        SynExpr.Paren($2, lpr, Some rpr, m) }
 
 withClauses:
   | WITH withPatternClauses       
@@ -4467,8 +4469,10 @@ atomicExpr:
         SynExpr.LongIdent (true, SynLongIdent([ident], [], [trivia]), None, rhs parseState 2), false }
 
   | atomicExpr QMARK dynamicArg
-      { let arg1, hpa1 = $1
-        mkSynInfix (rhs parseState 2) arg1 "?" $3, hpa1 }
+      { let m = rhs2 parseState 1 3
+        let mQmark = rhs parseState 2
+        let arg1, hpa1 = $1
+        SynExpr.Dynamic(arg1, mQmark, $3, m), hpa1 }
 
   | GLOBAL
       { let m = rhs parseState 1

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -6340,6 +6340,14 @@ FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Syntax.SynType get_targ
 FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Syntax.SynType targetType
 FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr expr
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr get_expr()
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr get_operation()
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr operation
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Text.Range get_qmark()
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Text.Range qmark
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+Fixed: FSharp.Compiler.Syntax.SynExpr expr
 FSharp.Compiler.Syntax.SynExpr+Fixed: FSharp.Compiler.Syntax.SynExpr get_expr()
 FSharp.Compiler.Syntax.SynExpr+Fixed: FSharp.Compiler.Text.Range get_range()
@@ -6671,6 +6679,7 @@ FSharp.Compiler.Syntax.SynExpr+Tags: Int32 DotIndexedSet
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 DotNamedIndexedPropertySet
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 DotSet
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Downcast
+FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Dynamic
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 Fixed
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 For
 FSharp.Compiler.Syntax.SynExpr+Tags: Int32 ForEach
@@ -6830,6 +6839,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean IsDotIndexedSet
 FSharp.Compiler.Syntax.SynExpr: Boolean IsDotNamedIndexedPropertySet
 FSharp.Compiler.Syntax.SynExpr: Boolean IsDotSet
 FSharp.Compiler.Syntax.SynExpr: Boolean IsDowncast
+FSharp.Compiler.Syntax.SynExpr: Boolean IsDynamic
 FSharp.Compiler.Syntax.SynExpr: Boolean IsFixed
 FSharp.Compiler.Syntax.SynExpr: Boolean IsFor
 FSharp.Compiler.Syntax.SynExpr: Boolean IsForEach
@@ -6897,6 +6907,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean get_IsDotIndexedSet()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsDotNamedIndexedPropertySet()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsDotSet()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsDowncast()
+FSharp.Compiler.Syntax.SynExpr: Boolean get_IsDynamic()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsFixed()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsFor()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsForEach()
@@ -6963,6 +6974,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotIndexedSet(
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotNamedIndexedPropertySet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynLongIdent, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDotSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynLongIdent, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDowncast(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewDynamic(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFixed(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewFor(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.Ident, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewForEach(FSharp.Compiler.Syntax.DebugPointAtFor, FSharp.Compiler.Syntax.DebugPointAtInOrTo, FSharp.Compiler.Syntax.SeqExprOnly, Boolean, FSharp.Compiler.Syntax.SynPat, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
@@ -7029,6 +7041,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+DotIndexedSet
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+DotNamedIndexedPropertySet
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+DotSet
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Downcast
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Dynamic
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+Fixed
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+For
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr+ForEach

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -6340,10 +6340,10 @@ FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Syntax.SynType get_targ
 FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Syntax.SynType targetType
 FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+Downcast: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr expr
-FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr get_expr()
-FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr get_operation()
-FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr operation
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr argExpr
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr funcExpr
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr get_argExpr()
+FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Syntax.SynExpr get_funcExpr()
 FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Text.Range get_qmark()
 FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+Dynamic: FSharp.Compiler.Text.Range qmark


### PR DESCRIPTION
A first attempt to solve https://github.com/dotnet/fsharp/issues/12755.
This currently moves the logic from the parser to the type checker.