### PR TITLE
Show arguments names in tooltips for local functions

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -990,6 +990,9 @@ module IncrClassChecking =
                     let memberInfo = MakeMemberDataAndMangledNameForMemberVal(g, tcref, false, [], [], memberFlags, valSynInfo, mkSynId v.Range name, true)
 
                     let copyOfTyconTypars = ctorInfo.GetNormalizedInstanceCtorDeclaredTypars cenv env.DisplayEnv ctorInfo.TyconRef.Range
+                    
+                    AdjustValToTopVal v (Parent tcref) topValInfo 
+                    
                     // Add the 'this' pointer on to the function
                     let memberTauTy, topValInfo = 
                         let tauTy = v.TauType

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.ParameterInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.ParameterInfo.fs
@@ -1555,13 +1555,6 @@ We really need to rewrite some code paths here to use the real parse tree rather
                 """, "bar(", ["int"]
 
                 """
-                type T() = 
-                    let foo x = x + 1
-                    member this.Run() = 
-                        foo(
-                """, "foo(", ["int"]
-
-                """
                 let f (Some x) = x + 1
                 f(
                 """, "f(", ["int option"]

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -764,7 +764,7 @@ Full name: Microsoft.FSharp.Control.Async""".TrimStart().Replace("\r\n", "\n")
             type A() = 
                 let fff n = n + 1                
             """
-        this.AssertQuickInfoContainsAtEndOfMarker(code, "let ff", "val fff: (int -> int)")
+        this.AssertQuickInfoContainsAtEndOfMarker(code, "let ff", "val fff: n: int -> int")
 
     // Regression for 2494
     [<Test>]

--- a/vsintegration/tests/UnitTests/QuickInfoTests.fs
+++ b/vsintegration/tests/UnitTests/QuickInfoTests.fs
@@ -429,15 +429,23 @@ module Test =
     ()
 
 [<Test>]
-let ``Automation.LetBindings.ArgumentNames``() =
-    let code1 = """
+let ``Automation.LetBindings.InsideModule``() =
+    let code = """
 namespace FsTest
 
 module Test =
     let fu$$nc x = ()
 """
+    let expectedSignature = "val func: x: 'a -> unit"
 
-    let code2 = """
+    let tooltip = GetQuickInfoTextFromCode code
+
+    StringAssert.StartsWith(expectedSignature, tooltip)
+    ()
+
+[<Test>]
+let ``Automation.LetBindings.InsideType``() =
+    let code = """
 namespace FsTest
 
 module Test =
@@ -447,9 +455,7 @@ module Test =
 
     let expectedSignature = "val func: x: 'a -> unit"
 
-    let tooltip1 = GetQuickInfoTextFromCode code1
-    let tooltip2 = GetQuickInfoTextFromCode code2
+    let tooltip = GetQuickInfoTextFromCode code
 
-    StringAssert.StartsWith(expectedSignature, tooltip1)
-    StringAssert.StartsWith(expectedSignature, tooltip2)
+    StringAssert.StartsWith(expectedSignature, tooltip)
     ()

--- a/vsintegration/tests/UnitTests/QuickInfoTests.fs
+++ b/vsintegration/tests/UnitTests/QuickInfoTests.fs
@@ -1,12 +1,10 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
 namespace Microsoft.VisualStudio.FSharp.Editor.Tests.Roslyn
 
 open System.IO
-open FSharp.Compiler.CodeAnalysis
-open Microsoft.CodeAnalysis
-open Microsoft.CodeAnalysis.Text
 open Microsoft.VisualStudio.FSharp.Editor
 open NUnit.Framework
-open UnitTests.TestLib.LanguageService
 open VisualFSharp.UnitTests.Roslyn
 
 [<Category "Roslyn Services">]
@@ -45,7 +43,6 @@ let GetQuickInfoTextFromCode (code:string) =
 
 let expectedLines (lines:string list) = System.String.Join("\n", lines)
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.EnumDUInterfacefromFSBrowse.InsideComputationExpression`` () =
     let code = """
@@ -70,7 +67,6 @@ module Test =
     let expected = "MyColors.Red: MyColors = 0"
     Assert.AreEqual(expected, quickInfo)
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.EnumDUInterfacefromFSBrowse.InsideMatch`` () =
     let code = """
@@ -100,7 +96,6 @@ module Test =
                         "Full name: FsTest.MyDistance" ]
     Assert.AreEqual(expected, quickInfo)
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.EnumDUInterfacefromFSBrowse.InsideLambda`` () =
     let code = """
@@ -129,7 +124,6 @@ module Test =
     let expected = "abstract IMyInterface.Represent: unit -> string"
     Assert.AreEqual(expected, quickInfo)
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.RecordAndInterfaceFromFSProj.InsideComputationExpression``() =
     let code = """
@@ -162,7 +156,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.RecordAndInterfaceFromFSProj.InsideQuotation``() =
     let code = """
@@ -186,7 +179,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.RecordAndInterfaceFromFSProj.InsideLambda``() =
     let code = """
@@ -212,7 +204,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.TupleRecordFromFSBrowse.InsideComputationExpression``() =
     let code = """
@@ -237,7 +228,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.TupleRecordFromFSBrowse.SequenceOfMethods``() =
     let code = """
@@ -266,7 +256,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.UnionAndStructFromFSProj.MatchExpression``() =
     let code = """
@@ -289,7 +278,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.UnionAndStructFromFSProj.MatchPattern``() =
     let code = """
@@ -312,7 +300,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.UnionAndStructFromFSProj.UnionIfPredicate``() =
     let code = """
@@ -334,7 +321,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.UnionAndStructFromFSProj.UnionForPattern``() =
     let code = """
@@ -356,7 +342,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.UnionAndStructFromFSProj.UnionMethodPatternMatch``() =
     let code = """
@@ -386,7 +371,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.UnionAndStructFromFSProj.UnionMethodPatternMatchBody``() =
     let code = """
@@ -414,7 +398,6 @@ module Test =
     Assert.AreEqual(expected, quickInfo)
     ()
 
-// migrated from legacy test
 [<Test>]
 let ``Automation.UnionAndStructFromFSProj.UnionPropertyInComputationExpression``() =
     let code = """
@@ -443,4 +426,30 @@ module Test =
     let quickInfo = GetQuickInfoTextFromCode code
     let expected = "property MyDistance.asNautical: MyDistance with get"
     Assert.AreEqual(expected, quickInfo)
+    ()
+
+[<Test>]
+let ``Automation.LetBindings.ArgumentNames``() =
+    let code1 = """
+namespace FsTest
+
+module Test =
+    let fu$$nc x = ()
+"""
+
+    let code2 = """
+namespace FsTest
+
+module Test =
+    type T() =
+        let fu$$nc x = ()
+"""
+
+    let expectedSignature = "val func: x: 'a -> unit"
+
+    let tooltip1 = GetQuickInfoTextFromCode code1
+    let tooltip2 = GetQuickInfoTextFromCode code2
+
+    StringAssert.StartsWith(expectedSignature, tooltip1)
+    StringAssert.StartsWith(expectedSignature, tooltip2)
     ()


### PR DESCRIPTION
partially fixes #7080 

So basically local functions were missing value representation info which the tooltips are relying on. This is fixed by calling `AdjustValToTopVal` function which sets this value representation (aka `top val info`) in the right place.

<img width="221" alt="image" src="https://user-images.githubusercontent.com/5451366/176903967-1416281a-3fe2-4b7e-9ef5-73631f93217b.png">

Note that this doesn't fix the other case described in the issue, see @dsyme's comment.
<img width="126" alt="image" src="https://user-images.githubusercontent.com/5451366/177141114-076584bd-f437-434a-a206-7112ef6448d7.png">