### PR TITLE
Create workspace + update launch configs for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,51 +11,51 @@
     ],
     "configurations": [
         {
-            "name": "Launch FSI (Debug, .NET 5.0)",
+            "name": "Launch FSI (Debug, .NET 6.0)",
             "type": "coreclr",
             "request": "launch",
             // TODO: Shall we assume that it's already been built, or build it every time we debug?
             // "preLaunchTask": "Build (Debug)",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/artifacts/bin/fsi/Debug/net5.0/fsi.dll",
+            "program": "${workspaceFolder}/artifacts/bin/fsi/Debug/net6.0/fsi.dll",
             "cwd": "${workspaceFolder}/src",
-            "console": "integratedTerminal",
+            "console": "integratedTerminal", // This is the default to be able to run in Codespaces.
             "stopAtEntry": false,
             "justMyCode": false,
-            "enableStepFiltering": false,
+            "enableStepFiltering": true,
             "symbolOptions": {
                 "searchMicrosoftSymbolServer": true,
                 "searchNuGetOrgSymbolServer": true
             },
             "sourceLinkOptions": {
                 "*": {
-                    "enabled": false
+                    "enabled": true
                 }
             },
         },
         {
-            "name": "Launch FSC (Debug, .NET 5.0)",
+            "name": "Launch FSC (Debug, .NET 6.0)",
             "type": "coreclr",
             "request": "launch",
             // TODO: Shall we assume that it's already been built, or build it every time we debug?
             // "preLaunchTask": "Build (Debug)",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/artifacts/bin/fsc/Debug/net5.0/fsc.dll",
+            "program": "${workspaceFolder}/artifacts/bin/fsc/Debug/net6.0/fsc.dll",
             "args": [
                 "${input:argsPrompt}"
             ],
             "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
+            "console": "integratedTerminal", // This is the default to be able to run in Codespaces.
             "stopAtEntry": false,
             "justMyCode": false,
-            "enableStepFiltering": false,
+            "enableStepFiltering": true,
             "symbolOptions": {
                 "searchMicrosoftSymbolServer": true,
                 "searchNuGetOrgSymbolServer": true
             },
             "sourceLinkOptions": {
                 "*": {
-                    "enabled": false
+                    "enabled": true
                 }
             },
         },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,11 @@
         "*.vsixmanifest": "xml",
         "*.vstemplate": "xml",
     },
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.expand": false,
+    "explorer.fileNesting.patterns": {
+        "*.fs": "${capture}.fsi"
+    },
     "FSharp.suggestGitignore": false,
     "FSharp.enableMSBuildProjectGraph": true,
     "FSharp.workspacePath": "FSharp.sln",

--- a/fsharp.code-workspace
+++ b/fsharp.code-workspace
@@ -28,50 +28,5 @@
 			"name": "Visual Studio (vsintegration)",
 			"path": "vsintegration"
 		}
-	],
-	"settings": {
-		"files.associations": {
-			"*.csproj": "msbuild",
-			"*.fsproj": "msbuild",
-			"*.nuspec": "xml",
-			"*.props": "msbuild",
-			"*.targets": "msbuild",
-			"*.vsixmanifest": "xml",
-			"*.vstemplate": "xml"
-		},
-		"explorer.fileNesting.enabled": true,
-		"explorer.fileNesting.expand": false,
-		"explorer.fileNesting.patterns": {
-			"*.fs": "${capture}.fsi"
-		},
-		"FSharp.suggestGitignore": false,
-		"FSharp.enableMSBuildProjectGraph": true,
-		"FSharp.workspacePath": "FSharp.sln",
-		"FSharp.workspaceModePeekDeepLevel": 1,
-		"FSharp.excludeProjectDirectories": [
-			".git",
-			"eng",
-			"artifacts",
-			"fcs-samples",
-			"tests/projects",
-			"tests/benchmarks",
-			"tests/EndToEndBuildTests"
-		],
-		"csharp.showOmnisharpLogOnError": false,
-		"csharp.suppressBuildAssetsNotification": true,
-		"csharp.suppressDotnetInstallWarning": true,
-		"csharp.suppressDotnetRestoreNotification": true,
-		"csharp.suppressHiddenDiagnostics": true,
-		"omnisharp.autoStart": true,
-		"omnisharp.enableMsBuildLoadProjectsOnDemand": true,
-		"omnisharp.disableMSBuildDiagnosticWarning": true,
-		"razor.disabled": true,
-		"powershell.promptToUpdatePowerShell": false,
-		"powershell.integratedConsole.showOnStartup": false,
-		"powershell.startAutomatically": false,
-		"dotnet-test-explorer.testProjectPath": "tests/+(FSharp.Compiler.Service.Tests|FSharp.Compiler.UnitTests|FSharp.Core.UnitTests|FSharp.Build.UnitTests|FSharp.Compiler.ComponentTests)/*Tests.fsproj",
-		"dotnet-test-explorer.addProblems": true,
-		"dotnet-test-explorer.autoWatch": false,
-		"dotnet-test-explorer.treeMode": "merged"
-	}
+	]
 }

--- a/fsharp.code-workspace
+++ b/fsharp.code-workspace
@@ -1,0 +1,77 @@
+{
+	"folders": [
+		{
+			"name": "All",
+			"path": "."
+		},
+		{
+			"name": "Artifacts (artifacts)",
+			"path": "artifacts"
+		},
+		{
+			"name": "Documentation (docs)",
+			"path": "docs"
+		},
+		{
+			"name": "Engineering (eng)",
+			"path": "eng"
+		},
+		{
+			"name": "Source (src)",
+			"path": "src"
+		},
+		{
+			"name": "Tests (tests)",
+			"path": "tests"
+		},
+		{
+			"name": "Visual Studio (vsintegration)",
+			"path": "vsintegration"
+		}
+	],
+	"settings": {
+		"files.associations": {
+			"*.csproj": "msbuild",
+			"*.fsproj": "msbuild",
+			"*.nuspec": "xml",
+			"*.props": "msbuild",
+			"*.targets": "msbuild",
+			"*.vsixmanifest": "xml",
+			"*.vstemplate": "xml"
+		},
+		"explorer.fileNesting.enabled": true,
+		"explorer.fileNesting.expand": false,
+		"explorer.fileNesting.patterns": {
+			"*.fs": "${capture}.fsi"
+		},
+		"FSharp.suggestGitignore": false,
+		"FSharp.enableMSBuildProjectGraph": true,
+		"FSharp.workspacePath": "FSharp.sln",
+		"FSharp.workspaceModePeekDeepLevel": 1,
+		"FSharp.excludeProjectDirectories": [
+			".git",
+			"eng",
+			"artifacts",
+			"fcs-samples",
+			"tests/projects",
+			"tests/benchmarks",
+			"tests/EndToEndBuildTests"
+		],
+		"csharp.showOmnisharpLogOnError": false,
+		"csharp.suppressBuildAssetsNotification": true,
+		"csharp.suppressDotnetInstallWarning": true,
+		"csharp.suppressDotnetRestoreNotification": true,
+		"csharp.suppressHiddenDiagnostics": true,
+		"omnisharp.autoStart": true,
+		"omnisharp.enableMsBuildLoadProjectsOnDemand": true,
+		"omnisharp.disableMSBuildDiagnosticWarning": true,
+		"razor.disabled": true,
+		"powershell.promptToUpdatePowerShell": false,
+		"powershell.integratedConsole.showOnStartup": false,
+		"powershell.startAutomatically": false,
+		"dotnet-test-explorer.testProjectPath": "tests/+(FSharp.Compiler.Service.Tests|FSharp.Compiler.UnitTests|FSharp.Core.UnitTests|FSharp.Build.UnitTests|FSharp.Compiler.ComponentTests)/*Tests.fsproj",
+		"dotnet-test-explorer.addProblems": true,
+		"dotnet-test-explorer.autoWatch": false,
+		"dotnet-test-explorer.treeMode": "merged"
+	}
+}


### PR DESCRIPTION
Added workspace file, for better grouping in the filetree (see screenshot below) + fixed launch settings for FSI and FSC:
![image](https://user-images.githubusercontent.com/1260985/168922500-aac4947a-5b47-4440-be79-ccbcaf6c235e.png)
![image](https://user-images.githubusercontent.com/1260985/168922524-0fe1bf94-3c42-42b3-86b4-3d3c5a80d437.png)

`fsharp` node is unmodified tree (for those who are used to it), and the rest are just shortcuts to Source/Tests/VS integration/Docs/etc.