### PR TITLE
Use the live FSharp.Core bits to bootstrap.

### DIFF
--- a/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/FSharp.Build/FSharp.Build.fsproj
@@ -52,7 +52,7 @@
     <None Include="Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)' == 'Proto'">
+  <ItemGroup Condition="'$(Configuration)' == 'Proto' and '$(DotNetBuildFromSource)' != 'true'">
     <!--
         The FSharp.Build built here may be loaded directly into a shipped Visual Studio, to that end, we cannot 
         rely on new API's just being added to FSharp.Core.
@@ -60,7 +60,7 @@
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" IncludeAssets="compile" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup  Condition="'$(Configuration)' != 'Proto'">
+  <ItemGroup  Condition="'$(Configuration)' != 'Proto' or '$(DotNetBuildFromSource)' == 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Source-build doesn't need to match the shipped bootstrap version. See https://github.com/dotnet/fsharp/issues/13463 for more details.