### PR TITLE
Remove Cross_Platform_Compiler

### DIFF
--- a/FSharp.Profiles.props
+++ b/FSharp.Profiles.props
@@ -4,9 +4,6 @@
 
   <Choose>
     <When Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-      <PropertyGroup>
-        <DefineConstants Condition="'$(MonoPackaging)' == 'true'">$(DefineConstants);CROSS_PLATFORM_COMPILER</DefineConstants>
-      </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>

--- a/src/Compiler/AbstractIL/ilreflect.fs
+++ b/src/Compiler/AbstractIL/ilreflect.fs
@@ -162,6 +162,7 @@ type TypeBuilder with
     member typB.CreateTypeAndLog() =
         if logRefEmitCalls then
             printfn "typeBuilder%d.CreateType()" (abs <| hash typB)
+
         typB.CreateTypeInfo().AsType()
 
     member typB.DefineNestedTypeAndLog(name, attrs) =
@@ -2546,6 +2547,7 @@ let mkDynamicAssemblyAndModule (assemblyName, optimize, collectible) =
             AssemblyBuilderAccess.RunAndCollect
         else
             AssemblyBuilderAccess.Run
+
     let asmB = defineDynamicAssemblyAndLog (asmName, asmAccess, asmDir)
 
     if not optimize then

--- a/src/Compiler/Legacy/LegacyMSBuildReferenceResolver.fs
+++ b/src/Compiler/Legacy/LegacyMSBuildReferenceResolver.fs
@@ -184,27 +184,15 @@ module FSharp.Compiler.CodeAnalysis.LegacyMSBuildReferenceResolver
         | AssemblyFolders ->
             lineIfExists resolvedPath
             + lineIfExists fusionName
-#if CROSS_PLATFORM_COMPILER
-            + "Found by AssemblyFolders registry key"
-#else
             + FSComp.SR.assemblyResolutionFoundByAssemblyFoldersKey()
-#endif
         | AssemblyFoldersEx -> 
             lineIfExists resolvedPath
             + lineIfExists fusionName
-#if CROSS_PLATFORM_COMPILER
-            + "Found by AssemblyFoldersEx registry key"
-#else
             + FSComp.SR.assemblyResolutionFoundByAssemblyFoldersExKey()
-#endif
         | TargetFrameworkDirectory -> 
             lineIfExists resolvedPath
             + lineIfExists fusionName
-#if CROSS_PLATFORM_COMPILER
-            + ".NET Framework"
-#else
             + FSComp.SR.assemblyResolutionNetFramework()
-#endif
         | Unknown ->
             // Unknown when resolved by plain directory search without help from MSBuild resolver.
             lineIfExists resolvedPath
@@ -213,11 +201,7 @@ module FSharp.Compiler.CodeAnalysis.LegacyMSBuildReferenceResolver
             lineIfExists fusionName
         | GlobalAssemblyCache -> 
             lineIfExists fusionName
-#if CROSS_PLATFORM_COMPILER
-            + "Global Assembly Cache"
-#else
             + lineIfExists (FSComp.SR.assemblyResolutionGAC())
-#endif
             + lineIfExists redist
         | Path _ ->
             lineIfExists resolvedPath

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -5117,9 +5117,6 @@ namespace Microsoft.FSharp.Core
             [<assembly: System.Runtime.InteropServices.ComVisible(false)>]
             [<assembly: System.CLSCompliant(true)>]
             [<assembly: System.Security.SecurityTransparent>] // assembly is fully transparent
-#if !CROSS_PLATFORM_COMPILER
-            [<assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level2)>] // v4 transparency; soon to be the default, but not yet
-#endif
             do ()
 
 #if FX_NO_MONITOR_REPORTS_LOCKTAKEN

--- a/src/fsc/fscmain.fs
+++ b/src/fsc/fscmain.fs
@@ -91,11 +91,7 @@ let main (argv) =
 
         // Get the handler for legacy resolution of references via MSBuild.
         let legacyReferenceResolver =
-#if CROSS_PLATFORM_COMPILER
-            SimulatedMSBuildReferenceResolver.SimulatedMSBuildResolver
-#else
             LegacyMSBuildReferenceResolver.getResolver ()
-#endif
 
         // Perform the main compilation.
         //

--- a/src/fsc/fscmain.fs
+++ b/src/fsc/fscmain.fs
@@ -90,8 +90,7 @@ let main (argv) =
             }
 
         // Get the handler for legacy resolution of references via MSBuild.
-        let legacyReferenceResolver =
-            LegacyMSBuildReferenceResolver.getResolver ()
+        let legacyReferenceResolver = LegacyMSBuildReferenceResolver.getResolver ()
 
         // Perform the main compilation.
         //

--- a/src/fsi/fsimain.fs
+++ b/src/fsi/fsimain.fs
@@ -253,8 +253,7 @@ let evaluateSession (argv: string[]) =
                     None
 #endif
 
-        let legacyReferenceResolver =
-            LegacyMSBuildReferenceResolver.getResolver ()
+        let legacyReferenceResolver = LegacyMSBuildReferenceResolver.getResolver ()
 
         // Update the configuration to include 'StartServer', WinFormsEventLoop and 'GetOptionalConsoleReadLine()'
         let rec fsiConfig =

--- a/src/fsi/fsimain.fs
+++ b/src/fsi/fsimain.fs
@@ -254,11 +254,8 @@ let evaluateSession (argv: string[]) =
 #endif
 
         let legacyReferenceResolver =
-#if CROSS_PLATFORM_COMPILER
-            SimulatedMSBuildReferenceResolver.SimulatedMSBuildResolver
-#else
             LegacyMSBuildReferenceResolver.getResolver ()
-#endif
+
         // Update the configuration to include 'StartServer', WinFormsEventLoop and 'GetOptionalConsoleReadLine()'
         let rec fsiConfig =
             { new FsiEvaluationSessionHostConfig() with

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Core/BigIntType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Core/BigIntType.fs
@@ -47,10 +47,7 @@ type BigIntType() =
         Assert.AreEqual((new BigInteger(168)).ToString(), "168")
         Assert.AreEqual(-168I.ToString(), "-168")
         Assert.AreEqual(-0I.ToString(),   "0")
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((BigInteger()).ToString(),   "0")
-#endif
         
     
     [<Fact>]
@@ -70,53 +67,35 @@ type BigIntType() =
         Assert.True( (c = a) )
         Assert.True( (z1 = z2) )
         Assert.True( (z2 = z3) )
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.True( (z3 = z4) )
         Assert.True( (z4 = z1) )
-#endif
         Assert.True( (z1 = -z2) )
         Assert.True( (z2 = -z3) )
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.True( (z3 = -z4) )
         Assert.True( (z4 = -z1) )
-#endif
         Assert.True( a.Equals(b) ); Assert.True( b.Equals(a) )
         Assert.True( b.Equals(c) ); Assert.True( c.Equals(b) )
         Assert.True( c.Equals(a) ); Assert.True( a.Equals(c) )
         Assert.True( z1.Equals(z2) ); Assert.True( z2.Equals(z3) )
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.True( z3.Equals(z4) ); Assert.True( z4.Equals(z1) )
-#endif
-        
+
         // Self equality
         let a = new BigInteger(168)
-        Assert.True( (a = a) )        
+        Assert.True( (a = a) )
         Assert.True( (z1 = z1) )
         Assert.True( (z2 = z2) )
         Assert.True( (z3 = z3) )
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.True( (z4 = z4) )
-#endif
         Assert.True(a.Equals(a))
         Assert.True(z1.Equals(z1))
         Assert.True(z2.Equals(z2))
         Assert.True(z3.Equals(z3))
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.True(z4.Equals(z4))
-#endif
-        
+
         // Null
         Assert.False(a.Equals(null))
 
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.True(0I.GetHashCode() = (BigInteger()).GetHashCode())
-#endif
     
     // static methods
     [<Fact>]
@@ -130,13 +109,10 @@ type BigIntType() =
         Assert.AreEqual(BigInteger.Abs(bigNegativeB),
                                    bigPositiveB)
         Assert.AreEqual(BigInteger.Abs(0I), 0I)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual(BigInteger.Abs(BigInteger()), 0I)
-#endif
-    
+
         ()
-        
+
     [<Fact>]
     member this.DivRem() = 
         let mutable r = BigInteger(0)        
@@ -159,38 +135,31 @@ type BigIntType() =
         Assert.AreEqual((q,r), (0I, -100I))
         
         q <- BigInteger.DivRem(-123I, -100I, &r)
-        Assert.AreEqual((q,r), (1I, -23I))        
+        Assert.AreEqual((q,r), (1I, -23I))
         
         q <- BigInteger.DivRem(0I, 100I, &r)
         Assert.AreEqual((q,r), (0I, 0I))
 
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         qr <- BigInteger.DivRem(BigInteger(), 1I)
         Assert.AreEqual(qr, (0I, 0I))
         CheckThrowsDivideByZeroException(fun () -> BigInteger.DivRem(100I, BigInteger()) |> ignore)
         CheckThrowsDivideByZeroException(fun () -> BigInteger.DivRem(BigInteger(), BigInteger()) |> ignore)
-#endif
-       
+
         CheckThrowsDivideByZeroException(fun () -> BigInteger.DivRem(100I,0I) |> ignore)
-        
+
         ()
-        
-       
+
     [<Fact>]
     member this.GreatestCommonDivisor() = 
         Assert.AreEqual(BigInteger.GreatestCommonDivisor(bigPositiveA, bigPositiveB), 900000000090I)
         Assert.AreEqual(BigInteger.GreatestCommonDivisor(bigNegativeA, bigNegativeB), 900000000090I)
         Assert.AreEqual(BigInteger.GreatestCommonDivisor(0I, bigPositiveA), bigPositiveA)
-#if !CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
         Assert.AreEqual(BigInteger.GreatestCommonDivisor(BigInteger(), bigPositiveA), bigPositiveA)
         Assert.AreEqual(BigInteger.GreatestCommonDivisor(bigPositiveA, BigInteger()), bigPositiveA)
         Assert.AreEqual(BigInteger.GreatestCommonDivisor(BigInteger(), bigNegativeA), bigPositiveA)
         Assert.AreEqual(BigInteger.GreatestCommonDivisor(BigInteger(), BigInteger()), 0I)
-#endif
-
         ()
-        
+
     [<Fact>]
     member this.One() = 
         Assert.AreEqual(BigInteger.One,1I)
@@ -225,15 +194,12 @@ type BigIntType() =
         Assert.AreEqual(BigInteger.Pow(2I, 0),   1I)
         Assert.AreEqual(BigInteger.Pow(-10I, 2), 100I)
         Assert.AreEqual(BigInteger.Pow(0I, 0),   1I)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual(BigInteger.Pow(BigInteger(), 0),   1I)
         Assert.AreEqual(BigInteger.Pow(BigInteger(), 1),   0I)
-#endif
         Assert.AreEqual(BigInteger.Pow(0I, 1),   0I)
         CheckThrowsArgumentOutOfRangeException(fun() -> BigInteger.Pow(100I, -2) |> ignore)              
         ()
-        
+
     [<Fact>]
     member this.Sign() = 
         Assert.AreEqual(0I.Sign,            0)
@@ -248,11 +214,8 @@ type BigIntType() =
         Assert.True(-0I.IsZero)
         Assert.True(BigInteger.Zero.IsZero)
         Assert.True((-BigInteger.Zero).IsZero)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.True(BigInteger().IsZero)
         Assert.True((-BigInteger()).IsZero)
-#endif
         Assert.True(BigInteger(0).IsZero)
         Assert.True((-BigInteger(0)).IsZero)
         Assert.False(1I.IsZero)
@@ -266,11 +229,8 @@ type BigIntType() =
         Assert.False(-0I.IsOne)
         Assert.False(BigInteger.Zero.IsOne)
         Assert.False((-BigInteger.Zero).IsOne)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.False(BigInteger().IsOne)
         Assert.False((-BigInteger()).IsOne)
-#endif
         Assert.False(BigInteger(0).IsOne)
         Assert.False((-BigInteger(0)).IsOne)
         Assert.True(1I.IsOne)
@@ -282,10 +242,7 @@ type BigIntType() =
     [<Fact>]
     member this.ToDouble() = 
         Assert.AreEqual(double 0I,       0.0)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual(double (BigInteger()), 0.0)
-#endif
         Assert.AreEqual(double 123I,   123.0)
         Assert.AreEqual(double -123I, -123.0)
         ()
@@ -293,10 +250,7 @@ type BigIntType() =
     [<Fact>]
     member this.ToInt32() = 
         Assert.AreEqual(int32 0I,       0)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual(int32 (BigInteger()), 0)
-#endif
         Assert.AreEqual(int32 123I,   123)
         Assert.AreEqual(int32 -123I, -123)
         ()
@@ -304,10 +258,7 @@ type BigIntType() =
     [<Fact>]
     member this.ToInt64() = 
         Assert.AreEqual(int64 0I,       0L)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual(int64 (BigInteger()), 0L)
-#endif
         Assert.AreEqual(int64 123I,   123L)
         Assert.AreEqual(int64 -123I, -123L)
          
@@ -316,149 +267,110 @@ type BigIntType() =
     [<Fact>]
     member this.Zero() = 
         Assert.AreEqual(BigInteger.Zero,0I)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual(BigInteger.Zero, BigInteger())
-#endif
         ()
-     
-    // operators    
+
+    // operators
     [<Fact>]
     member this.Addition() = 
         Assert.AreEqual((123I + 456I),579I)
         Assert.AreEqual((-123I + (-456I)),-579I)
         Assert.AreEqual((0I + 123I),123I)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((BigInteger() + 123I),123I)
         Assert.AreEqual((123I + BigInteger()),123I)
-#endif
         Assert.AreEqual((bigPositiveA + 0I),bigPositiveA)
         Assert.AreEqual((bigPositiveA + bigNegativeA),0I)                           
-           
         ()
-        
+
     [<Fact>]
     member this.Division() = 
         Assert.AreEqual((123I / 124I),0I)
         Assert.AreEqual((123I / (-124I)),0I)
         Assert.AreEqual((0I / 123I),0I) 
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((BigInteger() / 123I),0I)
-#endif
-
         ()
-    
-    [<Fact>]    
+
+    [<Fact>]
     member this.Equality() = 
         Assert.AreEqual((bigPositiveA = bigPositiveA),true)
         Assert.AreEqual((bigPositiveA = bigNegativeA),false)                                   
         Assert.AreEqual((bigNegativeA = bigPositiveA),false)
         Assert.AreEqual((bigNegativeA = (-123I)),false)
         Assert.AreEqual((0I = new BigInteger(0)),true)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((0I = new BigInteger()),true)
-#endif
-        
         ()
-    
-    [<Fact>]    
+
+    [<Fact>]
     member this.GreaterThan() = 
         Assert.AreEqual((bigPositiveA > bigPositiveB),false)
         Assert.AreEqual((bigNegativeA > bigPositiveB),false)
         Assert.AreEqual((bigNegativeA > (-123I)),false)
         Assert.AreEqual((0I > new BigInteger(0)),false)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((0I > new BigInteger()),false)
         Assert.AreEqual((BigInteger() > BigInteger()),false)
         Assert.AreEqual((BigInteger() > 1I),false)
         Assert.AreEqual((BigInteger() > -1I),true)
-#endif
-        
         ()
-    
-    [<Fact>]    
+
+    [<Fact>]
     member this.GreaterThanOrEqual() = 
         Assert.AreEqual((bigPositiveA >= bigPositiveB),false)
         Assert.AreEqual((bigPositiveA >= bigNegativeB),true)
         Assert.AreEqual((bigPositiveB >= bigPositiveA),true)                                             
         Assert.AreEqual((bigNegativeA >= bigNegativeA),true)
         Assert.AreEqual((0I >= new BigInteger(0)),true)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((0I >= new BigInteger()),true)
         Assert.AreEqual((BigInteger() >= BigInteger()),true)
         Assert.AreEqual((BigInteger() >= 1I),false)
         Assert.AreEqual((BigInteger() >= -1I),true)
-#endif
-        
         ()
-    
-    [<Fact>]    
+
+    [<Fact>]
     member this.LessThan() = 
         Assert.AreEqual((bigPositiveA < bigPositiveB),true)
         Assert.AreEqual((bigNegativeA < bigPositiveB),true)
         Assert.AreEqual((bigPositiveA < bigNegativeB),false)
         Assert.AreEqual((bigNegativeA < bigPositiveB),true)
         Assert.AreEqual((0I < new BigInteger(0)),false)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((0I < new BigInteger()),false)
         Assert.AreEqual((BigInteger() < BigInteger()),false)
         Assert.AreEqual((BigInteger() < 1I),true)
         Assert.AreEqual((BigInteger() < -1I),false)
-#endif
-
         ()
-    
-    [<Fact>]    
+
+    [<Fact>]
     member this.LessThanOrEqual() = 
         Assert.AreEqual((bigPositiveA <= bigPositiveB),true)
         Assert.AreEqual((bigPositiveA <= bigNegativeB),false)
         Assert.AreEqual((bigNegativeB <= bigPositiveA),true)                                             
         Assert.AreEqual((bigNegativeA <= bigNegativeA),true)        
         Assert.AreEqual((0I <= new BigInteger(-0)),true)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((0I <= new BigInteger()),true)
         Assert.AreEqual((BigInteger() <= BigInteger()),true)
         Assert.AreEqual((BigInteger() <= 1I),true)
         Assert.AreEqual((BigInteger() <= -1I),false)
-#endif
-
         ()
-        
+
     [<Fact>]
     member this.Modulus() = 
         Assert.AreEqual((bigPositiveA % bigPositiveB),bigPositiveA)
         Assert.AreEqual((bigNegativeA % bigNegativeB),bigNegativeA)
         Assert.AreEqual((0I % bigPositiveA),0I)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((BigInteger() % bigPositiveA),0I)
         CheckThrowsDivideByZeroException(fun () -> 2I % 0I |> ignore)
         CheckThrowsDivideByZeroException(fun () -> 2I % (BigInteger()) |> ignore)
-#endif
-
         ()
-        
+
     [<Fact>]
     member this.Multiply() = 
         Assert.AreEqual((123I * 100I),12300I)
         Assert.AreEqual((123I * (-100I)),-12300I)
         Assert.AreEqual((-123I * (-100I)),12300I)
         Assert.AreEqual((0I * bigPositiveA),0I)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((BigInteger() * bigPositiveA),0I)
-#endif
         Assert.AreEqual((1I * 0I),0I)
-           
         ()
-        
+
     [<Fact>]
     member this.Range() = 
         let resultPos = [123I..128I]
@@ -470,10 +382,10 @@ type BigIntType() =
                 126I
                 127I
                 128I
-            ]                                                           
+            ]
         VerifySeqsEqual resultPos seqPos
-        
-        let resultNeg = [(-128I) .. (-123I)]                                      
+
+        let resultNeg = [(-128I) .. (-123I)]
         let seqNeg =  
             [
                 -128I
@@ -489,15 +401,10 @@ type BigIntType() =
         let seqSmall = [0I;1I;2I;3I;4I;5I]        
         VerifySeqsEqual resultSmall1 seqSmall
 
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         let resultSmall2 = [BigInteger()..5I]
         VerifySeqsEqual resultSmall2 seqSmall
-#endif
-           
         ()
-        
-        
+
     [<Fact>]
     member this.RangeStep() = 
         let resultPos = [100I .. 3I .. 109I]
@@ -521,29 +428,22 @@ type BigIntType() =
         VerifySeqsEqual resultNeg seqNeg
         
         let resultSmall1 = [0I..3I..9I]
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         let resultSmall1 = [BigInteger()..3I..9I]
         let seqSmall = [0I;3I;6I;9I]        
         VerifySeqsEqual resultSmall1 seqSmall
 
         CheckThrowsArgumentException(fun () -> [0I .. BigInteger() .. 3I] |> ignore)
 
-#endif
         VerifySeqsEqual [0I .. -2I .. 10I] []
-                   
         ()
-        
+
     [<Fact>]
     member this.Subtraction() = 
         Assert.AreEqual((100I - 123I),-23I)
         Assert.AreEqual((0I - bigPositiveB),bigNegativeB)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual((BigInteger() - bigPositiveB),bigNegativeB)
         Assert.AreEqual((bigPositiveB - BigInteger()),bigPositiveB)
-#endif
-        Assert.AreEqual((bigPositiveB - 0I),bigPositiveB)                                      
+        Assert.AreEqual((bigPositiveB - 0I),bigPositiveB)
         Assert.AreEqual((-100I - (-123I)),23I)
         Assert.AreEqual((100I - (-123I)),223I)
         Assert.AreEqual((-100I - 123I),-223I)          
@@ -555,25 +455,17 @@ type BigIntType() =
         Assert.AreEqual(-bigPositiveA,bigNegativeA)
         Assert.AreEqual(-bigNegativeA,bigPositiveA)
         Assert.AreEqual(-0I,0I) 
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual(-BigInteger(),0I) 
-#endif
-        
         ()
-        
+
     [<Fact>]
     member this.UnaryPlus() = 
         Assert.AreEqual(+bigPositiveA,bigPositiveA)
         Assert.AreEqual(+bigNegativeA,bigNegativeA)
         Assert.AreEqual(+0I,0I)
-#if CROSS_PLATFORM_COMPILER // see https://bugzilla.xamarin.com/show_bug.cgi?id=22591
-#else
         Assert.AreEqual(+BigInteger(),0I)
-#endif
-        
         ()
-        
+
     // instance methods
     [<Fact>]
     member this.New_int32() = 
@@ -590,5 +482,3 @@ type BigIntType() =
         Assert.AreEqual(new BigInteger(System.Int64.MinValue), -9223372036854775808I)
         
         ()
-    
-           


### PR DESCRIPTION
Cross_Platform_Compiler is anotherway of saying Mono.

Remove Cross_Platform_Compiler #if from codebase.