### PR TITLE
Revert FCS compression

### DIFF
--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -29,7 +29,7 @@
 
   <!--  The FSharp.Compiler.Service dll provides a referencable public interface for tool builders -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
-      <CompressMetadata>true</CompressMetadata>
+      <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/FSharp.Build/FSharp.Build.fsproj
@@ -20,7 +20,9 @@
 
   <!--  The FSharp.Build dll does not provide a referencable public interface although it's used for testing -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
-      <CompressMetadata>true</CompressMetadata>
+      <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
+      <NoOptimizationData>true</NoOptimizationData>
+      <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
+++ b/src/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
@@ -11,7 +11,7 @@
 
   <!--  The FSharp.Compiler.Interactive.Settings dll provides a referencable public interface to tool builders  -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
-      <CompressMetadata>true</CompressMetadata>
+      <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharp.Compiler.Server.Shared/FSharp.Compiler.Server.Shared.fsproj
+++ b/src/FSharp.Compiler.Server.Shared/FSharp.Compiler.Server.Shared.fsproj
@@ -8,9 +8,9 @@
     <UseFSharpProductVersion>true</UseFSharpProductVersion>
   </PropertyGroup>
 
-  <!--  The FSharp.Compiler.Server.Shared dll does not provide a referencable public interface  -->
+  <!--  The FSharp.Core dll provides a referencable public interface -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
-      <CompressMetadata>true</CompressMetadata>
+      <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharp.Core/FSharp.Core.fsproj
+++ b/src/FSharp.Core/FSharp.Core.fsproj
@@ -40,8 +40,8 @@
   </PropertyGroup>
 
   <!--  The FSharp.Core dll provides a referencable public interface -->
-  <PropertyGroup Condition="'$(Configuration)' != 'Proto' and '$(CompressAllMetadata)' != 'true'">
-      <CompressMetadata>true</CompressMetadata>
+  <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
+      <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
@@ -14,7 +14,8 @@
 
   <!--  The FSharp.DependencyManager.Nuget dll does not provide a referencable public interface although it's used for testing -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
-      <CompressMetadata>true</CompressMetadata>
+    <NoOptimizationData>true</NoOptimizationData>
+    <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
   </PropertyGroup>
 
   <Target Name="CopyToBuiltBin" BeforeTargets="BuiltProjectOutputGroup" AfterTargets="CoreCompile">

--- a/src/fsc/fsc.targets
+++ b/src/fsc/fsc.targets
@@ -24,6 +24,7 @@
   <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
       <NoOptimizationData>true</NoOptimizationData>
       <NoInterfaceData>true</NoInterfaceData>
+      <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsi/fsi.targets
+++ b/src/fsi/fsi.targets
@@ -26,7 +26,9 @@
 
   <!--  The fsi application does not provide a referencable public interface  -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
-      <CompressMetadata>true</CompressMetadata>
+      <NoOptimizationData>true</NoOptimizationData>
+      <NoInterfaceData>true</NoInterfaceData>
+      <CompressMetadata Condition="'$(CompressAllMetadata)' != 'true'">false</CompressMetadata>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
My apologies.

In my enthusiasm for sucking the bytes out of the product I made it so no one could use any tooling to work with our repo.

My bad!

Anyway this puts things back into place.

I think we will not compress the FCS metadata until after VS 2022.4 has shipped.  So the first RTM FCS with compressed data will be the one that ships with VS 2022.5 ... obviously there will be previews prior to that.

That  will ensure that the RTM version of VS and any tools that rely on FCS will have time to adjust.  Primarily that means adopting the .Net 7.0 Sdk for builds.