### PR TITLE
Only process EmptyModuleOrNamespaces when showHeader is true.

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2433,7 +2433,7 @@ module InferredSigPrinting =
             wordL (tagKeyword keyword) ^^ sepListL SepL.dot pathL
 
         match expr with
-        | EmptyModuleOrNamespaces mspecs ->
+        | EmptyModuleOrNamespaces mspecs when showHeader ->
             List.map emptyModuleOrNamespace mspecs
             |> aboveListL
         | expr -> imdefL denv expr

--- a/tests/fsharp/core/load-script/out.stdout.bsl
+++ b/tests/fsharp/core/load-script/out.stdout.bsl
@@ -16,9 +16,7 @@ World
 -the end
 Test 3=================================================
 
-> module FSI_0001
-
-[Loading D:\staging\staging\src\tests\fsharp\core\load-script\1.fsx
+> [Loading D:\staging\staging\src\tests\fsharp\core\load-script\1.fsx
  Loading D:\staging\staging\src\tests\fsharp\core\load-script\2.fsx
  Loading D:\staging\staging\src\tests\fsharp\core\load-script\3.fsx]
 Hello

--- a/tests/fsharp/core/printing/output.1000.stdout.bsl
+++ b/tests/fsharp/core/printing/output.1000.stdout.bsl
@@ -1,6 +1,4 @@
 
-module FSI_0001
-
 > val it: unit = ()
 
 > val repeatId: string = "A"
@@ -236,9 +234,7 @@ module D1 =
   val words: System.Collections.Generic.IDictionary<string,int>
   val words2000: System.Collections.Generic.IDictionary<int,string>
 
-> module FSI_0020
-
-> module D2 =
+> > module D2 =
   val words: IDictionary<string,int>
   val words2000: IDictionary<int,string>
 val opt1: 'a option

--- a/tests/fsharp/core/printing/output.200.stdout.bsl
+++ b/tests/fsharp/core/printing/output.200.stdout.bsl
@@ -1,6 +1,4 @@
 
-module FSI_0001
-
 > val it: unit = ()
 
 > val repeatId: string = "A"
@@ -131,9 +129,7 @@ module D1 =
   val words: System.Collections.Generic.IDictionary<string,int>
   val words2000: System.Collections.Generic.IDictionary<int,string>
 
-> module FSI_0020
-
-> module D2 =
+> > module D2 =
   val words: IDictionary<string,int>
   val words2000: IDictionary<int,string>
 val opt1: 'a option

--- a/tests/fsharp/core/printing/output.47.stdout.bsl
+++ b/tests/fsharp/core/printing/output.47.stdout.bsl
@@ -1,7 +1,5 @@
 
-> module FSI_0001
-
-val repeatId: string = "A"
+> val repeatId: string = "A"
 
 > val repeatId: string = "B"
 
@@ -251,9 +249,7 @@ module D1 =
   val words: System.Collections.Generic.IDictionary<string,int>
   val words2000: System.Collections.Generic.IDictionary<int,string>
 
-> module FSI_0019
-
-> module D2 =
+> > module D2 =
   val words: IDictionary<string,int>
   val words2000: IDictionary<int,string>
 val opt1: 'a option

--- a/tests/fsharp/core/printing/output.multiemit.stdout.bsl
+++ b/tests/fsharp/core/printing/output.multiemit.stdout.bsl
@@ -1,7 +1,5 @@
 
-> module FSI_0001
-
-val repeatId: string = "A"
+> val repeatId: string = "A"
 
 > val repeatId: string = "B"
 
@@ -251,9 +249,7 @@ module D1 =
   val words: System.Collections.Generic.IDictionary<string,int>
   val words2000: System.Collections.Generic.IDictionary<int,string>
 
-> module FSI_0019
-
-> module D2 =
+> > module D2 =
   val words: IDictionary<string,int>
   val words2000: IDictionary<int,string>
 val opt1: 'a option

--- a/tests/fsharp/core/printing/output.off.stdout.bsl
+++ b/tests/fsharp/core/printing/output.off.stdout.bsl
@@ -1,6 +1,4 @@
 
-module FSI_0001
-
 > val it: unit = ()
 
 > val repeatId: string
@@ -96,9 +94,7 @@ module D1 =
   val words: System.Collections.Generic.IDictionary<string,int>
   val words2000: System.Collections.Generic.IDictionary<int,string>
 
-> module FSI_0020
-
-> module D2 =
+> > module D2 =
   val words: IDictionary<string,int>
   val words2000: IDictionary<int,string>
 val opt1: 'a option

--- a/tests/fsharp/core/printing/output.stdout.bsl
+++ b/tests/fsharp/core/printing/output.stdout.bsl
@@ -1,7 +1,5 @@
 
-> module FSI_0001
-
-val repeatId: string = "A"
+> val repeatId: string = "A"
 
 > val repeatId: string = "B"
 
@@ -251,9 +249,7 @@ module D1 =
   val words: System.Collections.Generic.IDictionary<string,int>
   val words2000: System.Collections.Generic.IDictionary<int,string>
 
-> module FSI_0019
-
-> module D2 =
+> > module D2 =
   val words: IDictionary<string,int>
   val words2000: IDictionary<int,string>
 val opt1: 'a option


### PR DESCRIPTION
Fixes #13869

![image](https://user-images.githubusercontent.com/2621499/189681987-c8065cec-feee-468a-abee-728b8a8fd926.png)

FSI passes `false` for `showHeader`:

https://github.com/dotnet/fsharp/blob/9a29bed37d0e8f28b85417b531ffc4b1ab7e851e/src/Compiler/Interactive/fsi.fs#L1608
