### PR TITLE
fix go-to-definition to symbols in large files

### DIFF
--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2142,6 +2142,7 @@ and [<Sealed>] TcImports
             CheckDisposed()
 
             let tcConfig = tcConfigP.Get ctok
+
             let runMethod =
                 match tcConfig.parallelReferenceResolution with
                 | ParallelReferenceResolution.On -> NodeCode.Parallel

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -610,7 +610,7 @@ module ResizeArray =
                     // * doing a block copy using `List.CopyTo(index, array, index, count)` (requires more copies to do the mapping)
                     // none are significantly better.
                     for i in 0 .. takeCount - 1 do
-                        holder[i] <- f items[i]
+                        holder[i] <- f items[startIndex+i]
 
                     yield holder
             |]

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -610,7 +610,7 @@ module ResizeArray =
                     // * doing a block copy using `List.CopyTo(index, array, index, count)` (requires more copies to do the mapping)
                     // none are significantly better.
                     for i in 0 .. takeCount - 1 do
-                        holder[i] <- f items[startIndex+i]
+                        holder[i] <- f items[startIndex + i]
 
                     yield holder
             |]


### PR DESCRIPTION
Such a simple fix...

The problem kicks whenever we're going to symbols in files that have above 10000 symbol resolutions

Fixes https://github.com/dotnet/fsharp/issues/13986