### PR TITLE
Change Dev17.3 dependencies version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,8 +55,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <VSMajorVersion>17</VSMajorVersion>
-    <VSMinorVersion>1</VSMinorVersion>
-    <VSGeneralVersion>$(VSMajorVersion).0</VSGeneralVersion>
+    <VSMinorVersion>3</VSMinorVersion>
+    <VSGeneralVersion>$(VSMajorVersion).5</VSGeneralVersion>
     <VSAssemblyVersionPrefix>$(VSMajorVersion).$(VSMinorVersion).0</VSAssemblyVersionPrefix>
     <VSAssemblyVersion>$(VSAssemblyVersionPrefix).0</VSAssemblyVersion>
   </PropertyGroup>


### PR DESCRIPTION
We have an internal process, that started to fail when we serviced dev17.2.  Because we ues the wrong version numbers for insertion packages.

/cc @vzarytovskii 