### PR TITLE
Run CoreCompile when building with different defined constants

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/FSharp.Build/Microsoft.FSharp.Targets
@@ -393,48 +393,6 @@ this file.
             ============================================================
     -->
 
-    <!--
-    ============================================================
-    Override _GenerateCompileDependencyCache
-
-    Workaround for Issue #3824 and #3739
-
-    MsBuild does some optimisations around CompileInputs
-    The project system erroneously uses this to determine whether 
-    to notify language services of CommandLine Information changes.
-    C# accidently changes it's file lists every build ... and so 
-    gets the notifications.
-    F# doesn't ... so we don't get CL notifications following rebuilds
-    or build.
-    This workaround is basically to adds the current time (in ticks) 
-    into the hash of CoreCompileInputs.cache at design time so that 
-    we always appear to have different options and overcome the
-    brokencache behaviour.
-    
-    Both msbuild and the project-system will fix their code at which time
-    this can go away.
-
-    ============================================================
-    -->
-    <Target Name="_GenerateCompileDependencyCache" DependsOnTargets="ResolveAssemblyReferences" Condition="'$(DesignTimeBuild)' == 'true'">
-        <ItemGroup>
-          <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
-          <CoreCompileCache Remove="@(Compile)" />
-          <CoreCompileCache Include="@(ReferencePath)" />
-          <CoreCompileCache Include="$([System.DateTime]::Now.Ticks)" />
-        </ItemGroup>
-
-        <Hash ItemsToHash="@(CoreCompileCache)">
-          <Output TaskParameter="HashResult" PropertyName="CoreCompileDependencyHash" />
-        </Hash>
-
-        <WriteLinesToFile Lines="$(CoreCompileDependencyHash)" File="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
-
-        <ItemGroup>
-          <FileWrites Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
-        </ItemGroup>
-    </Target>
-
     <Target Name="GenerateTargetFrameworkMonikerAttribute" BeforeTargets="BeforeCompile" DependsOnTargets="PrepareForBuild;GetReferenceAssemblyPaths" Inputs="$(MSBuildThisFileFullPath)" Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)" Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
 
         <PropertyGroup>


### PR DESCRIPTION
There is a mismatch how C# and F# incremental builds deal with changes in defined constants.
For example, when running such build commands:
```
dotnet build /v:n
dotnet build /v:n /p:DefineConstants=FOO
```

C# projects are going to be rebuilt but F# projects are skipped:
```
CoreCompile:
       Skipping target "CoreCompile" because all output files are up-to-date with respect to the input files.
```

### How to reproduce
- Extract the [FSharpDefineConstants.zip](https://github.com/dotnet/fsharp/files/8916846/FSharpDefineConstants.zip) solution
- Run `dotnet build /v:n` - See that `CoreCompile` runs for both C# and F# project
- Run `dotnet build /v:n /p:DefineConstants=FOO`  - See that `CoreCompile` runs only for the C# project

### Why it is broken
The `_GenerateCompileDependencyCache` target makes it possible to detect compiler input changes which can't otherwise be detected with timestamp comparisons. The default implementation is executed only for actual builds and it is not executed for design-time builds. Whereas, the F# implementation is disabled for actual builds, but it is run for design-time builds instead:

https://github.com/dotnet/msbuild/blob/3db83fdeb160404917b6bd3f4dd9e62338539a48/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3648-L3664:

```
   ============================================================
    _GenerateCompileDependencyCache
    Generate a file used to track compiler dependencies between incremental build
    executions. This handles cases where items are added or removed from a glob (e.g.
    <Compile Include="**\*.cs" />) and can't otherwise be detected with timestamp
    comparisons. The file contains a hash of compiler inputs that are known to
    contribute to incremental build inconsistencies.
    ============================================================
    -->

    <Target Name="_GenerateCompileDependencyCache" Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingProject)' == 'true'" DependsOnTargets="ResolveAssemblyReferences">
      <ItemGroup>
        <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
        <CoreCompileCache Include="@(Compile)" />
        <CoreCompileCache Include="@(ReferencePath)" />
        <CoreCompileCache Include="$(DefineConstants)" />
      </ItemGroup>
    ...
```

The reason for overriding the `_GenerateCompileDependencyCache` target was to workaround #3824 and #3739.

I suggest that we remove custom implementation of that target for F# so we have feature parity for both languages. 
I can't verify whether underlying issue was fixed and whether this workaround is still necessary because currently a similar issue with broken intellisense is reported: https://github.com/dotnet/fsharp/issues/12982. 

If this workaround is still necessary, I can update the F# specific target to run for actual and design-time builds.






