### PR TITLE
Staticize some overly instanced methods

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -7019,7 +7019,7 @@ and TcInterpolatedStringExpr cenv (overallTy: OverallTy) env m tpenv (parts: Syn
     let newFormatMethod =
         match GetIntrinsicConstructorInfosOfType cenv.infoReader m formatTy |> List.filter (fun minfo -> minfo.NumArgs = [3]) with
         | [ctorInfo] -> ctorInfo
-        | _ -> languageFeatureNotSupportedInLibraryError g.langVersion LanguageFeature.StringInterpolation m
+        | _ -> languageFeatureNotSupportedInLibraryError LanguageFeature.StringInterpolation m
 
     let stringKind =
         // If this is an interpolated string then try to force the result to be a string
@@ -7054,7 +7054,7 @@ and TcInterpolatedStringExpr cenv (overallTy: OverallTy) env m tpenv (parts: Syn
 
             match createMethodOpt with
             | Some createMethod -> Choice2Of2 createMethod
-            | None -> languageFeatureNotSupportedInLibraryError g.langVersion LanguageFeature.StringInterpolation m
+            | None -> languageFeatureNotSupportedInLibraryError LanguageFeature.StringInterpolation m
 
         // ... or if that fails then may be a PrintfFormat by a type-directed rule....
         elif not (isObjTy g overallTy.Commit) && AddCxTypeMustSubsumeTypeUndoIfFailed env.DisplayEnv cenv.css m overallTy.Commit formatTy then

--- a/src/Compiler/Checking/InfoReader.fs
+++ b/src/Compiler/Checking/InfoReader.fs
@@ -922,7 +922,7 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
 
 let checkLanguageFeatureRuntimeAndRecover (infoReader: InfoReader) langFeature m =
     if not (infoReader.IsLanguageFeatureRuntimeSupported langFeature) then
-        let featureStr = infoReader.g.langVersion.GetFeatureString langFeature
+        let featureStr = LanguageVersion.GetFeatureString langFeature
         errorR (Error(FSComp.SR.chkFeatureNotRuntimeSupported featureStr, m))
 
 let GetIntrinsicConstructorInfosOfType (infoReader: InfoReader) m ty = 

--- a/src/Compiler/Driver/CompilerOptions.fs
+++ b/src/Compiler/Driver/CompilerOptions.fs
@@ -1103,15 +1103,13 @@ let mlCompatibilityFlag (tcConfigB: TcConfigBuilder) =
 /// LanguageVersion management
 let setLanguageVersion specifiedVersion =
 
-    let languageVersion = LanguageVersion(specifiedVersion)
-
     let dumpAllowedValues () =
         printfn "%s" (FSComp.SR.optsSupportedLangVersions ())
 
-        for v in languageVersion.ValidOptions do
+        for v in LanguageVersion.ValidOptions do
             printfn "%s" v
 
-        for v in languageVersion.ValidVersions do
+        for v in LanguageVersion.ValidVersions do
             printfn "%s" v
 
         exit 0
@@ -1120,10 +1118,10 @@ let setLanguageVersion specifiedVersion =
         dumpAllowedValues ()
     elif specifiedVersion.ToUpperInvariant() = "PREVIEW" then
         ()
-    elif not (languageVersion.ContainsVersion specifiedVersion) then
+    elif not (LanguageVersion.ContainsVersion specifiedVersion) then
         error (Error(FSComp.SR.optsUnrecognizedLanguageVersion specifiedVersion, rangeCmdArgs))
 
-    languageVersion
+    LanguageVersion(specifiedVersion)
 
 let languageFlags tcConfigB =
     [

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -787,9 +787,9 @@ let NormalizeErrorString (text: string MaybeNull) =
 
 let private tryLanguageFeatureErrorAux (langVersion: LanguageVersion) (langFeature: LanguageFeature) (m: range) =
     if not (langVersion.SupportsFeature langFeature) then
-        let featureStr = langVersion.GetFeatureString langFeature
+        let featureStr = LanguageVersion.GetFeatureString langFeature
         let currentVersionStr = langVersion.SpecifiedVersionString
-        let suggestedVersionStr = langVersion.GetFeatureVersionString langFeature
+        let suggestedVersionStr = LanguageVersion.GetFeatureVersionString langFeature
         Some(Error(FSComp.SR.chkFeatureNotLanguageSupported (featureStr, currentVersionStr, suggestedVersionStr), m))
     else
         None
@@ -807,9 +807,9 @@ let internal checkLanguageFeatureAndRecover langVersion langFeature m =
 let internal tryLanguageFeatureErrorOption langVersion langFeature m =
     tryLanguageFeatureErrorAux langVersion langFeature m
 
-let internal languageFeatureNotSupportedInLibraryError (langVersion: LanguageVersion) (langFeature: LanguageFeature) (m: range) =
-    let featureStr = langVersion.GetFeatureString langFeature
-    let suggestedVersionStr = langVersion.GetFeatureVersionString langFeature
+let internal languageFeatureNotSupportedInLibraryError (langFeature: LanguageFeature) (m: range) =
+    let featureStr = LanguageVersion.GetFeatureString langFeature
+    let suggestedVersionStr = LanguageVersion.GetFeatureVersionString langFeature
     error (Error(FSComp.SR.chkFeatureNotSupportedInLibrary (featureStr, suggestedVersionStr), m))
 
 /// Guard against depth of expression nesting, by moving to new stack when a maximum depth is reached

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -386,8 +386,7 @@ val checkLanguageFeatureAndRecover: langVersion: LanguageVersion -> langFeature:
 val tryLanguageFeatureErrorOption:
     langVersion: LanguageVersion -> langFeature: LanguageFeature -> m: range -> exn option
 
-val languageFeatureNotSupportedInLibraryError:
-    langFeature: LanguageFeature -> m: range -> 'T
+val languageFeatureNotSupportedInLibraryError: langFeature: LanguageFeature -> m: range -> 'T
 
 type StackGuard =
     new: maxDepth: int -> StackGuard

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -387,7 +387,7 @@ val tryLanguageFeatureErrorOption:
     langVersion: LanguageVersion -> langFeature: LanguageFeature -> m: range -> exn option
 
 val languageFeatureNotSupportedInLibraryError:
-    langVersion: LanguageVersion -> langFeature: LanguageFeature -> m: range -> 'T
+    langFeature: LanguageFeature -> m: range -> 'T
 
 type StackGuard =
     new: maxDepth: int -> StackGuard

--- a/src/Compiler/Facilities/LanguageFeatures.fs
+++ b/src/Compiler/Facilities/LanguageFeatures.fs
@@ -147,7 +147,7 @@ type LanguageVersion(versionText) =
 
     let specified = getVersionFromString versionText
 
-    let versionToString v =
+    static let versionToString v =
         if v = previewVersion then "'PREVIEW'" else string v
 
     let specifiedString = versionToString specified
@@ -167,15 +167,15 @@ type LanguageVersion(versionText) =
     member _.IsPreviewEnabled = specified = previewVersion
 
     /// Does the languageVersion support this version string
-    member _.ContainsVersion version =
+    static member ContainsVersion version =
         let langVersion = getVersionFromString version
         langVersion <> 0m && languageVersions.Contains langVersion
 
     /// Get a list of valid strings for help text
-    member _.ValidOptions = validOptions
+    static member ValidOptions = validOptions
 
     /// Get a list of valid versions for help text
-    member _.ValidVersions =
+    static member ValidVersions =
         [|
             for v in languageVersions |> Seq.sort -> sprintf "%M%s" v (if v = defaultVersion then " (Default)" else "")
         |]
@@ -190,7 +190,7 @@ type LanguageVersion(versionText) =
     member _.SpecifiedVersionString = specifiedString
 
     /// Get a string name for the given feature.
-    member _.GetFeatureString feature =
+    static member GetFeatureString feature =
         match feature with
         | LanguageFeature.SingleUnderscorePattern -> FSComp.SR.featureSingleUnderscorePattern ()
         | LanguageFeature.WildCardInForLoop -> FSComp.SR.featureWildCardInForLoop ()
@@ -232,7 +232,7 @@ type LanguageVersion(versionText) =
         | LanguageFeature.SelfTypeConstraints -> FSComp.SR.featureSelfTypeConstraints ()
 
     /// Get a version string associated with the given feature.
-    member _.GetFeatureVersionString feature =
+    static member GetFeatureVersionString feature =
         match features.TryGetValue feature with
         | true, v -> versionToString v
         | _ -> invalidArg "feature" "Internal error: Unable to find feature."

--- a/src/Compiler/Facilities/LanguageFeatures.fsi
+++ b/src/Compiler/Facilities/LanguageFeatures.fsi
@@ -52,7 +52,7 @@ type LanguageVersion =
     new: string -> LanguageVersion
 
     /// Get the list of valid versions
-    member ContainsVersion: string -> bool
+    static member ContainsVersion: string -> bool
 
     /// Has preview been explicitly specified
     member IsPreviewEnabled: bool
@@ -64,10 +64,10 @@ type LanguageVersion =
     member SupportsFeature: LanguageFeature -> bool
 
     /// Get the list of valid versions
-    member ValidVersions: string[]
+    static member ValidVersions: string[]
 
     /// Get the list of valid options
-    member ValidOptions: string[]
+    static member ValidOptions: string[]
 
     /// Get the specified LanguageVersion
     member SpecifiedVersion: decimal
@@ -79,9 +79,9 @@ type LanguageVersion =
     member SpecifiedVersionString: string
 
     /// Get a string name for the given feature.
-    member GetFeatureString: feature: LanguageFeature -> string
+    static member GetFeatureString: feature: LanguageFeature -> string
 
     /// Get a version string associated with the given feature.
-    member GetFeatureVersionString: feature: LanguageFeature -> string
+    static member GetFeatureVersionString: feature: LanguageFeature -> string
 
     static member Default: LanguageVersion


### PR DESCRIPTION
While reviewing this PR:  I realized that we overused instance members on the LanguageVersion type.

too help out (and cover my embarrassment), I thought I could fix it up a bit.

This makes the APIs that don't need to be instanced static like they should have been in the first place.

