### PR TITLE
Fix 13345

### DIFF
--- a/src/Compiler/AbstractIL/ilmorph.fs
+++ b/src/Compiler/AbstractIL/ilmorph.fs
@@ -265,15 +265,15 @@ let morphILTypeDefs f (tdefs: ILTypeDefs) =
 
 let morphILLocals f locals = List.map (morphILLocal f) locals
 
-
 let morphILDebugImport fs debugImport =
     let _, f = fs
-    match debugImport with 
-    | ILDebugImport.ImportType ty ->  ILDebugImport.ImportType (f ty)
+
+    match debugImport with
+    | ILDebugImport.ImportType ty -> ILDebugImport.ImportType(f ty)
     | ILDebugImport.ImportNamespace _ns -> debugImport
 
 let morphILDebugImports fs ilDebugImports =
-    ilDebugImports |> Array.map(morphILDebugImport fs)
+    ilDebugImports |> Array.map (morphILDebugImport fs)
 
 let ilmbody_instr2instr_ty2ty fs (ilmbody: ILMethodBody) =
     let _, fTyInCtxt = fs
@@ -284,7 +284,12 @@ let ilmbody_instr2instr_ty2ty fs (ilmbody: ILMethodBody) =
         DebugImports =
             match ilmbody.DebugImports with
             | None -> None
-            | Some imports -> Some ({imports with Imports = morphILDebugImports fs imports.Imports  })
+            | Some imports ->
+                Some(
+                    { imports with
+                        Imports = morphILDebugImports fs imports.Imports
+                    }
+                )
     }
 
 let morphILMethodBody fMethBody (x: MethodBody) =

--- a/src/Compiler/AbstractIL/ilmorph.fs
+++ b/src/Compiler/AbstractIL/ilmorph.fs
@@ -265,12 +265,26 @@ let morphILTypeDefs f (tdefs: ILTypeDefs) =
 
 let morphILLocals f locals = List.map (morphILLocal f) locals
 
+
+let morphILDebugImport fs debugImport =
+    let _, f = fs
+    match debugImport with 
+    | ILDebugImport.ImportType ty ->  ILDebugImport.ImportType (f ty)
+    | ILDebugImport.ImportNamespace _ns -> debugImport
+
+let morphILDebugImports fs ilDebugImports =
+    ilDebugImports |> Array.map(morphILDebugImport fs)
+
 let ilmbody_instr2instr_ty2ty fs (ilmbody: ILMethodBody) =
-    let finstr, fTyInCtxt = fs
+    let _, fTyInCtxt = fs
 
     { ilmbody with
-        Code = code_instr2instr_ty2ty (finstr, fTyInCtxt) ilmbody.Code
+        Code = code_instr2instr_ty2ty fs ilmbody.Code
         Locals = morphILLocals fTyInCtxt ilmbody.Locals
+        DebugImports =
+            match ilmbody.DebugImports with
+            | None -> None
+            | Some imports -> Some ({imports with Imports = morphILDebugImports fs imports.Imports  })
     }
 
 let morphILMethodBody fMethBody (x: MethodBody) =


### PR DESCRIPTION
Fixes #13345 

The issue is that an addition reference to F# core is caused when embedding F# core in a target application.  On investigation it only happens when we build pdbs.  The issue arose when we added embedding imported namespaces and modules in Symbol files.

We were not remapping ILDebugImport.ImportTypes when doing the assembly morphing in StaticLinking.

Anyway the fix is here.