### PR TITLE
InfoReader: provide xmlDoc sig for default ctor

### DIFF
--- a/src/Compiler/Checking/InfoReader.fs
+++ b/src/Compiler/Checking/InfoReader.fs
@@ -1080,7 +1080,13 @@ let GetXmlDocSigOfMethInfo (infoReader: InfoReader)  m (minfo: MethInfo) =
             let normalizedName = ilminfo.ILName.Replace(".", "#")
 
             Some (ccuFileName, "M:"+actualTypeName+"."+normalizedName+genArity+XmlDocArgsEnc g (formalTypars, fmtps) args)
-    | DefaultStructCtor _ -> None
+
+    | DefaultStructCtor(g, ty) ->
+        match tryTcrefOfAppTy g ty with
+        | ValueSome tcref ->
+            Some(None, $"M:{tcref.CompiledRepresentationForNamedType.FullName}.#ctor")
+        | _ -> None
+
 #if !NO_TYPEPROVIDERS
     | ProvidedMeth _ -> None
 #endif


### PR DESCRIPTION
Fixes Symbols API would return empty string for default constructor xmlDoc signature.
We use these signatures extensively, and not returning it makes it harder to analyse symbol in some scenarios.