### PR TITLE
Remove NO_SYSTEM_CONFIGURATION

### DIFF
--- a/FSharp.Profiles.props
+++ b/FSharp.Profiles.props
@@ -13,7 +13,6 @@
         <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
         <DefineConstants>$(DefineConstants);FX_NO_APP_DOMAINS</DefineConstants>
         <DefineConstants>$(DefineConstants);FX_NO_CORHOST_SIGNER</DefineConstants>
-        <DefineConstants>$(DefineConstants);FX_NO_SYSTEM_CONFIGURATION</DefineConstants>
         <DefineConstants>$(DefineConstants);FX_NO_WIN_REGISTRY</DefineConstants>
         <DefineConstants>$(DefineConstants);FX_NO_WINFORMS</DefineConstants>
         <DefineConstants>$(DefineConstants);FX_RESHAPED_REFEMIT</DefineConstants>


### PR DESCRIPTION
Remove even more distinctions between the desktop fsharp compiler service dll and the netstandard version