### PR TITLE
Stop using GC batch mode

### DIFF
--- a/src/fsc/fscmain.fs
+++ b/src/fsc/fscmain.fs
@@ -34,8 +34,6 @@ let main (argv) =
         else
             "fsc.exe"
 
-    // Set the garbage collector to batch mode, which improves overall performance.
-    GCSettings.LatencyMode <- GCLatencyMode.Batch
     Thread.CurrentThread.Name <- "F# Main Thread"
 
     // Set the initial phase to garbage collector to batch mode, which improves overall performance.


### PR DESCRIPTION
The analysis in https://github.com/dotnet/fsharp/issues/13739 indicates that GC Batch mode is no longer gaining us anything.

GC Batch mode was one of the reasons we hit https://github.com/dotnet/runtime/issues/74286 and removing its use means the next compiler we insert into the SDK will not be exposed to https://github.com/dotnet/runtime/issues/74286.  So removing it is wise.