### PR TITLE
Improve debugging within the compiler

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -79,6 +79,10 @@
     <DefineConstants>$(DefineConstants);TESTING_ON_LINUX</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Proto'">
+    <DefineConstants>$(DefineConstants);COMPILING_PROTO</DefineConstants>
+  </PropertyGroup>
+
   <!-- SDK targets override -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto' AND '$(DisableCompilerRedirection)'!='true' AND Exists('$(ProtoOutputPath)')">
     <FSharpTargetsPath>$(ProtoOutputPath)\fsc\Microsoft.FSharp.Targets</FSharpTargetsPath>

--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -79,10 +79,6 @@
     <DefineConstants>$(DefineConstants);TESTING_ON_LINUX</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Proto'">
-    <DefineConstants>$(DefineConstants);COMPILING_PROTO</DefineConstants>
-  </PropertyGroup>
-
   <!-- SDK targets override -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto' AND '$(DisableCompilerRedirection)'!='true' AND Exists('$(ProtoOutputPath)')">
     <FSharpTargetsPath>$(ProtoOutputPath)\fsc\Microsoft.FSharp.Targets</FSharpTargetsPath>

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1211,7 +1211,7 @@ let CheckOneInput
                 let typeCheckOne =
                     if skipImplIfSigExists && hadSig then
                         (EmptyTopAttrs, CreateEmptyDummyImplFile qualNameOfFile rootSigOpt.Value, Unchecked.defaultof<_>, tcImplEnv, false)
-                        |> Cancellable.ret
+                        |> cancellable.Return
                     else
                         CheckOneImplFile(
                             tcGlobals,

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -267,8 +267,6 @@ val stopProcessingRecovery: exn: exn -> m: range -> unit
 
 val errorRecoveryNoRange: exn: exn -> unit
 
-val report: f: (unit -> 'T) -> 'T
-
 val deprecatedWithError: s: string -> m: range -> unit
 
 val libraryOnlyError: m: range -> unit

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -110,7 +110,7 @@ type internal DelayedILModuleReader =
                                 None
                         | _ -> Some this.result)
             }
-        | _ -> Cancellable.ret (Some this.result)
+        | _ -> cancellable.Return(Some this.result)
 
 [<RequireQualifiedAccess; NoComparison; CustomEquality>]
 type FSharpReferencedProject =

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -10,7 +10,9 @@ open System.IO
 open System.Threading
 open System.Threading.Tasks
 open System.Runtime.CompilerServices
+#if !COMPILING_PROTO
 open FSharp.Core.CompilerServices.StateMachineHelpers
+#endif
 
 [<AutoOpen>]
 module internal PervasiveAutoOpens =
@@ -941,13 +943,14 @@ type CancellableBuilder() =
 
     member inline _.Delay([<InlineIfLambda>] f) =
         Cancellable(fun ct ->
-            //__debugPoint ""
             let (Cancellable g) = f ()
             g ct)
 
     member inline _.Bind(comp, [<InlineIfLambda>] k) =
         Cancellable(fun ct ->
+#if !COMPILING_PROTO
             __debugPoint ""
+#endif
 
             match Cancellable.run ct comp with
             | ValueOrCancelled.Value v1 -> Cancellable.run ct (k v1)
@@ -955,7 +958,9 @@ type CancellableBuilder() =
 
     member inline _.BindReturn(comp, [<InlineIfLambda>] k) =
         Cancellable(fun ct ->
+#if !COMPILING_PROTO
             __debugPoint ""
+#endif
 
             match Cancellable.run ct comp with
             | ValueOrCancelled.Value v1 -> ValueOrCancelled.Value(k v1)
@@ -963,7 +968,9 @@ type CancellableBuilder() =
 
     member inline _.Combine(comp1, comp2) =
         Cancellable(fun ct ->
+#if !COMPILING_PROTO
             __debugPoint ""
+#endif
 
             match Cancellable.run ct comp1 with
             | ValueOrCancelled.Value () -> Cancellable.run ct comp2
@@ -971,7 +978,9 @@ type CancellableBuilder() =
 
     member inline _.TryWith(comp, [<InlineIfLambda>] handler) =
         Cancellable(fun ct ->
+#if !COMPILING_PROTO
             __debugPoint ""
+#endif
 
             let compRes =
                 try
@@ -990,7 +999,9 @@ type CancellableBuilder() =
 
     member inline _.Using(resource, [<InlineIfLambda>] comp) =
         Cancellable(fun ct ->
+#if !COMPILING_PROTO
             __debugPoint ""
+#endif
             let body = comp resource
 
             let compRes =
@@ -1012,7 +1023,9 @@ type CancellableBuilder() =
 
     member inline _.TryFinally(comp, [<InlineIfLambda>] compensation) =
         Cancellable(fun ct ->
+#if !COMPILING_PROTO
             __debugPoint ""
+#endif
 
             let compRes =
                 try
@@ -1032,9 +1045,7 @@ type CancellableBuilder() =
             | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
 
     member inline _.Return v =
-        Cancellable(fun _ ->
-            __debugPoint ""
-            ValueOrCancelled.Value v)
+        Cancellable(fun _ -> ValueOrCancelled.Value v)
 
     member inline _.ReturnFrom(v: Cancellable<'T>) = v
 

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -10,6 +10,7 @@ open System.IO
 open System.Threading
 open System.Threading.Tasks
 open System.Runtime.CompilerServices
+open FSharp.Core.CompilerServices.StateMachineHelpers
 
 [<AutoOpen>]
 module internal PervasiveAutoOpens =
@@ -885,51 +886,27 @@ type ValueOrCancelled<'TResult> =
 /// A cancellable computation is passed may be cancelled via a CancellationToken, which is propagated implicitly.
 /// If cancellation occurs, it is propagated as data rather than by raising an OperationCanceledException.
 [<Struct>]
-type Cancellable<'TResult> = Cancellable of (CancellationToken -> ValueOrCancelled<'TResult>)
+type Cancellable<'T> = Cancellable of (CancellationToken -> ValueOrCancelled<'T>)
 
 module Cancellable =
 
     /// Run a cancellable computation using the given cancellation token
-    let run (ct: CancellationToken) (Cancellable oper) =
+    let inline run (ct: CancellationToken) (Cancellable oper) =
         if ct.IsCancellationRequested then
             ValueOrCancelled.Cancelled(OperationCanceledException ct)
         else
             oper ct
 
-    /// Bind the result of a cancellable computation
-    let inline bind f comp1 =
-        Cancellable(fun ct ->
-            match run ct comp1 with
-            | ValueOrCancelled.Value v1 -> run ct (f v1)
-            | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
-
-    /// Map the result of a cancellable computation
-    let inline map f oper =
-        Cancellable(fun ct ->
-            match run ct oper with
-            | ValueOrCancelled.Value res -> ValueOrCancelled.Value(f res)
-            | ValueOrCancelled.Cancelled err -> ValueOrCancelled.Cancelled err)
-
-    /// Return a simple value as the result of a cancellable computation
-    let inline ret x =
-        Cancellable(fun _ -> ValueOrCancelled.Value x)
-
-    /// Fold a cancellable computation along a sequence of inputs
     let fold f acc seq =
         Cancellable(fun ct ->
-            (ValueOrCancelled.Value acc, seq)
-            ||> Seq.fold (fun acc x ->
+            let mutable acc = ValueOrCancelled.Value acc
+
+            for x in seq do
                 match acc with
-                | ValueOrCancelled.Value accv -> run ct (f accv x)
-                | res -> res))
+                | ValueOrCancelled.Value accv -> acc <- run ct (f accv x)
+                | ValueOrCancelled.Cancelled _ -> ()
 
-    /// Iterate a cancellable computation over a collection
-    let inline each f seq =
-        fold (fun acc x -> f x |> map (fun y -> (y :: acc))) [] seq |> map List.rev
-
-    /// Delay a cancellable computation
-    let inline delay (f: unit -> Cancellable<'T>) =
-        Cancellable(fun ct -> let (Cancellable g) = f () in g ct)
+            acc)
 
     /// Run the computation in a mode where it may not be cancelled. The computation never results in a
     /// ValueOrCancelled.Cancelled.
@@ -960,61 +937,109 @@ module Cancellable =
     let canceled () =
         Cancellable(fun ct -> ValueOrCancelled.Cancelled(OperationCanceledException ct))
 
-    /// Catch exceptions in a computation
-    let inline catch comp =
-        let (Cancellable f) = comp
-
-        Cancellable(fun ct ->
-            try
-                match f ct with
-                | ValueOrCancelled.Value res -> ValueOrCancelled.Value(Choice1Of2 res)
-                | ValueOrCancelled.Cancelled exn -> ValueOrCancelled.Cancelled exn
-            with err ->
-                ValueOrCancelled.Value(Choice2Of2 err))
-
-    /// Implement try/finally for a cancellable computation
-    let inline tryFinally comp compensation =
-        catch comp
-        |> bind (fun res ->
-            compensation ()
-
-            match res with
-            | Choice1Of2 r -> ret r
-            | Choice2Of2 err -> raise err)
-
-    /// Implement try/with for a cancellable computation
-    let inline tryWith comp handler =
-        catch comp
-        |> bind (fun res ->
-            match res with
-            | Choice1Of2 r -> ret r
-            | Choice2Of2 err -> handler err)
-
 type CancellableBuilder() =
 
-    member inline _.BindReturn(comp, k) = Cancellable.map k comp
+    member inline _.Delay([<InlineIfLambda>] f) =
+        Cancellable(fun ct ->
+            //__debugPoint ""
+            let (Cancellable g) = f ()
+            g ct)
 
-    member inline _.Bind(comp, k) = Cancellable.bind k comp
+    member inline _.Bind(comp, [<InlineIfLambda>] k) =
+        Cancellable(fun ct ->
+            __debugPoint ""
 
-    member inline _.Return v = Cancellable.ret v
+            match Cancellable.run ct comp with
+            | ValueOrCancelled.Value v1 -> Cancellable.run ct (k v1)
+            | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
+
+    member inline _.BindReturn(comp, [<InlineIfLambda>] k) =
+        Cancellable(fun ct ->
+            __debugPoint ""
+
+            match Cancellable.run ct comp with
+            | ValueOrCancelled.Value v1 -> ValueOrCancelled.Value(k v1)
+            | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
+
+    member inline _.Combine(comp1, comp2) =
+        Cancellable(fun ct ->
+            __debugPoint ""
+
+            match Cancellable.run ct comp1 with
+            | ValueOrCancelled.Value () -> Cancellable.run ct comp2
+            | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
+
+    member inline _.TryWith(comp, [<InlineIfLambda>] handler) =
+        Cancellable(fun ct ->
+            __debugPoint ""
+
+            let compRes =
+                try
+                    match Cancellable.run ct comp with
+                    | ValueOrCancelled.Value res -> ValueOrCancelled.Value(Choice1Of2 res)
+                    | ValueOrCancelled.Cancelled exn -> ValueOrCancelled.Cancelled exn
+                with err ->
+                    ValueOrCancelled.Value(Choice2Of2 err)
+
+            match compRes with
+            | ValueOrCancelled.Value res ->
+                match res with
+                | Choice1Of2 r -> ValueOrCancelled.Value r
+                | Choice2Of2 err -> Cancellable.run ct (handler err)
+            | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
+
+    member inline _.Using(resource, [<InlineIfLambda>] comp) =
+        Cancellable(fun ct ->
+            __debugPoint ""
+            let body = comp resource
+
+            let compRes =
+                try
+                    match Cancellable.run ct body with
+                    | ValueOrCancelled.Value res -> ValueOrCancelled.Value(Choice1Of2 res)
+                    | ValueOrCancelled.Cancelled exn -> ValueOrCancelled.Cancelled exn
+                with err ->
+                    ValueOrCancelled.Value(Choice2Of2 err)
+
+            match compRes with
+            | ValueOrCancelled.Value res ->
+                (resource :> IDisposable).Dispose()
+
+                match res with
+                | Choice1Of2 r -> ValueOrCancelled.Value r
+                | Choice2Of2 err -> raise err
+            | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
+
+    member inline _.TryFinally(comp, [<InlineIfLambda>] compensation) =
+        Cancellable(fun ct ->
+            __debugPoint ""
+
+            let compRes =
+                try
+                    match Cancellable.run ct comp with
+                    | ValueOrCancelled.Value res -> ValueOrCancelled.Value(Choice1Of2 res)
+                    | ValueOrCancelled.Cancelled exn -> ValueOrCancelled.Cancelled exn
+                with err ->
+                    ValueOrCancelled.Value(Choice2Of2 err)
+
+            match compRes with
+            | ValueOrCancelled.Value res ->
+                compensation ()
+
+                match res with
+                | Choice1Of2 r -> ValueOrCancelled.Value r
+                | Choice2Of2 err -> raise err
+            | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
+
+    member inline _.Return v =
+        Cancellable(fun _ ->
+            __debugPoint ""
+            ValueOrCancelled.Value v)
 
     member inline _.ReturnFrom(v: Cancellable<'T>) = v
 
-    member inline _.Combine(e1, e2) = e1 |> Cancellable.bind (fun () -> e2)
-
-    member inline _.For(es, f) = es |> Cancellable.each f
-
-    member inline _.TryWith(comp, handler) = Cancellable.tryWith comp handler
-
-    member inline _.Using(resource, comp) =
-        Cancellable.tryFinally (comp resource) (fun () -> (resource :> IDisposable).Dispose())
-
-    member inline _.TryFinally(comp, compensation) =
-        Cancellable.tryFinally comp compensation
-
-    member inline _.Delay f = Cancellable.delay f
-
-    member inline _.Zero() = Cancellable.ret ()
+    member inline _.Zero() =
+        Cancellable(fun _ -> ValueOrCancelled.Value())
 
 [<AutoOpen>]
 module CancellableAutoOpens =

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -10,7 +10,7 @@ open System.IO
 open System.Threading
 open System.Threading.Tasks
 open System.Runtime.CompilerServices
-#if !COMPILING_PROTO
+#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
 open FSharp.Core.CompilerServices.StateMachineHelpers
 #endif
 
@@ -948,7 +948,7 @@ type CancellableBuilder() =
 
     member inline _.Bind(comp, [<InlineIfLambda>] k) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO
+#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 
@@ -958,7 +958,7 @@ type CancellableBuilder() =
 
     member inline _.BindReturn(comp, [<InlineIfLambda>] k) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO
+#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 
@@ -968,7 +968,7 @@ type CancellableBuilder() =
 
     member inline _.Combine(comp1, comp2) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO
+#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 
@@ -978,7 +978,7 @@ type CancellableBuilder() =
 
     member inline _.TryWith(comp, [<InlineIfLambda>] handler) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO
+#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 
@@ -999,7 +999,7 @@ type CancellableBuilder() =
 
     member inline _.Using(resource, [<InlineIfLambda>] comp) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO
+#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
             let body = comp resource
@@ -1023,7 +1023,7 @@ type CancellableBuilder() =
 
     member inline _.TryFinally(comp, [<InlineIfLambda>] compensation) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO
+#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -10,7 +10,7 @@ open System.IO
 open System.Threading
 open System.Threading.Tasks
 open System.Runtime.CompilerServices
-#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
+#if !USE_SHIPPED_FSCORE
 open FSharp.Core.CompilerServices.StateMachineHelpers
 #endif
 
@@ -948,7 +948,7 @@ type CancellableBuilder() =
 
     member inline _.Bind(comp, [<InlineIfLambda>] k) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
+#if !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 
@@ -958,7 +958,7 @@ type CancellableBuilder() =
 
     member inline _.BindReturn(comp, [<InlineIfLambda>] k) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
+#if !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 
@@ -968,7 +968,7 @@ type CancellableBuilder() =
 
     member inline _.Combine(comp1, comp2) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
+#if !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 
@@ -978,7 +978,7 @@ type CancellableBuilder() =
 
     member inline _.TryWith(comp, [<InlineIfLambda>] handler) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
+#if !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 
@@ -999,7 +999,7 @@ type CancellableBuilder() =
 
     member inline _.Using(resource, [<InlineIfLambda>] comp) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
+#if !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
             let body = comp resource
@@ -1023,7 +1023,7 @@ type CancellableBuilder() =
 
     member inline _.TryFinally(comp, [<InlineIfLambda>] compensation) =
         Cancellable(fun ct ->
-#if !COMPILING_PROTO && !USE_SHIPPED_FSCORE
+#if !USE_SHIPPED_FSCORE
             __debugPoint ""
 #endif
 

--- a/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/FSharp.Build/FSharp.Build.fsproj
@@ -11,7 +11,7 @@
     <DefineConstants>$(DefineConstants);LOCALIZATION_FSBUILD</DefineConstants>
     <NoWarn>NU1701;FS0075</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <LangVersion>5.0</LangVersion>  <!-- FSharp.Build may run in Visual Studio with older FSharp.Cores so don't use unshipped features -->
+    <LangVersion>6.0</LangVersion>  <!-- FSharp.Build may run in Visual Studio with older FSharp.Cores so don't use unshipped features -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -57,7 +57,7 @@
         The FSharp.Build built here may be loaded directly into a shipped Visual Studio, to that end, we cannot 
         rely on new API's just being added to FSharp.Core.
     -->
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)"/>
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" IncludeAssets="compile" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup  Condition="'$(Configuration)' != 'Proto'">

--- a/src/FSharp.Core/FSharp.Core.fsproj
+++ b/src/FSharp.Core/FSharp.Core.fsproj
@@ -10,7 +10,6 @@
     <NoWarn>$(NoWarn);1204</NoWarn> <!-- This construct is for use in the FSharp.Core library and should not be used directly -->
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);FSHARP_CORE</DefineConstants>
-    <DefineConstants Condition="'$(Configuration)' == 'Proto'">BUILDING_WITH_LKG;$(DefineConstants)</DefineConstants>
     <!-- 3218: ArgumentsInSigAndImplMismatch -->
     <OtherFlags>$(OtherFlags) --warnon:3218</OtherFlags>
     <!-- 1182: Unused variables -->
@@ -26,8 +25,6 @@
     <!-- Turn off 3513: resumable code invocation' - expected for resumable code combinators -->
     <OtherFlags>$(OtherFlags) --nowarn:3513</OtherFlags>
     <OtherFlags>$(OtherFlags) --compiling-fslib --compiling-fslib-40 --maxerrors:100 --extraoptimizationloops:1</OtherFlags>
-    <!-- preview needed for use of state machines for tasks -->
-    <LangVersion>preview</LangVersion>
     <!-- .tail annotations always emitted for this binary, even in debug mode -->
     <Tailcalls>true</Tailcalls>
     <NGenBinary>true</NGenBinary>

--- a/src/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/FSharp.Core/fslib-extra-pervasives.fs
@@ -373,11 +373,9 @@ module ExtraTopLevelOperators =
     [<assembly: AutoOpen("Microsoft.FSharp.Core")>]
     [<assembly: AutoOpen("Microsoft.FSharp.Collections")>]
     [<assembly: AutoOpen("Microsoft.FSharp.Control")>]
-#if !BUILDING_WITH_LKG && !BUILD_FROM_SOURCE
     [<assembly: AutoOpen("Microsoft.FSharp.Control.TaskBuilderExtensions.LowPriority")>]
     [<assembly: AutoOpen("Microsoft.FSharp.Control.TaskBuilderExtensions.MediumPriority")>]
     [<assembly: AutoOpen("Microsoft.FSharp.Control.TaskBuilderExtensions.HighPriority")>]
-#endif
     [<assembly: AutoOpen("Microsoft.FSharp.Linq.QueryRunExtensions.LowPriority")>]
     [<assembly: AutoOpen("Microsoft.FSharp.Linq.QueryRunExtensions.HighPriority")>]
     do ()

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -4856,8 +4856,7 @@ namespace Microsoft.FSharp.Core
             [<assembly: System.Runtime.InteropServices.ComVisible(false)>]
             [<assembly: System.CLSCompliant(true)>]
             [<assembly: System.Security.SecurityTransparent>] // assembly is fully transparent
-#if CROSS_PLATFORM_COMPILER
-#else
+#if !CROSS_PLATFORM_COMPILER
             [<assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level2)>] // v4 transparency; soon to be the default, but not yet
 #endif
             do ()

--- a/src/FSharp.Core/resumable.fs
+++ b/src/FSharp.Core/resumable.fs
@@ -9,7 +9,6 @@
 #nowarn "51"
 namespace Microsoft.FSharp.Core.CompilerServices
 
-#if !BUILDING_WITH_LKG && !BUILD_FROM_SOURCE
 open System
 open System.Runtime.CompilerServices
 open Microsoft.FSharp.Core
@@ -444,5 +443,3 @@ module ResumableCode =
             //-- RESUMABLE CODE END
             else
                 YieldDynamic(&sm))
-
-#endif

--- a/src/FSharp.Core/resumable.fsi
+++ b/src/FSharp.Core/resumable.fsi
@@ -2,7 +2,6 @@
 
 namespace Microsoft.FSharp.Core.CompilerServices
 
-#if !BUILDING_WITH_LKG && !BUILD_FROM_SOURCE
 open Microsoft.FSharp.Collections
 open Microsoft.FSharp.Core
 open System
@@ -229,5 +228,3 @@ type NoEagerConstraintApplicationAttribute =
     /// <summary>Creates an instance of the attribute</summary>
     /// <returns>NoEagerConstraintApplicationAttribute</returns>
     new : unit -> NoEagerConstraintApplicationAttribute
-
-#endif

--- a/src/FSharp.Core/resumable.fsi
+++ b/src/FSharp.Core/resumable.fsi
@@ -66,7 +66,6 @@ and ResumptionFunc<'Data> = delegate of byref<ResumableStateMachine<'Data>> -> b
 type ResumableCode<'Data, 'T> = delegate of byref<ResumableStateMachine<'Data>> -> bool
 
 /// Contains functions for composing resumable code blocks
-[<Microsoft.FSharp.Core.Experimental("Experimental library feature, requires '--langversion:preview'")>]
 [<Microsoft.FSharp.Core.RequireQualifiedAccess>]
 module ResumableCode =
 
@@ -125,7 +124,6 @@ type SetStateMachineMethodImpl<'Data> = delegate of byref<ResumableStateMachine<
 type AfterCode<'Data, 'Result> = delegate of byref<ResumableStateMachine<'Data>> -> 'Result
 
 /// Contains compiler intrinsics related to the definition of state machines.
-[<Microsoft.FSharp.Core.Experimental("Experimental library feature, requires '--langversion:preview'")>]
 module StateMachineHelpers = 
 
     /// <summary>

--- a/src/FSharp.Core/tasks.fs
+++ b/src/FSharp.Core/tasks.fs
@@ -13,7 +13,6 @@
 
 namespace Microsoft.FSharp.Control
 
-#if !BUILDING_WITH_LKG && !BUILD_FROM_SOURCE
 open System
 open System.Runtime.CompilerServices
 open System.Threading
@@ -464,5 +463,3 @@ module MediumPriority =
 
         member inline this.ReturnFrom(computation: Async<'T>) : TaskCode<'T, 'T> =
             this.ReturnFrom(Async.StartAsTask computation)
-
-#endif

--- a/src/FSharp.Core/tasks.fsi
+++ b/src/FSharp.Core/tasks.fsi
@@ -4,7 +4,6 @@
 
 namespace Microsoft.FSharp.Control
 
-    #if !BUILDING_WITH_LKG && !BUILD_FROM_SOURCE
     open System
     open System.Runtime.CompilerServices
     open System.Threading.Tasks
@@ -286,4 +285,3 @@ namespace Microsoft.FSharp.Control.TaskBuilderExtensions
                 task: Task<'TResult1> *
                 continuation: ('TResult1 -> TaskCode<'TOverall, 'TResult2>)
                     -> bool
-#endif


### PR DESCRIPTION
While investigating a compiler issue together, @vzarytovskii and I spent some time looking at ways we can improve debugging in the compiler. @vzarytovskii has a list of items

This deals with two things we spotted

1. When in the constraint solver, the presence of control structures like `MapD` and `TryD` on the stacks reported in VS makes things harder to follow.  This is both with stacks and stepping.  While these have some semantic content - and so hiding the stack frames can suppress useful information - showing them on the stack is more confusing than helpful.  Further "step into" should go straight to the target function (StepThrough) rather than bothering to stop in these.

2. The "Cancellable" workflows were causing a complete loss of source location on the second phase of execution, e.g. on stacks like this reporting "no source location available".  This is because `inline` erases all debug points (preserving them causes as many problems as it helps)

![image](https://user-images.githubusercontent.com/7204669/174850853-86963e83-78e5-4380-9a20-10156ff65d14.png)

The actions in this PR are

1. Mark some functions like `MapD` as `DebuggerStepThrough` and `DebuggerHidden`.   Those that are considered to be important to show on the stack are only marked `DebuggerStepThrough`

2. Flatten out the Cancellable implementation, and use a combination of the F# 6.0 [`__debugPoint ""`](https://github.com/fsharp/fslang-design/blob/main/FSharp-6.0/FS-1087-resumable-code.md#library-additions-debuggable-two-phase-code)  and `InlineIfLambda` to improve debugging marginally, at least to the point that stack traces contain reliable source code locations.

Problems remain with the debugging of Cancellable, notably stepping is highly counter-intuitive, with "step over" often resulting in the loss of stepping (that is, computation jumps forward skipping the entire section after a `let!`).

