### PR TITLE
More tests for RFC FS-1126 Allow lowercase DU cases when RequireQualifiedAccess

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Conformance/UnionTypes/E_LowercaseWhenRequireQualifiedAccess.fsx
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/UnionTypes/E_LowercaseWhenRequireQualifiedAccess.fsx
@@ -20,3 +20,18 @@ type DU6 = a
 type du1 = du1 of string
 
 type du2 = | du2 of string
+
+[<RequireQualifiedAccess>]
+type du3 = 
+    | a
+    | ``c``
+    
+[<RequireQualifiedAccess>]
+type du4 = 
+    | a
+    | ``a.b``
+    
+[<RequireQualifiedAccess>]
+type du5 = 
+    | a
+    | ``A.C``

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/UnionTypes/LowercaseWhenRequireQualifiedAccess.fsx
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/UnionTypes/LowercaseWhenRequireQualifiedAccess.fsx
@@ -14,12 +14,26 @@ type DU2 =
     | a of int
     | B of string
     | C
+    | ``D`` of bool
+    | ``d`` of string * int
 
 [<RequireQualifiedAccess>]
 type DU3 = | a
 
 [<RequireQualifiedAccess>]
 type DU4 = a
+
+[<RequireQualifiedAccess>]
+type DU5 = ``a``
+
+[<RequireQualifiedAccess>]
+type DU6 = ``A``
+
+[<RequireQualifiedAccess>]
+type DU7 = | ``a``
+
+[<RequireQualifiedAccess>]
+type DU8 = | ``A``
 
 [<RequireQualifiedAccess>]
 type du1 = du1 of string

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/UnionTypes/UnionTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/UnionTypes/UnionTypes.fs
@@ -543,6 +543,8 @@ module UnionTypes =
             (Error 53, Line 18, Col 12, Line 18, Col 13, "Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute");
             (Error 53, Line 20, Col 12, Line 20, Col 15, "Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute");
             (Error 53, Line 22, Col 14, Line 22, Col 17, "Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute")
+            (Error 883, Line 32, Col 7, Line 32, Col 14, "Invalid namespace, module, type or union case name");
+            (Error 883, Line 37, Col 7, Line 37, Col 14, "Invalid namespace, module, type or union case name")
         ]
 
     //SOURCE=E_LowercaseWhenRequireQualifiedAccess.fsx                                                                 # E_LowercaseWhenRequireQualifiedAccess.fsx
@@ -565,6 +567,13 @@ module UnionTypes =
             (Error 53, Line 18, Col 12, Line 18, Col 13, "Discriminated union cases and exception labels must be uppercase identifiers");
             (Error 53, Line 20, Col 12, Line 20, Col 15, "Discriminated union cases and exception labels must be uppercase identifiers");
             (Error 53, Line 22, Col 14, Line 22, Col 17, "Discriminated union cases and exception labels must be uppercase identifiers")
+            (Error 53, Line 26, Col 7, Line 26, Col 8, "Discriminated union cases and exception labels must be uppercase identifiers");
+            (Error 53, Line 27, Col 7, Line 27, Col 12, "Discriminated union cases and exception labels must be uppercase identifiers")
+            (Error 53, Line 31, Col 7, Line 31, Col 8, "Discriminated union cases and exception labels must be uppercase identifiers");
+            (Error 883, Line 32, Col 7, Line 32, Col 14, "Invalid namespace, module, type or union case name");
+            (Error 53, Line 32, Col 7, Line 32, Col 14, "Discriminated union cases and exception labels must be uppercase identifiers");
+            (Error 53, Line 36, Col 7, Line 36, Col 8, "Discriminated union cases and exception labels must be uppercase identifiers");
+            (Error 883, Line 37, Col 7, Line 37, Col 14, "Invalid namespace, module, type or union case name")
         ]
 
     //SOURCE=W_GenericFunctionValuedStaticProp02.fs SCFLAGS="--test:ErrorRanges --warnaserror-"   # W_GenericFunctionValuedStaticProp02.fs


### PR DESCRIPTION
Now that Lowercase DU when `[<RequireQualifiedAccess>]` is in VS 17.4 preview [link](https://github.com/fsharp/fslang-design/blob/main/RFCs/FS-1126-allow-lower-case-du-cases%20when-require-qualified-access-is%20specified.md) . I realize that we could add some more testing :)