### PR TITLE
Fixed FSharp.Core as reference assembly

### DIFF
--- a/src/FSharp.Core/prim-types.fsi
+++ b/src/FSharp.Core/prim-types.fsi
@@ -888,7 +888,7 @@ namespace Microsoft.FSharp.Core
         /// <returns>NoDynamicInvocationAttribute</returns>
         new: unit -> NoDynamicInvocationAttribute
 
-        internal new: isLegacy: bool -> NoDynamicInvocationAttribute
+        new: isLegacy: bool -> NoDynamicInvocationAttribute
 
     /// <summary>This attribute is used to indicate that references to the elements of a module, record or union 
     /// type require explicit qualified access.</summary>


### PR DESCRIPTION
- Allows `FSharp.Core` to be exported as a reference assembly.
- Prevents an error being thrown during exporting. This seems to be the only error.

Note: Making the constructor internal in the implementation (to match the signature) still throws, but making it non-internal in the signature works.