### PR TITLE
Skip OBLOCKSEP for type alias function types.

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/FunctionTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/FunctionTypes.fs
@@ -1,0 +1,62 @@
+﻿namespace FSharp.Compiler.ComponentTests.Conformance.LexicalFiltering.Basic
+
+open Xunit
+open FSharp.Test.Compiler
+
+module FunctionTypes =
+
+    [<Fact>]
+    let ``function type alias`` () =
+        Fsx """
+type Meh =
+    int ->
+    string ->
+        double
+"""
+        |> withLangVersionPreview
+        |> withOptions ["--nowarn:20"]
+        |> parse
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``function type alias with generics`` () =
+        Fsx """
+type GetParseResultsForFile =
+    string<LocalPath> ->
+    FSharp.Compiler.Text.Position ->
+        Async<ResultOrString<ParseAndCheckResults * string * FSharp.Compiler.Text.ISourceText>>
+        """
+        |> withLangVersionPreview
+        |> withOptions ["--nowarn:20"]
+        |> parse
+        |> shouldSucceed
+        |> ignore
+
+    [<Fact>]
+    let ``function type alias with parentheses`` () =
+        Fsi """
+module Foo.Bar
+
+val GetParseResultsForFile :
+    (A ->
+     B ->
+      C)
+"""     |> withLangVersionPreview
+        |> withOptions ["--nowarn:20"]
+        |> parse
+        |> shouldSucceed
+        |> ignore
+        
+    [<Fact>]
+    let ``record types with function type alias declarations`` () =
+        Fsx """
+type R =
+    { F: (A ->
+          B ->
+            C) }
+"""     |> withLangVersionPreview
+        |> withOptions ["--nowarn:20"]
+        |> parse
+        |> shouldSucceed
+        |> ignore

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -74,6 +74,7 @@
     <Compile Include="Conformance\LexicalFiltering\HashLight\HashLight.fs" />
     <Compile Include="Conformance\LexicalFiltering\HighPrecedenceApplication\HighPrecedenceApplication.fs" />
     <Compile Include="Conformance\LexicalFiltering\OffsideExceptions\OffsideExceptions.fs" />
+    <Compile Include="Conformance\LexicalFiltering\FunctionTypes.fs" />
     <Compile Include="Conformance\MethodResolution\ParametersResolution.fs" />
     <Compile Include="Conformance\PatternMatching\Simple.fs" />
     <Compile Include="Conformance\Printing\Printing.fs" />


### PR DESCRIPTION
Hello @dsyme, this is an attempt to address the offset warnings of https://github.com/fsprojects/fantomas/issues/2012#issuecomment-1010265002.
The problem occurs when a `CtxtSeqBlock` is added and in this PR I tried to avoid them.
I'm not really sure if this is the right approach.