### PR TITLE
Added parallelization options to VS

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -93,20 +93,39 @@ type internal FSharpWorkspaceServiceFactory
                 match checkerSingleton with
                 | Some _ -> ()
                 | _ ->
-                    let checker = 
+                    let checker =
                         lazy
-                            let checker = 
+                            let editorOptions =
+                                let editorOptions = workspace.Services.GetService<EditorOptions>()
+
+                                match box editorOptions with
+                                | null -> None
+                                | _ -> Some editorOptions
+
+                            let enableParallelCheckingWithSignatureFiles =
+                                editorOptions
+                                |> Option.map (fun options -> options.LanguageServicePerformance.EnableParallelCheckingWithSignatureFiles)
+                                |> Option.defaultValue false
+
+                            let enableParallelReferenceResolution =
+                                editorOptions
+                                |> Option.map (fun options -> options.LanguageServicePerformance.EnableParallelReferenceResolution)
+                                |> Option.defaultValue false
+
+                            let checker =
                                 FSharpChecker.Create(
-                                    projectCacheSize = 5000, // We do not care how big the cache is. VS will actually tell FCS to clear caches, so this is fine. 
+                                    projectCacheSize = 5000, // We do not care how big the cache is. VS will actually tell FCS to clear caches, so this is fine.
                                     keepAllBackgroundResolutions = false,
                                     legacyReferenceResolver=LegacyMSBuildReferenceResolver.getResolver(),
                                     tryGetMetadataSnapshot = tryGetMetadataSnapshot,
                                     keepAllBackgroundSymbolUses = false,
                                     enableBackgroundItemKeyStoreAndSemanticClassification = true,
-                                    enablePartialTypeChecking = true)
-                            checker    
-                    checkerSingleton <- Some checker                   
-            )          
+                                    enablePartialTypeChecking = true,
+                                    enableParallelCheckingWithSignatureFiles = enableParallelCheckingWithSignatureFiles,
+                                    parallelReferenceResolution = enableParallelReferenceResolution)
+                            checker
+                    checkerSingleton <- Some checker
+            )
 
             let optionsManager = 
                 lazy

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -63,12 +63,16 @@ type LanguageServicePerformanceOptions =
     { EnableInMemoryCrossProjectReferences: bool
       AllowStaleCompletionResults: bool
       TimeUntilStaleCompletion: int
-      ProjectCheckCacheSize: int }
+      ProjectCheckCacheSize: int
+      EnableParallelCheckingWithSignatureFiles: bool
+      EnableParallelReferenceResolution: bool }
     static member Default =
       { EnableInMemoryCrossProjectReferences = true
         AllowStaleCompletionResults = true
         TimeUntilStaleCompletion = 2000 // In ms, so this is 2 seconds
-        ProjectCheckCacheSize = 200 }
+        ProjectCheckCacheSize = 200
+        EnableParallelCheckingWithSignatureFiles = false
+        EnableParallelReferenceResolution = false }
 
 [<CLIMutable>]
 type CodeLensOptions =

--- a/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
+++ b/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
@@ -24,4 +24,19 @@
     <InternalsVisibleTo Include="VisualFSharp.UnitTests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Strings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
@@ -75,6 +75,16 @@
                         </Grid>
                     </StackPanel>
                 </GroupBox>
+                <GroupBox Header="{x:Static local:Strings.Parallelization}">
+                    <StackPanel>
+                        <CheckBox x:Name="enableParallelCheckingWithSignatureFiles"
+                                  IsChecked="{Binding EnableParallelCheckingWithSignatureFiles}"
+                                  Content="{x:Static local:Strings.Enable_Parallel_Checking_With_Signature_Files}"/>
+                        <CheckBox x:Name="enableParallelReferenceResolution"
+                                  IsChecked="{Binding EnableParallelReferenceResolution}"
+                                  Content="{x:Static local:Strings.Enable_Parallel_Reference_Resolution}"/>
+                    </StackPanel>
+                </GroupBox>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parallel type checking with signature files.
+        ///   Looks up a localized string similar to Enable parallel type checking with signature files.
         /// </summary>
         public static string Enable_Parallel_Checking_With_Signature_Files {
             get {
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parallel reference resolution.
+        ///   Looks up a localized string similar to Enable parallel reference resolution.
         /// </summary>
         public static string Enable_Parallel_Reference_Resolution {
             get {

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -178,6 +178,24 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Parallel type checking with signature files.
+        /// </summary>
+        public static string Enable_Parallel_Checking_With_Signature_Files {
+            get {
+                return ResourceManager.GetString("Enable_Parallel_Checking_With_Signature_Files", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parallel reference resolution.
+        /// </summary>
+        public static string Enable_Parallel_Reference_Resolution {
+            get {
+                return ResourceManager.GetString("Enable_Parallel_Reference_Resolution", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable stale data for IntelliSense features.
         /// </summary>
         public static string Enable_Stale_IntelliSense_Results {
@@ -223,7 +241,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Re-format indentation on paste.
+        ///   Looks up a localized string similar to Re-format indentation on paste (Experimental).
         /// </summary>
         public static string Format_on_paste {
             get {
@@ -264,6 +282,15 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         public static string Outlining {
             get {
                 return ResourceManager.GetString("Outlining", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parallelization (requires restart).
+        /// </summary>
+        public static string Parallelization {
+            get {
+                return ResourceManager.GetString("Parallelization", resourceCulture);
             }
         }
         

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -241,9 +241,9 @@
     <value>Parallelization (requires restart)</value>
   </data>
   <data name="Enable_Parallel_Checking_With_Signature_Files" xml:space="preserve">
-    <value>Parallel type checking with signature files</value>
+    <value>Enable parallel type checking with signature files</value>
   </data>
   <data name="Enable_Parallel_Reference_Resolution" xml:space="preserve">
-    <value>Parallel reference resolution</value>
+    <value>Enable parallel reference resolution</value>
   </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -237,4 +237,13 @@
   <data name="Diagnostics" xml:space="preserve">
     <value>Diagnostics</value>
   </data>
+  <data name="Parallelization" xml:space="preserve">
+    <value>Parallelization (requires restart)</value>
+  </data>
+  <data name="Enable_Parallel_Checking_With_Signature_Files" xml:space="preserve">
+    <value>Parallel type checking with signature files</value>
+  </data>
+  <data name="Enable_Parallel_Reference_Resolution" xml:space="preserve">
+    <value>Parallel reference resolution</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Diagnostika</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Výkon</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Navigační odkazy</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Diagnose</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Leistung</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Navigationslinks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Diagnóstico</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Rendimiento</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Vínculos de navegación</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Diagnostics</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Performances</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Liens de navigation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Diagnostica</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Prestazioni</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Collegamenti di navigazione</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -47,6 +47,16 @@
         <target state="translated">診断</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">パフォーマンス</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">ナビゲーション リンク</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -47,6 +47,16 @@
         <target state="translated">진단</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">성능</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">탐색 링크</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Diagnostyka</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Wydajność</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Linki nawigacyjne</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Diagnóstico</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Desempenho</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Links de navegação</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Диагностика</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Производительность</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Ссылки навигации</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -47,6 +47,16 @@
         <target state="translated">Tanılama</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">Performans</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">Gezinti bağlantıları</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -47,6 +47,16 @@
         <target state="translated">诊断</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">性能</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">导航链接</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -47,6 +47,16 @@
         <target state="translated">診斷</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
+        <source>Parallel type checking with signature files</source>
+        <target state="new">Parallel type checking with signature files</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Parallel_Reference_Resolution">
+        <source>Parallel reference resolution</source>
+        <target state="new">Parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Language_Service_Performance">
         <source>Performance</source>
         <target state="translated">效能</target>
@@ -65,6 +75,11 @@
       <trans-unit id="Navigation_links">
         <source>Navigation links</source>
         <target state="translated">導覽連結</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parallelization">
+        <source>Parallelization (requires restart)</source>
+        <target state="new">Parallelization (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_all_symbols">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -48,13 +48,13 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Checking_With_Signature_Files">
-        <source>Parallel type checking with signature files</source>
-        <target state="new">Parallel type checking with signature files</target>
+        <source>Enable parallel type checking with signature files</source>
+        <target state="new">Enable parallel type checking with signature files</target>
         <note />
       </trans-unit>
       <trans-unit id="Enable_Parallel_Reference_Resolution">
-        <source>Parallel reference resolution</source>
-        <target state="new">Parallel reference resolution</target>
+        <source>Enable parallel reference resolution</source>
+        <target state="new">Enable parallel reference resolution</target>
         <note />
       </trans-unit>
       <trans-unit id="Language_Service_Performance">


### PR DESCRIPTION
Fixes #13909 and #13919

![image](https://user-images.githubusercontent.com/217092/193822661-504c6aba-693f-498c-b5b3-0ac2ce4955ad.png)

Currently it requires VS restart after changing the options. Enabling changing these during VS runtime seems it would complicate things quite a bit. Since we have a single instance of `FSharpChecker` and we'd either have to replace it with a new instance or somehow propagate the changes there. Neither seem worth it for this purpose. 