### PR TITLE
Update public pool names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,7 +210,7 @@ stages:
           - name: _SignType
             value: Test
           pool:
-            name: NetCore1ESPool-Svc-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals $(WindowsMachineQueueName)
           timeoutInMinutes: 90
           steps:
@@ -283,7 +283,7 @@ stages:
             #   WindowsMachineQueueName=Windows.vs2022.amd64.open
             # and there is an alternate build definition that sets this to a queue that is always scouting the
             # next preview of Visual Studio.
-            name: NetCore1ESPool-Svc-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals $(WindowsMachineQueueName)
           timeoutInMinutes: 120
           strategy:
@@ -341,7 +341,7 @@ stages:
             #   WindowsMachineQueueName=Windows.vs2022.amd64.open
             # and there is an alternate build definition that sets this to a queue that is always scouting the
             # next preview of Visual Studio.
-            name: NetCore1ESPool-Svc-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals $(WindowsMachineQueueName)
           timeoutInMinutes: 120
           strategy:
@@ -395,7 +395,7 @@ stages:
         # Mock official build
         - job: MockOfficial
           pool:
-            name: NetCore1ESPool-Svc-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals $(WindowsMachineQueueName)
           steps:
           - checkout: self
@@ -486,7 +486,7 @@ stages:
         # End to end build
         - job: EndToEndBuildTests
           pool:
-            name: NetCore1ESPool-Svc-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals $(WindowsMachineQueueName)
           steps:
           - checkout: self
@@ -511,7 +511,7 @@ stages:
         # Plain build Windows
         - job: Plain_Build_Windows
           pool:
-            name: NetCore1ESPool-Svc-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals $(WindowsMachineQueueName)
           variables:
           - name: _BuildConfig

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -46,7 +46,7 @@ jobs:
     # source-build builds run in Docker, including the default managed platform.
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Public
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Internal

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -28,7 +28,7 @@ jobs:
   ${{ if eq(parameters.pool, '') }}:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Public
         demands: ImageOverride -equals windows.vs2019.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Internal


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.