### PR TITLE
Stack overflow on localized languages.

### DIFF
--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -2362,12 +2362,10 @@ module internal MagicAssemblyResolution =
             let simpleAssemName = fullAssemName.Split([| ',' |]).[0]
             if progress then fsiConsoleOutput.uprintfn "ATTEMPT MAGIC LOAD ON ASSEMBLY, simpleAssemName = %s" simpleAssemName // "Attempting to load a dynamically required assembly in response to an AssemblyResolve event by using known static assembly references..."
 
-            // Special case: Mono Windows Forms attempts to load an assembly called something like "Windows.Forms.resources"
-            // We can't resolve this, so don't try.
-            // REVIEW: Suggest 4481, delete this special case.
-            if (runningOnMono && simpleAssemName.EndsWith(".resources",StringComparison.OrdinalIgnoreCase)) ||
+            // We can't resolve an assembly called blah.resources" so don't try.
+            if simpleAssemName.EndsWith(".resources", StringComparison.OrdinalIgnoreCase) ||
                simpleAssemName.EndsWith(".XmlSerializers", StringComparison.OrdinalIgnoreCase) ||
-               (runningOnMono && simpleAssemName = "UIAutomationWinforms") then null
+               (simpleAssemName = "UIAutomationWinforms") then null
             else
                 match fsiDynamicCompiler.FindDynamicAssembly(simpleAssemName) with
                 | Some asm -> asm


### PR DESCRIPTION
On a release build:
````
fsi --fsi-server-lcid:1036
printfn "Hello, World: The time is: %s" (System.DateTime.Now.ToString());;
````

Observe the output:
````

Process is terminated due to StackOverflowException.
````

This fixes it, for the longest time we have naiively tried to resolve .resources when trying to resolve assemblies.  This gets us in an endless loop when the .resources can't be resolved by us.  This PR get's us out of that game, we should never have tried.