### PR TITLE
`Cherry-pick for 6.x.x servicing` Custom equality on ModuleOrNamespaceKind (#13693)

### DIFF
--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -472,6 +472,7 @@ exception UndefinedName of
 
 exception InternalUndefinedItemRef of (string * string * string -> int * string) * string * string * string
 
+[<CustomEquality;NoComparison>]
 type ModuleOrNamespaceKind = 
 
     /// Indicates that a module is compiled to a class with the "Module" suffix added. 
@@ -485,6 +486,22 @@ type ModuleOrNamespaceKind =
         /// Indicates that the sourcecode had a namespace.
         /// If false, this namespace was implicitly constructed during type checking. 
         isExplicit: bool
+        
+    override this.Equals other =
+        match other with
+        | :? ModuleOrNamespaceKind as kind ->
+            match this, kind with
+            | FSharpModuleWithSuffix, FSharpModuleWithSuffix
+            | ModuleOrType, ModuleOrType
+            | Namespace _, Namespace _ -> true
+            | _ -> false
+        | _ -> false
+
+    override this.GetHashCode () =
+        match this with
+        | FSharpModuleWithSuffix -> 0
+        | ModuleOrType -> 1
+        | Namespace _ -> 2
 
 /// A public path records where a construct lives within the global namespace
 /// of a CCU.

--- a/src/Compiler/TypedTree/TypedTree.fsi
+++ b/src/Compiler/TypedTree/TypedTree.fsi
@@ -292,6 +292,7 @@ exception UndefinedName of depth: int * error: (string -> string) * id: Ident * 
 
 exception InternalUndefinedItemRef of (string * string * string -> int * string) * string * string * string
 
+[<CustomEquality; NoComparison>]
 type ModuleOrNamespaceKind =
 
     /// Indicates that a module is compiled to a class with the "Module" suffix added.

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.csproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.csproj
@@ -9,6 +9,13 @@
     <PackageDescription>.NET Core compatible version of the F# compiler fsc.exe.</PackageDescription>
     <PackageReleaseNotes>/blob/main/release-notes.md#FSharp-Tools-$(FSProductVersionReleaseNotesVersion)</PackageReleaseNotes>
     <NoDefaultExcludes>true</NoDefaultExcludes>
+    <!-- Workaround to get rid of:
+        error NU1505: Duplicate 'PackageDownload' items found.
+        Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior.
+        The duplicate 'PackageDownload' items are:
+          Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2].
+    -->
+    <NoWarn>$(NoWarn);NU1505</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/ModuleDefinitions/ModuleDefinitions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/ModuleDefinitions/ModuleDefinitions.fs
@@ -318,3 +318,36 @@ module ModuleDefinitions =
         |> withReferences [libFoo2; libFoo1]
         |> verifyCompileAndRun
         |> shouldSucceed
+
+    [<Fact>]
+    let ``Regression: compilation error with private types in namespace used in a different file`` () =
+        let types =
+            """
+            namespace FsErrorRepro
+
+            type private Blah = { Number: int }
+            """
+        let example =
+            """
+            [<RequireQualifiedAccess>]
+            module FsErrorRepro.Example
+
+            let dummy (blahNum: int) =
+                let blah : Blah = { Number = blahNum }
+                printf $"%i{blah.Number}"
+            """
+        let program =
+            """
+            module FsErrorRepro.Main
+
+            [<EntryPoint>]
+            let main _ = 
+                Example.dummy 15
+                0
+            """
+
+        FSharp types
+        |> withAdditionalSourceFiles [SourceCodeFileKind.Create("example.fs", example)
+                                      SourceCodeFileKind.Create("program.fs", program)]
+        |> compile
+        |> shouldSucceed


### PR DESCRIPTION
Fix for https://github.com/dotnet/fsharp/issues/13661