### PR TITLE
Don't add struct attribute for type aliases of primitives

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -1680,7 +1680,7 @@ module TastDefinitionPrinting =
         let ty = generalizedTyconRef g tcref 
 
         let start, tagger =
-            if isStructTy g ty then
+            if isStructTy g ty && not tycon.TypeAbbrev.IsSome then
                 // Always show [<Struct>] whether verbose or not
                 Some "struct", tagStruct
             elif isInterfaceTy g ty then

--- a/tests/fsharp/core/typeAliasPrimitives/test.fsx
+++ b/tests/fsharp/core/typeAliasPrimitives/test.fsx
@@ -1,0 +1,22 @@
+namespace Foo
+
+type A = bool
+type B = sbyte
+type C = byte
+type D = int16
+type E = uint16
+type F = int
+type G = uint
+type H = nativeint
+type I = unativeint
+type J = int64
+type K = single 
+type L = float32
+type M = float
+type N = double
+type O = bigint
+type P = decimal
+type Q = System.Char
+type R = System.String
+type S = System.Byte
+type T = unit

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3373,6 +3373,9 @@ module GeneratedSignatureTests =
 
     [<Test>]
     let ``typeAugmentation-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/typeAugmentation" FSC_NETFX_TEST_GENERATED_SIGNATURE
+
+    [<Test>]
+    let ``typeAliasPrimitives-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/typeAliasPrimitives" FSC_NETFX_TEST_GENERATED_SIGNATURE
 #endif
 
 #if !NETCOREAPP


### PR DESCRIPTION
Fixes #13362.
@dsyme please review.