### PR TITLE
Update Fantomas to the latest beta.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "5.0.0-alpha-011",
+      "version": "5.0.0-beta-005",
       "commands": [
         "fantomas"
       ]

--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -4843,7 +4843,7 @@ let openPEMetadataOnly (fileName, peinfo, pectxtEager, pevEager, mdfile: BinaryF
     openMetadataReader (fileName, mdfile, 0, peinfo, pectxtEager, pevEager, None, reduceMemoryUsage)
 
 type ILReaderMetadataSnapshot = obj * nativeint * int
-type ILReaderTryGetMetadataSnapshot = (* path: *) string (* snapshotTimeStamp: *)  * DateTime -> ILReaderMetadataSnapshot option
+type ILReaderTryGetMetadataSnapshot = (* path: *) string (* snapshotTimeStamp: *) * DateTime -> ILReaderMetadataSnapshot option
 
 [<RequireQualifiedAccess>]
 type MetadataOnlyFlag =

--- a/src/Compiler/AbstractIL/ilreflect.fs
+++ b/src/Compiler/AbstractIL/ilreflect.fs
@@ -162,6 +162,7 @@ type TypeBuilder with
     member typB.CreateTypeAndLog() =
         if logRefEmitCalls then
             printfn "typeBuilder%d.CreateType()" (abs <| hash typB)
+
         typB.CreateTypeInfo().AsType()
 
     member typB.DefineNestedTypeAndLog(name, attrs) =
@@ -2546,6 +2547,7 @@ let mkDynamicAssemblyAndModule (assemblyName, optimize, collectible) =
             AssemblyBuilderAccess.RunAndCollect
         else
             AssemblyBuilderAccess.Run
+
     let asmB = defineDynamicAssemblyAndLog (asmName, asmAccess, asmDir)
 
     if not optimize then

--- a/src/Compiler/Service/ServiceParsedInputOps.fsi
+++ b/src/Compiler/Service/ServiceParsedInputOps.fsi
@@ -138,7 +138,7 @@ module public ParsedInput =
         parsedInput: ParsedInput ->
         partiallyQualifiedName: MaybeUnresolvedIdent[] ->
         insertionPoint: OpenStatementInsertionPoint ->
-            (( (* requiresQualifiedAccessParent: *) ShortIdents option (* autoOpenParent: *)  * ShortIdents option (*  entityNamespace *)  * ShortIdents option (* entity: *)  * ShortIdents) -> (InsertionContextEntity * InsertionContext)[])
+            (( (* requiresQualifiedAccessParent: *) ShortIdents option (* autoOpenParent: *) * ShortIdents option (*  entityNamespace *) * ShortIdents option (* entity: *) * ShortIdents) -> (InsertionContextEntity * InsertionContext)[])
 
     /// Returns `InsertContext` based on current position and symbol idents.
     val FindNearestPointToInsertOpenDeclaration:

--- a/src/Compiler/Service/service.fsi
+++ b/src/Compiler/Service/service.fsi
@@ -404,7 +404,7 @@ type public FSharpChecker =
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member TryGetRecentCheckResultsForFile:
         fileName: string * options: FSharpProjectOptions * ?sourceText: ISourceText * ?userOpName: string ->
-            (FSharpParseFileResults * FSharpCheckFileResults (* hash *)  * int64) option
+            (FSharpParseFileResults * FSharpCheckFileResults (* hash *) * int64) option
 
     /// This function is called when the entire environment is known to have changed for reasons not encoded in the ProjectOptions of any project/compilation.
     member InvalidateAll: unit -> unit


### PR DESCRIPTION
Verifying Fantomas can still format the compiler.
@vzarytovskii could you add the package to the feed, please?

@dsyme this version contains fixes for:
- https://github.com/fsprojects/fantomas/issues/2264
- https://github.com/fsprojects/fantomas/issues/2230

which are listed in the `.fantomasignore` file.
So, potentially, these entries can be removed in a later PR.