### PR TITLE
Print attributes of nested modules in signatures.

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2387,7 +2387,9 @@ module InferredSigPrinting =
                 let nmL = layoutAccessibility denv mspec.Accessibility nmL
                 let denv = denv.AddAccessibility mspec.Accessibility
                 let basic = imdefL denv def
-                let modNameL = wordL (tagKeyword "module") ^^ nmL
+                let modNameL =
+                    wordL (tagKeyword "module") ^^ nmL
+                    |> layoutAttribs denv None false mspec.TypeOrMeasureKind mspec.Attribs
                 let modNameEqualsL = modNameL ^^ WordL.equals
                 let isNamespace = function | Namespace _ -> true | _ -> false
                 let modIsOuter = (outerPath |> List.forall (fun (_, istype) -> isNamespace istype) )

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
@@ -197,3 +197,25 @@ do ()
 """
     |> printSignatures
     |> should equal "namespace Foobar"
+
+[<Fact>]
+let ``Attribute on nested module`` () =
+    FSharp
+        """
+namespace MyApp.Types
+
+[<RequireQualifiedAccess>]
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Area =
+    type Meh =  class end
+"""
+    |> printSignatures
+    |> prependNewline
+    |> should equal """
+namespace MyApp.Types
+
+  [<RequireQualifiedAccess; CompilationRepresentation (enum<CompilationRepresentationFlags> (4))>]
+  module Area =
+
+    type Meh =
+      class end"""


### PR DESCRIPTION
Fixes #13758.

I'm not quite happy that 
```fsharp
[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
```

was printed as
```fsharp
[<CompilationRepresentation (enum<CompilationRepresentationFlags> (4))>]
```

but that is the behaviour today, I would perhaps revisit that in another PR.
