### PR TITLE
Update SourceBuild.props to build Microsoft.FSharp.Compiler.sln

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -5,28 +5,13 @@
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
 
-  <Target Name="ApplySourceBuildPatchFiles"
-          Condition="
-            '$(ArcadeBuildFromSource)' == 'true' and
-            '$(ArcadeInnerBuildFromSource)' == 'true'"
-          BeforeTargets="Execute">
-    <ItemGroup>
-      <SourceBuildPatchFile Include="$(RepositoryEngineeringDir)source-build-patches\*.patch" />
-    </ItemGroup>
-
-    <Exec
-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
-      WorkingDirectory="$(RepoRoot)"
-      Condition="'@(SourceBuildPatchFile)' != ''" />
-  </Target>
-
   <!--
     The build script passes in the full path of the sln to build.  This must be overridden in order to build
     the cloned source in the inner build.
   -->
   <Target Name="ConfigureInnerBuildArg" BeforeTargets="GetSourceBuildCommandConfiguration">
     <PropertyGroup>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)\FSharp.sln"</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)\Microsoft.FSharp.Compiler.sln"</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
This is a follow-up to https://github.com/dotnet/fsharp/pull/13239.  Source-build should be building the Microsoft.FSharp.Compiler.sln not FSharp.sln.

Since I am touching SourceBuild.props, I am doing a little cleanup to remove the `ApplySourceBuildPatchFiles` target which should never be needed again since we have eliminated all source-build patches for fsharp.