### PR TITLE
Fixing some rendering issues for LineLens

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeLens/LineLensDisplayService.fs
+++ b/vsintegration/src/FSharp.Editor/CodeLens/LineLensDisplayService.fs
@@ -16,23 +16,16 @@ type internal LineLensDisplayService (view, buffer) =
     /// Layouts all stack panels on the line
     override self.LayoutUIElementOnLine _ (line:ITextViewLine) (ui:Grid) =
         let left, top = 
-            match self.UiElementNeighbour.TryGetValue ui with
-            | true, parent -> 
-                let left = Canvas.GetLeft parent
-                let top = Canvas.GetTop parent
-                let width = parent.ActualWidth
-                left + width, top
-            | _ -> 
-                try
-                    let bounds = line.GetCharacterBounds(line.Start)
-                    line.TextRight + 5.0, bounds.Top - 1.
-                with e ->
+            try
+                let bounds = line.GetCharacterBounds(line.Start)
+                line.TextRight + 5.0, bounds.Top - 1.
+            with e ->
 #if DEBUG
-                    logExceptionWithContext (e, "Error in layout ui element on line")
+                logExceptionWithContext (e, "Error in layout ui element on line")
 #else
-                    ignore e
+                ignore e
 #endif
-                    Canvas.GetLeft ui, Canvas.GetTop ui
+                Canvas.GetLeft ui, Canvas.GetTop ui
         Canvas.SetLeft(ui, left)
         Canvas.SetTop(ui, top)
 


### PR DESCRIPTION
closes #13886 

This is the broken behavior that is addressed:

https://user-images.githubusercontent.com/5451366/193873546-3e47a97b-c042-4473-a1da-5a5086955dcc.mp4

Now it works:

https://user-images.githubusercontent.com/5451366/193873646-1eb81235-6d13-4735-8313-83d0e6d43ffc.mp4

The behavior was caused by some weird logic about LineLens placement (here just removed for good) and an incorrect algorithm for checking for the presence of existing LineLens (now testing function Id instead of function signature which actually can change).

F# CodeLens is still slow and quite miserable, so more stuff is coming soon.