### PR TITLE
Don't attempt to publish build artifacts for Determinism and Fantomas runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -266,6 +266,8 @@ stages:
 
         # Check code formatting
         - job: CheckCodeFormatting
+          parameters:
+              enablePublishBuildArtifacts: false
           pool:
             vmImage: $(UbuntuMachineQueueName)
           steps:
@@ -384,6 +386,8 @@ stages:
 
         # Determinism, we want to run it only in PR builds
         - job: Determinism_Debug
+          parameters:
+            enablePublishBuildArtifacts: false
           condition: eq(variables['Build.Reason'], 'PullRequest')
           variables:
           - name: _SignType

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,6 +180,78 @@ stages:
             condition: succeeded()
 
   #-------------------------------------------------------------------------------------------------------------------#
+  #                            PR builds without logs publishing                                                      #
+  #-------------------------------------------------------------------------------------------------------------------#
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        enableMicrobuild: true
+        enablePublishBuildArtifacts: false
+        enablePublishTestResults: false
+        enablePublishBuildAssets: false
+        enablePublishUsingPipelines: $(_PublishUsingPipelines)
+        enableSourceBuild: true
+        enableTelemetry: true
+        helixRepo: dotnet/fsharp
+        jobs:
+          # Determinism, we want to run it only in PR builds
+        - job: Determinism_Debug
+          condition: eq(variables['Build.Reason'], 'PullRequest')
+          variables:
+          - name: _SignType
+            value: Test
+          pool:
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals $(WindowsMachineQueueName)
+          timeoutInMinutes: 90
+          steps:
+          - checkout: self
+            clean: true
+          - task: UseDotNet@2
+            displayName: install SDK
+            inputs:
+              packageType: sdk
+              useGlobalJson: true
+              includePreviewVersions: false
+              workingDirectory: $(Build.SourcesDirectory)
+              installationPath: $(Build.SourcesDirectory)/.dotnet
+          - script: .\eng\test-determinism.cmd -configuration Debug
+            displayName: Determinism tests with Debug configuration
+          - task: PublishPipelineArtifact@1
+            displayName: Publish Determinism Logs
+            inputs:
+              targetPath: '$(Build.SourcesDirectory)/artifacts/log/Debug'
+              artifactName: 'Determinism_Debug Attempt $(System.JobAttempt) Logs'
+            continueOnError: true
+            condition: not(succeeded())
+
+          # Check code formatting
+        - job: CheckCodeFormatting
+          pool:
+            vmImage: $(UbuntuMachineQueueName)
+          steps:
+          - checkout: self
+            clean: true
+          - script: dotnet --list-sdks
+            displayName: Report dotnet SDK versions
+          - task: UseDotNet@2
+            displayName: install SDK
+            inputs:
+              packageType: sdk
+              useGlobalJson: true
+              includePreviewVersions: true
+              workingDirectory: $(Build.SourcesDirectory)
+              installationPath: $(Agent.ToolsDirectory)/dotnet
+          - script: dotnet tool restore
+            env:
+              DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1
+            displayName: Install tools
+          - script: dotnet fantomas src -r --check
+            env:
+              DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1
+            displayName: Check code formatting (run 'dotnet fantomas src -r' to fix)
+
+  #-------------------------------------------------------------------------------------------------------------------#
   #                                                    PR builds                                                      #
   #-------------------------------------------------------------------------------------------------------------------#
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -263,34 +335,6 @@ stages:
             clean: true
           - pwsh: .\eng\MockBuild.ps1
             displayName: Build with OfficialBuildId
-
-        # Check code formatting
-        - job: CheckCodeFormatting
-          parameters:
-              enablePublishBuildArtifacts: false
-          pool:
-            vmImage: $(UbuntuMachineQueueName)
-          steps:
-          - checkout: self
-            clean: true
-          - script: dotnet --list-sdks
-            displayName: Report dotnet SDK versions
-          - task: UseDotNet@2
-            displayName: install SDK
-            inputs:
-              packageType: sdk
-              useGlobalJson: true
-              includePreviewVersions: true
-              workingDirectory: $(Build.SourcesDirectory)
-              installationPath: $(Agent.ToolsDirectory)/dotnet
-          - script: dotnet tool restore
-            env:
-              DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1
-            displayName: Install tools
-          - script: dotnet fantomas src -r --check
-            env:
-              DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1
-            displayName: Check code formatting (run 'dotnet fantomas src -r' to fix)
 
         # Linux
         - job: Linux
@@ -383,39 +427,6 @@ stages:
           - script: .\Build.cmd -c Release -pack
           - script: .\tests\EndToEndBuildTests\EndToEndBuildTests.cmd -c Release
             displayName: End to end build tests
-
-        # Determinism, we want to run it only in PR builds
-        - job: Determinism_Debug
-          parameters:
-            enablePublishBuildArtifacts: false
-          condition: eq(variables['Build.Reason'], 'PullRequest')
-          variables:
-          - name: _SignType
-            value: Test
-          pool:
-            name: NetCore1ESPool-Public
-            demands: ImageOverride -equals $(WindowsMachineQueueName)
-          timeoutInMinutes: 90
-          steps:
-          - checkout: self
-            clean: true
-          - task: UseDotNet@2
-            displayName: install SDK
-            inputs:
-              packageType: sdk
-              useGlobalJson: true
-              includePreviewVersions: false
-              workingDirectory: $(Build.SourcesDirectory)
-              installationPath: $(Build.SourcesDirectory)/.dotnet
-          - script: .\eng\test-determinism.cmd -configuration Debug
-            displayName: Determinism tests with Debug configuration
-          - task: PublishPipelineArtifact@1
-            displayName: Publish Determinism Logs
-            inputs:
-              targetPath: '$(Build.SourcesDirectory)/artifacts/log/Debug'
-              artifactName: 'Determinism_Debug Attempt $(System.JobAttempt) Logs'
-            continueOnError: true
-            condition: not(succeeded())
 
         # Up-to-date - disabled due to it being flaky
         #- job: UpToDate_Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,11 +75,11 @@ stages:
   #                                                  Signed build                                                     #
   #-------------------------------------------------------------------------------------------------------------------#
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.2') }}:
+    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.3') }}:
       - template: /eng/common/templates/job/onelocbuild.yml
         parameters:
           MirrorRepo: fsharp
-          MirrorBranch: release/dev17.2
+          MirrorBranch: release/dev17.3
           LclSource: lclFilesfromPackage
           LclPackageId: 'LCL-JUNO-PROD-FSHARP'
     - template: /eng/common/templates/jobs/jobs.yml
@@ -185,12 +185,12 @@ stages:
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: /eng/common/templates/jobs/jobs.yml
       parameters:
-        enableMicrobuild: true
+        enableMicrobuild: false
         enablePublishBuildArtifacts: false
         enablePublishTestResults: false
         enablePublishBuildAssets: false
         enablePublishUsingPipelines: $(_PublishUsingPipelines)
-        enableSourceBuild: true
+        enableSourceBuild: false
         enableTelemetry: true
         helixRepo: dotnet/fsharp
         jobs:


### PR DESCRIPTION
By default our public builds are trying to upload artifacts from all jobs, which is not applicable to deterministic check and fantomas run. This moves both to a different leg with publishing and source build disabled.