### PR TITLE
Include Internal Attribute Constructors in reference assemblies.

### DIFF
--- a/src/Compiler/AbstractIL/ilwrite.fs
+++ b/src/Compiler/AbstractIL/ilwrite.fs
@@ -1144,7 +1144,10 @@ let canGenMethodDef (tdef: ILTypeDef) cenv (mdef: ILMethodDef) =
     //          member val internal Prop1 : int = 0 with get, set
     //      [<PublicWithInternalSetterPropertyAttribute(Prop1=4)>]
     //      type ClassPublicWithAttributes() = class end
-    else if tdef.IsKnownToBeAttribute && mdef.IsSpecialName && (not mdef.IsConstructor) && (not mdef.IsClassInitializer) then
+    
+    // TODO: add comment why constructors of attributes should always be included in the reference assembly.
+    // Example: NoDynamicInvocationAttribute has an internal constructor, which should be included in the reference assembly.
+    else if tdef.IsKnownToBeAttribute && mdef.IsSpecialName && (not mdef.IsClassInitializer) then
         true
     else
         match mdef.Access with

--- a/src/Compiler/AbstractIL/ilwrite.fs
+++ b/src/Compiler/AbstractIL/ilwrite.fs
@@ -1137,15 +1137,15 @@ let TryGetMethodRefAsMethodDefIdx cenv (mref: ILMethodRef) =
 let canGenMethodDef (tdef: ILTypeDef) cenv (mdef: ILMethodDef) =
     if not cenv.referenceAssemblyOnly then
         true
-    // If the method is part of attribute type, generate get_* and set_* methods for it, consider the following case:
+    // If the method is part of attribute type, generate get_* and set_* methods and .ctors for it, consider the following case:
     //      [<AttributeUsage(AttributeTargets.All)>]
     //      type PublicWithInternalSetterPropertyAttribute() =
     //          inherit Attribute()
     //          member val internal Prop1 : int = 0 with get, set
     //      [<PublicWithInternalSetterPropertyAttribute(Prop1=4)>]
     //      type ClassPublicWithAttributes() = class end
-    
-    // TODO: add comment why constructors of attributes should always be included in the reference assembly.
+
+    // We want to generate pretty much everything for attributes, because of serialization scenarios, and the fact that non-visible constructors, properties and fields can still be part of reference assembly.
     // Example: NoDynamicInvocationAttribute has an internal constructor, which should be included in the reference assembly.
     else if tdef.IsKnownToBeAttribute && mdef.IsSpecialName && (not mdef.IsClassInitializer) then
         true

--- a/src/FSharp.Core/FSharp.Core.fsproj
+++ b/src/FSharp.Core/FSharp.Core.fsproj
@@ -37,7 +37,6 @@
     <PackageDescription>FSharp.Core redistributables from F# Tools version $(FSProductVersionPrefix) For F# $(FSLanguageVersion).  Contains code from the F# Software Foundation.</PackageDescription>
     <PackageReleaseNotes>/blob/main/release-notes.md#FSharp-Core-$(FSCoreReleaseNotesVersion)</PackageReleaseNotes>
     <Configurations>Debug;Release;Proto</Configurations>
-	<ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharp.Core/FSharp.Core.fsproj
+++ b/src/FSharp.Core/FSharp.Core.fsproj
@@ -37,6 +37,7 @@
     <PackageDescription>FSharp.Core redistributables from F# Tools version $(FSProductVersionPrefix) For F# $(FSLanguageVersion).  Contains code from the F# Software Foundation.</PackageDescription>
     <PackageReleaseNotes>/blob/main/release-notes.md#FSharp-Core-$(FSCoreReleaseNotesVersion)</PackageReleaseNotes>
     <Configurations>Debug;Release;Proto</Configurations>
+	<ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
@@ -723,4 +723,134 @@ type MType() =
 
   } """
         ]
+
+    [<Test>]
+    let ``Internal constructor is emitted for attribute`` () =
+        FSharp """
+module ReferenceAssembly
+
+open System
+[<AttributeUsage(AttributeTargets.Method ||| AttributeTargets.Property, AllowMultiple=false)>]
+[<Sealed>]
+type CustomAttribute(smth: bool) =
+    inherit Attribute()
+    internal new () = CustomAttribute(false)
+    member _.Something = smth
+    
+type Person(name : string, age : int) =
+    [<Custom(true)>]
+    member val Name = name with get, set
+    [<Custom>]
+    member val Age = age with get, set
+    """
+        |> withOptions ["--refonly"]
+        |> compile
+        |> shouldSucceed
+        |> verifyIL [
+            referenceAssemblyAttributeExpectedIL
+            """.class auto ansi serializable sealed nested public CustomAttribute
+            extends [runtime]System.Attribute
+  {
+    .custom instance void [runtime]System.AttributeUsageAttribute::.ctor(valuetype [runtime]System.AttributeTargets) = ( 01 00 C0 00 00 00 01 00 54 02 0D 41 6C 6C 6F 77   
+                                                                                                                                          4D 75 6C 74 69 70 6C 65 00 )                      
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.SealedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+    .field assembly bool smth
+    .method public specialname rtspecialname 
+               instance void  .ctor(bool smth) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  throw
+    } 
+
+    .method assembly specialname rtspecialname 
+               instance void  .ctor() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  throw
+    } 
+
+    .method public hidebysig specialname 
+               instance bool  get_Something() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  throw
+    } 
+
+  } 
+
+  .class auto ansi serializable nested public Person
+            extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+    .method public specialname rtspecialname 
+               instance void  .ctor(string name,
+                                    int32 age) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  throw
+    } 
+
+    .method public hidebysig specialname 
+               instance string  get_Name() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  throw
+    } 
+
+    .method public hidebysig specialname 
+               instance void  set_Name(string v) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  throw
+    } 
+
+    .method public hidebysig specialname 
+               instance int32  get_Age() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  throw
+    } 
+
+    .method public hidebysig specialname 
+               instance void  set_Age(int32 v) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  throw
+    } 
+
+    .property instance bool Something()
+    {
+      .get instance bool ReferenceAssembly/CustomAttribute::get_Something()
+    } 
+    .property instance string Name()
+    {
+      .custom instance void ReferenceAssembly/CustomAttribute::.ctor(bool) = ( 01 00 01 00 00 ) 
+      .set instance void ReferenceAssembly/Person::set_Name(string)
+      .get instance string ReferenceAssembly/Person::get_Name()
+    } 
+    .property instance int32 Age()
+    {
+      .custom instance void ReferenceAssembly/CustomAttribute::.ctor() = ( 01 00 00 00 ) 
+      .set instance void ReferenceAssembly/Person::set_Age(int32)
+      .get instance int32 ReferenceAssembly/Person::get_Age()
+    } 
+  }"""
+        ]
     // TODO: Add tests for internal functions, types, interfaces, abstract types (with and without IVTs), (private, internal, public) fields, properties (+ different visibility for getters and setters), events.


### PR DESCRIPTION
This is an alternative for https://github.com/dotnet/fsharp/pull/13385.
After chatting with @vzarytovskii we came to the conclusion that constructors of attributes should always be included in the reference assembly.

Remaining work:
- [x] Add a better comment on why that is.
- [x] Add a unit test to verify the IL generation.