### PR TITLE
Update to latest stable SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.200",
+    "version": "6.0.301",
     "allowPrerelease": true,
     "rollForward": "minor"
   },
   "tools": {
-    "dotnet": "6.0.200",
+    "dotnet": "6.0.301",
     "vs": {
       "version": "16.8",
       "components": [


### PR DESCRIPTION
It should contain the fix for the subtype pattern matching as well as `function` matching with explicit type abbreviation.

cc @KevinRansom @baronfel @auduchinok 