### PR TITLE
Don't use DisplayNameCore for type name in augmentation.

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -1555,7 +1555,7 @@ module TastDefinitionPrinting =
     let layoutExtensionMember denv infoReader (vref: ValRef) =
         let (@@*) = if denv.printVerboseSignatures then (@@----) else (@@--)
         let tycon = vref.MemberApparentEntity.Deref
-        let nameL = ConvertNameToDisplayLayout (tagMethod >> mkNav vref.DefinitionRange >> wordL) tycon.DisplayNameCore
+        let nameL = layoutTyconRefImpl false denv vref.MemberApparentEntity
         let nameL = layoutAccessibility denv tycon.Accessibility nameL // "type-accessibility"
         let tps =
             match PartitionValTyparsForApparentEnclosingType denv.g vref.Deref with

--- a/tests/fsharp/core/printing/output.1000.stdout.bsl
+++ b/tests/fsharp/core/printing/output.1000.stdout.bsl
@@ -2621,9 +2621,9 @@ val x: optionRecord = { x = null }
     TwoFields2: obj
   }
 
-> type Int32 with
+> type System.Int32 with
   member ExtrinsicExtensionProperty: int
-type Int32 with
+type System.Int32 with
   member ExtrinsicExtensionMethod: unit -> int
 
 > val ``value with spaces in name`` : bool = true

--- a/tests/fsharp/core/printing/output.200.stdout.bsl
+++ b/tests/fsharp/core/printing/output.200.stdout.bsl
@@ -1866,9 +1866,9 @@ val x: optionRecord = { x = null }
     TwoFields2: obj
   }
 
-> type Int32 with
+> type System.Int32 with
   member ExtrinsicExtensionProperty: int
-type Int32 with
+type System.Int32 with
   member ExtrinsicExtensionMethod: unit -> int
 
 > val ``value with spaces in name`` : bool = true

--- a/tests/fsharp/core/printing/output.47.stdout.bsl
+++ b/tests/fsharp/core/printing/output.47.stdout.bsl
@@ -6166,9 +6166,9 @@ val x: optionRecord = { x = null }
     TwoFields2: obj
   }
 
-> type Int32 with
+> type System.Int32 with
   member ExtrinsicExtensionProperty: int
-type Int32 with
+type System.Int32 with
   member ExtrinsicExtensionMethod: unit -> int
 
 > val ``value with spaces in name`` : bool = true

--- a/tests/fsharp/core/printing/output.multiemit.stdout.bsl
+++ b/tests/fsharp/core/printing/output.multiemit.stdout.bsl
@@ -6168,9 +6168,9 @@ val x: optionRecord = { x = null }
     TwoFields2: obj
   }
 
-> type Int32 with
+> type System.Int32 with
   member ExtrinsicExtensionProperty: int
-type Int32 with
+type System.Int32 with
   member ExtrinsicExtensionMethod: unit -> int
 
 > val ``value with spaces in name`` : bool = true

--- a/tests/fsharp/core/printing/output.off.stdout.bsl
+++ b/tests/fsharp/core/printing/output.off.stdout.bsl
@@ -1636,9 +1636,9 @@ val x: optionRecord
     TwoFields2: obj
   }
 
-> type Int32 with
+> type System.Int32 with
   member ExtrinsicExtensionProperty: int
-type Int32 with
+type System.Int32 with
   member ExtrinsicExtensionMethod: unit -> int
 
 > val ``value with spaces in name`` : bool

--- a/tests/fsharp/core/printing/output.stdout.bsl
+++ b/tests/fsharp/core/printing/output.stdout.bsl
@@ -6168,9 +6168,9 @@ val x: optionRecord = { x = null }
     TwoFields2: obj
   }
 
-> type Int32 with
+> type System.Int32 with
   member ExtrinsicExtensionProperty: int
-type Int32 with
+type System.Int32 with
   member ExtrinsicExtensionMethod: unit -> int
 
 > val ``value with spaces in name`` : bool = true

--- a/tests/fsharp/core/typeAugmentation/test.fsx
+++ b/tests/fsharp/core/typeAugmentation/test.fsx
@@ -1,0 +1,8 @@
+module Foo
+
+open System
+
+type Int32 with
+    member this.PlusPlus () = this + 1
+    
+let two = (1).PlusPlus()

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3370,6 +3370,9 @@ module GeneratedSignatureTests =
 
     [<Test>]
     let ``classStructInterface-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/classStructInterface" FSC_NETFX_TEST_GENERATED_SIGNATURE
+
+    [<Test>]
+    let ``typeAugmentation-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/typeAugmentation" FSC_NETFX_TEST_GENERATED_SIGNATURE
 #endif
 
 #if !NETCOREAPP


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/13302.
@dsyme this fix works in terms of the signature output, but I'm not quite sure about the `tagMethod` and `mkNav` bits. 
I don't fully grasp how relevant these things are.