### PR TITLE
Nested module signature

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -5287,7 +5287,7 @@ let rec TcSignatureElementNonMutRec (cenv: cenv) parent typeNames endm (env: TcE
                 else 
                     longId, defs
 
-            let envNS = LocateEnv cenv.thisCcu env enclosingNamespacePath
+            let envNS = LocateEnv kind.IsModule cenv.thisCcu env enclosingNamespacePath
             let envNS = ImplicitlyOpenOwnNamespace cenv.tcSink g cenv.amap m enclosingNamespacePath envNS
 
             // For 'namespace rec' and 'module rec' we add the thing being defined 
@@ -5609,7 +5609,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
               else 
                   longId, defs
 
-          let envNS = LocateEnv cenv.thisCcu env enclosingNamespacePath
+          let envNS = LocateEnv kind.IsModule cenv.thisCcu env enclosingNamespacePath
           let envNS = ImplicitlyOpenOwnNamespace cenv.tcSink g cenv.amap m enclosingNamespacePath envNS
 
           let modTyNS = envNS.eModuleOrNamespaceTypeAccumulator.Value

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -253,9 +253,9 @@ let BuildRootModuleType enclosingNamespacePath (cpath: CompilationPath) moduleTy
         |> fun (_, (moduleTy, moduls)) -> moduleTy, List.rev moduls
         
 /// Given a resulting module expression, place that inside a namespace path implied by a "namespace X.Y.Z" definition
-let BuildRootModuleContents enclosingNamespacePath (cpath: CompilationPath) moduleContents = 
+let BuildRootModuleContents (isModule: bool) enclosingNamespacePath (cpath: CompilationPath) moduleContents = 
     (enclosingNamespacePath, (cpath, moduleContents)) 
-        ||> List.foldBack (fun id (cpath, moduleContents) -> (cpath.ParentCompPath, wrapModuleOrNamespaceContentsInNamespace id cpath.ParentCompPath moduleContents))
+        ||> List.foldBack (fun id (cpath, moduleContents) -> (cpath.ParentCompPath, wrapModuleOrNamespaceContentsInNamespace isModule id cpath.ParentCompPath moduleContents))
         |> snd
 
 /// Try to take the "FSINNN" prefix off a namespace path
@@ -5647,7 +5647,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
                       CombineCcuContentFragments m [env.eModuleOrNamespaceTypeAccumulator.Value; modTyRoot]
                   env, openDecls
           
-          let moduleContentsRoot = BuildRootModuleContents enclosingNamespacePath envNS.eCompPath moduleContents
+          let moduleContentsRoot = BuildRootModuleContents kind.IsModule enclosingNamespacePath envNS.eCompPath moduleContents
 
           let defns =
               match openDecls with 

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -3254,7 +3254,7 @@ module EstablishTypeDefinitionCores =
               () ]
 
     let ComputeModuleOrNamespaceKind g isModule typeNames attribs nm = 
-        if not isModule then Namespace 
+        if not isModule then (Namespace true)
         elif ModuleNameIsMangled g attribs || Set.contains nm typeNames then FSharpModuleWithSuffix 
         else ModuleOrType
 
@@ -5863,7 +5863,7 @@ let emptyTcEnv g =
       eAccessRights = ComputeAccessRights cpath [] None // compute this field 
       eInternalsVisibleCompPaths = []
       eContextInfo = ContextInfo.NoContext
-      eModuleOrNamespaceTypeAccumulator = ref (Construct.NewEmptyModuleOrNamespaceType Namespace)
+      eModuleOrNamespaceTypeAccumulator = ref (Construct.NewEmptyModuleOrNamespaceType (Namespace true))
       eFamilyType = None
       eCtorInfo = None
       eCallerMemberName = None 
@@ -5992,7 +5992,7 @@ let CheckModuleSignature g (cenv: cenv) m denvAtEnd rootSigOpt implFileTypePrior
 /// Make the initial type checking environment for a single file with an empty accumulator for the overall contents for the file
 let MakeInitialEnv env = 
     // Note: here we allocate a new module type accumulator 
-    let moduleTyAcc = ref (Construct.NewEmptyModuleOrNamespaceType Namespace)
+    let moduleTyAcc = ref (Construct.NewEmptyModuleOrNamespaceType (Namespace false))
     { env with eModuleOrNamespaceTypeAccumulator = moduleTyAcc }, moduleTyAcc
 
 /// Check an entire implementation file

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -860,7 +860,7 @@ let SetCurrAccumulatedModuleOrNamespaceType env x =
     env.eModuleOrNamespaceTypeAccumulator.Value <- x
 
 /// Set up the initial environment accounting for the enclosing "namespace X.Y.Z" definition
-let LocateEnv ccu env enclosingNamespacePath =
+let LocateEnv isModule ccu env enclosingNamespacePath =
     let cpath = compPathOfCcu ccu
     let env =
         {env with
@@ -869,7 +869,8 @@ let LocateEnv ccu env enclosingNamespacePath =
             eAccessPath = cpath
             // update this computed field
             eAccessRights = ComputeAccessRights cpath env.eInternalsVisibleCompPaths env.eFamilyType }
-    let env = List.fold (fun env id -> MakeInnerEnv false env id (Namespace true) |> fst) env enclosingNamespacePath
+    let isExplicitNamespace = not isModule
+    let env = List.fold (fun env id -> MakeInnerEnv false env id (Namespace isExplicitNamespace) |> fst) env enclosingNamespacePath
     let env = { env with eNameResEnv = { env.NameEnv with eDisplayEnv = env.DisplayEnv.AddOpenPath (pathOfLid env.ePath) } }
     env
 

--- a/src/Compiler/Checking/CheckExpressions.fsi
+++ b/src/Compiler/Checking/CheckExpressions.fsi
@@ -783,7 +783,7 @@ val InferGenericArityFromTyScheme: GeneralizedType -> prelimValReprInfo: PrelimV
 
 /// Locate the environment within a particular namespace path, used to process a
 /// 'namespace' declaration.
-val LocateEnv: ccu: CcuThunk -> env: TcEnv -> enclosingNamespacePath: Ident list -> TcEnv
+val LocateEnv: isModule: bool -> ccu: CcuThunk -> env: TcEnv -> enclosingNamespacePath: Ident list -> TcEnv
 
 /// Make the check for safe initialization of a member
 val MakeCheckSafeInit:

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2259,16 +2259,16 @@ module InferredSigPrinting =
                     let rec (|NestedModule|_|) (currentContents:ModuleOrNamespaceContents) =
                         match currentContents with
                         | ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, NestedModule(path, contents)) ]) ->
-                            Some ([ yield! path; yield mn.DisplayNameCore ], contents)
+                            Some ([ yield mn.DisplayNameCore; yield! path ], contents)
                         | ModuleOrNamespaceContents.TMDefs [ ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, NestedModule(path, contents)) ]) ] ->
-                            Some ([ yield! path; yield mn.DisplayNameCore ], contents)
+                            Some ([ yield mn.DisplayNameCore; yield! path ], contents)
                         | ModuleOrNamespaceContents.TMDefs [ ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, nestedModuleContents) ]) ] ->
-                            Some ([ mspec.DisplayNameCore ; mn.DisplayNameCore ], nestedModuleContents)
+                            Some ([ mn.DisplayNameCore ], nestedModuleContents)
                         | _ ->
                             None
 
                     match def with
-                    | NestedModule(path, nestedModuleContents) -> path, nestedModuleContents
+                    | NestedModule(path, nestedModuleContents) -> mspec.DisplayNameCore :: path, nestedModuleContents
                     | _ -> [ mspec.DisplayNameCore ], def
                 
                 let nmL = List.map (tagModule >> wordL) fullModuleName |> sepListL SepL.dot

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2247,13 +2247,7 @@ module InferredSigPrinting =
             let outerPath = mspec.CompilationPath.AccessPath
 
             let denv = denv.AddOpenPath (List.map fst innerPath)
-
-            let isWrappedNamespace =
-                match mspec.ModuleOrNamespaceType.ModuleOrNamespaceKind with
-                | Namespace false -> true
-                | _ -> false
-
-            if isWrappedNamespace then
+            if mspec.IsImplicitNamespace then
                 // The current mspec is a namespace that belongs to the `def` child (nested) module(s).                
                 let fullModuleName, def =
                     let rec (|NestedModule|_|) (currentContents:ModuleOrNamespaceContents) =

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2116,7 +2116,8 @@ module TastDefinitionPrinting =
                     mspec.ModuleOrNamespaceType.AllValsAndMembers |> Seq.isEmpty
 
                 // Check if its an outer module or a nested module
-                if (outerPath |> List.forall (fun (_, istype) -> istype = Namespace)) && isNil outerPath then 
+                let isNamespace = function | Namespace _ -> true | _ -> false
+                if (outerPath |> List.forall (fun (_, istype) -> isNamespace istype)) && isNil outerPath then
                     // If so print a "module" declaration
                     modNameL
                 elif modIsEmpty then
@@ -2271,7 +2272,8 @@ module InferredSigPrinting =
                 let basic = imdefL denv def
                 let modNameL = wordL (tagKeyword "module") ^^ nmL
                 let modNameEqualsL = modNameL ^^ WordL.equals
-                let modIsOuter = (outerPath |> List.forall (fun (_, istype) -> istype = Namespace) )
+                let isNamespace = function | Namespace _ -> true | _ -> false
+                let modIsOuter = (outerPath |> List.forall (fun (_, istype) -> isNamespace istype) )
                 let basicL =
                     // Check if its an outer module or a nested module
                     if modIsOuter then

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2246,8 +2246,12 @@ module InferredSigPrinting =
             let innerPath = (fullCompPathOfModuleOrNamespace mspec).AccessPath
             let outerPath = mspec.CompilationPath.AccessPath
 
-            let denv = denv.AddOpenPath (List.map fst innerPath) 
-            if mspec.IsNamespace then
+            let denv = denv.AddOpenPath (List.map fst innerPath)
+            let isNamespace =
+                match mspec.ModuleOrNamespaceType.ModuleOrNamespaceKind with
+                | Namespace false -> false
+                | _ -> mspec.IsNamespace
+            if isNamespace then
                 let basic = imdefL denv def
                 let basicL =
                     // Check if this namespace contains anything interesting

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2249,7 +2249,7 @@ module InferredSigPrinting =
             let denv = denv.AddOpenPath (List.map fst innerPath)
             if mspec.IsImplicitNamespace then
                 // The current mspec is a namespace that belongs to the `def` child (nested) module(s).                
-                let fullModuleName, def =
+                let fullModuleName, def, denv =
                     let rec (|NestedModule|_|) (currentContents:ModuleOrNamespaceContents) =
                         match currentContents with
                         | ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, NestedModule(path, contents)) ]) ->
@@ -2262,8 +2262,10 @@ module InferredSigPrinting =
                             None
 
                     match def with
-                    | NestedModule(path, nestedModuleContents) -> mspec.DisplayNameCore :: path, nestedModuleContents
-                    | _ -> [ mspec.DisplayNameCore ], def
+                    | NestedModule(path, nestedModuleContents) ->
+                        let fullPath = mspec.DisplayNameCore :: path
+                        fullPath, nestedModuleContents, denv.AddOpenPath(fullPath)
+                    | _ -> [ mspec.DisplayNameCore ], def, denv
                 
                 let nmL = List.map (tagModule >> wordL) fullModuleName |> sepListL SepL.dot
                 let nmL = layoutAccessibility denv mspec.Accessibility nmL

--- a/src/Compiler/Checking/import.fs
+++ b/src/Compiler/Checking/import.fs
@@ -525,13 +525,13 @@ and ImportILTypeDefList amap m (cpath: CompilationPath) enc items =
         items 
         |> multisetDiscriminateAndMap 
             (fun n tgs ->
-                let modty = lazy (ImportILTypeDefList amap m (cpath.NestedCompPath n Namespace) enc tgs)
+                let modty = lazy (ImportILTypeDefList amap m (cpath.NestedCompPath n (Namespace true)) enc tgs)
                 Construct.NewModuleOrNamespace (Some cpath) taccessPublic (mkSynId m n) XmlDoc.Empty [] (MaybeLazy.Lazy modty))
             (fun (n, info: Lazy<_>) -> 
                 let (scoref2, lazyTypeDef: ILPreTypeDef) = info.Force()
                 ImportILTypeDef amap m scoref2 cpath enc n (lazyTypeDef.GetTypeDef()))
 
-    let kind = match enc with [] -> Namespace | _ -> ModuleOrType
+    let kind = match enc with [] -> Namespace true | _ -> ModuleOrType
     Construct.NewModuleOrNamespaceType kind entities []
       
 /// Import a table of IL types as a ModuleOrNamespaceType.

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -406,13 +406,20 @@ let CompLocForSubModuleOrNamespace cloc (submod: ModuleOrNamespace) =
         { cloc with
             Enclosing = cloc.Enclosing @ [ n ]
         }
-    | Namespace ->
+    | Namespace _ ->
         { cloc with
             Namespace = Some(mkTopName cloc.Namespace n)
         }
 
 let CompLocForFixedPath fragName qname (CompPath (sref, cpath)) =
-    let ns, t = List.takeUntil (fun (_, mkind) -> mkind <> Namespace) cpath
+    let ns, t =
+        List.takeUntil
+            (fun (_, mkind) ->
+                match mkind with
+                | Namespace _ -> false
+                | _ -> true)
+            cpath
+
     let ns = List.map fst ns
     let ns = textOfPath ns
     let encl = t |> List.map (fun (s, _) -> s)

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -413,12 +413,11 @@ let CompLocForSubModuleOrNamespace cloc (submod: ModuleOrNamespace) =
 
 let CompLocForFixedPath fragName qname (CompPath (sref, cpath)) =
     let ns, t =
-        List.takeUntil
-            (fun (_, mkind) ->
-                match mkind with
-                | Namespace _ -> false
-                | _ -> true)
-            cpath
+        cpath
+        |> List.takeUntil (fun (_, mkind) ->
+            match mkind with
+            | Namespace _ -> false
+            | _ -> true)
 
     let ns = List.map fst ns
     let ns = textOfPath ns

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -1352,7 +1352,7 @@ and [<Sealed>] TcImports
                 tcImports.RegisterDll dllinfo
 
                 let ccuContents =
-                    Construct.NewCcuContents ilScopeRef m ilShortAssemName (Construct.NewEmptyModuleOrNamespaceType Namespace)
+                    Construct.NewCcuContents ilScopeRef m ilShortAssemName (Construct.NewEmptyModuleOrNamespaceType(Namespace true))
 
                 let ccuData: CcuData =
                     {
@@ -1597,11 +1597,11 @@ and [<Sealed>] TcImports
                         ILScopeRef.Local,
                         injectedNamespace
                         |> List.rev
-                        |> List.map (fun n -> (n, ModuleOrNamespaceKind.Namespace))
+                        |> List.map (fun n -> (n, ModuleOrNamespaceKind.Namespace true))
                     )
 
                 let mid = ident (next, rangeStartup)
-                let mty = Construct.NewEmptyModuleOrNamespaceType Namespace
+                let mty = Construct.NewEmptyModuleOrNamespaceType(Namespace true)
 
                 let newNamespace =
                     Construct.NewModuleOrNamespace (Some cpath) taccessPublic mid XmlDoc.Empty [] (MaybeLazy.Strict mty)

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1067,7 +1067,7 @@ let GetInitialTcState (m, ccuName, tcConfig: TcConfig, tcGlobals, tcImports: TcI
 
     // Create a ccu to hold all the results of compilation
     let ccuContents =
-        Construct.NewCcuContents ILScopeRef.Local m ccuName (Construct.NewEmptyModuleOrNamespaceType Namespace)
+        Construct.NewCcuContents ILScopeRef.Local m ccuName (Construct.NewEmptyModuleOrNamespaceType(Namespace true))
 
     let ccuData: CcuData =
         {
@@ -1105,7 +1105,7 @@ let GetInitialTcState (m, ccuName, tcConfig: TcConfig, tcGlobals, tcImports: TcI
         tcsCreatesGeneratedProvidedTypes = false
         tcsRootSigs = Zmap.empty qnameOrder
         tcsRootImpls = Zset.empty qnameOrder
-        tcsCcuSig = Construct.NewEmptyModuleOrNamespaceType Namespace
+        tcsCcuSig = Construct.NewEmptyModuleOrNamespaceType(Namespace true)
         tcsImplicitOpenDeclarations = openDecls0
     }
 

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -2519,7 +2519,10 @@ module internal ParseAndCheckFile =
                         return result
                     with e ->
                         errorR e
-                        let mty = Construct.NewEmptyModuleOrNamespaceType ModuleOrNamespaceKind.Namespace
+
+                        let mty =
+                            Construct.NewEmptyModuleOrNamespaceType(ModuleOrNamespaceKind.Namespace true)
+
                         return ((tcState.TcEnvFromSignatures, EmptyTopAttrs, [], [ mty ]), tcState)
                 }
 

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -423,7 +423,7 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
         match entity.CompilationPathOpt with 
         | None -> None
         | Some (CompPath(_, [])) -> None
-        | Some cp when cp.AccessPath |> List.forall (function _, ModuleOrNamespaceKind.Namespace -> true | _  -> false) -> 
+        | Some cp when cp.AccessPath |> List.forall (function _, ModuleOrNamespaceKind.Namespace _ -> true | _  -> false) -> 
             Some (buildAccessPath (Some cp))
         | Some _ -> None
 
@@ -747,7 +747,7 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
         let partsList =
             [ yield parts
               match parts with
-              | ("Microsoft", ModuleOrNamespaceKind.Namespace) :: rest when isDefinedInFSharpCore() -> yield rest
+              | ("Microsoft", ModuleOrNamespaceKind.Namespace _) :: rest when isDefinedInFSharpCore() -> yield rest
               | _ -> ()]
 
         let mapEachCurrentPath (paths: string list list) path =
@@ -837,7 +837,7 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
                         | [] -> acc
                         | (name, ModuleOrNamespaceKind.ModuleOrType) :: accessPath ->
                             getOpenPath accessPath (name :: acc)
-                        | (name, ModuleOrNamespaceKind.Namespace) :: accessPath ->
+                        | (name, ModuleOrNamespaceKind.Namespace _) :: accessPath ->
                             getOpenPath accessPath (name :: acc)
                         | (name, ModuleOrNamespaceKind.FSharpModuleWithSuffix) :: accessPath ->
                             getOpenPath accessPath (name :: acc)

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -867,10 +867,10 @@ type Entity =
     member x.IsModuleOrNamespace = x.entity_flags.IsModuleOrNamespace
 
     /// Indicates if the entity is a namespace
-    member x.IsNamespace = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace isExplicit -> isExplicit | _ -> false)
+    member x.IsNamespace = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace _ -> true | _ -> false)
 
     /// Indicates if the entity is an F# module definition
-    member x.IsModule = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace isExplicit -> not isExplicit | _ -> true)
+    member x.IsModule = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace _ -> true | _ -> true)
 #if !NO_TYPEPROVIDERS
 
     /// Indicates if the entity is a provided type or namespace definition

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -481,7 +481,7 @@ type ModuleOrNamespaceKind =
     | ModuleOrType 
 
     /// Indicates that a 'module' is really a namespace 
-    | Namespace
+    | Namespace of isExplicit: bool
 
 /// A public path records where a construct lives within the global namespace
 /// of a CCU.
@@ -867,10 +867,10 @@ type Entity =
     member x.IsModuleOrNamespace = x.entity_flags.IsModuleOrNamespace
 
     /// Indicates if the entity is a namespace
-    member x.IsNamespace = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace -> true | _ -> false)
+    member x.IsNamespace = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace isExplicit -> isExplicit | _ -> false)
 
     /// Indicates if the entity is an F# module definition
-    member x.IsModule = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace -> false | _ -> true)
+    member x.IsModule = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace isExplicit -> not isExplicit | _ -> true)
 #if !NO_TYPEPROVIDERS
 
     /// Indicates if the entity is a provided type or namespace definition
@@ -3206,12 +3206,12 @@ type NonLocalEntityRef =
                             entity.ModuleOrNamespaceType.AddProvidedTypeEntity newEntity
                             newEntity
                         else
-                            let cpath = entity.CompilationPath.NestedCompPath entity.LogicalName ModuleOrNamespaceKind.Namespace
+                            let cpath = entity.CompilationPath.NestedCompPath entity.LogicalName (ModuleOrNamespaceKind.Namespace false)
                             let newEntity = 
                                 Construct.NewModuleOrNamespace 
                                     (Some cpath) 
                                     (TAccess []) (ident(path[k], m)) XmlDoc.Empty [] 
-                                    (MaybeLazy.Strict (Construct.NewEmptyModuleOrNamespaceType Namespace)) 
+                                    (MaybeLazy.Strict (Construct.NewEmptyModuleOrNamespaceType (Namespace true))) 
                             entity.ModuleOrNamespaceType.AddModuleOrNamespaceByMutation newEntity
                             injectNamespacesFromIToJ newEntity (k+1)
                     let newEntity = injectNamespacesFromIToJ entity i
@@ -5666,7 +5666,7 @@ type Construct() =
             | None -> 
                 let ilScopeRef = st.TypeProviderAssemblyRef
                 let enclosingName = GetFSharpPathToProvidedType(st, m)
-                CompPath(ilScopeRef, enclosingName |> List.map(fun id->id, ModuleOrNamespaceKind.Namespace))
+                CompPath(ilScopeRef, enclosingName |> List.map(fun id->id, ModuleOrNamespaceKind.Namespace true))
             | Some p -> p
         let pubpath = cpath.NestedPublicPath id
 
@@ -5681,7 +5681,7 @@ type Construct() =
             entity_typars= LazyWithContext.NotLazy []
             entity_tycon_repr = repr
             entity_tycon_tcaug=TyconAugmentation.Create()
-            entity_modul_type = MaybeLazy.Lazy (lazy ModuleOrNamespaceType(Namespace, QueueList.ofList [], QueueList.ofList []))
+            entity_modul_type = MaybeLazy.Lazy (lazy ModuleOrNamespaceType(Namespace true, QueueList.ofList [], QueueList.ofList []))
             // Generated types get internal accessibility
             entity_pubpath = Some pubpath
             entity_cpath = Some cpath

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -481,7 +481,10 @@ type ModuleOrNamespaceKind =
     | ModuleOrType 
 
     /// Indicates that a 'module' is really a namespace 
-    | Namespace of isExplicit: bool
+    | Namespace of
+        /// Indicates that the sourcecode had a namespace.
+        /// If false, this namespace was implicitly constructed during type checking. 
+        isExplicit: bool
 
 /// A public path records where a construct lives within the global namespace
 /// of a CCU.
@@ -868,6 +871,9 @@ type Entity =
 
     /// Indicates if the entity is a namespace
     member x.IsNamespace = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace _ -> true | _ -> false)
+    
+    /// Indicates if the entity has an implicit namespace
+    member x.IsImplicitNamespace = (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace false -> true | _ -> false)
 
     /// Indicates if the entity is an F# module definition
     member x.IsModule = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace _ -> false | _ -> true)

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -870,7 +870,7 @@ type Entity =
     member x.IsNamespace = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace _ -> true | _ -> false)
 
     /// Indicates if the entity is an F# module definition
-    member x.IsModule = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace _ -> true | _ -> true)
+    member x.IsModule = x.IsModuleOrNamespace && (match x.ModuleOrNamespaceType.ModuleOrNamespaceKind with Namespace _ -> false | _ -> true)
 #if !NO_TYPEPROVIDERS
 
     /// Indicates if the entity is a provided type or namespace definition

--- a/src/Compiler/TypedTree/TypedTree.fsi
+++ b/src/Compiler/TypedTree/TypedTree.fsi
@@ -301,7 +301,10 @@ type ModuleOrNamespaceKind =
     | ModuleOrType
 
     /// Indicates that a 'module' is really a namespace
-    | Namespace of isExplicit: bool
+    | Namespace of
+        /// Indicates that the sourcecode had a namespace.
+        /// If false, this namespace was implicitly constructed during type checking.
+        isExplicit: bool
 
 /// A public path records where a construct lives within the global namespace
 /// of a CCU.
@@ -640,6 +643,9 @@ type Entity =
 
     /// Indicates if the entity is a namespace
     member IsNamespace: bool
+
+    /// Indicates if the entity has an implicit namespace
+    member IsImplicitNamespace: bool
 
     /// Indicates the type prefers the "tycon<a, b>" syntax for display etc.
     member IsPrefixDisplay: bool

--- a/src/Compiler/TypedTree/TypedTree.fsi
+++ b/src/Compiler/TypedTree/TypedTree.fsi
@@ -301,7 +301,7 @@ type ModuleOrNamespaceKind =
     | ModuleOrType
 
     /// Indicates that a 'module' is really a namespace
-    | Namespace
+    | Namespace of isExplicit: bool
 
 /// A public path records where a construct lives within the global namespace
 /// of a CCU.

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -1220,7 +1220,7 @@ let ensureCcuHasModuleOrNamespaceAtPath (ccu: CcuThunk) path (CompPath(_, cpath)
                 let smodul = Construct.NewModuleOrNamespace (Some cpath) taccessPublic hpath xml [] (MaybeLazy.Strict mty)
                 mtype.AddModuleOrNamespaceByMutation smodul
             let modul = Map.find modName mtype.AllEntitiesByCompiledAndLogicalMangledNames 
-            loop (prior_cpath @ [(modName, Namespace)]) tpath tcpath modul 
+            loop (prior_cpath @ [(modName, Namespace true)]) tpath tcpath modul 
 
         | _ -> () 
 
@@ -4408,10 +4408,10 @@ let wrapModuleOrNamespaceType id cpath mtyp =
 
 let wrapModuleOrNamespaceTypeInNamespace id cpath mtyp = 
     let mspec = wrapModuleOrNamespaceType id cpath mtyp
-    Construct.NewModuleOrNamespaceType Namespace [ mspec ] [], mspec
+    Construct.NewModuleOrNamespaceType (Namespace true) [ mspec ] [], mspec
 
 let wrapModuleOrNamespaceContentsInNamespace (id: Ident) cpath mexpr = 
-    let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType Namespace)
+    let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType (Namespace true))
     TMDefRec (false, [], [], [ModuleOrNamespaceBinding.Module(mspec, mexpr)], id.idRange)
 
 //--------------------------------------------------------------------------
@@ -9822,7 +9822,7 @@ let CombineCcuContentFragments m l =
     /// same namespace, making new module specs as we go.
     let rec CombineModuleOrNamespaceTypes path m (mty1: ModuleOrNamespaceType) (mty2: ModuleOrNamespaceType) = 
         match mty1.ModuleOrNamespaceKind, mty2.ModuleOrNamespaceKind with 
-        | Namespace, Namespace -> 
+        | Namespace _, Namespace _ -> 
             let kind = mty1.ModuleOrNamespaceKind
             let tab1 = mty1.AllEntitiesByLogicalMangledName
             let tab2 = mty2.AllEntitiesByLogicalMangledName
@@ -9840,7 +9840,7 @@ let CombineCcuContentFragments m l =
 
             ModuleOrNamespaceType(kind, vals, QueueList.ofList entities)
 
-        | Namespace, _ | _, Namespace -> 
+        | Namespace _, _ | _, Namespace _ -> 
             error(Error(FSComp.SR.tastNamespaceAndModuleWithSameNameInAssembly(textOfPath path), m))
 
         | _-> 

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -4408,10 +4408,10 @@ let wrapModuleOrNamespaceType id cpath mtyp =
 
 let wrapModuleOrNamespaceTypeInNamespace id cpath mtyp = 
     let mspec = wrapModuleOrNamespaceType id cpath mtyp
-    Construct.NewModuleOrNamespaceType (Namespace true) [ mspec ] [], mspec
+    Construct.NewModuleOrNamespaceType (Namespace false) [ mspec ] [], mspec
 
 let wrapModuleOrNamespaceContentsInNamespace (id: Ident) cpath mexpr = 
-    let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType (Namespace true))
+    let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType (Namespace false))
     TMDefRec (false, [], [], [ModuleOrNamespaceBinding.Module(mspec, mexpr)], id.idRange)
 
 //--------------------------------------------------------------------------

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -4410,8 +4410,9 @@ let wrapModuleOrNamespaceTypeInNamespace id cpath mtyp =
     let mspec = wrapModuleOrNamespaceType id cpath mtyp
     Construct.NewModuleOrNamespaceType (Namespace false) [ mspec ] [], mspec
 
-let wrapModuleOrNamespaceContentsInNamespace (id: Ident) cpath mexpr = 
-    let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType (Namespace false))
+let wrapModuleOrNamespaceContentsInNamespace (id: Ident) (cpath: CompilationPath) mexpr =
+    let isExplicitNamespace = not (List.isEmpty cpath.AccessPath) && cpath.AccessPath |> List.forall (fun (_, mnk) -> match mnk with | Namespace v -> v | _ -> false)
+    let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType (Namespace isExplicitNamespace))
     TMDefRec (false, [], [], [ModuleOrNamespaceBinding.Module(mspec, mexpr)], id.idRange)
 
 //--------------------------------------------------------------------------

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -4410,9 +4410,8 @@ let wrapModuleOrNamespaceTypeInNamespace id cpath mtyp =
     let mspec = wrapModuleOrNamespaceType id cpath mtyp
     Construct.NewModuleOrNamespaceType (Namespace false) [ mspec ] [], mspec
 
-let wrapModuleOrNamespaceContentsInNamespace (id: Ident) (cpath: CompilationPath) mexpr =
-    let isExplicitNamespace = not (List.isEmpty cpath.AccessPath) && cpath.AccessPath |> List.forall (fun (_, mnk) -> match mnk with | Namespace v -> v | _ -> false)
-    let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType (Namespace isExplicitNamespace))
+let wrapModuleOrNamespaceContentsInNamespace isModule (id: Ident) (cpath: CompilationPath) mexpr =
+    let mspec = wrapModuleOrNamespaceType id cpath (Construct.NewEmptyModuleOrNamespaceType (Namespace (not isModule)))
     TMDefRec (false, [], [], [ModuleOrNamespaceBinding.Module(mspec, mexpr)], id.idRange)
 
 //--------------------------------------------------------------------------

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -1284,11 +1284,11 @@ val mkRepackageRemapping: SignatureRepackageInfo -> Remap
 
 /// Wrap one module or namespace implementation in a 'namespace N' outer wrapper
 val wrapModuleOrNamespaceContentsInNamespace:
-    Ident -> CompilationPath -> ModuleOrNamespaceContents -> ModuleOrNamespaceContents
+    isModule: bool -> id: Ident -> cpath: CompilationPath -> ModuleOrNamespaceContents -> ModuleOrNamespaceContents
 
 /// Wrap one module or namespace definition in a 'namespace N' outer wrapper
 val wrapModuleOrNamespaceTypeInNamespace:
-    Ident -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespaceType * ModuleOrNamespace
+    Ident -> CompilationPath -> mexpr: ModuleOrNamespaceType -> ModuleOrNamespaceType * ModuleOrNamespace
 
 /// Wrap one module or namespace definition in a 'module M = ..' outer wrapper
 val wrapModuleOrNamespaceType: Ident -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespace

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -1284,11 +1284,15 @@ val mkRepackageRemapping: SignatureRepackageInfo -> Remap
 
 /// Wrap one module or namespace implementation in a 'namespace N' outer wrapper
 val wrapModuleOrNamespaceContentsInNamespace:
-    isModule: bool -> id: Ident -> cpath: CompilationPath -> ModuleOrNamespaceContents -> ModuleOrNamespaceContents
+    isModule: bool ->
+    id: Ident ->
+    cpath: CompilationPath ->
+    mexpr: ModuleOrNamespaceContents ->
+        ModuleOrNamespaceContents
 
 /// Wrap one module or namespace definition in a 'namespace N' outer wrapper
 val wrapModuleOrNamespaceTypeInNamespace:
-    Ident -> CompilationPath -> mexpr: ModuleOrNamespaceType -> ModuleOrNamespaceType * ModuleOrNamespace
+    Ident -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespaceType * ModuleOrNamespace
 
 /// Wrap one module or namespace definition in a 'module M = ..' outer wrapper
 val wrapModuleOrNamespaceType: Ident -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespace

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -1855,7 +1855,7 @@ let p_istype x st =
     match x with
     | FSharpModuleWithSuffix -> p_byte 0 st
     | ModuleOrType           -> p_byte 1 st
-    | Namespace              -> p_byte 2 st
+    | Namespace _            -> p_byte 2 st
 
 let p_cpath (CompPath(a, b)) st =
     p_tup2 p_ILScopeRef (p_list (p_tup2 p_string p_istype)) (a, b) st
@@ -1867,7 +1867,7 @@ let u_istype st =
     match tag with
     | 0 -> FSharpModuleWithSuffix
     | 1 -> ModuleOrType
-    | 2 -> Namespace
+    | 2 -> Namespace true
     | _ -> ufailwith st "u_istype"
 
 let u_cpath  st = let a, b = u_tup2 u_ILScopeRef (u_list (u_tup2 u_string u_istype)) st in (CompPath(a, b))

--- a/tests/fsharp/core/load-script/out.stdout.bsl
+++ b/tests/fsharp/core/load-script/out.stdout.bsl
@@ -22,11 +22,11 @@ Test 3=================================================
 Hello
 World
 -the end
-namespace FSI_0002
+module FSI_0002.1
 
-namespace FSI_0002
+module FSI_0002.2
 
-namespace FSI_0002
+module FSI_0002.3
 
 > 
 Test 4=================================================

--- a/tests/fsharp/core/nestedModule/test.fsx
+++ b/tests/fsharp/core/nestedModule/test.fsx
@@ -1,0 +1,3 @@
+module Top.Square.Middle.Level
+
+let value = 10

--- a/tests/fsharp/core/nestedModuleInNamespace/test.fsx
+++ b/tests/fsharp/core/nestedModuleInNamespace/test.fsx
@@ -1,0 +1,4 @@
+namespace Very.Real.NamespaceName
+
+module Foo =
+    let i = 1

--- a/tests/fsharp/core/printing/output.1000.stdout.bsl
+++ b/tests/fsharp/core/printing/output.1000.stdout.bsl
@@ -5,44 +5,44 @@
 
 > val repeatId: string = "B"
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0005.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0006
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0006.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0006
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile2 =
-    new: unit -> ClassInFile2
+module FSI_0006.TestLoadFile2
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile2 =
+  new: unit -> ClassInFile2
 
 > val x1: seq<string>
 val x2: seq<string>

--- a/tests/fsharp/core/printing/output.200.stdout.bsl
+++ b/tests/fsharp/core/printing/output.200.stdout.bsl
@@ -5,44 +5,44 @@
 
 > val repeatId: string = "B"
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0005.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0006
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0006.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0006
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile2 =
-    new: unit -> ClassInFile2
+module FSI_0006.TestLoadFile2
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile2 =
+  new: unit -> ClassInFile2
 
 > val x1: seq<string>
 val x2: seq<string>

--- a/tests/fsharp/core/printing/output.47.stdout.bsl
+++ b/tests/fsharp/core/printing/output.47.stdout.bsl
@@ -3,44 +3,44 @@
 
 > val repeatId: string = "B"
 
-namespace FSI_0004
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0004.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0005.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile2 =
-    new: unit -> ClassInFile2
+module FSI_0005.TestLoadFile2
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile2 =
+  new: unit -> ClassInFile2
 
 > val x1: seq<string>
 val x2: seq<string>

--- a/tests/fsharp/core/printing/output.multiemit.stdout.bsl
+++ b/tests/fsharp/core/printing/output.multiemit.stdout.bsl
@@ -3,44 +3,44 @@
 
 > val repeatId: string = "B"
 
-namespace FSI_0004
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0004.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0005.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile2 =
-    new: unit -> ClassInFile2
+module FSI_0005.TestLoadFile2
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile2 =
+  new: unit -> ClassInFile2
 
 > val x1: seq<string>
 val x2: seq<string>

--- a/tests/fsharp/core/printing/output.off.stdout.bsl
+++ b/tests/fsharp/core/printing/output.off.stdout.bsl
@@ -5,44 +5,44 @@
 
 > val repeatId: string
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0005.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0006
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0006.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0006
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile2 =
-    new: unit -> ClassInFile2
+module FSI_0006.TestLoadFile2
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile2 =
+  new: unit -> ClassInFile2
 
 > val x1: seq<string>
 val x2: seq<string>

--- a/tests/fsharp/core/printing/output.stdout.bsl
+++ b/tests/fsharp/core/printing/output.stdout.bsl
@@ -3,44 +3,44 @@
 
 > val repeatId: string = "B"
 
-namespace FSI_0004
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0004.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile1 =
-    new: unit -> ClassInFile1
+module FSI_0005.TestLoadFile
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile1 =
+  new: unit -> ClassInFile1
 
-namespace FSI_0005
-  val x1: int
-  val x2: string
-  val x3: 'a option
-  val x4: int option
-  val x5: 'a list
-  val x6: int list
-  val x7: System.Windows.Forms.Form
-  val x8: int[,]
-  val x9: Lazy<string>
-  type ClassInFile2 =
-    new: unit -> ClassInFile2
+module FSI_0005.TestLoadFile2
+val x1: int
+val x2: string
+val x3: 'a option
+val x4: int option
+val x5: 'a list
+val x6: int list
+val x7: System.Windows.Forms.Form
+val x8: int[,]
+val x9: Lazy<string>
+type ClassInFile2 =
+  new: unit -> ClassInFile2
 
 > val x1: seq<string>
 val x2: seq<string>

--- a/tests/fsharp/core/recursiveNestedModule/test.fsx
+++ b/tests/fsharp/core/recursiveNestedModule/test.fsx
@@ -1,0 +1,11 @@
+module rec Top.Square.Middle.Level
+
+let value = 10
+
+type Foo =
+    { Bar: Bar }
+    
+type Bar = { Meh: string }
+
+module Nested =
+       let x = ""

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3361,6 +3361,9 @@ module GeneratedSignatureTests =
 
     [<Test>]
     let ``nestedModule-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/nestedModule" FSC_NETFX_TEST_GENERATED_SIGNATURE
+
+    [<Test>]
+    let ``recursiveNestedModule-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/recursiveNestedModule" FSC_NETFX_TEST_GENERATED_SIGNATURE
 #endif
 
 #if !NETCOREAPP

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3358,6 +3358,9 @@ module GeneratedSignatureTests =
 
     [<Test>]
     let ``measures-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/measures" FSC_NETFX_TEST_GENERATED_SIGNATURE
+
+    [<Test>]
+    let ``nestedModule-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/nestedModule" FSC_NETFX_TEST_GENERATED_SIGNATURE
 #endif
 
 #if !NETCOREAPP

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1114,7 +1114,7 @@ module CoreTests =
          runPrintingTest "--use:preludePrintSize1000.fsx" "output.1000"
 
     [<Test>]
-    let ``printing-width-200`` () =
+    let ``printing-width-200`` () =  
          runPrintingTest "--use:preludePrintSize200.fsx" "output.200"
 
     [<Test>]

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3364,6 +3364,9 @@ module GeneratedSignatureTests =
 
     [<Test>]
     let ``recursiveNestedModule-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/recursiveNestedModule" FSC_NETFX_TEST_GENERATED_SIGNATURE
+
+    [<Test>]
+    let ``nestedModuleInNamespace-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/nestedModuleInNamespace" FSC_NETFX_TEST_GENERATED_SIGNATURE
 #endif
 
 #if !NETCOREAPP


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/12068

@dsyme I'm trying to capture in the typed tree if the namespace was artificial or not.
I'm not sure all the places where I've used  `ModuleOrNamespaceKind.Namespace` have the correct value.
My newly added test worked fine, but I'm not sure if I'm doing everything correctly in `NicePrint`.
Please review.