### PR TITLE
Desugar SynMemberDefns of SynExceptionDefn before type checking.

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -4635,7 +4635,8 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
           let env = MutRecBindingChecking.TcModuleAbbrevDecl cenv scopem env (id, p, m)
           return ([], [], []), env, env
 
-      | SynModuleDecl.Exception (edef, m) -> 
+      | SynModuleDecl.Exception (SynExceptionDefn(exnRepr, withKeyword, ms, mExDefn), m) ->
+          let edef = SynExceptionDefn(exnRepr, withKeyword, desugarGetSetMembers ms, mExDefn)
           let binds, decl, env = TcExceptionDeclarations.TcExnDefn cenv env parent (edef, scopem)
           let defn = TMDefRec(true, [], [decl], binds |> List.map ModuleOrNamespaceBinding.Binding, m)
           return ([defn], [], []), env, env

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckDeclarationsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckDeclarationsTests.fs
@@ -94,3 +94,16 @@ namespace FSharpTest
         |> compile
         |> shouldSucceed
         |> ignore
+
+    [<Fact>]
+    let ``CheckingExceptionDeclarations - SynMemberDefn.GetSetMember`` () =
+        FSharp """
+namespace FSharpTest
+
+exception CustomException of details: string
+    with
+        member self.Details with get (): string = self.details
+"""
+        |> compile
+        |> shouldSucceed
+        |> ignore


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/13658