### PR TITLE
Reactivate test

### DIFF
--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1587,9 +1587,11 @@ module CoreTests =
     [<Test>]
     let ``patterns-FSC_OPTIMIZED`` () = singleTestBuildAndRunVersion "core/patterns" FSC_OPTIMIZED "preview"
 
-//BUGBUG: https://github.com/dotnet/fsharp/issues/6601
-//    [<Test>]
-//    let ``patterns-FSI`` () = singleTestBuildAndRun' "core/patterns" FSI
+// This requires --multiemit on by default, which is not the case for .NET Framework
+#if NETCOREAPP
+    [<Test>]
+    let ``patterns-FSI`` () = singleTestBuildAndRun "core/patterns" FSI
+#endif
 
     [<Test>]
     let ``pinvoke-FSC_OPTIMIZED`` () = singleTestBuildAndRun "core/pinvoke" FSC_OPTIMIZED


### PR DESCRIPTION

This test now runs successfully on .NET 6, so we can reactivate it