### PR TITLE
"trees" docu corrected and updated

### DIFF
--- a/docs/fcs/typedtree.fsx
+++ b/docs/fcs/typedtree.fsx
@@ -189,7 +189,7 @@ let rec visitExpr f (e:FSharpExpr) =
         visitObjArg f objExprOpt; visitExprs f argExprs
     | FSharpExprPatterns.Coerce(targetType, inpExpr) -> 
         visitExpr f inpExpr
-    | FSharpExprPatterns.FastIntegerForLoop(startExpr, limitExpr, consumeExpr, isUp) -> 
+    | FSharpExprPatterns.FastIntegerForLoop(startExpr, limitExpr, consumeExpr, isUp, _, _) -> 
         visitExpr f startExpr; visitExpr f limitExpr; visitExpr f consumeExpr
     | FSharpExprPatterns.ILAsm(asmCode, typeArgs, argExprs) -> 
         visitExprs f argExprs
@@ -201,10 +201,11 @@ let rec visitExpr f (e:FSharpExpr) =
         visitExpr f guardExpr; visitExpr f thenExpr; visitExpr f elseExpr
     | FSharpExprPatterns.Lambda(lambdaVar, bodyExpr) -> 
         visitExpr f bodyExpr
-    | FSharpExprPatterns.Let((bindingVar, bindingExpr), bodyExpr) -> 
+    | FSharpExprPatterns.Let((bindingVar, bindingExpr, dbg), bodyExpr) -> 
         visitExpr f bindingExpr; visitExpr f bodyExpr
-    | FSharpExprPatterns.LetRec(recursiveBindings, bodyExpr) -> 
-        List.iter (snd >> visitExpr f) recursiveBindings; visitExpr f bodyExpr
+    | FSharpExprPatterns.LetRec(recursiveBindings, bodyExpr) ->
+        for _,bindingExpr,_ in recursiveBindings do visitExpr f bindingExpr
+        visitExpr f bodyExpr
     | FSharpExprPatterns.NewArray(arrayType, argExprs) -> 
         visitExprs f argExprs
     | FSharpExprPatterns.NewDelegate(delegateType, delegateBodyExpr) -> 
@@ -229,9 +230,9 @@ let rec visitExpr f (e:FSharpExpr) =
         visitObjArg f objExprOpt; visitExpr f argExpr
     | FSharpExprPatterns.Sequential(firstExpr, secondExpr) -> 
         visitExpr f firstExpr; visitExpr f secondExpr
-    | FSharpExprPatterns.TryFinally(bodyExpr, finalizeExpr) -> 
+    | FSharpExprPatterns.TryFinally(bodyExpr, finalizeExpr, dbgTry, dbgFinally) -> 
         visitExpr f bodyExpr; visitExpr f finalizeExpr
-    | FSharpExprPatterns.TryWith(bodyExpr, _, _, catchVar, catchExpr) -> 
+    | FSharpExprPatterns.TryWith(bodyExpr, _, _, catchVar, catchExpr, dbgTry, dbgWith) -> 
         visitExpr f bodyExpr; visitExpr f catchExpr
     | FSharpExprPatterns.TupleGet(tupleType, tupleElemIndex, tupleExpr) -> 
         visitExpr f tupleExpr
@@ -259,7 +260,7 @@ let rec visitExpr f (e:FSharpExpr) =
         visitExprs f argExprs
     | FSharpExprPatterns.ValueSet(valToSet, valueExpr) -> 
         visitExpr f valueExpr
-    | FSharpExprPatterns.WhileLoop(guardExpr, bodyExpr) -> 
+    | FSharpExprPatterns.WhileLoop(guardExpr, bodyExpr, dbg) -> 
         visitExpr f guardExpr; visitExpr f bodyExpr
     | FSharpExprPatterns.BaseValue baseType -> ()
     | FSharpExprPatterns.DefaultValue defaultType -> ()


### PR DESCRIPTION
* compiler errors corrected
* partially addd sym names instead of wildcards (consistency with surropunding code)
* slightly changed formatting

I also checked the other fsx in the "fcs" folder for compiler errors (by opening them) and couldn't see any further compiler errors.

Also noticed that indentation is a mix between 2 and 4 spaces, but I didn't change that since I'm not sure if that's compliant with the style guide.