### PR TITLE
regularize some names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ trigger:
     exclude:
     - .github/*
     - docs/
+    - tests/scripts/
     - attributions.md
     - CODE_OF_CONDUCT.md
     - DEVGUIDE.md

--- a/src/Compiler/AbstractIL/ilreflect.fs
+++ b/src/Compiler/AbstractIL/ilreflect.fs
@@ -479,11 +479,11 @@ module Zmap =
 
 let equalTypes (s: Type) (t: Type) = s.Equals t
 
-let equalTypeLists ss tt =
-    List.lengthsEqAndForall2 equalTypes ss tt
+let equalTypeLists (tys1: Type list) (tys2: Type list) =
+    List.lengthsEqAndForall2 equalTypes tys1 tys2
 
-let equalTypeArrays ss tt =
-    Array.lengthsEqAndForall2 equalTypes ss tt
+let equalTypeArrays (tys1: Type[]) (tys2: Type[]) =
+    Array.lengthsEqAndForall2 equalTypes tys1 tys2
 
 let getGenericArgumentsOfType (typT: Type) =
     if typT.IsGenericType then

--- a/src/Compiler/AbstractIL/ilx.fs
+++ b/src/Compiler/AbstractIL/ilx.fs
@@ -75,7 +75,7 @@ type IlxClosureApps =
 let rec instAppsAux n inst apps =
     match apps with
     | Apps_tyapp (ty, rest) -> Apps_tyapp(instILTypeAux n inst ty, instAppsAux n inst rest)
-    | Apps_app (dty, rest) -> Apps_app(instILTypeAux n inst dty, instAppsAux n inst rest)
+    | Apps_app (domainTy, rest) -> Apps_app(instILTypeAux n inst domainTy, instAppsAux n inst rest)
     | Apps_done retTy -> Apps_done(instILTypeAux n inst retTy)
 
 let rec instLambdasAux n inst lambdas =

--- a/src/Compiler/Checking/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/CheckComputationExpressions.fs
@@ -224,10 +224,10 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
     // Give bespoke error messages for the FSharp.Core "query" builder
     let isQuery = 
         match stripDebugPoints interpExpr with 
-        | Expr.Val (vf, _, m) -> 
-            let item = Item.CustomBuilder (vf.DisplayName, vf)
+        | Expr.Val (vref, _, m) -> 
+            let item = Item.CustomBuilder (vref.DisplayName, vref)
             CallNameResolutionSink cenv.tcSink (m, env.NameEnv, item, emptyTyparInst, ItemOccurence.Use, env.eAccessRights)
-            valRefEq cenv.g vf cenv.g.query_value_vref 
+            valRefEq cenv.g vref cenv.g.query_value_vref 
         | _ -> false
 
     /// Make a builder.Method(...) call
@@ -1909,8 +1909,8 @@ let TcSequenceExpression (cenv: cenv) env tpenv comp (overallTy: OverallTy) m =
             // This transformation is visible in quotations and thus needs to remain.
             | (TPat_as (TPat_wild _, PatternValBinding (v, _), _), 
                 [_],
-                DebugPoints(Expr.App (Expr.Val (vf, _, _), _, [genEnumElemTy], [yieldExpr], _mYield), recreate)) 
-                    when valRefEq cenv.g vf cenv.g.seq_singleton_vref ->
+                DebugPoints(Expr.App (Expr.Val (vref, _, _), _, [genEnumElemTy], [yieldExpr], _mYield), recreate)) 
+                    when valRefEq cenv.g vref cenv.g.seq_singleton_vref ->
 
                 // The debug point mFor is attached to the 'map'
                 // The debug point mIn is attached to the lambda
@@ -2051,11 +2051,11 @@ let TcSequenceExpression (cenv: cenv) env tpenv comp (overallTy: OverallTy) m =
             error(Error(FSComp.SR.tcUseForInSequenceExpression(), m))
 
         | SynExpr.Match (spMatch, expr, clauses, _m, _trivia) ->
-            let inputExpr, matchty, tpenv = TcExprOfUnknownType cenv env tpenv expr
+            let inputExpr, inputTy, tpenv = TcExprOfUnknownType cenv env tpenv expr
 
             let tclauses, tpenv = 
                 (tpenv, clauses) ||> List.mapFold (fun tpenv (SynMatchClause(pat, cond, innerComp, _, sp, _)) ->
-                      let patR, condR, vspecs, envinner, tpenv = TcMatchPattern cenv matchty env tpenv pat cond
+                      let patR, condR, vspecs, envinner, tpenv = TcMatchPattern cenv inputTy env tpenv pat cond
                       let envinner =
                           match sp with
                           | DebugPointAtTarget.Yes -> { envinner with eIsControlFlow = true }

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -291,9 +291,9 @@ let OpenModuleOrNamespaceRefs tcSink g amap scopem root env mvvs openDeclaration
     env
 
 /// Adjust the TcEnv to account for opening a type implied by an `open type` declaration
-let OpenTypeContent tcSink g amap scopem env (typ: TType) openDeclaration =
+let OpenTypeContent tcSink g amap scopem env (ty: TType) openDeclaration =
     let env =
-        { env with eNameResEnv = AddTypeContentsToNameEnv g amap env.eAccessRights scopem env.eNameResEnv typ }
+        { env with eNameResEnv = AddTypeContentsToNameEnv g amap env.eAccessRights scopem env.eNameResEnv ty }
     CallEnvSink tcSink (scopem, env.NameEnv, env.eAccessRights)
     CallOpenDeclarationSink tcSink openDeclaration
     env
@@ -658,16 +658,16 @@ let TcOpenTypeDecl (cenv: cenv) mOpenDecl scopem env (synType: SynType, m) =
 
     checkLanguageFeatureError g.langVersion LanguageFeature.OpenTypeDeclaration mOpenDecl
 
-    let typ, _tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.Open env emptyUnscopedTyparEnv synType
+    let ty, _tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.Open env emptyUnscopedTyparEnv synType
 
-    if not (isAppTy g typ) then
+    if not (isAppTy g ty) then
         error(Error(FSComp.SR.tcNamedTypeRequired("open type"), m))
 
-    if isByrefTy g typ then
+    if isByrefTy g ty then
         error(Error(FSComp.SR.tcIllegalByrefsInOpenTypeDeclaration(), m))
 
-    let openDecl = OpenDeclaration.Create (SynOpenDeclTarget.Type (synType, m), [], [typ], scopem, false)
-    let env = OpenTypeContent cenv.tcSink g cenv.amap scopem env typ openDecl
+    let openDecl = OpenDeclaration.Create (SynOpenDeclTarget.Type (synType, m), [], [ty], scopem, false)
+    let env = OpenTypeContent cenv.tcSink g cenv.amap scopem env ty openDecl
     env, [openDecl]
 
 let TcOpenDecl (cenv: cenv) mOpenDecl scopem env target = 
@@ -1060,7 +1060,7 @@ module MutRecBindingChecking =
                             Phase2BInherit (inheritsExpr, baseValOpt), innerState
                             
                         // Phase2B: let and let rec value and function definitions
-                        | Phase2AIncrClassBindings (tcref, binds, isStatic, isRec, bindsm) ->
+                        | Phase2AIncrClassBindings (tcref, binds, isStatic, isRec, mBinds) ->
                             let envForBinding = if isStatic then envStatic else envInstance
                             let binds, bindRs, env, tpenv = 
                                 if isRec then
@@ -1073,12 +1073,12 @@ module MutRecBindingChecking =
                                 else
 
                                     // Type check local binding 
-                                    let binds, env, tpenv = TcLetBindings cenv envForBinding ExprContainerInfo (ClassLetBinding isStatic) tpenv (binds, bindsm, scopem)
+                                    let binds, env, tpenv = TcLetBindings cenv envForBinding ExprContainerInfo (ClassLetBinding isStatic) tpenv (binds, mBinds, scopem)
                                     let binds, bindRs = 
                                         binds 
                                         |> List.map (function
                                             | TMDefLet(bind, _) -> [bind], IncrClassBindingGroup([bind], isStatic, false)
-                                            | TMDefDo(e, _) -> [], IncrClassDo(e, isStatic, bindsm)
+                                            | TMDefDo(e, _) -> [], IncrClassDo(e, isStatic, mBinds)
                                             | _ -> error(InternalError("unexpected definition kind", tcref.Range)))
                                         |> List.unzip
                                     List.concat binds, bindRs, env, tpenv
@@ -1473,7 +1473,7 @@ module MutRecBindingChecking =
                 envForDecls)
 
     /// Phase 2: Check the members and 'let' definitions in a mutually recursive group of definitions.
-    let TcMutRecDefns_Phase2_Bindings (cenv: cenv) envInitial tpenv bindsm scopem mutRecNSInfo (envMutRecPrelimWithReprs: TcEnv) (mutRecDefns: MutRecDefnsPhase2Info) =
+    let TcMutRecDefns_Phase2_Bindings (cenv: cenv) envInitial tpenv mBinds scopem mutRecNSInfo (envMutRecPrelimWithReprs: TcEnv) (mutRecDefns: MutRecDefnsPhase2Info) =
         let g = cenv.g
         let denv = envMutRecPrelimWithReprs.DisplayEnv
         
@@ -1601,12 +1601,12 @@ module MutRecBindingChecking =
              (fun morpher shape -> shape |> MutRecShapes.iterTyconsAndLets (p23 >> morpher) morpher)
              MutRecShape.Lets
              (fun morpher shape -> shape |> MutRecShapes.mapTyconsAndLets (fun (tyconOpt, fixupValueExprBinds, methodBinds) -> tyconOpt, (morpher fixupValueExprBinds @ methodBinds)) morpher)
-             bindsm 
+             mBinds 
         
         defnsEs, envMutRec
 
 /// Check and generalize the interface implementations, members, 'let' definitions in a mutually recursive group of definitions.
-let TcMutRecDefns_Phase2 (cenv: cenv) envInitial bindsm scopem mutRecNSInfo (envMutRec: TcEnv) (mutRecDefns: MutRecDefnsPhase2Data) = 
+let TcMutRecDefns_Phase2 (cenv: cenv) envInitial mBinds scopem mutRecNSInfo (envMutRec: TcEnv) (mutRecDefns: MutRecDefnsPhase2Data) = 
     let g = cenv.g
     let interfacesFromTypeDefn envForTycon tyconMembersData = 
         let (MutRecDefnsPhase2DataForTycon(_, _, declKind, tcref, _, _, declaredTyconTypars, members, _, _, _)) = tyconMembersData
@@ -1720,7 +1720,7 @@ let TcMutRecDefns_Phase2 (cenv: cenv) envInitial bindsm scopem mutRecNSInfo (env
                       (intfTypes, slotImplSets) ||> List.map2 (interfaceMembersFromTypeDefn tyconData) |> List.concat
               MutRecDefnsPhase2InfoForTycon(tyconOpt, tcref, declaredTyconTypars, declKind, obinds @ ibinds, fixupFinalAttrs))
       
-      MutRecBindingChecking.TcMutRecDefns_Phase2_Bindings cenv envInitial tpenv bindsm scopem mutRecNSInfo envMutRec binds
+      MutRecBindingChecking.TcMutRecDefns_Phase2_Bindings cenv envInitial tpenv mBinds scopem mutRecNSInfo envMutRec binds
 
     with exn -> errorRecovery exn scopem; [], envMutRec
 
@@ -3426,37 +3426,37 @@ module EstablishTypeDefinitionCores =
                 match stripTyparEqns ty with 
                 | TType_anon (_,l) 
                 | TType_tuple (_, l) -> accInAbbrevTypes l acc
-                | TType_ucase (UnionCaseRef(tc, _), tinst) 
-                | TType_app (tc, tinst, _) -> 
-                    let tycon2 = tc.Deref
+                | TType_ucase (UnionCaseRef(tcref2, _), tinst) 
+                | TType_app (tcref2, tinst, _) -> 
+                    let tycon2 = tcref2.Deref
                     let acc = accInAbbrevTypes tinst acc
                     // Record immediate recursive references 
                     if ListSet.contains (===) tycon2 tycons then 
                         (tycon, tycon2) :: acc 
                     // Expand the representation of abbreviations 
-                    elif tc.IsTypeAbbrev then
-                        accInAbbrevType (reduceTyconRefAbbrev tc tinst) acc
+                    elif tcref2.IsTypeAbbrev then
+                        accInAbbrevType (reduceTyconRefAbbrev tcref2 tinst) acc
                     // Otherwise H<inst> - explore the instantiation. 
                     else 
                         acc
 
-                | TType_fun (d, r, _) -> 
-                    accInAbbrevType d (accInAbbrevType r acc)
+                | TType_fun (domainTy, rangeTy, _) -> 
+                    accInAbbrevType domainTy (accInAbbrevType rangeTy acc)
                 
                 | TType_var _ -> acc
                 
-                | TType_forall (_, r) -> accInAbbrevType r acc
+                | TType_forall (_, bodyTy) -> accInAbbrevType bodyTy acc
                 
-                | TType_measure ms -> accInMeasure ms acc
+                | TType_measure measureTy -> accInMeasure measureTy acc
 
-            and accInMeasure ms acc =
-                match stripUnitEqns ms with
-                | Measure.Con tc when ListSet.contains (===) tc.Deref tycons ->  
-                    (tycon, tc.Deref) :: acc
-                | Measure.Con tc when tc.IsTypeAbbrev ->              
-                    accInMeasure (reduceTyconRefAbbrevMeasureable tc) acc
+            and accInMeasure measureTy acc =
+                match stripUnitEqns measureTy with
+                | Measure.Const tcref when ListSet.contains (===) tcref.Deref tycons ->  
+                    (tycon, tcref.Deref) :: acc
+                | Measure.Const tcref when tcref.IsTypeAbbrev ->              
+                    accInMeasure (reduceTyconRefAbbrevMeasureable tcref) acc
                 | Measure.Prod (ms1, ms2) -> accInMeasure ms1 (accInMeasure ms2 acc)
-                | Measure.Inv ms -> accInMeasure ms acc
+                | Measure.Inv invTy -> accInMeasure invTy acc
                 | _ -> acc
 
             and accInAbbrevTypes tys acc = 
@@ -3467,7 +3467,7 @@ module EstablishTypeDefinitionCores =
             | Some ty -> accInAbbrevType ty []
 
         let edges = List.collect edgesFrom tycons
-        let graph = Graph<Tycon, Stamp> ((fun tc -> tc.Stamp), tycons, edges)
+        let graph = Graph<Tycon, Stamp> ((fun tycon -> tycon.Stamp), tycons, edges)
         graph.IterateCycles (fun path -> 
             let tycon = path.Head 
             // The thing is cyclic. Set the abbreviation and representation to be "None" to stop later VS crashes

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -986,28 +986,28 @@ let UnifyFunctionType extraInfo cenv denv mFunExpr ty =
 let ReportImplicitlyIgnoredBoolExpression denv m ty expr =
     let checkExpr m expr =
         match stripDebugPoints expr with
-        | Expr.App (Expr.Val (vf, _, _), _, _, exprs, _) when vf.LogicalName = opNameEquals ->
+        | Expr.App (Expr.Val (vref, _, _), _, _, exprs, _) when vref.LogicalName = opNameEquals ->
             match List.map stripDebugPoints exprs with
-            | Expr.App (Expr.Val (propRef, _, _), _, _, Expr.Val (vf, _, _) :: _, _) :: _ ->
+            | Expr.App (Expr.Val (propRef, _, _), _, _, Expr.Val (vref, _, _) :: _, _) :: _ ->
                 if propRef.IsPropertyGetterMethod then
                     let propertyName = propRef.PropertyName
                     let hasCorrespondingSetter =
                         match propRef.DeclaringEntity with
                         | Parent entityRef ->
                             entityRef.MembersOfFSharpTyconSorted
-                            |> List.exists (fun valRef -> valRef.IsPropertySetterMethod && valRef.PropertyName = propertyName)
+                            |> List.exists (fun vref -> vref.IsPropertySetterMethod && vref.PropertyName = propertyName)
                         | _ -> false
 
                     if hasCorrespondingSetter then
-                        UnitTypeExpectedWithPossiblePropertySetter (denv, ty, vf.DisplayName, propertyName, m)
+                        UnitTypeExpectedWithPossiblePropertySetter (denv, ty, vref.DisplayName, propertyName, m)
                     else
                         UnitTypeExpectedWithEquality (denv, ty, m)
                 else
                     UnitTypeExpectedWithEquality (denv, ty, m)
-            | Expr.Op (TOp.ILCall (_, _, _, _, _, _, _, ilMethRef, _, _, _), _, Expr.Val (vf, _, _) :: _, _) :: _ when ilMethRef.Name.StartsWithOrdinal("get_") ->
-                UnitTypeExpectedWithPossiblePropertySetter (denv, ty, vf.DisplayName, ChopPropertyName(ilMethRef.Name), m)
-            | Expr.Val (vf, _, _) :: _ ->
-                UnitTypeExpectedWithPossibleAssignment (denv, ty, vf.IsMutable, vf.DisplayName, m)
+            | Expr.Op (TOp.ILCall (_, _, _, _, _, _, _, ilMethRef, _, _, _), _, Expr.Val (vref, _, _) :: _, _) :: _ when ilMethRef.Name.StartsWithOrdinal("get_") ->
+                UnitTypeExpectedWithPossiblePropertySetter (denv, ty, vref.DisplayName, ChopPropertyName(ilMethRef.Name), m)
+            | Expr.Val (vref, _, _) :: _ ->
+                UnitTypeExpectedWithPossibleAssignment (denv, ty, vref.IsMutable, vref.DisplayName, m)
             | _ -> UnitTypeExpectedWithEquality (denv, ty, m)
         | _ -> UnitTypeExpected (denv, ty, m)
 
@@ -1040,8 +1040,8 @@ let UnifyUnitType (cenv: cenv) (env: TcEnv) m ty expr =
 
             match env.eContextInfo with
             | ContextInfo.SequenceExpression seqTy ->
-                let lifted = mkSeqTy g ty
-                if typeEquiv g seqTy lifted then
+                let liftedTy = mkSeqTy g ty
+                if typeEquiv g seqTy liftedTy then
                     warning (Error (FSComp.SR.implicitlyDiscardedInSequenceExpression(NicePrint.prettyStringOfTy denv ty), m))
                 else
                     if isListTy g ty || isArrayTy g ty || typeEquiv g seqTy ty then
@@ -1099,7 +1099,7 @@ let TcConst (cenv: cenv) (overallTy: TType) m env synConst =
             let _, tcref = ForceRaise(ResolveTypeLongIdent cenv.tcSink cenv.nameResolver ItemOccurence.Use OpenQualified env.eNameResEnv ad tc TypeNameResolutionStaticArgsInfo.DefiniteEmpty PermitDirectReferenceToGeneratedType.No)
             match tcref.TypeOrMeasureKind with
             | TyparKind.Type -> error(Error(FSComp.SR.tcExpectedUnitOfMeasureNotType(), m))
-            | TyparKind.Measure -> Measure.Con tcref
+            | TyparKind.Measure -> Measure.Const tcref
 
         | SynMeasure.Power(ms, exponent, _) -> Measure.RationalPower (tcMeasure ms, TcSynRationalConst exponent)
         | SynMeasure.Product(ms1, ms2, _) -> Measure.Prod(tcMeasure ms1, tcMeasure ms2)
@@ -1113,7 +1113,7 @@ let TcConst (cenv: cenv) (overallTy: TType) m env synConst =
         | SynMeasure.Var(_, m) -> error(Error(FSComp.SR.tcNonZeroConstantCannotHaveGenericUnit(), m))
         | SynMeasure.Paren(measure, _) -> tcMeasure measure
 
-    let unif expected = UnifyTypes cenv env m overallTy expected
+    let unif expectedTy = UnifyTypes cenv env m overallTy expectedTy
 
     let unifyMeasureArg iszero tcr =
         let measureTy =
@@ -1311,7 +1311,7 @@ let MakeMemberDataAndMangledNameForMemberVal(g, tcref, isExtrinsic, attrs, implS
           // NOTE: This value is initially only set for interface implementations and those overrides
           // where we manage to pre-infer which abstract is overridden by the method. It is filled in
           // properly when we check the allImplemented implementation checks at the end of the inference scope.
-          ImplementedSlotSigs=implSlotTys |> List.map (fun ity -> TSlotSig(logicalName, ity, [], [], [], None)) }
+          ImplementedSlotSigs=implSlotTys |> List.map (fun intfTy -> TSlotSig(logicalName, intfTy, [], [], [], None)) }
 
     let isInstance = MemberIsCompiledAsInstance g tcref isExtrinsic memberInfo attrs
 
@@ -1528,8 +1528,8 @@ let MakeAndPublishVal (cenv: cenv) env (altActualParent, inSig, declKind, valRec
             let vis =
                 if MemberIsExplicitImpl g memberInfo then
                     let slotSig = List.head memberInfo.ImplementedSlotSigs
-                    match slotSig.ImplementedType with
-                    | TType_app (tyconref, _, _) -> Some tyconref.Accessibility
+                    match slotSig.DeclaringType with
+                    | TType_app (tcref, _, _) -> Some tcref.Accessibility
                     | _ -> None
                 else
                     None
@@ -1708,14 +1708,14 @@ let AdjustRecType (v: Val) vscheme =
 /// Record the generated value expression as a place where we will have to
 /// adjust using AdjustAndForgetUsesOfRecValue at a letrec point. Every use of a value
 /// under a letrec gets used at the _same_ type instantiation.
-let RecordUseOfRecValue cenv valRecInfo (vrefTgt: ValRef) vexp m =
+let RecordUseOfRecValue cenv valRecInfo (vrefTgt: ValRef) vExpr m =
     match valRecInfo with
     | ValInRecScope isComplete ->
-        let fixupPoint = ref vexp
+        let fixupPoint = ref vExpr
         cenv.recUses <- cenv.recUses.Add (vrefTgt.Deref, (fixupPoint, m, isComplete))
         Expr.Link fixupPoint
     | ValNotInRecScope ->
-        vexp
+        vExpr
 
 type RecursiveUseFixupPoints = RecursiveUseFixupPoints of (Expr ref * range) list
 
@@ -2151,9 +2151,9 @@ let rec ApplyUnionCaseOrExn (makerForUnionCase, makerForExnTag) m (cenv: cenv) e
         let ucref = ucinfo.UnionCaseRef
         CheckUnionCaseAttributes g ucref m |> CommitOperationResult
         CheckUnionCaseAccessible cenv.amap m ad ucref |> ignore
-        let gtyp2 = actualResultTyOfUnionCase ucinfo.TypeInst ucref
+        let resTy = actualResultTyOfUnionCase ucinfo.TypeInst ucref
         let inst = mkTyparInst ucref.TyconRef.TyparsNoRange ucinfo.TypeInst
-        UnifyTypes cenv env m overallTy gtyp2
+        UnifyTypes cenv env m overallTy resTy
         let mkf = makerForUnionCase(ucref, ucinfo.TypeInst)
         mkf, actualTysOfUnionCaseFields inst ucref, [ for f in ucref.AllFieldsAsList -> f.Id ]
     | _ -> invalidArg "item" "not a union case or exception reference"
@@ -2336,11 +2336,11 @@ module GeneralizationHelpers =
         let relevantUniqueSubtypeConstraint (tp: Typar) =
             // Find a single subtype constraint
             match tp.Constraints |> List.partition (function TyparConstraint.CoercesTo _ -> true | _ -> false) with
-            | [TyparConstraint.CoercesTo(cxty, _)], others ->
+            | [TyparConstraint.CoercesTo(tgtTy, _)], others ->
                  // Throw away null constraints if they are implied
-                 if others |> List.exists (function TyparConstraint.SupportsNull _ -> not (TypeSatisfiesNullConstraint g m cxty) | _ -> true)
+                 if others |> List.exists (function TyparConstraint.SupportsNull _ -> not (TypeSatisfiesNullConstraint g m tgtTy) | _ -> true)
                  then None
-                 else Some cxty
+                 else Some tgtTy
             | _ -> None
 
 
@@ -2735,8 +2735,8 @@ module EventDeclarationNormalization =
 
     let rec private RenameBindingPattern f declPattern =
         match declPattern with
-        | SynPat.FromParseError(p, _) -> RenameBindingPattern f p
-        | SynPat.Typed(pat', _, _) -> RenameBindingPattern f pat'
+        | SynPat.FromParseError(innerPat, _) -> RenameBindingPattern f innerPat
+        | SynPat.Typed(innerPat, _, _) -> RenameBindingPattern f innerPat
         | SynPat.Named (SynIdent(id,_), x2, vis2, m) -> SynPat.Named (SynIdent(ident(f id.idText, id.idRange), None), x2, vis2, m)
         | SynPat.InstanceMember(thisId, id, toolId, vis2, m) -> SynPat.InstanceMember(thisId, ident(f id.idText, id.idRange), toolId, vis2, m)
         | _ -> error(Error(FSComp.SR.tcOnlySimplePatternsInLetRec(), declPattern.Range))
@@ -2838,11 +2838,11 @@ let TcValEarlyGeneralizationConsistencyCheck cenv (env: TcEnv) (v: Val, valRecIn
     match valRecInfo with
     | ValInRecScope isComplete when isComplete && not (isNil tinst) ->
         cenv.css.PushPostInferenceCheck (preDefaults=false, check=fun () ->
-            let tpsorig, tau2 = tryDestForallTy g vTy
-            if not (isNil tpsorig) then
-              let tpsorig = NormalizeDeclaredTyparsForEquiRecursiveInference g tpsorig
-              let tau3 = instType (mkTyparInst tpsorig tinst) tau2
-              if not (AddCxTypeEqualsTypeUndoIfFailed env.DisplayEnv cenv.css m tau tau3) then
+            let vTypars, vTauTy = tryDestForallTy g vTy
+            if not (isNil vTypars) then
+              let vTypars = NormalizeDeclaredTyparsForEquiRecursiveInference g vTypars
+              let vTauTy = instType (mkTyparInst vTypars tinst) vTauTy
+              if not (AddCxTypeEqualsTypeUndoIfFailed env.DisplayEnv cenv.css m tau vTauTy) then
                   let txt = buildString (fun buf -> NicePrint.outputQualifiedValSpec env.DisplayEnv cenv.infoReader buf (mkLocalValRef v))
                   error(Error(FSComp.SR.tcInferredGenericTypeGivesRiseToInconsistency(v.DisplayName, txt), m)))
     | _ -> ()
@@ -2923,26 +2923,26 @@ let TcVal checkAttributes (cenv: cenv) env (tpenv: UnscopedTyparEnv) (vref: ValR
                                     warning(Error(FSComp.SR.tcDoesNotAllowExplicitTypeArguments(v.DisplayName), m))
                             match valRecInfo with
                             | ValInRecScope false ->
-                                let tpsorig, tau = vref.GeneralizedType
-                                let (tinst: TypeInst), tpenv = checkTys tpenv (tpsorig |> List.map (fun tp -> tp.Kind))
+                                let vTypars, vTauTy = vref.GeneralizedType
+                                let tinst, tpenv = checkTys tpenv (vTypars |> List.map (fun tp -> tp.Kind))
 
                                 checkInst tinst
 
-                                if tpsorig.Length <> tinst.Length then error(Error(FSComp.SR.tcTypeParameterArityMismatch(tpsorig.Length, tinst.Length), m))
+                                if vTypars.Length <> tinst.Length then error(Error(FSComp.SR.tcTypeParameterArityMismatch(vTypars.Length, tinst.Length), m))
 
-                                let tau2 = instType (mkTyparInst tpsorig tinst) tau
+                                let vRecTauTy = instType (mkTyparInst vTypars tinst) vTauTy
 
-                                (tpsorig, tinst) ||> List.iter2 (fun tp ty ->
+                                (vTypars, tinst) ||> List.iter2 (fun tp ty ->
                                     try UnifyTypes cenv env m (mkTyparTy tp) ty
-                                    with _ -> error (Recursion(env.DisplayEnv, v.Id, tau2, tau, m)))
+                                    with _ -> error (Recursion(env.DisplayEnv, v.Id, vRecTauTy, vTauTy, m)))
 
-                                tpsorig, vrefFlags, tinst, tau2, tpenv
+                                vTypars, vrefFlags, tinst, vRecTauTy, tpenv
 
                             | ValInRecScope true
                             | ValNotInRecScope ->
-                                let tpsorig, tps, tpTys, tau = FreshenPossibleForallTy g m TyparRigidity.Flexible vTy
+                                let vTypars, tps, tpTys, vTauTy = FreshenPossibleForallTy g m TyparRigidity.Flexible vTy
 
-                                let (tinst: TypeInst), tpenv = checkTys tpenv (tps |> List.map (fun tp -> tp.Kind))
+                                let tinst, tpenv = checkTys tpenv (tps |> List.map (fun tp -> tp.Kind))
 
                                 checkInst tinst
 
@@ -2950,9 +2950,9 @@ let TcVal checkAttributes (cenv: cenv) env (tpenv: UnscopedTyparEnv) (vref: ValR
 
                                 List.iter2 (UnifyTypes cenv env m) tpTys tinst
 
-                                TcValEarlyGeneralizationConsistencyCheck cenv env (v, valRecInfo, tinst, vTy, tau, m)
+                                TcValEarlyGeneralizationConsistencyCheck cenv env (v, valRecInfo, tinst, vTy, vTauTy, m)
 
-                                tpsorig, vrefFlags, tinst, tau, tpenv
+                                vTypars, vrefFlags, tinst, vTauTy, tpenv
 
                   let exprForVal = Expr.Val (vref, vrefFlags, m)
                   let exprForVal = mkTyAppExpr m (exprForVal, vTy) tinst
@@ -3249,7 +3249,7 @@ let BuildILFieldGet g amap m objExpr (finfo: ILFieldInfo) =
     let isStruct = finfo.IsValueType
     let boxity = if isStruct then AsValue else AsObject
     let tinst = finfo.TypeInst
-    let fieldType = finfo.FieldType (amap, m)
+    let fieldTy = finfo.FieldType (amap, m)
 #if !NO_TYPEPROVIDERS
     let ty = tyOfExpr g objExpr
     match finfo with
@@ -3259,7 +3259,7 @@ let BuildILFieldGet g amap m objExpr (finfo: ILFieldInfo) =
         | None ->
             error (Error(FSComp.SR.tcTPFieldMustBeLiteral(), m))
         | Some lit ->
-            Expr.Const (TcFieldInit m lit, m, fieldType)
+            Expr.Const (TcFieldInit m lit, m, fieldTy)
     | _ ->
 #endif
     let wrap, objExpr, _readonly, _writeonly = mkExprAddrOfExpr g isStruct false NeverMutates objExpr None m
@@ -3268,7 +3268,7 @@ let BuildILFieldGet g amap m objExpr (finfo: ILFieldInfo) =
       // polymorphic code, after inlining etc. *
     let fspec = mkILFieldSpec(fref, mkILNamedTy boxity fref.DeclaringTypeRef [])
     // Add an I_nop if this is an initonly field to make sure we never recognize it as an lvalue. See mkExprAddrOfExpr.
-    wrap (mkAsmExpr (([ mkNormalLdfld fspec ] @ (if finfo.IsInitOnly then [ AI_nop ] else [])), tinst, [objExpr], [fieldType], m))
+    wrap (mkAsmExpr (([ mkNormalLdfld fspec ] @ (if finfo.IsInitOnly then [ AI_nop ] else [])), tinst, [objExpr], [fieldTy], m))
 
 /// Checks that setting a field value does not set a literal or initonly field
 let private CheckFieldLiteralArg (finfo: ILFieldInfo) argExpr m =
@@ -3421,28 +3421,28 @@ let AnalyzeArbitraryExprAsEnumerable (cenv: cenv) (env: TcEnv) localAlloc m expr
     let tryType (exprToSearchForGetEnumeratorAndItem, tyToSearchForGetEnumeratorAndItem) =
         match findMethInfo true m "GetEnumerator" tyToSearchForGetEnumeratorAndItem with
         | Exception exn -> Exception exn
-        | Result getEnumerator_minfo ->
+        | Result getEnumeratorMethInfo ->
 
-        let getEnumerator_minst = FreshenMethInfo m getEnumerator_minfo
-        let retTypeOfGetEnumerator = getEnumerator_minfo.GetFSharpReturnType(cenv.amap, m, getEnumerator_minst)
-        if hasArgs getEnumerator_minfo getEnumerator_minst then err true tyToSearchForGetEnumeratorAndItem else
+        let getEnumeratorMethInst = FreshenMethInfo m getEnumeratorMethInfo
+        let getEnumeratorRetTy = getEnumeratorMethInfo.GetFSharpReturnType(cenv.amap, m, getEnumeratorMethInst)
+        if hasArgs getEnumeratorMethInfo getEnumeratorMethInst then err true tyToSearchForGetEnumeratorAndItem else
 
-        match findMethInfo false m "MoveNext" retTypeOfGetEnumerator with
+        match findMethInfo false m "MoveNext" getEnumeratorRetTy with
         | Exception exn -> Exception exn
-        | Result moveNext_minfo ->
+        | Result moveNextMethInfo ->
 
-        let moveNext_minst = FreshenMethInfo m moveNext_minfo
-        let retTypeOfMoveNext = moveNext_minfo.GetFSharpReturnType(cenv.amap, m, moveNext_minst)
-        if not (typeEquiv g g.bool_ty retTypeOfMoveNext) then err false retTypeOfGetEnumerator else
-        if hasArgs moveNext_minfo moveNext_minst then err false retTypeOfGetEnumerator else
+        let moveNextMethInst = FreshenMethInfo m moveNextMethInfo
+        let moveNextRetTy = moveNextMethInfo.GetFSharpReturnType(cenv.amap, m, moveNextMethInst)
+        if not (typeEquiv g g.bool_ty moveNextRetTy) then err false getEnumeratorRetTy else
+        if hasArgs moveNextMethInfo moveNextMethInst then err false getEnumeratorRetTy else
 
-        match findMethInfo false m "get_Current" retTypeOfGetEnumerator with
+        match findMethInfo false m "get_Current" getEnumeratorRetTy with
         | Exception exn -> Exception exn
-        | Result get_Current_minfo ->
+        | Result getCurrentMethInfo ->
 
-        let get_Current_minst = FreshenMethInfo m get_Current_minfo
-        if hasArgs get_Current_minfo get_Current_minst then err false retTypeOfGetEnumerator else
-        let enumElemTy = get_Current_minfo.GetFSharpReturnType(cenv.amap, m, get_Current_minst)
+        let getCurrentMethInst = FreshenMethInfo m getCurrentMethInfo
+        if hasArgs getCurrentMethInfo getCurrentMethInst then err false getEnumeratorRetTy else
+        let enumElemTy = getCurrentMethInfo.GetFSharpReturnType(cenv.amap, m, getCurrentMethInst)
 
         // Compute the element type of the strongly typed enumerator
         //
@@ -3486,23 +3486,23 @@ let AnalyzeArbitraryExprAsEnumerable (cenv: cenv) (env: TcEnv) localAlloc m expr
             else
                 enumElemTy
 
-        let isEnumeratorTypeStruct = isStructTy g retTypeOfGetEnumerator
-        let originalRetTypeOfGetEnumerator = retTypeOfGetEnumerator
+        let isEnumeratorTypeStruct = isStructTy g getEnumeratorRetTy
+        let originalRetTypeOfGetEnumerator = getEnumeratorRetTy
 
-        let (enumeratorVar, enumeratorExpr), retTypeOfGetEnumerator =
+        let (enumeratorVar, enumeratorExpr), getEnumeratorRetTy =
             if isEnumeratorTypeStruct then
                if localAlloc then
-                  mkMutableCompGenLocal m "enumerator" retTypeOfGetEnumerator, retTypeOfGetEnumerator
+                  mkMutableCompGenLocal m "enumerator" getEnumeratorRetTy, getEnumeratorRetTy
                else
-                  let refCellTyForRetTypeOfGetEnumerator = mkRefCellTy g retTypeOfGetEnumerator
+                  let refCellTyForRetTypeOfGetEnumerator = mkRefCellTy g getEnumeratorRetTy
                   let v, e = mkMutableCompGenLocal m "enumerator" refCellTyForRetTypeOfGetEnumerator
-                  (v, mkRefCellGet g m retTypeOfGetEnumerator e), refCellTyForRetTypeOfGetEnumerator
+                  (v, mkRefCellGet g m getEnumeratorRetTy e), refCellTyForRetTypeOfGetEnumerator
 
             else
-               mkCompGenLocal m "enumerator" retTypeOfGetEnumerator, retTypeOfGetEnumerator
+               mkCompGenLocal m "enumerator" getEnumeratorRetTy, getEnumeratorRetTy
 
         let getEnumExpr, getEnumTy =
-            let getEnumExpr, getEnumTy as res = BuildPossiblyConditionalMethodCall cenv env PossiblyMutates m false getEnumerator_minfo NormalValUse getEnumerator_minst [exprToSearchForGetEnumeratorAndItem] []
+            let getEnumExpr, getEnumTy as res = BuildPossiblyConditionalMethodCall cenv env PossiblyMutates m false getEnumeratorMethInfo NormalValUse getEnumeratorMethInst [exprToSearchForGetEnumeratorAndItem] []
             if not isEnumeratorTypeStruct || localAlloc then res
             else
                 // wrap enumerators that are represented as mutable structs into ref cells
@@ -3510,8 +3510,8 @@ let AnalyzeArbitraryExprAsEnumerable (cenv: cenv) (env: TcEnv) localAlloc m expr
                 let getEnumTy = mkRefCellTy g getEnumTy
                 getEnumExpr, getEnumTy
 
-        let guardExpr, guardTy = BuildPossiblyConditionalMethodCall cenv env DefinitelyMutates m false moveNext_minfo NormalValUse moveNext_minst [enumeratorExpr] []
-        let currentExpr, currentTy = BuildPossiblyConditionalMethodCall cenv env DefinitelyMutates m true get_Current_minfo NormalValUse get_Current_minst [enumeratorExpr] []
+        let guardExpr, guardTy = BuildPossiblyConditionalMethodCall cenv env DefinitelyMutates m false moveNextMethInfo NormalValUse moveNextMethInst [enumeratorExpr] []
+        let currentExpr, currentTy = BuildPossiblyConditionalMethodCall cenv env DefinitelyMutates m true getCurrentMethInfo NormalValUse getCurrentMethInst [enumeratorExpr] []
         let currentExpr = mkCoerceExpr(currentExpr, enumElemTy, currentExpr.Range, currentTy)
         let currentExpr, enumElemTy =
             // Implicitly dereference byref for expr 'for x in ...'
@@ -3521,7 +3521,7 @@ let AnalyzeArbitraryExprAsEnumerable (cenv: cenv) (env: TcEnv) localAlloc m expr
             else
                 currentExpr, enumElemTy
 
-        Result(enumeratorVar, enumeratorExpr, retTypeOfGetEnumerator, enumElemTy, getEnumExpr, getEnumTy, guardExpr, guardTy, currentExpr)
+        Result(enumeratorVar, enumeratorExpr, getEnumeratorRetTy, enumElemTy, getEnumExpr, getEnumTy, guardExpr, guardTy, currentExpr)
 
     // First try the original known static type
     match (if isArray1DTy g exprTy then Exception (Failure "") else tryType (expr, exprTy)) with
@@ -3560,12 +3560,12 @@ let ConvertArbitraryExprToEnumerable (cenv: cenv) ty (env: TcEnv) (expr: Expr) =
         expr, enumElemTy
     else
         let enumerableVar, enumerableExpr = mkCompGenLocal m "inputSequence" ty
-        let enumeratorVar, _, retTypeOfGetEnumerator, enumElemTy, getEnumExpr, _, guardExpr, guardTy, betterCurrentExpr =
+        let enumeratorVar, _, getEnumeratorRetTy, enumElemTy, getEnumExpr, _, guardExpr, guardTy, betterCurrentExpr =
             AnalyzeArbitraryExprAsEnumerable cenv env false m ty enumerableExpr
 
         let expr =
            mkCompGenLet m enumerableVar expr
-               (mkCallSeqOfFunctions g m retTypeOfGetEnumerator enumElemTy
+               (mkCallSeqOfFunctions g m getEnumeratorRetTy enumElemTy
                    (mkUnitDelayLambda g m getEnumExpr)
                    (mkLambda m enumeratorVar (guardExpr, guardTy))
                    (mkLambda m enumeratorVar (betterCurrentExpr, enumElemTy)))
@@ -3911,28 +3911,28 @@ let buildApp cenv expr resultTy arg m =
     match expr, arg with
 
     // Special rule for building applications of the 'x && y' operator
-    | ApplicableExpr(_, Expr.App (Expr.Val (vf, _, _), _, _, [x0], _), _), _
-         when valRefEq g vf g.and_vref
-           || valRefEq g vf g.and2_vref ->
+    | ApplicableExpr(_, Expr.App (Expr.Val (vref, _, _), _, _, [x0], _), _), _
+         when valRefEq g vref g.and_vref
+           || valRefEq g vref g.and2_vref ->
         MakeApplicableExprNoFlex cenv (mkLazyAnd g m x0 arg), resultTy
 
     // Special rule for building applications of the 'x || y' operator
-    | ApplicableExpr(_, Expr.App (Expr.Val (vf, _, _), _, _, [x0], _), _), _
-         when valRefEq g vf g.or_vref
-           || valRefEq g vf g.or2_vref ->
+    | ApplicableExpr(_, Expr.App (Expr.Val (vref, _, _), _, _, [x0], _), _), _
+         when valRefEq g vref g.or_vref
+           || valRefEq g vref g.or2_vref ->
         MakeApplicableExprNoFlex cenv (mkLazyOr g m x0 arg ), resultTy
 
     // Special rule for building applications of the 'reraise' operator
-    | ApplicableExpr(_, Expr.App (Expr.Val (vf, _, _), _, _, [], _), _), _
-         when valRefEq g vf g.reraise_vref ->
+    | ApplicableExpr(_, Expr.App (Expr.Val (vref, _, _), _, _, [], _), _), _
+         when valRefEq g vref g.reraise_vref ->
 
         // exprTy is of type: "unit -> 'a". Break it and store the 'a type here, used later as return type.
         MakeApplicableExprNoFlex cenv (mkCompGenSequential m arg (mkReraise m resultTy)), resultTy
 
     // Special rules for NativePtr.ofByRef to generalize result.
     // See RFC FS-1053.md
-    | ApplicableExpr(_, Expr.App (Expr.Val (vf, _, _), _, _, [], _), _), _
-         when (valRefEq g vf g.nativeptr_tobyref_vref) ->
+    | ApplicableExpr(_, Expr.App (Expr.Val (vref, _, _), _, _, [], _), _), _
+         when (valRefEq g vref g.nativeptr_tobyref_vref) ->
 
         let argTy = NewInferenceType g
         let resultTy = mkByrefTyWithInference g argTy (NewByRefKindInferenceType g m)
@@ -3942,10 +3942,10 @@ let buildApp cenv expr resultTy arg m =
     // address of an expression.
     //
     // See also RFC FS-1053.md
-    | ApplicableExpr(_, Expr.App (Expr.Val (vf, _, _), _, _, [], _), _), _
-         when valRefEq g vf g.addrof_vref ->
+    | ApplicableExpr(_, Expr.App (Expr.Val (vref, _, _), _, _, [], _), _), _
+         when valRefEq g vref g.addrof_vref ->
 
-        let wrap, e1a', readonly, _writeonly = mkExprAddrOfExpr g true false AddressOfOp arg (Some vf) m
+        let wrap, e1a', readonly, _writeonly = mkExprAddrOfExpr g true false AddressOfOp arg (Some vref) m
         // Assert the result type to be readonly if we couldn't take the address
         let resultTy =
             let argTy = tyOfExpr g arg
@@ -3967,11 +3967,11 @@ let buildApp cenv expr resultTy arg m =
 
     // Special rules for building applications of the &&expr' operators, which gets the
     // address of an expression.
-    | ApplicableExpr(_, Expr.App (Expr.Val (vf, _, _), _, _, [], _), _), _
-         when valRefEq g vf g.addrof2_vref ->
+    | ApplicableExpr(_, Expr.App (Expr.Val (vref, _, _), _, _, [], _), _), _
+         when valRefEq g vref g.addrof2_vref ->
 
         warning(UseOfAddressOfOperator m)
-        let wrap, e1a', _readonly, _writeonly = mkExprAddrOfExpr g true false AddressOfOp arg (Some vf) m
+        let wrap, e1a', _readonly, _writeonly = mkExprAddrOfExpr g true false AddressOfOp arg (Some vref) m
         MakeApplicableExprNoFlex cenv (wrap(e1a')), resultTy
 
     | _ when isByrefTy g resultTy ->
@@ -4588,7 +4588,7 @@ and TcLongIdent kindOpt cenv newOk checkConstraints occ env tpenv synLongId =
         error(Error(FSComp.SR.tcExpectedUnitOfMeasureNotType(), m))
         TType_measure (NewErrorMeasure ()), tpenv
     | _, TyparKind.Measure ->
-        TType_measure (Measure.Con tcref), tpenv
+        TType_measure (Measure.Const tcref), tpenv
     | _, TyparKind.Type ->
         TcTypeApp cenv newOk checkConstraints occ env tpenv m tcref tinstEnclosing []
 
@@ -4621,7 +4621,7 @@ and TcLongIdentAppType kindOpt cenv newOk checkConstraints occ env tpenv longId 
         match args, postfix with
         | [arg], true ->
             let ms, tpenv = TcMeasure cenv newOk checkConstraints occ env tpenv arg m
-            TType_measure (Measure.Prod(Measure.Con tcref, ms)), tpenv
+            TType_measure (Measure.Prod(Measure.Const tcref, ms)), tpenv
 
         | _, _ ->
             errorR(Error(FSComp.SR.tcUnitsOfMeasureInvalidInTypeConstructor(), m))
@@ -5101,8 +5101,8 @@ and TcNestedTypeApplication cenv newOk checkConstraints occ env tpenv mWholeType
 /// This means the range of syntactic expression forms that can be used here is limited.
 and ConvSynPatToSynExpr synPat =
     match synPat with
-    | SynPat.FromParseError(p, _) ->
-        ConvSynPatToSynExpr p
+    | SynPat.FromParseError(innerPat, _) ->
+        ConvSynPatToSynExpr innerPat
 
     | SynPat.Const (c, m) ->
         SynExpr.Const (c, m)
@@ -5110,8 +5110,8 @@ and ConvSynPatToSynExpr synPat =
     | SynPat.Named (SynIdent(id,_), _, None, _) ->
         SynExpr.Ident id
 
-    | SynPat.Typed (p, cty, m) ->
-        SynExpr.Typed (ConvSynPatToSynExpr p, cty, m)
+    | SynPat.Typed (innerPat, tgtTy, m) ->
+        SynExpr.Typed (ConvSynPatToSynExpr innerPat, tgtTy, m)
 
     | SynPat.LongIdent (longDotId=SynLongIdent(longId, dotms, trivia) as synLongId; argPats=args; accessibility=None; range=m) ->
         let args = match args with SynArgPats.Pats args -> args | _ -> failwith "impossible: active patterns can be used only with SynConstructorArgs.Pats"
@@ -5125,8 +5125,8 @@ and ConvSynPatToSynExpr synPat =
     | SynPat.Tuple (isStruct, args, m) ->
         SynExpr.Tuple (isStruct, List.map ConvSynPatToSynExpr args, [], m)
 
-    | SynPat.Paren (p, _) ->
-        ConvSynPatToSynExpr p
+    | SynPat.Paren (innerPat, _) ->
+        ConvSynPatToSynExpr innerPat
 
     | SynPat.ArrayOrList (isArray, args, m) ->
         SynExpr.ArrayOrList (isArray,List.map ConvSynPatToSynExpr args, m)
@@ -5141,26 +5141,26 @@ and ConvSynPatToSynExpr synPat =
         error(Error(FSComp.SR.tcInvalidArgForParameterizedPattern(), synPat.Range))
 
 /// Check a long identifier 'Case' or 'Case argsR' that has been resolved to an active pattern case
-and TcPatLongIdentActivePatternCase warnOnUpper cenv (env: TcEnv) vFlags patEnv ty (lidRange, item, apref, args, m) =
+and TcPatLongIdentActivePatternCase warnOnUpper cenv (env: TcEnv) vFlags patEnv ty (mLongId, item, apref, args, m) =
     let g = cenv.g
 
     let (TcPatLinearEnv(tpenv, names, takenNames)) = patEnv
     let (APElemRef (apinfo, vref, idx, isStructRetTy)) = apref
 
     // Report information about the 'active recognizer' occurrence to IDE
-    CallNameResolutionSink cenv.tcSink (lidRange, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.eAccessRights)
+    CallNameResolutionSink cenv.tcSink (mLongId, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.eAccessRights)
 
     // TOTAL/PARTIAL ACTIVE PATTERNS
-    let _, vexp, _, _, tinst, _ = TcVal true cenv env tpenv vref None None m
-    let vexp = MakeApplicableExprWithFlex cenv env vexp
-    let vexpty = vexp.Type
+    let _, vExpr, _, _, tinst, _ = TcVal true cenv env tpenv vref None None m
+    let vExpr = MakeApplicableExprWithFlex cenv env vExpr
+    let vExprTy = vExpr.Type
 
     let activePatArgsAsSynPats, patArg =
         match args with
         | [] -> [], SynPat.Const(SynConst.Unit, m)
         | _ ->
             // This bit of type-directed analysis ensures that parameterized partial active patterns returning unit do not need to take an argument
-            let dtys, retTy = stripFunTy g vexpty
+            let dtys, retTy = stripFunTy g vExprTy
 
             if dtys.Length = args.Length + 1 &&
                 ((isOptionTy g retTy && isUnitTy g (destOptionTy g retTy)) ||
@@ -5179,9 +5179,9 @@ and TcPatLongIdentActivePatternCase warnOnUpper cenv (env: TcEnv) vFlags patEnv 
 
     let delayed =
         activePatArgsAsSynExprs
-        |> List.map (fun arg -> DelayedApp(ExprAtomicFlag.NonAtomic, false, None, arg, unionRanges lidRange arg.Range))
+        |> List.map (fun arg -> DelayedApp(ExprAtomicFlag.NonAtomic, false, None, arg, unionRanges mLongId arg.Range))
 
-    let activePatExpr, tpenv = PropagateThenTcDelayed cenv (MustEqual activePatType) env tpenv m vexp vexpty ExprAtomicFlag.NonAtomic delayed
+    let activePatExpr, tpenv = PropagateThenTcDelayed cenv (MustEqual activePatType) env tpenv m vExpr vExprTy ExprAtomicFlag.NonAtomic delayed
 
     let patEnvR = TcPatLinearEnv(tpenv, names, takenNames)
 
@@ -6254,13 +6254,13 @@ and TcExprILAssembly cenv overallTy env tpenv (ilInstrs, synTyArgs, synArgs, syn
 and RewriteRangeExpr synExpr = 
     match synExpr with
     // a..b..c (parsed as (a..b)..c )
-    | SynExpr.IndexRange(Some (SynExpr.IndexRange(Some synExpr1, _, Some synStepExpr, _, _, _)), _, Some synExpr2, _m1, _m2, wholem) ->
-        Some (mkSynTrifix wholem ".. .." synExpr1 synStepExpr synExpr2)
+    | SynExpr.IndexRange(Some (SynExpr.IndexRange(Some synExpr1, _, Some synStepExpr, _, _, _)), _, Some synExpr2, _m1, _m2, mWhole) ->
+        Some (mkSynTrifix mWhole ".. .." synExpr1 synStepExpr synExpr2)
     // a..b
-    | SynExpr.IndexRange (Some synExpr1, mOperator, Some synExpr2, _m1, _m2, wholem) ->
+    | SynExpr.IndexRange (Some synExpr1, mOperator, Some synExpr2, _m1, _m2, mWhole) ->
         let otherExpr =
             match mkSynInfix mOperator synExpr1 ".." synExpr2 with
-            | SynExpr.App (a, b, c, d, _) -> SynExpr.App (a, b, c, d, wholem)
+            | SynExpr.App (a, b, c, d, _) -> SynExpr.App (a, b, c, d, mWhole)
             | _ -> failwith "impossible"
         Some otherExpr  
     | _ -> None
@@ -7686,8 +7686,8 @@ and TcForEachExpr cenv overallTy env tpenv (seqExprOnly, isFromSource, synPat, s
         match stripDebugPoints enumExpr with
 
         // optimize 'for i in n .. m do'
-        | Expr.App (Expr.Val (vf, _, _), _, [tyarg], [startExpr;finishExpr], _)
-             when valRefEq g vf g.range_op_vref && typeEquiv g tyarg g.int_ty ->
+        | Expr.App (Expr.Val (vref, _, _), _, [tyarg], [startExpr;finishExpr], _)
+             when valRefEq g vref g.range_op_vref && typeEquiv g tyarg g.int_ty ->
                (g.int32_ty, (fun _ x -> x), id, Choice1Of3 (startExpr, finishExpr))
 
         // optimize 'for i in arr do'
@@ -7873,9 +7873,9 @@ and Propagate cenv (overallTy: OverallTy) (env: TcEnv) tpenv (expr: ApplicableEx
                 // See RFC FS-1053.md
                 let isAddrOf =
                     match expr with
-                    | ApplicableExpr(_, Expr.App (Expr.Val (vf, _, _), _, _, [], _), _)
-                        when (valRefEq g vf g.addrof_vref ||
-                              valRefEq g vf g.nativeptr_tobyref_vref) -> true
+                    | ApplicableExpr(_, Expr.App (Expr.Val (vref, _, _), _, _, [], _), _)
+                        when (valRefEq g vref g.addrof_vref ||
+                              valRefEq g vref g.nativeptr_tobyref_vref) -> true
                     | _ -> false
 
                 propagate isAddrOf delayedList' mExprAndArg resultTy
@@ -8185,12 +8185,12 @@ and TcApplicationThen cenv (overallTy: OverallTy) env tpenv mExprAndArg synLeftE
                 // will have debug points on "f expr1" and "g expr2"
                 let env =
                     match leftExpr with
-                    | ApplicableExpr(_, Expr.Val (vf, _, _), _)
-                    | ApplicableExpr(_, Expr.App (Expr.Val (vf, _, _), _, _, [_], _), _)
-                         when valRefEq g vf g.and_vref
-                           || valRefEq g vf g.and2_vref 
-                           || valRefEq g vf g.or_vref
-                           || valRefEq g vf g.or2_vref ->
+                    | ApplicableExpr(_, Expr.Val (vref, _, _), _)
+                    | ApplicableExpr(_, Expr.App (Expr.Val (vref, _, _), _, _, [_], _), _)
+                         when valRefEq g vref g.and_vref
+                           || valRefEq g vref g.and2_vref 
+                           || valRefEq g vref g.or_vref
+                           || valRefEq g vref g.or2_vref ->
                         { env with eIsControlFlow = true }
                     | _ -> env
 
@@ -8747,7 +8747,7 @@ and TcValueItemThen cenv overallTy env vref tpenv mItem afterResolution delayed 
                 vTy
         // Always allow subsumption on assignment to fields
         let expr2R, tpenv = TcExprFlex cenv true false vty2 env tpenv expr2
-        let vexp =
+        let vExpr =
             if isInByrefTy g vTy then
                 errorR(Error(FSComp.SR.writeToReadOnlyByref(), mStmt))
                 mkAddrSet mStmt vref expr2R
@@ -8756,7 +8756,7 @@ and TcValueItemThen cenv overallTy env vref tpenv mItem afterResolution delayed 
             else
                 mkValSet mStmt vref expr2R
 
-        PropagateThenTcDelayed cenv overallTy env tpenv mStmt (MakeApplicableExprNoFlex cenv vexp) (tyOfExpr g vexp) ExprAtomicFlag.NonAtomic otherDelayed
+        PropagateThenTcDelayed cenv overallTy env tpenv mStmt (MakeApplicableExprNoFlex cenv vExpr) (tyOfExpr g vExpr) ExprAtomicFlag.NonAtomic otherDelayed
 
     // Value instantiation: v<tyargs> ...
     | DelayedTypeApp(tys, _mTypeArgs, mExprAndTypeArgs) :: otherDelayed ->
@@ -8770,24 +8770,24 @@ and TcValueItemThen cenv overallTy env vref tpenv mItem afterResolution delayed 
             match tys with
             | [SynType.Var(SynTypar(id, _, false) as tp, _m)] ->
                 let _tpR, tpenv = TcTypeOrMeasureParameter None cenv env ImplicitlyBoundTyparsAllowed.NoNewTypars tpenv tp
-                let vexp = TcNameOfExprResult cenv id mExprAndTypeArgs
-                let vexpFlex = MakeApplicableExprNoFlex cenv vexp
+                let vExpr = TcNameOfExprResult cenv id mExprAndTypeArgs
+                let vexpFlex = MakeApplicableExprNoFlex cenv vExpr
                 PropagateThenTcDelayed cenv overallTy env tpenv mExprAndTypeArgs vexpFlex g.string_ty ExprAtomicFlag.Atomic otherDelayed
             | _ ->
                 error (Error(FSComp.SR.expressionHasNoName(), mExprAndTypeArgs))
         | _ ->
         let checkTys tpenv kinds = TcTypesOrMeasures (Some kinds) cenv NewTyparsOK CheckCxs ItemOccurence.UseInType env tpenv tys mItem
-        let _, vexp, isSpecial, _, _, tpenv = TcVal true cenv env tpenv vref (Some (NormalValUse, checkTys)) (Some afterResolution) mItem
+        let _, vExpr, isSpecial, _, _, tpenv = TcVal true cenv env tpenv vref (Some (NormalValUse, checkTys)) (Some afterResolution) mItem
 
-        let vexpFlex = (if isSpecial then MakeApplicableExprNoFlex cenv vexp else MakeApplicableExprWithFlex cenv env vexp)
+        let vexpFlex = (if isSpecial then MakeApplicableExprNoFlex cenv vExpr else MakeApplicableExprWithFlex cenv env vExpr)
         // We need to eventually record the type resolution for an expression, but this is done
         // inside PropagateThenTcDelayed, so we don't have to explicitly call 'CallExprHasTypeSink' here
         PropagateThenTcDelayed cenv overallTy env tpenv mExprAndTypeArgs vexpFlex vexpFlex.Type ExprAtomicFlag.Atomic otherDelayed
 
     // Value get
     | _ ->
-        let _, vexp, isSpecial, _, _, tpenv = TcVal true cenv env tpenv vref None (Some afterResolution) mItem
-        let vexpFlex = (if isSpecial then MakeApplicableExprNoFlex cenv vexp else MakeApplicableExprWithFlex cenv env vexp)
+        let _, vExpr, isSpecial, _, _, tpenv = TcVal true cenv env tpenv vref None (Some afterResolution) mItem
+        let vexpFlex = (if isSpecial then MakeApplicableExprNoFlex cenv vExpr else MakeApplicableExprWithFlex cenv env vExpr)
         PropagateThenTcDelayed cenv overallTy env tpenv mItem vexpFlex vexpFlex.Type ExprAtomicFlag.Atomic delayed
 
 and TcPropertyItemThen cenv overallTy env nm pinfos tpenv mItem afterResolution delayed =
@@ -9044,8 +9044,8 @@ and TcLookupThen cenv overallTy env tpenv mObjExpr objExpr objExprTy longId dela
             PropagateThenTcDelayed cenv overallTy env tpenv mExprAndItem (MakeApplicableExprWithFlex cenv env objExpr') fieldTy ExprAtomicFlag.Atomic delayed
 
     | Item.AnonRecdField (anonInfo, tinst, n, _) ->
-        let tgty = TType_anon (anonInfo, tinst)
-        AddCxTypeMustSubsumeType ContextInfo.NoContext env.DisplayEnv cenv.css mItem NoTrace tgty objExprTy
+        let tgtTy = TType_anon (anonInfo, tinst)
+        AddCxTypeMustSubsumeType ContextInfo.NoContext env.DisplayEnv cenv.css mItem NoTrace tgtTy objExprTy
         let fieldTy = List.item n tinst
         match delayed with
         | DelayedSet _ :: _otherDelayed ->
@@ -9097,7 +9097,7 @@ and TcEventItemThen cenv overallTy env tpenv mItem mExprAndItem objDetails (einf
     MethInfoChecks g cenv.amap true None objArgs env.eAccessRights mItem delInvokeMeth
 
     // This checks for and drops the 'object' sender
-    let argsTy = ArgsTypOfEventInfo cenv.infoReader mItem ad einfo
+    let argsTy = ArgsTypeOfEventInfo cenv.infoReader mItem ad einfo
     if not (slotSigHasVoidReturnTy (delInvokeMeth.GetSlotSig(cenv.amap, mItem))) then errorR (nonStandardEventError einfo.EventName mItem)
     let delEventTy = mkIEventType g delTy argsTy
 
@@ -11254,14 +11254,13 @@ and AnalyzeRecursiveDecl
 
     let rec analyzeRecursiveDeclPat tpenv pat =
         match pat with
-        | SynPat.FromParseError(pat', _) -> analyzeRecursiveDeclPat tpenv pat'
-        | SynPat.Typed(pat', cty, _) ->
-            let ctyR, tpenv = TcTypeAndRecover cenv NewTyparsOK CheckCxs ItemOccurence.UseInType envinner tpenv cty
+        | SynPat.FromParseError(innerPat, _) -> analyzeRecursiveDeclPat tpenv innerPat
+        | SynPat.Typed(innerPat, tgtTy, _) ->
+            let ctyR, tpenv = TcTypeAndRecover cenv NewTyparsOK CheckCxs ItemOccurence.UseInType envinner tpenv tgtTy
             UnifyTypes cenv envinner mBinding ty ctyR
-            analyzeRecursiveDeclPat tpenv pat'
-        | SynPat.Attrib(_pat', _attribs, m) ->
+            analyzeRecursiveDeclPat tpenv innerPat
+        | SynPat.Attrib(_innerPat, _attribs, m) ->
             error(Error(FSComp.SR.tcAttributesInvalidInPatterns(), m))
-            //analyzeRecursiveDeclPat pat'
 
         // This is for the construct 'let rec x = ... and do ... and y = ...' (DEPRECATED IN pars.mly )
         //

--- a/src/Compiler/Checking/CheckExpressions.fsi
+++ b/src/Compiler/Checking/CheckExpressions.fsi
@@ -1179,7 +1179,7 @@ val TcPatLongIdentActivePatternCase:
     vFlags: TcPatValFlags ->
     patEnv: TcPatLinearEnv ->
     ty: TType ->
-    lidRange: range * item: Item * apref: ActivePatternElemRef * args: SynPat list * m: range ->
+    mLongId: range * item: Item * apref: ActivePatternElemRef * args: SynPat list * m: range ->
         (TcPatPhase2Input -> Pattern) * TcPatLinearEnv
 
 /// The pattern syntax can also represent active pattern arguments. This routine

--- a/src/Compiler/Checking/CheckFormatStrings.fs
+++ b/src/Compiler/Checking/CheckFormatStrings.fs
@@ -22,9 +22,9 @@ let copyAndFixupFormatTypar m tp =
 
 let lowestDefaultPriority = 0 (* See comment on TyparConstraint.DefaultsTo *)
 
-let mkFlexibleFormatTypar m tys dflt = 
+let mkFlexibleFormatTypar m tys dfltTy = 
     let tp = Construct.NewTypar (TyparKind.Type, TyparRigidity.Rigid, SynTypar(mkSynId m "fmt",TyparStaticReq.HeadType,true),false,TyparDynamicReq.Yes,[],false,false)
-    tp.SetConstraints [ TyparConstraint.SimpleChoice (tys,m); TyparConstraint.DefaultsTo (lowestDefaultPriority,dflt,m)]
+    tp.SetConstraints [ TyparConstraint.SimpleChoice (tys,m); TyparConstraint.DefaultsTo (lowestDefaultPriority,dfltTy,m)]
     copyAndFixupFormatTypar m tp
 
 let mkFlexibleIntFormatTypar (g: TcGlobals) m = 
@@ -449,19 +449,19 @@ let parseFormatStringInternal
                   | Some '+' -> 
                       collectSpecifierLocation fragLine fragCol 1
                       let i = skipPossibleInterpolationHole (i+1)
-                      let xty = NewInferenceType g
-                      percentATys.Add(xty)
-                      parseLoop ((posi, xty) :: acc)  (i, fragLine, fragCol+1) fragments
+                      let aTy = NewInferenceType g
+                      percentATys.Add(aTy)
+                      parseLoop ((posi, aTy) :: acc)  (i, fragLine, fragCol+1) fragments
                   | Some n ->
                       failwith (FSComp.SR.forDoesNotSupportPrefixFlag(ch.ToString(), n.ToString()))
 
               | 'a' ->
                   checkOtherFlags ch
-                  let xty = NewInferenceType g 
-                  let fty = mkFunTy g printerArgTy (mkFunTy g xty printerResidueTy)
+                  let aTy = NewInferenceType g 
+                  let fTy = mkFunTy g printerArgTy (mkFunTy g aTy printerResidueTy)
                   collectSpecifierLocation fragLine fragCol 2
                   let i = skipPossibleInterpolationHole (i+1)
-                  parseLoop ((Option.map ((+)1) posi, xty) ::  (posi, fty) :: acc) (i, fragLine, fragCol+1) fragments
+                  parseLoop ((Option.map ((+)1) posi, aTy) ::  (posi, fTy) :: acc) (i, fragLine, fragCol+1) fragments
 
               | 't' ->
                   checkOtherFlags ch

--- a/src/Compiler/Checking/CheckPatterns.fs
+++ b/src/Compiler/Checking/CheckPatterns.fs
@@ -503,7 +503,7 @@ and TcPatLongIdent warnOnUpper cenv env ad valReprInfo vFlags (patEnv: TcPatLine
         | SynArgPats.Pats [] -> warnOnUpper
         | _ -> AllIdsOK
 
-    let lidRange = rangeOfLid longId
+    let mLongId = rangeOfLid longId
 
     match ResolvePatternLongIdent cenv.tcSink cenv.nameResolver warnOnUpperForId false m ad env.NameEnv TypeNameResolutionInfo.Default longId with
     | Item.NewDef id ->
@@ -519,19 +519,19 @@ and TcPatLongIdent warnOnUpper cenv env ad valReprInfo vFlags (patEnv: TcPatLine
 
         let args = GetSynArgPatterns args
 
-        TcPatLongIdentActivePatternCase warnOnUpper cenv env vFlags patEnv ty (lidRange, item, apref, args, m)
+        TcPatLongIdentActivePatternCase warnOnUpper cenv env vFlags patEnv ty (mLongId, item, apref, args, m)
 
     | Item.UnionCase _ | Item.ExnCase _ as item ->
-        TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (lidRange, item, args, m)
+        TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (mLongId, item, args, m)
 
     | Item.ILField finfo ->
-        TcPatLongIdentILField warnOnUpper cenv env vFlags patEnv ty (lidRange, finfo, args, m)
+        TcPatLongIdentILField warnOnUpper cenv env vFlags patEnv ty (mLongId, finfo, args, m)
 
     | Item.RecdField rfinfo ->
-        TcPatLongIdentRecdField warnOnUpper cenv env vFlags patEnv ty (lidRange, rfinfo, args, m)
+        TcPatLongIdentRecdField warnOnUpper cenv env vFlags patEnv ty (mLongId, rfinfo, args, m)
 
     | Item.Value vref ->
-        TcPatLongIdentLiteral warnOnUpper cenv env vFlags patEnv ty (lidRange, vref, args, m)
+        TcPatLongIdentLiteral warnOnUpper cenv env vFlags patEnv ty (mLongId, vref, args, m)
 
     | _ -> error (Error(FSComp.SR.tcRequireVarConstRecogOrLiteral(), m))
 
@@ -577,9 +577,9 @@ and ApplyUnionCaseOrExn m (cenv: cenv) env overallTy item =
         let ucref = ucinfo.UnionCaseRef
         CheckUnionCaseAttributes g ucref m |> CommitOperationResult
         CheckUnionCaseAccessible cenv.amap m ad ucref |> ignore
-        let gtyp2 = actualResultTyOfUnionCase ucinfo.TypeInst ucref
+        let resTy = actualResultTyOfUnionCase ucinfo.TypeInst ucref
         let inst = mkTyparInst ucref.TyconRef.TyparsNoRange ucinfo.TypeInst
-        UnifyTypes cenv env m overallTy gtyp2
+        UnifyTypes cenv env m overallTy resTy
         let mkf mArgs args = TPat_unioncase(ucref, ucinfo.TypeInst, args, unionRanges m mArgs)
         mkf, actualTysOfUnionCaseFields inst ucref, [ for f in ucref.AllFieldsAsList -> f.Id ]
 
@@ -587,11 +587,11 @@ and ApplyUnionCaseOrExn m (cenv: cenv) env overallTy item =
         invalidArg "item" "not a union case or exception reference"
 
 /// Check a long identifier 'Case' or 'Case argsR that has been resolved to a union case or F# exception constructor
-and TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (lidRange, item, args, m) =
+and TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (mLongId, item, args, m) =
     let g = cenv.g
 
     // Report information about the case occurrence to IDE
-    CallNameResolutionSink cenv.tcSink (lidRange, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.eAccessRights)
+    CallNameResolutionSink cenv.tcSink (mLongId, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.eAccessRights)
 
     let mkf, argTys, argNames = ApplyUnionCaseOrExn m cenv env ty item
     let numArgTys = argTys.Length
@@ -693,38 +693,38 @@ and TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (l
     (fun values -> mkf m (List.map (fun f -> f values) argsR)), acc
 
 /// Check a long identifier that has been resolved to an IL field - valid if a literal
-and TcPatLongIdentILField warnOnUpper (cenv: cenv) env vFlags patEnv ty (lidRange, finfo, args, m) =
+and TcPatLongIdentILField warnOnUpper (cenv: cenv) env vFlags patEnv ty (mLongId, finfo, args, m) =
     let g = cenv.g
 
-    CheckILFieldInfoAccessible g cenv.amap lidRange env.AccessRights finfo
+    CheckILFieldInfoAccessible g cenv.amap mLongId env.AccessRights finfo
 
     if not finfo.IsStatic then
-        errorR (Error (FSComp.SR.tcFieldIsNotStatic finfo.FieldName, lidRange))
+        errorR (Error (FSComp.SR.tcFieldIsNotStatic finfo.FieldName, mLongId))
 
     CheckILFieldAttributes g finfo m
 
     match finfo.LiteralValue with
     | None ->
-        error (Error (FSComp.SR.tcFieldNotLiteralCannotBeUsedInPattern (), lidRange))
+        error (Error (FSComp.SR.tcFieldNotLiteralCannotBeUsedInPattern (), mLongId))
     | Some lit ->
         CheckNoArgsForLiteral args m
         let _, acc = TcArgPats warnOnUpper cenv env vFlags patEnv args
 
         UnifyTypes cenv env m ty (finfo.FieldType (cenv.amap, m))
-        let c' = TcFieldInit lidRange lit
+        let c' = TcFieldInit mLongId lit
         let item = Item.ILField finfo
-        CallNameResolutionSink cenv.tcSink (lidRange, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.AccessRights)
+        CallNameResolutionSink cenv.tcSink (mLongId, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.AccessRights)
         (fun _ -> TPat_const (c', m)), acc
 
 /// Check a long identifier that has been resolved to a record field
-and TcPatLongIdentRecdField warnOnUpper cenv env vFlags patEnv ty (lidRange, rfinfo, args, m) =
+and TcPatLongIdentRecdField warnOnUpper cenv env vFlags patEnv ty (mLongId, rfinfo, args, m) =
     let g = cenv.g
-    CheckRecdFieldInfoAccessible cenv.amap lidRange env.AccessRights rfinfo
-    if not rfinfo.IsStatic then errorR (Error (FSComp.SR.tcFieldIsNotStatic(rfinfo.DisplayName), lidRange))
-    CheckRecdFieldInfoAttributes g rfinfo lidRange |> CommitOperationResult
+    CheckRecdFieldInfoAccessible cenv.amap mLongId env.AccessRights rfinfo
+    if not rfinfo.IsStatic then errorR (Error (FSComp.SR.tcFieldIsNotStatic(rfinfo.DisplayName), mLongId))
+    CheckRecdFieldInfoAttributes g rfinfo mLongId |> CommitOperationResult
 
     match rfinfo.LiteralValue with
-    | None -> error (Error(FSComp.SR.tcFieldNotLiteralCannotBeUsedInPattern(), lidRange))
+    | None -> error (Error(FSComp.SR.tcFieldNotLiteralCannotBeUsedInPattern(), mLongId))
     | Some lit ->
         CheckNoArgsForLiteral args m
         let _, acc = TcArgPats warnOnUpper cenv env vFlags patEnv args
@@ -733,26 +733,26 @@ and TcPatLongIdentRecdField warnOnUpper cenv env vFlags patEnv ty (lidRange, rfi
         let item = Item.RecdField rfinfo
         // FUTURE: can we do better than emptyTyparInst here, in order to display instantiations
         // of type variables in the quick info provided in the IDE.
-        CallNameResolutionSink cenv.tcSink (lidRange, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.AccessRights)
+        CallNameResolutionSink cenv.tcSink (mLongId, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.AccessRights)
         (fun _ -> TPat_const (lit, m)), acc
 
 /// Check a long identifier that has been resolved to an F# value that is a literal
-and TcPatLongIdentLiteral warnOnUpper (cenv: cenv) env vFlags patEnv ty (lidRange, vref, args, m) =
+and TcPatLongIdentLiteral warnOnUpper (cenv: cenv) env vFlags patEnv ty (mLongId, vref, args, m) =
     let g = cenv.g
     let (TcPatLinearEnv(tpenv, _, _)) = patEnv
 
     match vref.LiteralValue with
     | None -> error (Error(FSComp.SR.tcNonLiteralCannotBeUsedInPattern(), m))
     | Some lit ->
-        let _, _, _, vexpty, _, _ = TcVal true cenv env tpenv vref None None lidRange
-        CheckValAccessible lidRange env.AccessRights vref
-        CheckFSharpAttributes g vref.Attribs lidRange |> CommitOperationResult
+        let _, _, _, vexpty, _, _ = TcVal true cenv env tpenv vref None None mLongId
+        CheckValAccessible mLongId env.AccessRights vref
+        CheckFSharpAttributes g vref.Attribs mLongId |> CommitOperationResult
         CheckNoArgsForLiteral args m
         let _, acc = TcArgPats warnOnUpper cenv env vFlags patEnv args
 
         UnifyTypes cenv env m ty vexpty
         let item = Item.Value vref
-        CallNameResolutionSink cenv.tcSink (lidRange, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.AccessRights)
+        CallNameResolutionSink cenv.tcSink (mLongId, env.NameEnv, item, emptyTyparInst, ItemOccurence.Pattern, env.AccessRights)
         (fun _ -> TPat_const (lit, m)), acc
 
 and TcPatterns warnOnUpper cenv env vFlags s argTys args =

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -136,12 +136,12 @@ let FreshenTypars m tpsorig =
     match tpsorig with 
     | [] -> []
     | _ -> 
-        let _, _, tptys = FreshenTypeInst m tpsorig
-        tptys
+        let _, _, tpTys = FreshenTypeInst m tpsorig
+        tpTys
 
 let FreshenMethInfo m (minfo: MethInfo) =
-    let _, _, tptys = FreshMethInst m (minfo.GetFormalTyparsOfDeclaringType m) minfo.DeclaringTypeInst minfo.FormalMethodTypars
-    tptys
+    let _, _, tpTys = FreshMethInst m (minfo.GetFormalTyparsOfDeclaringType m) minfo.DeclaringTypeInst minfo.FormalMethodTypars
+    tpTys
 
 //-------------------------------------------------------------------------
 // Unification of types: solve/record equality constraints
@@ -362,7 +362,7 @@ let rec occursCheck g un ty =
     | TType_app (_, l, _) 
     | TType_anon(_, l)
     | TType_tuple (_, l) -> List.exists (occursCheck g un) l
-    | TType_fun (d, r, _) -> occursCheck g un d || occursCheck g un r
+    | TType_fun (domainTy, rangeTy, _) -> occursCheck g un domainTy || occursCheck g un rangeTy
     | TType_var (r, _) ->  typarEq un r 
     | TType_forall (_, tau) -> occursCheck g un tau
     | _ -> false 
@@ -787,7 +787,7 @@ let UnifyMeasureWithOne (csenv: ConstraintSolverEnv) trace ms =
     match FindPreferredTypar nonRigidVars with
     | (v, e) :: vs ->
         let unexpandedCons = ListMeasureConOccsWithNonZeroExponents csenv.g false ms
-        let newms = ProdMeasures (List.map (fun (c, e') -> Measure.RationalPower (Measure.Con c, NegRational (DivRational e' e))) unexpandedCons 
+        let newms = ProdMeasures (List.map (fun (c, e') -> Measure.RationalPower (Measure.Const c, NegRational (DivRational e' e))) unexpandedCons 
                                 @ List.map (fun (v, e') -> Measure.RationalPower (Measure.Var v, NegRational (DivRational e' e))) (vs @ rigidVars))
 
         SubstMeasureWarnIfRigid csenv trace v newms
@@ -818,7 +818,7 @@ let SimplifyMeasure g vars ms =
           let newms =
               ProdMeasures [
                   for (c, e') in nonZeroCon do
-                      Measure.RationalPower (Measure.Con c, NegRational (DivRational e' e)) 
+                      Measure.RationalPower (Measure.Const c, NegRational (DivRational e' e)) 
                   for (v', e') in nonZeroVar do
                       if typarEq v v' then 
                           newvarExpr 
@@ -841,11 +841,11 @@ let rec SimplifyMeasuresInType g resultFirst (generalizable, generalized as para
     | TType_anon (_,l)
     | TType_tuple (_, l) -> SimplifyMeasuresInTypes g param l
 
-    | TType_fun (d, r, _) ->
+    | TType_fun (domainTy, rangeTy, _) ->
         if resultFirst then
-            SimplifyMeasuresInTypes g param [r;d]
+            SimplifyMeasuresInTypes g param [rangeTy;domainTy]
         else
-            SimplifyMeasuresInTypes g param [d;r]        
+            SimplifyMeasuresInTypes g param [domainTy;rangeTy]        
 
     | TType_var _ -> param
 
@@ -886,7 +886,7 @@ let rec GetMeasureVarGcdInType v ty =
     | TType_anon (_,l)
     | TType_tuple (_, l) -> GetMeasureVarGcdInTypes v l
 
-    | TType_fun (d, r, _) -> GcdRational (GetMeasureVarGcdInType v d) (GetMeasureVarGcdInType v r)
+    | TType_fun (domainTy, rangeTy, _) -> GcdRational (GetMeasureVarGcdInType v domainTy) (GetMeasureVarGcdInType v rangeTy)
     | TType_var _   -> ZeroRational
     | TType_forall (_, tau) -> GetMeasureVarGcdInType v tau
     | TType_measure unt -> MeasureVarExponent v unt
@@ -1027,7 +1027,7 @@ and solveTypMeetsTyparConstraints (csenv: ConstraintSolverEnv) ndeep m2 trace ty
                   AddConstraint csenv ndeep m2 trace destTypar (TyparConstraint.DefaultsTo(priority, dty, m))
           
       | TyparConstraint.SupportsNull m2                -> SolveTypeUseSupportsNull            csenv ndeep m2 trace ty
-      | TyparConstraint.IsEnum(underlying, m2)         -> SolveTypeIsEnum                     csenv ndeep m2 trace ty underlying
+      | TyparConstraint.IsEnum(underlyingTy, m2)       -> SolveTypeIsEnum                     csenv ndeep m2 trace ty underlyingTy
       | TyparConstraint.SupportsComparison(m2)         -> SolveTypeSupportsComparison         csenv ndeep m2 trace ty
       | TyparConstraint.SupportsEquality(m2)           -> SolveTypeSupportsEquality           csenv ndeep m2 trace ty
       | TyparConstraint.IsDelegate(aty, bty, m2)       -> SolveTypeIsDelegate                 csenv ndeep m2 trace ty aty bty
@@ -1054,17 +1054,17 @@ and SolveTyparEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalT
     }
 
 // Like SolveTyparEqualsType but asserts all typar equalities simultaneously instead of one by one
-and SolveTyparsEqualTypes (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTrace) tptys tys = trackErrors {
-    do! (tptys, tys) ||> Iterate2D (fun tpty ty -> 
-            match tpty with 
+and SolveTyparsEqualTypes (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTrace) tpTys tys = trackErrors {
+    do! (tpTys, tys) ||> Iterate2D (fun tpTy ty -> 
+            match tpTy with 
             | TType_var (r, _)
             | TType_measure (Measure.Var r) ->
-                SolveTyparEqualsTypePart1 csenv m2 trace tpty r ty 
+                SolveTyparEqualsTypePart1 csenv m2 trace tpTy r ty 
             | _ ->
                 failwith "SolveTyparsEqualTypes")
 
-    do! (tptys, tys) ||> Iterate2D (fun tpty ty -> 
-            match tpty with 
+    do! (tpTys, tys) ||> Iterate2D (fun tpTy ty -> 
+            match tpTy with 
             | TType_var (r, _)
             | TType_measure (Measure.Var r) ->
                 SolveTyparEqualsTypePart2 csenv ndeep m2 trace r ty 
@@ -1135,7 +1135,7 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
     match sty1, sty2 with 
 
     // type vars inside forall-types may be alpha-equivalent 
-    | TType_var (tp1, _), TType_var (tp2, _) when typarEq tp1 tp2 || (match aenv.EquivTypars.TryFind tp1 with | Some v when typeEquiv g v ty2 -> true | _ -> false) ->
+    | TType_var (tp1, _), TType_var (tp2, _) when typarEq tp1 tp2 || (match aenv.EquivTypars.TryFind tp1 with | Some tpTy1 when typeEquiv g tpTy1 ty2 -> true | _ -> false) ->
         CompleteD
 
     // 'v1 = 'v2
@@ -1173,18 +1173,18 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
         SolveAnonInfoEqualsAnonInfo csenv m2 anonInfo1 anonInfo2 ++ (fun () -> 
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace None l1 l2)
 
-    | TType_fun (d1, r1, _), TType_fun (d2, r2, _) ->
-        SolveFunTypeEqn csenv ndeep m2 trace None d1 d2 r1 r2
+    | TType_fun (domainTy1, rangeTy1, _), TType_fun (domainTy2, rangeTy2, _) ->
+        SolveFunTypeEqn csenv ndeep m2 trace None domainTy1 domainTy2 rangeTy1 rangeTy2
 
     | TType_measure ms1, TType_measure ms2 ->
         UnifyMeasures csenv trace ms1 ms2
 
-    | TType_forall(tps1, rty1), TType_forall(tps2, rty2) -> 
+    | TType_forall(tps1, bodyTy1), TType_forall(tps2, bodyTy2) -> 
         if tps1.Length <> tps2.Length then localAbortD else
         let aenv = aenv.BindEquivTypars tps1 tps2 
         let csenv = {csenv with EquivEnv = aenv }
         if not (typarsAEquiv g aenv tps1 tps2) then localAbortD else
-        SolveTypeEqualsTypeKeepAbbrevs csenv ndeep m2 trace rty1 rty2 
+        SolveTypeEqualsTypeKeepAbbrevs csenv ndeep m2 trace bodyTy1 bodyTy2 
 
     | TType_ucase (uc1, l1), TType_ucase (uc2, l2) when g.unionCaseRefEq uc1 uc2  -> SolveTypeEqualsTypeEqns csenv ndeep m2 trace None l1 l2
     | _  -> localAbortD
@@ -1214,9 +1214,9 @@ and SolveTypeEqualsTypeEqns csenv ndeep m2 trace cxsln origl1 origl2 =
                ErrorD(ConstraintSolverTupleDiffLengths(csenv.DisplayEnv, origl1, origl2, csenv.m, m2)) 
        loop origl1 origl2
 
-and SolveFunTypeEqn csenv ndeep m2 trace cxsln d1 d2 r1 r2 = trackErrors {
-    do! SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln d1 d2
-    return! SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln r1 r2
+and SolveFunTypeEqn csenv ndeep m2 trace cxsln domainTy1 domainTy2 rangeTy1 rangeTy2 = trackErrors {
+    do! SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln domainTy1 domainTy2
+    return! SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln rangeTy1 rangeTy2
   }
 
 // ty1: expected
@@ -1240,7 +1240,7 @@ and SolveTypeSubsumesType (csenv: ConstraintSolverEnv) ndeep m2 (trace: Optional
     match sty1, sty2 with 
     | TType_var (tp1, _), _ ->
         match aenv.EquivTypars.TryFind tp1 with
-        | Some v -> SolveTypeSubsumesType csenv ndeep m2 trace cxsln v ty2
+        | Some tpTy1 -> SolveTypeSubsumesType csenv ndeep m2 trace cxsln tpTy1 ty2
         | _ ->
         match sty2 with
         | TType_var (r2, _) when typarEq tp1 r2 -> CompleteD
@@ -1258,8 +1258,8 @@ and SolveTypeSubsumesType (csenv: ConstraintSolverEnv) ndeep m2 (trace: Optional
         SolveAnonInfoEqualsAnonInfo csenv m2 anonInfo1 anonInfo2 ++ (fun () -> 
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace cxsln l1 l2) (* nb. can unify since no variance *)
 
-    | TType_fun (d1, r1, _), TType_fun (d2, r2, _) ->
-        SolveFunTypeEqn csenv ndeep m2 trace cxsln d1 d2 r1 r2 (* nb. can unify since no variance *)
+    | TType_fun (domainTy1, rangeTy1, _), TType_fun (domainTy2, rangeTy2, _) ->
+        SolveFunTypeEqn csenv ndeep m2 trace cxsln domainTy1 domainTy2 rangeTy1 rangeTy2 (* nb. can unify since no variance *)
 
     | TType_measure ms1, TType_measure ms2 ->
         UnifyMeasures csenv trace ms1 ms2
@@ -1306,17 +1306,17 @@ and SolveTypeSubsumesType (csenv: ConstraintSolverEnv) ndeep m2 (trace: Optional
         // Note we don't support co-variance on array types nor 
         // the special .NET conversions for these types 
         match ty1 with
-        | AppTy g (tcr1, tinst) when
+        | AppTy g (tcref1, tinst1) when
             isArray1DTy g ty2 &&
-                (tyconRefEq g tcr1 g.tcref_System_Collections_Generic_IList || 
-                 tyconRefEq g tcr1 g.tcref_System_Collections_Generic_ICollection || 
-                 tyconRefEq g tcr1 g.tcref_System_Collections_Generic_IReadOnlyList || 
-                 tyconRefEq g tcr1 g.tcref_System_Collections_Generic_IReadOnlyCollection || 
-                 tyconRefEq g tcr1 g.tcref_System_Collections_Generic_IEnumerable) ->
-            match tinst with 
-            | [ty1arg] -> 
-                let ty2arg = destArrayTy g ty2
-                SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln ty1arg ty2arg
+                (tyconRefEq g tcref1 g.tcref_System_Collections_Generic_IList || 
+                 tyconRefEq g tcref1 g.tcref_System_Collections_Generic_ICollection || 
+                 tyconRefEq g tcref1 g.tcref_System_Collections_Generic_IReadOnlyList || 
+                 tyconRefEq g tcref1 g.tcref_System_Collections_Generic_IReadOnlyCollection || 
+                 tyconRefEq g tcref1 g.tcref_System_Collections_Generic_IEnumerable) ->
+            match tinst1 with 
+            | [elemTy1] -> 
+                let elemTy2 = destArrayTy g ty2
+                SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln elemTy1 elemTy2
             | _ -> error(InternalError("destArrayTy", m))
 
         | _ ->
@@ -1525,13 +1525,13 @@ and SolveMemberConstraint (csenv: ConstraintSolverEnv) ignoreUnresolvedOverload 
           
           if rankOfArrayTy g ty <> argTys.Length - 1 then
               do! ErrorD(ConstraintSolverError(FSComp.SR.csIndexArgumentMismatch((rankOfArrayTy g ty), (argTys.Length - 1)), m, m2))
-          let argTys, ety = List.frontAndBack argTys
+          let argTys, lastTy = List.frontAndBack argTys
 
           for argTy in argTys do
               do! SolveTypeEqualsTypeKeepAbbrevs csenv ndeep m2 trace argTy g.int_ty
 
-          let etys = destArrayTy g ty
-          do! SolveTypeEqualsTypeKeepAbbrevs csenv ndeep m2 trace ety etys
+          let elemTy = destArrayTy g ty
+          do! SolveTypeEqualsTypeKeepAbbrevs csenv ndeep m2 trace lastTy elemTy
           return TTraitBuiltIn
 
       | [], _, false, ("op_BitwiseAnd" | "op_BitwiseOr" | "op_ExclusiveOr"), [argTy1;argTy2] 
@@ -1845,10 +1845,10 @@ and MemberConstraintSolutionOfMethInfo css m minfo minst =
         match callMethInfoOpt, callExpr with 
         | Some methInfo, Expr.Op (TOp.ILCall (_, _, _, _, NormalValUse, _, _, ilMethRef, _, methInst, _), [], args, m)
              when (args, (objArgVars@allArgVars)) ||> List.lengthsEqAndForall2 (fun a b -> match a with Expr.Val (v, _, _) -> valEq v.Deref b | _ -> false) ->
-                let declaringType = ImportProvidedType amap m (methInfo.PApply((fun x -> x.DeclaringType), m))
-                if isILAppTy g declaringType then 
+                let declaringTy = ImportProvidedType amap m (methInfo.PApply((fun x -> x.DeclaringType), m))
+                if isILAppTy g declaringTy then 
                     let extOpt = None  // EXTENSION METHODS FROM TYPE PROVIDERS: for extension methods coming from the type providers we would have something here.
-                    ILMethSln(declaringType, extOpt, ilMethRef, methInst)
+                    ILMethSln(declaringTy, extOpt, ilMethRef, methInst)
                 else
                     closedExprSln
         | _ -> 
@@ -2090,8 +2090,8 @@ and AddConstraint (csenv: ConstraintSolverEnv) ndeep m2 trace tp newConstraint  
         | TyparConstraint.IsReferenceType _, TyparConstraint.IsReferenceType _
         | TyparConstraint.RequiresDefaultConstructor _, TyparConstraint.RequiresDefaultConstructor _ -> true
         | TyparConstraint.SimpleChoice (tys1, _), TyparConstraint.SimpleChoice (tys2, _) -> ListSet.isSubsetOf (typeEquiv g) tys1 tys2
-        | TyparConstraint.DefaultsTo (priority1, dty1, _), TyparConstraint.DefaultsTo (priority2, dty2, _) -> 
-             (priority1 = priority2) && typeEquiv g dty1 dty2
+        | TyparConstraint.DefaultsTo (priority1, defaultTy1, _), TyparConstraint.DefaultsTo (priority2, defaultTy2, _) -> 
+             (priority1 = priority2) && typeEquiv g defaultTy1 defaultTy2
         | _ -> false
         
     
@@ -2565,14 +2565,12 @@ and SolveTypeSubsumesTypeWithWrappedContextualReport (csenv: ConstraintSolverEnv
 and SolveTypeSubsumesTypeWithReport (csenv: ConstraintSolverEnv) ndeep m trace cxsln ty1 ty2 =
     SolveTypeSubsumesTypeWithWrappedContextualReport csenv ndeep m trace cxsln ty1 ty2 id
 
-// ty1: actual
-// ty2: expected
-and private SolveTypeEqualsTypeWithReport (csenv: ConstraintSolverEnv) ndeep m trace cxsln actual expected = 
+and SolveTypeEqualsTypeWithReport (csenv: ConstraintSolverEnv) ndeep m trace cxsln actualTy expectedTy = 
     TryD
-        (fun () -> SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m trace cxsln actual expected)
+        (fun () -> SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m trace cxsln actualTy expectedTy)
         (function
         | AbortForFailedMemberConstraintResolution as err -> ErrorD err
-        | res -> ErrorD (ErrorFromAddingTypeEquation(csenv.g, csenv.DisplayEnv, actual, expected, res, m)))
+        | res -> ErrorD (ErrorFromAddingTypeEquation(csenv.g, csenv.DisplayEnv, actualTy, expectedTy, res, m)))
   
 and ArgsMustSubsumeOrConvert 
         (csenv: ConstraintSolverEnv)

--- a/src/Compiler/Checking/FindUnsolved.fs
+++ b/src/Compiler/Checking/FindUnsolved.fs
@@ -201,7 +201,7 @@ and accDiscrim cenv env d =
     | DecisionTreeTest.ArrayLength(_, ty) -> accTy cenv env ty
     | DecisionTreeTest.Const _
     | DecisionTreeTest.IsNull -> ()
-    | DecisionTreeTest.IsInst (srcty, tgty) -> accTy cenv env srcty; accTy cenv env tgty
+    | DecisionTreeTest.IsInst (srcTy, tgtTy) -> accTy cenv env srcTy; accTy cenv env tgtTy
     | DecisionTreeTest.ActivePatternCase (exp, tys, _, _, _, _) -> 
         accExpr cenv env exp
         accTypeInst cenv env tys

--- a/src/Compiler/Checking/InfoReader.fsi
+++ b/src/Compiler/Checking/InfoReader.fsi
@@ -280,7 +280,7 @@ type SigOfFunctionForDelegate =
 /// Given a delegate type work out the minfo, argument types, return type
 /// and F# function type by looking at the Invoke signature of the delegate.
 val GetSigOfFunctionForDelegate:
-    infoReader: InfoReader -> delty: TType -> m: range -> ad: AccessorDomain -> SigOfFunctionForDelegate
+    infoReader: InfoReader -> delTy: TType -> m: range -> ad: AccessorDomain -> SigOfFunctionForDelegate
 
 /// Try and interpret a delegate type as a "standard" .NET delegate type associated with an event, with a "sender" parameter.
 val TryDestStandardDelegateType:
@@ -290,9 +290,9 @@ val TryDestStandardDelegateType:
 /// with a sender parameter.
 val IsStandardEventInfo: infoReader: InfoReader -> m: range -> ad: AccessorDomain -> einfo: EventInfo -> bool
 
-val ArgsTypOfEventInfo: infoReader: InfoReader -> m: range -> ad: AccessorDomain -> einfo: EventInfo -> TType
+val ArgsTypeOfEventInfo: infoReader: InfoReader -> m: range -> ad: AccessorDomain -> einfo: EventInfo -> TType
 
-val PropTypOfEventInfo: infoReader: InfoReader -> m: range -> ad: AccessorDomain -> einfo: EventInfo -> TType
+val PropTypeOfEventInfo: infoReader: InfoReader -> m: range -> ad: AccessorDomain -> einfo: EventInfo -> TType
 
 /// Try to find the name of the metadata file for this external definition
 val TryFindMetadataInfoOfExternalEntityRef:

--- a/src/Compiler/Checking/MethodCalls.fs
+++ b/src/Compiler/Checking/MethodCalls.fs
@@ -181,7 +181,7 @@ let TryFindRelevantImplicitConversion (infoReader: InfoReader) ad reqdTy actualT
         let reqdTy2 = 
             if isTyparTy g reqdTy then
                 let tp = destTyparTy g reqdTy 
-                match tp.Constraints |> List.choose (function TyparConstraint.CoercesTo (c, _) -> Some c | _ -> None) with
+                match tp.Constraints |> List.choose (function TyparConstraint.CoercesTo (tgtTy, _) -> Some tgtTy | _ -> None) with
                 | [reqdTy2] when tp.Rigidity = TyparRigidity.Flexible -> reqdTy2
                 | _ -> reqdTy
             else reqdTy
@@ -363,8 +363,8 @@ let AdjustCalledArgTypeForOptionals (infoReader: InfoReader) ad enforceNullableO
                         calledArgTy, TypeDirectedConversionUsed.No, None
                     | _ ->
                         let compgenId = mkSynId range0 unassignedTyparName
-                        let tp = mkTyparTy (Construct.NewTypar (TyparKind.Type, TyparRigidity.Flexible, SynTypar(compgenId, TyparStaticReq.None, true), false, TyparDynamicReq.No, [], false, false))
-                        tp, TypeDirectedConversionUsed.No, None
+                        let tpTy = mkTyparTy (Construct.NewTypar (TyparKind.Type, TyparRigidity.Flexible, SynTypar(compgenId, TyparStaticReq.None, true), false, TyparDynamicReq.No, [], false, false))
+                        tpTy, TypeDirectedConversionUsed.No, None
             else
                 AdjustCalledArgTypeForTypeDirectedConversionsAndAutoQuote infoReader ad callerArgTy calledArgTy calledArg m
 
@@ -456,7 +456,7 @@ type CalledMethArgSet<'T> =
 let MakeCalledArgs amap m (minfo: MethInfo) minst =
     // Mark up the arguments with their position, so we can sort them back into order later 
     let paramDatas = minfo.GetParamDatas(amap, m, minst)
-    paramDatas |> List.mapiSquared (fun i j (ParamData(isParamArrayArg, isInArg, isOutArg, optArgInfo, callerInfoFlags, nmOpt, reflArgInfo, typeOfCalledArg))  -> 
+    paramDatas |> List.mapiSquared (fun i j (ParamData(isParamArrayArg, isInArg, isOutArg, optArgInfo, callerInfoFlags, nmOpt, reflArgInfo, calledArgTy))  -> 
       { Position=(i,j)
         IsParamArray=isParamArrayArg
         OptArgInfo=optArgInfo
@@ -465,7 +465,7 @@ let MakeCalledArgs amap m (minfo: MethInfo) minst =
         IsOutArg=isOutArg
         ReflArgInfo=reflArgInfo
         NameOpt=nmOpt
-        CalledArgumentType=typeOfCalledArg })
+        CalledArgumentType=calledArgTy })
 
 /// <summary>
 /// Represents the syntactic matching between a caller of a method and the called method.
@@ -969,7 +969,7 @@ let BuildILMethInfoCall g amap m isProp (minfo: ILMethInfo) valUseFlags minst di
 ///
 /// QUERY: this looks overly complex considering that we are doing a fundamentally simple 
 /// thing here. 
-let BuildFSharpMethodApp g m (vref: ValRef) vexp vexprty (args: Exprs) =
+let BuildFSharpMethodApp g m (vref: ValRef) vExpr vexprty (args: Exprs) =
     let arities =  (arityOfVal vref.Deref).AritiesOfArgs
     
     let args3, (leftover, retTy) =
@@ -990,17 +990,17 @@ let BuildFSharpMethodApp g m (vref: ValRef) vexp vexprty (args: Exprs) =
                 (mkRefTupled g m tupargs tuptys),
                 (argst, rangeOfFunTy g fty) )
     if not leftover.IsEmpty then error(InternalError("Unexpected "+string(leftover.Length)+" remaining arguments in method application", m))
-    mkApps g ((vexp, vexprty), [], args3, m),
+    mkApps g ((vExpr, vexprty), [], args3, m),
     retTy
     
 /// Build a call to an F# method.
 let BuildFSharpMethodCall g m (ty, vref: ValRef) valUseFlags minst args =
-    let vexp = Expr.Val (vref, valUseFlags, m)
-    let vexpty = vref.Type
+    let vExpr = Expr.Val (vref, valUseFlags, m)
+    let vExprTy = vref.Type
     let tpsorig, tau =  vref.GeneralizedType
     let vtinst = argsOfAppTy g ty @ minst
     if tpsorig.Length <> vtinst.Length then error(InternalError("BuildFSharpMethodCall: unexpected List.length mismatch", m))
-    let expr = mkTyAppExpr m (vexp, vexpty) vtinst
+    let expr = mkTyAppExpr m (vExpr, vExprTy) vtinst
     let exprTy = instType (mkTyparInst tpsorig vtinst) tau
     BuildFSharpMethodApp g m vref expr exprTy args
     
@@ -1113,8 +1113,8 @@ let BuildMethodCall tcVal g amap isMutable m isProp minfo valUseFlags minst objA
                 if valRefEq amap.g fsValRef amap.g.reraise_vref then
                     mkReraise m exprTy, exprTy
                 else
-                    let vexp, vexpty = tcVal fsValRef valUseFlags (minfo.DeclaringTypeInst @ minst) m
-                    BuildFSharpMethodApp g m fsValRef vexp vexpty allArgs
+                    let vExpr, vExprTy = tcVal fsValRef valUseFlags (minfo.DeclaringTypeInst @ minst) m
+                    BuildFSharpMethodApp g m fsValRef vExpr vExprTy allArgs
             | None -> 
                 let ilMethRef = Import.ImportProvidedMethodBaseAsILMethodRef amap m providedMeth
                 let isNewObj = isCtor && (match valUseFlags with NormalValUse -> true | _ -> false)
@@ -1139,8 +1139,8 @@ let BuildMethodCall tcVal g amap isMutable m isProp minfo valUseFlags minst objA
 
             // Go see if this is a use of a recursive definition... Note we know the value instantiation 
             // we want to use so we pass that in order not to create a new one. 
-            let vexp, vexpty = tcVal vref valUseFlags (minfo.DeclaringTypeInst @ minst) m
-            BuildFSharpMethodApp g m vref vexp vexpty allArgs
+            let vExpr, vExprTy = tcVal vref valUseFlags (minfo.DeclaringTypeInst @ minst) m
+            BuildFSharpMethodApp g m vref vExpr vExprTy allArgs
 
         // Build a 'call' to a struct default constructor 
         | DefaultStructCtor (g, ty) -> 
@@ -1793,6 +1793,7 @@ module ProvidedMethodCalls =
             for v, e in Seq.zip (paramVars |> Seq.map (fun x -> x.PUntaint(id, m))) (Option.toList thisArg @ allArgs) do
                 dict.Add(v, (None, e))
             dict
+
         let rec exprToExprAndWitness top (ea: Tainted<ProvidedExpr>) =
             let fail() = error(Error(FSComp.SR.etUnsupportedProvidedExpression(ea.PUntaint((fun etree -> etree.UnderlyingExpressionString), m)), m))
             match ea with
@@ -1806,139 +1807,139 @@ module ProvidedMethodCalls =
                 let srcExpr = exprToExpr expr
                 let targetTy = Import.ImportProvidedType amap m (targetTy.PApply(id, m)) 
                 let sourceTy = Import.ImportProvidedType amap m (expr.PApply ((fun e -> e.Type), m)) 
-                let te = mkCoerceIfNeeded g targetTy sourceTy srcExpr
-                None, (te, tyOfExpr g te)
+                let exprR = mkCoerceIfNeeded g targetTy sourceTy srcExpr
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedTypeTestExpr (expr, targetTy) ->
                 let expr, targetTy = exprType.PApply2((fun _ -> (expr, targetTy)), m)
                 let srcExpr = exprToExpr expr
                 let targetTy = Import.ImportProvidedType amap m (targetTy.PApply(id, m)) 
-                let te = mkCallTypeTest g m targetTy srcExpr
-                None, (te, tyOfExpr g te)
+                let exprR = mkCallTypeTest g m targetTy srcExpr
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedIfThenElseExpr (test, thenBranch, elseBranch) ->
                 let test, thenBranch, elseBranch = exprType.PApply3((fun _ -> (test, thenBranch, elseBranch)), m)
                 let testExpr = exprToExpr test
                 let ifTrueExpr = exprToExpr thenBranch
                 let ifFalseExpr = exprToExpr elseBranch
-                let te = mkCond DebugPointAtBinding.NoneAtSticky m (tyOfExpr g ifTrueExpr) testExpr ifTrueExpr ifFalseExpr
-                None, (te, tyOfExpr g te)
+                let exprR = mkCond DebugPointAtBinding.NoneAtSticky m (tyOfExpr g ifTrueExpr) testExpr ifTrueExpr ifFalseExpr
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedVarExpr providedVar ->
                 let _, vTe = varToExpr (exprType.PApply((fun _ -> providedVar), m))
                 None, (vTe, tyOfExpr g vTe)
             | ProvidedConstantExpr (obj, prType) ->
-                let ce = convertConstExpr g amap m (exprType.PApply((fun _ -> (obj, prType)), m))
-                None, (ce, tyOfExpr g ce)
+                let exprR = convertConstExpr g amap m (exprType.PApply((fun _ -> (obj, prType)), m))
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedNewTupleExpr info ->
                 let elems = exprType.PApplyArray((fun _ -> info), "GetInvokerExpression", m)
-                let elemsT = elems |> Array.map exprToExpr |> Array.toList
-                let exprT = mkRefTupledNoTypes g m elemsT
-                None, (exprT, tyOfExpr g exprT)
+                let elemsR = elems |> Array.map exprToExpr |> Array.toList
+                let exprR = mkRefTupledNoTypes g m elemsR
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedNewArrayExpr (ty, elems) ->
                 let ty, elems = exprType.PApply2((fun _ -> (ty, elems)), m)
-                let tyT = Import.ImportProvidedType amap m ty
+                let tyR = Import.ImportProvidedType amap m ty
                 let elems = elems.PApplyArray(id, "GetInvokerExpression", m)
-                let elemsT = elems |> Array.map exprToExpr |> Array.toList
-                let exprT = Expr.Op (TOp.Array, [tyT], elemsT, m)
-                None, (exprT, tyOfExpr g exprT)
+                let elemsR = elems |> Array.map exprToExpr |> Array.toList
+                let exprR = Expr.Op (TOp.Array, [tyR], elemsR, m)
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedTupleGetExpr (inp, n) -> 
                 let inp, n = exprType.PApply2((fun _ -> (inp, n)), m)
-                let inpT = inp |> exprToExpr 
+                let inpR = inp |> exprToExpr 
                 // if type of expression is erased type then we need convert it to the underlying base type
-                let typeOfExpr =
-                    let t = tyOfExpr g inpT
+                let exprTy =
+                    let t = tyOfExpr g inpR
                     stripTyEqnsWrtErasure EraseMeasures g t
-                let tupInfo, tysT = tryDestAnyTupleTy g typeOfExpr
-                let exprT = mkTupleFieldGet g (tupInfo, inpT, tysT, n.PUntaint(id, m), m)
-                None, (exprT, tyOfExpr g exprT)
+                let tupInfo, tysT = tryDestAnyTupleTy g exprTy
+                let exprR = mkTupleFieldGet g (tupInfo, inpR, tysT, n.PUntaint(id, m), m)
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedLambdaExpr (v, b) ->
                 let v, b = exprType.PApply2((fun _ -> (v, b)), m)
-                let vT = addVar v
-                let bT = exprToExpr b
+                let vR = addVar v
+                let bR = exprToExpr b
                 removeVar v
-                let exprT = mkLambda m vT (bT, tyOfExpr g bT)
-                None, (exprT, tyOfExpr g exprT)
+                let exprR = mkLambda m vR (bR, tyOfExpr g bR)
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedLetExpr (v, e, b) ->
                 let v, e, b = exprType.PApply3((fun _ -> (v, e, b)), m)
-                let eT = exprToExpr  e
-                let vT = addVar v
-                let bT = exprToExpr  b
+                let eR = exprToExpr  e
+                let vR = addVar v
+                let bR = exprToExpr  b
                 removeVar v
-                let exprT = mkCompGenLet m vT eT bT
-                None, (exprT, tyOfExpr g exprT)
+                let exprR = mkCompGenLet m vR eR bR
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedVarSetExpr (v, e) ->
                 let v, e = exprType.PApply2((fun _ -> (v, e)), m)
-                let eT = exprToExpr  e
-                let vTopt, _ = varToExpr v
-                match vTopt with 
+                let eR = exprToExpr e
+                let vOptR, _ = varToExpr v
+                match vOptR with 
                 | None -> 
                     fail()
-                | Some vT ->
-                    let exprT = mkValSet m (mkLocalValRef vT) eT 
-                    None, (exprT, tyOfExpr g exprT)
+                | Some vR ->
+                    let exprR = mkValSet m (mkLocalValRef vR) eR 
+                    None, (exprR, tyOfExpr g exprR)
             | ProvidedWhileLoopExpr (guardExpr, bodyExpr) ->
                 let guardExpr, bodyExpr = (exprType.PApply2((fun _ -> (guardExpr, bodyExpr)), m))
-                let guardExprT = exprToExpr guardExpr
-                let bodyExprT = exprToExpr bodyExpr
-                let exprT = mkWhile g (DebugPointAtWhile.No, SpecialWhileLoopMarker.NoSpecialWhileLoopMarker, guardExprT, bodyExprT, m)
-                None, (exprT, tyOfExpr g exprT)
+                let guardExprR = exprToExpr guardExpr
+                let bodyExprR = exprToExpr bodyExpr
+                let exprR = mkWhile g (DebugPointAtWhile.No, SpecialWhileLoopMarker.NoSpecialWhileLoopMarker, guardExprR, bodyExprR, m)
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedForIntegerRangeLoopExpr (v, e1, e2, e3) -> 
                 let v, e1, e2, e3 = exprType.PApply4((fun _ -> (v, e1, e2, e3)), m)
-                let e1T = exprToExpr  e1
-                let e2T = exprToExpr  e2
-                let vT = addVar v
-                let e3T = exprToExpr  e3
+                let e1R = exprToExpr e1
+                let e2R = exprToExpr e2
+                let vR = addVar v
+                let e3R = exprToExpr e3
                 removeVar v
-                let exprT = mkFastForLoop g (DebugPointAtFor.No, DebugPointAtInOrTo.No, m, vT, e1T, true, e2T, e3T)
-                None, (exprT, tyOfExpr g exprT)
+                let exprR = mkFastForLoop g (DebugPointAtFor.No, DebugPointAtInOrTo.No, m, vR, e1R, true, e2R, e3R)
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedNewDelegateExpr (delegateTy, boundVars, delegateBodyExpr) ->
                 let delegateTy, boundVars, delegateBodyExpr = exprType.PApply3((fun _ -> (delegateTy, boundVars, delegateBodyExpr)), m)
-                let delegateTyT = Import.ImportProvidedType amap m delegateTy
+                let delegateTyR = Import.ImportProvidedType amap m delegateTy
                 let vs = boundVars.PApplyArray(id, "GetInvokerExpression", m) |> Array.toList 
                 let vsT = List.map addVar vs
-                let delegateBodyExprT = exprToExpr delegateBodyExpr
+                let delegateBodyExprR = exprToExpr delegateBodyExpr
                 List.iter removeVar vs
-                let lambdaExpr = mkLambdas g m [] vsT (delegateBodyExprT, tyOfExpr g delegateBodyExprT)
+                let lambdaExpr = mkLambdas g m [] vsT (delegateBodyExprR, tyOfExpr g delegateBodyExprR)
                 let lambdaExprTy = tyOfExpr g lambdaExpr
                 let infoReader = InfoReader(g, amap)
-                let exprT = CoerceFromFSharpFuncToDelegate g amap infoReader AccessorDomain.AccessibleFromSomewhere lambdaExprTy m lambdaExpr delegateTyT
-                None, (exprT, tyOfExpr g exprT)
+                let exprR = CoerceFromFSharpFuncToDelegate g amap infoReader AccessorDomain.AccessibleFromSomewhere lambdaExprTy m lambdaExpr delegateTyR
+                None, (exprR, tyOfExpr g exprR)
 #if PROVIDED_ADDRESS_OF
             | ProvidedAddressOfExpr e ->
-                let eT =  exprToExpr (exprType.PApply((fun _ -> e), m))
-                let wrap,ce, _readonly, _writeonly = mkExprAddrOfExpr g true false DefinitelyMutates eT None m
-                let ce = wrap ce
-                None, (ce, tyOfExpr g ce)
+                let eR =  exprToExpr (exprType.PApply((fun _ -> e), m))
+                let wrap,exprR, _readonly, _writeonly = mkExprAddrOfExpr g true false DefinitelyMutates eR None m
+                let exprR = wrap exprR
+                None, (exprR, tyOfExpr g exprR)
 #endif
             | ProvidedDefaultExpr pty ->
                 let ty = Import.ImportProvidedType amap m (exprType.PApply((fun _ -> pty), m))
-                let ce = mkDefault (m, ty)
-                None, (ce, tyOfExpr g ce)
+                let exprR = mkDefault (m, ty)
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedCallExpr (e1, e2, e3) ->
                 methodCallToExpr top ea (exprType.PApply((fun _ -> (e1, e2, e3)), m))
             | ProvidedSequentialExpr (e1, e2) ->
                 let e1, e2 = exprType.PApply2((fun _ -> (e1, e2)), m)
-                let e1T = exprToExpr e1
-                let e2T = exprToExpr e2
-                let ce = mkCompGenSequential m e1T e2T
-                None, (ce, tyOfExpr g ce)
+                let e1R = exprToExpr e1
+                let e2R = exprToExpr e2
+                let exprR = mkCompGenSequential m e1R e2R
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedTryFinallyExpr (e1, e2) ->
                 let e1, e2 = exprType.PApply2((fun _ -> (e1, e2)), m)
-                let e1T = exprToExpr e1
-                let e2T = exprToExpr e2
-                let ce = mkTryFinally g (e1T, e2T, m, tyOfExpr g e1T, DebugPointAtTry.No, DebugPointAtFinally.No)
-                None, (ce, tyOfExpr g ce)
+                let e1R = exprToExpr e1
+                let e2R = exprToExpr e2
+                let exprR = mkTryFinally g (e1R, e2R, m, tyOfExpr g e1R, DebugPointAtTry.No, DebugPointAtFinally.No)
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedTryWithExpr (e1, e2, e3, e4, e5) ->
                 let info = exprType.PApply((fun _ -> (e1, e2, e3, e4, e5)), m)
-                let bT = exprToExpr (info.PApply((fun (x, _, _, _, _) -> x), m))
+                let bR = exprToExpr (info.PApply((fun (x, _, _, _, _) -> x), m))
                 let v1 = info.PApply((fun (_, x, _, _, _) -> x), m)
-                let v1T = addVar v1
-                let e1T = exprToExpr (info.PApply((fun (_, _, x, _, _) -> x), m))
+                let v1R = addVar v1
+                let e1R = exprToExpr (info.PApply((fun (_, _, x, _, _) -> x), m))
                 removeVar v1
                 let v2 = info.PApply((fun (_, _, _, x, _) -> x), m)
-                let v2T = addVar v2
-                let e2T = exprToExpr (info.PApply((fun (_, _, _, _, x) -> x), m))
+                let v2R = addVar v2
+                let e2R = exprToExpr (info.PApply((fun (_, _, _, _, x) -> x), m))
                 removeVar v2
-                let ce = mkTryWith g (bT, v1T, e1T, v2T, e2T, m, tyOfExpr g bT, DebugPointAtTry.No, DebugPointAtWith.No)
-                None, (ce, tyOfExpr g ce)
+                let exprR = mkTryWith g (bR, v1R, e1R, v2R, e2R, m, tyOfExpr g bR, DebugPointAtTry.No, DebugPointAtWith.No)
+                None, (exprR, tyOfExpr g exprR)
             | ProvidedNewObjectExpr (e1, e2) ->
                 None, ctorCallToExpr (exprType.PApply((fun _ -> (e1, e2)), m))
 
@@ -1955,10 +1956,10 @@ module ProvidedMethodCalls =
             let nm = v.PUntaint ((fun v -> v.Name), m)
             let mut = v.PUntaint ((fun v -> v.IsMutable), m)
             let vRaw = v.PUntaint (id, m)
-            let tyT = Import.ImportProvidedType amap m (v.PApply ((fun v -> v.Type), m))
-            let vT, vTe = if mut then mkMutableCompGenLocal m nm tyT else mkCompGenLocal m nm tyT
-            varConv[vRaw] <- (Some vT, vTe)
-            vT
+            let tyR = Import.ImportProvidedType amap m (v.PApply ((fun v -> v.Type), m))
+            let vR, vTe = if mut then mkMutableCompGenLocal m nm tyR else mkCompGenLocal m nm tyR
+            varConv[vRaw] <- (Some vR, vTe)
+            vR
 
         and removeVar (v: Tainted<ProvidedVar>) =    
             let vRaw = v.PUntaint (id, m)

--- a/src/Compiler/Checking/MethodOverrides.fs
+++ b/src/Compiler/Checking/MethodOverrides.fs
@@ -160,7 +160,7 @@ module DispatchSlotChecking =
                 let belongsToReqdTy = 
                     match overrideBy.MemberInfo.Value.ImplementedSlotSigs with
                     | [] -> false
-                    | ss :: _ -> isInterfaceTy g ss.ImplementedType && typeEquiv g reqdTy ss.ImplementedType
+                    | ss :: _ -> isInterfaceTy g ss.DeclaringType && typeEquiv g reqdTy ss.DeclaringType
                 if belongsToReqdTy then 
                     CanImplementAnyInterfaceSlot
                 else
@@ -178,7 +178,7 @@ module DispatchSlotChecking =
         Override(implKind, overrideBy.MemberApparentEntity, mkSynId overrideBy.Range nm, memberMethodTypars, memberToParentInst, argTys, retTy, isFakeEventProperty, overrideBy.IsCompilerGenerated)
 
     /// Get the override information for an object expression method being used to implement dispatch slots
-    let GetObjectExprOverrideInfo g amap (implty, id: Ident, memberFlags, ty, arityInfo, bindingAttribs, rhsExpr) = 
+    let GetObjectExprOverrideInfo g amap (implTy, id: Ident, memberFlags, ty, arityInfo, bindingAttribs, rhsExpr) = 
         // Dissect the type. The '0' indicates there are no enclosing generic class type parameters relevant here.
         let tps, _, argInfos, retTy, _ = GetMemberTypeInMemberForm g memberFlags arityInfo 0 ty id.idRange
         let argTys = argInfos |> List.mapSquared fst
@@ -192,13 +192,13 @@ module DispatchSlotChecking =
             // Check for empty variable list from a () arg
             let vs = if List.isSingleton vs && argInfos.IsEmpty then [] else vs
             let implKind = 
-                if isInterfaceTy g implty then 
+                if isInterfaceTy g implTy then 
                     CanImplementAnyInterfaceSlot 
                 else 
                     CanImplementAnyClassHierarchySlot
                     //CanImplementAnySlot  <<----- Change to this to enable implicit interface implementation
             let isFakeEventProperty = CompileAsEvent g bindingAttribs
-            let overrideByInfo = Override(implKind, tcrefOfAppTy g implty, id, tps, [], argTys, retTy, isFakeEventProperty, false)
+            let overrideByInfo = Override(implKind, tcrefOfAppTy g implTy, id, tps, [], argTys, retTy, isFakeEventProperty, false)
             overrideByInfo, (baseValOpt, thisv, vs, bindingAttribs, rhsExpr)
         | _ -> 
             error(InternalError("Unexpected shape for object expression override", id.idRange))
@@ -749,7 +749,7 @@ module DispatchSlotChecking =
         let amap = infoReader.amap
 
         let tcaug = tycon.TypeContents        
-        let interfaces = tycon.ImmediateInterfacesOfFSharpTycon |> List.map (fun (ity, _compgen, m) -> (ity, m))
+        let interfaces = tycon.ImmediateInterfacesOfFSharpTycon |> List.map (fun (intfTy, _compgen, m) -> (intfTy, m))
 
         let overallTy = generalizedTyconRef g (mkLocalTyconRef tycon)
 
@@ -780,9 +780,9 @@ module DispatchSlotChecking =
            | [] -> 
                 // Are we looking at the implementation of the class hierarchy? If so include all the override members
                 not (isInterfaceTy g reqdTy)
-           | ss -> 
-                 ss |> List.forall (fun ss -> 
-                     let ty = ss.ImplementedType
+           | slotSigs -> 
+                 slotSigs |> List.forall (fun slotSig -> 
+                     let ty = slotSig.DeclaringType
                      if isInterfaceTy g ty then 
                          // Is this a method impl listed under the reqdTy?
                          typeEquiv g ty reqdTy

--- a/src/Compiler/Checking/MethodOverrides.fsi
+++ b/src/Compiler/Checking/MethodOverrides.fsi
@@ -89,7 +89,7 @@ module DispatchSlotChecking =
     val GetObjectExprOverrideInfo:
         g: TcGlobals ->
         amap: ImportMap ->
-        implty: TType *
+        implTy: TType *
         id: Ident *
         memberFlags: SynMemberFlags *
         ty: TType *

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -1420,10 +1420,10 @@ and AddModuleOrNamespaceContentsToNameEnv (g: TcGlobals) amap (ad: AccessorDomai
 and AddModuleOrNamespaceRefsContentsToNameEnv g amap ad m root nenv modrefs =
    (modrefs, nenv) ||> List.foldBack (fun modref acc -> AddModuleOrNamespaceRefContentsToNameEnv g amap ad m root acc modref)
 
-and AddTypeContentsToNameEnv g amap ad m nenv (typ: TType) =
-    assert (isAppTy g typ)
-    assert not (tcrefOfAppTy g typ).IsModuleOrNamespace
-    AddStaticContentOfTypeToNameEnv g amap ad m nenv typ
+and AddTypeContentsToNameEnv g amap ad m nenv (ty: TType) =
+    assert (isAppTy g ty)
+    assert not (tcrefOfAppTy g ty).IsModuleOrNamespace
+    AddStaticContentOfTypeToNameEnv g amap ad m nenv ty
 
 and AddModuleOrNamespaceRefContentsToNameEnv g amap ad m root nenv (modref: EntityRef) =
     assert modref.IsModuleOrNamespace 
@@ -2426,8 +2426,8 @@ let TryFindUnionCaseOfType g ty nm =
         ValueNone
 
 /// Try to find a union case of a type, with the given name
-let TryFindAnonRecdFieldOfType g typ nm =
-    match tryDestAnonRecdTy g typ with
+let TryFindAnonRecdFieldOfType g ty nm =
+    match tryDestAnonRecdTy g ty with
     | ValueSome (anonInfo, tys) ->
         match anonInfo.SortedIds |> Array.tryFindIndex (fun x -> x.idText = nm) with
         | Some i -> Some (Item.AnonRecdField(anonInfo, tys, i, anonInfo.SortedIds[i].idRange))
@@ -4113,7 +4113,7 @@ let rec ResolvePartialLongIdentInType (ncenv: NameResolver) nenv isApplicableMet
 
       // e.g. <val-id>.<event-id>.<more>
       for einfo in ncenv.InfoReader.GetEventInfosOfType(Some id, ad, m, ty) do
-         let einfoTy = PropTypOfEventInfo ncenv.InfoReader m ad einfo
+         let einfoTy = PropTypeOfEventInfo ncenv.InfoReader m ad einfo
          yield! ResolvePartialLongIdentInType ncenv nenv isApplicableMeth m ad false rest einfoTy
 
       // nested types
@@ -4811,7 +4811,7 @@ let rec ResolvePartialLongIdentInTypeForItem (ncenv: NameResolver) nenv m ad sta
 
           // e.g. <val-id>.<event-id>.<more>
           for einfo in ncenv.InfoReader.GetEventInfosOfType(Some id, ad, m, ty) do
-              let tyinfo = PropTypOfEventInfo ncenv.InfoReader m ad einfo
+              let tyinfo = PropTypeOfEventInfo ncenv.InfoReader m ad einfo
               yield! ResolvePartialLongIdentInTypeForItem ncenv nenv m ad false rest item tyinfo
 
           // nested types!

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -497,7 +497,7 @@ module PrintTypes =
         | _ -> itemL
 
     /// Layout a reference to a type 
-    let layoutTyconRef denv tycon = layoutTyconRefImpl false denv tycon
+    let layoutTyconRef denv tcref = layoutTyconRefImpl false denv tcref
 
     /// Layout the flags of a member 
     let layoutMemberFlags (memFlags: SynMemberFlags) = 
@@ -546,8 +546,8 @@ module PrintTypes =
         | TypeDefOfExpr denv.g ty ->
             LeftL.keywordTypedefof ^^ wordL (tagPunctuation "<") ^^ layoutType denv ty ^^ rightL (tagPunctuation ">")
 
-        | Expr.Op (TOp.Coerce, [tgTy;_], [arg2], _) ->
-            leftL (tagPunctuation "(") ^^ layoutAttribArg denv arg2 ^^ wordL (tagPunctuation ":>") ^^ layoutType denv tgTy ^^ rightL (tagPunctuation ")")
+        | Expr.Op (TOp.Coerce, [tgtTy;_], [arg2], _) ->
+            leftL (tagPunctuation "(") ^^ layoutAttribArg denv arg2 ^^ wordL (tagPunctuation ":>") ^^ layoutType denv tgtTy ^^ rightL (tagPunctuation ")")
 
         | AttribBitwiseOrExpr denv.g (arg1, arg2) ->
             layoutAttribArg denv arg1 ^^ wordL (tagPunctuation "|||") ^^ layoutAttribArg denv arg2
@@ -726,8 +726,8 @@ module PrintTypes =
     and layoutConstraintWithInfo denv env (tp, tpc) =
         let longConstraintPrefix l = (layoutTyparRefWithInfo denv env tp |> addColonL) ^^ l
         match tpc with 
-        | TyparConstraint.CoercesTo(tpct, _) -> 
-            [layoutTyparRefWithInfo denv env tp ^^ wordL (tagOperator ":>") --- layoutTypeWithInfo denv env tpct]
+        | TyparConstraint.CoercesTo(tgtTy, _) -> 
+            [layoutTyparRefWithInfo denv env tp ^^ wordL (tagOperator ":>") --- layoutTypeWithInfo denv env tgtTy]
 
         | TyparConstraint.MayResolveMember(traitInfo, _) ->
             [layoutTraitWithInfo denv env traitInfo]
@@ -815,8 +815,8 @@ module PrintTypes =
 
     /// Layout a unit of measure expression 
     and layoutMeasure denv unt =
-        let sortVars vs = vs |> List.sortBy (fun (v: Typar, _) -> v.DisplayName) 
-        let sortCons cs = cs |> List.sortBy (fun (c: TyconRef, _) -> c.DisplayName) 
+        let sortVars vs = vs |> List.sortBy (fun (tp: Typar, _) -> tp.DisplayName) 
+        let sortCons cs = cs |> List.sortBy (fun (tcref: TyconRef, _) -> tcref.DisplayName) 
         let negvs, posvs = ListMeasureVarOccsWithNonZeroExponents unt |> sortVars |> List.partition (fun (_, e) -> SignRational e < 0)
         let negcs, poscs = ListMeasureConOccsWithNonZeroExponents denv.g false unt |> sortCons |> List.partition (fun (_, e) -> SignRational e < 0)
         let unparL uv = layoutTyparRef denv uv
@@ -832,14 +832,14 @@ module PrintTypes =
         | _ -> prefix ^^ sepL (tagPunctuation "/") ^^ (if List.length negvs + List.length negcs > 1 then sepL (tagPunctuation "(") ^^ postfix ^^ sepL (tagPunctuation ")") else postfix)
 
     /// Layout type arguments, either NAME<ty, ..., ty> or (ty, ..., ty) NAME *)
-    and layoutTypeAppWithInfoAndPrec denv env tcL prec prefix args =
+    and layoutTypeAppWithInfoAndPrec denv env tcL prec prefix argTys =
         if prefix then 
-            match args with
+            match argTys with
             | [] -> tcL
-            | [arg] -> tcL ^^ sepL (tagPunctuation "<") ^^ (layoutTypeWithInfoAndPrec denv env 4 arg) ^^ rightL (tagPunctuation">")
-            | args -> bracketIfL (prec <= 1) (tcL ^^ angleL (layoutTypesWithInfoAndPrec denv env 2 (sepL (tagPunctuation ",")) args))
+            | [argTy] -> tcL ^^ sepL (tagPunctuation "<") ^^ (layoutTypeWithInfoAndPrec denv env 4 argTy) ^^ rightL (tagPunctuation">")
+            | _ -> bracketIfL (prec <= 1) (tcL ^^ angleL (layoutTypesWithInfoAndPrec denv env 2 (sepL (tagPunctuation ",")) argTys))
         else
-            match args with
+            match argTys with
             | [] -> tcL
             | [arg] -> layoutTypeWithInfoAndPrec denv env 2 arg ^^ tcL
             | args -> bracketIfL (prec <= 1) (bracketL (layoutTypesWithInfoAndPrec denv env 2 (sepL (tagPunctuation ",")) args) --- tcL)
@@ -1050,8 +1050,8 @@ module PrintTypes =
 
         prettyTyparInst, niceMethodTypars, layout
 
-    let prettyLayoutOfMemberType denv v typarInst argInfos retTy = 
-        match PartitionValRefTypars denv.g v with
+    let prettyLayoutOfMemberType denv vref typarInst argInfos retTy = 
+        match PartitionValRefTypars denv.g vref with
         | Some(_, _, memberMethodTypars, memberToParentInst, _) ->
             prettyLayoutOfMemberSigCore denv memberToParentInst (typarInst, memberMethodTypars, argInfos, retTy)
         | None -> 
@@ -1123,14 +1123,14 @@ module PrintTypes =
         let ty, _cxs = PrettyTypes.PrettifyType denv.g ty
         layoutTypeWithInfoAndPrec denv SimplifyTypes.typeSimplificationInfo0 5 ty
 
-    let layoutOfValReturnType denv (v: ValRef) =
-        match v.ValReprInfo with 
+    let layoutOfValReturnType denv (vref: ValRef) =
+        match vref.ValReprInfo with 
         | None ->
-            let tau = v.TauType
+            let tau = vref.TauType
             let _argTysl, retTy = stripFunTy denv.g tau
             layoutReturnType denv SimplifyTypes.typeSimplificationInfo0 retTy
         | Some (ValReprInfo(_typars, argInfos, _retInfo)) -> 
-            let tau = v.TauType
+            let tau = vref.TauType
             let _c, retTy = GetTopTauTypeInFSharpForm denv.g argInfos tau Range.range0
             layoutReturnType denv SimplifyTypes.typeSimplificationInfo0 retTy
 
@@ -1147,22 +1147,22 @@ module PrintTastMemberOrVals =
         else 
             nameL
 
-    let layoutMemberName (denv: DisplayEnv) (v: ValRef) niceMethodTypars tagFunction name =
-        let nameL = ConvertValNameToDisplayLayout v.IsBaseVal (tagFunction >> mkNav v.DefinitionRange >> wordL) name
+    let layoutMemberName (denv: DisplayEnv) (vref: ValRef) niceMethodTypars tagFunction name =
+        let nameL = ConvertValNameToDisplayLayout vref.IsBaseVal (tagFunction >> mkNav vref.DefinitionRange >> wordL) name
         let nameL =
             if denv.showMemberContainers then 
-                layoutTyconRef denv v.MemberApparentEntity ^^ SepL.dot ^^ nameL
+                layoutTyconRef denv vref.MemberApparentEntity ^^ SepL.dot ^^ nameL
             else
                 nameL
         let nameL = if denv.showTyparBinding then layoutTyparDecls denv nameL true niceMethodTypars else nameL
-        let nameL = layoutAccessibility denv v.Accessibility nameL
+        let nameL = layoutAccessibility denv vref.Accessibility nameL
         nameL
 
     let prettyLayoutOfMemberShortOption denv typarInst (v: Val) short =
-        let v = mkLocalValRef v
-        let membInfo = Option.get v.MemberInfo
+        let vref = mkLocalValRef v
+        let membInfo = Option.get vref.MemberInfo
         let stat = layoutMemberFlags membInfo.MemberFlags
-        let _tps, argInfos, retTy, _ = GetTypeOfMemberInFSharpForm denv.g v
+        let _tps, argInfos, retTy, _ = GetTypeOfMemberInFSharpForm denv.g vref
         
         if short then
             for argInfo in argInfos do
@@ -1173,22 +1173,22 @@ module PrintTastMemberOrVals =
         let prettyTyparInst, memberL =
             match membInfo.MemberFlags.MemberKind with
             | SynMemberKind.Member ->
-                let prettyTyparInst, niceMethodTypars,tauL = prettyLayoutOfMemberType denv v typarInst argInfos retTy
+                let prettyTyparInst, niceMethodTypars,tauL = prettyLayoutOfMemberType denv vref typarInst argInfos retTy
                 let resL =
                     if short then tauL
                     else
-                        let nameL = layoutMemberName denv v niceMethodTypars tagMember v.DisplayNameCoreMangled
-                        let nameL = if short then nameL else mkInlineL denv v.Deref nameL
+                        let nameL = layoutMemberName denv vref niceMethodTypars tagMember vref.DisplayNameCoreMangled
+                        let nameL = if short then nameL else mkInlineL denv vref.Deref nameL
                         stat --- ((nameL  |> addColonL) ^^ tauL)
                 prettyTyparInst, resL
 
             | SynMemberKind.ClassConstructor
             | SynMemberKind.Constructor ->
-                let prettyTyparInst, _, tauL = prettyLayoutOfMemberType denv v typarInst argInfos retTy
+                let prettyTyparInst, _, tauL = prettyLayoutOfMemberType denv vref typarInst argInfos retTy
                 let resL = 
                     if short then tauL
                     else
-                        let newL = layoutAccessibility denv v.Accessibility WordL.keywordNew
+                        let newL = layoutAccessibility denv vref.Accessibility WordL.keywordNew
                         stat ++ (newL |> addColonL) ^^ tauL
                 prettyTyparInst, resL
 
@@ -1198,8 +1198,8 @@ module PrintTastMemberOrVals =
             | SynMemberKind.PropertyGet ->
                 if isNil argInfos then
                     // use error recovery because intellisense on an incomplete file will show this
-                    errorR(Error(FSComp.SR.tastInvalidFormForPropertyGetter(), v.Id.idRange))
-                    let nameL = layoutMemberName denv v [] tagProperty v.DisplayNameCoreMangled
+                    errorR(Error(FSComp.SR.tastInvalidFormForPropertyGetter(), vref.Id.idRange))
+                    let nameL = layoutMemberName denv vref [] tagProperty vref.DisplayNameCoreMangled
                     let resL =
                         if short then nameL --- (WordL.keywordWith ^^ WordL.keywordGet)
                         else stat --- nameL --- (WordL.keywordWith ^^ WordL.keywordGet)
@@ -1209,31 +1209,31 @@ module PrintTastMemberOrVals =
                         match argInfos with
                         | [[(ty, _)]] when isUnitTy denv.g ty -> []
                         | _ -> argInfos
-                    let prettyTyparInst, niceMethodTypars,tauL = prettyLayoutOfMemberType denv v typarInst argInfos retTy
+                    let prettyTyparInst, niceMethodTypars,tauL = prettyLayoutOfMemberType denv vref typarInst argInfos retTy
                     let resL =
                         if short then
                             if isNil argInfos then tauL
                             else tauL --- (WordL.keywordWith ^^ WordL.keywordGet)
                         else
-                            let nameL = layoutMemberName denv v niceMethodTypars tagProperty v.DisplayNameCoreMangled
+                            let nameL = layoutMemberName denv vref niceMethodTypars tagProperty vref.DisplayNameCoreMangled
                             stat --- ((nameL  |> addColonL) ^^ (if isNil argInfos then tauL else tauL --- (WordL.keywordWith ^^ WordL.keywordGet)))
                     prettyTyparInst, resL
 
             | SynMemberKind.PropertySet ->
                 if argInfos.Length <> 1 || isNil argInfos.Head then
                     // use error recovery because intellisense on an incomplete file will show this
-                    errorR(Error(FSComp.SR.tastInvalidFormForPropertySetter(), v.Id.idRange))
-                    let nameL = layoutMemberName denv v [] tagProperty v.DisplayNameCoreMangled
+                    errorR(Error(FSComp.SR.tastInvalidFormForPropertySetter(), vref.Id.idRange))
+                    let nameL = layoutMemberName denv vref [] tagProperty vref.DisplayNameCoreMangled
                     let resL = stat --- nameL --- (WordL.keywordWith ^^ WordL.keywordSet)
                     emptyTyparInst, resL
                 else
                     let argInfos, valueInfo = List.frontAndBack argInfos.Head
-                    let prettyTyparInst, niceMethodTypars, tauL = prettyLayoutOfMemberType denv v typarInst (if isNil argInfos then [] else [argInfos]) (fst valueInfo)
+                    let prettyTyparInst, niceMethodTypars, tauL = prettyLayoutOfMemberType denv vref typarInst (if isNil argInfos then [] else [argInfos]) (fst valueInfo)
                     let resL =
                         if short then
                             (tauL --- (WordL.keywordWith ^^ WordL.keywordSet))
                         else
-                            let nameL = layoutMemberName denv v niceMethodTypars tagProperty v.DisplayNameCoreMangled
+                            let nameL = layoutMemberName denv vref niceMethodTypars tagProperty vref.DisplayNameCoreMangled
                             stat --- ((nameL |> addColonL) ^^ (tauL --- (WordL.keywordWith ^^ WordL.keywordSet)))
                     prettyTyparInst, resL
 
@@ -1729,23 +1729,23 @@ module TastDefinitionPrinting =
             typewordL ^^ tpsL
 
 
-        let sortKey (v: MethInfo) = 
-            (not v.IsConstructor,
-             not v.IsInstance, // instance first
-             v.DisplayNameCore, // sort by name 
-             List.sum v.NumArgs, // sort by #curried
-             v.NumArgs.Length)     // sort by arity 
+        let sortKey (minfo: MethInfo) = 
+            (not minfo.IsConstructor,
+             not minfo.IsInstance, // instance first
+             minfo.DisplayNameCore, // sort by name 
+             List.sum minfo.NumArgs, // sort by #curried
+             minfo.NumArgs.Length)     // sort by arity 
 
-        let shouldShow (valRef: ValRef option) =
-            match valRef with
+        let shouldShow (vrefOpt: ValRef option) =
+            match vrefOpt with
             | None -> true
-            | Some(vr) ->
-                (denv.showObsoleteMembers || not (CheckFSharpAttributesForObsolete denv.g vr.Attribs)) &&
-                (denv.showHiddenMembers || not (CheckFSharpAttributesForHidden denv.g vr.Attribs))
+            | Some vref ->
+                (denv.showObsoleteMembers || not (CheckFSharpAttributesForObsolete denv.g vref.Attribs)) &&
+                (denv.showHiddenMembers || not (CheckFSharpAttributesForHidden denv.g vref.Attribs))
                 
         let ctors =
             GetIntrinsicConstructorInfosOfType infoReader m ty
-            |> List.filter (fun v -> IsMethInfoAccessible amap m ad v && not v.IsClassConstructor && shouldShow v.ArbitraryValRef)
+            |> List.filter (fun minfo -> IsMethInfoAccessible amap m ad minfo && not minfo.IsClassConstructor && shouldShow minfo.ArbitraryValRef)
 
         let iimpls =
             if suppressInheritanceAndInterfacesForTyInSimplifiedDisplays g amap m ty then 
@@ -1759,15 +1759,15 @@ module TastDefinitionPrinting =
 
         let iimplsLs =
             iimpls
-            |> List.map (fun ity -> wordL (tagKeyword (if isInterfaceTy g ty then "inherit" else "interface")) -* layoutType denv ity)
+            |> List.map (fun intfTy -> wordL (tagKeyword (if isInterfaceTy g ty then "inherit" else "interface")) -* layoutType denv intfTy)
 
         let props =
             GetImmediateIntrinsicPropInfosOfType (None, ad) g amap m ty
-            |> List.filter (fun v -> shouldShow v.ArbitraryValRef)
+            |> List.filter (fun pinfo -> shouldShow pinfo.ArbitraryValRef)
 
         let events = 
             infoReader.GetEventInfosOfType(None, ad, m, ty)
-            |> List.filter (fun v -> shouldShow v.ArbitraryValRef && typeEquiv g ty v.ApparentEnclosingType)
+            |> List.filter (fun einfo -> shouldShow einfo.ArbitraryValRef && typeEquiv g ty einfo.ApparentEnclosingType)
 
         let impliedNames = 
             try 
@@ -1882,8 +1882,8 @@ module TastDefinitionPrinting =
         let inherits = 
             [ if not (suppressInheritanceAndInterfacesForTyInSimplifiedDisplays g amap m ty) then 
                 match GetSuperTypeOfType g amap m ty with 
-                | Some super when not (isObjTy g super) && not (isValueTypeTy g super) ->
-                    super
+                | Some superTy when not (isObjTy g superTy) && not (isValueTypeTy g superTy) ->
+                    superTy
                 | _ -> ()
             ]
 
@@ -2051,8 +2051,8 @@ module TastDefinitionPrinting =
                 |> addLhs
 
             | TNoRepr when tycon.TypeAbbrev.IsSome ->
-                let abbreviatedType = tycon.TypeAbbrev.Value
-                (lhsL ^^ WordL.equals) -* (layoutType { denv with shortTypeNames = false } abbreviatedType)
+                let abbreviatedTy = tycon.TypeAbbrev.Value
+                (lhsL ^^ WordL.equals) -* (layoutType { denv with shortTypeNames = false } abbreviatedTy)
 
             | _ when isNil allDecls ->
                 lhsL
@@ -2385,8 +2385,8 @@ module PrintData =
             else
                 layoutConst denv.g ty c
 
-        | Expr.Val (v, _, _) ->
-            wordL (tagLocal v.DisplayName)
+        | Expr.Val (vref, _, _) ->
+            wordL (tagLocal vref.DisplayName)
 
         | Expr.Link rX ->
             dataExprWrapL denv isAtomic rX.Value
@@ -2434,21 +2434,28 @@ let outputValOrMember denv infoReader os x = x |> PrintTastMemberOrVals.prettyLa
 let stringValOrMember denv infoReader x = x |> PrintTastMemberOrVals.prettyLayoutOfValOrMemberNoInst denv infoReader |> showL
 
 /// Print members with a qualification showing the type they are contained in 
-let layoutQualifiedValOrMember denv infoReader typarInst v = PrintTastMemberOrVals.prettyLayoutOfValOrMember { denv with showMemberContainers=true; } infoReader typarInst v
+let layoutQualifiedValOrMember denv infoReader typarInst vref =
+    PrintTastMemberOrVals.prettyLayoutOfValOrMember { denv with showMemberContainers=true; } infoReader typarInst vref
 
-let outputQualifiedValOrMember denv infoReader os v = outputValOrMember { denv with showMemberContainers=true; } infoReader os v
+let outputQualifiedValOrMember denv infoReader os vref =
+    outputValOrMember { denv with showMemberContainers=true; } infoReader os vref
 
-let outputQualifiedValSpec denv infoReader os v = outputQualifiedValOrMember denv infoReader os v
+let outputQualifiedValSpec denv infoReader os vref =
+    outputQualifiedValOrMember denv infoReader os vref
 
-let stringOfQualifiedValOrMember denv infoReader v = PrintTastMemberOrVals.prettyLayoutOfValOrMemberNoInst { denv with showMemberContainers=true; } infoReader v |> showL
+let stringOfQualifiedValOrMember denv infoReader vref =
+    PrintTastMemberOrVals.prettyLayoutOfValOrMemberNoInst { denv with showMemberContainers=true; } infoReader vref |> showL
 
 /// Convert a MethInfo to a string
-let formatMethInfoToBufferFreeStyle infoReader m denv buf d = InfoMemberPrinting.formatMethInfoToBufferFreeStyle infoReader m denv buf d
+let formatMethInfoToBufferFreeStyle infoReader m denv buf d =
+    InfoMemberPrinting.formatMethInfoToBufferFreeStyle infoReader m denv buf d
 
-let prettyLayoutOfMethInfoFreeStyle infoReader m denv typarInst minfo = InfoMemberPrinting.prettyLayoutOfMethInfoFreeStyle infoReader m denv typarInst minfo
+let prettyLayoutOfMethInfoFreeStyle infoReader m denv typarInst minfo =
+    InfoMemberPrinting.prettyLayoutOfMethInfoFreeStyle infoReader m denv typarInst minfo
 
 /// Convert a PropInfo to a string
-let prettyLayoutOfPropInfoFreeStyle g amap m denv d = InfoMemberPrinting.prettyLayoutOfPropInfoFreeStyle g amap m denv d
+let prettyLayoutOfPropInfoFreeStyle g amap m denv d =
+    InfoMemberPrinting.prettyLayoutOfPropInfoFreeStyle g amap m denv d
 
 /// Convert a MethInfo to a string
 let stringOfMethInfo infoReader m denv minfo =
@@ -2508,13 +2515,15 @@ let stringOfILAttrib denv x = x |> PrintTypes.layoutILAttrib denv |> squareAngle
 let layoutImpliedSignatureOfModuleOrNamespace showHeader denv infoReader ad m contents =
     InferredSigPrinting.layoutImpliedSignatureOfModuleOrNamespace showHeader denv infoReader ad m contents 
 
-let prettyLayoutOfValOrMember denv infoReader typarInst v = PrintTastMemberOrVals.prettyLayoutOfValOrMember denv infoReader typarInst v  
+let prettyLayoutOfValOrMember denv infoReader typarInst vref =
+    PrintTastMemberOrVals.prettyLayoutOfValOrMember denv infoReader typarInst vref  
 
-let prettyLayoutOfValOrMemberNoInst denv infoReader v = PrintTastMemberOrVals.prettyLayoutOfValOrMemberNoInst denv infoReader v
+let prettyLayoutOfValOrMemberNoInst denv infoReader vref =
+    PrintTastMemberOrVals.prettyLayoutOfValOrMemberNoInst denv infoReader vref
 
 let prettyLayoutOfMemberNoInstShort denv v = PrintTastMemberOrVals.prettyLayoutOfMemberNoInstShort denv v
 
-let layoutOfValReturnType denv v = v |> PrintTypes.layoutOfValReturnType denv
+let layoutOfValReturnType denv vref = vref |> PrintTypes.layoutOfValReturnType denv
 
 let prettyLayoutOfInstAndSig denv x = PrintTypes.prettyLayoutOfInstAndSig denv x
 
@@ -2522,14 +2531,14 @@ let prettyLayoutOfInstAndSig denv x = PrintTypes.prettyLayoutOfInstAndSig denv x
 ///
 /// If the output text is different without showing constraints and/or imperative type variable 
 /// annotations and/or fully qualifying paths then don't show them! 
-let minimalStringsOfTwoTypes denv t1 t2= 
-    let (t1, t2), tpcs = PrettyTypes.PrettifyTypePair denv.g (t1, t2)
+let minimalStringsOfTwoTypes denv ty1 ty2 =
+    let (ty1, ty2), tpcs = PrettyTypes.PrettifyTypePair denv.g (ty1, ty2)
 
     // try denv + no type annotations 
     let attempt1 = 
         let denv = { denv with showInferenceTyparAnnotations=false; showStaticallyResolvedTyparAnnotations=false }
-        let min1 = stringOfTy denv t1
-        let min2 = stringOfTy denv t2
+        let min1 = stringOfTy denv ty1
+        let min2 = stringOfTy denv ty2
         if min1 <> min2 then Some (min1, min2, "") else None
 
     match attempt1 with 
@@ -2539,8 +2548,8 @@ let minimalStringsOfTwoTypes denv t1 t2=
     // try denv + no type annotations + show full paths
     let attempt2 = 
         let denv = { denv with showInferenceTyparAnnotations=false; showStaticallyResolvedTyparAnnotations=false }.SetOpenPaths []
-        let min1 = stringOfTy denv t1
-        let min2 = stringOfTy denv t2
+        let min1 = stringOfTy denv ty1
+        let min2 = stringOfTy denv ty2
         if min1 <> min2 then Some (min1, min2, "") else None
 
     match attempt2 with 
@@ -2548,8 +2557,8 @@ let minimalStringsOfTwoTypes denv t1 t2=
     | None -> 
 
     let attempt3 = 
-        let min1 = stringOfTy denv t1
-        let min2 = stringOfTy denv t2
+        let min1 = stringOfTy denv ty1
+        let min2 = stringOfTy denv ty2
         if min1 <> min2 then Some (min1, min2, stringOfTyparConstraints denv tpcs) else None
 
     match attempt3 with 
@@ -2560,8 +2569,8 @@ let minimalStringsOfTwoTypes denv t1 t2=
         // try denv + show full paths + static parameters
         let denv = denv.SetOpenPaths []
         let denv = { denv with includeStaticParametersInTypeNames=true }
-        let min1 = stringOfTy denv t1
-        let min2 = stringOfTy denv t2
+        let min1 = stringOfTy denv ty1
+        let min2 = stringOfTy denv ty2
         if min1 <> min2 then Some (min1, min2, stringOfTyparConstraints denv tpcs) else None
 
     match attempt4 with
@@ -2575,19 +2584,19 @@ let minimalStringsOfTwoTypes denv t1 t2=
             let assemblyName = PrintTypes.layoutAssemblyName denv t |> function | null | "" -> "" | name -> sprintf " (%s)" name
             sprintf "%s%s" (stringOfTy denv t) assemblyName
 
-        (makeName t1, makeName t2, stringOfTyparConstraints denv tpcs)
+        (makeName ty1, makeName ty2, stringOfTyparConstraints denv tpcs)
     
 // Note: Always show imperative annotations when comparing value signatures 
-let minimalStringsOfTwoValues denv infoReader v1 v2= 
+let minimalStringsOfTwoValues denv infoReader vref1 vref2 = 
     let denvMin = { denv with showInferenceTyparAnnotations=true; showStaticallyResolvedTyparAnnotations=false }
-    let min1 = buildString (fun buf -> outputQualifiedValOrMember denvMin infoReader buf v1)
-    let min2 = buildString (fun buf -> outputQualifiedValOrMember denvMin infoReader buf v2) 
+    let min1 = buildString (fun buf -> outputQualifiedValOrMember denvMin infoReader buf vref1)
+    let min2 = buildString (fun buf -> outputQualifiedValOrMember denvMin infoReader buf vref2) 
     if min1 <> min2 then 
         (min1, min2) 
     else
         let denvMax = { denv with showInferenceTyparAnnotations=true; showStaticallyResolvedTyparAnnotations=true }
-        let max1 = buildString (fun buf -> outputQualifiedValOrMember denvMax infoReader buf v1)
-        let max2 = buildString (fun buf -> outputQualifiedValOrMember denvMax infoReader buf v2) 
+        let max1 = buildString (fun buf -> outputQualifiedValOrMember denvMax infoReader buf vref1)
+        let max2 = buildString (fun buf -> outputQualifiedValOrMember denvMax infoReader buf vref2) 
         max1, max2
     
 let minimalStringOfType denv ty = 

--- a/src/Compiler/Checking/NicePrint.fsi
+++ b/src/Compiler/Checking/NicePrint.fsi
@@ -155,6 +155,7 @@ val prettyLayoutOfInstAndSig:
 
 val minimalStringsOfTwoTypes: denv: DisplayEnv -> ty1: TType -> ty2: TType -> string * string * string
 
-val minimalStringsOfTwoValues: denv: DisplayEnv -> infoReader: InfoReader -> vref1: ValRef -> vref2: ValRef -> string * string
+val minimalStringsOfTwoValues:
+    denv: DisplayEnv -> infoReader: InfoReader -> vref1: ValRef -> vref2: ValRef -> string * string
 
 val minimalStringOfType: denv: DisplayEnv -> ty: TType -> string

--- a/src/Compiler/Checking/NicePrint.fsi
+++ b/src/Compiler/Checking/NicePrint.fsi
@@ -54,14 +54,14 @@ val layoutQualifiedValOrMember:
     denv: DisplayEnv ->
     infoReader: InfoReader ->
     typarInst: TyparInstantiation ->
-    v: ValRef ->
+    vref: ValRef ->
         TyparInstantiation * Layout
 
-val outputQualifiedValOrMember: denv: DisplayEnv -> infoReader: InfoReader -> os: StringBuilder -> v: ValRef -> unit
+val outputQualifiedValOrMember: denv: DisplayEnv -> infoReader: InfoReader -> os: StringBuilder -> vref: ValRef -> unit
 
-val outputQualifiedValSpec: denv: DisplayEnv -> infoReader: InfoReader -> os: StringBuilder -> v: ValRef -> unit
+val outputQualifiedValSpec: denv: DisplayEnv -> infoReader: InfoReader -> os: StringBuilder -> vref: ValRef -> unit
 
-val stringOfQualifiedValOrMember: denv: DisplayEnv -> infoReader: InfoReader -> v: ValRef -> string
+val stringOfQualifiedValOrMember: denv: DisplayEnv -> infoReader: InfoReader -> vref: ValRef -> string
 
 val formatMethInfoToBufferFreeStyle:
     infoReader: InfoReader -> m: range -> denv: DisplayEnv -> buf: StringBuilder -> d: MethInfo -> unit
@@ -139,22 +139,22 @@ val prettyLayoutOfValOrMember:
     denv: DisplayEnv ->
     infoReader: InfoReader ->
     typarInst: TyparInstantiation ->
-    v: ValRef ->
+    vref: ValRef ->
         TyparInstantiation * Layout
 
-val prettyLayoutOfValOrMemberNoInst: denv: DisplayEnv -> infoReader: InfoReader -> v: ValRef -> Layout
+val prettyLayoutOfValOrMemberNoInst: denv: DisplayEnv -> infoReader: InfoReader -> vref: ValRef -> Layout
 
 val prettyLayoutOfMemberNoInstShort: denv: DisplayEnv -> v: Val -> Layout
 
-val layoutOfValReturnType: denv: DisplayEnv -> v: ValRef -> Layout
+val layoutOfValReturnType: denv: DisplayEnv -> vref: ValRef -> Layout
 
 val prettyLayoutOfInstAndSig:
     denv: DisplayEnv ->
     TyparInstantiation * TTypes * TType ->
         TyparInstantiation * (TTypes * TType) * (Layout list * Layout) * Layout
 
-val minimalStringsOfTwoTypes: denv: DisplayEnv -> t1: TType -> t2: TType -> string * string * string
+val minimalStringsOfTwoTypes: denv: DisplayEnv -> ty1: TType -> ty2: TType -> string * string * string
 
-val minimalStringsOfTwoValues: denv: DisplayEnv -> infoReader: InfoReader -> v1: ValRef -> v2: ValRef -> string * string
+val minimalStringsOfTwoValues: denv: DisplayEnv -> infoReader: InfoReader -> vref1: ValRef -> vref2: ValRef -> string * string
 
 val minimalStringOfType: denv: DisplayEnv -> ty: TType -> string

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -312,8 +312,8 @@ let RefuteDiscrimSet g m path discrims =
             raise CannotRefute
     go path tm
 
-let rec CombineRefutations g r1 r2 =
-    match r1, r2 with
+let rec CombineRefutations g refutation1 refutation2 =
+    match refutation1, refutation2 with
     | Expr.Val (vref, _, _), other | other, Expr.Val (vref, _, _) when vref.LogicalName = "_" -> other
     | Expr.Val (vref, _, _), other | other, Expr.Val (vref, _, _) when vref.LogicalName = notNullText -> other
     | Expr.Val (vref, _, _), other | other, Expr.Val (vref, _, _) when vref.LogicalName = otherSubtypeText -> other
@@ -326,9 +326,9 @@ let rec CombineRefutations g r1 r2 =
             Expr.Op (op1, tinst1, List.map2 (CombineRefutations g) flds1 flds2, m1)
         (* Choose the greater of the two ucrefs based on name ordering *)
         elif ucref1.CaseName < ucref2.CaseName then
-            r2
+            refutation2
         else
-            r1
+            refutation1
 
     | Expr.Op (op1, tinst1, flds1, m1), Expr.Op (_, _, flds2, _) ->
         Expr.Op (op1, tinst1, List.map2 (CombineRefutations g) flds1 flds2, m1)
@@ -352,7 +352,7 @@ let rec CombineRefutations g r1 r2 =
 
         Expr.Const (c12, m1, ty1)
 
-    | _ -> r1
+    | _ -> refutation1
 
 let ShowCounterExample g denv m refuted =
     try
@@ -592,8 +592,8 @@ let getDiscrimOfPattern (g: TcGlobals) tpinst t =
     match t with
     | TPat_null _m ->
         Some(DecisionTreeTest.IsNull)
-    | TPat_isinst (srcty, tgty, _, _m) ->
-        Some(DecisionTreeTest.IsInst (instType tpinst srcty, instType tpinst tgty))
+    | TPat_isinst (srcTy, tgtTy, _, _m) ->
+        Some(DecisionTreeTest.IsInst (instType tpinst srcTy, instType tpinst tgtTy))
     | TPat_exnconstr(tcref, _, _m) ->
         Some(DecisionTreeTest.IsInst (g.exn_ty, mkAppTy tcref []))
     | TPat_const (c, _m) ->
@@ -624,7 +624,7 @@ let discrimsEq (g: TcGlobals) d1 d2 =
   | DecisionTreeTest.ArrayLength (n1, _),   DecisionTreeTest.ArrayLength(n2, _) -> (n1=n2)
   | DecisionTreeTest.Const c1,              DecisionTreeTest.Const c2 -> (c1=c2)
   | DecisionTreeTest.IsNull,               DecisionTreeTest.IsNull -> true
-  | DecisionTreeTest.IsInst (srcty1, tgty1), DecisionTreeTest.IsInst (srcty2, tgty2) -> typeEquiv g srcty1 srcty2 && typeEquiv g tgty1 tgty2
+  | DecisionTreeTest.IsInst (srcTy1, tgtTy1), DecisionTreeTest.IsInst (srcTy2, tgtTy2) -> typeEquiv g srcTy1 srcTy2 && typeEquiv g tgtTy1 tgtTy2
   | DecisionTreeTest.ActivePatternCase (_, _, _, vrefOpt1, n1, _), DecisionTreeTest.ActivePatternCase (_, _, _, vrefOpt2, n2, _) ->
       match vrefOpt1, vrefOpt2 with
       | Some (vref1, tinst1), Some (vref2, tinst2) -> valRefEq g vref1 vref2 && n1 = n2  && not (doesActivePatternHaveFreeTypars g vref1) && List.lengthsEqAndForall2 (typeEquiv g) tinst1 tinst2
@@ -1213,15 +1213,15 @@ let CompilePatternBasic
           // This is really an optimization that could be done more effectively in opt.fs
           // if we flowed a bit of information through
 
-         | [EdgeDiscrim(_i', DecisionTreeTest.IsInst (_srcty, tgty), m)]
+         | [EdgeDiscrim(_i', DecisionTreeTest.IsInst (_srcTy, tgtTy), m)]
                     // check we can use a simple 'isinst' instruction
-                    when isRefTy g tgty && canUseTypeTestFast g tgty && isNil origInputValTypars ->
+                    when isRefTy g tgtTy && canUseTypeTestFast g tgtTy && isNil origInputValTypars ->
 
-             let v, vExpr = mkCompGenLocal m "typeTestResult" tgty
+             let v, vExpr = mkCompGenLocal m "typeTestResult" tgtTy
              if origInputVal.IsMemberOrModuleBinding then
                  AdjustValToTopVal v origInputVal.DeclaringEntity ValReprInfo.emptyValData
              let argExpr = GetSubExprOfInput subexpr
-             let appExpr = mkIsInst tgty argExpr mMatch
+             let appExpr = mkIsInst tgtTy argExpr mMatch
              Some vExpr, Some(mkInvisibleBind v appExpr)
 
           // Any match on a struct union must take the address of its input.

--- a/src/Compiler/Checking/QuotationTranslator.fs
+++ b/src/Compiler/Checking/QuotationTranslator.fs
@@ -172,7 +172,7 @@ let (|ModuleValueOrMemberUse|_|) g expr =
         match stripExpr expr with
         | Expr.App (InnerExprPat(Expr.Val (vref, vFlags, _) as f), fty, tyargs, actualArgs, _m) when vref.IsMemberOrModuleBinding ->
             Some(vref, vFlags, f, fty, tyargs, actualArgs @ args)
-        | Expr.App (f, _fty, [], actualArgs, _) ->
+        | Expr.App (f, _fTy, [], actualArgs, _) ->
             loop f (actualArgs @ args)
         | Expr.Val (vref, vFlags, _m) as f when (match vref.DeclaringEntity with ParentNone -> false | _ -> true) ->
             let fty = tyOfExpr g f
@@ -292,8 +292,8 @@ and private ConvExprCore cenv (env : QuotationTranslationEnv) (expr: Expr) : QP.
     // Recognize applications of module functions.
     match expr with
     // Detect expression tree exprSplices
-    | Expr.App (InnerExprPat(Expr.Val (vf, _, _)), _, _, x0 :: rest, m)
-           when isSplice g vf ->
+    | Expr.App (InnerExprPat(Expr.Val (vref, _, _)), _, _, x0 :: rest, m)
+           when isSplice g vref ->
         let idx = cenv.exprSplices.Count
         let ty = tyOfExpr g expr
 
@@ -305,7 +305,7 @@ and private ConvExprCore cenv (env : QuotationTranslationEnv) (expr: Expr) : QP.
         let hole = QP.mkHole(ConvType cenv env m ty, idx)
         (hole, rest) ||> List.fold (fun fR arg -> QP.mkApp (fR, ConvExpr cenv env arg))
 
-    | ModuleValueOrMemberUse g (vref, vFlags, _f, _fty, tyargs, curriedArgs)
+    | ModuleValueOrMemberUse g (vref, vFlags, _f, _fTy, tyargs, curriedArgs)
         when not (isSplice g vref) ->
         let m = expr.Range
 
@@ -419,16 +419,16 @@ and private ConvExprCore cenv (env : QuotationTranslationEnv) (expr: Expr) : QP.
             List.fold (fun fR arg -> QP.mkApp (fR, ConvExpr cenv env arg)) callR laterArgs
 
     // Blast type application nodes and expression application nodes apart so values are left with just their type arguments
-    | Expr.App (f, fty, (_ :: _ as tyargs), (_ :: _ as args), m) ->
-        let rfty = applyForallTy g fty tyargs
-        ConvExpr cenv env (primMkApp (primMkApp (f, fty) tyargs [] m, rfty) [] args m)
+    | Expr.App (f, fTy, (_ :: _ as tyargs), (_ :: _ as args), m) ->
+        let reducedTy = applyForallTy g fTy tyargs
+        ConvExpr cenv env (primMkApp (primMkApp (f, fTy) tyargs [] m, reducedTy) [] args m)
 
     // Uses of possibly-polymorphic values
-    | Expr.App (InnerExprPat(Expr.Val (vref, _vFlags, m)), _fty, tyargs, [], _) ->
+    | Expr.App (InnerExprPat(Expr.Val (vref, _vFlags, m)), _fTy, tyargs, [], _) ->
         ConvValRef true cenv env m vref tyargs
 
     // Simple applications
-    | Expr.App (f, _fty, tyargs, args, m) ->
+    | Expr.App (f, _fTy, tyargs, args, m) ->
         if not (List.isEmpty tyargs) then wfail(Error(FSComp.SR.crefQuotationsCantContainGenericExprs(), m))
         List.fold (fun fR arg -> QP.mkApp (fR, ConvExpr cenv env arg)) (ConvExpr cenv env f) args
 
@@ -828,12 +828,12 @@ and ConvLValueExprCore cenv env expr =
         | TOp.UnionCaseFieldGetAddr (ucref, n, _), [e], _ -> ConvUnionFieldGet cenv env m ucref n tyargs e
         | TOp.ILAsm ([ I_ldflda(fspec) ], _), _, _ -> ConvLdfld  cenv env m fspec tyargs args
         | TOp.ILAsm ([ I_ldsflda(fspec) ], _), _, _ -> ConvLdfld  cenv env m fspec tyargs args
-        | TOp.ILAsm ([ I_ldelema(_ro, _isNativePtr, shape, _tyarg) ], _), arr :: idxs, [elemty] ->
+        | TOp.ILAsm ([ I_ldelema(_ro, _isNativePtr, shape, _tyarg) ], _), arr :: idxs, [elemTy] ->
             match shape.Rank, idxs with
-            | 1, [idx1] -> ConvExpr cenv env (mkCallArrayGet cenv.g m elemty arr idx1)
-            | 2, [idx1; idx2] -> ConvExpr cenv env (mkCallArray2DGet cenv.g m elemty arr idx1 idx2)
-            | 3, [idx1; idx2; idx3] -> ConvExpr cenv env (mkCallArray3DGet cenv.g m elemty arr idx1 idx2 idx3)
-            | 4, [idx1; idx2; idx3; idx4] -> ConvExpr cenv env (mkCallArray4DGet cenv.g m elemty arr idx1 idx2 idx3 idx4)
+            | 1, [idx1] -> ConvExpr cenv env (mkCallArrayGet cenv.g m elemTy arr idx1)
+            | 2, [idx1; idx2] -> ConvExpr cenv env (mkCallArray2DGet cenv.g m elemTy arr idx1 idx2)
+            | 3, [idx1; idx2; idx3] -> ConvExpr cenv env (mkCallArray3DGet cenv.g m elemTy arr idx1 idx2 idx3)
+            | 4, [idx1; idx2; idx3; idx4] -> ConvExpr cenv env (mkCallArray4DGet cenv.g m elemTy arr idx1 idx2 idx3 idx4)
             | _ -> ConvExpr cenv env expr
         | _ -> ConvExpr cenv env expr
     | _ -> ConvExpr cenv env expr
@@ -937,15 +937,15 @@ and private ConvValRefCore holeOk cenv env m (vref: ValRef) tyargs =
     elif v.IsCtorThisVal && cenv.isReflectedDefinition = IsReflectedDefinition.Yes then
         QP.mkThisVar(ConvType cenv env m v.Type)
     else
-        let vty = v.Type
+        let vTy = v.Type
         match v.DeclaringEntity with
         | ParentNone ->
               // References to local values are embedded by value
               if not holeOk then wfail(Error(FSComp.SR.crefNoSetOfHole(), m))
               let idx = cenv.exprSplices.Count
-              let liftExpr = mkCallLiftValueWithName cenv.g m vty v.LogicalName (exprForValRef m vref)
+              let liftExpr = mkCallLiftValueWithName cenv.g m vTy v.LogicalName (exprForValRef m vref)
               cenv.exprSplices.Add((liftExpr, m))
-              QP.mkHole(ConvType cenv env m vty, idx)
+              QP.mkHole(ConvType cenv env m vTy, idx)
 
         | Parent _ ->
             // First-class use or use of type function
@@ -1106,9 +1106,9 @@ and ConvDecisionTree cenv env tgs typR x =
                         let eqR = ConvExpr cenv env eq
                         QP.mkCond (eqR, ConvDecisionTree cenv env tgs typR dtree, acc)
 
-                | DecisionTreeTest.IsInst (_srcty, tgty) ->
+                | DecisionTreeTest.IsInst (_srcTy, tgtTy) ->
                     let e1R = ConvExpr cenv env e1
-                    QP.mkCond (QP.mkTypeTest (ConvType cenv env m tgty, e1R), ConvDecisionTree cenv env tgs typR dtree, acc)
+                    QP.mkCond (QP.mkTypeTest (ConvType cenv env m tgtTy, e1R), ConvDecisionTree cenv env tgs typR dtree, acc)
 
                 | DecisionTreeTest.ActivePatternCase _ ->
                     wfail(InternalError( "DecisionTreeTest.ActivePatternCase test in quoted expression", m))

--- a/src/Compiler/Checking/SignatureConformance.fs
+++ b/src/Compiler/Checking/SignatureConformance.fs
@@ -187,26 +187,26 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
             else 
                 let aenv = aenv.BindEquivTypars implTypars sigTypars 
 
-                let aintfs = implTycon.ImmediateInterfaceTypesOfFSharpTycon 
-                let fintfs = sigTycon.ImmediateInterfaceTypesOfFSharpTycon 
-                let aintfsUser = implTycon.TypeContents.tcaug_interfaces |> List.filter (fun (_, compgen, _) -> not compgen) |> List.map p13 
+                let implIntfTys = implTycon.ImmediateInterfaceTypesOfFSharpTycon 
+                let sigIntfTys = sigTycon.ImmediateInterfaceTypesOfFSharpTycon 
+                let implUserIntfTys = implTycon.TypeContents.tcaug_interfaces |> List.filter (fun (_, compgen, _) -> not compgen) |> List.map p13 
                 let flatten tys = 
                    tys 
                    |> List.collect (AllSuperTypesOfType g amap m AllowMultiIntfInstantiations.Yes) 
                    |> ListSet.setify (typeEquiv g) 
                    |> List.filter (isInterfaceTy g)
-                let aintfs     = flatten aintfs 
-                let fintfs     = flatten fintfs 
+                let implIntfTys     = flatten implIntfTys 
+                let sigIntfTys     = flatten sigIntfTys 
               
-                let unimpl = ListSet.subtract (fun fity aity -> typeAEquiv g aenv aity fity) fintfs aintfs
-                (unimpl 
+                let unimplIntfTys = ListSet.subtract (typeAEquiv g aenv) sigIntfTys implIntfTys
+                (unimplIntfTys 
                  |> List.forall (fun ity -> 
                     let errorMessage = FSComp.SR.DefinitionsInSigAndImplNotCompatibleMissingInterface(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName, NicePrint.minimalStringOfType denv ity)
                     errorR (Error(errorMessage, m)); false)) &&
                     
-                let aintfsUser = flatten aintfsUser
+                let implUserIntfTys = flatten implUserIntfTys
 
-                let hidden = ListSet.subtract (typeAEquiv g aenv) aintfsUser fintfs
+                let hidden = ListSet.subtract (typeAEquiv g aenv) implUserIntfTys sigIntfTys
                 let continueChecks, warningOrError = if implTycon.IsFSharpInterfaceTycon then false, errorR else true, warning
                 (hidden |> List.forall (fun ity -> warningOrError (InterfaceNotRevealed(denv, ity, implTycon.Range)); continueChecks)) &&
 
@@ -328,12 +328,12 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
             elif implVal.LiteralValue <> sigVal.LiteralValue then (err denv FSComp.SR.ValueNotContainedMutabilityLiteralConstantValuesDiffer)
             elif implVal.IsTypeFunction <> sigVal.IsTypeFunction then (err denv FSComp.SR.ValueNotContainedMutabilityOneIsTypeFunction)
             else 
-                let implTypars, atau = implVal.GeneralizedType
-                let sigTypars, ftau = sigVal.GeneralizedType
+                let implTypars, implValTy = implVal.GeneralizedType
+                let sigTypars, sigValTy = sigVal.GeneralizedType
                 if implTypars.Length <> sigTypars.Length then (err {denv with showTyparBinding=true} FSComp.SR.ValueNotContainedMutabilityParameterCountsDiffer) else
                 let aenv = aenv.BindEquivTypars implTypars sigTypars 
                 checkTypars m aenv implTypars sigTypars &&
-                if not (typeAEquiv g aenv atau ftau) then err denv FSComp.SR.ValueNotContainedMutabilityTypesDiffer
+                if not (typeAEquiv g aenv implValTy sigValTy) then err denv FSComp.SR.ValueNotContainedMutabilityTypesDiffer
                 elif not (checkValInfo aenv (err denv) implVal sigVal) then false
                 elif not (implVal.IsExtensionMember = sigVal.IsExtensionMember) then err denv FSComp.SR.ValueNotContainedMutabilityExtensionsDiffer
                 elif not (checkMemberDatasConform (err denv) (implVal.Attribs, implVal, implVal.MemberInfo) (sigVal.Attribs, sigVal, sigVal.MemberInfo)) then false

--- a/src/Compiler/Checking/SignatureConformance.fs
+++ b/src/Compiler/Checking/SignatureConformance.fs
@@ -198,7 +198,7 @@ type Checker(g, amap, denv, remapInfo: SignatureRepackageInfo, checkingSig) =
                 let implIntfTys     = flatten implIntfTys 
                 let sigIntfTys     = flatten sigIntfTys 
               
-                let unimplIntfTys = ListSet.subtract (typeAEquiv g aenv) sigIntfTys implIntfTys
+                let unimplIntfTys = ListSet.subtract (fun sigIntfTy implIntfTy -> typeAEquiv g aenv implIntfTy sigIntfTy) sigIntfTys implIntfTys
                 (unimplIntfTys 
                  |> List.forall (fun ity -> 
                     let errorMessage = FSComp.SR.DefinitionsInSigAndImplNotCompatibleMissingInterface(implTycon.TypeOrMeasureKind.ToString(), implTycon.DisplayName, NicePrint.minimalStringOfType denv ity)

--- a/src/Compiler/Checking/TypeHierarchy.fs
+++ b/src/Compiler/Checking/TypeHierarchy.fs
@@ -92,8 +92,8 @@ let GetImmediateInterfacesOfMetadataType g amap m skipUnref ty (tcref: TyconRef)
         match metadataOfTy g ty with
 #if !NO_TYPEPROVIDERS
         | ProvidedTypeMetadata info ->
-            for ity in info.ProvidedType.PApplyArray((fun st -> st.GetInterfaces()), "GetInterfaces", m) do
-                ImportProvidedType amap m ity
+            for intfTy in info.ProvidedType.PApplyArray((fun st -> st.GetInterfaces()), "GetInterfaces", m) do
+                ImportProvidedType amap m intfTy
 #endif
         | ILTypeMetadata (TILObjectReprData(scoref, _, tdef)) ->
             // ImportILType may fail for an interface if the assembly load set is incomplete and the interface
@@ -103,12 +103,12 @@ let GetImmediateInterfacesOfMetadataType g amap m skipUnref ty (tcref: TyconRef)
             // succeeded with more reported. There are pathological corner cases where this
             // doesn't apply: e.g. for mscorlib interfaces like IComparable, but we can always
             // assume those are present.
-            for ity in tdef.Implements do
-                if skipUnref = SkipUnrefInterfaces.No || CanRescopeAndImportILType scoref amap m ity then
-                    RescopeAndImportILType scoref amap m tinst ity
+            for intfTy in tdef.Implements do
+                if skipUnref = SkipUnrefInterfaces.No || CanRescopeAndImportILType scoref amap m intfTy then
+                    RescopeAndImportILType scoref amap m tinst intfTy
         | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata ->
-            for ity in tcref.ImmediateInterfaceTypesOfFSharpTycon do
-               instType (mkInstForAppTy g ty) ity ]
+            for intfTy in tcref.ImmediateInterfaceTypesOfFSharpTycon do
+               instType (mkInstForAppTy g ty) intfTy ]
 
 /// Collect the set of immediate declared interface types for an F# type, but do not
 /// traverse the type hierarchy to collect further interfaces.
@@ -163,10 +163,10 @@ let rec GetImmediateInterfacesOfType skipUnref g amap m ty =
 and GetImmediateInterfacesOfMeasureAnnotatedType skipUnref g amap m ty reprTy =
     [
         // Report any interfaces that don't derive from IComparable<_> or IEquatable<_>
-        for ity in GetImmediateInterfacesOfType skipUnref g amap m reprTy do
-            if not (ExistsHeadTypeInInterfaceHierarchy g.system_GenericIComparable_tcref skipUnref g amap m ity) &&
-               not (ExistsHeadTypeInInterfaceHierarchy g.system_GenericIEquatable_tcref skipUnref g amap m ity) then
-                ity
+        for intfTy in GetImmediateInterfacesOfType skipUnref g amap m reprTy do
+            if not (ExistsHeadTypeInInterfaceHierarchy g.system_GenericIComparable_tcref skipUnref g amap m intfTy) &&
+               not (ExistsHeadTypeInInterfaceHierarchy g.system_GenericIEquatable_tcref skipUnref g amap m intfTy) then
+                intfTy
 
         // NOTE: we should really only report the IComparable<A<'m>> interface for measure-annotated types
         // if the original type supports IComparable<A> somewhere in the hierarchy, likeiwse IEquatable<A<'m>>.
@@ -181,15 +181,15 @@ and GetImmediateInterfacesOfMeasureAnnotatedType skipUnref g amap m ty reprTy =
     ]
 
 // Check for IComparable<A>, IEquatable<A> and interfaces that derive from these
-and ExistsHeadTypeInInterfaceHierarchy target skipUnref g amap m ity =
-    ExistsInInterfaceHierarchy (function AppTy g (tcref,_) -> tyconRefEq g tcref target | _ -> false) skipUnref g amap m ity
+and ExistsHeadTypeInInterfaceHierarchy target skipUnref g amap m intfTy =
+    ExistsInInterfaceHierarchy (function AppTy g (tcref,_) -> tyconRefEq g tcref target | _ -> false) skipUnref g amap m intfTy
 
 // Check for IComparable<A>, IEquatable<A> and interfaces that derive from these
-and ExistsInInterfaceHierarchy p skipUnref g amap m ity =
-    match ity with
+and ExistsInInterfaceHierarchy p skipUnref g amap m intfTy =
+    match intfTy with
     | AppTy g (tcref, tinst) ->
-        p ity ||
-        (GetImmediateInterfacesOfMetadataType g amap m skipUnref ity tcref tinst 
+        p intfTy ||
+        (GetImmediateInterfacesOfMetadataType g amap m skipUnref intfTy tcref tinst 
          |> List.exists (ExistsInInterfaceHierarchy p skipUnref g amap m))
     | _ -> false
 
@@ -369,14 +369,14 @@ let CopyTyparConstraints m tprefInst (tporig: Typar) =
                TyparConstraint.DefaultsTo (priority, instType tprefInst ty, m)
            | TyparConstraint.SupportsNull _ ->
                TyparConstraint.SupportsNull m
-           | TyparConstraint.IsEnum (uty, _) ->
-               TyparConstraint.IsEnum (instType tprefInst uty, m)
+           | TyparConstraint.IsEnum (underlyingTy, _) ->
+               TyparConstraint.IsEnum (instType tprefInst underlyingTy, m)
            | TyparConstraint.SupportsComparison _ ->
                TyparConstraint.SupportsComparison m
            | TyparConstraint.SupportsEquality _ ->
                TyparConstraint.SupportsEquality m
-           | TyparConstraint.IsDelegate(aty, bty, _) ->
-               TyparConstraint.IsDelegate (instType tprefInst aty, instType tprefInst bty, m)
+           | TyparConstraint.IsDelegate(argTys, retTy, _) ->
+               TyparConstraint.IsDelegate (instType tprefInst argTys, instType tprefInst retTy, m)
            | TyparConstraint.IsNonNullableStruct _ ->
                TyparConstraint.IsNonNullableStruct m
            | TyparConstraint.IsUnmanaged _ ->

--- a/src/Compiler/Checking/TypeRelations.fs
+++ b/src/Compiler/Checking/TypeRelations.fs
@@ -46,24 +46,25 @@ let rec TypeDefinitelySubsumesTypeNoCoercion ndeep g amap m ty1 ty2 =
 
 type CanCoerce = CanCoerce | NoCoerce
 
+let stripAll stripMeasures g ty =
+    if stripMeasures then
+        ty |> stripTyEqnsWrtErasure EraseAll g |> stripMeasuresFromTy g
+    else
+        ty |> stripTyEqns g
+
 /// The feasible equivalence relation. Part of the language spec.
 let rec TypesFeasiblyEquivalent stripMeasures ndeep g amap m ty1 ty2 = 
 
     if ndeep > 100 then error(InternalError("recursive class hierarchy (detected in TypeFeasiblySubsumesType), ty1 = " + (DebugPrint.showType ty1), m));
-    let stripAll ty =
-        if stripMeasures then
-            ty |> stripTyEqnsWrtErasure EraseAll g |> stripMeasuresFromTType g
-        else
-            ty |> stripTyEqns g
 
-    let ty1str = stripAll ty1
-    let ty2str = stripAll ty2
+    let ty1 = stripAll stripMeasures g ty1
+    let ty2 = stripAll stripMeasures g ty2
 
-    match ty1str, ty2str with
+    match ty1, ty2 with
     | TType_var _, _  
     | _, TType_var _ -> true
 
-    | TType_app (tc1, l1, _), TType_app (tc2, l2, _) when tyconRefEq g tc1 tc2 ->
+    | TType_app (tcref1, l1, _), TType_app (tcref2, l2, _) when tyconRefEq g tcref1 tcref2 ->
         List.lengthsEqAndForall2 (TypesFeasiblyEquivalent stripMeasures ndeep g amap m) l1 l2
 
     | TType_anon (anonInfo1, l1),TType_anon (anonInfo2, l2)      -> 
@@ -76,9 +77,9 @@ let rec TypesFeasiblyEquivalent stripMeasures ndeep g amap m ty1 ty2 =
         evalTupInfoIsStruct tupInfo1 = evalTupInfoIsStruct tupInfo2 &&
         List.lengthsEqAndForall2 (TypesFeasiblyEquivalent stripMeasures ndeep g amap m) l1 l2 
 
-    | TType_fun (d1, r1, _), TType_fun (d2, r2, _) -> 
-        TypesFeasiblyEquivalent stripMeasures ndeep g amap m d1 d2 &&
-        TypesFeasiblyEquivalent stripMeasures ndeep g amap m r1 r2
+    | TType_fun (domainTy1, rangeTy1, _), TType_fun (domainTy2, rangeTy2, _) -> 
+        TypesFeasiblyEquivalent stripMeasures ndeep g amap m domainTy1 domainTy2 &&
+        TypesFeasiblyEquivalent stripMeasures ndeep g amap m rangeTy1 rangeTy2
 
     | TType_measure _, TType_measure _ ->
         true
@@ -133,51 +134,51 @@ let rec TypeFeasiblySubsumesType ndeep g amap m ty1 canCoerce ty2 =
 /// Here x gets a generalized type "list<'T>".
 let ChooseTyparSolutionAndRange (g: TcGlobals) amap (tp:Typar) =
     let m = tp.Range
-    let max, m = 
-         let initial = 
+    let maxTy, m = 
+         let initialTy = 
              match tp.Kind with 
              | TyparKind.Type -> g.obj_ty 
              | TyparKind.Measure -> TType_measure Measure.One
          // Loop through the constraints computing the lub
-         ((initial, m), tp.Constraints) ||> List.fold (fun (maxSoFar, _) tpc -> 
+         ((initialTy, m), tp.Constraints) ||> List.fold (fun (maxTy, _) tpc -> 
              let join m x = 
-                 if TypeFeasiblySubsumesType 0 g amap m x CanCoerce maxSoFar then maxSoFar
-                 elif TypeFeasiblySubsumesType 0 g amap m maxSoFar CanCoerce x then x
-                 else errorR(Error(FSComp.SR.typrelCannotResolveImplicitGenericInstantiation((DebugPrint.showType x), (DebugPrint.showType maxSoFar)), m)); maxSoFar
+                 if TypeFeasiblySubsumesType 0 g amap m x CanCoerce maxTy then maxTy
+                 elif TypeFeasiblySubsumesType 0 g amap m maxTy CanCoerce x then x
+                 else errorR(Error(FSComp.SR.typrelCannotResolveImplicitGenericInstantiation((DebugPrint.showType x), (DebugPrint.showType maxTy)), m)); maxTy
              // Don't continue if an error occurred and we set the value eagerly 
-             if tp.IsSolved then maxSoFar, m else
+             if tp.IsSolved then maxTy, m else
              match tpc with 
              | TyparConstraint.CoercesTo(x, m) -> 
                  join m x, m
              | TyparConstraint.MayResolveMember(_traitInfo, m) -> 
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.SimpleChoice(_, m) -> 
                  errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInPrintf(), m))
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.SupportsNull m -> 
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.SupportsComparison m -> 
                  join m g.mk_IComparable_ty, m
              | TyparConstraint.SupportsEquality m -> 
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.IsEnum(_, m) -> 
                  errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInEnum(), m))
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.IsDelegate(_, _, m) -> 
                  errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInDelegate(), m))
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.IsNonNullableStruct m -> 
                  join m g.int_ty, m
              | TyparConstraint.IsUnmanaged m ->
                  errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInUnmanaged(), m))
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.RequiresDefaultConstructor m -> 
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.IsReferenceType m -> 
-                 maxSoFar, m
+                 maxTy, m
              | TyparConstraint.DefaultsTo(_priority, _ty, m) -> 
-                 maxSoFar, m)
-    max, m
+                 maxTy, m)
+    maxTy, m
 
 let ChooseTyparSolution g amap tp = 
     let ty, _m = ChooseTyparSolutionAndRange g amap tp
@@ -249,11 +250,11 @@ let tryDestTopLambda g amap (ValReprInfo (tpNames, _, _) as tvd) (e, ty) =
             (None, None, [], e, ty)
 
     let n = tvd.NumCurriedArgs
-    let tps, taue, tauty = 
+    let tps, bodyExpr, bodyTy = 
         match stripDebugPoints e with 
         | Expr.TyLambda (_, tps, b, _, retTy) when not (isNil tpNames) -> tps, b, retTy 
         | _ -> [], e, ty
-    let ctorThisValOpt, baseValOpt, vsl, body, retTy = startStripLambdaUpto n (taue, tauty)
+    let ctorThisValOpt, baseValOpt, vsl, body, retTy = startStripLambdaUpto n (bodyExpr, bodyTy)
     if vsl.Length <> n then 
         None 
     else

--- a/src/Compiler/Checking/import.fs
+++ b/src/Compiler/Checking/import.fs
@@ -174,8 +174,8 @@ let rec ImportILType (env: ImportMap) m tinst ty =
 
     | ILType.Array(bounds, ty) -> 
         let n = bounds.Rank
-        let elementType = ImportILType env m tinst ty
-        mkArrayTy env.g n elementType m
+        let elemTy = ImportILType env m tinst ty
+        mkArrayTy env.g n elemTy m
 
     | ILType.Boxed  tspec | ILType.Value tspec ->
         let tcref = ImportILTypeRef env m tspec.TypeRef 
@@ -335,10 +335,10 @@ let rec ImportProvidedType (env: ImportMap) (m: range) (* (tinst: TypeInst) *) (
                 if tp.Kind = TyparKind.Measure then  
                     let rec conv ty = 
                         match ty with 
-                        | TType_app (tcref, [t1;t2], _) when tyconRefEq g tcref g.measureproduct_tcr -> Measure.Prod (conv t1, conv t2)
-                        | TType_app (tcref, [t1], _) when tyconRefEq g tcref g.measureinverse_tcr -> Measure.Inv (conv t1)
+                        | TType_app (tcref, [ty1;ty2], _) when tyconRefEq g tcref g.measureproduct_tcr -> Measure.Prod (conv ty1, conv ty2)
+                        | TType_app (tcref, [ty1], _) when tyconRefEq g tcref g.measureinverse_tcr -> Measure.Inv (conv ty1)
                         | TType_app (tcref, [], _) when tyconRefEq g tcref g.measureone_tcr -> Measure.One 
-                        | TType_app (tcref, [], _) when tcref.TypeOrMeasureKind = TyparKind.Measure -> Measure.Con tcref
+                        | TType_app (tcref, [], _) when tcref.TypeOrMeasureKind = TyparKind.Measure -> Measure.Const tcref
                         | TType_app (tcref, _, _) -> 
                             errorR(Error(FSComp.SR.impInvalidMeasureArgument1(tcref.CompiledName, tp.Name), m))
                             Measure.One

--- a/src/Compiler/Checking/infos.fs
+++ b/src/Compiler/Checking/infos.fs
@@ -55,7 +55,7 @@ type ValRef with
         | Some membInfo ->
         not membInfo.MemberFlags.IsDispatchSlot &&
         (match membInfo.ImplementedSlotSigs with
-         | TSlotSig(_, oty, _, _, _, _) :: _ -> isInterfaceTy g oty
+         | slotSig :: _ -> isInterfaceTy g slotSig.DeclaringType
          | [] -> false)
 
     member vref.ImplementedSlotSignatures =
@@ -312,8 +312,8 @@ let OptionalArgInfoOfProvidedParameter (amap: ImportMap) m (provParam : Tainted<
                 elif isObjTy g ty then MissingValue
                 else  DefaultValue
 
-            let pty = ImportProvidedType amap m (provParam.PApply((fun p -> p.ParameterType), m))
-            CallerSide (analyze pty)
+            let paramTy = ImportProvidedType amap m (provParam.PApply((fun p -> p.ParameterType), m))
+            CallerSide (analyze paramTy)
         | _ ->
             let v = provParam.PUntaint((fun p ->  p.RawDefaultValue), m)
             CallerSide (Constant (ILFieldInit.FromProvidedObj m v))
@@ -1217,8 +1217,8 @@ type MethInfo =
                     let formalRetTy = ImportReturnTypeFromMetadata amap m ilminfo.RawMetadata.Return.Type (fun _ -> ilminfo.RawMetadata.Return.CustomAttrs) ftinfo.ILScopeRef ftinfo.TypeInstOfRawMetadata formalMethTyparTys
                     let formalParams =
                         [ [ for p in ilminfo.RawMetadata.Parameters do
-                                let paramType = ImportILTypeFromMetadataWithAttributes amap m ftinfo.ILScopeRef ftinfo.TypeInstOfRawMetadata formalMethTyparTys p.Type (fun _ -> p.CustomAttrs)
-                                yield TSlotParam(p.Name, paramType, p.IsIn, p.IsOut, p.IsOptional, []) ] ]
+                                let paramTy = ImportILTypeFromMetadataWithAttributes amap m ftinfo.ILScopeRef ftinfo.TypeInstOfRawMetadata formalMethTyparTys p.Type (fun _ -> p.CustomAttrs)
+                                yield TSlotParam(p.Name, paramTy, p.IsIn, p.IsOut, p.IsOptional, []) ] ]
                     formalRetTy, formalParams
 #if !NO_TYPEPROVIDERS
                 | ProvidedMeth (_, mi, _, _) ->
@@ -1230,9 +1230,9 @@ type MethInfo =
                     let formalParams =
                         [ [ for p in mi.PApplyArray((fun mi -> mi.GetParameters()), "GetParameters", m) do
                                 let paramName = p.PUntaint((fun p -> match p.Name with null -> None | s -> Some s), m)
-                                let paramType = ImportProvidedType amap m (p.PApply((fun p -> p.ParameterType), m))
+                                let paramTy = ImportProvidedType amap m (p.PApply((fun p -> p.ParameterType), m))
                                 let isIn, isOut, isOptional = p.PUntaint((fun p -> p.IsIn, p.IsOut, p.IsOptional), m)
-                                yield TSlotParam(paramName, paramType, isIn, isOut, isOptional, []) ] ]
+                                yield TSlotParam(paramName, paramTy, isIn, isOut, isOptional, []) ] ]
                     formalRetTy, formalParams
 #endif
                 | _ -> failwith "unreachable"
@@ -1256,15 +1256,15 @@ type MethInfo =
             | ProvidedMeth(amap, mi, _, _) ->
                 // A single set of tupled parameters
                 [ [for p in mi.PApplyArray((fun mi -> mi.GetParameters()), "GetParameters", m) do
-                        let pname =
+                        let paramName =
                             match p.PUntaint((fun p -> p.Name), m) with
                             | null -> None
                             | name -> Some (mkSynId m name)
-                        let pty =
+                        let paramTy =
                             match p.PApply((fun p -> p.ParameterType), m) with
                             | Tainted.Null ->  amap.g.unit_ty
                             | parameterType -> ImportProvidedType amap m parameterType
-                        yield ParamNameAndType(pname, pty) ] ]
+                        yield ParamNameAndType(paramName, paramTy) ] ]
 
 #endif
 
@@ -1866,14 +1866,14 @@ type PropInfo =
         | ProvidedProp (_, pi, m) ->
             [ for p in pi.PApplyArray((fun pi -> pi.GetIndexParameters()), "GetIndexParameters", m) do
                 let paramName = p.PUntaint((fun p -> match p.Name with null -> None | s -> Some (mkSynId m s)), m)
-                let paramType = ImportProvidedType amap m (p.PApply((fun p -> p.ParameterType), m))
-                yield ParamNameAndType(paramName, paramType) ]
+                let paramTy = ImportProvidedType amap m (p.PApply((fun p -> p.ParameterType), m))
+                yield ParamNameAndType(paramName, paramTy) ]
 #endif
 
     /// Get the details of the indexer parameters associated with the property
     member x.GetParamDatas(amap, m) =
         x.GetParamNamesAndTypes(amap, m)
-        |> List.map (fun (ParamNameAndType(nmOpt, pty)) -> ParamData(false, false, false, NotOptional, NoCallerInfo, nmOpt, ReflectedArgInfo.None, pty))
+        |> List.map (fun (ParamNameAndType(nmOpt, paramTy)) -> ParamData(false, false, false, NotOptional, NoCallerInfo, nmOpt, ReflectedArgInfo.None, paramTy))
 
     /// Get the types of the indexer parameters associated with the property
     member x.GetParamTypes(amap, m) =
@@ -1908,14 +1908,16 @@ type PropInfo =
     /// Uses the same techniques as 'MethInfosUseIdenticalDefinitions'.
     /// Must be compatible with ItemsAreEffectivelyEqual relation.
     static member PropInfosUseIdenticalDefinitions x1 x2 =
+
         let optVrefEq g = function
-          | Some v1, Some v2 -> valRefEq g v1 v2
+          | Some vref1, Some vref2 -> valRefEq g vref1 vref2
           | None, None -> true
           | _ -> false
+
         match x1, x2 with
         | ILProp ilpinfo1, ILProp ilpinfo2 -> (ilpinfo1.RawMetadata === ilpinfo2.RawMetadata)
         | FSProp(g, _, vrefa1, vrefb1), FSProp(_, _, vrefa2, vrefb2) ->
-            (optVrefEq g (vrefa1, vrefa2)) && (optVrefEq g (vrefb1, vrefb2))
+            optVrefEq g (vrefa1, vrefa2) && optVrefEq g (vrefb1, vrefb2)
 #if !NO_TYPEPROVIDERS
         | ProvidedProp(_, pi1, _), ProvidedProp(_, pi2, _) -> ProvidedPropertyInfo.TaintedEquals (pi1, pi2)
 #endif
@@ -1927,7 +1929,7 @@ type PropInfo =
         | ILProp ilpinfo -> hash ilpinfo.RawMetadata.Name
         | FSProp(_, _, vrefOpt1, vrefOpt2) ->
             // Hash on string option * string option
-            let vth = (vrefOpt1 |> Option.map (fun vr -> vr.LogicalName), (vrefOpt2 |> Option.map (fun vr -> vr.LogicalName)))
+            let vth = (vrefOpt1 |> Option.map (fun vr -> vr.LogicalName), (vrefOpt2 |> Option.map (fun vref -> vref.LogicalName)))
             hash vth
 #if !NO_TYPEPROVIDERS
         | ProvidedProp(_, pi, _) -> ProvidedPropertyInfo.TaintedGetHashCode pi

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -164,7 +164,7 @@ type AttributeDecoder(namedArgs) =
 
     let findTyconRef x =
         match NameMap.tryFind x nameMap with
-        | Some (AttribExpr (_, Expr.App (_, _, [ TType_app (tr, _, _) ], _, _))) -> Some tr
+        | Some (AttribExpr (_, Expr.App (_, _, [ TType_app (tcref, _, _) ], _, _))) -> Some tcref
         | _ -> None
 
     member _.FindInt16 x dflt =
@@ -571,7 +571,7 @@ type TypeReprEnv(reprs: Map<Stamp, uint16>, count: int, templateReplacement: (Ty
     member eenv.ForTycon(tycon: Tycon) = eenv.ForTypars tycon.TyparsNoRange
 
     /// Get the environment for generating a reference to items within a type definition
-    member eenv.ForTyconRef(tycon: TyconRef) = eenv.ForTycon tycon.Deref
+    member eenv.ForTyconRef(tcref: TyconRef) = eenv.ForTycon tcref.Deref
 
 //--------------------------------------------------------------------------
 // Generate type references
@@ -2162,16 +2162,16 @@ type AssemblyBuilder(cenv: cenv, anonTypeTable: AnonTypeGenerationTable) as mgbu
                 )
 
             let tcref = mkLocalTyconRef tycon
-            let typ = generalizedTyconRef g tcref
+            let ty = generalizedTyconRef g tcref
             let tcaug = tcref.TypeContents
 
             tcaug.tcaug_interfaces <-
                 [
                     (g.mk_IStructuralComparable_ty, true, m)
                     (g.mk_IComparable_ty, true, m)
-                    (mkAppTy g.system_GenericIComparable_tcref [ typ ], true, m)
+                    (mkAppTy g.system_GenericIComparable_tcref [ ty ], true, m)
                     (g.mk_IStructuralEquatable_ty, true, m)
-                    (mkAppTy g.system_GenericIEquatable_tcref [ typ ], true, m)
+                    (mkAppTy g.system_GenericIEquatable_tcref [ ty ], true, m)
                 ]
 
             let vspec1, vspec2 = AugmentWithHashCompare.MakeValsForEqualsAugmentation g tcref
@@ -2200,7 +2200,7 @@ type AssemblyBuilder(cenv: cenv, anonTypeTable: AnonTypeGenerationTable) as mgbu
 
             let ilInterfaceTys =
                 [
-                    for ity, _, _ in tcaug.tcaug_interfaces -> GenType cenv m (TypeReprEnv.Empty.ForTypars tps) ity
+                    for intfTy, _, _ in tcaug.tcaug_interfaces -> GenType cenv m (TypeReprEnv.Empty.ForTypars tps) intfTy
                 ]
 
             let ilTypeDef =
@@ -2959,7 +2959,7 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr (sequel: sequel) =
             match op, args, tyargs with
             | TOp.ExnConstr c, _, _ -> GenAllocExn cenv cgbuf eenv (c, args, m) sequel
             | TOp.UnionCase c, _, _ -> GenAllocUnionCase cenv cgbuf eenv (c, tyargs, args, m) sequel
-            | TOp.Recd (isCtor, tycon), _, _ -> GenAllocRecd cenv cgbuf eenv isCtor (tycon, tyargs, args, m) sequel
+            | TOp.Recd (isCtor, tcref), _, _ -> GenAllocRecd cenv cgbuf eenv isCtor (tcref, tyargs, args, m) sequel
             | TOp.AnonRecd anonInfo, _, _ -> GenAllocAnonRecd cenv cgbuf eenv (anonInfo, tyargs, args, m) sequel
             | TOp.AnonRecdGet (anonInfo, n), [ e ], _ -> GenGetAnonRecdField cenv cgbuf eenv (anonInfo, e, tyargs, n, m) sequel
             | TOp.TupleFieldGet (tupInfo, n), [ e ], _ -> GenGetTupleField cenv cgbuf eenv (tupInfo, e, tyargs, n, m) sequel
@@ -2986,10 +2986,10 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr (sequel: sequel) =
               [] -> GenIntegerForLoop cenv cgbuf eenv (spFor, spTo, v, e1, dir, e2, e3, m) sequel
             | TOp.TryFinally (spTry, spFinally),
               [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ _ ], e2, _, _) ],
-              [ resty ] -> GenTryFinally cenv cgbuf eenv (e1, e2, m, resty, spTry, spFinally) sequel
+              [ resTy ] -> GenTryFinally cenv cgbuf eenv (e1, e2, m, resTy, spTry, spFinally) sequel
             | TOp.TryWith (spTry, spWith),
               [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ vf ], ef, _, _); Expr.Lambda (_, _, _, [ vh ], eh, _, _) ],
-              [ resty ] -> GenTryWith cenv cgbuf eenv (e1, vf, ef, vh, eh, m, resty, spTry, spWith) sequel
+              [ resTy ] -> GenTryWith cenv cgbuf eenv (e1, vf, ef, vh, eh, m, resTy, spTry, spWith) sequel
             | TOp.ILCall (isVirtual, _, isStruct, isCtor, valUseFlag, _, noTailCall, ilMethRef, enclTypeInst, methInst, returnTypes),
               args,
               [] ->
@@ -3000,8 +3000,8 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr (sequel: sequel) =
                     (isVirtual, isStruct, isCtor, valUseFlag, noTailCall, ilMethRef, enclTypeInst, methInst, args, returnTypes, m)
                     sequel
             | TOp.RefAddrGet _readonly, [ e ], [ ty ] -> GenGetAddrOfRefCellField cenv cgbuf eenv (e, ty, m) sequel
-            | TOp.Coerce, [ e ], [ tgty; srcty ] -> GenCoerce cenv cgbuf eenv (e, tgty, m, srcty) sequel
-            | TOp.Reraise, [], [ rtnty ] -> GenReraise cenv cgbuf eenv (rtnty, m) sequel
+            | TOp.Coerce, [ e ], [ tgtTy; srcTy ] -> GenCoerce cenv cgbuf eenv (e, tgtTy, m, srcTy) sequel
+            | TOp.Reraise, [], [ retTy ] -> GenReraise cenv cgbuf eenv (retTy, m) sequel
             | TOp.TraitCall traitInfo, args, [] -> GenTraitCall cenv cgbuf eenv (traitInfo, args, m) expr sequel
             | TOp.LValueOp (LSet, v), [ e ], [] -> GenSetVal cenv cgbuf eenv (v, e, m) sequel
             | TOp.LValueOp (LByrefGet, v), [], [] -> GenGetByref cenv cgbuf eenv (v, m) sequel
@@ -3271,17 +3271,17 @@ and GenGetTupleField cenv cgbuf eenv (tupInfo, e, tys, n, m) sequel =
         if ar <= 0 then
             failwith "getCompiledTupleItem"
         elif ar < maxTuple then
-            let tcr' = mkCompiledTupleTyconRef g tupInfo ar
-            let ty = GenNamedTyApp cenv m eenv.tyenv tcr' tys
+            let tcref = mkCompiledTupleTyconRef g tupInfo ar
+            let ty = GenNamedTyApp cenv m eenv.tyenv tcref tys
             mkGetTupleItemN g m n ty tupInfo e tys[n]
         else
             let tysA, tysB = List.splitAfter goodTupleFields tys
             let tyB = mkCompiledTupleTy g tupInfo tysB
-            let tys' = tysA @ [ tyB ]
-            let tcr' = mkCompiledTupleTyconRef g tupInfo (List.length tys')
-            let ty' = GenNamedTyApp cenv m eenv.tyenv tcr' tys'
-            let n' = (min n goodTupleFields)
-            let elast = mkGetTupleItemN g m n' ty' tupInfo e tys'[n']
+            let tysC = tysA @ [ tyB ]
+            let tcref = mkCompiledTupleTyconRef g tupInfo (List.length tysC)
+            let tyR = GenNamedTyApp cenv m eenv.tyenv tcref tysC
+            let nR = min n goodTupleFields
+            let elast = mkGetTupleItemN g m nR tyR tupInfo e tysC[nR]
 
             if n < goodTupleFields then
                 elast
@@ -3664,16 +3664,16 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
         else
             GenNewArraySimple cenv cgbuf eenv (elems, elemTy, m) sequel
 
-and GenCoerce cenv cgbuf eenv (e, tgty, m, srcty) sequel =
+and GenCoerce cenv cgbuf eenv (e, tgtTy, m, srcTy) sequel =
     let g = cenv.g
     // Is this an upcast?
-    if TypeDefinitelySubsumesTypeNoCoercion 0 g cenv.amap m tgty srcty
+    if TypeDefinitelySubsumesTypeNoCoercion 0 g cenv.amap m tgtTy srcTy
        &&
        // Do an extra check - should not be needed
-       TypeFeasiblySubsumesType 0 g cenv.amap m tgty NoCoerce srcty then
-        if isInterfaceTy g tgty then
+       TypeFeasiblySubsumesType 0 g cenv.amap m tgtTy NoCoerce srcTy then
+        if isInterfaceTy g tgtTy then
             GenExpr cenv cgbuf eenv e Continue
-            let ilToTy = GenType cenv m eenv.tyenv tgty
+            let ilToTy = GenType cenv m eenv.tyenv tgtTy
             // Section "III.1.8.1.3 Merging stack states" of ECMA-335 implies that no unboxing
             // is required, but we still push the coerced type on to the code gen buffer.
             CG.EmitInstrs cgbuf (pop 1) (Push [ ilToTy ]) []
@@ -3683,18 +3683,18 @@ and GenCoerce cenv cgbuf eenv (e, tgty, m, srcty) sequel =
     else
         GenExpr cenv cgbuf eenv e Continue
 
-        if not (isObjTy g srcty) then
-            let ilFromTy = GenType cenv m eenv.tyenv srcty
+        if not (isObjTy g srcTy) then
+            let ilFromTy = GenType cenv m eenv.tyenv srcTy
             CG.EmitInstr cgbuf (pop 1) (Push [ g.ilg.typ_Object ]) (I_box ilFromTy)
 
-        if not (isObjTy g tgty) then
-            let ilToTy = GenType cenv m eenv.tyenv tgty
+        if not (isObjTy g tgtTy) then
+            let ilToTy = GenType cenv m eenv.tyenv tgtTy
             CG.EmitInstr cgbuf (pop 1) (Push [ ilToTy ]) (I_unbox_any ilToTy)
 
         GenSequel cenv eenv.cloc cgbuf sequel
 
-and GenReraise cenv cgbuf eenv (rtnty, m) sequel =
-    let ilReturnTy = GenType cenv m eenv.tyenv rtnty
+and GenReraise cenv cgbuf eenv (retTy, m) sequel =
+    let ilReturnTy = GenType cenv m eenv.tyenv retTy
     CG.EmitInstr cgbuf (pop 0) Push0 I_rethrow
     // [See comment related to I_throw].
     // Rethrow does not return. Required to push dummy value on the stack.
@@ -4512,14 +4512,14 @@ and GenNamedLocalTyFuncCall cenv (cgbuf: CodeGenBuffer) eenv ty cloinfo tyargs m
     actualRetTy
 
 /// Generate an indirect call, converting to an ILX callfunc instruction
-and GenCurriedArgsAndIndirectCall cenv cgbuf eenv (functy, tyargs, curriedArgs, m) sequel =
+and GenCurriedArgsAndIndirectCall cenv cgbuf eenv (funcTy, tyargs, curriedArgs, m) sequel =
 
     // Generate the curried arguments to the indirect call
     GenExprs cenv cgbuf eenv curriedArgs
-    GenIndirectCall cenv cgbuf eenv (functy, tyargs, curriedArgs, m) sequel
+    GenIndirectCall cenv cgbuf eenv (funcTy, tyargs, curriedArgs, m) sequel
 
 /// Generate an indirect call, converting to an ILX callfunc instruction
-and GenIndirectCall cenv cgbuf eenv (functy, tyargs, curriedArgs, m) sequel =
+and GenIndirectCall cenv cgbuf eenv (funcTy, tyargs, curriedArgs, m) sequel =
     let g = cenv.g
 
     // Fold in the new types into the environment as we generate the formal types.
@@ -4527,7 +4527,7 @@ and GenIndirectCall cenv cgbuf eenv (functy, tyargs, curriedArgs, m) sequel =
         // keep only non-erased type arguments when computing indirect call
         let tyargs = DropErasedTyargs tyargs
 
-        let typars, formalFuncTy = tryDestForallTy g functy
+        let typars, formalFuncTy = tryDestForallTy g funcTy
 
         let feenv = eenv.tyenv.Add typars
 
@@ -4542,7 +4542,7 @@ and GenIndirectCall cenv cgbuf eenv (functy, tyargs, curriedArgs, m) sequel =
 
         List.foldBack (fun tyarg acc -> Apps_tyapp(GenType cenv m eenv.tyenv tyarg, acc)) tyargs (appBuilder ilxRetApps)
 
-    let actualRetTy = applyTys g functy (tyargs, curriedArgs)
+    let actualRetTy = applyTys g funcTy (tyargs, curriedArgs)
     let ilActualRetTy = GenType cenv m eenv.tyenv actualRetTy
 
     // Check if any byrefs are involved to make sure we don't tailcall
@@ -4684,14 +4684,14 @@ and eligibleForFilter (cenv: cenv) expr =
     && not isTrivial
     && check expr
 
-and GenTryWith cenv cgbuf eenv (e1, valForFilter: Val, filterExpr, valForHandler: Val, handlerExpr, m, resty, spTry, spWith) sequel =
+and GenTryWith cenv cgbuf eenv (e1, valForFilter: Val, filterExpr, valForHandler: Val, handlerExpr, m, resTy, spTry, spWith) sequel =
     let g = cenv.g
 
     // Save the stack - gross because IL flushes the stack at the exn. handler
     // note: eenvinner notes spill vars are live
     LocalScope "trystack" cgbuf (fun scopeMarks ->
         let whereToSaveOpt, eenvinner, stack, tryMarks, afterHandler =
-            GenTry cenv cgbuf eenv scopeMarks (e1, m, resty, spTry)
+            GenTry cenv cgbuf eenv scopeMarks (e1, m, resTy, spTry)
 
         let seh =
             if cenv.options.generateFilterBlocks || eligibleForFilter cenv filterExpr then
@@ -4798,13 +4798,13 @@ and GenTryWith cenv cgbuf eenv (e1, valForFilter: Val, filterExpr, valForHandler
             GenSequel cenv eenv.cloc cgbuf sequel
         | None -> GenUnitThenSequel cenv eenv m eenv.cloc cgbuf sequel)
 
-and GenTryFinally cenv cgbuf eenv (bodyExpr, handlerExpr, m, resty, spTry, spFinally) sequel =
+and GenTryFinally cenv cgbuf eenv (bodyExpr, handlerExpr, m, resTy, spTry, spFinally) sequel =
     // Save the stack - needed because IL flushes the stack at the exn. handler
     // note: eenvinner notes spill vars are live
     LocalScope "trystack" cgbuf (fun scopeMarks ->
 
         let whereToSaveOpt, eenvinner, stack, tryMarks, afterHandler =
-            GenTry cenv cgbuf eenv scopeMarks (bodyExpr, m, resty, spTry)
+            GenTry cenv cgbuf eenv scopeMarks (bodyExpr, m, resTy, spTry)
 
         // Now the catch/finally block
         let startOfHandler = CG.GenerateMark cgbuf "startOfHandler"
@@ -7494,8 +7494,8 @@ and GenDecisionTreeSwitch
                         CG.EmitInstr cgbuf (pop 1) (Push [ g.ilg.typ_Object ]) (I_box ilFromTy)
 
                     BI_brfalse
-                | DecisionTreeTest.IsInst (_srcty, tgty) ->
-                    let e = mkCallTypeTest g m tgty e
+                | DecisionTreeTest.IsInst (_srcTy, tgtTy) ->
+                    let e = mkCallTypeTest g m tgtTy e
                     GenExpr cenv cgbuf eenv e Continue
                     BI_brtrue
                 | _ -> failwith "internal error: GenDecisionTreeSwitch"
@@ -9433,7 +9433,7 @@ and AllocLocal cenv cgbuf eenv compgen (v, ty, isFixed) (scopeMarks: Mark * Mark
     let j, realloc =
         if cenv.options.localOptimizationsEnabled then
             cgbuf.ReallocLocal(
-                (fun i (_, ty', isFixed') -> not isFixed' && not isFixed && not (IntMap.mem i eenv.liveLocals) && (ty = ty')),
+                (fun i (_, ty2, isFixed2) -> not isFixed2 && not isFixed && not (IntMap.mem i eenv.liveLocals) && (ty = ty2)),
                 ranges,
                 ty,
                 isFixed
@@ -10426,7 +10426,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
 
                             for slotsig in memberInfo.ImplementedSlotSigs do
 
-                                if isInterfaceTy g slotsig.ImplementedType then
+                                if isInterfaceTy g slotsig.DeclaringType then
 
                                     match vref.ValReprInfo with
                                     | Some _ ->

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -895,7 +895,8 @@ let OutputPhasedErrorR (os: StringBuilder) (diagnostic: PhasedDiagnostic) (canSu
 
         | ParameterlessStructCtor _ -> os.AppendString(ParameterlessStructCtorE().Format)
 
-        | InterfaceNotRevealed (denv, intfTy, _) -> os.AppendString(InterfaceNotRevealedE().Format(NicePrint.minimalStringOfType denv intfTy))
+        | InterfaceNotRevealed (denv, intfTy, _) ->
+            os.AppendString(InterfaceNotRevealedE().Format(NicePrint.minimalStringOfType denv intfTy))
 
         | NotAFunctionButIndexer (_, _, name, _, _, old) ->
             if old then

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -895,7 +895,7 @@ let OutputPhasedErrorR (os: StringBuilder) (diagnostic: PhasedDiagnostic) (canSu
 
         | ParameterlessStructCtor _ -> os.AppendString(ParameterlessStructCtorE().Format)
 
-        | InterfaceNotRevealed (denv, ity, _) -> os.AppendString(InterfaceNotRevealedE().Format(NicePrint.minimalStringOfType denv ity))
+        | InterfaceNotRevealed (denv, intfTy, _) -> os.AppendString(InterfaceNotRevealedE().Format(NicePrint.minimalStringOfType denv intfTy))
 
         | NotAFunctionButIndexer (_, _, name, _, _, old) ->
             if old then
@@ -1501,7 +1501,7 @@ let OutputPhasedErrorR (os: StringBuilder) (diagnostic: PhasedDiagnostic) (canSu
                     |> List.exists (function
                         | TType_app (maybeUnit, [], _) ->
                             match maybeUnit.TypeAbbrev with
-                            | Some ttype when isUnitTy g ttype -> true
+                            | Some ty when isUnitTy g ty -> true
                             | _ -> false
                         | _ -> false)
 
@@ -1687,7 +1687,7 @@ let OutputPhasedErrorR (os: StringBuilder) (diagnostic: PhasedDiagnostic) (canSu
 
         | PatternMatchCompilation.RuleNeverMatched _ -> os.AppendString(RuleNeverMatchedE().Format)
 
-        | ValNotMutable (_, valRef, _) -> os.AppendString(ValNotMutableE().Format(valRef.DisplayName))
+        | ValNotMutable (_, vref, _) -> os.AppendString(ValNotMutableE().Format(vref.DisplayName))
 
         | ValNotLocal _ -> os.AppendString(ValNotLocalE().Format)
 

--- a/src/Compiler/Facilities/TextLayoutRender.fs
+++ b/src/Compiler/Facilities/TextLayoutRender.fs
@@ -204,5 +204,5 @@ module LayoutRender =
 
     let toArray layout =
         let output = ResizeArray()
-        renderL (taggedTextListR (fun tt -> output.Add(tt))) layout |> ignore
+        renderL (taggedTextListR output.Add) layout |> ignore
         output.ToArray()

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -1814,9 +1814,9 @@ type internal FsiDynamicCompiler(
                     ilTy |> Morphs.morphILTypeRefsInILType emEnv.ReverseMapTypeRef
                 | _ -> ilTy)
 
-        ((istate, []), ilTys) ||> List.fold (fun (state, addedTypes) ilTy ->
-            let nextState, addedType = addTypeToEnvironment state ilTy
-            nextState, addedTypes @ [addedType]) 
+        ((istate, []), ilTys) ||> List.fold (fun (state, addedTys) ilTy ->
+            let nextState, addedTy = addTypeToEnvironment state ilTy
+            nextState, addedTys @ [addedTy]) 
 
     member _.DynamicAssemblies = dynamicAssemblies.ToArray()
 

--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -606,9 +606,9 @@ let inline BindInternalValsToUnknown cenv vs env =
     ignore vs
     env
 
-let BindTypeVar tyv typeinfo env = { env with typarInfos= (tyv, typeinfo) :: env.typarInfos } 
+let BindTypar tyv typeinfo env = { env with typarInfos= (tyv, typeinfo) :: env.typarInfos } 
 
-let BindTypeVarsToUnknown (tps: Typar list) env = 
+let BindTyparsToUnknown (tps: Typar list) env = 
     if isNil tps then env else
     // The optimizer doesn't use the type values it could track. 
     // However here we mutate to provide better names for generalized type parameters 
@@ -617,7 +617,7 @@ let BindTypeVarsToUnknown (tps: Typar list) env =
     (tps, nms) ||> List.iter2 (fun tp nm -> 
             if PrettyTypes.NeedsPrettyTyparName tp then 
                 tp.typar_id <- ident (nm, tp.Range))      
-    List.fold (fun sofar arg -> BindTypeVar arg UnknownTypeValue sofar) env tps 
+    List.fold (fun sofar arg -> BindTypar arg UnknownTypeValue sofar) env tps 
 
 let BindCcu (ccu: CcuThunk) mval env (_g: TcGlobals) = 
     { env with globalModuleInfos=env.globalModuleInfos.Add(ccu.AssemblyName, mval) }
@@ -2245,8 +2245,8 @@ let TryDetectQueryQuoteAndRun cenv (expr: Expr) =
                     match reqdResultInfo, exprIsEnumerableInfo with 
                     | Some _, Some _ | None, None -> resultExpr // the expression is a QuerySource, the result is a QuerySource, nothing to do
                     | Some resultElemTy, None ->
-                        let iety = TType_app(g.tcref_System_Collections_IEnumerable, [], g.knownWithoutNull)
-                        mkCallGetQuerySourceAsEnumerable g expr.Range resultElemTy iety resultExpr
+                        let enumerableTy = TType_app(g.tcref_System_Collections_IEnumerable, [], g.knownWithoutNull)
+                        mkCallGetQuerySourceAsEnumerable g expr.Range resultElemTy enumerableTy resultExpr
                     | None, Some (resultElemTy, qTy) ->
                         mkCallNewQuerySource g expr.Range resultElemTy qTy resultExpr 
                 Some resultExprAfterConvertToResultTy
@@ -2425,7 +2425,7 @@ and OptimizeMethods cenv env baseValOpt methods =
 
 and OptimizeMethod cenv env baseValOpt (TObjExprMethod(slotsig, attribs, tps, vs, e, m) as tmethod) = 
     let env = {env with latestBoundId=Some tmethod.Id; functionVal = None}
-    let env = BindTypeVarsToUnknown tps env
+    let env = BindTyparsToUnknown tps env
     let env = BindInternalValsToUnknown cenv vs env
     let env = Option.foldBack (BindInternalValToUnknown cenv) baseValOpt env
     let eR, einfo = OptimizeExpr cenv env e
@@ -2508,11 +2508,11 @@ and OptimizeExprOp cenv env (op, tyargs, args, m) =
 
     // Special cases 
     match op, tyargs, args with 
-    | TOp.Coerce, [toty;fromty], [arg] -> 
+    | TOp.Coerce, [tgtTy; srcTy], [arg] -> 
         let argR, einfo = OptimizeExpr cenv env arg
-        if typeEquiv g toty fromty then argR, einfo 
+        if typeEquiv g tgtTy srcTy then argR, einfo 
         else 
-          mkCoerceExpr(argR, toty, m, fromty), 
+          mkCoerceExpr(argR, tgtTy, m, srcTy), 
           { TotalSize=einfo.TotalSize + 1
             FunctionSize=einfo.FunctionSize + 1
             HasEffect = true  
@@ -3742,7 +3742,7 @@ and OptimizeLambdas (vspec: Val option) cenv env valReprInfo expr exprTy =
         let env = { env with functionVal = (match vspec with None -> None | Some v -> Some (v, valReprInfo)) }
         let env = Option.foldBack (BindInternalValToUnknown cenv) ctorThisValOpt env
         let env = Option.foldBack (BindInternalValToUnknown cenv) baseValOpt env
-        let env = BindTypeVarsToUnknown tps env
+        let env = BindTyparsToUnknown tps env
         let env = List.foldBack (BindInternalValsToUnknown cenv) vsl env
         let bodyR, bodyinfo = OptimizeExpr cenv env body
         let exprR = mkMemberLambdas g m tps ctorThisValOpt baseValOpt vsl (bodyR, bodyTy)
@@ -3977,7 +3977,7 @@ and TryOptimizeDecisionTreeTest cenv test vinfo =
     | DecisionTreeTest.ArrayLength _, _ -> None
     | DecisionTreeTest.Const c1, StripConstValue c2 -> if c1 = Const.Zero || c2 = Const.Zero then None else Some(c1=c2)
     | DecisionTreeTest.IsNull, StripConstValue c2 -> Some(c2=Const.Zero)
-    | DecisionTreeTest.IsInst (_srcty1, _tgty1), _ -> None
+    | DecisionTreeTest.IsInst (_srcTy1, _tgtTy1), _ -> None
     // These should not occur in optimization
     | DecisionTreeTest.ActivePatternCase _, _ -> None
     | _ -> None
@@ -3989,8 +3989,8 @@ and OptimizeSwitch cenv env (e, cases, dflt, m) =
     // Replace IsInst tests by calls to the helper for type tests, which may then get optimized
     let e, cases =
         match cases with
-        | [ TCase(DecisionTreeTest.IsInst (_srcTy, tgTy), success)] ->
-            let testExpr = mkCallTypeTest g m tgTy e
+        | [ TCase(DecisionTreeTest.IsInst (_srcTy, tgtTy), success)] ->
+            let testExpr = mkCallTypeTest g m tgtTy e
             let testCases = [TCase(DecisionTreeTest.Const(Const.Bool true), success)]
             testExpr, testCases
         | _ -> e, cases

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -351,13 +351,13 @@ type internal TypeCheckInfo
 
         // Find the most deeply nested enclosing scope that contains given position
         sResolutions.CapturedEnvs
-        |> ResizeArray.iter (fun (possm, env, ad) ->
-            if rangeContainsPos possm cursorPos then
+        |> ResizeArray.iter (fun (mPossible, env, ad) ->
+            if rangeContainsPos mPossible cursorPos then
                 match bestSoFar with
                 | Some (bestm, _, _) ->
-                    if rangeContainsRange bestm possm then
-                        bestSoFar <- Some(possm, env, ad)
-                | None -> bestSoFar <- Some(possm, env, ad))
+                    if rangeContainsRange bestm mPossible then
+                        bestSoFar <- Some(mPossible, env, ad)
+                | None -> bestSoFar <- Some(mPossible, env, ad))
 
         let mostDeeplyNestedEnclosingScope = bestSoFar
 
@@ -370,21 +370,21 @@ type internal TypeCheckInfo
         let mutable bestAlmostIncludedSoFar = None
 
         sResolutions.CapturedEnvs
-        |> ResizeArray.iter (fun (possm, env, ad) ->
+        |> ResizeArray.iter (fun (mPossible, env, ad) ->
             // take only ranges that strictly do not include cursorPos (all ranges that touch cursorPos were processed during 'Strict Inclusion' part)
-            if rangeBeforePos possm cursorPos && not (posEq possm.End cursorPos) then
+            if rangeBeforePos mPossible cursorPos && not (posEq mPossible.End cursorPos) then
                 let contained =
                     match mostDeeplyNestedEnclosingScope with
-                    | Some (bestm, _, _) -> rangeContainsRange bestm possm
+                    | Some (bestm, _, _) -> rangeContainsRange bestm mPossible
                     | None -> true
 
                 if contained then
                     match bestAlmostIncludedSoFar with
                     | Some (rightm: range, _, _) ->
-                        if posGt possm.End rightm.End
-                           || (posEq possm.End rightm.End && posGt possm.Start rightm.Start) then
-                            bestAlmostIncludedSoFar <- Some(possm, env, ad)
-                    | _ -> bestAlmostIncludedSoFar <- Some(possm, env, ad))
+                        if posGt mPossible.End rightm.End
+                           || (posEq mPossible.End rightm.End && posGt mPossible.Start rightm.Start) then
+                            bestAlmostIncludedSoFar <- Some(mPossible, env, ad)
+                    | _ -> bestAlmostIncludedSoFar <- Some(mPossible, env, ad))
 
         let resEnv =
             match bestAlmostIncludedSoFar, mostDeeplyNestedEnclosingScope with

--- a/src/Compiler/Service/ItemKey.fs
+++ b/src/Compiler/Service/ItemKey.fs
@@ -239,10 +239,10 @@ and [<Sealed>] ItemKeyStoreBuilder() =
             writeString anonInfo.ILTypeRef.BasicQualifiedName
             tinst |> List.iter (writeType false)
 
-        | TType_fun (d, r, _) ->
+        | TType_fun (domainTy, rangeTy, _) ->
             writeString ItemKeyTags.typeFunction
-            writeType false d
-            writeType false r
+            writeType false domainTy
+            writeType false rangeTy
 
         | TType_measure ms ->
             if isStandalone then
@@ -263,7 +263,7 @@ and [<Sealed>] ItemKeyStoreBuilder() =
         | Measure.Var typar ->
             writeString ItemKeyTags.typeMeasureVar
             writeTypar isStandalone typar
-        | Measure.Con tcref ->
+        | Measure.Const tcref ->
             writeString ItemKeyTags.typeMeasureCon
             writeEntityRef tcref
         | _ -> ()

--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -150,8 +150,8 @@ module TcResolutionsExtensions =
                         protectAssemblyExplorationNoReraise false false (fun () ->
                             ExistsHeadTypeInEntireHierarchy g amap range0 vref.Type g.tcref_System_IDisposable)
 
-                    let isStructTyconRef (tyconRef: TyconRef) =
-                        let ty = generalizedTyconRef g tyconRef
+                    let isStructTyconRef (tcref: TyconRef) =
+                        let ty = generalizedTyconRef g tcref
                         let underlyingTy = stripTyEqnsAndMeasureEqns g ty
                         isStructTy g underlyingTy
 

--- a/src/Compiler/Service/ServiceNavigation.fs
+++ b/src/Compiler/Service/ServiceNavigation.fs
@@ -121,8 +121,8 @@ module NavigationImpl =
             |> List.fold (fun st (SynField (_, _, _, _, _, _, _, m)) -> unionRangesChecked m st) range.Zero
         | SynUnionCaseKind.FullType (ty, _) -> ty.Range
 
-    let bodyRange mb decls =
-        unionRangesChecked (rangeOfDecls decls) mb
+    let bodyRange mBody decls =
+        unionRangesChecked (rangeOfDecls decls) mBody
 
     /// Get information for implementation file
     let getNavigationFromImplFile (modules: SynModuleOrNamespace list) =
@@ -143,18 +143,18 @@ module NavigationImpl =
             sprintf "%s_%d_of_%d" name idx total
 
         // Create declaration (for the left dropdown)
-        let createDeclLid (baseName, lid, kind, baseGlyph, m, bodym, nested, enclosingEntityKind, access) =
+        let createDeclLid (baseName, lid, kind, baseGlyph, m, mBody, nested, enclosingEntityKind, access) =
             let name = (if baseName <> "" then baseName + "." else "") + textOfLid lid
-            let item = NavigationItem.Create(name, kind, baseGlyph, m, bodym, false, enclosingEntityKind, false, access)
+            let item = NavigationItem.Create(name, kind, baseGlyph, m, mBody, false, enclosingEntityKind, false, access)
             item, addItemName name, nested
 
-        let createDecl (baseName, id: Ident, kind, baseGlyph, m, bodym, nested, enclosingEntityKind, isAbstract, access) =
+        let createDecl (baseName, id: Ident, kind, baseGlyph, m, mBody, nested, enclosingEntityKind, isAbstract, access) =
             let name = (if baseName <> "" then baseName + "." else "") + id.idText
-            let item = NavigationItem.Create(name, kind, baseGlyph, m, bodym, false, enclosingEntityKind, isAbstract, access)
+            let item = NavigationItem.Create(name, kind, baseGlyph, m, mBody, false, enclosingEntityKind, isAbstract, access)
             item, addItemName name, nested
 
-        let createTypeDecl (baseName, lid, baseGlyph, m, bodym, nested, enclosingEntityKind, access) =
-            createDeclLid (baseName, lid, NavigationItemKind.Type, baseGlyph, m, bodym, nested, enclosingEntityKind, access)
+        let createTypeDecl (baseName, lid, baseGlyph, m, mBody, nested, enclosingEntityKind, access) =
+            createDeclLid (baseName, lid, NavigationItemKind.Type, baseGlyph, m, mBody, nested, enclosingEntityKind, access)
 
         // Create member-kind-of-thing for the right dropdown
         let createMemberLid (lid, kind, baseGlyph, m, enclosingEntityKind, isAbstract, access) =
@@ -226,10 +226,10 @@ module NavigationImpl =
         let rec processExnDefnRepr baseName nested synExnRepr =
             let (SynExceptionDefnRepr (_, ucase, _, _, access, m)) = synExnRepr
             let (SynUnionCase (ident = SynIdent (id, _); caseType = fldspec)) = ucase
-            let bodym = fldspecRange fldspec
+            let mBody = fldspecRange fldspec
 
             [
-                createDecl (baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, bodym, nested, NavigationEntityKind.Exception, false, access)
+                createDecl (baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, mBody, nested, NavigationEntityKind.Exception, false, access)
             ]
 
         // Process a class declaration or F# type declaration
@@ -247,35 +247,35 @@ module NavigationImpl =
             match repr with
             | SynTypeDefnRepr.Exception repr -> processExnDefnRepr baseName [] repr
 
-            | SynTypeDefnRepr.ObjectModel (_, membDefns, mb) ->
+            | SynTypeDefnRepr.ObjectModel (_, membDefns, mBody) ->
                 // F# class declaration
                 let members = processMembers membDefns NavigationEntityKind.Class |> snd
                 let nested = members @ topMembers
-                let bodym = bodyRange mb nested
+                let mBody = bodyRange mBody nested
 
                 [
-                    createTypeDecl (baseName, lid, FSharpGlyph.Class, m, bodym, nested, NavigationEntityKind.Class, access)
+                    createTypeDecl (baseName, lid, FSharpGlyph.Class, m, mBody, nested, NavigationEntityKind.Class, access)
                 ]
 
             | SynTypeDefnRepr.Simple (simple, _) ->
                 // F# type declaration
                 match simple with
-                | SynTypeDefnSimpleRepr.Union (_, cases, mb) ->
+                | SynTypeDefnSimpleRepr.Union (_, cases, mBody) ->
                     let cases =
                         [
                             for SynUnionCase (ident = SynIdent (id, _); caseType = fldspec) in cases ->
-                                let bodym = unionRanges (fldspecRange fldspec) id.idRange
-                                createMember (id, NavigationItemKind.Other, FSharpGlyph.Struct, bodym, NavigationEntityKind.Union, false, access)
+                                let mBody = unionRanges (fldspecRange fldspec) id.idRange
+                                createMember (id, NavigationItemKind.Other, FSharpGlyph.Struct, mBody, NavigationEntityKind.Union, false, access)
                         ]
 
                     let nested = cases @ topMembers
-                    let bodym = bodyRange mb nested
+                    let mBody = bodyRange mBody nested
 
                     [
-                        createTypeDecl (baseName, lid, FSharpGlyph.Union, m, bodym, nested, NavigationEntityKind.Union, access)
+                        createTypeDecl (baseName, lid, FSharpGlyph.Union, m, mBody, nested, NavigationEntityKind.Union, access)
                     ]
 
-                | SynTypeDefnSimpleRepr.Enum (cases, mb) ->
+                | SynTypeDefnSimpleRepr.Enum (cases, mBody) ->
                     let cases =
                         [
                             for SynEnumCase (ident = SynIdent (id, _); range = m) in cases ->
@@ -283,13 +283,13 @@ module NavigationImpl =
                         ]
 
                     let nested = cases @ topMembers
-                    let bodym = bodyRange mb nested
+                    let mBody = bodyRange mBody nested
 
                     [
-                        createTypeDecl (baseName, lid, FSharpGlyph.Enum, m, bodym, nested, NavigationEntityKind.Enum, access)
+                        createTypeDecl (baseName, lid, FSharpGlyph.Enum, m, mBody, nested, NavigationEntityKind.Enum, access)
                     ]
 
-                | SynTypeDefnSimpleRepr.Record (_, fields, mb) ->
+                | SynTypeDefnSimpleRepr.Record (_, fields, mBody) ->
                     let fields =
                         [
                             for SynField (_, _, id, _, _, _, _, m) in fields do
@@ -299,17 +299,17 @@ module NavigationImpl =
                         ]
 
                     let nested = fields @ topMembers
-                    let bodym = bodyRange mb nested
+                    let mBody = bodyRange mBody nested
 
                     [
-                        createTypeDecl (baseName, lid, FSharpGlyph.Type, m, bodym, nested, NavigationEntityKind.Record, access)
+                        createTypeDecl (baseName, lid, FSharpGlyph.Type, m, mBody, nested, NavigationEntityKind.Record, access)
                     ]
 
-                | SynTypeDefnSimpleRepr.TypeAbbrev (_, _, mb) ->
-                    let bodym = bodyRange mb topMembers
+                | SynTypeDefnSimpleRepr.TypeAbbrev (_, _, mBody) ->
+                    let mBody = bodyRange mBody topMembers
 
                     [
-                        createTypeDecl (baseName, lid, FSharpGlyph.Typedef, m, bodym, topMembers, NavigationEntityKind.Class, access)
+                        createTypeDecl (baseName, lid, FSharpGlyph.Typedef, m, mBody, topMembers, NavigationEntityKind.Class, access)
                     ]
 
                 //| SynTypeDefnSimpleRepr.General of TyconKind * (SynType * Range * ident option) list * (valSpfn * MemberFlags) list * fieldDecls * bool * bool * Range
@@ -371,8 +371,8 @@ module NavigationImpl =
                 for decl in decls do
                     match decl with
                     | SynModuleDecl.ModuleAbbrev (id, lid, m) ->
-                        let bodym = rangeOfLid lid
-                        createDecl (baseName, id, NavigationItemKind.Module, FSharpGlyph.Module, m, bodym, [], NavigationEntityKind.Namespace, false, None)
+                        let mBody = rangeOfLid lid
+                        createDecl (baseName, id, NavigationItemKind.Module, FSharpGlyph.Module, m, mBody, [], NavigationEntityKind.Namespace, false, None)
 
                     | SynModuleDecl.NestedModule (moduleInfo = SynComponentInfo (longId = lid; accessibility = access); decls = decls; range = m) ->
                         // Find let bindings (for the right dropdown)
@@ -380,8 +380,8 @@ module NavigationImpl =
                         let newBaseName = (if (baseName = "") then "" else baseName + ".") + (textOfLid lid)
                         let other = processNavigationTopLevelDeclarations (newBaseName, decls)
 
-                        let bodym = unionRangesChecked (rangeOfDecls nested) (moduleRange (rangeOfLid lid) other)
-                        createDeclLid (baseName, lid, NavigationItemKind.Module, FSharpGlyph.Module, m, bodym, nested, NavigationEntityKind.Module, access)
+                        let mBody = unionRangesChecked (rangeOfDecls nested) (moduleRange (rangeOfLid lid) other)
+                        createDeclLid (baseName, lid, NavigationItemKind.Module, FSharpGlyph.Module, m, mBody, nested, NavigationEntityKind.Module, access)
                         // Get nested modules and types (for the left dropdown)
                         yield! other
 
@@ -414,11 +414,11 @@ module NavigationImpl =
                             else
                                 NavigationItemKind.Namespace
 
-                        let bodym = unionRangesChecked (rangeOfDecls nested) (moduleRange (rangeOfLid id) other)
+                        let mBody = unionRangesChecked (rangeOfDecls nested) (moduleRange (rangeOfLid id) other)
                         let nm = textOfLid id
 
                         let item =
-                            NavigationItem.Create(nm, kind, FSharpGlyph.Module, m, bodym, singleTopLevel, NavigationEntityKind.Module, false, access)
+                            NavigationItem.Create(nm, kind, FSharpGlyph.Module, m, mBody, singleTopLevel, NavigationEntityKind.Module, false, access)
 
                         let decl = (item, addItemName (nm), nested)
                         decl
@@ -462,17 +462,17 @@ module NavigationImpl =
             sprintf "%s_%d_of_%d" name idx total
 
         // Create declaration (for the left dropdown)
-        let createDeclLid (baseName, lid, kind, baseGlyph, m, bodym, nested, enclosingEntityKind, access) =
+        let createDeclLid (baseName, lid, kind, baseGlyph, m, mBody, nested, enclosingEntityKind, access) =
             let name = (if baseName <> "" then baseName + "." else "") + (textOfLid lid)
-            let item = NavigationItem.Create(name, kind, baseGlyph, m, bodym, false, enclosingEntityKind, false, access)
+            let item = NavigationItem.Create(name, kind, baseGlyph, m, mBody, false, enclosingEntityKind, false, access)
             item, addItemName name, nested
 
-        let createTypeDecl (baseName, lid, baseGlyph, m, bodym, nested, enclosingEntityKind, access) =
-            createDeclLid (baseName, lid, NavigationItemKind.Type, baseGlyph, m, bodym, nested, enclosingEntityKind, access)
+        let createTypeDecl (baseName, lid, baseGlyph, m, mBody, nested, enclosingEntityKind, access) =
+            createDeclLid (baseName, lid, NavigationItemKind.Type, baseGlyph, m, mBody, nested, enclosingEntityKind, access)
 
-        let createDecl (baseName, id: Ident, kind, baseGlyph, m, bodym, nested, enclosingEntityKind, isAbstract, access) =
+        let createDecl (baseName, id: Ident, kind, baseGlyph, m, mBody, nested, enclosingEntityKind, isAbstract, access) =
             let name = (if baseName <> "" then baseName + "." else "") + id.idText
-            let item = NavigationItem.Create(name, kind, baseGlyph, m, bodym, false, enclosingEntityKind, isAbstract, access)
+            let item = NavigationItem.Create(name, kind, baseGlyph, m, mBody, false, enclosingEntityKind, isAbstract, access)
             item, addItemName name, nested
 
         let createMember (id: Ident, kind, baseGlyph, m, enclosingEntityKind, isAbstract, access) =
@@ -481,10 +481,10 @@ module NavigationImpl =
 
         let rec processExnRepr baseName nested inp =
             let (SynExceptionDefnRepr (_, SynUnionCase (ident = SynIdent (id, _); caseType = fldspec), _, _, access, m)) = inp
-            let bodym = fldspecRange fldspec
+            let mBody = fldspecRange fldspec
 
             [
-                createDecl (baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, bodym, nested, NavigationEntityKind.Exception, false, access)
+                createDecl (baseName, id, NavigationItemKind.Exception, FSharpGlyph.Exception, m, mBody, nested, NavigationEntityKind.Exception, false, access)
             ]
 
         and processExnSig baseName inp =
@@ -501,16 +501,16 @@ module NavigationImpl =
             [
                 match repr with
                 | SynTypeDefnSigRepr.Exception repr -> yield! processExnRepr baseName [] repr
-                | SynTypeDefnSigRepr.ObjectModel (_, membDefns, mb) ->
+                | SynTypeDefnSigRepr.ObjectModel (_, membDefns, mBody) ->
                     // F# class declaration
                     let members = processSigMembers membDefns
                     let nested = members @ topMembers
-                    let bodym = bodyRange mb nested
-                    createTypeDecl (baseName, lid, FSharpGlyph.Class, m, bodym, nested, NavigationEntityKind.Class, access)
+                    let mBody = bodyRange mBody nested
+                    createTypeDecl (baseName, lid, FSharpGlyph.Class, m, mBody, nested, NavigationEntityKind.Class, access)
                 | SynTypeDefnSigRepr.Simple (simple, _) ->
                     // F# type declaration
                     match simple with
-                    | SynTypeDefnSimpleRepr.Union (_, cases, mb) ->
+                    | SynTypeDefnSimpleRepr.Union (_, cases, mBody) ->
                         let cases =
                             [
                                 for SynUnionCase (ident = SynIdent (id, _); caseType = fldspec) in cases ->
@@ -519,9 +519,9 @@ module NavigationImpl =
                             ]
 
                         let nested = cases @ topMembers
-                        let bodym = bodyRange mb nested
-                        createTypeDecl (baseName, lid, FSharpGlyph.Union, m, bodym, nested, NavigationEntityKind.Union, access)
-                    | SynTypeDefnSimpleRepr.Enum (cases, mb) ->
+                        let mBody = bodyRange mBody nested
+                        createTypeDecl (baseName, lid, FSharpGlyph.Union, m, mBody, nested, NavigationEntityKind.Union, access)
+                    | SynTypeDefnSimpleRepr.Enum (cases, mBody) ->
                         let cases =
                             [
                                 for SynEnumCase (ident = SynIdent (id, _); range = m) in cases ->
@@ -529,9 +529,9 @@ module NavigationImpl =
                             ]
 
                         let nested = cases @ topMembers
-                        let bodym = bodyRange mb nested
-                        createTypeDecl (baseName, lid, FSharpGlyph.Enum, m, bodym, nested, NavigationEntityKind.Enum, access)
-                    | SynTypeDefnSimpleRepr.Record (_, fields, mb) ->
+                        let mBody = bodyRange mBody nested
+                        createTypeDecl (baseName, lid, FSharpGlyph.Enum, m, mBody, nested, NavigationEntityKind.Enum, access)
+                    | SynTypeDefnSimpleRepr.Record (_, fields, mBody) ->
                         let fields =
                             [
                                 for SynField (_, _, id, _, _, _, _, m) in fields do
@@ -541,11 +541,11 @@ module NavigationImpl =
                             ]
 
                         let nested = fields @ topMembers
-                        let bodym = bodyRange mb nested
-                        createTypeDecl (baseName, lid, FSharpGlyph.Type, m, bodym, nested, NavigationEntityKind.Record, access)
-                    | SynTypeDefnSimpleRepr.TypeAbbrev (_, _, mb) ->
-                        let bodym = bodyRange mb topMembers
-                        createTypeDecl (baseName, lid, FSharpGlyph.Typedef, m, bodym, topMembers, NavigationEntityKind.Class, access)
+                        let mBody = bodyRange mBody nested
+                        createTypeDecl (baseName, lid, FSharpGlyph.Type, m, mBody, nested, NavigationEntityKind.Record, access)
+                    | SynTypeDefnSimpleRepr.TypeAbbrev (_, _, mBody) ->
+                        let mBody = bodyRange mBody topMembers
+                        createTypeDecl (baseName, lid, FSharpGlyph.Typedef, m, mBody, topMembers, NavigationEntityKind.Class, access)
 
                     //| SynTypeDefnSimpleRepr.General of TyconKind * (SynType * range * ident option) list * (valSpfn * MemberFlags) list * fieldDecls * bool * bool * range
                     //| SynTypeDefnSimpleRepr.LibraryOnlyILAssembly of ILType * range
@@ -581,8 +581,8 @@ module NavigationImpl =
                 for decl in decls do
                     match decl with
                     | SynModuleSigDecl.ModuleAbbrev (id, lid, m) ->
-                        let bodym = rangeOfLid lid
-                        createDecl (baseName, id, NavigationItemKind.Module, FSharpGlyph.Module, m, bodym, [], NavigationEntityKind.Module, false, None)
+                        let mBody = rangeOfLid lid
+                        createDecl (baseName, id, NavigationItemKind.Module, FSharpGlyph.Module, m, mBody, [], NavigationEntityKind.Module, false, None)
 
                     | SynModuleSigDecl.NestedModule (moduleInfo = SynComponentInfo (longId = lid; accessibility = access); moduleDecls = decls; range = m) ->
                         // Find let bindings (for the right dropdown)
@@ -591,8 +591,8 @@ module NavigationImpl =
                         let other = processNavigationTopLevelSigDeclarations (newBaseName, decls)
 
                         // Get nested modules and types (for the left dropdown)
-                        let bodym = unionRangesChecked (rangeOfDecls nested) (moduleRange (rangeOfLid lid) other)
-                        createDeclLid (baseName, lid, NavigationItemKind.Module, FSharpGlyph.Module, m, bodym, nested, NavigationEntityKind.Module, access)
+                        let mBody = unionRangesChecked (rangeOfDecls nested) (moduleRange (rangeOfLid lid) other)
+                        createDeclLid (baseName, lid, NavigationItemKind.Module, FSharpGlyph.Module, m, mBody, nested, NavigationEntityKind.Module, access)
                         yield! other
 
                     | SynModuleSigDecl.Types (tydefs, _) ->
@@ -623,10 +623,10 @@ module NavigationImpl =
                         else
                             NavigationItemKind.Namespace
 
-                    let bodym = unionRangesChecked (rangeOfDecls nested) (moduleRange (rangeOfLid id) other)
+                    let mBody = unionRangesChecked (rangeOfDecls nested) (moduleRange (rangeOfLid id) other)
 
                     let item =
-                        NavigationItem.Create(textOfLid id, kind, FSharpGlyph.Module, m, bodym, singleTopLevel, NavigationEntityKind.Module, false, access)
+                        NavigationItem.Create(textOfLid id, kind, FSharpGlyph.Module, m, mBody, singleTopLevel, NavigationEntityKind.Module, false, access)
 
                     let decl = (item, addItemName (textOfLid id), nested)
                     decl

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -476,8 +476,8 @@ module ParsedInput =
                             ]
                             |> pick expr
 
-                        | SynExpr.DotGet (exprLeft, dotm, lidwd, _m) ->
-                            let afterDotBeforeLid = mkRange dotm.FileName dotm.End lidwd.Range.Start
+                        | SynExpr.DotGet (exprLeft, mDot, lidwd, _m) ->
+                            let afterDotBeforeLid = mkRange mDot.FileName mDot.End lidwd.Range.Start
 
                             [
                                 dive exprLeft exprLeft.Range traverseSynExpr

--- a/src/Compiler/Service/ServiceStructure.fs
+++ b/src/Compiler/Service/ServiceStructure.fs
@@ -360,30 +360,30 @@ module Structure =
                                members = ms
                                extraImpls = extraImpls
                                newExprRange = newRange
-                               range = wholeRange) ->
+                               range = mWhole) ->
                 let bindings = unionBindingAndMembers bindings ms
 
                 match argOpt with
                 | Some (args, _) ->
-                    let collapse = Range.endToEnd args.Range wholeRange
-                    rcheck Scope.ObjExpr Collapse.Below wholeRange collapse
+                    let collapse = Range.endToEnd args.Range mWhole
+                    rcheck Scope.ObjExpr Collapse.Below mWhole collapse
                 | None ->
-                    let collapse = Range.endToEnd newRange wholeRange
-                    rcheck Scope.ObjExpr Collapse.Below wholeRange collapse
+                    let collapse = Range.endToEnd newRange mWhole
+                    rcheck Scope.ObjExpr Collapse.Below mWhole collapse
 
                 parseBindings bindings
                 parseExprInterfaces extraImpls
 
-            | SynExpr.TryWith (e, matchClauses, wholeRange, tryPoint, withPoint, _trivia) ->
+            | SynExpr.TryWith (e, matchClauses, mWhole, tryPoint, withPoint, _trivia) ->
                 match tryPoint, withPoint with
                 | DebugPointAtTry.Yes tryRange, DebugPointAtWith.Yes withRange ->
-                    let fullrange = Range.startToEnd tryRange wholeRange
-                    let collapse = Range.endToEnd tryRange wholeRange
+                    let mFull = Range.startToEnd tryRange mWhole
+                    let collapse = Range.endToEnd tryRange mWhole
                     let collapseTry = Range.endToStart tryRange withRange
                     let fullrangeTry = Range.startToStart tryRange withRange
-                    let collapseWith = Range.endToEnd withRange wholeRange
-                    let fullrangeWith = Range.startToEnd withRange wholeRange
-                    rcheck Scope.TryWith Collapse.Below fullrange collapse
+                    let collapseWith = Range.endToEnd withRange mWhole
+                    let fullrangeWith = Range.startToEnd withRange mWhole
+                    rcheck Scope.TryWith Collapse.Below mFull collapse
                     rcheck Scope.TryInTryWith Collapse.Below fullrangeTry collapseTry
                     rcheck Scope.WithInTryWith Collapse.Below fullrangeWith collapseWith
                 | _ -> ()
@@ -395,10 +395,10 @@ module Structure =
                 match tryPoint, finallyPoint with
                 | DebugPointAtTry.Yes tryRange, DebugPointAtFinally.Yes finallyRange ->
                     let collapse = Range.endToEnd tryRange finallyExpr.Range
-                    let fullrange = Range.startToEnd tryRange finallyExpr.Range
+                    let mFull = Range.startToEnd tryRange finallyExpr.Range
                     let collapseFinally = Range.endToEnd finallyRange r
                     let fullrangeFinally = Range.startToEnd finallyRange r
-                    rcheck Scope.TryFinally Collapse.Below fullrange collapse
+                    rcheck Scope.TryFinally Collapse.Below mFull collapse
                     rcheck Scope.FinallyInTryFinally Collapse.Below fullrangeFinally collapseFinally
                 | _ -> ()
 
@@ -414,9 +414,9 @@ module Structure =
                 match spIfToThen with
                 | DebugPointAtBinding.Yes rt ->
                     // Outline the entire IfThenElse
-                    let fullrange = Range.startToEnd rt r
+                    let mFull = Range.startToEnd rt r
                     let collapse = Range.endToEnd ifExpr.Range r
-                    rcheck Scope.IfThenElse Collapse.Below fullrange collapse
+                    rcheck Scope.IfThenElse Collapse.Below mFull collapse
                     // Outline the `then` scope
                     let thenRange = Range.endToEnd (Range.modEnd -4 trivia.IfToThenRange) thenExpr.Range
                     let thenCollapse = Range.endToEnd trivia.IfToThenRange thenExpr.Range
@@ -649,24 +649,24 @@ module Structure =
             | _ -> ()
 
         and parseTypeDefn typeDefn =
-            let (SynTypeDefn (typeInfo = typeInfo; typeRepr = objectModel; members = members; range = fullrange)) =
+            let (SynTypeDefn (typeInfo = typeInfo; typeRepr = objectModel; members = members; range = mFull)) =
                 typeDefn
 
             let (SynComponentInfo (typeParams = TyparDecls typeArgs; range = r)) = typeInfo
             let typeArgsRange = rangeOfTypeArgsElse r typeArgs
-            let collapse = Range.endToEnd (Range.modEnd 1 typeArgsRange) fullrange
+            let collapse = Range.endToEnd (Range.modEnd 1 typeArgsRange) mFull
 
             match objectModel with
             | SynTypeDefnRepr.ObjectModel (defnKind, objMembers, r) ->
                 match defnKind with
-                | SynTypeDefnKind.Augmentation _ -> rcheck Scope.TypeExtension Collapse.Below fullrange collapse
-                | _ -> rcheck Scope.Type Collapse.Below fullrange collapse
+                | SynTypeDefnKind.Augmentation _ -> rcheck Scope.TypeExtension Collapse.Below mFull collapse
+                | _ -> rcheck Scope.Type Collapse.Below mFull collapse
 
                 List.iter (parseSynMemberDefn r) objMembers
                 // visit the members of a type extension
                 List.iter (parseSynMemberDefn r) members
             | SynTypeDefnRepr.Simple (simpleRepr, r) ->
-                rcheck Scope.Type Collapse.Below fullrange collapse
+                rcheck Scope.Type Collapse.Below mFull collapse
                 parseSimpleRepr simpleRepr
                 List.iter (parseSynMemberDefn r) members
             | SynTypeDefnRepr.Exception _ -> ()
@@ -770,12 +770,12 @@ module Structure =
         let parseModuleOrNamespace (SynModuleOrNamespace (longId, _, kind, decls, _, attribs, _, r, _)) =
             parseAttributes attribs
             let idRange = longIdentRange longId
-            let fullrange = Range.startToEnd idRange r
+            let mFull = Range.startToEnd idRange r
             let collapse = Range.endToEnd idRange r
 
             // do not return range for top level implicit module in scripts
             if kind = SynModuleOrNamespaceKind.NamedModule then
-                rcheck Scope.Module Collapse.Below fullrange collapse
+                rcheck Scope.Module Collapse.Below mFull collapse
 
             collectHashDirectives decls
             collectOpens decls
@@ -889,9 +889,9 @@ module Structure =
             | SynMemberSig.Member (valSigs, _, r) ->
                 let collapse = Range.endToEnd valSigs.RangeOfId r
                 rcheck Scope.Member Collapse.Below r collapse
-            | SynMemberSig.ValField (SynField (attrs, _, _, _, _, _, _, fr), fullrange) ->
-                let collapse = Range.endToEnd fr fullrange
-                rcheck Scope.Val Collapse.Below fullrange collapse
+            | SynMemberSig.ValField (SynField (attrs, _, _, _, _, _, _, fr), mFull) ->
+                let collapse = Range.endToEnd fr mFull
+                rcheck Scope.Val Collapse.Below mFull collapse
                 parseAttributes attrs
             | SynMemberSig.Interface (tp, r) -> rcheck Scope.Interface Collapse.Below r (Range.endToEnd tp.Range r)
             | SynMemberSig.NestedType (typeDefSig, _r) -> parseTypeDefnSig typeDefSig
@@ -909,8 +909,8 @@ module Structure =
                 let typeArgsRange = rangeOfTypeArgsElse r typeArgs
                 let rangeEnd = lastMemberSigRangeElse r memberSigs
                 let collapse = Range.endToEnd (Range.modEnd 1 typeArgsRange) rangeEnd
-                let fullrange = Range.startToEnd (longIdentRange longId) rangeEnd
-                fullrange, collapse
+                let mFull = Range.startToEnd (longIdentRange longId) rangeEnd
+                mFull, collapse
 
             List.iter parseSynMemberDefnSig memberSigs
 
@@ -918,23 +918,23 @@ module Structure =
             // matches against a type declaration with <'T, ...> and (args, ...)
             | SynTypeDefnSigRepr.ObjectModel (SynTypeDefnKind.Unspecified, objMembers, _) ->
                 List.iter parseSynMemberDefnSig objMembers
-                let fullrange, collapse = makeRanges objMembers
-                rcheck Scope.Type Collapse.Below fullrange collapse
+                let mFull, collapse = makeRanges objMembers
+                rcheck Scope.Type Collapse.Below mFull collapse
 
             | SynTypeDefnSigRepr.ObjectModel (kind = SynTypeDefnKind.Augmentation _; memberSigs = objMembers) ->
-                let fullrange, collapse = makeRanges objMembers
-                rcheck Scope.TypeExtension Collapse.Below fullrange collapse
+                let mFull, collapse = makeRanges objMembers
+                rcheck Scope.TypeExtension Collapse.Below mFull collapse
                 List.iter parseSynMemberDefnSig objMembers
 
             | SynTypeDefnSigRepr.ObjectModel (_, objMembers, _) ->
-                let fullrange, collapse = makeRanges objMembers
-                rcheck Scope.Type Collapse.Below fullrange collapse
+                let mFull, collapse = makeRanges objMembers
+                rcheck Scope.Type Collapse.Below mFull collapse
                 List.iter parseSynMemberDefnSig objMembers
             // visit the members of a type extension
 
             | SynTypeDefnSigRepr.Simple (simpleRepr, _) ->
-                let fullrange, collapse = makeRanges memberSigs
-                rcheck Scope.Type Collapse.Below fullrange collapse
+                let mFull, collapse = makeRanges memberSigs
+                rcheck Scope.Type Collapse.Below mFull collapse
                 parseSimpleRepr simpleRepr
 
             | SynTypeDefnSigRepr.Exception _ -> ()
@@ -1017,8 +1017,8 @@ module Structure =
                 let rangeEnd = lastModuleSigDeclRangeElse moduleRange decls
                 // Outline the full scope of the module
                 let collapse = Range.endToEnd cmpRange rangeEnd
-                let fullrange = Range.startToEnd moduleRange rangeEnd
-                rcheck Scope.Module Collapse.Below fullrange collapse
+                let mFull = Range.startToEnd moduleRange rangeEnd
+                rcheck Scope.Module Collapse.Below mFull collapse
                 // A module's component info stores the ranges of its attributes
                 parseAttributes attrs
                 collectSigOpens decls
@@ -1030,11 +1030,11 @@ module Structure =
             parseAttributes attribs
             let rangeEnd = lastModuleSigDeclRangeElse r decls
             let idrange = longIdentRange longId
-            let fullrange = Range.startToEnd idrange rangeEnd
+            let mFull = Range.startToEnd idrange rangeEnd
             let collapse = Range.endToEnd idrange rangeEnd
 
             if kind.IsModule then
-                rcheck Scope.Module Collapse.Below fullrange collapse
+                rcheck Scope.Module Collapse.Below mFull collapse
 
             collectSigHashDirectives decls
             collectSigOpens decls

--- a/src/Compiler/Symbols/SymbolHelpers.fs
+++ b/src/Compiler/Symbols/SymbolHelpers.fs
@@ -631,9 +631,9 @@ module internal SymbolHelpers =
         match item with
         | Item.Types(_name, tys) ->
             match tys with
-            | [AppTy g (tyconRef, _typeInst)] ->
-                if tyconRef.IsProvidedErasedTycon || tyconRef.IsProvidedGeneratedTycon then
-                    Some tyconRef
+            | [AppTy g (tcref, _typeInst)] ->
+                if tcref.IsProvidedErasedTycon || tcref.IsProvidedGeneratedTycon then
+                    Some tcref
                 else
                     None
             | _ -> None
@@ -644,10 +644,10 @@ module internal SymbolHelpers =
         match item with
         | Item.Types(_name, tys) ->
             match tys with
-            | [AppTy g (tyconRef, _typeInst)] ->
-                if tyconRef.IsProvidedErasedTycon || tyconRef.IsProvidedGeneratedTycon then
+            | [AppTy g (tcref, _typeInst)] ->
+                if tcref.IsProvidedErasedTycon || tcref.IsProvidedGeneratedTycon then
                     let typeBeforeArguments = 
-                        match tyconRef.TypeReprInfo with 
+                        match tcref.TypeReprInfo with 
                         | TProvidedTypeRepr info -> info.ProvidedType
                         | _ -> failwith "unreachable"
                     let staticParameters = typeBeforeArguments.PApplyWithProvider((fun (typeBeforeArguments, provider) -> typeBeforeArguments.GetStaticParameters provider), range=m) 

--- a/src/Compiler/Symbols/SymbolPatterns.fs
+++ b/src/Compiler/Symbols/SymbolPatterns.fs
@@ -43,7 +43,7 @@ module FSharpSymbolPatterns =
         if entity.IsFSharpAbbreviation then
             match entity.AbbreviatedType with
             | TypeWithDefinition def -> getEntityAbbreviatedType def
-            | abbreviatedType -> entity, Some abbreviatedType
+            | abbreviatedTy -> entity, Some abbreviatedTy
         else entity, None
 
     let (|Attribute|_|) (entity: FSharpEntity) =
@@ -151,12 +151,12 @@ module FSharpSymbolPatterns =
             | _ -> false
         if isMutable then Some() else None
 
-    /// Entity (originalEntity, abbreviatedEntity, abbreviatedType)
+    /// Entity (originalEntity, abbreviatedEntity, abbreviatedTy)
     let (|FSharpEntity|_|) (symbol: FSharpSymbol) =
         match symbol with
         | :? FSharpEntity as entity -> 
-            let abbreviatedEntity, abbreviatedType = getEntityAbbreviatedType entity
-            Some (entity, abbreviatedEntity, abbreviatedType)
+            let abbreviatedEntity, abbreviatedTy = getEntityAbbreviatedType entity
+            Some (entity, abbreviatedEntity, abbreviatedTy)
         | _ -> None
 
     let (|Parameter|_|) (symbol: FSharpSymbol) = 

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -350,7 +350,7 @@ type FSharpSymbol(cenv: SymbolEnv, item: unit -> Item, access: FSharpSymbol -> C
     member sym.TryGetAttribute<'T>() =
         sym.Attributes |> Seq.tryFind (fun attr -> attr.IsAttribute<'T>())
 
-type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) = 
+type FSharpEntity(cenv: SymbolEnv, entity: EntityRef) = 
     inherit FSharpSymbol(cenv, 
                          (fun () -> 
                               checkEntityIsResolved entity
@@ -588,8 +588,8 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
         if isUnresolved() then makeReadOnlyCollection [] else
         let ty = generalizedTyconRef cenv.g entity
         DiagnosticsLogger.protectAssemblyExploration [] (fun () -> 
-            [ for ity in GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes cenv.g cenv.amap range0 ty do 
-                 yield FSharpType(cenv, ity) ])
+            [ for intfTy in GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes cenv.g cenv.amap range0 ty do 
+                 yield FSharpType(cenv, intfTy) ])
         |> makeReadOnlyCollection
 
     member _.AllInterfaces = 
@@ -642,10 +642,13 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
            else
                for minfo in GetImmediateIntrinsicMethInfosOfType (None, AccessibleFromSomeFSharpCode) cenv.g cenv.amap range0 entityTy do
                     yield createMember minfo
+
            let props = GetImmediateIntrinsicPropInfosOfType (None, AccessibleFromSomeFSharpCode) cenv.g cenv.amap range0 entityTy
            let events = cenv.infoReader.GetImmediateIntrinsicEventsOfType (None, AccessibleFromSomeFSharpCode, range0, entityTy)
+
            for pinfo in props do
                 yield FSharpMemberOrFunctionOrValue(cenv, P pinfo, Item.Property (pinfo.PropertyName, [pinfo]))
+
            for einfo in events do
                 yield FSharpMemberOrFunctionOrValue(cenv, E einfo, Item.Event einfo)
 
@@ -657,8 +660,8 @@ type FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
                    let vref = mkNestedValRef entity v
                    yield FSharpMemberOrFunctionOrValue(cenv, V vref, Item.Value vref) 
                    match v.MemberInfo.Value.MemberFlags.MemberKind, v.ApparentEnclosingEntity with
-                   | SynMemberKind.PropertyGet, Parent p -> 
-                        let pinfo = FSProp(cenv.g, generalizedTyconRef cenv.g p, Some vref, None)
+                   | SynMemberKind.PropertyGet, Parent tcref -> 
+                        let pinfo = FSProp(cenv.g, generalizedTyconRef cenv.g tcref, Some vref, None)
                         yield FSharpMemberOrFunctionOrValue(cenv, P pinfo, Item.Property (pinfo.PropertyName, [pinfo]))
                    | SynMemberKind.PropertySet, Parent p -> 
                         let pinfo = FSProp(cenv.g, generalizedTyconRef cenv.g p, None, Some vref)
@@ -1306,7 +1309,7 @@ type FSharpActivePatternGroup(cenv, apinfo:ActivePatternInfo, ty, valOpt) =
         |> Option.bind (fun vref -> 
             match vref.DeclaringEntity with 
             | ParentNone -> None
-            | Parent p -> Some (FSharpEntity(cenv, p)))
+            | Parent tcref -> Some (FSharpEntity(cenv, tcref)))
 
 type FSharpGenericParameter(cenv, v:Typar) = 
 
@@ -1411,7 +1414,7 @@ type FSharpAbstractSignature(cenv, info: SlotSig) =
 
     member _.Name = info.Name 
     
-    member _.DeclaringType = FSharpType(cenv, info.ImplementedType)
+    member _.DeclaringType = FSharpType(cenv, info.DeclaringType)
 
 type FSharpGenericParameterMemberConstraint(cenv, info: TraitConstraintInfo) = 
     let (TTrait(tys, nm, flags, atys, retTy, _)) = info 
@@ -2076,7 +2079,7 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         | E e -> 
             // INCOMPLETENESS: Attribs is empty here, so we can't look at return attributes for .NET or F# methods
             let retTy = 
-                try PropTypOfEventInfo cenv.infoReader range0 AccessibleFromSomewhere e
+                try PropTypeOfEventInfo cenv.infoReader range0 AccessibleFromSomewhere e
                 with _ -> 
                     // For non-standard events, just use the delegate type as the ReturnParameter type
                     e.GetDelegateType(cenv.amap, range0)
@@ -2197,17 +2200,17 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
 
     member _.IsValCompiledAsMethod =
         match d with
-        | V valRef -> IlxGen.IsFSharpValCompiledAsMethod cenv.g valRef.Deref
+        | V vref -> IlxGen.IsFSharpValCompiledAsMethod cenv.g vref.Deref
         | _ -> false
 
     member _.IsValue =
         match d with
-        | V valRef -> not (isForallFunctionTy cenv.g valRef.Type)
+        | V vref -> not (isForallFunctionTy cenv.g vref.Type)
         | _ -> false
 
     member _.IsFunction =
         match d with
-        | V valRef -> isForallFunctionTy cenv.g valRef.Type
+        | V vref -> isForallFunctionTy cenv.g vref.Type
         | _ -> false
 
     override x.Equals(other: obj) =
@@ -2326,7 +2329,7 @@ type FSharpType(cenv, ty:TType) =
        DiagnosticsLogger.protectAssemblyExploration true <| fun () -> 
         match stripTyparEqns ty with 
         | TType_app (tcref, _, _) -> FSharpEntity(cenv, tcref).IsUnresolved
-        | TType_measure (Measure.Con tcref) ->  FSharpEntity(cenv, tcref).IsUnresolved
+        | TType_measure (Measure.Const tcref) ->  FSharpEntity(cenv, tcref).IsUnresolved
         | TType_measure (Measure.Prod _) ->  FSharpEntity(cenv, cenv.g.measureproduct_tcr).IsUnresolved 
         | TType_measure Measure.One ->  FSharpEntity(cenv, cenv.g.measureone_tcr).IsUnresolved 
         | TType_measure (Measure.Inv _) ->  FSharpEntity(cenv, cenv.g.measureinverse_tcr).IsUnresolved 
@@ -2342,7 +2345,7 @@ type FSharpType(cenv, ty:TType) =
        isResolved() &&
        protect <| fun () -> 
          match stripTyparEqns ty with 
-         | TType_app _ | TType_measure (Measure.Con _ | Measure.Prod _ | Measure.Inv _ | Measure.One _) -> true 
+         | TType_app _ | TType_measure (Measure.Const _ | Measure.Prod _ | Measure.Inv _ | Measure.One _) -> true 
          | _ -> false
 
     member _.IsTupleType = 
@@ -2363,7 +2366,7 @@ type FSharpType(cenv, ty:TType) =
        protect <| fun () -> 
         match stripTyparEqns ty with 
         | TType_app (tcref, _, _) -> FSharpEntity(cenv, tcref) 
-        | TType_measure (Measure.Con tcref) ->  FSharpEntity(cenv, tcref) 
+        | TType_measure (Measure.Const tcref) ->  FSharpEntity(cenv, tcref) 
         | TType_measure (Measure.Prod _) ->  FSharpEntity(cenv, cenv.g.measureproduct_tcr) 
         | TType_measure Measure.One ->  FSharpEntity(cenv, cenv.g.measureone_tcr) 
         | TType_measure (Measure.Inv _) ->  FSharpEntity(cenv, cenv.g.measureinverse_tcr) 
@@ -2375,8 +2378,8 @@ type FSharpType(cenv, ty:TType) =
         | TType_anon (_, tyargs) 
         | TType_app (_, tyargs, _) 
         | TType_tuple (_, tyargs) -> (tyargs |> List.map (fun ty -> FSharpType(cenv, ty)) |> makeReadOnlyCollection) 
-        | TType_fun(d, r, _) -> [| FSharpType(cenv, d); FSharpType(cenv, r) |] |> makeReadOnlyCollection
-        | TType_measure (Measure.Con _) ->  [| |] |> makeReadOnlyCollection
+        | TType_fun(domainTy, rangeTy, _) -> [| FSharpType(cenv, domainTy); FSharpType(cenv, rangeTy) |] |> makeReadOnlyCollection
+        | TType_measure (Measure.Const _) ->  [| |] |> makeReadOnlyCollection
         | TType_measure (Measure.Prod (t1, t2)) ->  [| FSharpType(cenv, TType_measure t1); FSharpType(cenv, TType_measure t2) |] |> makeReadOnlyCollection
         | TType_measure Measure.One ->  [| |] |> makeReadOnlyCollection
         | TType_measure (Measure.Inv t1) ->  [| FSharpType(cenv, TType_measure t1) |] |> makeReadOnlyCollection
@@ -2443,8 +2446,8 @@ type FSharpType(cenv, ty:TType) =
         |> Option.map (fun ty -> FSharpType(cenv, ty)) 
 
     member _.Instantiate(instantiation:(FSharpGenericParameter * FSharpType) list) = 
-        let typI = instType (instantiation |> List.map (fun (tyv, ty) -> tyv.TypeParameter, ty.Type)) ty
-        FSharpType(cenv, typI)
+        let resTy = instType (instantiation |> List.map (fun (tyv, ty) -> tyv.TypeParameter, ty.Type)) ty
+        FSharpType(cenv, resTy)
 
     member _.Type = ty
     member private x.cenv = cenv
@@ -2469,7 +2472,7 @@ type FSharpType(cenv, ty:TType) =
             | TType_app (tc1, b1, _)  -> 10200 + int32 tc1.Stamp + List.sumBy hashType b1
             | TType_ucase _   -> 10300  // shouldn't occur in symbols
             | TType_tuple (_, l1) -> 10400 + List.sumBy hashType l1
-            | TType_fun (dty, rty, _) -> 10500 + hashType dty + hashType rty
+            | TType_fun (domainTy, rangeTy, _) -> 10500 + hashType domainTy + hashType rangeTy
             | TType_measure _ -> 10600 
             | TType_anon (_,l1) -> 10800 + List.sumBy hashType l1
         hashType ty
@@ -2593,9 +2596,9 @@ type FSharpStaticParameter(cenv, sp: Tainted< TypeProviders.ProvidedParameterInf
     inherit FSharpSymbol(cenv, 
                          (fun () -> 
                               protect <| fun () -> 
-                                let spKind = Import.ImportProvidedType cenv.amap m (sp.PApply((fun x -> x.ParameterType), m))
+                                let paramTy = Import.ImportProvidedType cenv.amap m (sp.PApply((fun x -> x.ParameterType), m))
                                 let nm = sp.PUntaint((fun p -> p.Name), m)
-                                Item.ArgName((mkSynId m nm, spKind, None))), 
+                                Item.ArgName((mkSynId m nm, paramTy, None))), 
                          (fun _ _ _ -> true))
 
     member _.Name = 

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -373,12 +373,12 @@ let mkSynOperator (opm: range) (oper: string) =
 
 let mkSynInfix opm (l: SynExpr) oper (r: SynExpr) =
     let firstTwoRange = unionRanges l.Range opm
-    let wholeRange = unionRanges l.Range r.Range
+    let mWhole = unionRanges l.Range r.Range
 
     let app1 =
         SynExpr.App(ExprAtomicFlag.NonAtomic, true, mkSynOperator opm oper, l, firstTwoRange)
 
-    SynExpr.App(ExprAtomicFlag.NonAtomic, false, app1, r, wholeRange)
+    SynExpr.App(ExprAtomicFlag.NonAtomic, false, app1, r, mWhole)
 
 let mkSynBifix m oper x1 x2 =
     let app1 = SynExpr.App(ExprAtomicFlag.NonAtomic, true, mkSynOperator m oper, x1, m)
@@ -417,17 +417,17 @@ let mkSynDotBrackGet m mDot a b = SynExpr.DotIndexedGet(a, b, mDot, m)
 
 let mkSynQMarkSet m a b c = mkSynTrifix m qmarkSet a b c
 
-let mkSynDotParenGet lhsm dotm a b =
+let mkSynDotParenGet mLhs mDot a b =
     match b with
     | SynExpr.Tuple (false, [ _; _ ], _, _) ->
-        errorR (Deprecated(FSComp.SR.astDeprecatedIndexerNotation (), lhsm))
-        SynExpr.Const(SynConst.Unit, lhsm)
+        errorR (Deprecated(FSComp.SR.astDeprecatedIndexerNotation (), mLhs))
+        SynExpr.Const(SynConst.Unit, mLhs)
 
     | SynExpr.Tuple (false, [ _; _; _ ], _, _) ->
-        errorR (Deprecated(FSComp.SR.astDeprecatedIndexerNotation (), lhsm))
-        SynExpr.Const(SynConst.Unit, lhsm)
+        errorR (Deprecated(FSComp.SR.astDeprecatedIndexerNotation (), mLhs))
+        SynExpr.Const(SynConst.Unit, mLhs)
 
-    | _ -> mkSynInfix dotm a parenGet b
+    | _ -> mkSynInfix mDot a parenGet b
 
 let mkSynUnit m = SynExpr.Const(SynConst.Unit, m)
 
@@ -452,24 +452,24 @@ let mkSynAssign (l: SynExpr) (r: SynExpr) =
     | SynExpr.App (_, _, SynExpr.DotGet (e, _, v, _), x, _) -> SynExpr.DotNamedIndexedPropertySet(e, v, x, r, m)
     | l -> SynExpr.Set(l, r, m)
 
-let mkSynDot dotm m l (SynIdent (r, rTrivia)) =
+let mkSynDot mDot m l (SynIdent (r, rTrivia)) =
     match l with
     | SynExpr.LongIdent (isOpt, SynLongIdent (lid, dots, trivia), None, _) ->
         // REVIEW: MEMORY PERFORMANCE: This list operation is memory intensive (we create a lot of these list nodes)
-        SynExpr.LongIdent(isOpt, SynLongIdent(lid @ [ r ], dots @ [ dotm ], trivia @ [ rTrivia ]), None, m)
-    | SynExpr.Ident id -> SynExpr.LongIdent(false, SynLongIdent([ id; r ], [ dotm ], [ None; rTrivia ]), None, m)
+        SynExpr.LongIdent(isOpt, SynLongIdent(lid @ [ r ], dots @ [ mDot ], trivia @ [ rTrivia ]), None, m)
+    | SynExpr.Ident id -> SynExpr.LongIdent(false, SynLongIdent([ id; r ], [ mDot ], [ None; rTrivia ]), None, m)
     | SynExpr.DotGet (e, dm, SynLongIdent (lid, dots, trivia), _) ->
         // REVIEW: MEMORY PERFORMANCE: This is memory intensive (we create a lot of these list nodes)
-        SynExpr.DotGet(e, dm, SynLongIdent(lid @ [ r ], dots @ [ dotm ], trivia @ [ rTrivia ]), m)
-    | expr -> SynExpr.DotGet(expr, dotm, SynLongIdent([ r ], [], [ rTrivia ]), m)
+        SynExpr.DotGet(e, dm, SynLongIdent(lid @ [ r ], dots @ [ mDot ], trivia @ [ rTrivia ]), m)
+    | expr -> SynExpr.DotGet(expr, mDot, SynLongIdent([ r ], [], [ rTrivia ]), m)
 
-let mkSynDotMissing dotm m l =
+let mkSynDotMissing mDot m l =
     match l with
     | SynExpr.LongIdent (isOpt, SynLongIdent (lid, dots, trivia), None, _) ->
         // REVIEW: MEMORY PERFORMANCE: This list operation is memory intensive (we create a lot of these list nodes)
-        SynExpr.LongIdent(isOpt, SynLongIdent(lid, dots @ [ dotm ], trivia), None, m)
-    | SynExpr.Ident id -> SynExpr.LongIdent(false, SynLongIdent([ id ], [ dotm ], []), None, m)
-    | SynExpr.DotGet (e, dm, SynLongIdent (lid, dots, trivia), _) -> SynExpr.DotGet(e, dm, SynLongIdent(lid, dots @ [ dotm ], trivia), m) // REVIEW: MEMORY PERFORMANCE: This is memory intensive (we create a lot of these list nodes)
+        SynExpr.LongIdent(isOpt, SynLongIdent(lid, dots @ [ mDot ], trivia), None, m)
+    | SynExpr.Ident id -> SynExpr.LongIdent(false, SynLongIdent([ id ], [ mDot ], []), None, m)
+    | SynExpr.DotGet (e, dm, SynLongIdent (lid, dots, trivia), _) -> SynExpr.DotGet(e, dm, SynLongIdent(lid, dots @ [ mDot ], trivia), m) // REVIEW: MEMORY PERFORMANCE: This is memory intensive (we create a lot of these list nodes)
     | expr -> SynExpr.DiscardAfterMissingQualificationAfterDot(expr, m)
 
 let mkSynFunMatchLambdas synArgNameGenerator isMember wholem ps arrow e =
@@ -974,9 +974,9 @@ let (|ParsedHashDirectiveArguments|) (input: ParsedHashDirectiveArgument list) =
         | ParsedHashDirectiveArgument.SourceIdentifier (_, v, _) -> v)
         input
 
-let prependIdentInLongIdentWithTrivia (SynIdent (ident, identTrivia)) dotm lid =
+let prependIdentInLongIdentWithTrivia (SynIdent (ident, identTrivia)) mDot lid =
     match lid with
-    | SynLongIdent (lid, dots, trivia) -> SynLongIdent(ident :: lid, dotm :: dots, identTrivia :: trivia)
+    | SynLongIdent (lid, dots, trivia) -> SynLongIdent(ident :: lid, mDot :: dots, identTrivia :: trivia)
 
 let mkDynamicArgExpr expr =
     match expr with

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
@@ -143,7 +143,7 @@ val mkSynQMarkSet: m: range -> a: SynExpr -> b: SynExpr -> c: SynExpr -> SynExpr
 
 //val mkSynDotBrackSeqSliceGet: m:range -> mDot:range -> arr:SynExpr -> argsList:SynIndexerArg list -> SynExpr
 
-val mkSynDotParenGet: lhsm: range -> dotm: range -> a: SynExpr -> b: SynExpr -> SynExpr
+val mkSynDotParenGet: mLhs: range -> mDot: range -> a: SynExpr -> b: SynExpr -> SynExpr
 
 val mkSynUnit: m: range -> SynExpr
 
@@ -153,9 +153,9 @@ val mkSynDelay: m: range -> e: SynExpr -> SynExpr
 
 val mkSynAssign: l: SynExpr -> r: SynExpr -> SynExpr
 
-val mkSynDot: dotm: range -> m: range -> l: SynExpr -> r: SynIdent -> SynExpr
+val mkSynDot: mDot: range -> m: range -> l: SynExpr -> r: SynIdent -> SynExpr
 
-val mkSynDotMissing: dotm: range -> m: range -> l: SynExpr -> SynExpr
+val mkSynDotMissing: mDot: range -> m: range -> l: SynExpr -> SynExpr
 
 val mkSynFunMatchLambdas:
     synArgNameGenerator: SynArgNameGenerator ->
@@ -337,7 +337,7 @@ val (|SynPipeRight2|_|): SynExpr -> (SynExpr * SynExpr * SynExpr) option
 /// 'e1 |||> e2'
 val (|SynPipeRight3|_|): SynExpr -> (SynExpr * SynExpr * SynExpr * SynExpr) option
 
-val prependIdentInLongIdentWithTrivia: ident: SynIdent -> dotm: range -> lid: SynLongIdent -> SynLongIdent
+val prependIdentInLongIdentWithTrivia: ident: SynIdent -> mDot: range -> lid: SynLongIdent -> SynLongIdent
 
 val mkDynamicArgExpr: expr: SynExpr -> SynExpr
 

--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -564,8 +564,8 @@ type TcGlobals(
 
   let tryDecodeTupleTy tupInfo l =
       match l with
-      | [t1;t2;t3;t4;t5;t6;t7;marker] ->
-          match marker with
+      | [t1;t2;t3;t4;t5;t6;t7;markerTy] ->
+          match markerTy with
           | TType_app(tcref, [t8], _) when tyconRefEq tcref v_ref_tuple1_tcr -> mkRawRefTupleTy [t1;t2;t3;t4;t5;t6;t7;t8] |> Some
           | TType_app(tcref, [t8], _) when tyconRefEq tcref v_struct_tuple1_tcr -> mkRawStructTupleTy [t1;t2;t3;t4;t5;t6;t7;t8] |> Some
           | TType_tuple (_structness2, t8plus) -> TType_tuple (tupInfo, [t1;t2;t3;t4;t5;t6;t7] @ t8plus) |> Some
@@ -1832,11 +1832,11 @@ type TcGlobals(
         let info = makeOtherIntrinsicValRef (fslib_MFOperators_nleref, lower, None, Some nm, [vara], ([[varaTy]], varaTy))
         let tyargs = [aty]
         Some (info, tyargs, argExprs)
-    | "get_Item", [arrTy; _], Some rty, [_; _] when isArrayTy g arrTy ->
-        Some (g.array_get_info, [rty], argExprs)
-    | "set_Item", [arrTy; _; ety], _, [_; _; _] when isArrayTy g arrTy ->
-        Some (g.array_set_info, [ety], argExprs)
-    | "get_Item", [sty; _; _], _, [_; _] when isStringTy g sty ->
+    | "get_Item", [arrTy; _], Some retTy, [_; _] when isArrayTy g arrTy ->
+        Some (g.array_get_info, [retTy], argExprs)
+    | "set_Item", [arrTy; _; elemTy], _, [_; _; _] when isArrayTy g arrTy ->
+        Some (g.array_set_info, [elemTy], argExprs)
+    | "get_Item", [stringTy; _; _], _, [_; _] when isStringTy g stringTy ->
         Some (g.getstring_info, [], argExprs)
     | "op_UnaryPlus", [aty], _, [_] ->
         // Call Operators.id

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -1156,7 +1156,7 @@ type Entity =
     member x.MembersOfFSharpTyconSorted =
         x.TypeContents.tcaug_adhoc 
         |> NameMultiMap.rangeReversingEachBucket 
-        |> List.filter (fun v -> not v.IsCompilerGenerated)
+        |> List.filter (fun vref -> not vref.IsCompilerGenerated)
 
     /// Gets all immediate members of an F# type definition keyed by name, including compiler-generated ones.
     /// Note: result is a indexed table, and for each name the results are in reverse declaration order
@@ -1179,16 +1179,16 @@ type Entity =
     member x.AllGeneratedValues = 
         [ match x.GeneratedCompareToValues with 
           | None -> ()
-          | Some (v1, v2) -> yield v1; yield v2
+          | Some (vref1, vref2) -> yield vref1; yield vref2
           match x.GeneratedCompareToWithComparerValues with
           | None -> ()
           | Some v -> yield v
           match x.GeneratedHashAndEqualsValues with
           | None -> ()
-          | Some (v1, v2) -> yield v1; yield v2
+          | Some (vref1, vref2) -> yield vref1; yield vref2
           match x.GeneratedHashAndEqualsWithComparerValues with
           | None -> ()
-          | Some (v1, v2, v3) -> yield v1; yield v2; yield v3 ]
+          | Some (vref1, vref2, vref3) -> yield vref1; yield vref2; yield vref3 ]
     
 
     /// Gets the data indicating the compiled representation of a type or module in terms of Abstract IL data structures.
@@ -3701,32 +3701,32 @@ type ValRef =
     member x.ResolvedTarget = x.binding
 
     /// Dereference the ValRef to a Val.
-    member vr.Deref = 
-        if obj.ReferenceEquals(vr.binding, null) then
+    member x.Deref = 
+        if obj.ReferenceEquals(x.binding, null) then
             let res = 
-                let nlr = vr.nlr 
+                let nlr = x.nlr 
                 let e = nlr.EnclosingEntity.Deref 
                 let possible = e.ModuleOrNamespaceType.TryLinkVal(nlr.EnclosingEntity.nlr.Ccu, nlr.ItemKey)
                 match possible with 
                 | ValueNone -> error (InternalUndefinedItemRef (FSComp.SR.tastUndefinedItemRefVal, e.DisplayNameWithStaticParameters, nlr.AssemblyName, sprintf "%+A" nlr.ItemKey.PartialKey))
                 | ValueSome h -> h
-            vr.binding <- nullableSlotFull res 
+            x.binding <- nullableSlotFull res 
             res 
-        else vr.binding
+        else x.binding
 
     /// Dereference the ValRef to a Val option.
-    member vr.TryDeref = 
-        if obj.ReferenceEquals(vr.binding, null) then
+    member x.TryDeref = 
+        if obj.ReferenceEquals(x.binding, null) then
             let resOpt = 
-                match vr.nlr.EnclosingEntity.TryDeref with 
+                match x.nlr.EnclosingEntity.TryDeref with 
                 | ValueNone -> ValueNone
-                | ValueSome e -> e.ModuleOrNamespaceType.TryLinkVal(vr.nlr.EnclosingEntity.nlr.Ccu, vr.nlr.ItemKey)
+                | ValueSome e -> e.ModuleOrNamespaceType.TryLinkVal(x.nlr.EnclosingEntity.nlr.Ccu, x.nlr.ItemKey)
             match resOpt with 
             | ValueNone -> ()
             | ValueSome res -> 
-                vr.binding <- nullableSlotFull res 
+                x.binding <- nullableSlotFull res 
             resOpt
-        else ValueSome vr.binding
+        else ValueSome x.binding
 
     /// The type of the value. May be a TType_forall for a generic value. 
     /// May be a type variable or type containing type variables during type inference. 
@@ -3923,7 +3923,7 @@ type ValRef =
 /// Represents a reference to a case of a union type
 [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
 type UnionCaseRef = 
-    | UnionCaseRef of TyconRef * string
+    | UnionCaseRef of tyconRef: TyconRef * caseName: string
 
     /// Get a reference to the type containing this union case
     member x.TyconRef = let (UnionCaseRef(tcref, _)) = x in tcref
@@ -3982,7 +3982,7 @@ type UnionCaseRef =
 /// Represents a reference to a field in a record, class or struct
 [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
 type RecdFieldRef = 
-    | RecdFieldRef of tcref: TyconRef * id: string
+    | RecdFieldRef of tyconRef: TyconRef * fieldName: string
 
     /// Get a reference to the type containing this union case
     member x.TyconRef = let (RecdFieldRef(tcref, _)) = x in tcref
@@ -4079,7 +4079,7 @@ type TType =
         | TType_anon (anonInfo, _tinst) -> defaultArg anonInfo.Assembly.QualifiedName ""
         | TType_fun _ -> ""
         | TType_measure _ -> ""
-        | TType_var (tp, _) -> tp.Solution |> function Some sln -> sln.GetAssemblyName() | None -> ""
+        | TType_var (tp, _) -> tp.Solution |> function Some slnTy -> slnTy.GetAssemblyName() | None -> ""
         | TType_ucase (_uc, _tinst) ->
             let (TILObjectReprData(scope, _nesting, _definition)) = _uc.Tycon.ILTyconInfo
             scope.QualifiedName
@@ -4101,7 +4101,7 @@ type TType =
              | TupInfo.Const false -> ""
              | TupInfo.Const true -> "struct ")
              + "{|" + String.concat "," (Seq.map2 (fun nm ty -> nm + " " + string ty + ";") anonInfo.SortedNames tinst) + ")" + "|}"
-        | TType_fun (d, r, _) -> "(" + string d + " -> " + string r + ")"
+        | TType_fun (domainTy, retTy, _) -> "(" + string domainTy + " -> " + string retTy + ")"
         | TType_ucase (uc, tinst) -> "ucase " + uc.CaseName + (match tinst with [] -> "" | tys -> "<" + String.concat "," (List.map string tys) + ">")
         | TType_var (tp, _) -> 
             match tp.Solution with 
@@ -4178,7 +4178,7 @@ type Measure =
     | Var of typar: Typar
 
     /// A constant, leaf unit-of-measure such as 'kg' or 'm'
-    | Con of tyconRef: TyconRef
+    | Const of tyconRef: TyconRef
 
     /// A product of two units of measure
     | Prod of measure1: Measure * measure2: Measure
@@ -5042,7 +5042,7 @@ type ObjExprMethod =
 type SlotSig = 
     | TSlotSig of
         methodName: string *
-        implementedType: TType *
+        declaringType: TType *
         classTypars: Typars *
         methodTypars: Typars *
         formalParams: SlotParam list list *
@@ -5052,7 +5052,7 @@ type SlotSig =
     member ss.Name = let (TSlotSig(nm, _, _, _, _, _)) = ss in nm
 
     /// The (instantiated) type which the slot is logically a part of 
-    member ss.ImplementedType = let (TSlotSig(_, ty, _, _, _, _)) = ss in ty
+    member ss.DeclaringType = let (TSlotSig(_, ty, _, _, _, _)) = ss in ty
 
     /// The class type parameters of the slot
     member ss.ClassTypars = let (TSlotSig(_, _, ctps, _, _, _)) = ss in ctps

--- a/src/Compiler/TypedTree/TypedTree.fsi
+++ b/src/Compiler/TypedTree/TypedTree.fsi
@@ -2805,7 +2805,7 @@ type ValRef =
 /// Represents a reference to a case of a union type
 [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
 type UnionCaseRef =
-    | UnionCaseRef of TyconRef * string
+    | UnionCaseRef of tyconRef: TyconRef * caseName: string
 
     /// Get a field of the union case by index
     member FieldByIndex: n: int -> RecdField
@@ -2854,7 +2854,7 @@ type UnionCaseRef =
 /// Represents a reference to a field in a record, class or struct
 [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
 type RecdFieldRef =
-    | RecdFieldRef of tcref: TyconRef * id: string
+    | RecdFieldRef of tyconRef: TyconRef * fieldName: string
 
     override ToString: unit -> string
 
@@ -2977,7 +2977,7 @@ type Measure =
     | Var of typar: Typar
 
     /// A constant, leaf unit-of-measure such as 'kg' or 'm'
-    | Con of tyconRef: TyconRef
+    | Const of tyconRef: TyconRef
 
     /// A product of two units of measure
     | Prod of measure1: Measure * measure2: Measure
@@ -3675,7 +3675,7 @@ type ObjExprMethod =
 type SlotSig =
     | TSlotSig of
         methodName: string *
-        implementedType: TType *
+        declaringType: TType *
         classTypars: Typars *
         methodTypars: Typars *
         formalParams: SlotParam list list *
@@ -3696,7 +3696,7 @@ type SlotSig =
     member FormalReturnType: TType option
 
     /// The (instantiated) type which the slot is logically a part of
-    member ImplementedType: TType
+    member DeclaringType: TType
 
     /// The method type parameters of the slot
     member MethodTypars: Typars

--- a/src/Compiler/TypedTree/TypedTreeBasics.fs
+++ b/src/Compiler/TypedTree/TypedTreeBasics.fs
@@ -77,24 +77,24 @@ let mkRawStructTupleTy tys = TType_tuple (tupInfoStruct, tys)
 // Equality relations on locally defined things 
 //---------------------------------------------------------------------------
 
-let typarEq (lv1: Typar) (lv2: Typar) = (lv1.Stamp = lv2.Stamp)
+let typarEq (tp1: Typar) (tp2: Typar) = (tp1.Stamp = tp2.Stamp)
 
 /// Equality on type variables, implemented as reference equality. This should be equivalent to using typarEq.
 let typarRefEq (tp1: Typar) (tp2: Typar) = (tp1 === tp2)
 
 /// Equality on value specs, implemented as reference equality
-let valEq (lv1: Val) (lv2: Val) = (lv1 === lv2)
+let valEq (v1: Val) (v2: Val) = (v1 === v2)
 
 /// Equality on CCU references, implemented as reference equality except when unresolved
-let ccuEq (mv1: CcuThunk) (mv2: CcuThunk) = 
-    (mv1 === mv2) || 
-    (if mv1.IsUnresolvedReference || mv2.IsUnresolvedReference then 
-        mv1.AssemblyName = mv2.AssemblyName
+let ccuEq (ccu1: CcuThunk) (ccu2: CcuThunk) = 
+    (ccu1 === ccu2) || 
+    (if ccu1.IsUnresolvedReference || ccu2.IsUnresolvedReference then 
+        ccu1.AssemblyName = ccu2.AssemblyName
      else 
-        mv1.Contents === mv2.Contents)
+        ccu1.Contents === ccu2.Contents)
 
 /// For dereferencing in the middle of a pattern
-let (|ValDeref|) (vr: ValRef) = vr.Deref
+let (|ValDeref|) (vref: ValRef) = vref.Deref
 
 //--------------------------------------------------------------------------
 // Make references to TAST items

--- a/src/Compiler/TypedTree/TypedTreeBasics.fsi
+++ b/src/Compiler/TypedTree/TypedTreeBasics.fsi
@@ -57,19 +57,19 @@ val mkRawRefTupleTy: tys: TTypes -> TType
 
 val mkRawStructTupleTy: tys: TTypes -> TType
 
-val typarEq: lv1: Typar -> lv2: Typar -> bool
+val typarEq: tp1: Typar -> tp2: Typar -> bool
 
 /// Equality on type variables, implemented as reference equality. This should be equivalent to using typarEq.
 val typarRefEq: tp1: Typar -> tp2: Typar -> bool
 
 /// Equality on value specs, implemented as reference equality
-val valEq: lv1: Val -> lv2: Val -> bool
+val valEq: v1: Val -> v2: Val -> bool
 
 /// Equality on CCU references, implemented as reference equality except when unresolved
-val ccuEq: mv1: CcuThunk -> mv2: CcuThunk -> bool
+val ccuEq: ccu1: CcuThunk -> ccu2: CcuThunk -> bool
 
 /// For dereferencing in the middle of a pattern
-val (|ValDeref|): vr: ValRef -> Val
+val (|ValDeref|): vref: ValRef -> Val
 
 val mkRecdFieldRef: tcref: TyconRef -> f: string -> RecdFieldRef
 

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -45,32 +45,32 @@ type TyparMap<'T> =
     | TPMap of StampMap<'T>
 
     member tm.Item 
-        with get (v: Typar) = 
+        with get (tp: Typar) = 
             let (TPMap m) = tm
-            m[v.Stamp]
+            m[tp.Stamp]
 
-    member tm.ContainsKey (v: Typar) = 
+    member tm.ContainsKey (tp: Typar) = 
         let (TPMap m) = tm
-        m.ContainsKey(v.Stamp)
+        m.ContainsKey(tp.Stamp)
 
-    member tm.TryFind (v: Typar) = 
+    member tm.TryFind (tp: Typar) = 
         let (TPMap m) = tm
-        m.TryFind(v.Stamp)
+        m.TryFind(tp.Stamp)
 
-    member tm.Add (v: Typar, x) = 
+    member tm.Add (tp: Typar, x) = 
         let (TPMap m) = tm
-        TPMap (m.Add(v.Stamp, x))
+        TPMap (m.Add(tp.Stamp, x))
 
     static member Empty: TyparMap<'T> = TPMap Map.empty
 
 [<NoEquality; NoComparison; Sealed>]
 type TyconRefMap<'T>(imap: StampMap<'T>) =
-    member m.Item with get (v: TyconRef) = imap[v.Stamp]
-    member m.TryFind (v: TyconRef) = imap.TryFind v.Stamp 
-    member m.ContainsKey (v: TyconRef) = imap.ContainsKey v.Stamp 
-    member m.Add (v: TyconRef) x = TyconRefMap (imap.Add (v.Stamp, x))
-    member m.Remove (v: TyconRef) = TyconRefMap (imap.Remove v.Stamp)
-    member m.IsEmpty = imap.IsEmpty
+    member _.Item with get (tcref: TyconRef) = imap[tcref.Stamp]
+    member _.TryFind (tcref: TyconRef) = imap.TryFind tcref.Stamp 
+    member _.ContainsKey (tcref: TyconRef) = imap.ContainsKey tcref.Stamp 
+    member _.Add (tcref: TyconRef) x = TyconRefMap (imap.Add (tcref.Stamp, x))
+    member _.Remove (tcref: TyconRef) = TyconRefMap (imap.Remove tcref.Stamp)
+    member _.IsEmpty = imap.IsEmpty
 
     static member Empty: TyconRefMap<'T> = TyconRefMap Map.empty
     static member OfList vs = (vs, TyconRefMap<'T>.Empty) ||> List.foldBack (fun (x, y) acc -> acc.Add x y) 
@@ -79,14 +79,14 @@ type TyconRefMap<'T>(imap: StampMap<'T>) =
 [<NoEquality; NoComparison>]
 type ValMap<'T>(imap: StampMap<'T>) = 
      
-    member m.Contents = imap
-    member m.Item with get (v: Val) = imap[v.Stamp]
-    member m.TryFind (v: Val) = imap.TryFind v.Stamp 
-    member m.ContainsVal (v: Val) = imap.ContainsKey v.Stamp 
-    member m.Add (v: Val) x = ValMap (imap.Add(v.Stamp, x))
-    member m.Remove (v: Val) = ValMap (imap.Remove(v.Stamp))
+    member _.Contents = imap
+    member _.Item with get (v: Val) = imap[v.Stamp]
+    member _.TryFind (v: Val) = imap.TryFind v.Stamp 
+    member _.ContainsVal (v: Val) = imap.ContainsKey v.Stamp 
+    member _.Add (v: Val) x = ValMap (imap.Add(v.Stamp, x))
+    member _.Remove (v: Val) = ValMap (imap.Remove(v.Stamp))
     static member Empty = ValMap<'T> Map.empty
-    member m.IsEmpty = imap.IsEmpty
+    member _.IsEmpty = imap.IsEmpty
     static member OfList vs = (vs, ValMap<'T>.Empty) ||> List.foldBack (fun (x, y) acc -> acc.Add x y) 
 
 //--------------------------------------------------------------------------
@@ -207,11 +207,11 @@ let rec remapTypeAux (tyenv: Remap) (ty: TType) =
       if tupInfo === tupInfoR && l === lR then ty else  
       TType_tuple (tupInfoR, lR)
 
-  | TType_fun (d, r, flags) as ty -> 
-      let dR = remapTypeAux tyenv d
-      let rR = remapTypeAux tyenv r
-      if d === dR && r === rR then ty else
-      TType_fun (dR, rR, flags)
+  | TType_fun (domainTy, rangeTy, flags) as ty -> 
+      let domainTyR = remapTypeAux tyenv domainTy
+      let retTyR = remapTypeAux tyenv rangeTy
+      if domainTy === domainTyR && rangeTy === retTyR then ty else
+      TType_fun (domainTyR, retTyR, flags)
 
   | TType_forall (tps, ty) -> 
       let tpsR, tyenv = copyAndRemapAndBindTypars tyenv tps
@@ -224,9 +224,9 @@ let rec remapTypeAux (tyenv: Remap) (ty: TType) =
 and remapMeasureAux tyenv unt =
     match unt with
     | Measure.One -> unt
-    | Measure.Con tcref ->
+    | Measure.Const tcref ->
         match tyenv.tyconRefRemap.TryFind tcref with 
-        | Some tcref -> Measure.Con tcref
+        | Some tcref -> Measure.Const tcref
         | None -> unt
     | Measure.Prod(u1, u2) -> Measure.Prod(remapMeasureAux tyenv u1, remapMeasureAux tyenv u2)
     | Measure.RationalPower(u, q) -> Measure.RationalPower(remapMeasureAux tyenv u, q)
@@ -235,8 +235,8 @@ and remapMeasureAux tyenv unt =
        match tp.Solution with
        | None -> 
           match ListAssoc.tryFind typarEq tp tyenv.tpinst with
-          | Some v -> 
-              match v with
+          | Some tpTy -> 
+              match tpTy with
               | TType_measure unt -> unt
               | _ -> failwith "remapMeasureAux: incorrect kinds"
           | None -> unt
@@ -257,10 +257,10 @@ and remapTyparConstraintsAux tyenv cs =
              Some(TyparConstraint.MayResolveMember (remapTraitInfo tyenv traitInfo, m))
          | TyparConstraint.DefaultsTo(priority, ty, m) ->
              Some(TyparConstraint.DefaultsTo(priority, remapTypeAux tyenv ty, m))
-         | TyparConstraint.IsEnum(uty, m) -> 
-             Some(TyparConstraint.IsEnum(remapTypeAux tyenv uty, m))
-         | TyparConstraint.IsDelegate(uty1, uty2, m) -> 
-             Some(TyparConstraint.IsDelegate(remapTypeAux tyenv uty1, remapTypeAux tyenv uty2, m))
+         | TyparConstraint.IsEnum(underlyingTy, m) -> 
+             Some(TyparConstraint.IsEnum(remapTypeAux tyenv underlyingTy, m))
+         | TyparConstraint.IsDelegate(argTys, retTy, m) -> 
+             Some(TyparConstraint.IsDelegate(remapTypeAux tyenv argTys, remapTypeAux tyenv retTy, m))
          | TyparConstraint.SimpleChoice(tys, m) ->
              Some(TyparConstraint.SimpleChoice(remapTypesAux tyenv tys, m))
          | TyparConstraint.SupportsComparison _ 
@@ -443,7 +443,7 @@ let reduceTyconRefAbbrevMeasureable (tcref: TyconRef) =
 
 let rec stripUnitEqnsFromMeasureAux canShortcut unt = 
     match stripUnitEqnsAux canShortcut unt with 
-    | Measure.Con tcref when tcref.IsTypeAbbrev ->  
+    | Measure.Const tcref when tcref.IsTypeAbbrev ->  
         stripUnitEqnsFromMeasureAux canShortcut (reduceTyconRefAbbrevMeasureable tcref) 
     | m -> m
 
@@ -456,7 +456,7 @@ let stripUnitEqnsFromMeasure m = stripUnitEqnsFromMeasureAux false m
 /// What is the contribution of unit-of-measure constant ucref to unit-of-measure expression measure? 
 let rec MeasureExprConExponent g abbrev ucref unt =
     match (if abbrev then stripUnitEqnsFromMeasure unt else stripUnitEqns unt) with
-    | Measure.Con ucrefR -> if tyconRefEq g ucrefR ucref then OneRational else ZeroRational
+    | Measure.Const ucrefR -> if tyconRefEq g ucrefR ucref then OneRational else ZeroRational
     | Measure.Inv untR -> NegRational(MeasureExprConExponent g abbrev ucref untR)
     | Measure.Prod(unt1, unt2) -> AddRational(MeasureExprConExponent g abbrev ucref unt1) (MeasureExprConExponent g abbrev ucref unt2)
     | Measure.RationalPower(untR, q) -> MulRational (MeasureExprConExponent g abbrev ucref untR) q
@@ -466,7 +466,7 @@ let rec MeasureExprConExponent g abbrev ucref unt =
 /// after remapping tycons? 
 let rec MeasureConExponentAfterRemapping g r ucref unt =
     match stripUnitEqnsFromMeasure unt with
-    | Measure.Con ucrefR -> if tyconRefEq g (r ucrefR) ucref then OneRational else ZeroRational
+    | Measure.Const ucrefR -> if tyconRefEq g (r ucrefR) ucref then OneRational else ZeroRational
     | Measure.Inv untR -> NegRational(MeasureConExponentAfterRemapping g r ucref untR)
     | Measure.Prod(unt1, unt2) -> AddRational(MeasureConExponentAfterRemapping g r ucref unt1) (MeasureConExponentAfterRemapping g r ucref unt2)
     | Measure.RationalPower(untR, q) -> MulRational (MeasureConExponentAfterRemapping g r ucref untR) q
@@ -511,7 +511,7 @@ let ListMeasureVarOccsWithNonZeroExponents untexpr =
 let ListMeasureConOccsWithNonZeroExponents g eraseAbbrevs untexpr =
     let rec gather acc unt =  
         match (if eraseAbbrevs then stripUnitEqnsFromMeasure unt else stripUnitEqns unt) with
-        | Measure.Con c -> 
+        | Measure.Const c -> 
             if List.exists (fun (cR, _) -> tyconRefEq g c cR) acc then acc else 
             let e = MeasureExprConExponent g eraseAbbrevs c untexpr
             if e = ZeroRational then acc else (c, e) :: acc
@@ -526,7 +526,7 @@ let ListMeasureConOccsWithNonZeroExponents g eraseAbbrevs untexpr =
 let ListMeasureConOccsAfterRemapping g r unt =
     let rec gather acc unt =  
         match stripUnitEqnsFromMeasure unt with
-        | Measure.Con c -> if List.exists (tyconRefEq g (r c)) acc then acc else r c :: acc
+        | Measure.Const c -> if List.exists (tyconRefEq g (r c)) acc then acc else r c :: acc
         | Measure.Prod(unt1, unt2) -> gather (gather acc unt1) unt2
         | Measure.RationalPower(untR, _) -> gather acc untR
         | Measure.Inv untR -> gather acc untR
@@ -552,8 +552,8 @@ let ProdMeasures ms =
     | [] -> Measure.One 
     | m :: ms -> List.foldBack MeasureProdOpt ms m
 
-let isDimensionless g tyarg =
-    match stripTyparEqns tyarg with
+let isDimensionless g ty =
+    match stripTyparEqns ty with
     | TType_measure unt ->
       isNil (ListMeasureVarOccsWithNonZeroExponents unt) && 
       isNil (ListMeasureConOccsWithNonZeroExponents g true unt)
@@ -581,7 +581,7 @@ let normalizeMeasure g ms =
     match vs, cs with
     | [], [] -> Measure.One
     | [(v, e)], [] when e = OneRational -> Measure.Var v
-    | vs, cs -> List.foldBack (fun (v, e) -> fun m -> Measure.Prod (Measure.RationalPower (Measure.Var v, e), m)) vs (List.foldBack (fun (c, e) -> fun m -> Measure.Prod (Measure.RationalPower (Measure.Con c, e), m)) cs Measure.One)
+    | vs, cs -> List.foldBack (fun (v, e) -> fun m -> Measure.Prod (Measure.RationalPower (Measure.Var v, e), m)) vs (List.foldBack (fun (c, e) -> fun m -> Measure.Prod (Measure.RationalPower (Measure.Const c, e), m)) cs Measure.One)
  
 let tryNormalizeMeasureInType g ty =
     match ty with
@@ -789,8 +789,8 @@ let rec stripTyEqnsAndErase eraseFuncAndTuple (g: TcGlobals) ty =
         else
             ty
 
-    | TType_fun(a, b, flags) when eraseFuncAndTuple ->
-        TType_app(g.fastFunc_tcr, [ a; b ], flags) 
+    | TType_fun(domainTy, rangeTy, flags) when eraseFuncAndTuple ->
+        TType_app(g.fastFunc_tcr, [ domainTy; rangeTy ], flags) 
 
     | TType_tuple(tupInfo, l) when eraseFuncAndTuple ->
         mkCompiledTupleTy g (evalTupInfoIsStruct tupInfo) l
@@ -816,7 +816,7 @@ let rec stripExnEqns (eref: TyconRef) =
 
 let primDestForallTy g ty = ty |> stripTyEqns g |> (function TType_forall (tyvs, tau) -> (tyvs, tau) | _ -> failwith "primDestForallTy: not a forall type")
 
-let destFunTy g ty = ty |> stripTyEqns g |> (function TType_fun (tyv, tau, _) -> (tyv, tau) | _ -> failwith "destFunTy: not a function type")
+let destFunTy g ty = ty |> stripTyEqns g |> (function TType_fun (domainTy, rangeTy, _) -> (domainTy, rangeTy) | _ -> failwith "destFunTy: not a function type")
 
 let destAnyTupleTy g ty = ty |> stripTyEqns g |> (function TType_tuple (tupInfo, l) -> tupInfo, l | _ -> failwith "destAnyTupleTy: not a tuple type")
 
@@ -880,7 +880,7 @@ let argsOfAppTy g ty = ty |> stripTyEqns g |> (function TType_app(_, tinst, _) -
 
 let tryDestTyparTy g ty = ty |> stripTyEqns g |> (function TType_var (v, _) -> ValueSome v | _ -> ValueNone)
 
-let tryDestFunTy g ty = ty |> stripTyEqns g |> (function TType_fun (tyv, tau, _) -> ValueSome(tyv, tau) | _ -> ValueNone)
+let tryDestFunTy g ty = ty |> stripTyEqns g |> (function TType_fun (domainTy, rangeTy, _) -> ValueSome(domainTy, rangeTy) | _ -> ValueNone)
 
 let tryTcrefOfAppTy g ty = ty |> stripTyEqns g |> (function TType_app(tcref, _, _) -> ValueSome tcref | _ -> ValueNone)
 
@@ -900,14 +900,14 @@ let tryNiceEntityRefOfTy ty =
     let ty = stripTyparEqnsAux false ty 
     match ty with
     | TType_app (tcref, _, _) -> ValueSome tcref
-    | TType_measure (Measure.Con tcref) -> ValueSome tcref
+    | TType_measure (Measure.Const tcref) -> ValueSome tcref
     | _ -> ValueNone
 
 let tryNiceEntityRefOfTyOption ty = 
     let ty = stripTyparEqnsAux false ty 
     match ty with
     | TType_app (tcref, _, _) -> Some tcref
-    | TType_measure (Measure.Con tcref) -> Some tcref
+    | TType_measure (Measure.Const tcref) -> Some tcref
     | _ -> None
     
 let mkInstForAppTy g ty = 
@@ -931,12 +931,12 @@ let convertToTypeWithMetadataIfPossible g ty =
 // TType modifications
 //---------------------------------------------------------------------------
 
-let stripMeasuresFromTType g tt = 
-    match tt with
-    | TType_app(a, b, flags) ->
-        let bR = b |> List.filter (isMeasureTy g >> not)
-        TType_app(a, bR, flags)
-    | _ -> tt
+let stripMeasuresFromTy g ty = 
+    match ty with
+    | TType_app(tcref, tinst, flags) ->
+        let tinstR = tinst |> List.filter (isMeasureTy g >> not)
+        TType_app(tcref, tinstR, flags)
+    | _ -> ty
 
 //---------------------------------------------------------------------------
 // Equivalence of types up to alpha-equivalence 
@@ -990,30 +990,29 @@ and traitKeysAEquivAux erasureFlag g aenv witnessInfo1 witnessInfo2 =
 and returnTypesAEquivAux erasureFlag g aenv retTy retTy2 =
     match retTy, retTy2 with  
     | None, None -> true
-    | Some t1, Some t2 -> typeAEquivAux erasureFlag g aenv t1 t2
+    | Some ty1, Some ty2 -> typeAEquivAux erasureFlag g aenv ty1 ty2
     | _ -> false
-
     
 and typarConstraintsAEquivAux erasureFlag g aenv tpc1 tpc2 =
     match tpc1, tpc2 with
-    | TyparConstraint.CoercesTo(acty, _), 
-      TyparConstraint.CoercesTo(fcty, _) -> 
-        typeAEquivAux erasureFlag g aenv acty fcty
+    | TyparConstraint.CoercesTo(tgtTy1, _), 
+      TyparConstraint.CoercesTo(tgtTy2, _) -> 
+        typeAEquivAux erasureFlag g aenv tgtTy1 tgtTy2
 
     | TyparConstraint.MayResolveMember(trait1, _),
       TyparConstraint.MayResolveMember(trait2, _) -> 
         traitsAEquivAux erasureFlag g aenv trait1 trait2 
 
-    | TyparConstraint.DefaultsTo(_, acty, _), 
-      TyparConstraint.DefaultsTo(_, fcty, _) -> 
-        typeAEquivAux erasureFlag g aenv acty fcty
+    | TyparConstraint.DefaultsTo(_, dfltTy1, _), 
+      TyparConstraint.DefaultsTo(_, dfltTy2, _) -> 
+        typeAEquivAux erasureFlag g aenv dfltTy1 dfltTy2
 
-    | TyparConstraint.IsEnum(uty1, _), TyparConstraint.IsEnum(uty2, _) -> 
-        typeAEquivAux erasureFlag g aenv uty1 uty2
+    | TyparConstraint.IsEnum(underlyingTy1, _), TyparConstraint.IsEnum(underlyingTy2, _) -> 
+        typeAEquivAux erasureFlag g aenv underlyingTy1 underlyingTy2
 
-    | TyparConstraint.IsDelegate(aty1, bty1, _), TyparConstraint.IsDelegate(aty2, bty2, _) -> 
-        typeAEquivAux erasureFlag g aenv aty1 aty2 && 
-        typeAEquivAux erasureFlag g aenv bty1 bty2 
+    | TyparConstraint.IsDelegate(argTys1, retTy1, _), TyparConstraint.IsDelegate(argTys2, retTy2, _) -> 
+        typeAEquivAux erasureFlag g aenv argTys1 argTys2 && 
+        typeAEquivAux erasureFlag g aenv retTy1 retTy2 
 
     | TyparConstraint.SimpleChoice (tys1, _), TyparConstraint.SimpleChoice(tys2, _) -> 
         ListSet.equals (typeAEquivAux erasureFlag g aenv) tys1 tys2
@@ -1036,9 +1035,9 @@ and typarsAEquivAux erasureFlag g (aenv: TypeEquivEnv) tps1 tps2 =
     let aenv = aenv.BindEquivTypars tps1 tps2 
     List.forall2 (typarConstraintSetsAEquivAux erasureFlag g aenv) tps1 tps2
 
-and tcrefAEquiv g aenv tc1 tc2 = 
-    tyconRefEq g tc1 tc2 || 
-      (match aenv.EquivTycons.TryFind tc1 with Some v -> tyconRefEq g v tc2 | None -> false)
+and tcrefAEquiv g aenv tcref1 tcref2 = 
+    tyconRefEq g tcref1 tcref2 || 
+      (match aenv.EquivTycons.TryFind tcref1 with Some v -> tyconRefEq g v tcref2 | None -> false)
 
 and typeAEquivAux erasureFlag g aenv ty1 ty2 = 
     let ty1 = stripTyEqnsWrtErasure erasureFlag g ty1 
@@ -1052,27 +1051,27 @@ and typeAEquivAux erasureFlag g aenv ty1 ty2 =
 
     | TType_var (tp1, _), _ ->
         match aenv.EquivTypars.TryFind tp1 with
-        | Some v -> typeEquivAux erasureFlag g v ty2
+        | Some tpTy1 -> typeEquivAux erasureFlag g tpTy1 ty2
         | None -> false
 
-    | TType_app (tc1, b1, _), TType_app (tc2, b2, _) -> 
-        tcrefAEquiv g aenv tc1 tc2 &&
-        typesAEquivAux erasureFlag g aenv b1 b2
+    | TType_app (tcref1, tinst1, _), TType_app (tcref2, tinst2, _) -> 
+        tcrefAEquiv g aenv tcref1 tcref2 &&
+        typesAEquivAux erasureFlag g aenv tinst1 tinst2
 
-    | TType_ucase (UnionCaseRef(tc1, n1), b1), TType_ucase (UnionCaseRef(tc2, n2), b2) -> 
-        n1=n2 &&
-        tcrefAEquiv g aenv tc1 tc2 &&
-        typesAEquivAux erasureFlag g aenv b1 b2
+    | TType_ucase (UnionCaseRef(tcref1, ucase1), tinst1), TType_ucase (UnionCaseRef(tcref2, ucase2), tinst2) -> 
+        ucase1=ucase2 &&
+        tcrefAEquiv g aenv tcref1 tcref2 &&
+        typesAEquivAux erasureFlag g aenv tinst1 tinst2
 
-    | TType_tuple (s1, l1), TType_tuple (s2, l2) -> 
-        structnessAEquiv s1 s2 && typesAEquivAux erasureFlag g aenv l1 l2
+    | TType_tuple (tupInfo1, l1), TType_tuple (tupInfo2, l2) -> 
+        structnessAEquiv tupInfo1 tupInfo2 && typesAEquivAux erasureFlag g aenv l1 l2
 
     | TType_anon (anonInfo1, l1), TType_anon (anonInfo2, l2) -> 
         anonInfoEquiv anonInfo1 anonInfo2 &&
         typesAEquivAux erasureFlag g aenv l1 l2
 
-    | TType_fun (dtys1, rty1, _), TType_fun (dtys2, retTy2, _) -> 
-        typeAEquivAux erasureFlag g aenv dtys1 dtys2 && typeAEquivAux erasureFlag g aenv rty1 retTy2
+    | TType_fun (domainTy1, rangeTy1, _), TType_fun (domainTy2, rangeTy2, _) -> 
+        typeAEquivAux erasureFlag g aenv domainTy1 domainTy2 && typeAEquivAux erasureFlag g aenv rangeTy1 rangeTy2
 
     | TType_measure m1, TType_measure m2 -> 
         match erasureFlag with 
@@ -1080,7 +1079,6 @@ and typeAEquivAux erasureFlag g aenv ty1 ty2 =
         | _ -> true 
 
     | _ -> false
-
 
 and anonInfoEquiv (anonInfo1: AnonRecdTypeInfo) (anonInfo2: AnonRecdTypeInfo) =
     ccuEq anonInfo1.Assembly anonInfo2.Assembly && 
@@ -1094,7 +1092,7 @@ and structnessAEquiv un1 un2 =
 and measureAEquiv g aenv un1 un2 =
     let vars1 = ListMeasureVarOccs un1
     let trans tp1 = if aenv.EquivTypars.ContainsKey tp1 then destAnyParTy g aenv.EquivTypars[tp1] else tp1
-    let remapTyconRef tc = if aenv.EquivTycons.ContainsKey tc then aenv.EquivTycons[tc] else tc
+    let remapTyconRef tcref = if aenv.EquivTycons.ContainsKey tcref then aenv.EquivTycons[tcref] else tcref
     let vars1R = List.map trans vars1
     let vars2 = ListSet.subtract typarEq (ListMeasureVarOccs un2) vars1R
     let cons1 = ListMeasureConOccsAfterRemapping g remapTyconRef un1
@@ -1161,7 +1159,9 @@ let rec getErasedTypes g ty =
 //---------------------------------------------------------------------------
 
 let valOrder = { new IComparer<Val> with member _.Compare(v1, v2) = compare v1.Stamp v2.Stamp }
-let tyconOrder = { new IComparer<Tycon> with member _.Compare(tc1, tc2) = compare tc1.Stamp tc2.Stamp }
+
+let tyconOrder = { new IComparer<Tycon> with member _.Compare(tycon1, tycon2) = compare tycon1.Stamp tycon2.Stamp }
+
 let recdFieldRefOrder = 
     { new IComparer<RecdFieldRef> with 
          member _.Compare(RecdFieldRef(tcref1, nm1), RecdFieldRef(tcref2, nm2)) = 
@@ -1180,8 +1180,8 @@ let unionCaseRefOrder =
 // Make some common types
 //---------------------------------------------------------------------------
 
-let mkFunTy (g: TcGlobals) d r =
-    TType_fun (d, r, g.knownWithoutNull)
+let mkFunTy (g: TcGlobals) domainTy rangeTy =
+    TType_fun (domainTy, rangeTy, g.knownWithoutNull)
 
 let mkForallTy d r = TType_forall (d, r)
 
@@ -1396,7 +1396,7 @@ let NormalizeDeclaredTyparsForEquiRecursiveInference g tps =
 type GeneralizedType = GeneralizedType of Typars * TType    
   
 let mkGenericBindRhs g m generalizedTyparsForRecursiveBlock typeScheme bodyExpr = 
-    let (GeneralizedType(generalizedTypars, tauType)) = typeScheme
+    let (GeneralizedType(generalizedTypars, tauTy)) = typeScheme
 
     // Normalize the generalized typars
     let generalizedTypars = NormalizeDeclaredTyparsForEquiRecursiveInference g generalizedTypars
@@ -1414,7 +1414,7 @@ let mkGenericBindRhs g m generalizedTyparsForRecursiveBlock typeScheme bodyExpr 
     // We record an expression node that indicates that a free choice can be made 
     // for these. This expression node effectively binds the type variables. 
     let freeChoiceTypars = ListSet.subtract typarEq generalizedTyparsForRecursiveBlock generalizedTypars
-    mkTypeLambda m generalizedTypars (mkTypeChoose m freeChoiceTypars bodyExpr, tauType)
+    mkTypeLambda m generalizedTypars (mkTypeChoose m freeChoiceTypars bodyExpr, tauTy)
 
 let isBeingGeneralized tp typeScheme = 
     let (GeneralizedType(generalizedTypars, _)) = typeScheme
@@ -1512,36 +1512,36 @@ let mkExnCaseFieldGet (e1, ecref, j, m) =
 let mkExnCaseFieldSet (e1, ecref, j, e2, m) =
     Expr.Op (TOp.ExnFieldSet (ecref, j), [], [e1;e2], m)
 
-let mkDummyLambda (g: TcGlobals) (e: Expr, ety) = 
-    let m = e.Range
-    mkLambda m (fst (mkCompGenLocal m "unitVar" g.unit_ty)) (e, ety)
+let mkDummyLambda (g: TcGlobals) (bodyExpr: Expr, bodyExprTy) = 
+    let m = bodyExpr.Range
+    mkLambda m (fst (mkCompGenLocal m "unitVar" g.unit_ty)) (bodyExpr, bodyExprTy)
                            
-let mkWhile (g: TcGlobals) (spWhile, marker, e1, e2, m) = 
-    Expr.Op (TOp.While (spWhile, marker), [], [mkDummyLambda g (e1, g.bool_ty);mkDummyLambda g (e2, g.unit_ty)], m)
+let mkWhile (g: TcGlobals) (spWhile, marker, guardExpr, bodyExpr, m) = 
+    Expr.Op (TOp.While (spWhile, marker), [], [mkDummyLambda g (guardExpr, g.bool_ty);mkDummyLambda g (bodyExpr, g.unit_ty)], m)
 
-let mkIntegerForLoop (g: TcGlobals) (spFor, spIn, v, e1, dir, e2, e3: Expr, m) = 
-    Expr.Op (TOp.IntegerForLoop (spFor, spIn, dir), [], [mkDummyLambda g (e1, g.int_ty) ;mkDummyLambda g (e2, g.int_ty);mkLambda e3.Range v (e3, g.unit_ty)], m)
+let mkIntegerForLoop (g: TcGlobals) (spFor, spIn, v, startExpr, dir, finishExpr, bodyExpr: Expr, m) = 
+    Expr.Op (TOp.IntegerForLoop (spFor, spIn, dir), [], [mkDummyLambda g (startExpr, g.int_ty) ;mkDummyLambda g (finishExpr, g.int_ty);mkLambda bodyExpr.Range v (bodyExpr, g.unit_ty)], m)
 
-let mkTryWith g (e1, vf, ef: Expr, vh, eh: Expr, m, ty, spTry, spWith) = 
-    Expr.Op (TOp.TryWith (spTry, spWith), [ty], [mkDummyLambda g (e1, ty);mkLambda ef.Range vf (ef, ty);mkLambda eh.Range vh (eh, ty)], m)
+let mkTryWith g (bodyExpr, filterVal, filterExpr: Expr, handlerVal, handlerExpr: Expr, m, ty, spTry, spWith) = 
+    Expr.Op (TOp.TryWith (spTry, spWith), [ty], [mkDummyLambda g (bodyExpr, ty);mkLambda filterExpr.Range filterVal (filterExpr, ty);mkLambda handlerExpr.Range handlerVal (handlerExpr, ty)], m)
 
-let mkTryFinally (g: TcGlobals) (e1, e2, m, ty, spTry, spFinally) = 
-    Expr.Op (TOp.TryFinally (spTry, spFinally), [ty], [mkDummyLambda g (e1, ty);mkDummyLambda g (e2, g.unit_ty)], m)
+let mkTryFinally (g: TcGlobals) (bodyExpr, finallyExpr, m, ty, spTry, spFinally) = 
+    Expr.Op (TOp.TryFinally (spTry, spFinally), [ty], [mkDummyLambda g (bodyExpr, ty);mkDummyLambda g (finallyExpr, g.unit_ty)], m)
 
 let mkDefault (m, ty) =
     Expr.Const (Const.Zero, m, ty) 
 
-let mkValSet m v e =
-    Expr.Op (TOp.LValueOp (LSet, v), [], [e], m)             
+let mkValSet m vref e =
+    Expr.Op (TOp.LValueOp (LSet, vref), [], [e], m)             
 
-let mkAddrSet m v e =
-    Expr.Op (TOp.LValueOp (LByrefSet, v), [], [e], m)       
+let mkAddrSet m vref e =
+    Expr.Op (TOp.LValueOp (LByrefSet, vref), [], [e], m)       
 
-let mkAddrGet m v =
-    Expr.Op (TOp.LValueOp (LByrefGet, v), [], [], m)          
+let mkAddrGet m vref =
+    Expr.Op (TOp.LValueOp (LByrefGet, vref), [], [], m)          
 
-let mkValAddr m readonly v =
-    Expr.Op (TOp.LValueOp (LAddrOf readonly, v), [], [], m)           
+let mkValAddr m readonly vref =
+    Expr.Op (TOp.LValueOp (LAddrOf readonly, vref), [], [], m)           
 
 //--------------------------------------------------------------------------
 // Maps tracking extra information for values
@@ -1682,9 +1682,9 @@ let tryDestForallTy g ty =
 
 let rec stripFunTy g ty = 
     if isFunTy g ty then 
-        let d, r = destFunTy g ty 
-        let more, rty = stripFunTy g r 
-        d :: more, rty
+        let domainTy, rangeTy = destFunTy g ty 
+        let more, retTy = stripFunTy g rangeTy 
+        domainTy :: more, retTy
     else [], ty
 
 let applyForallTy g ty tyargs = 
@@ -1696,23 +1696,24 @@ let reduceIteratedFunTy g ty args =
         if not (isFunTy g ty) then failwith "reduceIteratedFunTy"
         snd (destFunTy g ty)) ty args
 
-let applyTyArgs g functy tyargs = 
-    if isForallTy g functy then applyForallTy g functy tyargs else functy
+let applyTyArgs g ty tyargs = 
+    if isForallTy g ty then applyForallTy g ty tyargs else ty
 
-let applyTys g functy (tyargs, argTys) = 
-    let afterTyappTy = applyTyArgs g functy tyargs
+let applyTys g funcTy (tyargs, argTys) = 
+    let afterTyappTy = applyTyArgs g funcTy tyargs
     reduceIteratedFunTy g afterTyappTy argTys
 
-let formalApplyTys g functy (tyargs, args) = 
+let formalApplyTys g funcTy (tyargs, args) = 
     reduceIteratedFunTy g
-      (if isNil tyargs then functy else snd (destForallTy g functy))
+      (if isNil tyargs then funcTy else snd (destForallTy g funcTy))
       args
 
 let rec stripFunTyN g n ty = 
     assert (n >= 0)
     if n > 0 && isFunTy g ty then 
         let d, r = destFunTy g ty
-        let more, rty = stripFunTyN g (n-1) r in d :: more, rty
+        let more, retTy = stripFunTyN g (n-1) r
+        d :: more, retTy
     else [], ty
         
 let tryDestAnyTupleTy g ty = 
@@ -1796,10 +1797,10 @@ let destListTy (g: TcGlobals) ty =
     | ValueSome (tcref, [ty]) when tyconRefEq g tcref g.list_tcr_canon -> ty
     | _ -> failwith "destListTy"
 
-let tyconRefEqOpt g tcOpt tc = 
-    match tcOpt with
+let tyconRefEqOpt g tcrefOpt tcref = 
+    match tcrefOpt with
     | None -> false
-    | Some tc2 -> tyconRefEq g tc2 tc
+    | Some tcref2 -> tyconRefEq g tcref2 tcref
 
 let isStringTy g ty = ty |> stripTyEqns g |> (function TType_app(tcref, _, _) -> tyconRefEq g tcref g.system_String_tcref | _ -> false)
 
@@ -1830,13 +1831,13 @@ let isByrefTy g ty =
 let isInByrefTag g ty = ty |> stripTyEqns g |> (function TType_app(tcref, [], _) -> tyconRefEq g g.byrefkind_In_tcr tcref | _ -> false) 
 let isInByrefTy g ty = 
     ty |> stripTyEqns g |> (function 
-        | TType_app(tcref, [_; tag], _) when g.byref2_tcr.CanDeref -> tyconRefEq g g.byref2_tcr tcref && isInByrefTag g tag         
+        | TType_app(tcref, [_; tagTy], _) when g.byref2_tcr.CanDeref -> tyconRefEq g g.byref2_tcr tcref && isInByrefTag g tagTy         
         | _ -> false) 
 
 let isOutByrefTag g ty = ty |> stripTyEqns g |> (function TType_app(tcref, [], _) -> tyconRefEq g g.byrefkind_Out_tcr tcref | _ -> false) 
 let isOutByrefTy g ty = 
     ty |> stripTyEqns g |> (function 
-        | TType_app(tcref, [_; tag], _) when g.byref2_tcr.CanDeref -> tyconRefEq g g.byref2_tcr tcref && isOutByrefTag g tag         
+        | TType_app(tcref, [_; tagTy], _) when g.byref2_tcr.CanDeref -> tyconRefEq g g.byref2_tcr tcref && isOutByrefTag g tagTy         
         | _ -> false) 
 
 #if !NO_TYPEPROVIDERS
@@ -2059,7 +2060,7 @@ let MemberIsExplicitImpl g (membInfo: ValMemberInfo) =
    membInfo.MemberFlags.IsOverrideOrExplicitImpl &&
    match membInfo.ImplementedSlotSigs with 
    | [] -> false
-   | slotsigs -> slotsigs |> List.forall (fun slotsig -> isInterfaceTy g slotsig.ImplementedType)
+   | slotsigs -> slotsigs |> List.forall (fun slotsig -> isInterfaceTy g slotsig.DeclaringType)
 
 let ValIsExplicitImpl g (v: Val) = 
     match v.MemberInfo with 
@@ -2239,8 +2240,8 @@ and accFreeInTyparConstraint opts tpc acc =
     | TyparConstraint.MayResolveMember (traitInfo, _) -> accFreeInTrait opts traitInfo acc
     | TyparConstraint.DefaultsTo(_, defaultTy, _) -> accFreeInType opts defaultTy acc
     | TyparConstraint.SimpleChoice(tys, _) -> accFreeInTypes opts tys acc
-    | TyparConstraint.IsEnum(uty, _) -> accFreeInType opts uty acc
-    | TyparConstraint.IsDelegate(aty, bty, _) -> accFreeInType opts aty (accFreeInType opts bty acc)
+    | TyparConstraint.IsEnum(underlyingTy, _) -> accFreeInType opts underlyingTy acc
+    | TyparConstraint.IsDelegate(argTys, retTy, _) -> accFreeInType opts argTys (accFreeInType opts retTy acc)
     | TyparConstraint.SupportsComparison _
     | TyparConstraint.SupportsEquality _
     | TyparConstraint.SupportsNull _ 
@@ -2302,18 +2303,18 @@ and accFreeInType opts ty acc =
     | TType_anon (anonInfo, l) ->
         accFreeInTypes opts l (accFreeInTupInfo opts anonInfo.TupInfo acc)
 
-    | TType_app (tc, tinst, _) -> 
-        let acc = accFreeTycon opts tc acc
+    | TType_app (tcref, tinst, _) -> 
+        let acc = accFreeTycon opts tcref acc
         match tinst with 
         | [] -> acc  // optimization to avoid unneeded call
         | [h] -> accFreeInType opts h acc // optimization to avoid unneeded call
         | _ -> accFreeInTypes opts tinst acc
 
-    | TType_ucase (UnionCaseRef(tc, _), tinst) ->
-        accFreeInTypes opts tinst (accFreeTycon opts tc acc)
+    | TType_ucase (UnionCaseRef(tcref, _), tinst) ->
+        accFreeInTypes opts tinst (accFreeTycon opts tcref acc)
 
-    | TType_fun (d, r, _) ->
-        accFreeInType opts d (accFreeInType opts r acc)
+    | TType_fun (domainTy, rangeTy, _) ->
+        accFreeInType opts domainTy (accFreeInType opts rangeTy acc)
 
     | TType_var (r, _) ->
         accFreeTyparRef opts r acc
@@ -2375,10 +2376,10 @@ and accFreeInTyparConstraintLeftToRight g cxFlag thruFlag acc tpc =
         accFreeInTypeLeftToRight g cxFlag thruFlag acc defaultTy 
     | TyparConstraint.SimpleChoice(tys, _) ->
         accFreeInTypesLeftToRight g cxFlag thruFlag acc tys 
-    | TyparConstraint.IsEnum(uty, _) ->
-        accFreeInTypeLeftToRight g cxFlag thruFlag acc uty
-    | TyparConstraint.IsDelegate(aty, bty, _) ->
-        accFreeInTypeLeftToRight g cxFlag thruFlag (accFreeInTypeLeftToRight g cxFlag thruFlag acc aty) bty  
+    | TyparConstraint.IsEnum(underlyingTy, _) ->
+        accFreeInTypeLeftToRight g cxFlag thruFlag acc underlyingTy
+    | TyparConstraint.IsDelegate(argTys, retTy, _) ->
+        accFreeInTypeLeftToRight g cxFlag thruFlag (accFreeInTypeLeftToRight g cxFlag thruFlag acc argTys) retTy  
     | TyparConstraint.SupportsComparison _ 
     | TyparConstraint.SupportsEquality _ 
     | TyparConstraint.SupportsNull _ 
@@ -2419,9 +2420,9 @@ and accFreeInTypeLeftToRight g cxFlag thruFlag acc ty =
     | TType_ucase (_, tinst) -> 
         accFreeInTypesLeftToRight g cxFlag thruFlag acc tinst 
 
-    | TType_fun (d, r, _) -> 
-        let dacc = accFreeInTypeLeftToRight g cxFlag thruFlag acc d 
-        accFreeInTypeLeftToRight g cxFlag thruFlag dacc r
+    | TType_fun (domainTy, rangeTy, _) -> 
+        let dacc = accFreeInTypeLeftToRight g cxFlag thruFlag acc domainTy 
+        accFreeInTypeLeftToRight g cxFlag thruFlag dacc rangeTy
 
     | TType_var (r, _) -> 
         accFreeTyparRefLeftToRight g cxFlag thruFlag acc r 
@@ -2546,12 +2547,12 @@ let GetMemberTypeInMemberForm g memberFlags valReprInfo numEnclosingTypars ty m 
     let paramArgInfos = 
         match paramArgInfos, valReprInfo.ArgInfos with 
         // static member and module value unit argument elimination
-        | [[(argType, _)]], [[]] -> 
-            assert isUnitTy g argType 
+        | [[(argTy, _)]], [[]] -> 
+            assert isUnitTy g argTy 
             [[]]
         // instance member unit argument elimination
-        | [[(argType, _)]], [[_objArg];[]] -> 
-            assert isUnitTy g argType 
+        | [[(argTy, _)]], [[_objArg];[]] -> 
+            assert isUnitTy g argTy 
             [[]]
         | _ -> 
             paramArgInfos
@@ -2770,10 +2771,10 @@ module PrettyTypes =
         let niceTypars, renaming = NewPrettyTypars [] ftps names 
         
         // strip universal types for printing
-        let getTauStayTau t = 
-            match t with
+        let getTauStayTau ty = 
+            match ty with
             | TType_forall (_, tau) -> tau
-            | _ -> t
+            | _ -> ty
         let tauThings = mapTys getTauStayTau things
                         
         let prettyThings = mapTys (instType renaming) tauThings
@@ -2858,8 +2859,8 @@ module SimplifyTypes =
         let ty = stripTyparEqns ty 
         let z = f z ty
         match ty with
-        | TType_forall (_, body) ->
-            foldTypeButNotConstraints f z body
+        | TType_forall (_, bodyTy) ->
+            foldTypeButNotConstraints f z bodyTy
 
         | TType_app (_, tys, _) 
         | TType_ucase (_, tys) 
@@ -2867,8 +2868,8 @@ module SimplifyTypes =
         | TType_tuple (_, tys) ->
             List.fold (foldTypeButNotConstraints f) z tys
 
-        | TType_fun (s, t, _) ->
-            foldTypeButNotConstraints f (foldTypeButNotConstraints f z s) t
+        | TType_fun (domainTy, rangeTy, _) ->
+            foldTypeButNotConstraints f (foldTypeButNotConstraints f z domainTy) rangeTy
 
         | TType_var _ -> z
 
@@ -3184,7 +3185,7 @@ let tyconRefToFullName (tcref:TyconRef) =
     seq { yield! namespaceParts; yield tcref.DisplayName } |> String.concat "."
 
 let rec qualifiedInterfaceImplementationNameAux g (x:TType) : string =
-    match stripMeasuresFromTType g (stripTyEqnsAndErase true g x) with
+    match stripMeasuresFromTy g (stripTyEqnsAndErase true g x) with
     | TType_app (a, [], _) ->
         tyconRefToFullName a
 
@@ -3203,8 +3204,8 @@ let rec qualifiedInterfaceImplementationNameAux g (x:TType) : string =
         failwithf "unexpected: expected TType_app but got %O" (x.GetType())
 
 /// for types in the global namespace, `global is prepended (note the backtick)
-let qualifiedInterfaceImplementationName g (tt:TType) memberName =
-    let interfaceName = tt |> qualifiedInterfaceImplementationNameAux g
+let qualifiedInterfaceImplementationName g (ty: TType) memberName =
+    let interfaceName = ty |> qualifiedInterfaceImplementationNameAux g
     sprintf "%s.%s" interfaceName memberName
 
 let qualifiedMangledNameOfTyconRef tcref nm = 
@@ -4951,7 +4952,7 @@ and accFreeInTest (opts: FreeVarOptions) discrim acc =
     | DecisionTreeTest.ArrayLength(_, ty) -> accFreeVarsInTy opts ty acc
     | DecisionTreeTest.Const _
     | DecisionTreeTest.IsNull -> acc
-    | DecisionTreeTest.IsInst (srcty, tgty) -> accFreeVarsInTy opts srcty (accFreeVarsInTy opts tgty acc)
+    | DecisionTreeTest.IsInst (srcTy, tgtTy) -> accFreeVarsInTy opts srcTy (accFreeVarsInTy opts tgtTy acc)
     | DecisionTreeTest.ActivePatternCase (exp, tys, _, activePatIdentity, _, _) -> 
         accFreeInExpr opts exp 
             (accFreeVarsInTys opts tys 
@@ -5825,7 +5826,7 @@ and remapDecisionTree ctxt compgen tmenv x =
                     | DecisionTreeTest.UnionCase (uc, tinst) -> DecisionTreeTest.UnionCase(remapUnionCaseRef tmenv.tyconRefRemap uc, remapTypes tmenv tinst)
                     | DecisionTreeTest.ArrayLength (n, ty) -> DecisionTreeTest.ArrayLength(n, remapType tmenv ty)
                     | DecisionTreeTest.Const _ -> test
-                    | DecisionTreeTest.IsInst (srcty, tgty) -> DecisionTreeTest.IsInst (remapType tmenv srcty, remapType tmenv tgty) 
+                    | DecisionTreeTest.IsInst (srcTy, tgtTy) -> DecisionTreeTest.IsInst (remapType tmenv srcTy, remapType tmenv tgtTy) 
                     | DecisionTreeTest.IsNull -> DecisionTreeTest.IsNull 
                     | DecisionTreeTest.ActivePatternCase _ -> failwith "DecisionTreeTest.ActivePatternCase should only be used during pattern match compilation"
                     | DecisionTreeTest.Error(m) -> DecisionTreeTest.Error(m)
@@ -8596,8 +8597,8 @@ let rec typeEnc g (gtpsType, gtpsMethod) ty =
         else 
             sprintf "System.Tuple%s"(tyargsEnc g (gtpsType, gtpsMethod) tys)
 
-    | TType_fun (f, x, _) -> 
-        "Microsoft.FSharp.Core.FSharpFunc" + tyargsEnc g (gtpsType, gtpsMethod) [f;x]
+    | TType_fun (domainTy, rangeTy, _) -> 
+        "Microsoft.FSharp.Core.FSharpFunc" + tyargsEnc g (gtpsType, gtpsMethod) [domainTy; rangeTy]
 
     | TType_var (typar, _) -> 
         typarEnc g (gtpsType, gtpsMethod) typar
@@ -8868,22 +8869,22 @@ let canUseUnboxFast g m ty =
 //
 // No sequence point is generated for this expression form as this function is only
 // used for compiler-generated code.
-let mkIsInstConditional g m tgty vinputExpr v e2 e3 = 
+let mkIsInstConditional g m tgtTy vinputExpr v e2 e3 = 
     
-    if canUseTypeTestFast g tgty && isRefTy g tgty then 
+    if canUseTypeTestFast g tgtTy && isRefTy g tgtTy then 
 
         let mbuilder = MatchBuilder(DebugPointAtBinding.NoneAtInvisible, m)
         let tg2 = mbuilder.AddResultTarget(e2)
         let tg3 = mbuilder.AddResultTarget(e3)
         let dtree = TDSwitch(exprForVal m v, [TCase(DecisionTreeTest.IsNull, tg3)], Some tg2, m)
         let expr = mbuilder.Close(dtree, m, tyOfExpr g e2)
-        mkCompGenLet m v (mkIsInst tgty vinputExpr m) expr
+        mkCompGenLet m v (mkIsInst tgtTy vinputExpr m) expr
 
     else
         let mbuilder = MatchBuilder(DebugPointAtBinding.NoneAtInvisible, m)
-        let tg2 = TDSuccess([mkCallUnbox g m tgty vinputExpr], mbuilder.AddTarget(TTarget([v], e2, None)))
+        let tg2 = TDSuccess([mkCallUnbox g m tgtTy vinputExpr], mbuilder.AddTarget(TTarget([v], e2, None)))
         let tg3 = mbuilder.AddResultTarget(e3)
-        let dtree = TDSwitch(vinputExpr, [TCase(DecisionTreeTest.IsInst(tyOfExpr g vinputExpr, tgty), tg2)], Some tg3, m)
+        let dtree = TDSwitch(vinputExpr, [TCase(DecisionTreeTest.IsInst(tyOfExpr g vinputExpr, tgtTy), tg2)], Some tg3, m)
         let expr = mbuilder.Close(dtree, m, tyOfExpr g e2)
         expr
 
@@ -10113,7 +10114,7 @@ let (|ResumableCodeInvoke|_|) g expr =
 
 let ComputeUseMethodImpl g (v: Val) =
     v.ImplementedSlotSigs |> List.exists (fun slotsig ->
-        let oty = slotsig.ImplementedType
+        let oty = slotsig.DeclaringType
         let otcref = tcrefOfAppTy g oty
         let tcref = v.MemberApparentEntity
 

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -845,7 +845,7 @@ val isDimensionless: TcGlobals -> TType -> bool
 // TType modifications and comparisons
 //---------------------------------------------------------------------------
 
-val stripMeasuresFromTType: TcGlobals -> TType -> TType
+val stripMeasuresFromTy: TcGlobals -> TType -> TType
 
 //-------------------------------------------------------------------------
 // Equivalence of types (up to substitution of type variables in the left-hand type)

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -1575,7 +1575,7 @@ let p_measure_one = p_byte 4
 // Pickle a unit-of-measure variable or constructor
 let p_measure_varcon unt st =
      match unt with
-     | Measure.Con tcref   -> p_measure_con tcref st
+     | Measure.Const tcref   -> p_measure_con tcref st
      | Measure.Var v       -> p_measure_var v st
      | _                  -> pfailwith st "p_measure_varcon: expected measure variable or constructor"
 
@@ -1604,7 +1604,7 @@ let rec p_measure_power unt q st =
 let rec p_normalized_measure unt st =
      let unt = stripUnitEqnsAux false unt
      match unt with
-     | Measure.Con tcref   -> p_measure_con tcref st
+     | Measure.Const tcref   -> p_measure_con tcref st
      | Measure.Inv x       -> p_byte 1 st; p_normalized_measure x st
      | Measure.Prod(x1, x2) -> p_byte 2 st; p_normalized_measure x1 st; p_normalized_measure x2 st
      | Measure.Var v       -> p_measure_var v st
@@ -1625,7 +1625,7 @@ let u_rational st =
 let rec u_measure_expr st =
     let tag = u_byte st
     match tag with
-    | 0 -> let a = u_tcref st in Measure.Con a
+    | 0 -> let a = u_tcref st in Measure.Const a
     | 1 -> let a = u_measure_expr st in Measure.Inv a
     | 2 -> let a, b = u_tup2 u_measure_expr u_measure_expr st in Measure.Prod (a, b)
     | 3 -> let a = u_tpref st in Measure.Var a
@@ -2436,7 +2436,7 @@ and p_dtree_discrim x st =
     | DecisionTreeTest.UnionCase (ucref, tinst) -> p_byte 0 st; p_tup2 p_ucref p_tys (ucref, tinst) st
     | DecisionTreeTest.Const c                   -> p_byte 1 st; p_const c st
     | DecisionTreeTest.IsNull                    -> p_byte 2 st
-    | DecisionTreeTest.IsInst (srcty, tgty)       -> p_byte 3 st; p_ty srcty st; p_ty tgty st
+    | DecisionTreeTest.IsInst (srcTy, tgtTy)       -> p_byte 3 st; p_ty srcTy st; p_ty tgtTy st
     | DecisionTreeTest.ArrayLength (n, ty)       -> p_byte 4 st; p_tup2 p_int p_ty (n, ty) st
     | DecisionTreeTest.ActivePatternCase _ -> pfailwith st "DecisionTreeTest.ActivePatternCase: only used during pattern match compilation"
     | DecisionTreeTest.Error _ -> pfailwith st "DecisionTreeTest.Error: only used during pattern match compilation"

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -141,15 +141,15 @@ type BindingSet = BindingSetPreAttrs of range * bool * bool * (SynAttributes -> 
 
 let mkClassMemberLocalBindings(isStatic, initialRangeOpt, attrs, vis, BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, bindingSetRange)) = 
    let ignoredFreeAttrs, decls = declsPreAttrs attrs vis
-   let wholeRange = 
+   let mWhole = 
        match initialRangeOpt with 
        | None -> bindingSetRange
        | Some m -> unionRanges m bindingSetRange
        // decls could have a leading attribute
        |> fun m -> (m, decls) ||> unionRangeWithListBy (fun (SynBinding(range = m)) -> m)
-   if not (isNil ignoredFreeAttrs) then warning(Error(FSComp.SR.parsAttributesIgnored(), wholeRange));
-   if isUse then errorR(Error(FSComp.SR.parsUseBindingsIllegalInImplicitClassConstructors(), wholeRange))
-   SynMemberDefn.LetBindings (decls, isStatic, isRec, wholeRange)
+   if not (isNil ignoredFreeAttrs) then warning(Error(FSComp.SR.parsAttributesIgnored(), mWhole));
+   if isUse then errorR(Error(FSComp.SR.parsUseBindingsIllegalInImplicitClassConstructors(), mWhole))
+   SynMemberDefn.LetBindings (decls, isStatic, isRec, mWhole)
 
 let mkLocalBindings (mWhole, BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, _), mIn, body: SynExpr) = 
    let ignoredFreeAttrs, decls = declsPreAttrs [] None
@@ -830,12 +830,12 @@ moduleSpfn:
         _xmlDoc.MarkAsInvalid()
         let attrs = $1 @ cas
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
-        let mTc =
+        let mDefn =
             (d3, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             |> unionRanges range
             |> unionRangeWithXmlDoc xmlDoc
-        let tc = (SynTypeDefnSig(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), equalsRange, typeRepr,  withKeyword, members, mTc))
-        let m = (mTc, $5) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range) |> unionRanges (rhs parseState 3)
+        let tc = SynTypeDefnSig(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), equalsRange, typeRepr,  withKeyword, members, mDefn)
+        let m = (mDefn, $5) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range) |> unionRanges (rhs parseState 3)
         SynModuleSigDecl.Types (tc :: $5, m) }
 
   | opt_attributes opt_declVisibility exconSpfn
@@ -844,8 +844,8 @@ moduleSpfn:
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
         let mDefnReprWithAttributes = (d2, $1) ||> unionRangeWithListBy (fun a -> a.Range) |> unionRangeWithXmlDoc xmlDoc
         let mWhole = (mDefnReprWithAttributes, members) ||> unionRangeWithListBy (fun (m: SynMemberSig) -> m.Range)
-        let ec = SynExceptionSig(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, mDefnReprWithAttributes), withKeyword, members, mWhole)
-        SynModuleSigDecl.Exception(ec, mWhole) }
+        let synExnDefn = SynExceptionSig(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, mDefnReprWithAttributes), withKeyword, members, mWhole)
+        SynModuleSigDecl.Exception(synExnDefn, mWhole) }
 
   | openDecl
       { SynModuleSigDecl.Open($1, (rhs parseState 1)) }
@@ -901,7 +901,8 @@ tyconSpfnList:
   | AND tyconSpfn tyconSpfnList
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        let tyconSpfn =
-           let (SynTypeDefnSig(SynComponentInfo (a, typars, c, lid, _xmlDoc, fixity, vis, rangeOfLid) as componentInfo, equalsRange, typeRepr, withKeyword, members, range)) = $2
+           let (SynTypeDefnSig(componentInfo, equalsRange, typeRepr, withKeyword, members, range)) = $2
+           let (SynComponentInfo(a, typars, c, lid, _xmlDoc, fixity, vis, mLongId)) = componentInfo
            if xmlDoc.IsEmpty then
                if _xmlDoc.IsEmpty then $2 else
                let range = unionRangeWithXmlDoc _xmlDoc range
@@ -910,7 +911,8 @@ tyconSpfnList:
            else
                _xmlDoc.MarkAsInvalid()
                let range = unionRangeWithXmlDoc xmlDoc range
-               SynTypeDefnSig(SynComponentInfo (a, typars, c, lid, xmlDoc, fixity, vis, rangeOfLid), equalsRange, typeRepr, withKeyword, members, range)
+               let componentInfo = SynComponentInfo (a, typars, c, lid, xmlDoc, fixity, vis, mLongId)
+               SynTypeDefnSig(componentInfo, equalsRange, typeRepr, withKeyword, members, range)
        tyconSpfn :: $3 }
 
   |
@@ -920,9 +922,9 @@ tyconSpfnList:
 /* A type definition in a signature */
 tyconSpfn: 
   | typeNameInfo  EQUALS tyconSpfnRhsBlock 
-      { let lhsm = rhs parseState 1 
+      { let mLhs = rhs parseState 1 
         let mEquals = rhs parseState 2
-        $3 lhsm $1 (Some mEquals) }
+        $3 mLhs $1 (Some mEquals) }
   | typeNameInfo  opt_classSpfn       
       { let mWithKwd, members = $2
         let (SynComponentInfo(range=range)) = $1
@@ -949,22 +951,22 @@ tyconSpfnRhsBlock:
   /* representation. */
   | OBLOCKBEGIN  tyconSpfnRhs opt_OBLOCKSEP classSpfnMembers opt_classSpfn oblockend opt_classSpfn  
      { let m = lhs parseState 
-       (fun lhsm nameInfo mEquals -> 
+       (fun mLhs nameInfo mEquals -> 
            let members = $4 @ (snd $5)
-           $2 lhsm nameInfo mEquals (checkForMultipleAugmentations m members (snd $7))) }
+           $2 mLhs nameInfo mEquals (checkForMultipleAugmentations m members (snd $7))) }
 
   | tyconSpfnRhs opt_classSpfn
      { let m = lhs parseState 
-       (fun lhsm nameInfo mEquals ->
+       (fun mLhs nameInfo mEquals ->
            let _, members = $2 
-           $1 lhsm nameInfo mEquals members) }
+           $1 mLhs nameInfo mEquals members) }
 
 
 /* The right-hand-side of a type definition in a signature */
 tyconSpfnRhs: 
   | tyconDefnOrSpfnSimpleRepr 
-     { (fun lhsm nameInfo mEquals augmentation -> 
-           let declRange = unionRanges lhsm $1.Range
+     { (fun mLhs nameInfo mEquals augmentation -> 
+           let declRange = unionRanges mLhs $1.Range
            let mWhole = (declRange, augmentation) ||> unionRangeWithListBy (fun (mem: SynMemberSig) -> mem.Range)
            SynTypeDefnSig(nameInfo, mEquals, SynTypeDefnSigRepr.Simple ($1, $1.Range), None, augmentation, mWhole)) }
 
@@ -1063,7 +1065,7 @@ classMemberSpfn:
        let isInline, doc, vis2, id, explicitValTyparDecls, (ty, arity), (mEquals, optLiteralValue) = $4, grabXmlDoc(parseState, $1, 1), $5, $6, $7, $9, $11
        let mWith, getSetRangeOpt, getSet = $10 
        let getSetAdjuster arity = match arity, getSet with SynValInfo([], _), SynMemberKind.Member -> SynMemberKind.PropertyGet | _ -> getSet
-       let wholeRange = 
+       let mWhole = 
            let m = rhs parseState 3 
            match getSetRangeOpt with 
            | None -> unionRanges m ty.Range
@@ -1074,9 +1076,9 @@ classMemberSpfn:
                match optLiteralValue with
                | None -> m
                | Some e -> unionRanges m e.Range
-       let valSpfn = SynValSig($1, id, explicitValTyparDecls, ty, arity, isInline, false, doc, vis2, optLiteralValue, wholeRange, { ValKeyword = None; WithKeyword = mWith; EqualsRange = mEquals })
+       let valSpfn = SynValSig($1, id, explicitValTyparDecls, ty, arity, isInline, false, doc, vis2, optLiteralValue, mWhole, { ValKeyword = None; WithKeyword = mWith; EqualsRange = mEquals })
        let _, flags = $3 
-       SynMemberSig.Member(valSpfn, flags (getSetAdjuster arity), wholeRange) }
+       SynMemberSig.Member(valSpfn, flags (getSetAdjuster arity), mWhole) }
 
   | opt_attributes opt_declVisibility interfaceMember appType  
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
@@ -1087,18 +1089,18 @@ classMemberSpfn:
        SynMemberSig.Inherit ($4, unionRanges (rhs parseState 3) ($4).Range) }
 
   | opt_attributes opt_declVisibility VAL fieldDecl 
-     { let wholeRange = rhs2 parseState 1 4
+     { let mWhole = rhs2 parseState 1 4
        if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
-       let (SynField(_, _, _, _, _, xmlDoc, _, _)) as field = $4 $1 false wholeRange
-       let wholeRange = unionRangeWithXmlDoc xmlDoc wholeRange
-       SynMemberSig.ValField (field, wholeRange) }
+       let (SynField(_, _, _, _, _, xmlDoc, _, _)) as field = $4 $1 false mWhole
+       let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
+       SynMemberSig.ValField (field, mWhole) }
 
   | opt_attributes opt_declVisibility STATIC VAL fieldDecl 
-     { let wholeRange = rhs2 parseState 1 5
+     { let mWhole = rhs2 parseState 1 5
        if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
-       let (SynField(_, _, _, _, _, xmlDoc, _, _)) as field = $5 $1 true wholeRange
-       let wholeRange = unionRangeWithXmlDoc xmlDoc wholeRange
-       SynMemberSig.ValField(field, wholeRange) }
+       let (SynField(_, _, _, _, _, xmlDoc, _, _)) as field = $5 $1 true mWhole
+       let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
+       SynMemberSig.ValField(field, mWhole) }
 
   | opt_attributes  opt_declVisibility STATIC typeKeyword tyconSpfn 
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
@@ -1374,9 +1376,9 @@ moduleDefn:
         let (SynTypeDefn(SynComponentInfo(cas, a, cs, b, _xmlDoc, d, d2, d3), e, f, g, h, trivia)) = $4
         _xmlDoc.MarkAsInvalid()
         let attrs = $1@cas
-        let mTc = (h, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range) |> unionRangeWithXmlDoc xmlDoc
+        let mDefn = (h, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range) |> unionRangeWithXmlDoc xmlDoc
         let mType = rhs parseState 3
-        let tc = (SynTypeDefn(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), e, f, g, mTc, { trivia with TypeKeyword = Some mType }))
+        let tc = SynTypeDefn(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), e, f, g, mDefn, { trivia with TypeKeyword = Some mType })
         let types = tc :: $5
         [ SynModuleDecl.Types(types, (rhs parseState 3, types) ||> unionRangeWithListBy (fun t -> t.Range) ) ] }
 
@@ -1387,8 +1389,8 @@ moduleDefn:
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
         let defnReprRange = (d2, $1) ||> unionRangeWithListBy (fun a -> a.Range) |> unionRangeWithXmlDoc xmlDoc
         let mWhole = (f, $1) ||> unionRangeWithListBy (fun a -> a.Range) |> unionRangeWithXmlDoc xmlDoc
-        let ec = (SynExceptionDefn(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, defnReprRange), withKeyword, e, mWhole))
-        [ SynModuleDecl.Exception(ec, mWhole) ] }
+        let synExnDefn = SynExceptionDefn(SynExceptionDefnRepr($1@cas, a, b, xmlDoc, d, defnReprRange), withKeyword, e, mWhole)
+        [ SynModuleDecl.Exception(synExnDefn, mWhole) ] }
 
   /* 'module' definitions */
   | opt_attributes opt_declVisibility moduleIntro EQUALS namedModuleDefnBlock
@@ -1614,7 +1616,8 @@ tyconDefnList:
   | AND tyconDefn tyconDefnList 
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        let tyconDefn =
-           let (SynTypeDefn(SynComponentInfo (a, typars, c, lid, _xmlDoc, fixity, vis, rangeOfLid) as componentInfo, typeRepr, members, implicitConstructor, range, trivia)) = $2
+           let (SynTypeDefn(componentInfo, typeRepr, members, implicitConstructor, range, trivia)) = $2
+           let (SynComponentInfo(a, typars, c, lid, _xmlDoc, fixity, vis, mLongId)) = componentInfo
            if xmlDoc.IsEmpty then
                if _xmlDoc.IsEmpty then $2 else
                let range = unionRangeWithXmlDoc _xmlDoc range
@@ -1623,7 +1626,8 @@ tyconDefnList:
            else
                _xmlDoc.MarkAsInvalid()
                let range = unionRangeWithXmlDoc xmlDoc range
-               SynTypeDefn(SynComponentInfo (a, typars, c, lid, xmlDoc, fixity, vis, rangeOfLid), typeRepr, members, implicitConstructor, range, trivia)
+               let componentInfo = SynComponentInfo (a, typars, c, lid, xmlDoc, fixity, vis, mLongId)
+               SynTypeDefn(componentInfo, typeRepr, members, implicitConstructor, range, trivia)
        tyconDefn :: $3 }
   |                             
      { [] }
@@ -1910,15 +1914,15 @@ classDefnMember:
        let isInline, doc, id, explicitValTyparDecls = $4, grabXmlDoc(parseState, $1, 1), $5, $6
        let mWith, getSetRangeOpt, getSet = $9
        let getSetAdjuster arity = match arity, getSet with SynValInfo([], _), SynMemberKind.Member -> SynMemberKind.PropertyGet | _ -> getSet
-       let wholeRange = 
+       let mWhole = 
            let m = rhs parseState 1
            match getSetRangeOpt with 
            | None -> unionRanges m ty.Range
            | Some m2 -> unionRanges m m2
            |> unionRangeWithXmlDoc doc
-       if Option.isSome $2 then errorR(Error(FSComp.SR.parsAccessibilityModsIllegalForAbstract(), wholeRange))
-       let valSpfn = SynValSig($1, id, explicitValTyparDecls, ty, arity, isInline, false, doc, None, None, wholeRange, { ValKeyword = None; WithKeyword = mWith; EqualsRange = None })
-       [ SynMemberDefn.AbstractSlot(valSpfn, AbstractMemberFlags $3 (getSetAdjuster arity), wholeRange) ] }
+       if Option.isSome $2 then errorR(Error(FSComp.SR.parsAccessibilityModsIllegalForAbstract(), mWhole))
+       let valSpfn = SynValSig($1, id, explicitValTyparDecls, ty, arity, isInline, false, doc, None, None, mWhole, { ValKeyword = None; WithKeyword = mWith; EqualsRange = None })
+       [ SynMemberDefn.AbstractSlot(valSpfn, AbstractMemberFlags $3 (getSetAdjuster arity), mWhole) ] }
        
   | opt_attributes opt_declVisibility inheritsDefn
      {  if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalOnInherit(), rhs parseState 1))
@@ -1998,13 +2002,13 @@ atomicPatternLongIdent:
           raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedSymbolDot())
 
        let underscore = ident("_", rhs parseState 1)
-       let dotm = rhs parseState 2
-       None, prependIdentInLongIdentWithTrivia (SynIdent(underscore, None)) dotm $3 }
+       let mDot = rhs parseState 2
+       None, prependIdentInLongIdentWithTrivia (SynIdent(underscore, None)) mDot $3 }
 
   | GLOBAL DOT pathOp
      { let globalIdent = ident(MangledGlobalName, rhs parseState 1)
-       let dotm = rhs parseState 2
-       None, prependIdentInLongIdentWithTrivia (SynIdent(globalIdent, None)) dotm $3 }
+       let mDot = rhs parseState 2
+       None, prependIdentInLongIdentWithTrivia (SynIdent(globalIdent, None)) mDot $3 }
 
   | pathOp
      { (None, $1) }
@@ -2014,8 +2018,8 @@ atomicPatternLongIdent:
           raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedSymbolDot())
 
        let underscore = ident("_", rhs parseState 2)
-       let dotm = rhs parseState 3
-       Some($1), prependIdentInLongIdentWithTrivia (SynIdent(underscore, None)) dotm $4 } 
+       let mDot = rhs parseState 3
+       Some($1), prependIdentInLongIdentWithTrivia (SynIdent(underscore, None)) mDot $4 } 
 
   | access pathOp
      { (Some($1), $2) }
@@ -2184,7 +2188,7 @@ tyconDefnOrSpfnSimpleRepr:
   /* A union type definition */
   | opt_attributes opt_declVisibility unionTypeRepr
      { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(), rhs parseState 1))
-       let rangesOf3 = $3 |> List.map (function |Choice1Of2(ec)->ec.Range | Choice2Of2(uc)->uc.Range)
+       let rangesOf3 = $3 |> List.map (function Choice1Of2 ec -> ec.Range | Choice2Of2 uc -> uc.Range)
        let mWhole = (rhs2 parseState 1 2, rangesOf3) ||> List.fold unionRanges 
        if $3 |> List.exists (function Choice1Of2 _ -> true | _ -> false) then (
            if Option.isSome $2 then errorR(Error(FSComp.SR.parsEnumTypesCannotHaveVisibilityDeclarations(), rhs parseState 2));
@@ -2207,12 +2211,12 @@ tyconDefnOrSpfnSimpleRepr:
   /* An inline-assembly type definition, for FSharp.Core library only */
   | opt_attributes opt_declVisibility LPAREN HASH string HASH rparen
      { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(), rhs parseState 1))
-       let lhsm = lhs parseState
-       if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyError lhsm
+       let mLhs = lhs parseState
+       if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyError mLhs
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsInlineAssemblyCannotHaveVisibilityDeclarations(), rhs parseState 2))
        let s, _ = $5
        let ilType = ParseAssemblyCodeType s parseState.LexBuffer.ReportLibraryOnlyFeatures parseState.LexBuffer.LanguageVersion (rhs parseState 5)
-       SynTypeDefnSimpleRepr.LibraryOnlyILAssembly (box ilType, lhsm)  }
+       SynTypeDefnSimpleRepr.LibraryOnlyILAssembly (box ilType, mLhs)  }
 
 
 /* The core of a record type definition */
@@ -2513,8 +2517,8 @@ unionCaseReprElements:
 unionCaseReprElement:
   | ident COLON appType
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
-       let wholeRange = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-       mkSynNamedField ($1, $3, xmlDoc, wholeRange) }
+       let mWhole = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
+       mkSynNamedField ($1, $3, xmlDoc, mWhole) }
 
   | appType
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
@@ -2539,19 +2543,19 @@ recdFieldDeclList:
 /* A field declaration in a record type */
 recdFieldDecl: 
   | opt_attributes fieldDecl
-     { let wholeRange = rhs2 parseState 1 2
-       let fld = $2 $1 false wholeRange
-       let (SynField (a, b, c, d, e, xmlDoc, vis, wholeRange)) = fld
+     { let mWhole = rhs2 parseState 1 2
+       let fld = $2 $1 false mWhole
+       let (SynField (a, b, c, d, e, xmlDoc, vis, mWhole)) = fld
        if Option.isSome vis then errorR (Error (FSComp.SR.parsRecordFieldsCannotHaveVisibilityDeclarations (), rhs parseState 2))
-       let wholeRange = unionRangeWithXmlDoc xmlDoc wholeRange
-       SynField (a, b, c, d, e, xmlDoc, None, wholeRange) }
+       let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
+       SynField (a, b, c, d, e, xmlDoc, None, mWhole) }
 
 /* Part of a field or val declaration in a record type or object type */
 fieldDecl: 
   | opt_mutable opt_access ident COLON  typ 
-     { fun attrs stat wholeRange ->
-           let xmlDoc = grabXmlDocAtRangeStart(parseState, attrs, wholeRange)
-           SynField(attrs, stat, Some $3, $5, $1, xmlDoc, $2, wholeRange) }
+     { fun attrs stat mWhole ->
+           let xmlDoc = grabXmlDocAtRangeStart(parseState, attrs, mWhole)
+           SynField(attrs, stat, Some $3, $5, $1, xmlDoc, $2, mWhole) }
 
 /* An exception definition */
 exconDefn: 
@@ -3322,12 +3326,12 @@ parenPattern:
       { SynPat.Ands(List.rev $1, rhs2 parseState 1 3) }
 
   | parenPattern COLON  typeWithTypeConstraints %prec paren_pat_colon
-      { let lhsm = lhs parseState 
-        SynPat.Typed($1, $3, lhsm) } 
+      { let mLhs = lhs parseState 
+        SynPat.Typed($1, $3, mLhs) } 
 
   | attributes parenPattern  %prec paren_pat_attribs
-      { let lhsm = lhs parseState 
-        SynPat.Attrib($2, $1, lhsm) } 
+      { let mLhs = lhs parseState 
+        SynPat.Attrib($2, $1, mLhs) } 
 
   | parenPattern COLON_COLON  parenPattern 
       { SynPat.LongIdent (SynLongIdent(mkSynCaseName (rhs parseState 2) opNameCons, [], [ Some (IdentTrivia.OriginalNotation "::") ]), None, None, SynArgPats.Pats [ SynPat.Tuple (false, [$1;$3], rhs2 parseState 1 3) ], None, lhs parseState) }
@@ -3990,18 +3994,18 @@ declExpr:
 
   | declExpr DOT_DOT declExpr 
       { let wholem = rhs2 parseState 1 3
-        let opm = rhs parseState 2
-        SynExpr.IndexRange(Some $1, opm, Some $3, rhs parseState 1, rhs parseState 3, wholem) }
+        let mOperator = rhs parseState 2
+        SynExpr.IndexRange(Some $1, mOperator, Some $3, rhs parseState 1, rhs parseState 3, wholem) }
 
   | declExpr DOT_DOT %prec open_range_expr   
       { let wholem = rhs2 parseState 1 2
-        let opm = rhs parseState 2
-        SynExpr.IndexRange(Some $1, opm, None, rhs parseState 1, opm, wholem) }
+        let mOperator = rhs parseState 2
+        SynExpr.IndexRange(Some $1, mOperator, None, rhs parseState 1, mOperator, wholem) }
 
   | DOT_DOT declExpr %prec open_range_expr
       { let wholem = rhs2 parseState 1 2
-        let opm = rhs parseState 1
-        SynExpr.IndexRange(None, opm, Some $2, opm, rhs parseState 2, wholem) }
+        let mOperator = rhs parseState 1
+        SynExpr.IndexRange(None, mOperator, Some $2, mOperator, rhs parseState 2, wholem) }
       
   | STAR 
       { let m = rhs parseState 1
@@ -4351,61 +4355,61 @@ atomicExpr:
 atomicExprQualification:
   | identOrOp 
       { let idm = rhs parseState 1 
-        (fun e lhsm dotm -> mkSynDot dotm lhsm e $1) }
+        (fun e mLhs mDot -> mkSynDot mDot mLhs e $1) }
 
   | GLOBAL
-      { (fun e lhsm dotm -> 
+      { (fun e mLhs mDot -> 
             reportParseErrorAt (rhs parseState 3) (FSComp.SR.nrGlobalUsedOnlyAsFirstName()) 
-            let fixedLhsm = mkRange lhsm.FileName lhsm.Start dotm.End // previous lhsm is wrong after 'recover'
-            mkSynDotMissing dotm fixedLhsm e) }
+            let fixedLhsm = mkRange mLhs.FileName mLhs.Start mDot.End // previous mLhs is wrong after 'recover'
+            mkSynDotMissing mDot fixedLhsm e) }
 
   | /* empty */
-      { (fun e lhsm dotm -> 
-            reportParseErrorAt dotm (FSComp.SR.parsMissingQualificationAfterDot()) 
-            let fixedLhsm = mkRange lhsm.FileName lhsm.Start dotm.End // previous lhsm is wrong after 'recover'
-            mkSynDotMissing dotm fixedLhsm e) }
+      { (fun e mLhs mDot -> 
+            reportParseErrorAt mDot (FSComp.SR.parsMissingQualificationAfterDot()) 
+            let fixedLhsm = mkRange mLhs.FileName mLhs.Start mDot.End // previous mLhs is wrong after 'recover'
+            mkSynDotMissing mDot fixedLhsm e) }
   | recover 
-      { (fun e lhsm dotm -> 
-            reportParseErrorAt dotm (FSComp.SR.parsMissingQualificationAfterDot()) 
-            let fixedLhsm = mkRange lhsm.FileName lhsm.Start dotm.End // previous lhsm is wrong after 'recover'
+      { (fun e mLhs mDot -> 
+            reportParseErrorAt mDot (FSComp.SR.parsMissingQualificationAfterDot()) 
+            let fixedLhsm = mkRange mLhs.FileName mLhs.Start mDot.End // previous mLhs is wrong after 'recover'
             // Include 'e' in the returned expression but throw it away
             SynExpr.DiscardAfterMissingQualificationAfterDot (e, fixedLhsm)) }
   | LPAREN COLON_COLON rparen DOT INT32  
-      { (fun e lhsm dotm -> 
+      { (fun e mLhs mDot -> 
             if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyError(lhs parseState)
-            SynExpr.LibraryOnlyUnionCaseFieldGet (e, mkSynCaseName lhsm opNameCons, (fst $5), lhsm)) }
+            SynExpr.LibraryOnlyUnionCaseFieldGet (e, mkSynCaseName mLhs opNameCons, (fst $5), mLhs)) }
 
   | LPAREN  typedSequentialExpr rparen  
       { let lpr = rhs parseState 1
         let rpr = rhs parseState 3
-        (fun e lhsm dotm -> 
+        (fun e mLhs mDot -> 
             // Check for expr.( * )
             // Note that "*" is parsed as an expression (it is allowed in "foo.[3,*]")
             match $2 with
-            | SynExpr.IndexRange (None, opm, None, _m1, _m2, _) ->
-                mkSynDot dotm lhsm e (SynIdent(ident(CompileOpName "*", opm), Some(IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr))))
+            | SynExpr.IndexRange (None, mOperator, None, _m1, _m2, _) ->
+                mkSynDot mDot mLhs e (SynIdent(ident(CompileOpName "*", mOperator), Some(IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr))))
             | _ ->
                 if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
                     mlCompatError (FSComp.SR.mlCompatMultiPrefixTyparsNoLongerSupported()) (lhs parseState) 
                 else
                     mlCompatWarning (FSComp.SR.parsParenFormIsForML()) (lhs parseState) 
-                mkSynDotParenGet lhsm dotm e $2) }
+                mkSynDotParenGet mLhs mDot e $2) }
 
   | LBRACK  typedSequentialExpr RBRACK
-      { (fun e lhsm dotm -> mkSynDotBrackGet lhsm dotm e $2) }
+      { (fun e mLhs mDot -> mkSynDotBrackGet mLhs mDot e $2) }
 
   | LBRACK  typedSequentialExpr recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
-        (fun e lhsm dotm -> exprFromParseError (mkSynDotBrackGet lhsm dotm e $2)) }
+        (fun e mLhs mDot -> exprFromParseError (mkSynDotBrackGet mLhs mDot e $2)) }
 
   | LBRACK  error RBRACK  
       { let mArg = rhs2 parseState 1 3
-        (fun e lhsm dotm -> mkSynDotBrackGet lhsm dotm e (arbExpr("indexerExpr1", mArg))) }
+        (fun e mLhs mDot -> mkSynDotBrackGet mLhs mDot e (arbExpr("indexerExpr1", mArg))) }
 
   | LBRACK  recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket())
         let mArg = (rhs parseState 1).EndRange 
-        (fun e lhsm dotm -> exprFromParseError (mkSynDotBrackGet lhsm dotm e (arbExpr("indexerExpr2", mArg)))) }
+        (fun e mLhs mDot -> exprFromParseError (mkSynDotBrackGet mLhs mDot e (arbExpr("indexerExpr2", mArg)))) }
 
 /* the start of atomicExprAfterType must not overlap with the valid postfix tokens of the type syntax, e.g. new List<T>(...) */
 atomicExprAfterType:
@@ -4499,8 +4503,8 @@ parenExpr:
 
   | LPAREN parenExprBody ends_other_than_rparen_coming_soon_or_recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
-        let lhsm = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).End
-        SynExpr.Paren (exprFromParseError ($2 lhsm), rhs parseState 1, None, lhsm) }
+        let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).End
+        SynExpr.Paren (exprFromParseError ($2 mLhs), rhs parseState 1, None, mLhs) }
 
   | LPAREN error rparen 
       { // silent recovery
@@ -4508,18 +4512,18 @@ parenExpr:
 
   | LPAREN TYPE_COMING_SOON
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
-        let lhsm = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
-        arbExpr("parenExpr2tcs", lhsm) }
+        let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
+        arbExpr("parenExpr2tcs", mLhs) }
 
   | LPAREN MODULE_COMING_SOON
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
-        let lhsm = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
-        arbExpr("parenExpr2mcs", lhsm) }
+        let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
+        arbExpr("parenExpr2mcs", mLhs) }
 
   | LPAREN RBRACE_COMING_SOON
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
-        let lhsm = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
-        arbExpr("parenExpr2rbcs", lhsm) }
+        let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
+        arbExpr("parenExpr2rbcs", mLhs) }
 
   | LPAREN OBLOCKEND_COMING_SOON 
       { let lparenRange = (rhs parseState 1)
@@ -4534,8 +4538,8 @@ parenExpr:
         // to extend all the way over the "recover", to the end of the file if necessary
         // 
         // let mLeftParen = rhs parseState 1
-        //let lhsm = if $2 then unionRangeWithPos mLeftParen (rhs parseState 2).Start else mLeftParen
-        //arbExpr("parenExpr2", lhsm)  }  
+        //let mLhs = if $2 then unionRangeWithPos mLeftParen (rhs parseState 2).Start else mLeftParen
+        //arbExpr("parenExpr2", mLhs)  }  
 
 parenExprBody:
   | staticallyKnownHeadTypars COLON LPAREN classMemberSpfn rparen  typedSequentialExpr 
@@ -4596,21 +4600,21 @@ braceExprBody:
 
 listExprElements: 
   | sequentialExpr
-     { (fun lhsm -> SynExpr.ArrayOrListComputed (false, $1, lhsm)) }
+     { (fun mLhs -> SynExpr.ArrayOrListComputed (false, $1, mLhs)) }
 
   | 
-     { (fun lhsm -> SynExpr.ArrayOrList (false, [ ], lhsm)) }
+     { (fun mLhs -> SynExpr.ArrayOrList (false, [ ], mLhs)) }
 
 arrayExprElements: 
   | sequentialExpr
-     { (fun lhsm -> SynExpr.ArrayOrListComputed (true, $1, lhsm)) }
+     { (fun mLhs -> SynExpr.ArrayOrListComputed (true, $1, mLhs)) }
 
   | 
-     { (fun lhsm -> SynExpr.ArrayOrList (true, [ ], lhsm)) }
+     { (fun mLhs -> SynExpr.ArrayOrList (true, [ ], mLhs)) }
 
 computationExpr: 
   | sequentialExpr
-     { $1.Range, (fun lhsm -> SynExpr.ComputationExpr (false, $1, lhsm)) }
+     { $1.Range, (fun mLhs -> SynExpr.ComputationExpr (false, $1, mLhs)) }
 
 arrowThenExprR:
   | RARROW typedSequentialExprBlockR 

--- a/src/FSharp.Core/Linq.fs
+++ b/src/FSharp.Core/Linq.fs
@@ -593,11 +593,11 @@ module LeafExpressionConverter =
             | NullableConstruction arg -> Expression.Convert(ConvExprToLinqInContext env arg, x.Type) |> asExpr
             | _ -> Expression.New(ctorInfo, ConvExprsToLinq env args) |> asExpr
 
-        | Patterns.NewDelegate(dty, vs, b) ->
+        | Patterns.NewDelegate(delegateTy, vs, b) ->
             let vsP = List.map ConvVarToLinq vs
             let env = {env with varEnv = List.foldBack2 (fun (v:Var) vP -> Map.add v (vP |> asExpr)) vs vsP env.varEnv }
             let bodyP = ConvExprToLinqInContext env b
-            Expression.Lambda(dty, bodyP, vsP) |> asExpr
+            Expression.Lambda(delegateTy, bodyP, vsP) |> asExpr
 
         | Patterns.NewTuple args ->
              let tupTy = 

--- a/src/FSharp.Core/quotations.fs
+++ b/src/FSharp.Core/quotations.fs
@@ -1408,11 +1408,11 @@ module Patterns =
         | Unique of 'T
         | Ambiguous of 'R
 
-    let typeEquals (s: Type) (t: Type) =
-        s.Equals t
+    let typeEquals (ty1: Type) (ty2: Type) =
+        ty1.Equals ty2
 
-    let typesEqual (ss: Type list) (tt: Type list) =
-        (ss.Length = tt.Length) && List.forall2 typeEquals ss tt
+    let typesEqual (tys1: Type list) (tys2: Type list) =
+        (tys1.Length = tys2.Length) && List.forall2 typeEquals tys1 tys2
 
     let instFormal (typarEnv: Type[]) (ty: Instantiable<'T>) =
         ty (fun i -> typarEnv.[i])

--- a/tests/scripts/identifierAnalysisByType.fsx
+++ b/tests/scripts/identifierAnalysisByType.fsx
@@ -60,7 +60,7 @@ symbols
 |> Array.filter (fun (v, _) -> v.GenericParameters.Count = 0)
 |> Array.filter (fun (v, _) -> v.CurriedParameterGroups.Count = 0)
 |> Array.filter (fun (v, _) -> not v.FullType.IsGenericParameter)
-|> Array.map (fun (v, vUse) -> getTypeText v, v, vUse)
+|> Array.map (fun (v, vUse) -> getTypeText v, v, vUse.ToString())
 |> Array.filter (fun (vTypeText, v, _) -> 
     match vTypeText with 
     | "System.String" -> false
@@ -77,6 +77,7 @@ symbols
 |> Array.map (fun (key, g) ->
     key, 
     (g 
+     |> Array.distinctBy (fun (_, _, vUse) -> vUse)
      |> Array.groupBy (fun (_, v, _) -> v.DisplayName)
      |> Array.sortByDescending (snd >> Array.length)))
 |> Array.filter (fun (_, g) -> g.Length > 1)
@@ -87,7 +88,7 @@ symbols
     for (nm, entries) in g do
        printfn "    %s (%d times)" nm (Array.length entries)
        for (_, _, vUse) in entries do
-           printfn "        %s" (vUse.ToString())
+           printfn "        %s" vUse
     printfn "")
 
 (*


### PR DESCRIPTION
Based on the analysis script #13486 I did some normalizing of the names used for 

* TType  
* ValRef
* TyconRef
* Range

It is not complete by any means but represents a substantial regularization.
