### PR TITLE
Disable implicit FSharp.Core and System.ValueTuple when using Central Package Management

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.Core.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.Core.NetSdk.props
@@ -16,7 +16,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-   <PropertyGroup>
+  <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 

--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -67,6 +67,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <DotnetFsiCompilerPath Condition="'$(DotnetFscCompilerPath)' == ''">"$(MSBuildThisFileDirectory)fsi.dll"</DotnetFsiCompilerPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(ManagePackageVersionsCentrally)' == 'true' ">
+    <DisableImplicitSystemValueTupleReference Condition="'$(DisableImplicitSystemValueTupleReference)' == ''">true</DisableImplicitSystemValueTupleReference>
+    <DisableImplicitFSharpCoreReference Condition="'$(DisableImplicitFSharpCoreReference)' == ''">true</DisableImplicitFSharpCoreReference>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(DisableImplicitSystemValueTupleReference)' != 'true'
                         and ('$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp')
                         and !('$(_TargetFrameworkVersionWithoutV)' >= '2.0' )">


### PR DESCRIPTION
https://devblogs.microsoft.com/nuget/introducing-central-package-management/

`DisableImplicitLibraryPacksFolder = true` because it is necessary to [map source packages](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping) when using Central Package Management