### PR TITLE
Update System.Memory to 4.5.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,7 +93,7 @@
     <SystemIoCompressionVersion>4.3.0</SystemIoCompressionVersion>
     <SystemLinqExpressionsVersion>4.3.0</SystemLinqExpressionsVersion>
     <SystemLinqQueryableVersion>4.3.0</SystemLinqQueryableVersion>
-    <SystemMemoryVersion>4.5.4</SystemMemoryVersion>
+    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemNetRequestsVersion>4.3.0</SystemNetRequestsVersion>
     <SystemNetSecurityVersion>4.3.1</SystemNetSecurityVersion>
     <SystemReflectionEmitVersion>4.3.0</SystemReflectionEmitVersion>


### PR DESCRIPTION
The latest version of System.Memory is 4.5.5: https://www.nuget.org/packages/System.Memory. Upgrading this package prevents a package downgrade error in source-build.
