### PR TITLE
On arm64 vs default to platform specific compiler

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/FSharp.Build/Microsoft.FSharp.Targets
@@ -57,9 +57,13 @@ this file.
       <FSharpPreferNetFrameworkTools>  boolean: true or false === default value true
 
       Suggest that the compiler used be the 64 Bit compiler.  On computers without Visual Studio this property is ignored.
+      <FSharpPreferAnyCpuTools>      boolean: true or false === default value true
       <FSharpPrefer64BitTools>      boolean: true or false === default value true
 
-      If Shim helpers are present then the values are valid and set by the Microsoft.FSharp.Helpers.props
+      These are stupidly complex for performance reasons:
+        Arm64 is faster than AnyCpu on an Arm64 machine
+
+      On Windows Arm64 default to Arm64 build, otherwise default to AnyCpu.
     -->
 
     <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true'">
@@ -67,9 +71,13 @@ this file.
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true' and '$(FSharpPreferNetFrameworkTools)' == 'true'">
+
+        <FSharpPreferAnyCpuTools Condition="'$(FSharpPreferAnyCpuTools)' == '' and '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">false</FSharpPreferAnyCpuTools>
+        <FSharpPreferAnyCpuTools Condition="'$(FSharpPreferAnyCpuTools)' == '' and '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' != 'Arm64'">$(FSharpPrefer64BitTools)</FSharpPreferAnyCpuTools>
         <FscToolPath>$(Fsc_NetFramework_ToolPath)</FscToolPath>
-        <FscToolExe Condition="'$(FSharpPrefer64BitTools)' != 'false'">$(Fsc_NetFramework_AnyCpu_ToolExe)</FscToolExe>
-        <FscToolExe Condition="'$(FSharpPrefer64BitTools)' == 'false'">$(Fsc_NetFramework_PlatformSpecific_ToolExe)</FscToolExe>
+        <FscToolExe Condition="'$(FSharpPreferAnyCpuTools)' != 'false'">$(Fsc_NetFramework_AnyCpu_ToolExe)</FscToolExe>
+        <FscToolExe Condition="'$(FSharpPreferAnyCpuTools)' == 'false'">$(Fsc_NetFramework_PlatformSpecific_ToolExe)</FscToolExe>
+
         <DotnetFscCompilerPath></DotnetFscCompilerPath>
     </PropertyGroup>
 

--- a/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Explicit Desktop - AnyCpuWins.proj
+++ b/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Explicit Desktop - AnyCpuWins.proj
@@ -1,0 +1,27 @@
+<Project ToolsVersion="4.0" DefaultTargets="Test" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Initialize Variables -->
+  <PropertyGroup>
+    <FSharpCompilerPath></FSharpCompilerPath>
+  </PropertyGroup>
+
+  <!-- Expected Values -->
+  <PropertyGroup>
+    <ExpectedFSharpShimPresent>true</ExpectedFSharpShimPresent>
+    <ExpectedFSharpCompilerPath>/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFSharpCompilerPath>
+    <ExpectedFscToolExe>fsc.exe</ExpectedFscToolExe>
+    <ExpectedFscToolPath>_VsInstallRoot_/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFscToolPath>
+    <ExpectedDotnetFscCompilerPath></ExpectedDotnetFscCompilerPath>
+  </PropertyGroup>
+
+  <Import Project="ToolsTest.props" />
+
+  <PropertyGroup>
+    <FSharpPreferNetFrameworkTools>true</FSharpPreferNetFrameworkTools>
+    <FSharpPreferAnyCpuTools>false</FSharpPreferAnyCpuTools>
+    <FSharpPrefer64BitTools>true</FSharpPrefer64BitTools>
+  </PropertyGroup>
+
+  <Import Project="ToolsTest.targets" />
+
+</Project>

--- a/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Explicit Desktop - PreferAnyCpuFalse.proj
+++ b/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Explicit Desktop - PreferAnyCpuFalse.proj
@@ -1,0 +1,26 @@
+<Project ToolsVersion="4.0" DefaultTargets="Test" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Initialize Variables -->
+  <PropertyGroup>
+    <FSharpCompilerPath></FSharpCompilerPath>
+  </PropertyGroup>
+
+  <!-- Expected Values -->
+  <PropertyGroup>
+    <ExpectedFSharpShimPresent>true</ExpectedFSharpShimPresent>
+    <ExpectedFSharpCompilerPath>/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFSharpCompilerPath>
+    <ExpectedFscToolExe>fsc.exe</ExpectedFscToolExe>
+    <ExpectedFscToolPath>_VsInstallRoot_/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFscToolPath>
+    <ExpectedDotnetFscCompilerPath></ExpectedDotnetFscCompilerPath>
+  </PropertyGroup>
+
+  <Import Project="ToolsTest.props" />
+
+  <PropertyGroup>
+    <FSharpPreferNetFrameworkTools>true</FSharpPreferNetFrameworkTools>
+    <FSharpPreferAnyCpuTools>false</FSharpPreferAnyCpuTools>
+  </PropertyGroup>
+
+  <Import Project="ToolsTest.targets" />
+
+</Project>

--- a/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Explicit Desktop - PreferAnyCpuTrue.proj
+++ b/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Explicit Desktop - PreferAnyCpuTrue.proj
@@ -1,0 +1,26 @@
+<Project ToolsVersion="4.0" DefaultTargets="Test" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Initialize Variables -->
+  <PropertyGroup>
+    <FSharpCompilerPath></FSharpCompilerPath>
+  </PropertyGroup>
+
+  <!-- Expected Values -->
+  <PropertyGroup>
+    <ExpectedFSharpShimPresent>true</ExpectedFSharpShimPresent>
+    <ExpectedFSharpCompilerPath>/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFSharpCompilerPath>
+    <ExpectedFscToolExe>fscAnyCpu.exe</ExpectedFscToolExe>
+    <ExpectedFscToolPath>_VsInstallRoot_/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFscToolPath>
+    <ExpectedDotnetFscCompilerPath></ExpectedDotnetFscCompilerPath>
+  </PropertyGroup>
+
+  <Import Project="ToolsTest.props" />
+
+  <PropertyGroup>
+    <FSharpPreferNetFrameworkTools>true</FSharpPreferNetFrameworkTools>
+    <FSharpPreferAnyCpuTools>true</FSharpPreferAnyCpuTools>
+  </PropertyGroup>
+
+  <Import Project="ToolsTest.targets" />
+
+</Project>


### PR DESCRIPTION

On VS for Arm the platform specific compiler is faster, so by default use that, to switch back to AnyCpu use this property in the project file.

````
        <FSharpPreferAnyCpuTools>true</FSharpPreferAnyCpuTools>
````