### PR TITLE
[Draft] Fix #5647, difference in max/min in debug with floats and nans

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/OperatorsModule2.fs
@@ -307,6 +307,15 @@ type OperatorsModule2() =
         // reference type
         let result = Operators.max "A" "ABC"
         Assert.AreEqual("ABC", result)
+
+        // floating point
+        let assertNaN f result = Assert.True(f result, "Operators.max with NaN must result in NaN.")
+        Operators.max nan 1.0 |> assertNaN Double.IsNaN 
+        Operators.max 1.0 nan |> assertNaN Double.IsNaN
+        Operators.max nan nan |> assertNaN Double.IsNaN
+        Operators.max 1.0f nanf |> assertNaN Single.IsNaN
+        Operators.max nanf 1.0f |> assertNaN Single.IsNaN
+        Operators.max nanf nanf |> assertNaN Single.IsNaN
         
     [<Fact>]
     member _.min() =
@@ -325,6 +334,15 @@ type OperatorsModule2() =
         // reference type
         let result = Operators.min "A" "ABC"
         Assert.AreEqual("A", result)
+
+        // floating point
+        let assertNaN f result = Assert.True(f result, "Operators.min with NaN must result in NaN.")
+        Operators.min nan 1.0 |> assertNaN Double.IsNaN 
+        Operators.min 1.0 nan |> assertNaN Double.IsNaN
+        Operators.min nan nan |> assertNaN Double.IsNaN
+        Operators.min 1.0f nanf |> assertNaN Single.IsNaN
+        Operators.min nanf 1.0f |> assertNaN Single.IsNaN
+        Operators.min nanf nanf |> assertNaN Single.IsNaN
         
     [<Fact>]
     member _.nan() =


### PR DESCRIPTION
As mentioned in the issue, the Core `min` and `max` functions behave incorrect when used with `float/float32` types in relation to `nan/nanf`. The output should always be `nan/nanf`, but this isn't the case in Debug mode, because optimizations aren't applied and instead, the default comparer is being used (that is, the line `if e1 < e2 then e2 else e1` from the implementation is executed, as opposed to the specialized paths).

Since I can't run the tests at the moment (see #13557), I use CI to check if the tests properly fail indeed. 