### PR TITLE
format removing extra blank lines and add some fantomas defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,13 @@ root = true
 
 [*.fs]
 fsharp_newline_between_type_definition_and_members=true
+fsharp_max_infix_operator_expression=80
+fsharp_max_array_or_list_width=80
+fsharp_max_array_or_list_number_of_items=5
+fsharp_max_dot_get_expression_width=80
+fsharp_multiline_block_brackets_on_same_column=true
+fsharp_keep_max_number_of_blank_lines=1
 
 [*.fsi]
 fsharp_newline_between_type_definition_and_members=true
+fsharp_keep_max_number_of_blank_lines=1

--- a/src/Compiler/AbstractIL/il.fsi
+++ b/src/Compiler/AbstractIL/il.fsi
@@ -1535,7 +1535,6 @@ type ILPreTypeDef =
     /// Realise the actual full typedef
     abstract GetTypeDef: unit -> ILTypeDef
 
-
 [<NoEquality; NoComparison; Sealed>]
 type internal ILPreTypeDefImpl =
     interface ILPreTypeDef
@@ -1709,7 +1708,6 @@ type ILAssemblyManifest =
 
     member CustomAttrs: ILAttributes
     member SecurityDecls: ILSecurityDecls
-
 
 [<RequireQualifiedAccess>]
 type ILNativeResource =

--- a/src/Compiler/AbstractIL/ilbinary.fsi
+++ b/src/Compiler/AbstractIL/ilbinary.fsi
@@ -108,7 +108,6 @@ type HasFieldMarshalTag =
 val hfm_FieldDef: HasFieldMarshalTag
 val hfm_ParamDef: HasFieldMarshalTag
 
-
 [<Struct>]
 type HasDeclSecurityTag =
     member Tag: int32
@@ -116,7 +115,6 @@ type HasDeclSecurityTag =
 val hds_TypeDef: HasDeclSecurityTag
 val hds_MethodDef: HasDeclSecurityTag
 val hds_Assembly: HasDeclSecurityTag
-
 
 [<Struct>]
 type MemberRefParentTag =
@@ -127,14 +125,12 @@ val mrp_ModuleRef: MemberRefParentTag
 val mrp_MethodDef: MemberRefParentTag
 val mrp_TypeSpec: MemberRefParentTag
 
-
 [<Struct>]
 type HasSemanticsTag =
     member Tag: int32
 
 val hs_Event: HasSemanticsTag
 val hs_Property: HasSemanticsTag
-
 
 [<Struct>]
 type MethodDefOrRefTag =
@@ -143,14 +139,12 @@ type MethodDefOrRefTag =
 val mdor_MethodDef: MethodDefOrRefTag
 val mdor_MemberRef: MethodDefOrRefTag
 
-
 [<Struct>]
 type MemberForwardedTag =
     member Tag: int32
 
 val mf_FieldDef: MemberForwardedTag
 val mf_MethodDef: MemberForwardedTag
-
 
 [<Struct>]
 type ImplementationTag =

--- a/src/Compiler/AbstractIL/ilx.fsi
+++ b/src/Compiler/AbstractIL/ilx.fsi
@@ -27,7 +27,6 @@ type IlxUnionCase =
     member IsNullary: bool
     member FieldTypes: ILType[]
 
-
 type IlxUnionHasHelpers =
     | NoHelpers
     | AllHelpers
@@ -108,7 +107,6 @@ type IlxClosureSpec =
 
     /// Indicates if a static field being used to store an instance of this closure (because it has no free variables)
     member UseStaticField: bool
-
 
 /// IlxClosureApps - i.e. types being applied at a callsite.
 type IlxClosureApps =

--- a/src/Compiler/Checking/InfoReader.fsi
+++ b/src/Compiler/Checking/InfoReader.fsi
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-
 /// Select members from a type by name, searching the type hierarchy if needed
 module internal FSharp.Compiler.InfoReader
 

--- a/src/Compiler/Checking/NameResolution.fsi
+++ b/src/Compiler/Checking/NameResolution.fsi
@@ -510,7 +510,6 @@ type TcResultsSink =
     static member NoSink: TcResultsSink
     static member WithSink: ITypecheckResultsSink -> TcResultsSink
 
-
 /// Indicates if we only need one result or all possible results from a resolution.
 [<RequireQualifiedAccess>]
 type ResultCollectionSettings =
@@ -598,7 +597,6 @@ type LookupKind =
     | Expr
     | Type
     | Ctor
-
 
 /// Indicates if a warning should be given for the use of upper-case identifiers in patterns
 type WarnOnUpperFlag =

--- a/src/Compiler/Driver/CompilerImports.fsi
+++ b/src/Compiler/Driver/CompilerImports.fsi
@@ -117,7 +117,6 @@ type ImportedAssembly =
 #endif
       FSharpOptimizationData: Lazy<Option<LazyModuleInfo>> }
 
-
 /// Tables of assembly resolutions
 [<Sealed>]
 type TcAssemblyResolutions =

--- a/src/Compiler/Interactive/fsi.fsi
+++ b/src/Compiler/Interactive/fsi.fsi
@@ -354,7 +354,6 @@ module Settings =
 
         member internal AddedPrinters: Choice<Type * (obj -> string), Type * (obj -> obj)> list
 
-
         /// <summary>The command line arguments after ignoring the arguments relevant to the interactive
         /// environment and replacing the first argument with the name of the last script file,
         /// if any. Thus 'fsi.exe test1.fs test2.fs -- hello goodbye' will give arguments

--- a/src/Compiler/Optimize/Optimizer.fsi
+++ b/src/Compiler/Optimize/Optimizer.fsi
@@ -42,7 +42,6 @@ type OptimizationSettings =
         reportTotalSizes: bool
     }
 
-
     member JitOptimizationsEnabled: bool
 
     member LocalOptimizationsEnabled: bool

--- a/src/Compiler/Service/SemanticClassificationKey.fsi
+++ b/src/Compiler/Service/SemanticClassificationKey.fsi
@@ -20,7 +20,6 @@ type internal SemanticClassificationKeyStore =
     /// Get a read only view on the semantic classification key store
     member GetView: unit -> SemanticClassificationView
 
-
 /// A builder that will build an semantic classification key store based on the written Item and its associated range.
 [<Sealed>]
 type internal SemanticClassificationKeyStoreBuilder =

--- a/src/Compiler/Service/ServiceLexing.fsi
+++ b/src/Compiler/Service/ServiceLexing.fsi
@@ -6,7 +6,6 @@ open System
 open System.Threading
 open FSharp.Compiler
 open FSharp.Compiler.Text
-
 #nowarn "57"
 
 /// Represents encoded information for the end-of-line continuation of lexing

--- a/src/Compiler/Symbols/SymbolHelpers.fsi
+++ b/src/Compiler/Symbols/SymbolHelpers.fsi
@@ -31,7 +31,6 @@ type public FSharpXmlDoc =
     /// Indicates that the XML for the documentation can be found in a .xml documentation file for the given DLL, using the given signature key
     | FromXmlFile of dllName: string * xmlSig: string
 
-
 // Implementation details used by other code in the compiler
 module internal SymbolHelpers =
 

--- a/src/Compiler/Symbols/Symbols.fsi
+++ b/src/Compiler/Symbols/Symbols.fsi
@@ -990,7 +990,6 @@ type FSharpParameter =
     /// Indicate this is an optional argument
     member IsOptionalArg: bool
 
-
 /// A subtype of FSharpSymbol that represents a single case within an active pattern
 [<Class>]
 type FSharpActivePatternCase =

--- a/src/Compiler/TypedTree/TypeProviders.fsi
+++ b/src/Compiler/TypedTree/TypeProviders.fsi
@@ -306,7 +306,6 @@ type ProvidedFieldInfo =
 
     inherit ProvidedMemberInfo
 
-
     member IsInitOnly: bool
 
     member IsStatic: bool

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -920,7 +920,6 @@ val MeasureExprConExponent: TcGlobals -> bool -> TyconRef -> Measure -> Rational
 
 val normalizeMeasure: TcGlobals -> Measure -> Measure
 
-
 //-------------------------------------------------------------------------
 // Members
 //-------------------------------------------------------------------------
@@ -1936,7 +1935,6 @@ val mkByteArrayTy: TcGlobals -> TType
 
 val mkInvalidCastExnNewobj: TcGlobals -> ILInstr
 
-
 //-------------------------------------------------------------------------
 // Construct calls to some intrinsic functions
 //-------------------------------------------------------------------------
@@ -2253,7 +2251,6 @@ val IsMatchingSignatureDataVersionAttr: ILVersionInfo -> ILAttribute -> bool
 val mkCompilationMappingAttr: TcGlobals -> int -> ILAttribute
 
 val mkCompilationMappingAttrWithSeqNum: TcGlobals -> int -> int -> ILAttribute
-
 
 val mkCompilationMappingAttrWithVariantNumAndSeqNum: TcGlobals -> int -> int -> int -> ILAttribute
 

--- a/src/Compiler/TypedTree/tainted.fsi
+++ b/src/Compiler/TypedTree/tainted.fsi
@@ -42,7 +42,6 @@ type internal TypeProviderError =
     /// provides uniform way to process aggregated errors
     member Iter: (TypeProviderError -> unit) -> unit
 
-
 /// This struct wraps a value produced by a type provider to properly attribute any failures.
 [<NoEquality; NoComparison; Class>]
 type internal Tainted<'T> =

--- a/src/Compiler/Utilities/FileSystem.fsi
+++ b/src/Compiler/Utilities/FileSystem.fsi
@@ -215,7 +215,6 @@ type public IFileSystem =
     /// Used to determine if a file will not be subject to deletion during the lifetime of a typical client process.
     abstract IsStableFileHeuristic: fileName: string -> bool
 
-
 /// Represents a default (memory-mapped) implementation of the file system
 type DefaultFileSystem =
     /// Create a default implementation of the file system

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -229,7 +229,6 @@ module internal ValueOptionInternal =
 
     val inline bind: f: ('a -> 'b voption) -> x: 'a voption -> 'b voption
 
-
 module internal String =
 
     val make: n: int -> c: char -> string
@@ -521,7 +520,6 @@ module internal NameMap =
 
     val exists: f: ('a -> 'b -> bool) -> m: Map<'a, 'b> -> bool when 'a: comparison
 
-
     val ofKeyedList: f: ('a -> 'b) -> l: 'a list -> Map<'b, 'a> when 'b: comparison
 
     val ofList: l: (string * 'T) list -> NameMap<'T>
@@ -611,7 +609,6 @@ module internal MultiMap =
     val initBy: f: ('a -> 'b) -> xs: seq<'a> -> MultiMap<'b, 'a> when 'b: comparison
 
 type internal LayeredMap<'Key, 'Value when 'Key: comparison> = Map<'Key, 'Value>
-
 
 [<AutoOpen>]
 module internal MapAutoOpens =

--- a/src/FSharp.Compiler.Interactive.Settings/fsiaux.fsi
+++ b/src/FSharp.Compiler.Interactive.Settings/fsiaux.fsi
@@ -71,7 +71,6 @@ type InteractiveSession =
     /// <summary>Sets the current event loop being used to process interactions.</summary>
     member internal SetEventLoop: (unit -> bool) * ((unit -> obj) -> obj) * (unit -> unit) -> unit
 
-
 module Settings =
 
     /// <summary>The settings associated with the interactive session.</summary>

--- a/src/FSharp.Core/option.fsi
+++ b/src/FSharp.Core/option.fsi
@@ -6,7 +6,6 @@ open System
 open Microsoft.FSharp.Core
 open Microsoft.FSharp.Collections
 
-
 /// <summary>Contains operations for working with options.</summary>
 ///
 /// <category>Options</category>

--- a/src/FSharp.Core/set.fsi
+++ b/src/FSharp.Core/set.fsi
@@ -380,7 +380,6 @@ module Set =
     [<CompiledName("IsProperSuperset")>]
     val isProperSuperset: set1: Set<'T> -> set2: Set<'T> -> bool
 
-
     /// <summary>Returns the number of elements in the set. Same as <c>size</c>.</summary>
     ///
     /// <param name="set">The input set.</param>


### PR DESCRIPTION
Fantomas has an option to remove extraneous blank lines.  Let's use it.

Also setting `fsharp_max_infix_operator_expression` and some other values to larger values based on discussions.  We may remove/tweak these