### PR TITLE
Temporarily converging CodeLens and LineLens monikers to Lens

### DIFF
--- a/docs/tooling-features.md
+++ b/docs/tooling-features.md
@@ -42,7 +42,7 @@ Most of the syntax operations require an entire document's source text or parse 
 |---------|---------------|---------------|-----------------|
 | Most code fixes | Current document's typecheck data | Set (1 or more) of suggested text replacements | S-M |
 | Semantic classification | Current document's typecheck data | Spans of text with semantic classification type for all constructs in a document | S-L |
-| Code lenses | Current document's typecheck data and top-level declarations (for showing signatures); graph of all projects that reference the current one (for showing references) | Signature data for each top-level construct; spans of text for each reference to a top-level construct with navigation information | S-XL |
+| Lenses | Current document's typecheck data and top-level declarations (for showing signatures); graph of all projects that reference the current one (for showing references) | Signature data for each top-level construct; spans of text for each reference to a top-level construct with navigation information | S-XL |
 | Code generation / refactorings | Current document's typecheck data and/or current resolved symbol/symbols | Text replacement(s) | S-L |
 | Code completion | Current document's typecheck data and currently-resolved symbol user is typing at | List of all symbols in scope that are "completable" based on where completion is invoked | S-L |
 | Editor tooltips | Current document's typecheck data and resolved symbol where user invoked a tooltip | F# tooltip data based on inspecting a type and its declarations, then pretty-printing them | S-XL |

--- a/vsintegration/src/FSharp.Editor/Common/Constants.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Constants.fs
@@ -83,7 +83,7 @@ module internal Guids =
     
     [<Literal>]
     /// "00BE7FD9-8145-4A2E-A1BF-3BAF0F4F47DD"
-    let codeLensOptionPageIdString = "00BE7FD9-8145-4A2E-A1BF-3BAF0F4F47DD"
+    let lensOptionPageIdString = "00BE7FD9-8145-4A2E-A1BF-3BAF0F4F47DD"
 
     [<Literal>]
     /// "8FDA964A-263D-4B4E-9560-29897535217C"

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -125,9 +125,9 @@
     <Compile Include="Build\SetGlobalPropertiesForSdkProjects.fs" />
     <Compile Include="AutomaticCompletion\BraceCompletionSessionProvider.fsi" />
     <Compile Include="AutomaticCompletion\BraceCompletionSessionProvider.fs" />
-    <Compile Include="CodeLens\AbstractCodeLensDisplayService.fs" />
-    <Compile Include="CodeLens\FSharpCodeLensService.fs" />
-    <Compile Include="CodeLens\CodeLensProvider.fs" />
+    <Compile Include="Lens\LensDisplayService.fs" />
+    <Compile Include="Lens\LensService.fs" />
+    <Compile Include="Lens\LensProvider.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
@@ -178,7 +178,7 @@
     <value>Advanced</value>
   </data>
   <data name="6013" xml:space="preserve">
-    <value>CodeLens</value>
+    <value>Lens</value>
   </data>
   <data name="6014" xml:space="preserve">
     <value>Formatting</value>

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -198,7 +198,7 @@ type internal FSharpSettingsFactory
 [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.CodeFixesOptionPage>, "F#", null, "Code Fixes", "6010")>]
 [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.LanguageServicePerformanceOptionPage>, "F#", null, "Performance", "6011")>]
 [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.AdvancedSettingsOptionPage>, "F#", null, "Advanced", "6012")>]
-[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.CodeLensOptionPage>, "F#", null, "CodeLens", "6013")>]
+[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.LensOptionPage>, "F#", null, "Lens", "6013")>]
 [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.FormattingOptionPage>, "F#", null, "Formatting", "6014")>]
 [<ProvideFSharpVersionRegistration(FSharpConstants.projectPackageGuidString, "Microsoft Visual F#")>]
 // 64 represents a hex number. It needs to be greater than 37 so the TextMate editor will not be chosen as higher priority.

--- a/vsintegration/src/FSharp.Editor/Lens/LensProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Lens/LensProvider.fs
@@ -17,7 +17,7 @@ open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor.Shared.Utilities
 [<Export(typeof<IViewTaggerProvider>)>]
 [<ContentType(FSharpConstants.FSharpContentTypeName)>]
 [<TextViewRole(PredefinedTextViewRoles.Document)>]
-type internal CodeLensProvider  
+type internal LensProvider  
     [<ImportingConstructor>]
     (
         [<Import(typeof<SVsServiceProvider>)>] serviceProvider: IServiceProvider,
@@ -32,32 +32,32 @@ type internal CodeLensProvider
         | true, document -> Some document
         | _ -> None
 
-    let lineLensProviders = ResizeArray()
+    let lensProviders = ResizeArray()
     let componentModel = Package.GetGlobalService(typeof<ComponentModelHost.SComponentModel>) :?> ComponentModelHost.IComponentModel
     let workspace = componentModel.GetService<VisualStudioWorkspace>()
 
-    let addLineLensProvider wpfView buffer =
+    let addLensProvider wpfView buffer =
         textDocumentFactory
         |> tryGetTextDocument buffer
         |> Option.map (fun document -> workspace.CurrentSolution.GetDocumentIdsWithFilePath(document.FilePath))
         |> Option.bind Seq.tryHead
         |> Option.map (fun documentId ->
-            let service = FSharpCodeLensService(serviceProvider, workspace, documentId, buffer, metadataAsSource, componentModel.GetService(), typeMap, CodeLensDisplayService(wpfView, buffer), settings)
+            let service = LensService(serviceProvider, workspace, documentId, buffer, metadataAsSource, componentModel.GetService(), typeMap, LensDisplayService(wpfView, buffer), settings)
             let provider = (wpfView, service)
-            wpfView.Closed.Add (fun _ -> lineLensProviders.Remove provider |> ignore)
-            lineLensProviders.Add(provider))
+            wpfView.Closed.Add (fun _ -> lensProviders.Remove provider |> ignore)
+            lensProviders.Add(provider))
 
-    [<Export(typeof<AdornmentLayerDefinition>); Name("LineLens");
+    [<Export(typeof<AdornmentLayerDefinition>); Name("Lens");
       Order(Before = PredefinedAdornmentLayers.Text);
       TextViewRole(PredefinedTextViewRoles.Document)>]
-    member val LineLensAdornmentLayerDefinition : AdornmentLayerDefinition = null with get, set
+    member val LensAdornmentLayerDefinition : AdornmentLayerDefinition = null with get, set
 
     interface IWpfTextViewCreationListener with
         override _.TextViewCreated view =
-            if settings.CodeLens.Enabled then
+            if settings.Lens.Enabled then
                 let provider = 
-                    lineLensProviders 
+                    lensProviders 
                     |> Seq.tryFind (fun (v, _) -> v = view)
 
                 if provider.IsNone then
-                    addLineLensProvider view (view.TextBuffer) |> ignore
+                    addLensProvider view (view.TextBuffer) |> ignore

--- a/vsintegration/src/FSharp.Editor/Lens/LensService.fs
+++ b/vsintegration/src/FSharp.Editor/Lens/LensService.fs
@@ -26,13 +26,13 @@ open Microsoft.VisualStudio.Text.Classification
 
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor.Shared.Utilities
 
-type internal CodeLens(taggedText, computed, funcID, uiElement) =
+type internal Lens(taggedText, computed, funcID, uiElement) =
     member val TaggedText: Async<(ResizeArray<TaggedText> * FSharpNavigation) option> = taggedText
     member val Computed: bool = computed with get, set
     member val FuncID: string = funcID
     member val UiElement: UIElement = uiElement with get, set
 
-type internal FSharpCodeLensService
+type internal LensService
     (
         serviceProvider: IServiceProvider,
         workspace: Workspace, 
@@ -41,11 +41,9 @@ type internal FSharpCodeLensService
         metadataAsSource: FSharpMetadataAsSourceService,
         classificationFormatMapService: IClassificationFormatMapService,
         typeMap: Lazy<FSharpClassificationTypeMap>,
-        codeLens : CodeLensDisplayService,
+        lensDisplayService : LensDisplayService,
         settings: EditorOptions
     ) as self =
-
-    let lineLens = codeLens
 
     let visit pos parseTree = 
         SyntaxTraversal.Traverse(pos, parseTree, { new SyntaxVisitorBase<_>() with 
@@ -72,7 +70,7 @@ type internal FSharpCodeLensService
 
     let formatMap = lazy classificationFormatMapService.GetClassificationFormatMap "tooltip"
 
-    let mutable lastResults = Dictionary<string, ITrackingSpan * CodeLens>()
+    let mutable lastResults = Dictionary<string, ITrackingSpan * Lens>()
     let mutable firstTimeChecked = false
     let mutable bufferChangedCts = new CancellationTokenSource()
     let uiContext = SynchronizationContext.Current
@@ -84,7 +82,7 @@ type internal FSharpCodeLensService
         |> typeMap.Value.GetClassificationType
         |> formatMap.Value.GetTextProperties   
 
-    let createTextBox (lens:CodeLens) =
+    let createTextBox (lens:Lens) =
         async {
             do! Async.SwitchToContext uiContext
             let! res = lens.TaggedText
@@ -96,7 +94,7 @@ type internal FSharpCodeLensService
                 let textBlock = new TextBlock(Background = Brushes.AliceBlue, Opacity = 0.0, TextTrimming = TextTrimming.None)
                 FSharpDependencyObjectExtensions.SetDefaultTextProperties(textBlock, formatMap.Value)
 
-                let prefix = Documents.Run settings.CodeLens.Prefix
+                let prefix = Documents.Run settings.Lens.Prefix
                 prefix.Foreground <- SolidColorBrush(Color.FromRgb(153uy, 153uy, 153uy))
                 textBlock.Inlines.Add prefix
 
@@ -104,7 +102,7 @@ type internal FSharpCodeLensService
 
                     let coloredProperties = layoutTagToFormatting text.Tag
                     let actualProperties =
-                        if settings.CodeLens.UseColors
+                        if settings.Lens.UseColors
                         then
                             // If color is gray (R=G=B), change to correct gray color.
                             // Otherwise, use the provided color.
@@ -141,7 +139,7 @@ type internal FSharpCodeLensService
                 return false
         }  
 
-    let executeCodeLenseAsync () =  
+    let executeLensAsync () =  
         asyncMaybe {
             do! Async.Sleep 800 |> liftAsync
 #if DEBUG
@@ -168,7 +166,7 @@ type internal FSharpCodeLensService
             let unattachedSymbols = ResizeArray()
             // Tags which are new or need to be updated due to changes.
             let tagsToUpdate = Dictionary()
-            let codeLensToAdd = ResizeArray()
+            let lensToAdd = ResizeArray()
 
             let useResults (displayContext: FSharpDisplayContext, func: FSharpMemberOrFunctionOrValue, realPosition: range) =
                 async {
@@ -190,13 +188,13 @@ type internal FSharpCodeLensService
                                 return Some (taggedText, navigation)
                             | None -> 
 #if DEBUG
-                                logWarningf "Couldn't acquire CodeLens data for function %A" func
+                                logWarningf "Couldn't acquire Lens data for function %A" func
 #endif
                                 return None
                         else return None
                     with e ->
 #if DEBUG
-                        logErrorf "Error in lazy line lens computation. %A" e
+                        logErrorf "Error in lazy lens computation. %A" e
 #else
                         ignore e
 #endif
@@ -219,8 +217,8 @@ type internal FSharpCodeLensService
                         if lastResults.ContainsKey funcID then
                             // Make sure that the results are usable
                             let inline setNewResultsAndWarnIfOverridenLocal value = setNewResultsAndWarnIfOverriden funcID value
-                            let lastTrackingSpan, codeLens as lastResult = lastResults.[funcID]
-                            if codeLens.FuncID = funcID then
+                            let lastTrackingSpan, lens as lastResult = lastResults.[funcID]
+                            if lens.FuncID = funcID then
                                 setNewResultsAndWarnIfOverridenLocal lastResult
                                 oldResults.Remove funcID |> ignore
                             else
@@ -237,7 +235,7 @@ type internal FSharpCodeLensService
                                     textSnapshot.CreateTrackingSpan(declarationSpan, SpanTrackingMode.EdgeExclusive)
                                 // Push back the new results
                                 let res =
-                                        CodeLens( Async.cache (useResults (symbolUse.DisplayContext, func, range)),
+                                        Lens( Async.cache (useResults (symbolUse.DisplayContext, func, range)),
                                             false,
                                             funcID,
                                             null)
@@ -261,23 +259,23 @@ type internal FSharpCodeLensService
                     | _ -> func.DeclarationLocation.StartLine - 1, func.DeclarationLocation
                     
                 let test (v:KeyValuePair<_, _>) =
-                    let _, (codeLens:CodeLens) = v.Value
-                    codeLens.FuncID = funcID
+                    let _, (lens:Lens) = v.Value
+                    lens.FuncID = funcID
                 match oldResults |> Seq.tryFind test with
                 | Some res ->
-                    let (trackingSpan : ITrackingSpan), (codeLens : CodeLens) = res.Value
+                    let (trackingSpan : ITrackingSpan), (lens : Lens) = res.Value
                     let declarationSpan = 
                         let line = textSnapshot.GetLineFromLineNumber declarationLine
                         let offset = line.GetText() |> Seq.findIndex (Char.IsWhiteSpace >> not)
                         SnapshotSpan(line.Start.Add offset, line.End).Span
                     let newTrackingSpan = 
                         textSnapshot.CreateTrackingSpan(declarationSpan, SpanTrackingMode.EdgeExclusive)
-                    if codeLens.Computed && (isNull codeLens.UiElement |> not) then
-                        newResults.[funcID] <- (newTrackingSpan, codeLens)
-                        tagsToUpdate.[trackingSpan] <- (newTrackingSpan, funcID, codeLens)
+                    if lens.Computed && (isNull lens.UiElement |> not) then
+                        newResults.[funcID] <- (newTrackingSpan, lens)
+                        tagsToUpdate.[trackingSpan] <- (newTrackingSpan, funcID, lens)
                     else
                         let res = 
-                            CodeLens(
+                            Lens(
                                 Async.cache (useResults (symbolUse.DisplayContext, func, range)),
                                 false,
                                 funcID,
@@ -292,7 +290,7 @@ type internal FSharpCodeLensService
                     // So create completely new results
                     // And finally add a tag for this.
                     let res = 
-                        CodeLens(
+                        Lens(
                             Async.cache (useResults (symbolUse.DisplayContext, func, range)),
                             false,
                             funcID,
@@ -304,26 +302,26 @@ type internal FSharpCodeLensService
                             SnapshotSpan(line.Start.Add offset, line.End).Span
                         let trackingSpan = 
                             textSnapshot.CreateTrackingSpan(declarationSpan, SpanTrackingMode.EdgeExclusive)
-                        codeLensToAdd.Add (trackingSpan, res)
+                        lensToAdd.Add (trackingSpan, res)
                         newResults.[funcID] <- (trackingSpan, res)
                     with e ->
 #if DEBUG
-                        logExceptionWithContext (e, "Line Lens tracking tag span creation")
+                        logExceptionWithContext (e, "Lens tracking tag span creation")
 #endif
                         ignore e
                 ()
             lastResults <- newResults
             do! Async.SwitchToContext uiContext |> liftAsync
-            let createCodeLensUIElement (codeLens:CodeLens) trackingSpan _ =
-                if codeLens.Computed |> not then
+            let createLensUIElement (lens:Lens) trackingSpan _ =
+                if lens.Computed |> not then
                     async {
-                        let! res = createTextBox codeLens
+                        let! res = createTextBox lens
                         if res then
                             do! Async.SwitchToContext uiContext
 #if DEBUG
-                            logInfof "Adding ui element for %A" (codeLens.TaggedText)
+                            logInfof "Adding ui element for %A" (lens.TaggedText)
 #endif
-                            let uiElement = codeLens.UiElement
+                            let uiElement = lens.UiElement
                             let animation = 
                                 DoubleAnimation(
                                     To = Nullable 0.8,
@@ -334,44 +332,44 @@ type internal FSharpCodeLensService
                             Storyboard.SetTarget(sb, uiElement)
                             Storyboard.SetTargetProperty(sb, PropertyPath Control.OpacityProperty)
                             sb.Children.Add animation
-                            lineLens.AddUiElementToCodeLensOnce (trackingSpan, uiElement)
-                            lineLens.RelayoutRequested.Enqueue ()
+                            lensDisplayService.AddUiElementToLensOnce (trackingSpan, uiElement)
+                            lensDisplayService.RelayoutRequested.Enqueue ()
                             sb.Begin()
                         else
 #if DEBUG
-                            logWarningf "Couldn't retrieve code lens information for %A" codeLens.FuncID
+                            logWarningf "Couldn't retrieve lens information for %A" lens.FuncID
 #endif
                             ()
                     } |> (RoslynHelpers.StartAsyncSafe CancellationToken.None) "UIElement creation"
 
             for value in tagsToUpdate do
-                let trackingSpan, (newTrackingSpan, _, codeLens) = value.Key, value.Value
-                lineLens.RemoveCodeLens trackingSpan |> ignore
-                let Grid = lineLens.AddCodeLens newTrackingSpan
-                if codeLens.Computed && (isNull codeLens.UiElement |> not) then
-                    let uiElement = codeLens.UiElement
-                    lineLens.AddUiElementToCodeLensOnce (newTrackingSpan, uiElement)
+                let trackingSpan, (newTrackingSpan, _, lens) = value.Key, value.Value
+                lensDisplayService.RemoveLens trackingSpan |> ignore
+                let Grid = lensDisplayService.AddLens newTrackingSpan
+                if lens.Computed && (isNull lens.UiElement |> not) then
+                    let uiElement = lens.UiElement
+                    lensDisplayService.AddUiElementToLensOnce (newTrackingSpan, uiElement)
                 else
                     Grid.IsVisibleChanged
                     |> Event.filter (fun eventArgs -> eventArgs.NewValue :?> bool)
-                    |> Event.add (createCodeLensUIElement codeLens newTrackingSpan)
+                    |> Event.add (createLensUIElement lens newTrackingSpan)
 
-            for value in codeLensToAdd do
-                let trackingSpan, codeLens = value
-                let Grid = lineLens.AddCodeLens trackingSpan
+            for value in lensToAdd do
+                let trackingSpan, lens = value
+                let Grid = lensDisplayService.AddLens trackingSpan
 #if DEBUG
                 logInfof "Trackingspan %A is being added." trackingSpan
 #endif
                 
                 Grid.IsVisibleChanged
                 |> Event.filter (fun eventArgs -> eventArgs.NewValue :?> bool)
-                |> Event.add (createCodeLensUIElement codeLens trackingSpan)
+                |> Event.add (createLensUIElement lens trackingSpan)
 
             for oldResult in oldResults do
                 let trackingSpan, _ = oldResult.Value
-                lineLens.RemoveCodeLens trackingSpan |> ignore
+                lensDisplayService.RemoveLens trackingSpan |> ignore
 #if DEBUG
-            logInfof "Finished updating line lens."
+            logInfof "Finished updating lens."
 #endif
             
             if not firstTimeChecked then
@@ -385,12 +383,12 @@ type internal FSharpCodeLensService
               let mutable numberOfFails = 0
               while not firstTimeChecked && numberOfFails < 10 do
                   try
-                      do! executeCodeLenseAsync()
+                      do! executeLensAsync()
                       do! Async.Sleep(1000)
                   with
                   | e ->
 #if DEBUG
-                      logErrorf "Line Lens startup failed with: %A" e
+                      logErrorf "Lens startup failed with: %A" e
 #else
                       ignore e
 #endif
@@ -402,4 +400,4 @@ type internal FSharpCodeLensService
         bufferChangedCts.Cancel() // Stop all ongoing async workflow. 
         bufferChangedCts.Dispose()
         bufferChangedCts <- new CancellationTokenSource()
-        executeCodeLenseAsync () |> Async.Ignore |> RoslynHelpers.StartAsyncSafe bufferChangedCts.Token "Buffer Changed"
+        executeLensAsync () |> Async.Ignore |> RoslynHelpers.StartAsyncSafe bufferChangedCts.Token "Buffer Changed"

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -73,7 +73,7 @@ type LanguageServicePerformanceOptions =
         EnableParallelReferenceResolution = false }
 
 [<CLIMutable>]
-type CodeLensOptions =
+type LensOptions =
   { Enabled : bool
     UseColors: bool
     Prefix : string }
@@ -112,7 +112,7 @@ type EditorOptions
         store.Register LanguageServicePerformanceOptions.Default
         store.Register AdvancedOptions.Default
         store.Register IntelliSenseOptions.Default
-        store.Register CodeLensOptions.Default
+        store.Register LensOptions.Default
         store.Register FormattingOptions.Default
 
     member _.IntelliSense : IntelliSenseOptions = store.Get()
@@ -120,7 +120,7 @@ type EditorOptions
     member _.CodeFixes : CodeFixesOptions = store.Get()
     member _.LanguageServicePerformance : LanguageServicePerformanceOptions = store.Get()
     member _.Advanced: AdvancedOptions = store.Get()
-    member _.CodeLens: CodeLensOptions = store.Get()
+    member _.Lens: LensOptions = store.Get()
     member _.Formatting : FormattingOptions = store.Get()
 
     interface Microsoft.CodeAnalysis.Host.IWorkspaceService
@@ -171,11 +171,11 @@ module internal OptionsUI =
         override this.CreateView() =
             upcast LanguageServicePerformanceOptionControl()
 
-    [<Guid(Guids.codeLensOptionPageIdString)>]
-    type internal CodeLensOptionPage() =
-        inherit AbstractOptionPage<CodeLensOptions>()
+    [<Guid(Guids.lensOptionPageIdString)>]
+    type internal LensOptionPage() =
+        inherit AbstractOptionPage<LensOptions>()
         override this.CreateView() =
-            upcast CodeLensOptionControl()
+            upcast LensOptionControl()
 
     [<Guid(Guids.advancedSettingsPageIdSring)>]
     type internal AdvancedSettingsOptionPage() =

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="6013">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
       <trans-unit id="6014">

--- a/vsintegration/src/FSharp.UIResources/LensOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/LensOptionControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Microsoft.VisualStudio.FSharp.UIResources.CodeLensOptionControl"
+﻿<UserControl x:Class="Microsoft.VisualStudio.FSharp.UIResources.LensOptionControl"
              x:ClassModifier="internal"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -17,27 +17,27 @@
     <Grid>
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel>
-                <GroupBox Header="{x:Static local:Strings.CodeLens}">
+                <GroupBox Header="{x:Static local:Strings.Lens}">
                     <StackPanel>
                         <StackPanel>
-                            <CheckBox x:Name="enableCodeLens" IsChecked="{Binding Enabled}"
-                                  Content="{x:Static local:Strings.CodeLens_Switch}"/>
+                            <CheckBox x:Name="enableLens" IsChecked="{Binding Enabled}"
+                                  Content="{x:Static local:Strings.Lens_Switch}"/>
                         </StackPanel>
                         <StackPanel Margin="15 0 0 0">
                             <CheckBox x:Name="useColors" IsChecked="{Binding UseColors}"
-                                  Content="{x:Static local:Strings.CodeLens_UseColors}"
-                                  IsEnabled="{Binding IsChecked, ElementName=enableCodeLens}"/>
+                                  Content="{x:Static local:Strings.Lens_UseColors}"
+                                  IsEnabled="{Binding IsChecked, ElementName=enableLens}"/>
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="70" />
                                 </Grid.ColumnDefinitions>
-                                <Label Grid.Column="0" Content="{x:Static local:Strings.CodeLens_Prefix}"/>
+                                <Label Grid.Column="0" Content="{x:Static local:Strings.Lens_Prefix}"/>
                                 <TextBox x:Name="prefix" Grid.Column="1"
                                      Text="{Binding Prefix, UpdateSourceTrigger=PropertyChanged}"
                                      HorizontalContentAlignment="Right"
                                      VerticalContentAlignment="Center" Margin="7,0,-116,0"
-                                     IsEnabled="{Binding IsChecked, ElementName=enableCodeLens}">
+                                     IsEnabled="{Binding IsChecked, ElementName=enableLens}">
                                 </TextBox>
                             </Grid>
                         </StackPanel>

--- a/vsintegration/src/FSharp.UIResources/LensOptionControl.xaml.cs
+++ b/vsintegration/src/FSharp.UIResources/LensOptionControl.xaml.cs
@@ -16,11 +16,11 @@ using System.Windows.Shapes;
 namespace Microsoft.VisualStudio.FSharp.UIResources
 {
     /// <summary>
-    /// Interaction logic for CodeLensOptionPage.xaml
+    /// Interaction logic for LensOptionPage.xaml
     /// </summary>
-    internal partial class CodeLensOptionControl : UserControl
+    internal partial class LensOptionControl : UserControl
     {
-        public CodeLensOptionControl()
+        public LensOptionControl()
         {
             InitializeComponent();
         }

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -88,51 +88,6 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CodeLens.
-        /// </summary>
-        public static string CodeLens {
-            get {
-                return ResourceManager.GetString("CodeLens", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Annotation prefix.
-        /// </summary>
-        public static string CodeLens_Prefix {
-            get {
-                return ResourceManager.GetString("CodeLens_Prefix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Show annotations to the right instead of above the line.
-        /// </summary>
-        public static string CodeLens_Replace_LineLens {
-            get {
-                return ResourceManager.GetString("CodeLens_Replace_LineLens", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Enable CodeLens (Experimental).
-        /// </summary>
-        public static string CodeLens_Switch {
-            get {
-                return ResourceManager.GetString("CodeLens_Switch", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Use colors in annotations.
-        /// </summary>
-        public static string CodeLens_UseColors {
-            get {
-                return ResourceManager.GetString("CodeLens_UseColors", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Completion Lists.
         /// </summary>
         public static string Completion_Lists {
@@ -264,6 +219,42 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         public static string Language_Service_Performance {
             get {
                 return ResourceManager.GetString("Language_Service_Performance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Lens.
+        /// </summary>
+        public static string Lens {
+            get {
+                return ResourceManager.GetString("Lens", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Annotation prefix.
+        /// </summary>
+        public static string Lens_Prefix {
+            get {
+                return ResourceManager.GetString("Lens_Prefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Lens (Experimental).
+        /// </summary>
+        public static string Lens_Switch {
+            get {
+                return ResourceManager.GetString("Lens_Switch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use colors in annotations.
+        /// </summary>
+        public static string Lens_UseColors {
+            get {
+                return ResourceManager.GetString("Lens_UseColors", resourceCulture);
             }
         }
         

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -120,19 +120,16 @@
   <data name="Always_place_opens_at_top_level" xml:space="preserve">
     <value>Always place open statements at the top level</value>
   </data>
-  <data name="CodeLens" xml:space="preserve">
-    <value>CodeLens</value>
+  <data name="Lens" xml:space="preserve">
+    <value>Lens</value>
   </data>
-  <data name="CodeLens_Replace_LineLens" xml:space="preserve">
-    <value>Show annotations to the right instead of above the line</value>
+  <data name="Lens_Switch" xml:space="preserve">
+    <value>Enable Lens (Experimental)</value>
   </data>
-  <data name="CodeLens_Switch" xml:space="preserve">
-    <value>Enable CodeLens (Experimental)</value>
-  </data>
-  <data name="CodeLens_Prefix" xml:space="preserve">
+  <data name="Lens_Prefix" xml:space="preserve">
     <value>Annotation prefix</value>
   </data>
-  <data name="CodeLens_UseColors" xml:space="preserve">
+  <data name="Lens_UseColors" xml:space="preserve">
     <value>Use colors in annotations</value>
   </data>
   <data name="Code_Fixes" xml:space="preserve">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Vždy umístit otevřené příkazy na nejvyšší úroveň</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Zobrazí poznámky napravo místo nad řádkem.</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Povolit funkci Lens (experimentální)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">Povolit funkci CodeLens (experimentální)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Předpona poznámky</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Použít barvy v poznámkách</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -7,27 +7,22 @@
         <target state="translated">open-Anweisungen immer an oberster Ebene platzieren</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Anmerkungen nicht oberhalb der Zeile, sondern rechts neben der Zeile anzeigen</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Lens aktivieren (experimentell)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">CodeLens aktivieren (experimentell)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Anmerkungspräfix</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Farben in Anmerkungen verwenden</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Colocar siempre las instrucciones open en el nivel superior</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Mostrar anotaciones a la derecha en lugar de encima de la línea</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Habilitar Lens (experimental)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">Habilitar CodeLens (experimental)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Prefijo de anotación</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Usar colores en anotaciones</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Placer toujours les instructions open au niveau supérieur</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Afficher les annotations à droite plutôt qu'au-dessus de la ligne</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Activer Lens (expérimental)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">Activer CodeLens (expérimental)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Préfixe d'annotation</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Utiliser des couleurs dans les annotations</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Inserisci sempre le istruzioni OPEN al primo livello</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Mostra le annotazioni a destra anziché sopra la riga</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Abilita Lens (sperimentale)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">Abilita CodeLens (sperimentale)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Prefisso annotazione</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Usa colori nelle annotazioni</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Open ステートメントを常に最上位に配置する</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">注釈を行の上ではなく右に表示する</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Lens を有効にする (試験段階)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">CodeLens を有効にする (試験段階)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">注釈のプレフィックス</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">注釈でカラーを使用する</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -7,27 +7,22 @@
         <target state="translated">항상 최상위에 open 문 배치</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">선 위가 아니라 오른쪽에 주석 표시</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Lens 사용(실험적)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">CodeLens 사용(실험적)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">주석 접두사</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">주석에서 색 사용</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Zawsze umieszczaj otwarte instrukcje na najwyższym poziomie</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Pokaż adnotacje po prawej, a nie ponad wierszem</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Włącz funkcję Lens (eksperymentalna)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">Włącz funkcję CodeLens (eksperymentalna)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Prefiks adnotacji</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Stosuj kolory w adnotacjach</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Sempre coloque as instruções abertas no nível superior</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Mostrar anotações à direita da linha, em vez de acima dela</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Habilitar Lens (Experimental)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">Habilitar CodeLens (Experimental)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Prefixo da anotação</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Usar cores em anotações</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Всегда располагайте открытые операторы на верхнем уровне</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Показать примечания справа от строки, а не над ней</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Включить Lens (экспериментальная функция)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">Включить CodeLens (экспериментальная функция)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Префикс примечания</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Использовать цветные примечания</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -7,27 +7,22 @@
         <target state="translated">Açık deyimleri her zaman en üst düzeye yerleştir</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">Ek açıklamaları satırın üstü yerine sağ tarafta göster</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">Lens’i Etkinleştir (Deneysel)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">CodeLens’i Etkinleştir (Deneysel)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">Ek açıklama ön eki</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">Ek açıklamalarda renk kullan</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -7,27 +7,22 @@
         <target state="translated">始终在顶层放置 open 语句</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">在行右侧而非上方显示批注</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">启用 Lens (试验)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">启用 CodeLens (试验)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">批注前缀</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">在批注中使用颜色</target>
         <note />

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -7,27 +7,22 @@
         <target state="translated">一律將 open 陳述式放在最上層</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens">
-        <source>CodeLens</source>
-        <target state="translated">CodeLens</target>
+      <trans-unit id="Lens">
+        <source>Lens</source>
+        <target state="translated">Lens</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Replace_LineLens">
-        <source>Show annotations to the right instead of above the line</source>
-        <target state="translated">在行的右方而非上方顯示註釋</target>
+      <trans-unit id="Lens_Switch">
+        <source>Enable Lens (Experimental)</source>
+        <target state="translated">啟用 Lens (實驗性)</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_Switch">
-        <source>Enable CodeLens (Experimental)</source>
-        <target state="translated">啟用 CodeLens (實驗性)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CodeLens_Prefix">
+      <trans-unit id="Lens_Prefix">
         <source>Annotation prefix</source>
         <target state="translated">註釋前置詞</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeLens_UseColors">
+      <trans-unit id="Lens_UseColors">
         <source>Use colors in annotations</source>
         <target state="translated">在註釋中使用色彩</target>
         <note />


### PR DESCRIPTION
The proper branding is in progress, this - again - is just about making the code clearer.