### PR TITLE
Include star in topTupleType rule.

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -5030,7 +5030,8 @@ topType:
 topTupleType:
   | topAppType STAR topTupleTypeElements 
      { let t, argInfo = $1
-       let path = SynTupleTypeSegment.Type t :: (List.map fst $3)
+       let mStar = rhs parseState 2
+       let path = SynTupleTypeSegment.Type t :: SynTupleTypeSegment.Star mStar :: (List.map fst $3)
        let mdata = argInfo :: (List.choose snd $3)
        mkSynTypeTuple false path, mdata }
 

--- a/tests/service/SyntaxTreeTests/BindingTests.fs
+++ b/tests/service/SyntaxTreeTests/BindingTests.fs
@@ -366,3 +366,35 @@ let a =
     ]) ])) ->
         assertRange (3, 4) (3, 7) mLet
     | _ -> Assert.Fail "Could not get valid AST"
+
+[<Test>]
+let ``Tuple return type of binding should contain stars`` () =
+    let parseResults = 
+        getParseResults """
+let a : int * string = failwith "todo"
+let b : int * string * bool = 1, "", false
+"""
+
+    match parseResults with
+    | ParsedInput.ImplFile (ParsedImplFileInput (modules = [ SynModuleOrNamespace.SynModuleOrNamespace(decls = [
+        SynModuleDecl.Let(bindings = [
+            SynBinding(returnInfo =
+                Some (SynBindingReturnInfo(typeName = SynType.Tuple(path = [
+                    SynTupleTypeSegment.Type _
+                    SynTupleTypeSegment.Star _
+                    SynTupleTypeSegment.Type _
+                ]))))
+        ])
+        SynModuleDecl.Let(bindings = [
+            SynBinding(returnInfo =
+                Some (SynBindingReturnInfo(typeName = SynType.Tuple(path = [
+                    SynTupleTypeSegment.Type _
+                    SynTupleTypeSegment.Star _
+                    SynTupleTypeSegment.Type _
+                    SynTupleTypeSegment.Star _
+                    SynTupleTypeSegment.Type _
+                ]))))
+        ])
+    ]) ])) ->
+        Assert.Pass ()
+    | _ -> Assert.Fail $"Could not get valid AST, got {parseResults}"


### PR DESCRIPTION
Aftermath of https://github.com/dotnet/fsharp/pull/13440, the first `*` was missing in `SynType.Tuple` was missing when the type is coming from the `topTupleType` grammar rule.