### PR TITLE
enable codeql in default pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,8 @@ variables:
     value: .NETCore
   - name: VisualStudioDropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+  - name: Codeql.Enabled
+    value: true
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _DotNetValidationArtifactsCategory
       value: .NETCoreValidation


### PR DESCRIPTION
Internal builds need CodeQL enabled, and thankfully it only requires adding a variable.  Previously done in dotnet/interactive#2112.