### PR TITLE
fix regression in editing .NET Core scripts in devenv.exe

### DIFF
--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2142,6 +2142,7 @@ and [<Sealed>] TcImports
             CheckDisposed()
 
             let tcConfig = tcConfigP.Get ctok
+
             let runMethod =
                 match tcConfig.parallelReferenceResolution with
                 | ParallelReferenceResolution.On -> NodeCode.Parallel

--- a/src/Compiler/Driver/FxResolver.fs
+++ b/src/Compiler/Driver/FxResolver.fs
@@ -386,7 +386,7 @@ type internal FxResolver
     // On coreclr it uses the deps.json file
     //
     // On-demand because (a) some FxResolver are ephemeral (b) we want to avoid recomputation
-    let tryGetRunningTfm() =
+    let tryGetRunningTfm () =
         let runningTfmOpt =
             let getTfmNumber (v: string) =
                 let arr = v.Split([| '.' |], 3)
@@ -831,13 +831,14 @@ type internal FxResolver
 
             let targetTfm =
                 if isInteractive then
-                    tryGetRunningTfm()
+                    tryGetRunningTfm ()
                 else
                     let sdkDir = tryGetSdkDir () |> replayWarnings
 
                     match sdkDir with
                     | Some dir ->
                         let dotnetConfigFile = Path.Combine(dir, "dotnet.runtimeconfig.json")
+
                         try
                             use stream = FileSystem.OpenFileForReadShim(dotnetConfigFile)
                             let dotnetConfig = stream.ReadAllText()
@@ -851,9 +852,8 @@ type internal FxResolver
                             let tfm = dotnetConfig[startPos .. endPos - 1]
                             tfm
                         with _ ->
-                            tryGetRunningTfm()
-                    | None ->
-                        tryGetRunningTfm()
+                            tryGetRunningTfm ()
+                    | None -> tryGetRunningTfm ()
 
             // Coreclr has mechanism for getting rid
             //      System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier

--- a/src/Compiler/Driver/FxResolver.fs
+++ b/src/Compiler/Driver/FxResolver.fs
@@ -853,7 +853,7 @@ type internal FxResolver
                     let sdkDir = tryGetSdkDir () |> replayWarnings
 
                     match sdkDir with
-                    | Some dir -> tryGetTfmFromSdkDir ()
+                    | Some dir -> tryGetTfmFromSdkDir dir
                     | None -> tryGetRunningTfm ()
 
             // Coreclr has mechanism for getting rid

--- a/src/Compiler/Driver/FxResolver.fs
+++ b/src/Compiler/Driver/FxResolver.fs
@@ -382,16 +382,16 @@ type internal FxResolver
 
     let tryGetNetCoreRefsPackDirectoryRoot () = tryNetCoreRefsPackDirectoryRoot.Force()
 
+    let getTfmNumber (v: string) =
+        let arr = v.Split([| '.' |], 3)
+        arr[0] + "." + arr[1]
+
     // Tries to figure out the tfm for the compiler instance.
     // On coreclr it uses the deps.json file
     //
     // On-demand because (a) some FxResolver are ephemeral (b) we want to avoid recomputation
     let tryGetRunningTfm () =
         let runningTfmOpt =
-            let getTfmNumber (v: string) =
-                let arr = v.Split([| '.' |], 3)
-                arr[0] + "." + arr[1]
-
             // Compute TFM from System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
             // System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;;
             // val it: string = ".NET 6.0.7"
@@ -928,7 +928,7 @@ type internal FxResolver
             let defaultReferences =
                 if assumeDotNetFramework then
                     getDotNetFrameworkDefaultReferences useFsiAuxLib, assumeDotNetFramework
-                else if useSdkRefs then
+                elif useSdkRefs then
                     // Go fetch references
                     let sdkDir = tryGetSdkRefsPackDirectory () |> replayWarnings
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -182,7 +182,7 @@ type private FSharpProjectOptionsReactor (checker: FSharpChecker) =
                 let! scriptProjectOptions, _ =
                     checker.GetProjectOptionsFromScript(document.FilePath,
                         sourceText.ToFSharpSourceText(),
-                        SessionsProperties.fsiPreview,
+                        previewEnabled=SessionsProperties.fsiPreview,
                         assumeDotNetFramework=not SessionsProperties.fsiUseNetCore,
                         userOpName=userOpName)
 

--- a/vsintegration/src/FSharp.VS.FSI/fsiLanguageService.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiLanguageService.fs
@@ -46,6 +46,11 @@ type FsiPropertyPage() =
     [<ResourceDescription(SRProperties.FSharpInteractiveShadowCopyDescr)>]
     member this.FsiShadowCopy with get() = SessionsProperties.fsiShadowCopy and set (x:bool) = SessionsProperties.fsiShadowCopy <- x
 
+    [<ResourceCategory(SRProperties.FSharpInteractiveMisc)>]
+    [<ResourceDisplayName(SRProperties.FSharpInteractiveUseNetCore)>]
+    [<ResourceDescription(SRProperties.FSharpInteractiveUseNetCoreDescr)>]
+    member this.FsiUseNetCore with get() = SessionsProperties.fsiUseNetCore and set (x:bool) = SessionsProperties.fsiUseNetCore <- x
+
     [<ResourceCategory(SRProperties.FSharpInteractiveDebugging)>]
     [<ResourceDisplayName(SRProperties.FSharpInteractiveDebugMode)>]
     [<ResourceDescription(SRProperties.FSharpInteractiveDebugModeDescr)>]
@@ -55,11 +60,6 @@ type FsiPropertyPage() =
     [<ResourceDisplayName(SRProperties.FSharpInteractivePreviewMode)>]
     [<ResourceDescription(SRProperties.FSharpInteractivePreviewModeDescr)>]
     member this.FsiPreview with get() = SessionsProperties.fsiPreview and set (x:bool) = SessionsProperties.fsiPreview <- x
-
-    [<ResourceCategory(SRProperties.FSharpInteractivePreview)>]
-    [<ResourceDisplayName(SRProperties.FSharpInteractiveUseNetCore)>]
-    [<ResourceDescription(SRProperties.FSharpInteractiveUseNetCoreDescr)>]
-    member this.FsiUseNetCore with get() = SessionsProperties.fsiUseNetCore and set (x:bool) = SessionsProperties.fsiUseNetCore <- x
 
 // CompletionSet
 type internal FsiCompletionSet(imageList,source:Source) =


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/13993

The TFM we need to return from FxResolver is the correct TFM to use for script analysis (which is often the running TFM, but not always, in-editor). See notes in code

This resurrects a small portion of the code removed in #13993 (which removed lots of other ugly code, but this bit should not have been removed, and is the only technique we know of to get the target TFM based on an SDK dir)

@vzarytovskii I'll target this to dev17.4
