### PR TITLE
Fixes #10621

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -8052,7 +8052,6 @@ and TcNameOfExpr cenv env tpenv (synArg: SynExpr) =
                 | Result (_, item, _, _, _ as res)
                     when
                          (match item with
-                          | Item.Types _
                           | Item.DelegateCtor _
                           | Item.CtorGroup _
                           | Item.FakeInterfaceCtor _ -> false

--- a/tests/FSharp.Compiler.ComponentTests/Language/NameofTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/NameofTests.fs
@@ -24,3 +24,22 @@ if actual <> expected then failwith $"Expected nameof({{expected}}) to be '{{exp
         |> withLangVersion50
         |> compileAndRun
         |> shouldSucceed
+        
+    [<Theory>]
+    [<InlineData(1)>]
+    [<InlineData(2)>]
+    [<InlineData(3)>]
+    let ``nameof() with member of a generic type should return the name`` numberOfGenericParameters =    
+        let source = $"""
+type A<{(seq {for i in 1 .. numberOfGenericParameters -> "'a" + string i } |> String.concat ", ")}>() =
+    static member P = ()
+
+let expected = "P"
+let actual = nameof(A<{(seq {for _ in 1 .. numberOfGenericParameters -> "_" } |> String.concat ", ")}>.P)
+if actual <> expected then failwith $"Expected nameof({{expected}}) to be '{{expected}}', but got '{{actual}}'"
+        """
+        Fsx source
+        |> asExe
+        |> withLangVersion50
+        |> compileAndRun
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Language/NameofTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/NameofTests.fs
@@ -25,6 +25,23 @@ if actual <> expected then failwith $"Expected nameof({{expected}}) to be '{{exp
         |> compileAndRun
         |> shouldSucceed
         
+    [<Fact>]
+    let ``nameof() with member of a generic type should return the name without types provided`` () =    
+        let source = $"""
+type A<'a>() =
+    static member P = ()
+
+let expected = "P"
+let actual = nameof(A.P)
+if actual <> expected then failwith $"Expected nameof({{expected}}) to be '{{expected}}', but got '{{actual}}'"
+        """
+        Fsx source
+        |> asExe
+        |> withLangVersion50
+        |> ignoreWarnings
+        |> compileAndRun
+        |> shouldSucceed
+        
     [<Theory>]
     [<InlineData(1)>]
     [<InlineData(2)>]


### PR DESCRIPTION
Looks like deleting this one line is fine. From history it is not clear to me why it was added. I was thinking about writing some more complicated checks (`| Item.Types _ when ... -> true`) but I could not think of cases when we have Item.Types and cannot use the nameof.