### PR TITLE
[WIP] Trial removing frameworkTcImports

### DIFF
--- a/src/Compiler/Driver/CompilerConfig.fs
+++ b/src/Compiler/Driver/CompilerConfig.fs
@@ -1378,28 +1378,6 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
 
     member _.GetNativeProbingRoots() = data.GetNativeProbingRoots()
 
-    /// A closed set of assemblies where, for any subset S:
-    ///    - the TcImports object built for S (and thus the F# Compiler CCUs for the assemblies in S)
-    ///       is a resource that can be shared between any two IncrementalBuild objects that reference
-    ///       precisely S
-    ///
-    /// Determined by looking at the set of assemblies referenced by f# .
-    ///
-    /// Returning true may mean that the file is locked and/or placed into the
-    /// 'framework' reference set that is potentially shared across multiple compilations.
-    member tcConfig.IsSystemAssembly(fileName: string) =
-        try
-            FileSystem.FileExistsShim fileName
-            && ((tcConfig.GetTargetFrameworkDirectories()
-                 |> List.exists (fun clrRoot -> clrRoot = Path.GetDirectoryName fileName))
-                || (tcConfig
-                       .FxResolver
-                       .GetSystemAssemblies()
-                       .Contains(FileSystemUtils.fileNameWithoutExtension fileName))
-                || tcConfig.FxResolver.IsInReferenceAssemblyPackDirectory fileName)
-        with _ ->
-            false
-
     member tcConfig.GenerateSignatureData =
         not tcConfig.standalone && not tcConfig.noSignatureData
 

--- a/src/Compiler/Driver/CompilerConfig.fsi
+++ b/src/Compiler/Driver/CompilerConfig.fsi
@@ -819,8 +819,6 @@ type TcConfig =
 
     member GetSearchPathsForLibraryFiles: unit -> string list
 
-    member IsSystemAssembly: string -> bool
-
     member PrimaryAssemblyDllReference: unit -> AssemblyReference
 
     member CoreLibraryDllReference: unit -> AssemblyReference

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -979,8 +979,7 @@ and TcImportsWeakHack(tciLock: TcImportsLock, tcImports: WeakReference<TcImports
             RequireTcImportsLock(tcitok, dllInfos)
             dllInfos <- value |> List.map (fun x -> { FileName = x.FileName }))
 
-    member self.Base: TcImportsWeakHack option =
-        Some self
+    member self.Base: TcImportsWeakHack option = Some self
 
     member _.SystemRuntimeContainsType typeName =
         match tcImports.TryGetTarget() with
@@ -990,12 +989,7 @@ and TcImportsWeakHack(tciLock: TcImportsLock, tcImports: WeakReference<TcImports
 /// Represents a table of imported assemblies with their resolutions.
 /// Is a disposable object, but it is recommended not to explicitly call Dispose unless you absolutely know nothing will be using its contents after the disposal.
 /// Otherwise, simply allow the GC to collect this and it will properly call Dispose from the finalizer.
-and [<Sealed>] TcImports
-    (
-        tcConfigP: TcConfigProvider,
-        initialResolutions: TcAssemblyResolutions,
-        dependencyProvider: DependencyProvider
-    ) as this
+and [<Sealed>] TcImports(tcConfigP: TcConfigProvider, initialResolutions: TcAssemblyResolutions, dependencyProvider: DependencyProvider) as this
 #if !NO_TYPEPROVIDERS
 #endif
  =
@@ -1150,6 +1144,7 @@ and [<Sealed>] TcImports
         | Some res -> ResolvedImportedAssembly res
         | None ->
             tcImports.ImplicitLoadIfAllowed(ctok, m, assemblyName, lookupOnly)
+
             match NameMap.tryFind assemblyName ccuTable with
             | Some res -> ResolvedImportedAssembly res
             | None -> UnresolvedImportedAssembly assemblyName
@@ -1432,8 +1427,7 @@ and [<Sealed>] TcImports
 
         match tcGlobals with
         | Some g -> g
-        | None ->
-            failwith "unreachable: GetGlobals - are the references to mscorlib.dll and FSharp.Core.dll valid?"
+        | None -> failwith "unreachable: GetGlobals - are the references to mscorlib.dll and FSharp.Core.dll valid?"
 
     member private tcImports.SetTcGlobals g =
         CheckDisposed()
@@ -2158,7 +2152,12 @@ and [<Sealed>] TcImports
     // Note: This returns a TcImports object. However, framework TcImports are not currently disposed. The only reason
     // we dispose TcImports is because we need to dispose type providers, and type providers are never included in the framework DLL set.
     // If a framework set ever includes type providers, you will not have to worry about explicitly calling Dispose as the Finalizer will handle it.
-    static member BuildTcImports(tcConfigP: TcConfigProvider, tcResolutions: TcAssemblyResolutions, dependencyProvider: DependencyProvider) =
+    static member BuildTcImports
+        (
+            tcConfigP: TcConfigProvider,
+            tcResolutions: TcAssemblyResolutions,
+            dependencyProvider: DependencyProvider
+        ) =
         node {
             let ctok = CompilationThreadToken()
             let tcConfig = tcConfigP.Get ctok

--- a/src/Compiler/Driver/CompilerImports.fsi
+++ b/src/Compiler/Driver/CompilerImports.fsi
@@ -80,9 +80,6 @@ type AssemblyResolution =
         /// Create the tooltip text for the assembly reference
         prepareToolTip: unit -> string
 
-        /// Whether or not this is an installed system assembly (for example, System.dll)
-        sysdir: bool
-
         /// Lazily populated ilAssemblyRef for this reference.
         mutable ilAssemblyRef: ILAssemblyRef option
     }
@@ -124,14 +121,13 @@ type TcAssemblyResolutions =
 
     member GetAssemblyResolutions: unit -> AssemblyResolution list
 
-    static member SplitNonFoundationalResolutions:
-        tcConfig: TcConfig -> AssemblyResolution list * AssemblyResolution list * UnresolvedAssemblyReference list
+    member GetUnresolvedReferences: unit -> UnresolvedAssemblyReference list
 
-    static member BuildFromPriorResolutions:
-        tcConfig: TcConfig * AssemblyResolution list * UnresolvedAssemblyReference list -> TcAssemblyResolutions
+    static member ResolveAssemblyReferences:
+        tcConfig: TcConfig -> TcAssemblyResolutions
 
     static member GetAssemblyResolutionInformation:
-        tcConfig: TcConfig -> AssemblyResolution list * UnresolvedAssemblyReference list
+        tcConfig: TcConfig -> TcAssemblyResolutions
 
 [<Sealed>]
 type RawFSharpAssemblyData =
@@ -152,9 +148,6 @@ type TcImports =
     member GetImportedAssemblies: unit -> ImportedAssembly list
 
     member GetCcusInDeclOrder: unit -> CcuThunk list
-
-    /// This excludes any framework imports (which may be shared between multiple builds)
-    member GetCcusExcludingBase: unit -> CcuThunk list
 
     member FindDllInfo: CompilationThreadToken * range * string -> ImportedBinary
 
@@ -196,14 +189,8 @@ type TcImports =
 
     member SystemRuntimeContainsType: string -> bool
 
-    member internal Base: TcImports option
-
-    static member BuildFrameworkTcImports:
-        TcConfigProvider * AssemblyResolution list * AssemblyResolution list -> NodeCode<TcGlobals * TcImports>
-
-    static member BuildNonFrameworkTcImports:
-        TcConfigProvider * TcImports * AssemblyResolution list * UnresolvedAssemblyReference list * DependencyProvider ->
-            NodeCode<TcImports>
+    static member BuildTcImports:
+        tcConfigP: TcConfigProvider * tcResolutions: TcAssemblyResolutions * dependencyProvider: DependencyProvider -> NodeCode<TcGlobals * TcImports>
 
     static member BuildTcImports:
         tcConfigP: TcConfigProvider * dependencyProvider: DependencyProvider -> NodeCode<TcGlobals * TcImports>

--- a/src/Compiler/Driver/CompilerImports.fsi
+++ b/src/Compiler/Driver/CompilerImports.fsi
@@ -123,11 +123,9 @@ type TcAssemblyResolutions =
 
     member GetUnresolvedReferences: unit -> UnresolvedAssemblyReference list
 
-    static member ResolveAssemblyReferences:
-        tcConfig: TcConfig -> TcAssemblyResolutions
+    static member ResolveAssemblyReferences: tcConfig: TcConfig -> TcAssemblyResolutions
 
-    static member GetAssemblyResolutionInformation:
-        tcConfig: TcConfig -> TcAssemblyResolutions
+    static member GetAssemblyResolutionInformation: tcConfig: TcConfig -> TcAssemblyResolutions
 
 [<Sealed>]
 type RawFSharpAssemblyData =
@@ -190,7 +188,8 @@ type TcImports =
     member SystemRuntimeContainsType: string -> bool
 
     static member BuildTcImports:
-        tcConfigP: TcConfigProvider * tcResolutions: TcAssemblyResolutions * dependencyProvider: DependencyProvider -> NodeCode<TcGlobals * TcImports>
+        tcConfigP: TcConfigProvider * tcResolutions: TcAssemblyResolutions * dependencyProvider: DependencyProvider ->
+            NodeCode<TcGlobals * TcImports>
 
     static member BuildTcImports:
         tcConfigP: TcConfigProvider * dependencyProvider: DependencyProvider -> NodeCode<TcGlobals * TcImports>

--- a/src/Compiler/Driver/ScriptClosure.fs
+++ b/src/Compiler/Driver/ScriptClosure.fs
@@ -571,11 +571,13 @@ module ScriptPreprocessClosure =
 
             use unwindEL = PushDiagnosticsLoggerPhaseUntilUnwind(fun _ -> diagnosticsLogger)
 
-            let references, unresolvedReferences =
-                TcAssemblyResolutions.GetAssemblyResolutionInformation(tcConfig)
+            let tcResolutions = TcAssemblyResolutions.GetAssemblyResolutionInformation(tcConfig)
 
-            let references = references |> List.map (fun ar -> ar.resolvedPath, ar)
-            references, unresolvedReferences, diagnosticsLogger.Diagnostics
+            let resolutions = tcResolutions.GetAssemblyResolutions()
+            let unresolved = tcResolutions.GetUnresolvedReferences()
+
+            let references = resolutions |> List.map (fun ar -> ar.resolvedPath, ar)
+            references, unresolved, diagnosticsLogger.Diagnostics
 
         // Root errors and warnings - look at the last item in the closureFiles list
         let loadClosureRootDiagnostics, allRootDiagnostics =
@@ -662,14 +664,13 @@ module ScriptPreprocessClosure =
                     reduceMemoryUsage
                 )
 
-            let resolutions0, _unresolvedReferences =
+            let tcResolutions0 =
                 TcAssemblyResolutions.GetAssemblyResolutionInformation(tcConfig)
 
             let references0 =
-                resolutions0
+                tcResolutions0.GetAssemblyResolutions()
                 |> List.map (fun r -> r.originalReference.Range, r.resolvedPath)
-                |> Seq.distinct
-                |> List.ofSeq
+                |> List.distinct
 
             references0, tcConfig.assumeDotNetFramework, scriptDefaultReferencesDiagnostics
 

--- a/src/Compiler/Service/IncrementalBuild.fsi
+++ b/src/Compiler/Service/IncrementalBuild.fsi
@@ -23,16 +23,6 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.BuildGraph
 
-/// Lookup the global static cache for building the FrameworkTcImports
-type internal FrameworkImportsCache =
-    new: size: int -> FrameworkImportsCache
-
-    member Get: TcConfig -> NodeCode<TcGlobals * TcImports * AssemblyResolution list * UnresolvedAssemblyReference list>
-
-    member Clear: unit -> unit
-
-    member Downsize: unit -> unit
-
 /// Used for unit testing
 module internal IncrementalBuilderEventTesting =
 
@@ -249,7 +239,6 @@ type internal IncrementalBuilder =
     static member TryCreateIncrementalBuilderForProjectOptions:
         legacyReferenceResolver: LegacyReferenceResolver *
         defaultFSharpBinariesDir: string *
-        frameworkTcImportsCache: FrameworkImportsCache *
         loadClosureOpt: LoadClosure option *
         sourceFiles: string list *
         commandLineArgs: string list *
@@ -263,7 +252,7 @@ type internal IncrementalBuilder =
         keepAllBackgroundSymbolUses: bool *
         enableBackgroundItemKeyStoreAndSemanticClassification: bool *
         enablePartialTypeChecking: bool *
-        dependencyProvider: DependencyProvider option ->
+        dependencyProviderOpt: DependencyProvider option ->
             NodeCode<IncrementalBuilder option * FSharpDiagnostic[]>
 
 /// Generalized Incremental Builder. This is exposed only for unit testing purposes.

--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -309,8 +309,6 @@ type BackgroundCompiler
             areSimilar = FSharpProjectOptions.UseSameProject
         )
 
-    let frameworkTcImportsCache = FrameworkImportsCache(frameworkTcImportsCacheStrongSize)
-
     // We currently share one global dependency provider for all scripts for the FSharpChecker.
     // For projects, one is used per project.
     //
@@ -405,7 +403,6 @@ type BackgroundCompiler
                 IncrementalBuilder.TryCreateIncrementalBuilderForProjectOptions(
                     legacyReferenceResolver,
                     FSharpCheckerResultsSettings.defaultFSharpBinariesDir,
-                    frameworkTcImportsCache,
                     loadClosure,
                     Array.toList options.SourceFiles,
                     Array.toList options.OtherOptions,
@@ -1180,7 +1177,6 @@ type BackgroundCompiler
                 parseFileCache.Clear(ltok))
 
             incrementalBuildersCache.Clear(AnyCallerThread)
-            frameworkTcImportsCache.Clear()
             scriptClosureCache.Clear AnyCallerThread)
 
     member _.DownsizeCaches() =
@@ -1190,10 +1186,7 @@ type BackgroundCompiler
                 parseFileCache.Resize(ltok, newKeepStrongly = 1))
 
             incrementalBuildersCache.Resize(AnyCallerThread, newKeepStrongly = 1, newKeepMax = 1)
-            frameworkTcImportsCache.Downsize()
             scriptClosureCache.Resize(AnyCallerThread, newKeepStrongly = 1, newKeepMax = 1))
-
-    member _.FrameworkImportsCache = frameworkTcImportsCache
 
     static member ActualParseFileCount = actualParseFileCount
 
@@ -1695,8 +1688,6 @@ type FSharpChecker
     static member ActualCheckFileCount = BackgroundCompiler.ActualCheckFileCount
 
     static member Instance = globalInstance.Force()
-
-    member internal _.FrameworkImportsCache = backgroundCompiler.FrameworkImportsCache
 
     /// Tokenize a single line, returning token information and a tokenization state represented by an integer
     member _.TokenizeLine(line: string, state: FSharpTokenizerLexState) =

--- a/src/Compiler/Service/service.fsi
+++ b/src/Compiler/Service/service.fsi
@@ -464,7 +464,7 @@ type public FSharpChecker =
 
     [<Obsolete("Please create an instance of FSharpChecker using FSharpChecker.Create")>]
     static member Instance: FSharpChecker
-    member internal FrameworkImportsCache: FrameworkImportsCache
+
     member internal ReferenceResolver: LegacyReferenceResolver
 
     /// Tokenize a single line, returning token information and a tokenization state represented by an integer


### PR DESCRIPTION
We noticed that `SplitNonFoundationalTcImports` is causing a spawn of `dotnet` to find the installed .NET SDKs, in order to determine which assembly references are "system" assemblies.

As a short term fix for that problem I'd say it's sufficient just to look for `"dotnet/packs"` or `dotnet/packs/Microsoft.NETCore.App.Ref` in the normalized path of the assembly reference. But these are not good solutions.

Instead I wonder if we should just remove this "foundational/framework TcImports" altogether.  This thing adds a lot of complexity to the code and loads of edge cases would disappear if we removed it. 

As background, the aim of that object is to try to share resources related to common referenced assemblies in projects that have the full set of SDK references in common.  For this to work, we must have **exactly** the same set of "system" references shared between two loaded projects.  So it relies heavily on a heuristic about what is a "system" reference.

This seemed useful in the days of .NET 1.0-2.0, when all projects would tend to reference the whole .NET framework from the installed location.  Then gradually reference assemblies etc. came in and I suspect it's really rare that two projects share the same foundational imports.  I guess we could measure that. 

However there are caveats

* It may be much less rare that two scripts share the same set of imports - it would almost be normal.  So scenarios like having 300 scripts open in the IDE need to be considered.  However again we should measure if we're getting any actual important reduction in memory usage - and perhaps we should just rely on the other resource-sharing-and-reduction mechanisms we have in place.

* Our tests certainly repeatedly share the same foundational imports.  This is probably actually the biggest problem.

Note many of the resources associated with referenced binaries are shared/held-weakly in `ilModuleReaderCache1` and `ilModuleReaderCache2` .   However this doesn't include the resources associated with converting ILModule --> Ccu, i.e. the TypedTree nodes created on-demand via `ImportILAssembly`, which are really the only things we're trying to share here. 

Here I've spiked the total removal of foundational/framework TcImports.  
* [ ] Check run times of tests
* [ ] Check VS memory usage when 200 scripts are loaded and each has been analysed


