### PR TITLE
Fix Zero constraint printing in signature file.

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -810,7 +810,10 @@ module PrintTypes =
 
             let argTysL = layoutTypesWithInfoAndPrec denv env 2 (wordL (tagPunctuation "*")) argTys
             let retTyL = layoutReturnType denv env retTy
-            let sigL = curriedLayoutsL "->" [argTysL] retTyL
+            let sigL =
+                match argTys with
+                | [] -> retTyL
+                | _ -> curriedLayoutsL "->" [argTysL] retTyL
             (tysL |> addColonL) --- bracketL (stat ++ (nameL |> addColonL) --- sigL)
 
     /// Layout a unit of measure expression 

--- a/src/Compiler/SyntaxTree/PrettyNaming.fs
+++ b/src/Compiler/SyntaxTree/PrettyNaming.fs
@@ -584,6 +584,8 @@ let ConvertValNameToDisplayLayout isBaseVal nonOpLayout name =
         else
             leftL (TaggedText.tagPunctuation "(")
             ^^ wordL (TaggedText.tagOperator nm) ^^ rightL (TaggedText.tagPunctuation ")")
+    elif name = "get_Zero" then
+        ConvertNameToDisplayLayout nonOpLayout "Zero"
     else
         ConvertNameToDisplayLayout nonOpLayout name
 

--- a/tests/fsharp/core/zeroConstraint/test.fs
+++ b/tests/fsharp/core/zeroConstraint/test.fs
@@ -1,0 +1,5 @@
+module Foo.Array
+    
+[<CompiledName("Average")>]
+let inline average (array: 'T[] when ^T: (static member Zero: ^T) and ^T: (static member (+) :  ^T *  ^T ->  ^T) and ^T: (static member DivideByInt:  ^T * int ->  ^T)) : 'T =
+    failwith "todo"

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -3385,6 +3385,9 @@ module GeneratedSignatureTests =
 
     [<Test>]
     let ``mixCurriedTupled-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/mixCurriedTupled" FSC_NETFX_TEST_GENERATED_SIGNATURE
+
+    [<Test>]
+    let ``zeroConstraint-FSC_NETFX_TEST_GENERATED_SIGNATURE`` () = singleTestBuildAndRun "core/zeroConstraint" FSC_NETFX_TEST_GENERATED_SIGNATURE
 #endif
 
 #if !NETCOREAPP

--- a/tests/fsharp/typecheck/overloads/neg_known_return_type_and_known_type_arguments.bsl
+++ b/tests/fsharp/typecheck/overloads/neg_known_return_type_and_known_type_arguments.bsl
@@ -6,11 +6,11 @@ Known return type: MonoidSample
 Known type parameters: < MonoidSample , Zero >
 
 Available overloads:
- - static member Zero.Zero:  ^t * Default1 ->  ^t when  ^t: (static member get_Zero: ->  ^t) // Argument at index 1 doesn't match
+ - static member Zero.Zero:  ^t * Default1 ->  ^t when  ^t: (static member Zero:  ^t) // Argument at index 1 doesn't match
  - static member Zero.Zero:  ^t * Default1 -> ('a1 -> 'a1) when  ^t: null and  ^t: struct // Argument at index 1 doesn't match
  - static member Zero.Zero:  ^t * Default2 ->  ^t when (FromInt32 or  ^t) : (static member FromInt32:  ^t * FromInt32 -> (int32 ->  ^t)) // Argument at index 1 doesn't match
  - static member Zero.Zero:  ^t * Default2 -> ('a1 -> 'a1) when  ^t: null and  ^t: struct // Argument at index 1 doesn't match
- - static member Zero.Zero:  ^t * Default3 ->  ^t when  ^t: (static member get_Empty: ->  ^t) // Argument at index 1 doesn't match
+ - static member Zero.Zero:  ^t * Default3 ->  ^t when  ^t: (static member get_Empty:  ^t) // Argument at index 1 doesn't match
  - static member Zero.Zero: 'a array * Zero -> 'a array // Argument at index 1 doesn't match
  - static member Zero.Zero: 'a list * Zero -> 'a list // Argument at index 1 doesn't match
  - static member Zero.Zero: 'a option * Zero -> 'a option // Argument at index 1 doesn't match


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/13357
The `elif name = "get_Zero" then` check is a bit on the noise, @dsyme any thoughts to improve this?