### PR TITLE
Not null value returned from trait call test

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Language/RegressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/RegressionTests.fs
@@ -19,3 +19,22 @@ type TestItemSeq =
         |> compile
         |> withErrorCodes [39]
         |> ignore
+
+    [<Fact>]
+    let ``No null value should be returned from trait call``() =
+        FSharp """
+module FSharpBug
+
+type A = A with
+    static member ($) (A, a: float) = 0.0
+    static member ($) (A, a: decimal) = 0M
+    static member ($) (A, a: 't) = 0
+    
+let inline call x = ($) A x
+let expected = 0.0
+let actual = call 42.
+if actual <> expected then failwith "Unexpected result"
+        """
+        |> asExe
+        |> compileAndRun
+        |> shouldSucceed


### PR DESCRIPTION
Closes https://github.com/dotnet/fsharp/issues/12386
This seems to have been fixed at some point in F# 6 . So this Test we can ensure that there is not a regression :) 