### PR TITLE
Add "class end" for TFSharpObjectRepr without decls.

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -1988,9 +1988,18 @@ module TastDefinitionPrinting =
                 |> aboveListL
                 |> addLhs
 
-            | TFSharpObjectRepr _ when isNil allDecls ->
-                WordL.keywordClass ^^ WordL.keywordEnd
-                |> addLhs
+            | TFSharpObjectRepr objRepr when isNil allDecls ->
+                match objRepr.fsobjmodel_kind with
+                | TFSharpClass ->
+                    WordL.keywordClass ^^ WordL.keywordEnd
+                    |> addLhs
+                | TFSharpInterface ->
+                    WordL.keywordInterface ^^ WordL.keywordEnd
+                    |> addLhs
+                | TFSharpStruct ->
+                    WordL.keywordStruct ^^ WordL.keywordEnd
+                    |> addLhs
+                | _ -> lhsL
 
             | TFSharpObjectRepr _ ->
                 allDecls

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -1989,7 +1989,8 @@ module TastDefinitionPrinting =
                 |> addLhs
 
             | TFSharpObjectRepr _ when isNil allDecls ->
-                lhsL
+                WordL.keywordClass ^^ WordL.keywordEnd
+                |> addLhs
 
             | TFSharpObjectRepr _ ->
                 allDecls

--- a/src/Compiler/Facilities/TextLayoutRender.fs
+++ b/src/Compiler/Facilities/TextLayoutRender.fs
@@ -46,6 +46,7 @@ module WordL =
     let bar = wordL TaggedText.bar
     let keywordStruct = wordL TaggedText.keywordStruct
     let keywordClass = wordL TaggedText.keywordClass
+    let keywordInterface = wordL TaggedText.keywordInterface
     let keywordInherit = wordL TaggedText.keywordInherit
     let keywordBegin = wordL TaggedText.keywordBegin
     let keywordEnd = wordL TaggedText.keywordEnd

--- a/src/Compiler/Facilities/TextLayoutRender.fs
+++ b/src/Compiler/Facilities/TextLayoutRender.fs
@@ -45,6 +45,7 @@ module WordL =
     let keywordFalse = wordL TaggedText.keywordFalse
     let bar = wordL TaggedText.bar
     let keywordStruct = wordL TaggedText.keywordStruct
+    let keywordClass = wordL TaggedText.keywordClass
     let keywordInherit = wordL TaggedText.keywordInherit
     let keywordBegin = wordL TaggedText.keywordBegin
     let keywordEnd = wordL TaggedText.keywordEnd

--- a/src/Compiler/Facilities/TextLayoutRender.fsi
+++ b/src/Compiler/Facilities/TextLayoutRender.fsi
@@ -84,6 +84,7 @@ module internal WordL =
     val keywordFalse: Layout
     val bar: Layout
     val keywordStruct: Layout
+    val keywordClass: Layout
     val keywordInherit: Layout
     val keywordBegin: Layout
     val keywordEnd: Layout

--- a/src/Compiler/Facilities/TextLayoutRender.fsi
+++ b/src/Compiler/Facilities/TextLayoutRender.fsi
@@ -85,6 +85,7 @@ module internal WordL =
     val bar: Layout
     val keywordStruct: Layout
     val keywordClass: Layout
+    val keywordInterface: Layout
     val keywordInherit: Layout
     val keywordBegin: Layout
     val keywordEnd: Layout

--- a/src/Compiler/Utilities/sformat.fs
+++ b/src/Compiler/Utilities/sformat.fs
@@ -232,6 +232,7 @@ module TaggedText =
     let keywordGet = tagKeyword "get"
     let bar = tagPunctuation "|"
     let keywordStruct = tagKeyword "struct"
+    let keywordClass = tagKeyword "class"
     let keywordInherit = tagKeyword "inherit"
     let keywordEnd = tagKeyword "end"
     let keywordBegin = tagKeyword "begin"

--- a/src/Compiler/Utilities/sformat.fs
+++ b/src/Compiler/Utilities/sformat.fs
@@ -233,6 +233,7 @@ module TaggedText =
     let bar = tagPunctuation "|"
     let keywordStruct = tagKeyword "struct"
     let keywordClass = tagKeyword "class"
+    let keywordInterface = tagKeyword "interface"
     let keywordInherit = tagKeyword "inherit"
     let keywordEnd = tagKeyword "end"
     let keywordBegin = tagKeyword "begin"

--- a/src/Compiler/Utilities/sformat.fsi
+++ b/src/Compiler/Utilities/sformat.fsi
@@ -189,6 +189,7 @@ module internal TaggedText =
     val internal bar: TaggedText
     val internal keywordStruct: TaggedText
     val internal keywordClass: TaggedText
+    val internal keywordInterface: TaggedText
     val internal keywordInherit: TaggedText
     val internal keywordBegin: TaggedText
     val internal keywordEnd: TaggedText

--- a/src/Compiler/Utilities/sformat.fsi
+++ b/src/Compiler/Utilities/sformat.fsi
@@ -188,6 +188,7 @@ module internal TaggedText =
     val internal keywordGet: TaggedText
     val internal bar: TaggedText
     val internal keywordStruct: TaggedText
+    val internal keywordClass: TaggedText
     val internal keywordInherit: TaggedText
     val internal keywordBegin: TaggedText
     val internal keywordEnd: TaggedText

--- a/tests/fsharp/core/classStructInterface/test.fsx
+++ b/tests/fsharp/core/classStructInterface/test.fsx
@@ -1,0 +1,5 @@
+module Foo
+
+type C = class end
+type S = struct end
+type I = interface end

--- a/tests/fsharp/core/printing/output.1000.stdout.bsl
+++ b/tests/fsharp/core/printing/output.1000.stdout.bsl
@@ -1133,7 +1133,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   { x: int }
 
-> type internal T3
+> type internal T3 =
+  class end
 
 > type internal T4 =
   new: unit -> T4
@@ -1166,7 +1167,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   private { x: int }
 
-> type private T3
+> type private T3 =
+  class end
 
 > type private T4 =
   new: unit -> T4
@@ -1373,7 +1375,8 @@ val x1564_A3: int = 3
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -1396,7 +1399,8 @@ val x1564_A3: int = 3
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 module internal PrivateM =
@@ -1411,7 +1415,8 @@ module internal PrivateM =
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -1434,7 +1439,8 @@ module internal PrivateM =
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 

--- a/tests/fsharp/core/printing/output.200.stdout.bsl
+++ b/tests/fsharp/core/printing/output.200.stdout.bsl
@@ -453,7 +453,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   { x: int }
 
-> type internal T3
+> type internal T3 =
+  class end
 
 > type internal T4 =
   new: unit -> T4
@@ -486,7 +487,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   private { x: int }
 
-> type private T3
+> type private T3 =
+  class end
 
 > type private T4 =
   new: unit -> T4
@@ -618,7 +620,8 @@ val x1564_A3: int = 3
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -641,7 +644,8 @@ val x1564_A3: int = 3
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 module internal PrivateM =
@@ -656,7 +660,8 @@ module internal PrivateM =
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -679,7 +684,8 @@ module internal PrivateM =
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 

--- a/tests/fsharp/core/printing/output.47.stdout.bsl
+++ b/tests/fsharp/core/printing/output.47.stdout.bsl
@@ -4090,7 +4090,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   { x: int }
 
-> type internal T3
+> type internal T3 =
+  class end
 
 > type internal T4 =
   new: unit -> T4
@@ -4123,7 +4124,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   private { x: int }
 
-> type private T3
+> type private T3 =
+  class end
 
 > type private T4 =
   new: unit -> T4
@@ -4918,7 +4920,8 @@ val x1564_A3: int = 3
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -4941,7 +4944,8 @@ val x1564_A3: int = 3
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 module internal PrivateM =
@@ -4956,7 +4960,8 @@ module internal PrivateM =
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -4979,7 +4984,8 @@ module internal PrivateM =
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 

--- a/tests/fsharp/core/printing/output.multiemit.stdout.bsl
+++ b/tests/fsharp/core/printing/output.multiemit.stdout.bsl
@@ -4092,7 +4092,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   { x: int }
 
-> type internal T3
+> type internal T3 =
+  class end
 
 > type internal T4 =
   new: unit -> T4
@@ -4125,7 +4126,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   private { x: int }
 
-> type private T3
+> type private T3 =
+  class end
 
 > type private T4 =
   new: unit -> T4
@@ -4920,7 +4922,8 @@ val x1564_A3: int = 3
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -4943,7 +4946,8 @@ val x1564_A3: int = 3
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 module internal PrivateM =
@@ -4958,7 +4962,8 @@ module internal PrivateM =
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -4981,7 +4986,8 @@ module internal PrivateM =
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 

--- a/tests/fsharp/core/printing/output.off.stdout.bsl
+++ b/tests/fsharp/core/printing/output.off.stdout.bsl
@@ -280,7 +280,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   { x: int }
 
-> type internal T3
+> type internal T3 =
+  class end
 
 > type internal T4 =
   new: unit -> T4
@@ -313,7 +314,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   private { x: int }
 
-> type private T3
+> type private T3 =
+  class end
 
 > type private T4 =
   new: unit -> T4
@@ -418,7 +420,8 @@ val x1564_A3: int
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -441,7 +444,8 @@ val x1564_A3: int
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 module internal PrivateM =
@@ -456,7 +460,8 @@ module internal PrivateM =
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -479,7 +484,8 @@ module internal PrivateM =
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 

--- a/tests/fsharp/core/printing/output.stdout.bsl
+++ b/tests/fsharp/core/printing/output.stdout.bsl
@@ -4092,7 +4092,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   { x: int }
 
-> type internal T3
+> type internal T3 =
+  class end
 
 > type internal T4 =
   new: unit -> T4
@@ -4125,7 +4126,8 @@ type 'a T4063 = | AT4063 of 'a
 > type internal T2 =
   private { x: int }
 
-> type private T3
+> type private T3 =
+  class end
 
 > type private T4 =
   new: unit -> T4
@@ -4920,7 +4922,8 @@ val x1564_A3: int = 3
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -4943,7 +4946,8 @@ val x1564_A3: int = 3
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 module internal PrivateM =
@@ -4958,7 +4962,8 @@ module internal PrivateM =
     | B
   type T2 =
     { x: int }
-  type T3
+  type T3 =
+    class end
   type T4 =
     new: unit -> T4
   type T5 =
@@ -4981,7 +4986,8 @@ module internal PrivateM =
             | B
   type T12 =
     private { x: int }
-  type private T13
+  type private T13 =
+    class end
   type private T14 =
     new: unit -> T14
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3367,6 +3367,9 @@ module GeneratedSignatureTests =
 
     [<Test>]
     let ``nestedModuleInNamespace-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/nestedModuleInNamespace" FSC_NETFX_TEST_GENERATED_SIGNATURE
+
+    [<Test>]
+    let ``classStructInterface-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/classStructInterface" FSC_NETFX_TEST_GENERATED_SIGNATURE
 #endif
 
 #if !NETCOREAPP


### PR DESCRIPTION
This is a related fix for https://github.com/dotnet/fsharp/issues/13301.

```fsharp
type Context = class end
```

currently returns

```fsharp
type Context
```

but this gives a warning.

![image](https://user-images.githubusercontent.com/2621499/174985826-0186928a-9c88-4ccd-957b-838d5b19119c.png)

In this PR I'm adding the `class end` part.
Please review @dsyme.
Thanks!
