### PR TITLE
fix 13607

### DIFF
--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -474,7 +474,7 @@ let computeWhatSuccessfulNullTestImpliesAboutTypeTest g tgtTy2 =
 let computeWhatFailingNullTestImpliesAboutTypeTest _g _tgtTy2 =
     Implication.Nothing
 
-/// Work out what one successful type test (on tgtTy1) implies about another type test (against tgtTy2)
+/// Work out what one successful type test (against tgtTy1) implies about another type test (against tgtTy2)
 /// for the same input value.
 let computeWhatSuccessfulTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
     let tgtTy1 = stripTyEqnsWrtErasure EraseAll g tgtTy1

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -418,17 +418,17 @@ type Implication =
     /// Indicates nothing in particular
     | Nothing
 
-/// Work out what one successful type test implies about a null test
+/// Work out what a successful type test (against tgtTy1) implies about a null test for the same input value.
 ///
 /// Example:
 ///     match x with 
-///     | :? string -> ...
+///     | :? string when false -> ... // note: "when false" used so type test succeeds but proceed to next type test
 ///     | null -> ...
 /// For any inputs where ':? string' succeeds, 'null' will fail
 ///
 /// Example:
 ///     match x with 
-///     | :? (int option) -> ...
+///     | :? (int option) when false -> ... // note: "when false" used so type test succeeds but proceed to next type test
 ///     | null -> ...
 /// Nothing can be learned.  If ':? (int option)' succeeds, 'null' may still have to be run.
 let computeWhatSuccessfulTypeTestImpliesAboutNullTest g tgtTy1 =
@@ -437,7 +437,7 @@ let computeWhatSuccessfulTypeTestImpliesAboutNullTest g tgtTy1 =
     else
         Implication.Fails
 
-/// Work out what a failing type test implies about a null test.
+/// Work out what a failing type test (against tgtTy1) implies about a null test for the same input value.
 ///
 /// Example:
 ///     match x with 
@@ -450,17 +450,17 @@ let computeWhatFailingTypeTestImpliesAboutNullTest g tgtTy1 =
     else
         Implication.Nothing
 
-/// Work out what one successful null test implies about a type test.
+/// Work out what one successful null test implies about a type test (against tgtTy2) for the same input value.
 ///
 /// Example:
 ///     match x with 
-///     | null -> ...
+///     | null when false -> ...  // note: "when false" used so null test succeeds but proceed to next type test
 ///     | :? string -> ...
 /// For any inputs where 'null' succeeds, ':? string' will fail
 ///
 /// Example:
 ///     match x with 
-///     | null -> ...
+///     | null when false -> ... // note: "when false" used so null test succeeds but proceed to next type test
 ///     | :? (int option) -> ...
 /// For any inputs where 'null' succeeds, ':? (int option)' will succeed
 let computeWhatSuccessfulNullTestImpliesAboutTypeTest g tgtTy2 =
@@ -469,54 +469,65 @@ let computeWhatSuccessfulNullTestImpliesAboutTypeTest g tgtTy2 =
     else
         Implication.Fails
 
-/// Work out what a failing null test implies about a type test. The answer is "nothing" but it's included for symmetry.
+/// Work out what a failing null test implies about a type test (against tgtTy2) for the same
+/// input balue. The answer is "nothing" but it's included for symmetry.
 let computeWhatFailingNullTestImpliesAboutTypeTest _g _tgtTy2 =
     Implication.Nothing
 
-/// Work out what one successful type test implies about another type test
+/// Work out what one successful type test (on tgtTy1) implies about another type test (against tgtTy2)
+/// for the same input value.
 let computeWhatSuccessfulTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
     let tgtTy1 = stripTyEqnsWrtErasure EraseAll g tgtTy1
     let tgtTy2 = stripTyEqnsWrtErasure EraseAll g tgtTy2
 
-    //  A successful type test on any type implies all supertypes always succeed
+    // A successful type test of an input value against a type (tgtTy1)
+    // implies all type tests of the same input value on equivalent or
+    // supertypes (tgtTy2) always succeed.
     //
     // Example:
     //     match x with 
-    //     | :? string -> ...
+    //     | :? string when false -> ... // note: "when false" used so type test succeeds but proceed to next type test
     //     | :? IComparable -> ...
     //
     // Example:
     //     match x with 
-    //     | :? string -> ...
+    //     | :? string when false -> ... // note: "when false" used so type test succeeds but proceed to next type test
     //     | :? string -> ...
     //
     if TypeDefinitelySubsumesTypeNoCoercion 0 g amap m tgtTy2 tgtTy1 then
         Implication.Succeeds
 
-    //  A successful type test on a sealed type (tgtTy1) implies all non-related types fail (tgtTy2)
+    // A successful type test of an input value against a sealed target type (tgtTy1) implies all
+    // type tests of the same object against a unrelated target type (tgtTy2) fails.
     //
     // Example:
     //     match x with 
-    //     | :? int -> ...
+    //     | :? int when false -> ... // note: "when false" used so type test succeeds but proceed to next type test
     //     | :? string -> ...
     //
     // For any inputs where ':? int' succeeds, ':? string' will fail
     //
-    // This doesn't apply to related types:
+    //
+    // This only applies if tgtTy2 is not potetnially related to the sealed type tgtTy1:
     //     match x with 
-    //     | :? int -> ...
+    //     | :? int when false -> ... // note: "when false" used so type test succeeds but proceed to next type test
     //     | :? IComparable -> ...
     //
-    // Here IComparable neither fails nor is redundant
+    // Here IComparable is not known to fail (NOTE: indeed it is actually known to succeed,
+    // give ":? int" succeeded, however this is not utilised in the analysis, because it involves coercion).
     //
-    // This doesn't apply to unsealed types:
+    //
+    // This rule also doesn't apply to unsealed types:
     //     match x with 
-    //     | :? SomeClass -> ...
+    //     | :? SomeUnsealedClass when false -> ... // note: "when false" used so type test succeeds but proceed to next type test
     //     | :? SomeInterface -> ...
+    // because the input may be some subtype of SomeUnsealedClass and that type could implement SomeInterface even if
+    // SomeUnsealedClass doesnt.
     //
-    // This doesn't apply to types with null as true value:
+    //
+    // This rule also doesn't apply to types with null as true value:
     //     match x with 
-    //     | :? (int option) -> ...
+    //     | :? (int option) when false -> ... // "when false" means type test succeeds but proceed to next type test
     //     | :? (string option) -> ...
     //
     // Here on 'null' input the first pattern succeeds, and the second pattern will also succeed
@@ -525,11 +536,12 @@ let computeWhatSuccessfulTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
          not (TypeFeasiblySubsumesType 0 g amap m tgtTy2 CanCoerce tgtTy1) then
         Implication.Fails
 
-    //  A successful type test on an unsealed class type implies type tests on unrelated non-interface types always fail
+    // A successful type test of an input value against an unsealed class type (tgtTy1) implies
+    // a type test of the same input value against an unrelated non-interface type (tgtTy2) always fails
     //
     // Example:
     //     match x with 
-    //     | :? SomeUnsealedClass -> ...
+    //     | :? SomeUnsealedClass when false -> ... // "when false" used so type test succeeds but proceed to next type test
     //     | :? SomeUnrelatedClass -> ...
     //
     // For any inputs where ':? SomeUnsealedClass' succeeds, ':? SomeUnrelatedClass' will fail
@@ -543,11 +555,13 @@ let computeWhatSuccessfulTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
          not (TypeFeasiblySubsumesType 0 g amap m tgtTy2 CanCoerce tgtTy1) then
         Implication.Fails
 
-    //  A successful type test on an interface type refutes sealed types that do not support that interface
+    // A successful type test of an input value against an interface type (tgtTy1) implies
+    // a type test of the same object against a sealed types (tgtTy2) that does not support that interface
+    // always fails.
     //
     // Example:
     //     match x with 
-    //     | :? IComparable -> ...
+    //     | :? IComparable when false -> ... // "when false" used so type test succeeds but proceed to next type test
     //     | :? SomeOtherSealedClass -> ...
     //
     // For any inputs where ':? IComparable' succeeds, ':? SomeOtherSealedClass' will fail
@@ -561,12 +575,13 @@ let computeWhatSuccessfulTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
     else
         Implication.Nothing
 
-/// Work out what one failing type test implies about another type test
+/// Work out what one failing type test (tgtTy1) implies about another type test (tgtTy2)
 let computeWhatFailingTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
     let tgtTy1 = stripTyEqnsWrtErasure EraseAll g tgtTy1
     let tgtTy2 = stripTyEqnsWrtErasure EraseAll g tgtTy2
 
-    //  A failing type test on any type implies all subtypes fail
+    // If testing an input value against a target type (tgtTy1) fails then
+    // testing the same input value against an equivalent or subtype type (tgtTy2) always fails.
     //
     // Example:
     //     match x with 

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -493,7 +493,7 @@ let computeWhatSuccessfulTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
     if TypeDefinitelySubsumesTypeNoCoercion 0 g amap m tgtTy2 tgtTy1 then
         Implication.Succeeds
 
-    //  A successful type test on a sealed type implies all non-related types fail
+    //  A successful type test on a sealed type (tgtTy1) implies all non-related types fail (tgtTy2)
     //
     // Example:
     //     match x with 
@@ -522,7 +522,7 @@ let computeWhatSuccessfulTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
     // Here on 'null' input the first pattern succeeds, and the second pattern will also succeed
     elif isSealedTy g tgtTy1 &&
          not (TypeNullIsTrueValue g tgtTy1) &&
-         not (TypeDefinitelySubsumesTypeNoCoercion 0 g amap m tgtTy2 tgtTy1) then
+         not (TypeFeasiblySubsumesType 0 g amap m tgtTy2 CanCoerce tgtTy1) then
         Implication.Fails
 
     //  A successful type test on an unsealed class type implies type tests on unrelated non-interface types always fail
@@ -561,7 +561,7 @@ let computeWhatSuccessfulTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
     else
         Implication.Nothing
 
-/// Work out what one successful type test implies about another type test
+/// Work out what one failing type test implies about another type test
 let computeWhatFailingTypeTestImpliesAboutTypeTest g amap m tgtTy1 tgtTy2 =
     let tgtTy1 = stripTyEqnsWrtErasure EraseAll g tgtTy1
     let tgtTy2 = stripTyEqnsWrtErasure EraseAll g tgtTy2

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
@@ -66,7 +66,7 @@ module Simple =
     [<InlineData("DateTime", "DateTime.Now")>]
     [<InlineData("int", "1")>]
     [<InlineData("Guid", "(Guid.NewGuid())")>]
-    [<InlineData("Char", "'1'")>]
+    [<InlineData("char", "'1'")>]
     [<InlineData("Byte", "0x1")>]
     [<InlineData("Decimal", "1m")>]
     let ``Test type matching for subtypes and interfaces`` typ value =

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
@@ -60,3 +60,28 @@ module Simple =
         |> withLangVersionPreview
         |> compileExeAndRun
         |> shouldSucceed
+
+
+    [<Theory>]
+    [<InlineData("DateTime", "DateTime.Now")>]
+    [<InlineData("int", "1")>]
+    [<InlineData("Guid", "Guid.NewGuid()")>]
+    [<InlineData("Char", "'1'")>]
+    [<InlineData("Byte", "0x1")>]
+    [<InlineData("Decimal", "1m")>]
+    let ``Test type matching for subtypes and interfaces`` typ value =
+        Fsx $"""
+open System
+let classify (o: obj) =
+    match o with
+    | :? {typ} as d when d = Unchecked.defaultof<_> -> "default"
+    | :? IFormattable -> "formattable"
+    | _ -> "not a {typ}"
+
+let res = classify {value}
+if res <> "formattable" then
+    failwith $"Unexpected result: {{res}}"
+         """
+         |> asExe
+         |> compileAndRun
+         |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
@@ -66,7 +66,6 @@ module Simple =
     [<InlineData("DateTime", "DateTime.Now")>]
     [<InlineData("int", "1")>]
     [<InlineData("Guid", "(Guid.NewGuid())")>]
-    [<InlineData("char", "'1'")>]
     [<InlineData("Byte", "0x1")>]
     [<InlineData("Decimal", "1m")>]
     let ``Test type matching for subtypes and interfaces`` typ value =

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple.fs
@@ -65,7 +65,7 @@ module Simple =
     [<Theory>]
     [<InlineData("DateTime", "DateTime.Now")>]
     [<InlineData("int", "1")>]
-    [<InlineData("Guid", "Guid.NewGuid()")>]
+    [<InlineData("Guid", "(Guid.NewGuid())")>]
     [<InlineData("Char", "'1'")>]
     [<InlineData("Byte", "0x1")>]
     [<InlineData("Decimal", "1m")>]

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -2497,6 +2497,33 @@ module TestStructMatching3 =
     check "cnwcki4cewweq3" (toName System.DateTime.Now) "B"
     check "cnwcki4cewweq4" (toName (obj())) "other"
 
+module TestStructMatching4 =
+
+    let toName (x: obj) =
+        match x with
+        | :? IFormattable when false -> "A" // note: "when false" used so type test succeeds but proceed to next type test
+        | :? DateTime -> "B"
+        | _ -> "other"
+
+    check "cnwcki4cewweq1" (toName 1) "other"
+    check "cnwcki4cewweq2" (toName "a") "other"
+    check "cnwcki4cewweq3" (toName System.DateTime.Now) "B"
+    check "cnwcki4cewweq4" (toName (obj())) "other"
+
+module TestStructMatching5 =
+
+    let toName (x: obj) =
+        match x with
+        | :? IFormattable when false -> "A" // note: "when false" used so type test succeeds but proceed to next type test
+        | :? Guid -> "B"
+        | _ -> "other"
+
+    check "cnwcki4cewweq11" (toName 1) "other"
+    check "cnwcki4cewweq22" (toName "a") "other"
+    check "cnwcki4cewweq33" (toName System.DateTime.Now) "other"
+    check "cnwcki4cewweq34" (toName (System.Guid())) "B"
+    check "cnwcki4cewweq45" (toName (obj())) "other"
+
 #if !NETCOREAPP
 module TestConverter =
     open System

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -2462,7 +2462,7 @@ module TestStructMatching1 =
 
     let toName (x: obj) =
         match x with
-        | :? int when false -> "A"
+        | :? int when false -> "A" // note: "when false" used so type test succeeds but proceed to next type test
         | :? IComparable -> "B"
         | _ -> "other"
 
@@ -2475,7 +2475,7 @@ module TestStructMatching2 =
 
     let toName (x: obj) =
         match x with
-        | :? DateTime when false -> "A"
+        | :? DateTime when false -> "A" // note: "when false" used so type test succeeds but proceed to next type test
         | :? IComparable -> "B"
         | _ -> "other"
 
@@ -2488,7 +2488,7 @@ module TestStructMatching3 =
 
     let toName (x: obj) =
         match x with
-        | :? IComparable when false-> "A"
+        | :? IComparable when false -> "A" // note: "when false" used so type test succeeds but proceed to next type test
         | :? DateTime -> "B"
         | _ -> "other"
 

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -2458,6 +2458,45 @@ module TestSubtypeMatching13 =
     check "cnwcki4d3" (toName (C())) "IA"
     check "cnwcki4d4" (toName (obj())) "other"
 
+module TestStructMatching1 =
+
+    let toName (x: obj) =
+        match x with
+        | :? int when false -> "A"
+        | :? IComparable -> "B"
+        | _ -> "other"
+
+    check "cnwcki4cewweq1" (toName 1) "B"
+    check "cnwcki4cewweq2" (toName "a") "B"
+    check "cnwcki4cewweq3" (toName System.DateTime.Now) "B"
+    check "cnwcki4cewweq4" (toName (obj())) "other"
+
+module TestStructMatching2 =
+
+    let toName (x: obj) =
+        match x with
+        | :? DateTime when false -> "A"
+        | :? IComparable -> "B"
+        | _ -> "other"
+
+    check "cnwcki4cewweq1" (toName 1) "B"
+    check "cnwcki4cewweq2" (toName "a") "B"
+    check "cnwcki4cewweq3" (toName System.DateTime.Now) "B"
+    check "cnwcki4cewweq4" (toName (obj())) "other"
+
+module TestStructMatching3 =
+
+    let toName (x: obj) =
+        match x with
+        | :? IComparable when false-> "A"
+        | :? DateTime -> "B"
+        | _ -> "other"
+
+    check "cnwcki4cewweq1" (toName 1) "other"
+    check "cnwcki4cewweq2" (toName "a") "other"
+    check "cnwcki4cewweq3" (toName System.DateTime.Now) "B"
+    check "cnwcki4cewweq4" (toName (obj())) "other"
+
 #if !NETCOREAPP
 module TestConverter =
     open System


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/13607

The problem is if the type test on the struct succeeds, but the condition fails, then later type tests for related interfaces are assumed to fail.  

This is actually noted as a case of concern in the comment but there was not a matching test for it, which shows that my testing for this change was inadequate - it should have at least covered every case identified in the comments.

Some baselines may need updating