### PR TITLE
Use ReferencePathWithRefAssemblies instead of ReferencePath

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/FSharp.Build/Microsoft.FSharp.Targets
@@ -252,7 +252,7 @@ this file.
                 @(ManifestNonResxWithNoCultureOnDisk);
                 $(ApplicationIcon);
                 $(AssemblyOriginatorKeyFile);
-                @(ReferencePath);
+                @(ReferencePathWithRefAssemblies);
                 @(CompiledLicenseFile);
                 @(EmbeddedDocumentation); 
                 $(Win32Resource);
@@ -346,8 +346,8 @@ this file.
               PreferredUILang="$(PreferredUILang)"
               ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
               PublicSign="$(PublicSign)"
-              References="@(ReferencePath)"
-              ReferencePath="$(ReferencePath)"
+              References="@(ReferencePathWithRefAssemblies)"
+              ReferencePath="$(ReferencePathWithRefAssemblies)"
               RefOnly="$(ProduceOnlyReferenceAssembly)"
               Resources="@(ActualEmbeddedResources)"
               SkipCompilerExecution="$(SkipCompilerExecution)"


### PR DESCRIPTION
One more bit towards resolving the https://github.com/dotnet/fsharp/issues/13223.
Previously I opened a PR that enabled the generation of reference assemblies by the FSC tasks (https://github.com/dotnet/fsharp/pull/13263). But I forgot to make the FSC task consume reference assemblies. 
Without this change only `C# -> C#` and `C# -> F#` scenarios were supported, after this change `F# -> F#` and `F# -> C#` scenarios will be supported as well.


