### PR TITLE
Don't create assembly resolver handler with empty probing paths

### DIFF
--- a/src/Compiler/DependencyManager/AssemblyResolveHandler.fs
+++ b/src/Compiler/DependencyManager/AssemblyResolveHandler.fs
@@ -106,12 +106,15 @@ type AssemblyResolveHandlerDeskTop(assemblyProbingPaths: AssemblyResolutionProbe
 type AssemblyResolveHandler internal (assemblyProbingPaths: AssemblyResolutionProbe option) =
 
     let handler =
-        if isRunningOnCoreClr then
-            new AssemblyResolveHandlerCoreclr(assemblyProbingPaths) :> IDisposable
-        else
-            new AssemblyResolveHandlerDeskTop(assemblyProbingPaths) :> IDisposable
+        assemblyProbingPaths |> Option.map (fun _ ->
+            if isRunningOnCoreClr then
+                new AssemblyResolveHandlerCoreclr(assemblyProbingPaths) :> IDisposable
+            else
+                new AssemblyResolveHandlerDeskTop(assemblyProbingPaths) :> IDisposable
+        )
 
     new(assemblyProbingPaths: AssemblyResolutionProbe) = new AssemblyResolveHandler(Option.ofObj assemblyProbingPaths)
 
     interface IDisposable with
-        member _.Dispose() = handler.Dispose()
+        member _.Dispose() =
+            handler |> Option.iter (fun handler -> handler.Dispose())


### PR DESCRIPTION
There're cases when assembly resolve handler may be created with empty probing paths. There's no need to add the handler, as it won't do anything with assembly resolution, only do some unneeded reflection in its constructor.

There're cases where these handlers are created and then never disposed, like this: https://github.com/dotnet/fsharp/blob/0155fd5ac55630dff2f82a6ef1d2358f70b80070/src/Compiler/Service/IncrementalBuild.fs#L1606-L1611

This change also prevents leaking of such handlers.