### PR TITLE
No warning or error is raised when consuming IL Event with an Obsolete attribute

### DIFF
--- a/src/Compiler/Checking/AttributeChecking.fs
+++ b/src/Compiler/Checking/AttributeChecking.fs
@@ -412,6 +412,9 @@ let CheckEntityAttributes g (tcref: TyconRef) m =
         CheckILAttributes g (isByrefLikeTyconRef g m tcref) tcref.ILTyconRawMetadata.CustomAttrs m
     else 
         CheckFSharpAttributes g tcref.Attribs m
+        
+let CheckILEventAttributes g (tcref: TyconRef) cattrs m  =    
+    CheckILAttributes g (isByrefLikeTyconRef g m tcref) cattrs m 
 
 /// Check the attributes associated with a method, returning warnings and errors as data.
 let CheckMethInfoAttributes g m tyargsOpt (minfo: MethInfo) = 

--- a/src/Compiler/Checking/AttributeChecking.fsi
+++ b/src/Compiler/Checking/AttributeChecking.fsi
@@ -101,3 +101,5 @@ val IsSecurityAttribute:
 val IsSecurityCriticalAttribute: g: TcGlobals -> Attrib -> bool
 
 val IsAssemblyVersionAttribute: g: TcGlobals -> Attrib -> bool
+
+val CheckILEventAttributes: g: TcGlobals -> tcref: TyconRef -> cattrs: ILAttributes -> m: range ->  OperationResult<unit>

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -9095,7 +9095,14 @@ and TcEventItemThen (cenv: cenv) overallTy env tpenv mItem mExprAndItem objDetai
     let (SigOfFunctionForDelegate(delInvokeMeth, delArgTys, _, _)) = GetSigOfFunctionForDelegate cenv.infoReader delTy mItem ad
     let objArgs = Option.toList (Option.map fst objDetails)
     MethInfoChecks g cenv.amap true None objArgs env.eAccessRights mItem delInvokeMeth
-
+    
+    let ilEventDefCustomAttrs =
+        match einfo with
+        | ILEvent(ILEventInfo(_, ilEventDef))-> ilEventDef.CustomAttrs
+        | _ -> ILAttributes.Empty
+        
+    CheckILEventAttributes g einfo.DeclaringTyconRef ilEventDefCustomAttrs mItem |> CommitOperationResult
+   
     // This checks for and drops the 'object' sender
     let argsTy = ArgsTypeOfEventInfo cenv.infoReader mItem ad einfo
     if not (slotSigHasVoidReturnTy (delInvokeMeth.GetSlotSig(cenv.amap, mItem))) then errorR (nonStandardEventError einfo.EventName mItem)

--- a/tests/FSharp.Compiler.ComponentTests/Language/ObsoleteAttributeCheckingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ObsoleteAttributeCheckingTests.fs
@@ -917,6 +917,7 @@ Class.ObsoleteEvent |> ignore
             (Warning 44, Line 3, Col 1, Line 3, Col 20, "This construct is deprecated. Field is obsolete");
             (Warning 44, Line 4, Col 1, Line 4, Col 21, "This construct is deprecated. Method is obsolete");
             (Warning 44, Line 5, Col 1, Line 5, Col 23, "This construct is deprecated. Property is obsolete")
+            (Warning 44, Line 6, Col 1, Line 6, Col 20, "This construct is deprecated. Event is obsolete")
         ]
 
     [<Fact>]
@@ -955,4 +956,5 @@ Class.ObsoleteEvent |> ignore
             (Error 101, Line 3, Col 1, Line 3, Col 20, "This construct is deprecated. Field is obsolete");
             (Error 101, Line 4, Col 1, Line 4, Col 21, "This construct is deprecated. Method is obsolete");
             (Error 101, Line 5, Col 1, Line 5, Col 23, "This construct is deprecated. Property is obsolete")
+            (Error 101, Line 6, Col 1, Line 6, Col 20, "This construct is deprecated. Event is obsolete")
         ]


### PR DESCRIPTION
This PR fixes a BUG mentioned on https://github.com/dotnet/fsharp/issues/13511#issuecomment-1184348037