### PR TITLE
Workaroud for emptying FSharp.Editor cache due to duplicate PS events

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -346,7 +346,7 @@ type internal HackCpsCommandLineChanges
     /// This handles commandline change notifications from the Dotnet Project-system
     /// Prior to VS 15.7 path contained path to project file, post 15.7 contains target binpath
     /// binpath is more accurate because a project file can have multiple in memory projects based on configuration
-    member _.HandleCommandLineChanges(path:string, sources:ImmutableArray<CommandLineSourceFile>, _references:ImmutableArray<CommandLineReference>, options:ImmutableArray<string>) =
+    member _.HandleCommandLineChanges(path:string, sources:ImmutableArray<CommandLineSourceFile>, references:ImmutableArray<CommandLineReference>, options:ImmutableArray<string>) =
         use _logBlock = Logger.LogBlock(LogEditorFunctionId.LanguageService_HandleCommandLineArgs)
 
         let projectId =
@@ -363,5 +363,11 @@ type internal HackCpsCommandLineChanges
 
         let sourcePaths = sources |> Seq.map(fun s -> getFullPath s.Path) |> Seq.toArray
 
-        let workspaceService = workspace.Services.GetRequiredService<IFSharpWorkspaceService>()
-        workspaceService.FSharpProjectOptionsManager.SetCommandLineOptions(projectId, sourcePaths, options)
+        /// Due to an issue in project system, when we close and reopen solution, it sends is the CommandLineChanges twice for every project.
+        /// First time it sends a correct path, sources, references and options.
+        /// Second time it sends a correct path, empty sources, empty references and empty options, and we rewrite our cache, and fail to colourize the document later.
+        /// As a woraround, until we have a fix from PS or will move to Roslyn as a source of truth, we will not overwrite the cache in case of empty lists.
+
+        if not (sources.IsEmpty && references.IsEmpty && options.IsEmpty) then
+            let workspaceService = workspace.Services.GetRequiredService<IFSharpWorkspaceService>()
+            workspaceService.FSharpProjectOptionsManager.SetCommandLineOptions(projectId, sourcePaths, options)


### PR DESCRIPTION
**Workaround, until we have a proper fix from the project system or move to Roslyn as a source of truth:**
Do not update cache if we receive completely empty list from project system.
A workaround for https://github.com/dotnet/fsharp/issues/12982.
More details:

When we open the solution, `HandleCommandLineChanges` is getting called by project system (CPS):
https://github.com/dotnet/fsharp/blob/12c8309f7621c7e7833d561bebb4e573c1dd249f/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs#L347-L365

When project system calls us, it sends us project id, source files and options, and we store them in cache:
https://github.com/dotnet/fsharp/blob/12c8309f7621c7e7833d561bebb4e573c1dd249f/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs#L540-L541

Project system calls us here:
https://github.com/dotnet/project-system/blob/2d8184bf78a11568ae502597ed5ba6d24bdd736c/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs#L83-L94

Notification, apparently, originates from here:

https://github.com/dotnet/project-system/blob/9815fdcba096f21ae64a0dd1803d61b21b0c8b62/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineNotificationHandler.cs#L26-L33

We use that cache afterwards, to get documents from it and then apply colouring, tooltips, etc.

However, what's happening now is:
1. We open a solution
2. We receive project system"events" once for every project, we store it in cache, and we successfully store everything in cache.
3. We close solution, we empty the cache.
4. We REopen the solution, we receive project system "events" for every projects, we store it in cache, **BUT**
5. We again receive project system events, for each project (usually, for all of them, except if there are any documents open already).
    **HOWEVER** those events contain empty source file list as well as options list, and we are rewriting the cache with empty lists.
6. Later on, when we use this cache, we don't find any documents in it, and cannot apply colour, tooltips, etc.

 