### PR TITLE
Remove unneeded codebase registration

### DIFF
--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -49,7 +49,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="FSharp.LanguageService.Base.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="FSharp.LanguageService.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="FSharp.Editor.pkgdef" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="FSharp.ProjectSystem.PropertyPages.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="FSharp.Compiler.Server.Shared.pkgdef" />
 
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="FSharp.Editor" Path="|FSharp.Editor|" />

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharp.Core.targets
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharp.Core.targets
@@ -188,7 +188,7 @@
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.ProjectSystem.PropertyPages\FSharp.ProjectSystem.PropertyPages.vbproj">
       <Project>{FCFB214C-462E-42B3-91CA-FC557EFEE74F}</Project>
       <Name>FSharp.PropertiesPages</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>true</Ngen>
       <NgenArchitecture>All</NgenArchitecture>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/FSharp.ProjectSystem.FSharp.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/FSharp.ProjectSystem.FSharp.fsproj
@@ -67,16 +67,6 @@
     </AssemblyAttribute>
 
     <AssemblyAttribute Include="Microsoft.VisualStudio.Shell.ProvideCodeBaseAttribute">
-      <AssemblyName>FSharp.Core</AssemblyName>
-      <Version>$(FSCoreVersion)</Version>
-      <CodeBase>$PackageFolder$\FSharp.Core.dll</CodeBase>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="Microsoft.VisualStudio.Shell.ProvideCodeBaseAttribute">
-      <AssemblyName>FSharp.ProjectSystem.FSharp</AssemblyName>
-      <Version>$(VSAssemblyVersion)</Version>
-      <CodeBase>$PackageFolder$\FSharp.ProjectSystem.FSharp.dll</CodeBase>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="Microsoft.VisualStudio.Shell.ProvideCodeBaseAttribute">
       <AssemblyName>FSharp.Compiler.Service</AssemblyName>
       <Version>$(FSharpCompilerServiceVersion)</Version>
       <CodeBase>$PackageFolder$\FSharp.Compiler.Service.dll</CodeBase>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/AssemblyInfo.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/AssemblyInfo.vb
@@ -1,5 +1,0 @@
-' Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
-
-Imports Microsoft.VisualStudio.Shell
-
-<Assembly: ProvideCodeBase(CodeBase := "$PackageFolder$\\FSharp.ProjectSystem.PropertyPages.dll")>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.ProjectSystem.PropertyPages.vbproj
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.ProjectSystem.PropertyPages.vbproj
@@ -16,6 +16,7 @@
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <ImportVsSDK>true</ImportVsSDK>
     <CreateVsixContainer>false</CreateVsixContainer>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <DeployExtension>false</DeployExtension>
     <UseCodebase>true</UseCodebase>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
@@ -61,7 +62,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.vb" />
     <Compile Include="Common\ArgumentValidation.vb" />
     <Compile Include="Common\DTEUtils.vb" />
     <Compile Include="Common\ShellUtil.vb" />


### PR DESCRIPTION
This code base registration is not being used due to the existing binding redirections which specify a codebase by default.

This fixes these warnings in ActivityLog:

```
Found both a Binding Redirection and a Code Base entries for the same Assembly. Ignoring Code Base, keeping Binding Redirection.
          FSharp.ProjectSystem.FSharp, Version=17.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
          FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
          FSharp.ProjectSystem.PropertyPages, Version=17.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
```