### PR TITLE
Emit all documents from command line in debug info

### DIFF
--- a/src/Compiler/AbstractIL/ilwrite.fsi
+++ b/src/Compiler/AbstractIL/ilwrite.fsi
@@ -16,6 +16,7 @@ type options =
       embeddedPDB: bool
       embedAllSource: bool
       embedSourceList: string list
+      allGivenSources: ILSourceDocument list
       sourceLink: string
       checksumAlgorithm: HashAlgorithm
       signer: ILStrongNameSigner option

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -1445,6 +1445,8 @@ type internal FsiDynamicCompiler(
               embeddedPDB = false
               embedAllSource = tcConfig.embedAllSource
               embedSourceList = tcConfig.embedSourceList
+              // we don't add additional source files to the debug document set
+              allGivenSources = []
               sourceLink = tcConfig.sourceLink
               checksumAlgorithm = tcConfig.checksumAlgorithm
               signer = None

--- a/tests/service/data/TestTP/ProvidedTypes.fs
+++ b/tests/service/data/TestTP/ProvidedTypes.fs
@@ -10819,7 +10819,7 @@ namespace ProviderImplementation.ProvidedTypes
             member codebuf.EmitExceptionClause seh = codebuf.seh.Add(seh)
 
 #if DEBUG_INFO
-            member codebuf.EmitSeqPoint cenv (m:ILDebugPoint)  = ()
+            member codebuf.EmitDebugPoint cenv (m:ILDebugPoint)  = ()
                 if cenv.generatePdb then 
                   // table indexes are 1-based, document array indexes are 0-based 
                   let doc = (cenv.documents.FindOrAddSharedEntry m.Document) - 1  
@@ -11131,7 +11131,7 @@ namespace ProviderImplementation.ProvidedTypes
                     codebuf.RecordReqdBrFixup (ILCmpInstrMap.Value[cmp], Some ILCmpInstrRevMap.Value[cmp]) tg1
                 | I_br tg -> codebuf.RecordReqdBrFixup (i_br, Some i_br_s) tg
 #if EMIT_DEBUG_INFO
-                | I_seqpoint s ->   codebuf.EmitSeqPoint cenv s
+                | I_seqpoint s ->   codebuf.EmitDebugPoint cenv s
 #endif
                 | I_leave tg -> codebuf.RecordReqdBrFixup (i_leave, Some i_leave_s) tg
                 | I_call  (tl, mspec, varargs)      -> 

--- a/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/ProvidedTypes.fs
+++ b/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/ProvidedTypes.fs
@@ -10360,7 +10360,7 @@ namespace ProviderImplementation.ProvidedTypes
             member codebuf.EmitExceptionClause seh = codebuf.seh.Add(seh)
 
 #if DEBUG_INFO
-            member codebuf.EmitSeqPoint cenv (m:ILSourceMarker)  = ()
+            member codebuf.EmitDebugPoint cenv (m:ILSourceMarker)  = ()
                 if cenv.generatePdb then 
                   // table indexes are 1-based, document array indexes are 0-based 
                   let doc = (cenv.documents.FindOrAddSharedEntry m.Document) - 1  
@@ -10672,7 +10672,7 @@ namespace ProviderImplementation.ProvidedTypes
                     codebuf.RecordReqdBrFixup (ILCmpInstrMap.Value.[cmp], Some ILCmpInstrRevMap.Value.[cmp]) tg1
                 | I_br tg -> codebuf.RecordReqdBrFixup (i_br, Some i_br_s) tg
 #if EMIT_DEBUG_INFO
-                | I_seqpoint s ->   codebuf.EmitSeqPoint cenv s
+                | I_seqpoint s ->   codebuf.EmitDebugPoint cenv s
 #endif
                 | I_leave tg -> codebuf.RecordReqdBrFixup (i_leave, Some i_leave_s) tg
                 | I_call  (tl, mspec, varargs)      -> 


### PR DESCRIPTION
This is a step to resolving https://github.com/dotnet/fsharp/issues/13138

The signature files from the command line were not being included in the listed debug documents.

@KevinRansom I'm not sure the best way to test this - do we have something dumping and testing the documents table?

thanks
