### PR TITLE
Add OutputRefAssembly and RefOnly to the FSC task

### DIFF
--- a/src/FSharp.Build/Fsc.fs
+++ b/src/FSharp.Build/Fsc.fs
@@ -45,6 +45,7 @@ type public Fsc() as this =
     let mutable optimize: bool = true
     let mutable otherFlags: string MaybeNull = null
     let mutable outputAssembly: string MaybeNull = null
+    let mutable outputRefAssembly: string MaybeNull = null
     let mutable pathMap: string MaybeNull = null
     let mutable pdbFile: string MaybeNull = null
     let mutable platform: string MaybeNull = null
@@ -54,6 +55,7 @@ type public Fsc() as this =
     let mutable provideCommandLineArgs: bool = false
     let mutable references: ITaskItem[] = [||]
     let mutable referencePath: string MaybeNull = null
+    let mutable refOnly: bool = false
     let mutable resources: ITaskItem[] = [||]
     let mutable skipCompilerExecution: bool = false
     let mutable sources: ITaskItem[] = [||]
@@ -324,6 +326,12 @@ type public Fsc() as this =
         builder.AppendFileNamesIfNotNull(sources, " ")
         capturedFilenames <- builder.CapturedFilenames()
 
+        // Ref assemblies
+        builder.AppendSwitchIfNotNull("--refout:", outputRefAssembly)
+
+        if refOnly then
+            builder.AppendSwitch("--refonly")
+
         builder
 
     // --baseaddress
@@ -446,6 +454,11 @@ type public Fsc() as this =
         with get () = outputAssembly
         and set (s) = outputAssembly <- s
 
+    // --refout <string>: Name the output ref file
+    member _.OutputRefAssembly
+        with get () = outputRefAssembly
+        and set (s) = outputRefAssembly <- s
+
     // --pathmap <string>: Paths to rewrite when producing deterministic builds
     member _.PathMap
         with get () = pathMap
@@ -492,6 +505,11 @@ type public Fsc() as this =
     member _.ReferencePath
         with get () = referencePath
         and set (s) = referencePath <- s
+
+    // --refonly
+    member _.RefOnly
+        with get () = refOnly
+        and set (b) = refOnly <- b
 
     // --resource <string>: Embed the specified managed resources (.resource).
     //   Produce .resource files from .resx files using resgen.exe or resxc.exe.

--- a/src/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/FSharp.Build/Microsoft.FSharp.Targets
@@ -264,6 +264,7 @@ this file.
                 $(LoadSource)"
         Outputs="@(DocFileItem);
                  @(IntermediateAssembly);
+                 @(IntermediateRefAssembly);
                  @(_DebugSymbolsIntermediatePath);
                  $(NonExistentFile);
                  @(CustomAdditionalCompileOutputs)"
@@ -337,6 +338,7 @@ this file.
               Optimize="$(Optimize)"
               OtherFlags="$(FscOtherFlags)"
               OutputAssembly="@(IntermediateAssembly)"
+              OutputRefAssembly="@(IntermediateRefAssembly)"
               PathMap="$(PathMap)"
               PdbFile="$(PdbFile)"
               Platform="$(PlatformTarget)"
@@ -346,6 +348,7 @@ this file.
               PublicSign="$(PublicSign)"
               References="@(ReferencePath)"
               ReferencePath="$(ReferencePath)"
+              RefOnly="$(ProduceOnlyReferenceAssembly)"
               Resources="@(ActualEmbeddedResources)"
               SkipCompilerExecution="$(SkipCompilerExecution)"
               SourceLink="$(SourceLink)"


### PR DESCRIPTION
This is a step toward resolving the https://github.com/dotnet/fsharp/issues/13223.

It adds new parameters to the FSC task to match Roslyn's CSC task (See [OutputRefAssembly](https://github.com/dotnet/roslyn/blob/094bee3a6ed7ae1b1042c19764ee55817033645f/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs#L270) and [RefOnly](https://github.com/dotnet/roslyn/blob/094bee3a6ed7ae1b1042c19764ee55817033645f/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs#L306-L310)).

I've tested manually that after this change, it is possible to use `<ProduceReferenceAssembly>true</ProduceReferenceAssembly>` in a project to generate reference assembly. Note that until https://github.com/dotnet/fsharp/issues/13216 is resolved, build optimization based on ref assemblies will not yet work. 

