### PR TITLE
Add extra space when first type argument is a statically resolved type parameter

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -199,6 +199,7 @@
     <Compile Include="Signatures\TestHelpers.fs" />
     <Compile Include="Signatures\ModuleOrNamespaceTests.fs" />
     <Compile Include="Signatures\RecordTests.fs" />
+    <Compile Include="Signatures\StaticallyResolvedTypeParameterTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="resources\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="PreserveNewest" />

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/RecordTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/RecordTests.fs
@@ -18,7 +18,7 @@ type PullActions =
             Log : int
         }
 """
-    |> printSignaturesWith 80
+    |> printSignaturesWithPageWidth 80
     |> should
         equal
         """

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/StaticallyResolvedTypeParameterTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/StaticallyResolvedTypeParameterTests.fs
@@ -1,0 +1,53 @@
+﻿module FSharp.Compiler.ComponentTests.Signatures.StaticallyResolvedTypeParameterTests
+
+open Xunit
+open FsUnit
+open FSharp.Test.Compiler
+open FSharp.Compiler.ComponentTests.Signatures.TestHelpers
+
+[<Fact>]
+let ``Generic function with constraint`` () =
+    FSharp
+        """
+module MyApp.GoodStuff
+
+let inline toString< ^revision when ^revision: (static member GetCommitHash: ^revision -> string)>
+    (p: System.Threading.Tasks.Task< ^revision >)
+    : string =
+    ""
+"""
+    |> printSignaturesWithPageWidth 80
+    |> should
+        equal
+        """
+module MyApp.GoodStuff
+
+val inline toString:
+  p: System.Threading.Tasks.Task< ^revision> -> string
+    when ^revision: (static member GetCommitHash: ^revision -> string)"""
+
+[<Fact>]
+let ``Multiple constraints parameters in type definition`` () =
+    FSharp
+        """
+module Foo
+
+type Meh<'g, 'f> =
+    class 
+    end
+
+let inline toString< ^revision>
+    (p: Meh< ^revision, ^revision>)
+    : string =
+    ""
+"""
+    |> printSignaturesWithPageWidth 80
+    |> should
+        equal
+        """
+module Foo
+
+type Meh<'g,'f> =
+  class end
+
+val inline toString: p: Meh< ^revision,^revision> -> string"""

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -1342,4 +1342,4 @@ module rec Compiler =
             |> String.concat "\n"
     
     let printSignatures cUnit = printSignaturesImpl None cUnit
-    let printSignaturesWith pageWidth cUnit = printSignaturesImpl (Some pageWidth) cUnit
+    let printSignaturesWithPageWidth pageWidth cUnit = printSignaturesImpl (Some pageWidth) cUnit


### PR DESCRIPTION
Fixes #13760.