### PR TITLE
FsharpCompilerService benchmark for changes in a cascade of files referencing each other

### DIFF
--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/FSharp.Compiler.Benchmarks.fsproj
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/FSharp.Compiler.Benchmarks.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="SourceText.fs" />
     <Compile Include="DecentlySizedStandAloneFileBenchmark.fs" />
     <Compile Include="CompilerServiceBenchmarks.fs" />
+    <Compile Include="FileCascadeBenchmarks.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/FileCascadeBenchmarks.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/FileCascadeBenchmarks.fs
@@ -1,0 +1,75 @@
+﻿namespace FSharp.Compiler.Benchmarks
+
+open System
+open System.IO
+open System.Text
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Diagnostics
+open FSharp.Compiler.EditorServices
+open FSharp.Compiler.Text
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.ILBinaryReader
+open BenchmarkDotNet.Attributes
+open FSharp.Compiler.Benchmarks
+open Microsoft.CodeAnalysis.Text
+
+[<AutoOpen>]
+module private Helpers =
+        
+    let createProject files projectFilename =       
+        {
+            ProjectFileName = projectFilename
+            ProjectId = None
+            SourceFiles = files
+            OtherOptions =  [|"--optimize+" |] 
+            ReferencedProjects = [||]
+            IsIncompleteTypeCheckEnvironment = false
+            UseScriptResolutionRules = false
+            LoadTime = DateTime()
+            UnresolvedReferences = None
+            OriginalLoadReferences = []
+            Stamp = Some 0L (* set the stamp to 0L on each run so we don't evaluate the whole project again *)
+        }
+
+    let baselineModule =
+        $"""
+module Benchmark0
+let returnValue = 5
+let myFunc0 () = 5"""
+
+    let generateSourceCode number =
+        $"""
+module Benchmark%i{number}
+open Benchmark%i{number-1}
+let myFunc%i{number} () = myFunc%i{number-1}()"""
+
+[<MemoryDiagnoser>]
+type FileCascadeBenchmarks() = 
+        let mutable project : FSharpProjectOptions option = None
+
+        let filesToCreate = 100
+        
+        [<GlobalSetup>]
+        member _.Setup() =
+                match project with
+                | Some p -> p
+                | None ->
+                    let projectFolder = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(),"CascadeBenchmarkProject"))                    
+                    if(projectFolder.Exists) then
+                        do projectFolder.Delete(recursive=true)
+                    do Directory.CreateDirectory(projectFolder.FullName) |> ignore
+
+                    let inProjectFolder fileName = Path.Combine(projectFolder.FullName,fileName)
+
+                    File.WriteAllText(inProjectFolder "Benchmark0.fs",baselineModule)
+                    for i = 1 to filesToCreate do
+                        File.WriteAllText(inProjectFolder $"Benchmark%i{i}.fs", generateSourceCode i)
+
+                    let dllFileName = inProjectFolder "CascadingBenchMark.dll"
+                    let allSourceCodeFiles = [| for i in 0 .. 100 -> inProjectFolder $"Benchmark%i{i}.fs"|]
+                    let x = createProject allSourceCodeFiles dllFileName
+                    project <- Some x
+                    x
+                
+
+

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/FileCascadeBenchmarks.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/FileCascadeBenchmarks.fs
@@ -12,9 +12,11 @@ open FSharp.Compiler.AbstractIL.ILBinaryReader
 open BenchmarkDotNet.Attributes
 open FSharp.Compiler.Benchmarks
 open Microsoft.CodeAnalysis.Text
+open BenchmarkDotNet.Order
+open BenchmarkDotNet.Mathematics
 
 [<AutoOpen>]
-module private Helpers =
+module private CascadeProjectHelpers =
         
     let createProject files projectFilename =       
         {
@@ -41,35 +43,76 @@ let myFunc0 () = 5"""
         $"""
 module Benchmark%i{number}
 open Benchmark%i{number-1}
-let myFunc%i{number} () = myFunc%i{number-1}()"""
+let myFunc%i{number} () = myFunc%i{number-1}()
+//$COMMENTAREA$"""
 
 [<MemoryDiagnoser>]
+[<LongRunJob>]
+[<Orderer(SummaryOrderPolicy.FastestToSlowest)>]
+[<RankColumn(NumeralSystem.Roman)>]
 type FileCascadeBenchmarks() = 
-        let mutable project : FSharpProjectOptions option = None
+    let mutable project : FSharpProjectOptions option = None
 
-        let filesToCreate = 100
+    let getProject() = project.Value
+    
+    let checker = FSharpChecker.Create(projectCacheSize = 5, enableParallelCheckingWithSignatureFiles = true, parallelReferenceResolution = true)
+    let filesToCreate = 64
+
+    let mutable finalFileContents = SourceText.ofString ""
         
-        [<GlobalSetup>]
-        member _.Setup() =
-                match project with
-                | Some p -> p
-                | None ->
-                    let projectFolder = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(),"CascadeBenchmarkProject"))                    
-                    if(projectFolder.Exists) then
-                        do projectFolder.Delete(recursive=true)
-                    do Directory.CreateDirectory(projectFolder.FullName) |> ignore
+    [<GlobalSetup>]
+    member _.Setup() =
+        let projectFolder = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(),"CascadeBenchmarkProject"))                    
+        if(projectFolder.Exists) then
+            do projectFolder.Delete(recursive=true)
+        do Directory.CreateDirectory(projectFolder.FullName) |> ignore
 
-                    let inProjectFolder fileName = Path.Combine(projectFolder.FullName,fileName)
+        let inProjectFolder fileName = Path.Combine(projectFolder.FullName,fileName)
 
-                    File.WriteAllText(inProjectFolder "Benchmark0.fs",baselineModule)
-                    for i = 1 to filesToCreate do
-                        File.WriteAllText(inProjectFolder $"Benchmark%i{i}.fs", generateSourceCode i)
+        File.WriteAllText(inProjectFolder "Benchmark0.fs",baselineModule)
+        for i = 1 to filesToCreate do
+            File.WriteAllText(inProjectFolder $"Benchmark%i{i}.fs", generateSourceCode i)
 
-                    let dllFileName = inProjectFolder "CascadingBenchMark.dll"
-                    let allSourceCodeFiles = [| for i in 0 .. 100 -> inProjectFolder $"Benchmark%i{i}.fs"|]
-                    let x = createProject allSourceCodeFiles dllFileName
-                    project <- Some x
-                    x
-                
+        let dllFileName = inProjectFolder "CascadingBenchMark.dll"
+        let allSourceCodeFiles = [| for i in 0 .. filesToCreate -> inProjectFolder $"Benchmark%i{i}.fs"|]
+        let x = createProject allSourceCodeFiles dllFileName
+        project <- Some x
+        finalFileContents <- generateSourceCode filesToCreate |> SourceText.ofString
 
 
+    member x.ChangeFile(fileIndex:int, action) = 
+        let project = getProject()
+        let fileName = project.SourceFiles.[fileIndex]
+        let fullOriginalSource = File.ReadAllText(fileName)
+        try
+            File.WriteAllText(fileName, fullOriginalSource.Replace("$COMMENTAREA$","$FILEMODIFIED"))
+            action()
+        finally
+            File.WriteAllText(fileName,fullOriginalSource)
+
+    member x.CheckFinalFile () =
+        let project = getProject()
+        let lastFile = project.SourceFiles |> Array.last
+        checker.ParseAndCheckFileInProject(lastFile,999,finalFileContents,project)
+               
+    [<Benchmark>]
+    member x.ParseProjectAsIs() =
+        x.CheckFinalFile()
+
+    [<Benchmark(Baseline=true)>]
+    member x.ParseProjectWithFullCacheClear() =
+        checker.ClearCache([getProject()])
+        checker.InvalidateConfiguration(getProject())
+        x.CheckFinalFile()
+
+    [<Benchmark>]
+    member x.ParseProjectWithChangingFirstFile() =
+        x.ChangeFile(fileIndex=0, action= fun () -> x.CheckFinalFile())  
+
+    [<Benchmark>]
+    member x.ParseProjectWithChanging25thPercentileFile() =
+        x.ChangeFile(fileIndex=filesToCreate/4, action= fun () -> x.CheckFinalFile())  
+
+    [<Benchmark>]
+    member x.ParseProjectWithChangingMiddleFile() =
+        x.ChangeFile(fileIndex=filesToCreate/2, action= fun () -> x.CheckFinalFile())  


### PR DESCRIPTION
This benchmark suite now proves that F# is not very clever in incremental builds - any change of files invalidates the subsequent files, even if their signatures would not change.

It can be used as a basis for testing improvement via new features/ideas.

The current results are:
``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22000.1098/21H2)
11th Gen Intel Core i9-11950H 2.60GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.100-rc.2.22477.23
  [Host]  : .NET 7.0.0 (7.0.22.47203), X64 RyuJIT AVX2 DEBUG
  LongRun : .NET 7.0.0 (7.0.22.47203), X64 RyuJIT AVX2

Job=LongRun  IterationCount=100  LaunchCount=3  
WarmupCount=15  

```
|                                     Method |          Mean |        Error |        StdDev |        Median | Ratio | RatioSD | Rank |      Gen0 |      Gen1 |      Gen2 | Allocated | Alloc Ratio |
|------------------------------------------- |--------------:|-------------:|--------------:|--------------:|------:|--------:|-----:|----------:|----------:|----------:|----------:|------------:|
|                           ParseProjectAsIs |      98.19 ns |     0.723 ns |      3.766 ns |      98.70 ns | 0.001 |    0.00 |    I |    0.0223 |         - |         - |     280 B |        0.17 |
|             ParseProjectWithFullCacheClear |  89,898.93 ns |   190.661 ns |    986.896 ns |  89,727.05 ns | 1.000 |    0.00 |   II | 1000.0000 | 1000.0000 | 1000.0000 |    1664 B |        1.00 |
|          ParseProjectWithChangingFirstFile | 531,555.27 ns | 2,579.920 ns | 13,145.366 ns | 531,244.04 ns | 5.914 |    0.16 |  III |         - |         - |         - |    8600 B |        5.17 |
|         ParseProjectWithChangingMiddleFile | 544,790.07 ns | 7,099.963 ns | 36,750.697 ns | 553,684.03 ns | 6.061 |    0.41 |   IV |         - |         - |         - |    8896 B |        5.35 |
| ParseProjectWithChanging25thPercentileFile | 553,487.15 ns | 7,892.799 ns | 40,713.491 ns | 551,352.78 ns | 6.158 |    0.46 |   IV |         - |         - |         - |    8896 B |        5.35 |
