### PR TITLE
Resurrecting quick info provider tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ nCrunchTemp_*
 .fake
 *.pdb
 *.dll
+
+/test.fs
+/test.fsx

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -107,11 +107,9 @@
     <Compile Include="GoToDefinitionServiceTests.fs">
       <Link>Roslyn\GoToDefinitionServiceTests.fs</Link>
     </Compile>
-<!--
     <Compile Include="QuickInfoProviderTests.fs">
       <Link>Roslyn\QuickInfoProviderTests.fs</Link>
     </Compile>
--->
     <Compile Include="DocumentHighlightsServiceTests.fs">
       <Link>Roslyn\DocumentHighlightsServiceTests.fs</Link>
     </Compile>


### PR DESCRIPTION
Since I'm working on the #12062, I'll most probably need to do some changes around quick info provider, so the first step is reviving this old tests "temporary commented out" in 2018 :) 

Basically just making things work again without fancy refactoring.