### PR TITLE
Rework to ctrl+C to match updated apis

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fsi
+++ b/src/Compiler/Checking/CheckExpressions.fsi
@@ -126,7 +126,6 @@ val TcFieldInit: range -> ILFieldInit -> Const
 val LightweightTcValForUsingInBuildMethodCall:
     g: TcGlobals -> vref: ValRef -> vrefFlags: ValUseFlag -> vrefTypeInst: TTypes -> m: range -> Expr * TType
 
-
 /// Indicates whether a syntactic type is allowed to include new type variables
 /// not declared anywhere, e.g. `let f (x: 'T option) = x.Value`
 type ImplicitlyBoundTyparsAllowed =

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -2262,10 +2262,7 @@ type internal FsiInterruptController(
                         if killThreadRequest = ThreadAbortRequest then
                             if progress then fsiConsoleOutput.uprintnfn "%s" (FSIstrings.SR.fsiAbortingMainThread())
                             killThreadRequest <- NoRequest
-                            let rec abortLoop n =
-                                if n > 0 then
-                                    if not (controlledExecution.TryAbort(TimeSpan.FromSeconds(30))) then abortLoop (n-1)
-                            abortLoop 3
+                            controlledExecution.TryAbort()
                         ()), Name="ControlCAbortThread")
                 killerThread.IsBackground <- true
                 killerThread.Start()
@@ -2888,7 +2885,8 @@ type FsiInteractionProcessor
             fsiInterruptController.ControlledExecution().ResetAbort()
             (istate,CtrlC)
 
-        | :? TargetInvocationException as e when (ControlledExecution.StripTargetInvocationException(e)).GetType().Name = "ThreadAbortException" ->
+        | :? TargetInvocationException as e when (ControlledExecution.StripTargetInvocationException(e)).GetType().Name = "ThreadAbortException" ||
+                                                 (ControlledExecution.StripTargetInvocationException(e)).GetType().Name = "OperationCanceledException" ->
             fsiInterruptController.ClearInterruptRequest()
             fsiInterruptController.InterruptAllowed <- InterruptIgnored
             fsiInterruptController.ControlledExecution().ResetAbort()
@@ -3386,7 +3384,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let fsiDynamicCompiler = FsiDynamicCompiler(fsi, timeReporter, tcConfigB, tcLockObject, outWriter, tcImports, tcGlobals, fsiOptions, fsiConsoleOutput, fsiCollectible, niceNameGen, resolveAssemblyRef)
 
-    let controlledExecution = ControlledExecution(Thread.CurrentThread)
+    let controlledExecution = ControlledExecution()
 
     let fsiInterruptController = FsiInterruptController(fsiOptions, controlledExecution, fsiConsoleOutput)
 


### PR DESCRIPTION
The thread abort feature in the clr apis, have now gone through approval.

This pr, updates our use of them to match the modified APIs.

I cannot explain why CheckExpressions has a white space change.  It came when I ran fantomas so there.

To run we have to wait until, the net7 rc makes it into vs.

Or install the rc net sdk, build this change, and copy built files and then run it.

The abort happens when the clr chooses to allow, so cancel will often continue to process for a short while, until the clr is ready to abort the thread.


