### PR TITLE
First steps towards reviving CodeLens

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeLens/FSharpCodeLensService.fs
+++ b/vsintegration/src/FSharp.Editor/CodeLens/FSharpCodeLensService.fs
@@ -42,7 +42,7 @@ type internal FSharpCodeLensService
     (
         serviceProvider: IServiceProvider,
         workspace: Workspace, 
-        documentId: Lazy<DocumentId>,
+        documentId: DocumentId,
         buffer: ITextBuffer, 
         metadataAsSource: FSharpMetadataAsSourceService,
         classificationFormatMapService: IClassificationFormatMapService,
@@ -153,7 +153,7 @@ type internal FSharpCodeLensService
 #if DEBUG
             logInfof "Rechecking code due to buffer edit!"
 #endif
-            let! document = workspace.CurrentSolution.GetDocument(documentId.Value) |> Option.ofObj
+            let! document = workspace.CurrentSolution.GetDocument documentId |> Option.ofObj
             let! parseFileResults, checkFileResults = document.GetFSharpParseAndCheckResultsAsync(nameof(FSharpUseMutationWhenValueIsMutableFixProvider)) |> liftAsync
             let parsedInput = parseFileResults.ParseTree
 #if DEBUG


### PR DESCRIPTION
closes #12627 

This is primarily a small refactoring but it also removes one hack from the code (with `Option.get`) which should at least fix the above bug.

I removed a lazy thing primarily to simplify the code for now. The whole CodeLens is dramatically slow so it's hard to make things worse anyway. I'll address performance in the next PRs. 