### PR TITLE
Add arrow to SynType.Fun trivia.

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -5091,7 +5091,7 @@ module TcDeclarations =
                         memberFlags.MemberKind=SynMemberKind.Constructor && 
                         // REVIEW: This is a syntactic approximation
                         (match synValSig.SynType, synValSig.SynInfo.CurriedArgInfos with 
-                         | StripParenTypes (SynType.Fun (StripParenTypes (SynType.LongIdent (SynLongIdent([id], _, _))), _, _)), [[_]] when id.idText = "unit" -> true
+                         | StripParenTypes (SynType.Fun (argType = StripParenTypes (SynType.LongIdent (SynLongIdent([id], _, _))))), [[_]] when id.idText = "unit" -> true
                          | _ -> false) 
                     | _ -> false) 
 

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4537,7 +4537,7 @@ and TcTypeOrMeasure kindOpt cenv newOk checkConstraints occ env (tpenv: Unscoped
     | SynType.AnonRecd(isStruct, args, m) ->
         TcAnonRecdType cenv newOk checkConstraints occ env tpenv isStruct args m
 
-    | SynType.Fun(domainTy, resultTy, _) ->
+    | SynType.Fun(argType = domainTy; returnType = resultTy) ->
         TcFunctionType cenv newOk checkConstraints occ env tpenv domainTy resultTy
 
     | SynType.Array (rank , elemTy, m) ->

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -807,7 +807,7 @@ module SyntaxTraversal =
                 | SynType.App (typeName, _, typeArgs, _, _, _, _)
                 | SynType.LongIdentApp (typeName, _, _, typeArgs, _, _, _) ->
                     [ yield typeName; yield! typeArgs ] |> List.tryPick (traverseSynType path)
-                | SynType.Fun (ty1, ty2, _) -> [ ty1; ty2 ] |> List.tryPick (traverseSynType path)
+                | SynType.Fun (argType = ty1; returnType = ty2) -> [ ty1; ty2 ] |> List.tryPick (traverseSynType path)
                 | SynType.MeasurePower (ty, _, _)
                 | SynType.HashConstraint (ty, _)
                 | SynType.WithGlobalConstraints (ty, _, _)

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -663,7 +663,7 @@ module ParsedInput =
             | SynType.LongIdentApp (_, _, _, types, _, _, _) -> List.tryPick walkType types
             | SynType.Tuple (_, ts, _) -> ts |> List.tryPick (fun (_, t) -> walkType t)
             | SynType.Array (_, t, _) -> walkType t
-            | SynType.Fun (t1, t2, _) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
+            | SynType.Fun (argType = t1; returnType = t2) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
             | SynType.WithGlobalConstraints (t, _, _) -> walkType t
             | SynType.HashConstraint (t, _) -> walkType t
             | SynType.MeasureDivide (t1, t2, _) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
@@ -1651,7 +1651,7 @@ module ParsedInput =
             | SynType.HashConstraint (t, _)
             | SynType.MeasurePower (t, _, _)
             | SynType.Paren (t, _) -> walkType t
-            | SynType.Fun (t1, t2, _)
+            | SynType.Fun (argType = t1; returnType = t2)
             | SynType.MeasureDivide (t1, t2, _) ->
                 walkType t1
                 walkType t2

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -398,7 +398,7 @@ type SynType =
 
     | Array of rank: int * elementType: SynType * range: range
 
-    | Fun of argType: SynType * returnType: SynType * range: range
+    | Fun of argType: SynType * returnType: SynType * range: range * trivia: SynTypeFunTrivia
 
     | Var of typar: SynTypar * range: range
 

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -471,7 +471,7 @@ type SynType =
     | Array of rank: int * elementType: SynType * range: range
 
     /// F# syntax: type -> type
-    | Fun of argType: SynType * returnType: SynType * range: range
+    | Fun of argType: SynType * returnType: SynType * range: range * trivia: SynTypeFunTrivia
 
     /// F# syntax: 'Var
     | Var of typar: SynTypar * range: range

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -230,3 +230,6 @@ type SynValSigTrivia =
             WithKeyword = None
             EqualsRange = None
         }
+
+[<NoEquality; NoComparison>]
+type SynTypeFunTrivia = { ArrowRange: range }

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -324,3 +324,11 @@ type SynValSigTrivia =
     }
 
     static member Zero: SynValSigTrivia
+
+/// Represents additional information for SynType.Fun
+[<NoEquality; NoComparison>]
+type SynTypeFunTrivia =
+    {
+        /// The syntax range of the `->` token.
+        ArrowRange: range
+    }

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -4993,8 +4993,9 @@ opt_topReturnTypeWithTypeConstraints:
 topType: 
   | topTupleType RARROW topType 
      { let dty, dmdata= $1 
-       let rty, (SynValInfo(dmdatas, rmdata)) = $3 
-       SynType.Fun(dty, rty, lhs parseState), (SynValInfo(dmdata :: dmdatas, rmdata)) }
+       let rty, (SynValInfo(dmdatas, rmdata)) = $3
+       let mArrow = rhs parseState 2
+       SynType.Fun(dty, rty, lhs parseState, { ArrowRange = mArrow }), (SynValInfo(dmdata :: dmdatas, rmdata)) }
 
   | topTupleType 
      { let ty, rmdata = $1 in ty, (SynValInfo([], (match rmdata with [md] -> md | _ -> SynInfo.unnamedRetVal))) }
@@ -5040,7 +5041,8 @@ topAppType:
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
 typ:
   | tupleType RARROW typ  
-     { SynType.Fun($1, $3, lhs parseState) }
+     { let mArrow = rhs parseState 2
+       SynType.Fun($1, $3, lhs parseState, { ArrowRange = mArrow }) }
 
   | tupleType %prec prec_typ_prefix 
      { $1 }

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -8408,6 +8408,8 @@ FSharp.Compiler.Syntax.SynType+Fun: FSharp.Compiler.Syntax.SynType argType
 FSharp.Compiler.Syntax.SynType+Fun: FSharp.Compiler.Syntax.SynType get_argType()
 FSharp.Compiler.Syntax.SynType+Fun: FSharp.Compiler.Syntax.SynType get_returnType()
 FSharp.Compiler.Syntax.SynType+Fun: FSharp.Compiler.Syntax.SynType returnType
+FSharp.Compiler.Syntax.SynType+Fun: FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia get_trivia()
+FSharp.Compiler.Syntax.SynType+Fun: FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia trivia
 FSharp.Compiler.Syntax.SynType+Fun: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+Fun: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType get_innerType()
@@ -8531,7 +8533,7 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewAnon(FSharp.Co
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewAnonRecd(Boolean, Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`2[FSharp.Compiler.Syntax.Ident,FSharp.Compiler.Syntax.SynType]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewApp(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewArray(Int32, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFun(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFun(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewHashConstraint(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdent(FSharp.Compiler.Syntax.SynLongIdent)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdentApp(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
@@ -9463,6 +9465,11 @@ FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Microsoft.FSharp.Core.FSharpOpti
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_WithKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia
+FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia: FSharp.Compiler.Text.Range ArrowRange
+FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia: FSharp.Compiler.Text.Range get_ArrowRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia: System.String ToString()
+FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia: Void .ctor(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] BarRange
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_BarRange()

--- a/tests/service/ServiceUntypedParseTests.fs
+++ b/tests/service/ServiceUntypedParseTests.fs
@@ -152,7 +152,7 @@ let rec getParenTypes (synType: SynType): SynType list =
           yield synType
           yield! getParenTypes innerType
 
-      | SynType.Fun (argType, returnType, _) ->
+      | SynType.Fun (argType = argType; returnType = returnType) ->
           yield! getParenTypes argType
           yield! getParenTypes returnType
 

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -4699,3 +4699,26 @@ module Measures =
             Assert.AreEqual("weeks", weeksIdent.idText)
             assertRange (2, 9) (2, 22) mParen
         | _ -> Assert.Fail $"Could not get valid AST, got {parseResults}"
+
+module SyntaxTypes =
+    [<Test>]
+    let ``SynType.Fun has range of arrow`` () =
+        let parseResults =
+            getParseResults
+                 """
+     type X = string -> // after a tuple, mixed needs an indent 
+                 int
+     """
+ 
+        match parseResults with
+        | ParsedInput.ImplFile (ParsedImplFileInput(modules = [
+            SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+                SynModuleDecl.Types(typeDefns = [
+                    SynTypeDefn(typeRepr = SynTypeDefnRepr.Simple(simpleRepr =
+                        SynTypeDefnSimpleRepr.TypeAbbrev(rhsType =
+                            SynType.Fun(trivia = { ArrowRange = mArrow }))))
+                ])
+            ])
+        ])) ->
+            assertRange (2, 21) (2, 23) mArrow
+        | _ -> Assert.Fail $"Could not get valid AST, got {parseResults}"


### PR DESCRIPTION
The range of the arrow keyword is interesting to restore comments like:
```fsharp
    type X = string -> // after a tuple, mixed needs an indent 
                 int
```
//cc @dsyme 