### PR TITLE
[WIP] Enable double dollar for triple quoted interpolated strings

### DIFF
--- a/src/Compiler/Facilities/prim-lexing.fsi
+++ b/src/Compiler/Facilities/prim-lexing.fsi
@@ -115,6 +115,9 @@ type internal LexBuffer<'Char> =
     /// Determine if Lexeme contains a specific character
     member LexemeContains: 'Char -> bool
 
+    /// The length of the lexeme.
+    member LexemeLength: int
+
     /// Fast helper to turn the matched characters into a string, avoiding an intermediate array.
     static member LexemeString: LexBuffer<char> -> string
 

--- a/src/Compiler/Facilities/prim-lexing.fsi
+++ b/src/Compiler/Facilities/prim-lexing.fsi
@@ -116,7 +116,7 @@ type internal LexBuffer<'Char> =
     member LexemeContains: 'Char -> bool
 
     /// The length of the lexeme.
-    member LexemeLength: int
+    member LexemeLength: int with get, set
 
     /// Fast helper to turn the matched characters into a string, avoiding an intermediate array.
     static member LexemeString: LexBuffer<char> -> string

--- a/src/Compiler/Service/ServiceLexing.fs
+++ b/src/Compiler/Service/ServiceLexing.fs
@@ -615,7 +615,7 @@ module internal LexerStateEncoding =
                 match stringNest with
                 | [] -> false, 0, 0, false, []
                 | (i1, kind1, b1, _)::rest -> true, i1, encodeStringStyle kind1, b1, rest
-            
+
             let tag2, i2, kind2, b2 =
                 match rest with
                 | [] -> false, 0, 0, false

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -274,6 +274,7 @@ type LexerStringKind =
         IsByteString: bool
         IsInterpolated: bool
         IsInterpolatedFirst: bool
+        IsDoubleDollarInterpolated: bool
     }
 
     static member String =
@@ -281,6 +282,7 @@ type LexerStringKind =
             IsByteString = false
             IsInterpolated = false
             IsInterpolatedFirst = false
+            IsDoubleDollarInterpolated = false
         }
 
     static member ByteString =
@@ -288,25 +290,28 @@ type LexerStringKind =
             IsByteString = true
             IsInterpolated = false
             IsInterpolatedFirst = false
+            IsDoubleDollarInterpolated = false
         }
 
-    static member InterpolatedStringFirst =
+    static member InterpolatedStringFirst(isDoubleDollar) =
         {
             IsByteString = false
             IsInterpolated = true
             IsInterpolatedFirst = true
+            IsDoubleDollarInterpolated = isDoubleDollar
         }
 
-    static member InterpolatedStringPart =
+    static member InterpolatedStringPart(isDoubleDollar) =
         {
             IsByteString = false
             IsInterpolated = true
             IsInterpolatedFirst = false
+            IsDoubleDollarInterpolated = isDoubleDollar
         }
 
 /// Represents the degree of nesting of '{..}' and the style of the string to continue afterwards, in an interpolation fill.
 /// Nesting counters and styles of outer interpolating strings are pushed on this stack.
-type LexerInterpolatedStringNesting = (int * LexerStringStyle * range) list
+type LexerInterpolatedStringNesting = (int * LexerStringStyle * bool * range) list
 
 /// The parser defines a number of tokens for whitespace and
 /// comments eliminated by the lexer.  These carry a specification of

--- a/src/Compiler/SyntaxTree/ParseHelpers.fsi
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fsi
@@ -106,17 +106,18 @@ type LexerStringStyle =
 type LexerStringKind =
     { IsByteString: bool
       IsInterpolated: bool
-      IsInterpolatedFirst: bool }
+      IsInterpolatedFirst: bool
+      IsDoubleDollarInterpolated: bool }
 
     static member ByteString: LexerStringKind
 
-    static member InterpolatedStringFirst: LexerStringKind
+    static member InterpolatedStringFirst: bool -> LexerStringKind
 
-    static member InterpolatedStringPart: LexerStringKind
+    static member InterpolatedStringPart: bool -> LexerStringKind
 
     static member String: LexerStringKind
 
-type LexerInterpolatedStringNesting = (int * LexerStringStyle * range) list
+type LexerInterpolatedStringNesting = (int * LexerStringStyle * bool * range) list
 
 [<RequireQualifiedAccess; NoComparison; NoEquality>]
 type LexerContinuation =

--- a/src/Compiler/lex.fsl
+++ b/src/Compiler/lex.fsl
@@ -854,6 +854,9 @@ rule token args skip = parse
          // Note, we do not update the 'm', any incomplete-interpolation error
          // will be reported w.r.t. the first '{'
          args.stringNest <- (counter + 1, style, isDoubleDollar, m) :: rest
+       | _ when isDouble ->
+           lexbuf.LexemeLength <- 1
+           lexbuf.EndPos <- lexbuf.EndPos.ShiftColumnBy -1
        | _ -> ()
        // To continue token-by-token lexing may involve picking up the new args.stringNes
        let cont = LexCont.Token(args.ifdefStack, args.stringNest)
@@ -887,6 +890,9 @@ rule token args skip = parse
            RBRACE cont
 
         | _ ->
+           if isDouble then
+               lexbuf.LexemeLength <- 1
+               lexbuf.EndPos <- lexbuf.EndPos.ShiftColumnBy -1
            let cont = LexCont.Token(args.ifdefStack, args.stringNest)
            RBRACE cont
      }

--- a/src/Compiler/lex.fsl
+++ b/src/Compiler/lex.fsl
@@ -600,14 +600,14 @@ rule token args skip = parse
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
-       | (_, LexerStringStyle.TripleQuote, _) :: _ -> ()
+       | (_, LexerStringStyle.TripleQuote, _, _) :: _ -> ()
        | _ :: _ -> errorR(Error(FSComp.SR.lexSingleQuoteInSingleQuote(), m))
        | [] -> ()
 
        if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.SingleQuote, LexerStringKind.String, m))
        else singleQuoteString (buf, fin, m, LexerStringKind.String, args) skip lexbuf }
 
- | '$' '"' '"' '"'
+ | ("$$" | "$") '"' '"' '"'
      { let buf, fin, m = startString args lexbuf
 
        // Single quote in triple quote ok, others disallowed
@@ -615,20 +615,21 @@ rule token args skip = parse
        | _ :: _ -> errorR(Error(FSComp.SR.lexTripleQuoteInTripleQuote(), m))
        | [] -> ()
 
-       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.TripleQuote, LexerStringKind.InterpolatedStringFirst, m))
-       else tripleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringFirst, args) skip lexbuf }
+       let doubleDollar = lexbuf.LexemeLength > 4
+       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.TripleQuote, LexerStringKind.InterpolatedStringFirst(doubleDollar), m))
+       else tripleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringFirst(doubleDollar), args) skip lexbuf }
 
  | '$' '"'
      { let buf,fin,m = startString args lexbuf
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
-       | (_, LexerStringStyle.TripleQuote, _) :: _ -> ()
+       | (_, LexerStringStyle.TripleQuote, _, _) :: _ -> ()
        | _ :: _ -> errorR(Error(FSComp.SR.lexSingleQuoteInSingleQuote(), m))
        | _ -> ()
 
-       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.SingleQuote, LexerStringKind.InterpolatedStringFirst, m))
-       else singleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringFirst, args) skip lexbuf }
+       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.SingleQuote, LexerStringKind.InterpolatedStringFirst(false), m))
+       else singleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringFirst(false), args) skip lexbuf }
 
  | '"' '"' '"'
      { let buf, fin, m = startString args lexbuf
@@ -646,7 +647,7 @@ rule token args skip = parse
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
-       | (_, LexerStringStyle.TripleQuote, _) :: _ -> ()
+       | (_, LexerStringStyle.TripleQuote, _, _) :: _ -> ()
        | _ :: _ -> errorR(Error(FSComp.SR.lexSingleQuoteInSingleQuote(), m))
        | _ -> ()
 
@@ -658,12 +659,12 @@ rule token args skip = parse
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
-       | (_, LexerStringStyle.TripleQuote, _) :: _ -> ()
+       | (_, LexerStringStyle.TripleQuote, _, _) :: _ -> ()
        | _ :: _ -> errorR(Error(FSComp.SR.lexSingleQuoteInSingleQuote(), m))
        | _ -> ()
 
-       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.Verbatim, LexerStringKind.InterpolatedStringFirst, m))
-       else verbatimString (buf, fin, m, LexerStringKind.InterpolatedStringFirst, args) skip lexbuf }
+       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.Verbatim, LexerStringKind.InterpolatedStringFirst(false), m))
+       else verbatimString (buf, fin, m, LexerStringKind.InterpolatedStringFirst(false), args) skip lexbuf }
 
  | truewhite+
      { if skip then token args skip lexbuf
@@ -845,14 +846,15 @@ rule token args skip = parse
 
  | ">]" { GREATER_RBRACK }
 
- | "{"
+ | ("{{" | "{")
      {
+       let isDouble = lexbuf.LexemeLength > 1
        match args.stringNest with
-       | [] -> ()
-       | (counter, style, m) :: rest ->
+       | (counter, style, isDoubleDollar, m) :: rest when isDoubleDollar = isDouble ->
          // Note, we do not update the 'm', any incomplete-interpolation error
          // will be reported w.r.t. the first '{'
-         args.stringNest <- (counter + 1, style, m) :: rest
+         args.stringNest <- (counter + 1, style, isDoubleDollar, m) :: rest
+       | _ -> ()
        // To continue token-by-token lexing may involve picking up the new args.stringNes
        let cont = LexCont.Token(args.ifdefStack, args.stringNest)
        LBRACE cont
@@ -860,26 +862,27 @@ rule token args skip = parse
 
  | "|" { BAR }
 
- | "}"
+ | ("}}" | "}")
      {
        // We encounter a '}' in the expression token stream.  First check if we're in an interpolated string expression
        // and continue the string if necessary
+       let isDouble = lexbuf.LexemeLength > 1
        match args.stringNest with
-       | (1, style, _) :: rest ->
+       | (1, style, isDoubleDollar, _) :: rest when isDoubleDollar = isDouble ->
            args.stringNest <- rest
            let buf, fin, m = startString args lexbuf
            if not skip then
-               STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, style, LexerStringKind.InterpolatedStringPart, m))
+               STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, style, LexerStringKind.InterpolatedStringPart(isDoubleDollar), m))
            else
                match style with
-               | LexerStringStyle.Verbatim -> verbatimString (buf, fin, m, LexerStringKind.InterpolatedStringPart, args) skip lexbuf
-               | LexerStringStyle.SingleQuote -> singleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringPart, args) skip lexbuf
-               | LexerStringStyle.TripleQuote -> tripleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringPart, args) skip lexbuf
+               | LexerStringStyle.Verbatim -> verbatimString (buf, fin, m, LexerStringKind.InterpolatedStringPart(isDoubleDollar), args) skip lexbuf
+               | LexerStringStyle.SingleQuote -> singleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringPart(isDoubleDollar), args) skip lexbuf
+               | LexerStringStyle.TripleQuote -> tripleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringPart(isDoubleDollar), args) skip lexbuf
 
-        | (counter, style, m) :: rest ->
+        | (counter, style, isDoubleDollar, m) :: rest when isDoubleDollar = isDouble ->
            // Note, we do not update the 'm', any incomplete-interpolation error
            // will be reported w.r.t. the first '{'
-           args.stringNest <- (counter - 1, style, m) :: rest
+           args.stringNest <- (counter - 1, style, isDoubleDollar, m) :: rest
            let cont = LexCont.Token(args.ifdefStack, args.stringNest)
            RBRACE cont
 
@@ -1189,36 +1192,33 @@ and singleQuoteString sargs skip = parse
       fin.Finish buf { kind with IsByteString = true } (enum<LexerStringFinisherContext>(0)) cont
     }
 
- | ("{{" | "}}")
-    { let (buf, _fin, m, kind, args) = sargs
-      let s = lexeme lexbuf
-      addUnicodeString buf (if kind.IsInterpolated then s.[0..0] else s)
-      if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.SingleQuote, kind, m))
-      else singleQuoteString sargs skip lexbuf }
-
- | "{"
+ | ("{{" | "{")
     { let (buf, fin, m, kind, args) = sargs
-      if kind.IsInterpolated then
+      let isDouble = lexbuf.LexemeLength > 1
+      if kind.IsInterpolated && kind.IsDoubleDollarInterpolated = isDouble then
           // get a new range for where the fill starts
           let m2 = lexbuf.LexemeRange
-          args.stringNest <- (1, LexerStringStyle.SingleQuote, m2) :: args.stringNest
+          args.stringNest <- (1, LexerStringStyle.SingleQuote, kind.IsDoubleDollarInterpolated, m2) :: args.stringNest
           let cont = LexCont.Token(args.ifdefStack, args.stringNest)
           fin.Finish buf kind LexerStringFinisherContext.InterpolatedPart cont
       else
-          addUnicodeString buf (lexeme lexbuf)
+          let s = lexeme lexbuf
+          addUnicodeString buf (if kind.IsInterpolated && not kind.IsDoubleDollarInterpolated then s.[0..0] else s)
           if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.SingleQuote, kind, m))
           else singleQuoteString sargs skip lexbuf
     }
 
- | "}"
+ | ("}}" | "}")
     { let (buf, _fin, m, kind, args) = sargs
       let result() =
           if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.SingleQuote, kind, m))
           else singleQuoteString sargs skip lexbuf
-      if kind.IsInterpolated then
+      let isDouble = lexbuf.LexemeLength > 1
+      if kind.IsInterpolated && kind.IsDoubleDollarInterpolated = isDouble then
           fail args lexbuf (FSComp.SR.lexRBraceInInterpolatedString()) (result())
       else
-          addUnicodeString buf (lexeme lexbuf)
+          let s = lexeme lexbuf
+          addUnicodeString buf (if kind.IsInterpolated && not kind.IsDoubleDollarInterpolated then s.[0..0] else s)
           (result())
     }
 
@@ -1286,36 +1286,33 @@ and verbatimString sargs skip = parse
       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.Verbatim, kind, m))
       else verbatimString sargs skip lexbuf }
 
- | ("{{" | "}}")
-    { let (buf, _fin, m, kind, args) = sargs
-      let s = lexeme lexbuf
-      addUnicodeString buf (if kind.IsInterpolated then s.[0..0] else s)
-      if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.Verbatim, kind, m))
-      else verbatimString sargs skip lexbuf }
-
- | "{"
+ | ("{{" | "{")
     { let (buf, fin, m, kind, args) = sargs
-      if kind.IsInterpolated then
+      let isDouble = lexbuf.LexemeLength > 1
+      if kind.IsInterpolated && kind.IsDoubleDollarInterpolated = isDouble then
           // get a new range for where the fill starts
           let m2 = lexbuf.LexemeRange
-          args.stringNest <- (1, LexerStringStyle.Verbatim, m2) :: args.stringNest
+          args.stringNest <- (1, LexerStringStyle.Verbatim, kind.IsDoubleDollarInterpolated, m2) :: args.stringNest
           let cont = LexCont.Token(args.ifdefStack, args.stringNest)
           fin.Finish buf kind (enum<LexerStringFinisherContext>(3)) cont
       else
-          addUnicodeString buf (lexeme lexbuf)
+          let s = lexeme lexbuf
+          addUnicodeString buf (if kind.IsInterpolated && not kind.IsDoubleDollarInterpolated then s.[0..0] else s)
           if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.Verbatim, kind, m))
           else verbatimString sargs skip lexbuf
     }
 
- | "}"
+ | ("}}" | "}")
     { let (buf, _fin, m, kind, args) = sargs
       let result() =
           if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.Verbatim, kind, m))
           else verbatimString sargs skip lexbuf
-      if kind.IsInterpolated then
+      let isDouble = lexbuf.LexemeLength > 1
+      if kind.IsInterpolated && kind.IsDoubleDollarInterpolated = isDouble then
           fail args lexbuf (FSComp.SR.lexRBraceInInterpolatedString()) (result())
       else
-          addUnicodeString buf (lexeme lexbuf)
+          let s = lexeme lexbuf
+          addUnicodeString buf (if kind.IsInterpolated && not kind.IsDoubleDollarInterpolated then s.[0..0] else s)
           (result())
     }
 
@@ -1382,36 +1379,33 @@ and tripleQuoteString sargs skip = parse
       if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.TripleQuote, kind, m))
       else tripleQuoteString sargs skip lexbuf }
 
- | ("{{" | "}}")
-    { let (buf, _fin, m, kind, args) = sargs
-      let s = lexeme lexbuf
-      addUnicodeString buf (if kind.IsInterpolated then s.[0..0] else s)
-      if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.TripleQuote, kind, m))
-      else tripleQuoteString sargs skip lexbuf }
-
- | "{"
+ | ("{{" | "{")
     { let (buf, fin, m, kind, args) = sargs
-      if kind.IsInterpolated then
+      let isDouble = lexbuf.LexemeLength > 1
+      if kind.IsInterpolated && kind.IsDoubleDollarInterpolated = isDouble then
           // get a new range for where the fill starts
           let m2 = lexbuf.LexemeRange
-          args.stringNest <- (1, LexerStringStyle.TripleQuote, m2) :: args.stringNest
+          args.stringNest <- (1, LexerStringStyle.TripleQuote, kind.IsDoubleDollarInterpolated, m2) :: args.stringNest
           let cont = LexCont.Token(args.ifdefStack, args.stringNest)
           fin.Finish buf kind (enum<LexerStringFinisherContext>(5)) cont
       else
-          addUnicodeString buf (lexeme lexbuf)
+          let s = lexeme lexbuf
+          addUnicodeString buf (if kind.IsInterpolated && not kind.IsDoubleDollarInterpolated then s.[0..0] else s)
           if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.TripleQuote, kind, m))
           else tripleQuoteString sargs skip lexbuf
     }
 
- | "}"
+ | ("}}" | "}")
     { let (buf, _fin, m, kind, args) = sargs
       let result() =
           if not skip then STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, LexerStringStyle.TripleQuote, kind, m))
           else tripleQuoteString sargs skip lexbuf
-      if kind.IsInterpolated then
+      let isDouble = lexbuf.LexemeLength > 1
+      if kind.IsInterpolated && kind.IsDoubleDollarInterpolated = isDouble then
           fail args lexbuf (FSComp.SR.lexRBraceInInterpolatedString()) (result())
       else
-          addUnicodeString buf (lexeme lexbuf)
+          let s = lexeme lexbuf
+          addUnicodeString buf (if kind.IsInterpolated && not kind.IsDoubleDollarInterpolated then s.[0..0] else s)
           (result())
     }
 

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -142,7 +142,7 @@ let checkEndOfFileError t =
       | (_, m) :: _  -> reportParseErrorAt m (FSComp.SR.parsNoHashEndIfFound())
       match nesting with 
       | [] -> ()
-      | (_, _, m) :: _  -> reportParseErrorAt m (FSComp.SR.parsEofInInterpolatedStringFill())
+      | (_, _, _, m) :: _  -> reportParseErrorAt m (FSComp.SR.parsEofInInterpolatedStringFill())
 
 type BindingSet = BindingSetPreAttrs of range * bool * bool * (SynAttributes -> SynAccess option -> SynAttributes * SynBinding list) * range
 

--- a/tests/fsharp/Compiler/Language/StringInterpolation.fs
+++ b/tests/fsharp/Compiler/Language/StringInterpolation.fs
@@ -464,6 +464,16 @@ check "vcewweh229f" "}}" "}}"
             """
 
     [<Test>]
+    let ``String interpolation using escaped braces - double dollar`` () =
+        SimpleCheckTest
+            """
+check "vcewweh226i" $$\"\"\"{\"\"\" "{"
+check "vcewweh226f" $$\"\"\"{}\"\"\" "{}"
+check "vcewweh226p" $$\"\"\"{ {{1}} }\"\"\" "{ 1 }"
+check "vcewweh227a" $$\"\"\"}\"\"\" "}"
+            """
+
+    [<Test>]
     let ``String interpolation using verbatim strings`` () =
         SimpleCheckTest
             """
@@ -487,10 +497,18 @@ type R2 = { X : int ; Y: int }
 // Check record expression (parenthesized)
 check "vcewweh18" $"abc{({contents=1}.contents)}def" "abc1def"
 
+// Check record expression (parenthesized) - double dollar
+check "vcewweh18b" $$\"\"\"abc{{({contents=1}.contents)}}def\"\"\" "abc1def"
+
 // Check record expression (unparenthesized, spaced)
 check "vcewweh19a" $"abc{   {X=1}   }def" "abc{ X = 1 }def"
 
 check "vcewweh19b" $"abc{ {X=1} }def" "abc{ X = 1 }def"
+
+// Check record expression (unparenthesized, spaced) - double dollar
+check "vcewweh19c" $$"abc{{   {X=1}   }}def" "abc{ X = 1 }def"
+
+check "vcewweh19d" $$\"\"\"abc{{ {X=1} }}def\"\"\" "abc{ X = 1 }def"
 
 // Check record expression (unparenthesized, spaced ending in token brace then string hole brace)
 check "vcewweh19v" $"abc{ {X=1}}def" "abc{ X = 1 }def"
@@ -500,6 +518,9 @@ check "vcewweh20" $"abc{{X=1}}def" "abc{X=1}def"
 
 // Check thing that is not really a record expression (braces are escaped)
 check "vcewweh20b" $"abc{{quack=1}}def" "abc{quack=1}def"
+
+// Check thing that is not really a record expression (double dollar)
+check "vcewweh20c" $$\"\"\"abc{X=1}def\"\"\" "abc{X=1}def"
 
 // Check thing that is not really a record expression (braces are escaped)
 check "vcewweh21" $"abc{{X=1; Y=2}}def" "abc{X=1; Y=2}def"


### PR DESCRIPTION
See https://github.com/fsharp/fslang-suggestions/issues/1150

This doesn't include percent symbol yet, I'm sending the draft PR to see if the approach is correct. I started trying to implement variable dollar length as in C# but then I realized `LexerStringKind` is byte encoded in ServiceLexing.fs, so I kept is as a flag for simplicity. If we finally only allow double dollar (and not triple, quadruple) this should be stated in the RFC.