### PR TITLE
Set the NativeTools flag in a better place

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -425,6 +425,8 @@ try {
 
     [System.Environment]::SetEnvironmentVariable('DOTNET_ROLL_FORWARD_TO_PRERELEASE', '1', [System.EnvironmentVariableTarget]::User)
 
+    $env:NativeToolsOnMachine = $true
+
     Process-Arguments
 
     . (Join-Path $PSScriptRoot "build-utils.ps1")
@@ -453,8 +455,6 @@ try {
     $dotnetPath = InitializeDotNetCli
     $env:DOTNET_ROOT = "$dotnetPath"
     Get-Item -Path Env:
-
-    $env:NativeToolsOnMachine = $true
 
     if ($bootstrap) {
         $script:BuildMessage = "Failure building bootstrap compiler"


### PR DESCRIPTION
Setting the flag to use local tools after we have grabbed the local tools and downloaded them might not be the best way to do it.