### PR TITLE
Anon union case field range

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -438,7 +438,8 @@ module TcRecdUnionAndEnumDeclarations =
         rfspec
 
     let TcAnonFieldDecl cenv env parent tpenv nm (SynField(Attributes attribs, isStatic, idOpt, ty, isMutable, xmldoc, vis, m)) =
-        let id = match idOpt with None -> mkSynId ty.Range.StartRange nm | Some id -> id
+        let mName = m.MakeSynthetic()
+        let id = match idOpt with None -> mkSynId mName nm | Some id -> id
         let xmlDoc = xmldoc.ToXmlDoc(true, Some [])
         TcFieldDecl cenv env parent false tpenv (isStatic, attribs, id, idOpt.IsNone, ty, isMutable, xmlDoc, vis, m)
 

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -438,7 +438,7 @@ module TcRecdUnionAndEnumDeclarations =
         rfspec
 
     let TcAnonFieldDecl cenv env parent tpenv nm (SynField(Attributes attribs, isStatic, idOpt, ty, isMutable, xmldoc, vis, m)) =
-        let id = (match idOpt with None -> mkSynId m nm | Some id -> id)
+        let id = match idOpt with None -> mkSynId ty.Range.StartRange nm | Some id -> id
         let xmlDoc = xmldoc.ToXmlDoc(true, Some [])
         TcFieldDecl cenv env parent false tpenv (isStatic, attribs, id, idOpt.IsNone, ty, isMutable, xmlDoc, vis, m)
 

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -2194,7 +2194,7 @@ and u_recdfield_spec st =
       rfield_xmldoc= defaultArg xmldoc XmlDoc.Empty
       rfield_xmldocsig=f
       rfield_access=g
-      rfield_name_generated = false
+      rfield_name_generated = d.idRange.Start = d.idRange.End
       rfield_other_range = None }
 
 and u_rfield_table st = Construct.MakeRecdFieldsTable (u_list u_recdfield_spec st)

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -2194,7 +2194,7 @@ and u_recdfield_spec st =
       rfield_xmldoc= defaultArg xmldoc XmlDoc.Empty
       rfield_xmldocsig=f
       rfield_access=g
-      rfield_name_generated = d.idRange.Start = d.idRange.End
+      rfield_name_generated = d.idRange.IsSynthetic
       rfield_other_range = None }
 
 and u_rfield_table st = Construct.MakeRecdFieldsTable (u_list u_recdfield_spec st)

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/InferenceProcedures/ByrefSafetyAnalysis/ByrefSafetyAnalysis.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/InferenceProcedures/ByrefSafetyAnalysis/ByrefSafetyAnalysis.fs
@@ -135,7 +135,7 @@ module ByrefSafetyAnalysis =
         |> shouldFail
         |> withDiagnostics [
             (Warning 1178, Line 8, Col 6, Line 8, Col 17, "The struct, record or union type 'DUWithByref' is not structurally comparable because the type 'byref<int>' does not satisfy the 'comparison' constraint. Consider adding the 'NoComparison' attribute to the type 'DUWithByref' to clarify that the type is not comparable")
-            (Error 412, Line 9, Col 18, Line 9, Col 28, "A type instantiation involves a byref type. This is not permitted by the rules of Common IL.")
+            (Error 412, Line 9, Col 18, Line 9, Col 18, "A type instantiation involves a byref type. This is not permitted by the rules of Common IL.")
             (Error 437, Line 8, Col 6, Line 8, Col 17, "A type would store a byref typed value. This is not permitted by Common IL.")
             (Error 412, Line 9, Col 7, Line 9, Col 8, "A type instantiation involves a byref type. This is not permitted by the rules of Common IL.")
         ]

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/InferenceProcedures/ByrefSafetyAnalysis/ByrefSafetyAnalysis.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/InferenceProcedures/ByrefSafetyAnalysis/ByrefSafetyAnalysis.fs
@@ -135,7 +135,7 @@ module ByrefSafetyAnalysis =
         |> shouldFail
         |> withDiagnostics [
             (Warning 1178, Line 8, Col 6, Line 8, Col 17, "The struct, record or union type 'DUWithByref' is not structurally comparable because the type 'byref<int>' does not satisfy the 'comparison' constraint. Consider adding the 'NoComparison' attribute to the type 'DUWithByref' to clarify that the type is not comparable")
-            (Error 412, Line 9, Col 18, Line 9, Col 18, "A type instantiation involves a byref type. This is not permitted by the rules of Common IL.")
+            (Error 412, Line 9, Col 18, Line 9, Col 28, "A type instantiation involves a byref type. This is not permitted by the rules of Common IL.")
             (Error 437, Line 8, Col 6, Line 8, Col 17, "A type would store a byref typed value. This is not permitted by Common IL.")
             (Error 412, Line 9, Col 7, Line 9, Col 8, "A type instantiation involves a byref type. This is not permitted by the rules of Common IL.")
         ]


### PR DESCRIPTION
Consider the following union declaration:
```fsharp
type U =
    | A of f: int
    | B of int

```
The `f` field of `A` union case has the correct range that includes the `f` name only, it doesn't include the field type.
The anon field range inside `B` case spans over the field type which is inconsistent and probably not expected.

In tooling there are cases where we'd want to distinguish user defined and it was implemented for source-defined fields in #4225. It wasn't implemented for assembly-defined fields as that would require changing F# metadata, and that was undesired.

This PR fixes `IsNameGenerated` for assembly-defined fields (for assemblies compiled with a newer compiler including this change) by changing ranges of anon fields in TypedTree and the metadata and making them empty for anon fields.