### PR TITLE
Add range of access to SyntaxTree.

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -422,7 +422,8 @@ module TcRecdUnionAndEnumDeclarations =
             error(Error(FSComp.SR.tcVolatileOnlyOnClassLetBindings(), m))
 
         if isIncrClass && (not zeroInit || not isMutable) then errorR(Error(FSComp.SR.tcUninitializedValFieldsMustBeMutable(), m))
-        if isStatic && (not zeroInit || not isMutable || vis <> Some SynAccess.Private ) then errorR(Error(FSComp.SR.tcStaticValFieldsMustBeMutableAndPrivate(), m))
+        let isPrivate = match vis with | Some (SynAccess.Private _) -> true | _ -> false
+        if isStatic && (not zeroInit || not isMutable || not isPrivate) then errorR(Error(FSComp.SR.tcStaticValFieldsMustBeMutableAndPrivate(), m))
         let konst = if zeroInit then Some Const.Zero else None
         let rfspec = MakeRecdFieldSpec cenv env parent (isStatic, konst, tyR, attrsForProperty, attrsForField, id, nameGenerated, isMutable, isVolatile, xmldoc, vis, m)
         match parent with
@@ -815,7 +816,7 @@ module IncrClassChecking =
                 let prelimValReprInfo = TranslateSynValInfo m (TcAttributes cenv env) valSynData
                 let prelimTyschemeG = GeneralizedType(copyOfTyconTypars, cctorTy)
                 let topValInfo = InferGenericArityFromTyScheme prelimTyschemeG prelimValReprInfo
-                let cctorValScheme = ValScheme(id, prelimTyschemeG, Some topValInfo, Some memberInfo, false, ValInline.Never, NormalVal, Some SynAccess.Private, false, true, false, false)
+                let cctorValScheme = ValScheme(id, prelimTyschemeG, Some topValInfo, Some memberInfo, false, ValInline.Never, NormalVal, Some (SynAccess.Private Range.Zero), false, true, false, false)
                  
                 let cctorVal = MakeAndPublishVal cenv env (Parent tcref, false, ModuleOrMemberBinding, ValNotInRecScope, cctorValScheme, [(* no attributes*)], XmlDoc.Empty, None, false) 
                 cctorArgs, cctorVal, cctorValScheme)

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -1446,9 +1446,9 @@ let ComputeAccessAndCompPath env declKindOpt m vis overrideVis actualParent =
         match overrideVis, vis with
         | Some v, _ -> v
         | _, None -> taccessPublic (* a module or member binding defaults to "public" *)
-        | _, Some SynAccess.Public -> taccessPublic
-        | _, Some SynAccess.Private -> taccessPrivate accessPath
-        | _, Some SynAccess.Internal -> taccessInternal
+        | _, Some (SynAccess.Public _) -> taccessPublic
+        | _, Some (SynAccess.Private _) -> taccessPrivate accessPath
+        | _, Some (SynAccess.Internal _) -> taccessInternal
 
     let vis =
         match actualParent with

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -198,17 +198,23 @@ type SynRationalConst =
 
 [<RequireQualifiedAccess>]
 type SynAccess =
-    | Public
+    | Public of range: range
 
-    | Internal
+    | Internal of range: range
 
-    | Private
+    | Private of range: range
 
     override this.ToString() =
         match this with
-        | Public -> "Public"
-        | Internal -> "Internal"
-        | Private -> "Private"
+        | Public _ -> "Public"
+        | Internal _ -> "Internal"
+        | Private _ -> "Private"
+
+    member this.Range: range =
+        match this with
+        | Public m
+        | Internal m
+        | Private m -> m
 
 [<RequireQualifiedAccess>]
 type DebugPointAtTarget =

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -224,13 +224,15 @@ type SynRationalConst =
 [<RequireQualifiedAccess>]
 type SynAccess =
     /// A construct marked or assumed 'public'
-    | Public
+    | Public of range: range
 
     /// A construct marked or assumed 'internal'
-    | Internal
+    | Internal of range: range
 
     /// A construct marked or assumed 'private'
-    | Private
+    | Private of range: range
+
+    member Range: range
 
 /// Represents whether a debug point should be present for the target
 /// of a decision tree, that is whether the construct corresponds to a debug

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2228,13 +2228,16 @@ opt_access:
 
 access:
   | PRIVATE
-     { SynAccess.Private }
+     { let m = rhs parseState 1
+       SynAccess.Private m }
 
   | PUBLIC
-     { SynAccess.Public }
+     { let m = rhs parseState 1
+       SynAccess.Public m }
 
   | INTERNAL
-     { SynAccess.Internal }
+     { let m = rhs parseState 1
+       SynAccess.Internal m }
 
 /* only valid on 'NEW' */
 opt_declVisibility:

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -5762,6 +5762,12 @@ FSharp.Compiler.Syntax.SeqExprOnly: Int32 Tag
 FSharp.Compiler.Syntax.SeqExprOnly: Int32 get_Tag()
 FSharp.Compiler.Syntax.SeqExprOnly: System.String ToString()
 FSharp.Compiler.Syntax.SynAccess
+FSharp.Compiler.Syntax.SynAccess+Internal: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynAccess+Internal: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynAccess+Private: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynAccess+Private: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynAccess+Public: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynAccess+Public: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynAccess+Tags: Int32 Internal
 FSharp.Compiler.Syntax.SynAccess+Tags: Int32 Private
 FSharp.Compiler.Syntax.SynAccess+Tags: Int32 Public
@@ -5774,16 +5780,15 @@ FSharp.Compiler.Syntax.SynAccess: Boolean IsPublic
 FSharp.Compiler.Syntax.SynAccess: Boolean get_IsInternal()
 FSharp.Compiler.Syntax.SynAccess: Boolean get_IsPrivate()
 FSharp.Compiler.Syntax.SynAccess: Boolean get_IsPublic()
-FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess Internal
-FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess Private
-FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess Public
-FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess get_Internal()
-FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess get_Private()
-FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess get_Public()
+FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess NewInternal(FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess NewPrivate(FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess NewPublic(FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess+Internal
+FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess+Private
+FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess+Public
 FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Syntax.SynAccess+Tags
-FSharp.Compiler.Syntax.SynAccess: Int32 CompareTo(FSharp.Compiler.Syntax.SynAccess)
-FSharp.Compiler.Syntax.SynAccess: Int32 CompareTo(System.Object)
-FSharp.Compiler.Syntax.SynAccess: Int32 CompareTo(System.Object, System.Collections.IComparer)
+FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynAccess: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynAccess: Int32 GetHashCode()
 FSharp.Compiler.Syntax.SynAccess: Int32 GetHashCode(System.Collections.IEqualityComparer)
 FSharp.Compiler.Syntax.SynAccess: Int32 Tag

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -157,68 +157,68 @@ type NavigationItem with
         | FSharpGlyph.Type
         | FSharpGlyph.Exception ->
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.ClassPrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.ClassInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.ClassPrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.ClassInternal
             | _ -> FSharpRoslynGlyph.ClassPublic
         | FSharpGlyph.Constant -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.ConstantPrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.ConstantInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.ConstantPrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.ConstantInternal
             | _ -> FSharpRoslynGlyph.ConstantPublic
         | FSharpGlyph.Delegate -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.DelegatePrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.DelegateInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.DelegatePrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.DelegateInternal
             | _ -> FSharpRoslynGlyph.DelegatePublic
         | FSharpGlyph.Union
         | FSharpGlyph.Enum -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.EnumPrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.EnumInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.EnumPrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.EnumInternal
             | _ -> FSharpRoslynGlyph.EnumPublic
         | FSharpGlyph.EnumMember
         | FSharpGlyph.Variable
         | FSharpGlyph.Field -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.FieldPrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.FieldInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.FieldPrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.FieldInternal
             | _ -> FSharpRoslynGlyph.FieldPublic
         | FSharpGlyph.Event -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.EventPrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.EventInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.EventPrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.EventInternal
             | _ -> FSharpRoslynGlyph.EventPublic
         | FSharpGlyph.Interface -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.InterfacePrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.InterfaceInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.InterfacePrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.InterfaceInternal
             | _ -> FSharpRoslynGlyph.InterfacePublic
         | FSharpGlyph.Method
         | FSharpGlyph.OverridenMethod -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.MethodPrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.MethodInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.MethodPrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.MethodInternal
             | _ -> FSharpRoslynGlyph.MethodPublic
         | FSharpGlyph.Module -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.ModulePrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.ModuleInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.ModulePrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.ModuleInternal
             | _ -> FSharpRoslynGlyph.ModulePublic
         | FSharpGlyph.NameSpace -> FSharpRoslynGlyph.Namespace
         | FSharpGlyph.Property -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.PropertyPrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.PropertyInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.PropertyPrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.PropertyInternal
             | _ -> FSharpRoslynGlyph.PropertyPublic
         | FSharpGlyph.Struct -> 
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.StructurePrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.StructureInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.StructurePrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.StructureInternal
             | _ -> FSharpRoslynGlyph.StructurePublic
         | FSharpGlyph.ExtensionMethod ->
             match x.Access with
-            | Some SynAccess.Private -> FSharpRoslynGlyph.ExtensionMethodPrivate
-            | Some SynAccess.Internal -> FSharpRoslynGlyph.ExtensionMethodInternal
+            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.ExtensionMethodPrivate
+            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.ExtensionMethodInternal
             | _ -> FSharpRoslynGlyph.ExtensionMethodPublic
         | FSharpGlyph.Error -> FSharpRoslynGlyph.Error
         | FSharpGlyph.TypeParameter -> FSharpRoslynGlyph.TypeParameter


### PR DESCRIPTION
@dsyme this would solve the problem when we need to restore trivia that surrounds the accessibility keyword:

For example:

```fsharp
type Currency =
    // Temporary fix until a new Thoth.Json.Net package is released
    // See https://github.com/MangelMaxime/Thoth/pull/70

#if FABLE_COMPILER
    private
#endif
    | Code of string
```

The hash directives are best linked to `private` in this example.