### PR TITLE
Fix13216

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/AssemblyHasMvidSection.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/AssemblyHasMvidSection.fs
@@ -1,8 +1,19 @@
-﻿open System
+﻿module AssemblyHasMvidSection
+
+open System
 open System.IO
 open System.Reflection
-open Testing
+open FSharp.Compiler.ComponentTests.EmittedIL
 
-let pathToMe = Assembly.GetExecutingAssembly().Location
+let  pathToDll =
+    let d = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+    Path.Combine(d, "SimpleFsProgram.dll")
 
-let stream = File.Open(pathToMe, FileMode.Open)
+Console.WriteLine($"Verify mvid section for: {pathToDll}");
+let stream = File.OpenRead(pathToDll);
+let mvid = MvidReader.ReadAssemblyMvidOrEmpty(stream)
+
+let message = $"Mvid for {pathToDll} = {mvid}"
+printfn $"{message}"
+
+if mvid = Guid.Empty then failwith message

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/AssemblyHasMvidSection.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/AssemblyHasMvidSection.fs
@@ -1,0 +1,8 @@
+﻿open System
+open System.IO
+open System.Reflection
+open Testing
+
+let pathToMe = Assembly.GetExecutingAssembly().Location
+
+let stream = File.Open(pathToMe, FileMode.Open)

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/MvidReader.cs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/MvidReader.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 
-namespace Testing
+namespace FSharp.Compiler.ComponentTests.EmittedIL
 {
     public static class MvidReader
     {
@@ -87,7 +87,7 @@ namespace Testing
             for (int i = 0; i < count; i++)
             {
                 // Section: Name (8)
-                if (!ReadBytes(reader, 8, out byte[]? name))
+                if (!ReadBytes(reader, 8, out byte[] name))
                 {
                     return s_empty;
                 }
@@ -138,7 +138,7 @@ namespace Testing
                 return s_empty;
             }
 
-            if (!ReadBytes(reader, 16, out byte[]? guidBytes))
+            if (!ReadBytes(reader, 16, out byte[] guidBytes))
             {
                 return s_empty;
             }
@@ -170,7 +170,7 @@ namespace Testing
             return true;
         }
 
-        private static bool ReadBytes(BinaryReader reader, int count, out byte[]? output)
+        private static bool ReadBytes(BinaryReader reader, int count, out byte[] output)
         {
             if (reader.BaseStream.Position + count >= reader.BaseStream.Length)
             {

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/MvidReader.cs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/MvidReader.cs
@@ -1,0 +1,207 @@
+using System;
+using System.IO;
+
+namespace Testing
+{
+    public static class MvidReader
+    {
+        private static readonly Guid s_empty = Guid.Empty;
+
+        public static Guid ReadAssemblyMvidOrEmpty(Stream stream)
+        {
+            return ReadAssemblyMvidOrEmpty(new BinaryReader(stream));
+        }
+
+        private static Guid ReadAssemblyMvidOrEmpty(BinaryReader reader)
+        {
+            // DOS Header: Magic number (2)
+            if (!ReadUInt16(reader, out ushort magicNumber) || magicNumber != 0x5a4d) // "MZ"
+            {
+                return s_empty;
+            }
+
+            // DOS Header: Address of PE Signature (at 0x3C)
+            if (!MoveTo(0x3C, reader))
+            {
+                return s_empty;
+            }
+            if (!ReadUInt32(reader, out uint pointerToPeSignature))
+            {
+                return s_empty;
+            }
+
+            // jump over the MS DOS Stub to the PE Signature
+            if (!MoveTo(pointerToPeSignature, reader))
+            {
+                return s_empty;
+            }
+
+            // PE Signature ('P' 'E' null null)
+            if (!ReadUInt32(reader, out uint peSig) || peSig != 0x00004550)
+            {
+                return s_empty;
+            }
+
+            // COFF Header: Machine (2)
+            if (!Skip(2, reader))
+            {
+                return s_empty;
+            }
+
+            // COFF Header: NumberOfSections (2)
+            if (!ReadUInt16(reader, out ushort sections))
+            {
+                return s_empty;
+            }
+
+            // COFF Header: TimeDateStamp (4), PointerToSymbolTable (4), NumberOfSymbols (4)
+            if (!Skip(12, reader))
+            {
+                return s_empty;
+            }
+
+            // COFF Header: OptionalHeaderSize (2)
+            if (!ReadUInt16(reader, out ushort optionalHeaderSize))
+            {
+                return s_empty;
+            }
+
+            // COFF Header: Characteristics (2)
+            if (!Skip(2, reader))
+            {
+                return s_empty;
+            }
+
+            // Optional header
+            if (!Skip(optionalHeaderSize, reader))
+            {
+                return s_empty;
+            }
+
+            // Section headers
+            return FindMvidInSections(sections, reader);
+        }
+
+        private static Guid FindMvidInSections(ushort count, BinaryReader reader)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                // Section: Name (8)
+                if (!ReadBytes(reader, 8, out byte[]? name))
+                {
+                    return s_empty;
+                }
+
+                if (name!.Length == 8 && name[0] == '.' &&
+                    name[1] == 'm' && name[2] == 'v' && name[3] == 'i' && name[4] == 'd' && name[5] == '\0')
+                {
+                    // Section: VirtualSize (4)
+                    if (!ReadUInt32(reader, out uint virtualSize) || virtualSize != 16)
+                    {
+                        // The .mvid section only stores a Guid
+                        return s_empty;
+                    }
+
+                    // Section: VirtualAddress (4), SizeOfRawData (4)
+                    if (!Skip(8, reader))
+                    {
+                        return s_empty;
+                    }
+
+                    // Section: PointerToRawData (4)
+                    if (!ReadUInt32(reader, out uint pointerToRawData))
+                    {
+                        return s_empty;
+                    }
+
+                    return ReadMvidSection(reader, pointerToRawData);
+                }
+                else
+                {
+                    // Section: VirtualSize (4), VirtualAddress (4), SizeOfRawData (4),
+                    // PointerToRawData (4), PointerToRelocations (4), PointerToLineNumbers (4),
+                    // NumberOfRelocations (2), NumberOfLineNumbers (2), Characteristics (4)
+                    if (!Skip(4 + 4 + 4 + 4 + 4 + 4 + 2 + 2 + 4, reader))
+                    {
+                        return s_empty;
+                    }
+                }
+            }
+
+            return s_empty;
+        }
+
+        private static Guid ReadMvidSection(BinaryReader reader, uint pointerToMvidSection)
+        {
+            if (!MoveTo(pointerToMvidSection, reader))
+            {
+                return s_empty;
+            }
+
+            if (!ReadBytes(reader, 16, out byte[]? guidBytes))
+            {
+                return s_empty;
+            }
+
+            return new Guid(guidBytes!);
+        }
+
+        private static bool ReadUInt16(BinaryReader reader, out ushort output)
+        {
+            if (reader.BaseStream.Position + 2 >= reader.BaseStream.Length)
+            {
+                output = 0;
+                return false;
+            }
+
+            output = reader.ReadUInt16();
+            return true;
+        }
+
+        private static bool ReadUInt32(BinaryReader reader, out uint output)
+        {
+            if (reader.BaseStream.Position + 4 >= reader.BaseStream.Length)
+            {
+                output = 0;
+                return false;
+            }
+
+            output = reader.ReadUInt32();
+            return true;
+        }
+
+        private static bool ReadBytes(BinaryReader reader, int count, out byte[]? output)
+        {
+            if (reader.BaseStream.Position + count >= reader.BaseStream.Length)
+            {
+                output = null;
+                return false;
+            }
+
+            output = reader.ReadBytes(count);
+            return true;
+        }
+
+        private static bool Skip(int bytes, BinaryReader reader)
+        {
+            if (reader.BaseStream.Position + bytes >= reader.BaseStream.Length)
+            {
+                return false;
+            }
+
+            reader.BaseStream.Seek(bytes, SeekOrigin.Current);
+            return true;
+        }
+
+        private static bool MoveTo(uint position, BinaryReader reader)
+        {
+            if (position >= reader.BaseStream.Length)
+            {
+                return false;
+            }
+
+            reader.BaseStream.Seek(position, SeekOrigin.Begin);
+            return true;
+        }
+    }
+}

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/Platform.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/Platform.fs
@@ -8,10 +8,6 @@ open System.Runtime.InteropServices
 
 module Platform =
 
-    let assemblyHasMvidSection =
-        CsFromPath (Path.Combine(__SOURCE_DIRECTORY__, "AssemblyHasMvidSection.fs"))
-        |> withName "AssemblyHasMvidSection"
-
     let isArm =
         match System.Runtime.InteropServices.Architecture() with
         | Architecture.Arm | Architecture.Arm64 -> true
@@ -140,11 +136,39 @@ module Platform =
         |> compileExeAndRun
         |> shouldSucceed
 
-    //[<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AssemblyHasMvidSection.fs"|])>]
-    //let generatedExeHasMvidSection compilation =
-    //    compilation
-    //    |> asExe
-    //    |> withReferences [assemblyHasMvidSection]
-    //    |> withRefOut "test"
-    //    |> compileExeAndRun
-    //    |> shouldSucceed
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AssemblyHasMvidSection.fs"|])>]
+    let withRefOnlyGeneratesMvidSection compilation =
+
+        let mvidReader =
+            CsFromPath (Path.Combine(__SOURCE_DIRECTORY__, "MvidReader.cs"))
+            |> withName "MvidReader"
+
+        let assemblyHasMvidSection =
+            FsFromPath (Path.Combine(__SOURCE_DIRECTORY__, "SimpleFsProgram.fs"))
+            |> asLibrary
+            |> withRefOnly
+
+        compilation
+        |> asExe
+        |> withReferences [mvidReader]
+        |> withReferences [assemblyHasMvidSection]
+        |> compileExeAndRun
+        |> shouldSucceed
+
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AssemblyHasMvidSection.fs"|])>]
+    let withoutRefOnlyGeneratesNoMvidSection compilation =
+
+        let mvidReader =
+            CsFromPath (Path.Combine(__SOURCE_DIRECTORY__, "MvidReader.cs"))
+            |> withName "MvidReader"
+
+        let assemblyHasMvidSection =
+            FsFromPath (Path.Combine(__SOURCE_DIRECTORY__, "SimpleFsProgram.fs"))
+            |> asLibrary
+
+        compilation
+        |> asExe
+        |> withReferences [mvidReader]
+        |> withReferences [assemblyHasMvidSection]
+        |> compileExeAndRun
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/Platform.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/Platform.fs
@@ -3,9 +3,14 @@
 open Xunit
 open FSharp.Test
 open FSharp.Test.Compiler
+open System.IO
 open System.Runtime.InteropServices
 
 module Platform =
+
+    let assemblyHasMvidSection =
+        CsFromPath (Path.Combine(__SOURCE_DIRECTORY__, "AssemblyHasMvidSection.fs"))
+        |> withName "AssemblyHasMvidSection"
 
     let isArm =
         match System.Runtime.InteropServices.Architecture() with
@@ -134,3 +139,12 @@ module Platform =
         |> withReferences [ buildPlatformedDll |> withPlatform ExecutionPlatform.X64 ]
         |> compileExeAndRun
         |> shouldSucceed
+
+    //[<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AssemblyHasMvidSection.fs"|])>]
+    //let generatedExeHasMvidSection compilation =
+    //    compilation
+    //    |> asExe
+    //    |> withReferences [assemblyHasMvidSection]
+    //    |> withRefOut "test"
+    //    |> compileExeAndRun
+    //    |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/Platform.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/Platform.fs
@@ -171,4 +171,4 @@ module Platform =
         |> withReferences [mvidReader]
         |> withReferences [assemblyHasMvidSection]
         |> compileExeAndRun
-        |> shouldSucceed
+        |> shouldFail

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/SimpleFsProgram.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Platform/SimpleFsProgram.fs
@@ -1,0 +1,1 @@
+﻿namespace NothingMuch

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -440,6 +440,14 @@ module rec Compiler =
     let withNoInterfaceData (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ "--nointerfacedata" ] "withNoInterfaceData is only supported for F#" cUnit
 
+    //--refonly[+|-]
+    let withRefOnly (cUnit: CompilationUnit) : CompilationUnit =
+        withOptionsHelper [ $"--refonly+" ] "withRefOnly is only supported for F#" cUnit
+
+    //--refonly[+|-]
+    let withNoRefOnly (cUnit: CompilationUnit) : CompilationUnit =
+        withOptionsHelper [ $"--refonly-" ] "withRefOnly is only supported for F#" cUnit
+
     //--refout:<file>                          Produce a reference assembly with the specified file path.
     let withRefOut (name:string) (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ $"--refout:{name}" ] "withNoInterfaceData is only supported for F#" cUnit

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -265,6 +265,11 @@ module rec Compiler =
     let CsSource source =
         SourceCodeFileKind.Cs({FileName="test.cs"; SourceText=Some source })
 
+    let CsFromPath (path: string) : CompilationUnit =
+        csFromString (SourceFromPath path)
+        |> CS
+        |> withName (Path.GetFileNameWithoutExtension(path))
+
     let Fsx (source: string) : CompilationUnit =
         fsFromString (FsxSourceCode source) |> FS
 
@@ -434,6 +439,10 @@ module rec Compiler =
     /// Don't add a resource to the generated assembly containing F#-specific metadata
     let withNoInterfaceData (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ "--nointerfacedata" ] "withNoInterfaceData is only supported for F#" cUnit
+
+    //--refout:<file>                          Produce a reference assembly with the specified file path.
+    let withRefOut (name:string) cUnit: CompilationUnit) : CompilationUnit =
+        withOptionsHelper [ $"--refout:{name}" ] "withNoInterfaceData is only supported for F#" cUnit
 
     let asLibrary (cUnit: CompilationUnit) : CompilationUnit =
         match cUnit with

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -441,7 +441,7 @@ module rec Compiler =
         withOptionsHelper [ "--nointerfacedata" ] "withNoInterfaceData is only supported for F#" cUnit
 
     //--refout:<file>                          Produce a reference assembly with the specified file path.
-    let withRefOut (name:string) cUnit: CompilationUnit) : CompilationUnit =
+    let withRefOut (name:string) (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ $"--refout:{name}" ] "withNoInterfaceData is only supported for F#" cUnit
 
     let asLibrary (cUnit: CompilationUnit) : CompilationUnit =


### PR DESCRIPTION
Fixes #13216 - CopyRefAssembly Could not extract the MVID from reference assembly

Just checking that nothing is broken.  It's a PE file, and stuff can break ... they are as fragile as daisies in a field in spring.

- [x] Needs: testcase
