### PR TITLE
Make tests show as active

### DIFF
--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3282,7 +3282,7 @@ open System.Runtime.InteropServices
         fv.LegalTrademarks |> Assert.areEqual "CST \u2122"
 #endif
 
-#if NET472
+#if !NETCOREAPP
 [<NonParallelizable>]
 module ProductVersionTest =
 


### PR DESCRIPTION
I'm not sure why, but these tests were not showing as active code in the VS editor when using `#if NET472`, but do show using the formulation `#if !NETCOREAPP` which is used in the rest of the file to .NET Framework-only tests.

It's odd because https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives seems to indicate `#if NET472` should work - and indeed the tests appear in the test explorer. 

In any case this makes things more consistent.