### PR TITLE
Eagerly format exceptions in FSI's interactive scripting API

### DIFF
--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -3521,6 +3521,8 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let dummyScriptFileName = "input.fsx"
 
+    let eagerFormat (diag : PhasedDiagnostic) = diag.EagerlyFormatCore true
+
     interface IDisposable with
         member _.Dispose() =
             (tcImports :> IDisposable).Dispose()
@@ -3639,7 +3641,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         let ctok = AssumeCompilationThreadWithoutEvidence()
 
         let errorOptions = TcConfig.Create(tcConfigB,validate = false).diagnosticsOptions
-        let diagnosticsLogger = CompilationDiagnosticLogger("EvalInteraction", errorOptions)
+        let diagnosticsLogger = CompilationDiagnosticLogger("EvalInteraction", errorOptions, eagerFormat)
         fsiInteractionProcessor.EvalExpression(ctok, code, dummyScriptFileName, diagnosticsLogger)
         |> commitResultNonThrowing errorOptions dummyScriptFileName diagnosticsLogger
 
@@ -3661,7 +3663,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         let cancellationToken = defaultArg cancellationToken CancellationToken.None
 
         let errorOptions = TcConfig.Create(tcConfigB,validate = false).diagnosticsOptions
-        let diagnosticsLogger = CompilationDiagnosticLogger("EvalInteraction", errorOptions)
+        let diagnosticsLogger = CompilationDiagnosticLogger("EvalInteraction", errorOptions, eagerFormat)
         fsiInteractionProcessor.EvalInteraction(ctok, code, dummyScriptFileName, diagnosticsLogger, cancellationToken)
         |> commitResultNonThrowing errorOptions "input.fsx" diagnosticsLogger
 
@@ -3682,7 +3684,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
         let ctok = AssumeCompilationThreadWithoutEvidence()
 
         let errorOptions = TcConfig.Create(tcConfigB, validate = false).diagnosticsOptions
-        let diagnosticsLogger = CompilationDiagnosticLogger("EvalInteraction", errorOptions)
+        let diagnosticsLogger = CompilationDiagnosticLogger("EvalInteraction", errorOptions, eagerFormat)
         fsiInteractionProcessor.EvalScript(ctok, filePath, diagnosticsLogger)
         |> commitResultNonThrowing errorOptions filePath diagnosticsLogger
         |> function Choice1Of2 _, errs -> Choice1Of2 (), errs | Choice2Of2 exn, errs -> Choice2Of2 exn, errs

--- a/src/Compiler/Symbols/FSharpDiagnostic.fs
+++ b/src/Compiler/Symbols/FSharpDiagnostic.fs
@@ -168,7 +168,7 @@ type internal CompilationDiagnosticLogger (debugName: string, options: FSharpDia
         let diagnostic =
             match preprocess with
             | Some f -> f diagnostic
-            | _ -> diagnostic
+            | None -> diagnostic
 
         if diagnostic.ReportAsError (options, severity) then
             diagnostics.Add(diagnostic, FSharpDiagnosticSeverity.Error)

--- a/src/Compiler/Symbols/FSharpDiagnostic.fs
+++ b/src/Compiler/Symbols/FSharpDiagnostic.fs
@@ -158,13 +158,18 @@ type DiagnosticsScope()  =
             | None -> err ""
 
 /// A diagnostics logger that capture diagnostics, filtering them according to warning levels etc.
-type internal CompilationDiagnosticLogger (debugName: string, options: FSharpDiagnosticOptions) = 
+type internal CompilationDiagnosticLogger (debugName: string, options: FSharpDiagnosticOptions, ?preprocess: (PhasedDiagnostic -> PhasedDiagnostic)) =
     inherit DiagnosticsLogger("CompilationDiagnosticLogger("+debugName+")")
             
     let mutable errorCount = 0
     let diagnostics = ResizeArray<_>()
 
     override _.DiagnosticSink(diagnostic, severity) = 
+        let diagnostic =
+            match preprocess with
+            | Some f -> f diagnostic
+            | _ -> diagnostic
+
         if diagnostic.ReportAsError (options, severity) then
             diagnostics.Add(diagnostic, FSharpDiagnosticSeverity.Error)
             errorCount <- errorCount + 1
@@ -172,7 +177,7 @@ type internal CompilationDiagnosticLogger (debugName: string, options: FSharpDia
             diagnostics.Add(diagnostic, FSharpDiagnosticSeverity.Warning)
         elif diagnostic.ReportAsInfo (options, severity) then
             diagnostics.Add(diagnostic, severity)
-    
+
     override _.ErrorCount = errorCount
 
     member _.GetDiagnostics() = diagnostics.ToArray()

--- a/src/Compiler/Symbols/FSharpDiagnostic.fsi
+++ b/src/Compiler/Symbols/FSharpDiagnostic.fsi
@@ -106,7 +106,9 @@ type internal CompilationDiagnosticLogger =
     inherit DiagnosticsLogger
 
     /// Create the diagnostics logger
-    new: debugName: string * options: FSharpDiagnosticOptions -> CompilationDiagnosticLogger
+    new:
+        debugName: string * options: FSharpDiagnosticOptions * ?preprocess: (PhasedDiagnostic -> PhasedDiagnostic) ->
+            CompilationDiagnosticLogger
 
     /// Get the captured diagnostics
     member GetDiagnostics: unit -> (PhasedDiagnostic * FSharpDiagnosticSeverity)[]

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -23,7 +23,7 @@ type InteractiveTests() =
         let _, errors = script.Eval(code)
         Assert.Equal(1, errors.Length)
         let msg = errors[0].Message
-        Assert.DoesNotMatch("obj -> obj", msg)
+        Assert.Matches("'_\\w+ -> '_\\w+", msg)
 
     [<Fact>]
     member _.``Eval object value``() =

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -17,6 +17,15 @@ open Xunit
 type InteractiveTests() =
 
     [<Fact>]
+    member _.``ValueRestriction error message should not have type variables fully solved``() =
+        use script = new FSharpScript()
+        let code = "id id"
+        let _, errors = script.Eval(code)
+        Assert.Equal(1, errors.Length)
+        let msg = errors[0].Message
+        Assert.DoesNotMatch("obj -> obj", msg)
+
+    [<Fact>]
     member _.``Eval object value``() =
         use script = new FSharpScript()
         let opt = script.Eval("1+1") |> getValue


### PR DESCRIPTION
Adds eager formatting of exceptions to CompilationDiagnosticLogger (which accumulates exceptions in an array) in FsiEvaluationSession.

This should fix https://github.com/dotnet/fsharp/issues/13921 which was due to the fact, that type variables contained in ValueRestriction exception were mutated before diagnostics were committed.

Not sure whether this same approach should be used wider or not. 