### PR TITLE
[WIP] Benchmark for background compiler using synthetic project

### DIFF
--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/BackgroundCompilerBenchmarks.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/BackgroundCompilerBenchmarks.fs
@@ -1,0 +1,242 @@
+﻿module FSharp.Benchmarks.BackgroundCompilerBenchmarks
+
+open System
+open System.IO
+open BenchmarkDotNet.Attributes
+open FSharp.Compiler.Text
+
+let projectRoot = __SOURCE_DIRECTORY__
+
+
+type SyntheticSourceFile = {
+    Id: string
+    PublicVersion: int
+    InternalVersion: int
+    PublicUnusedVersion: int
+    DependsOn: string list
+    EntryPoint: bool
+} with
+    member this.FileName = $"File{this.Id}.fs"
+
+let sourceFile id deps = {
+    Id = id
+    PublicVersion = 1
+    InternalVersion = 1
+    PublicUnusedVersion = 1
+    DependsOn = deps
+    EntryPoint = false
+}
+
+type SyntheticProject = {
+    Name: string
+    SourceFiles: SyntheticSourceFile list
+} with
+    member this.Find id = this.SourceFiles |> List.find (fun f -> f.Id = id)
+
+let somethingToCompile = File.ReadAllText (projectRoot ++ "SomethingToCompile.fs")
+
+let renderSourceFile projectName (f: SyntheticSourceFile) =
+    seq {
+        $"module %s{projectName}.Module{f.Id}"
+
+        $"type T{f.Id}v{f.PublicVersion}<'a> = T{f.Id} of 'a"
+
+        "let f x ="
+        for dep in f.DependsOn do
+            $"    Module{dep}.f x,"
+        $"    T{f.Id} x"
+
+        $"let NobodyUsesThis_v{f.PublicUnusedVersion} = ()"
+
+        $"let private PrivateFunc_v{f.InternalVersion} = ()"
+
+        somethingToCompile
+
+        if f.EntryPoint then
+            "[<EntryPoint>]"
+            "let main _ ="
+            "   f 1 |> ignore"
+            "   printfn \"Hello World!\""
+            "   0"
+    }
+    |> String.concat Environment.NewLine
+
+let renderFsProj (p: SyntheticProject) =
+    seq {
+        """
+        <Project Sdk="Microsoft.NET.Sdk">
+
+        <PropertyGroup>
+            <OutputType>Exe</OutputType>
+            <TargetFramework>net7.0</TargetFramework>
+        </PropertyGroup>
+        """
+
+        "<ItemGroup>"
+
+        for f in p.SourceFiles do
+            $"<Compile Include=\"{f.FileName}\" />"
+
+        "</ItemGroup>"
+
+        "</Project>"
+    }
+    |> String.concat Environment.NewLine
+
+let writeFileIfChanged path content =
+    if not (File.Exists path) || File.ReadAllText(path) <> content then
+        File.WriteAllText(path, content)
+
+let saveFile projectDir (p: SyntheticProject) (f: SyntheticSourceFile) =
+    let fileName = projectDir ++ f.FileName
+    let content = renderSourceFile p.Name f
+    writeFileIfChanged fileName content
+
+let writeProject dir (p: SyntheticProject) =
+    let projectDir = dir ++ p.Name
+    Directory.CreateDirectory(projectDir) |> ignore
+    for f in p.SourceFiles do
+        saveFile projectDir p f
+    writeFileIfChanged (projectDir ++ $"{p.Name}.fsproj") (renderFsProj p)
+
+let createProject name size =
+    {
+        Name = name
+        SourceFiles = [
+            sourceFile "First" []
+            sourceFile "1" [ "First" ]
+            for n in 2..(size / 2) do
+                sourceFile $"{n}" [ "First"; $"{n-1}" ]
+            sourceFile "Middle" [ $"{size / 4}" ]
+            for n in ((size / 2) + 1)..size do
+                sourceFile $"{n}" [ "First"; "Middle" ]
+            { sourceFile "Last" [ for n in (size / 2)..size -> $"{n}" ] with EntryPoint = true }
+        ]
+    }
+
+let updateFile id f project =
+    let index = project.SourceFiles |> List.findIndex (fun f -> f.Id = id)
+    { project with SourceFiles = project.SourceFiles |> List.updateAt index (f project.SourceFiles[index]) }
+
+let counter = (Seq.initInfinite id).GetEnumerator()
+
+let updatePublicSurface f =
+    counter.MoveNext() |> ignore
+    { f with PublicVersion = counter.Current }
+
+let updateUnused f =
+    counter.MoveNext() |> ignore
+    { f with PublicUnusedVersion = counter.Current }
+
+let updateInternal f =
+    counter.MoveNext() |> ignore
+    { f with InternalVersion = counter.Current }
+
+
+[<MemoryDiagnoser>]
+[<BenchmarkCategory(FSharpCategory)>]
+type BackgroundCompilerBenchmarks () =
+
+    let size = 20
+
+    let initialProjectModel = createProject "SyntheticProject" size
+    let projDir = projectRoot ++ initialProjectModel.Name
+    do if Directory.Exists projDir then DirectoryInfo(projDir).Delete(true)
+
+    do initialProjectModel |> writeProject projectRoot
+
+    let projectDir, projectOptions, checker = prepareProject initialProjectModel.Name |> parseAndTypeCheckProject
+
+    let checkFile fileId (project: SyntheticProject) =
+        let file = project.Find fileId
+        let contents = renderSourceFile project.Name file
+        let absFileName = projectDir ++ file.FileName
+        checker.ParseAndCheckFileInProject(absFileName, 0, SourceText.ofString contents, projectOptions)
+        |> Async.RunSynchronously
+        |> validateCheckResult
+        |> ignore
+        project
+
+    let editFile fileId f = updateFile fileId f >> checkFile fileId
+
+    let save fileId (project: SyntheticProject) =
+        let f = project.Find fileId
+        saveFile projectDir project f
+        project
+
+    let editAndSave fileId f = editFile fileId f >> save fileId
+
+    [<IterationSetup(Targets = [| "EditFirstFile_CheckLastFile"; "EditFirstFile_CheckMiddleFile" |])>]
+    member _.EditFirstFile() =
+        initialProjectModel
+        |> updateFile "First" updatePublicSurface
+        |> writeProject projectRoot
+
+    [<Benchmark>]
+    member _.EditFirstFile_CheckLastFile() =
+        initialProjectModel |> checkFile "Last"
+
+    [<Benchmark>]
+    member _.EditFirstFile_CheckMiddleFile() =
+        initialProjectModel |> checkFile "Middle"
+
+    [<IterationSetup(Targets = [| "EditFirstFile_OnlyInternalChange_CheckLastFile" |])>]
+    member _.EditFirstFile_OnlyInternalChange() =
+        initialProjectModel
+        |> updateFile "First" updateInternal
+        |> writeProject projectRoot
+
+    [<Benchmark>]
+    member _.EditFirstFile_OnlyInternalChange_CheckLastFile() =
+        initialProjectModel |> checkFile "Last"
+
+    [<IterationSetup(Targets = [| "EditFirstFile_ChangeUnusedFunction_CheckLastFile" |])>]
+    member _.EditFirstFile_ChangeUnusedFunction() =
+        initialProjectModel
+        |> updateFile "First" updateUnused
+        |> writeProject projectRoot
+
+    [<Benchmark>]
+    member _.EditFirstFile_ChangeUnusedFunction_CheckLastFile() =
+        initialProjectModel |> checkFile "Last"
+
+    [<IterationSetup(Targets = [| "EditMiddleFile_CheckMiddleFile"
+                                  "EditMiddleFile_CheckLastFile"
+                                  "EditMiddleFile_CheckSecondToLastFile" |])>]
+    member _.EditMiddleFile() =
+        initialProjectModel
+        |> updateFile "Middle" updatePublicSurface
+        |> writeProject projectRoot
+
+    [<Benchmark>]
+    member _.EditMiddleFile_CheckMiddleFile() =
+        initialProjectModel |> checkFile "Middle"
+
+    [<Benchmark>]
+    member _.EditMiddleFile_CheckLastFile() =
+        initialProjectModel |> checkFile "Last"
+
+    [<Benchmark>]
+    // The checked file depends only on first and middle file, not on the ones in between
+    member _.EditMiddleFile_CheckSecondToLastFile() =
+        initialProjectModel |> checkFile $"{size}"
+
+    [<Benchmark>]
+    member _.EditCycle_WithoutSaving() =
+        initialProjectModel
+        |> editFile "First" updatePublicSurface
+        |> editFile "Middle" updatePublicSurface
+        |> editFile "Last" updatePublicSurface
+        |> editFile "First" updateInternal
+        |> editFile "Middle" updateInternal
+        |> editFile "Last" updateInternal
+
+    [<Benchmark>]
+    member _.EditCycle_WithSaving() =
+        initialProjectModel
+        |> editAndSave "First" updatePublicSurface
+        |> editAndSave "Middle" updatePublicSurface
+        |> editAndSave "Last" updatePublicSurface
+        |> editAndSave "First" updateInternal
+        |> editAndSave "Middle" updateInternal
+        |> editAndSave "Last" updateInternal

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/FSharp.Compiler.Benchmarks.fsproj
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/FSharp.Compiler.Benchmarks.fsproj
@@ -14,10 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Utils.fs" />
     <Compile Include="SourceText.fs" />
     <Compile Include="DecentlySizedStandAloneFileBenchmark.fs" />
     <Compile Include="CompilerServiceBenchmarks.fs" />
     <Compile Include="FileCascadeBenchmarks.fs" />
+    <Compile Include="BackgroundCompilerBenchmarks.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/SomethingToCompile.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/SomethingToCompile.fs
@@ -1,0 +1,251 @@
+
+let SomethingToCompile f =
+
+    let inline map
+        (mapper: 'okInput -> 'okOutput)
+        (input: Result<'okInput, 'error>)
+        =
+        match input with
+        | Ok x -> Ok(f (mapper x))
+        | Error e -> Error e
+
+    let inline mapError
+        (errorMapper: 'errorInput -> 'errorOutput)
+        (input: Result<'ok, 'errorInput>)
+        : Result<'ok, 'errorOutput> =
+        match input with
+        | Ok x -> Ok x
+        | Error e -> Error(errorMapper e)
+
+    let inline bind
+        (binder: 'okInput -> Result<'okOutput, 'error>)
+        (input: Result<'okInput, 'error>)
+        : Result<'okOutput, 'error> =
+        match input with
+        | Ok x -> binder x
+        | Error e -> Error e
+
+    let inline isOk (value: Result<'ok, 'error>) : bool =
+        match value with
+        | Ok _ -> true
+        | Error _ -> false
+
+    let inline isError (value: Result<'ok, 'error>) : bool =
+        match value with
+        | Ok _ -> false
+        | Error _ -> true
+
+    let inline either
+        (onOk: 'okInput -> 'output)
+        (onError: 'errorInput -> 'output)
+        (input: Result<'okInput, 'errorInput>)
+        : 'output =
+        match input with
+        | Ok x -> onOk x
+        | Error err -> onError err
+
+    let inline eitherMap
+        (onOk: 'okInput -> 'okOutput)
+        (onError: 'errorInput -> 'errorOutput)
+        (input: Result<'okInput, 'errorInput>)
+        : Result<'okOutput, 'errorOutput> =
+        match input with
+        | Ok x -> Ok(onOk x)
+        | Error err -> Error(onError err)
+
+    let inline apply
+        (applier: Result<'okInput -> 'okOutput, 'error>)
+        (input: Result<'okInput, 'error>)
+        : Result<'okOutput, 'error> =
+        match (applier, input) with
+        | Ok f, Ok x -> Ok(f x)
+        | Error e, _
+        | _, Error e -> Error e
+
+    let inline map2
+        (mapper: 'okInput1 -> 'okInput2 -> 'okOutput)
+        (input1: Result<'okInput1, 'error>)
+        (input2: Result<'okInput2, 'error>)
+        : Result<'okOutput, 'error> =
+        match (input1, input2) with
+        | Ok x, Ok y -> Ok(mapper x y)
+        | Error e, _
+        | _, Error e -> Error e
+
+
+    let inline map3
+        (mapper: 'okInput1 -> 'okInput2 -> 'okInput3 -> 'okOutput)
+        (input1: Result<'okInput1, 'error>)
+        (input2: Result<'okInput2, 'error>)
+        (input3: Result<'okInput3, 'error>)
+        : Result<'okOutput, 'error> =
+        match (input1, input2, input3) with
+        | Ok x, Ok y, Ok z -> Ok(mapper x y z)
+        | Error e, _, _
+        | _, Error e, _
+        | _, _, Error e -> Error e
+
+    let inline fold
+        (onOk: 'okInput -> 'output)
+        (onError: 'errorInput -> 'output)
+        (input: Result<'okInput, 'errorInput>)
+        : 'output =
+        match input with
+        | Ok x -> onOk x
+        | Error err -> onError err
+
+    let inline ofChoice (input: Choice<'ok, 'error>) : Result<'ok, 'error> =
+        match input with
+        | Choice1Of2 x -> Ok x
+        | Choice2Of2 e -> Error e
+
+    let inline tryCreate (fieldName: string) (x: 'a) : Result< ^b, (string * 'c) > =
+        let tryCreate' x =
+            (^b: (static member TryCreate: 'a -> Result< ^b, 'c >) x)
+
+        tryCreate' x |> mapError (fun z -> (fieldName, z))
+
+
+    let inline orElse (ifError: Result<'ok, 'errorOutput>) (result: Result<'ok, 'error>) : Result<'ok, 'errorOutput> =
+        match result with
+        | Ok x -> Ok x
+        | Error e -> ifError
+
+
+    let inline orElseWith
+        (ifErrorFunc: 'error -> Result<'ok, 'errorOutput>)
+        (result: Result<'ok, 'error>)
+        : Result<'ok, 'errorOutput> =
+        match result with
+        | Ok x -> Ok x
+        | Error e -> ifErrorFunc e
+
+    let inline ignore (result: Result<'ok, 'error>) : Result<unit, 'error> =
+        match result with
+        | Ok _ -> Ok()
+        | Error e -> Error e
+
+    let inline requireTrue (error: 'error) (value: bool) : Result<unit, 'error> = if value then Ok() else Error error
+
+    let inline requireFalse (error: 'error) (value: bool) : Result<unit, 'error> =
+        if not value then Ok() else Error error
+
+    let inline requireSome (error: 'error) (option: 'ok option) : Result<'ok, 'error> =
+        match option with
+        | Some x -> Ok x
+        | None -> Error error
+
+    let inline requireNone (error: 'error) (option: 'value option) : Result<unit, 'error> =
+        match option with
+        | Some _ -> Error error
+        | None -> Ok()
+
+    let inline requireNotNull (error: 'error) (value: 'ok) : Result<'ok, 'error> =
+        match value with
+        | null -> Error error
+        | nonnull -> Ok nonnull
+
+    let inline requireEqualTo (other: 'value) (error: 'error) (this: 'value) : Result<unit, 'error> =
+        if this = other then
+            Ok()
+        else
+            Error error
+
+    let inline requireEqual (x1: 'value) (x2: 'value) (error: 'error) : Result<unit, 'error> =
+        if x1 = x2 then Ok() else Error error
+
+    let inline requireEmpty (error: 'error) (xs: #seq<'value>) : Result<unit, 'error> =
+        if Seq.isEmpty xs then
+            Ok()
+        else
+            Error error
+
+    let inline requireNotEmpty (error: 'error) (xs: #seq<'value>) : Result<unit, 'error> =
+        if Seq.isEmpty xs then
+            Error error
+        else
+            Ok()
+
+    let inline requireHead (error: 'error) (xs: #seq<'ok>) : Result<'ok, 'error> =
+        match Seq.tryHead xs with
+        | Some x -> Ok x
+        | None -> Error error
+
+    let inline setError (error: 'error) (result: Result<'ok, 'errorIgnored>) : Result<'ok, 'error> =
+        result |> mapError (fun _ -> error)
+
+    let inline withError (error: 'error) (result: Result<'ok, unit>) : Result<'ok, 'error> =
+        result |> mapError (fun () -> error)
+
+    let inline defaultValue (ifError: 'ok) (result: Result<'ok, 'error>) : 'ok =
+        match result with
+        | Ok x -> x
+        | Error _ -> ifError
+
+    let inline defaultError (ifOk: 'error) (result: Result<'ok, 'error>) : 'error =
+        match result with
+        | Error error -> error
+        | Ok _ -> ifOk
+
+    let inline defaultWith (ifErrorThunk: unit -> 'ok) (result: Result<'ok, 'error>) : 'ok =
+        match result with
+        | Ok x -> x
+        | Error _ -> ifErrorThunk ()
+
+    let inline ignoreError (result: Result<unit, 'error>) : unit = defaultValue () result
+
+    let inline teeIf
+        (predicate: 'ok -> bool)
+        (inspector: 'ok -> unit)
+        (result: Result<'ok, 'error>)
+        : Result<'ok, 'error> =
+        match result with
+        | Ok x -> if predicate x then inspector x
+        | Error _ -> ()
+
+        result
+
+    let inline teeErrorIf
+        (predicate: 'error -> bool)
+        (inspector: 'error -> unit)
+        (result: Result<'ok, 'error>)
+        : Result<'ok, 'error> =
+        match result with
+        | Ok _ -> ()
+        | Error x -> if predicate x then inspector x
+
+        result
+
+    let inline tee (inspector: 'ok -> unit) (result: Result<'ok, 'error>) : Result<'ok, 'error> =
+        teeIf (fun _ -> true) inspector result
+
+    let inline teeError
+        (inspector: 'error -> unit)
+        (result: Result<'ok, 'error>)
+        : Result<'ok, 'error> =
+        teeErrorIf (fun _ -> true) inspector result
+
+    let inline valueOr (f: 'error -> 'ok) (res: Result<'ok, 'error>) : 'ok =
+        match res with
+        | Ok x -> x
+        | Error x -> f x
+
+    let zip (left: Result<'leftOk, 'error>) (right: Result<'rightOk, 'error>) : Result<'leftOk * 'rightOk, 'error> =
+        match left, right with
+        | Ok x1res, Ok x2res -> Ok(x1res, x2res)
+        | Error e, _ -> Error e
+        | _, Error e -> Error e
+
+    let zipError
+        (left: Result<'ok, 'leftError>)
+        (right: Result<'ok, 'rightError>)
+        : Result<'ok, 'leftError * 'rightError> =
+        match left, right with
+        | Error x1res, Error x2res -> Error(x1res, x2res)
+        | Ok e, _ -> Ok e
+        | _, Ok e -> Ok e
+
+    map id
+
+let whatever x = SomethingToCompile f x
+

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/Utils.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/Utils.fs
@@ -1,0 +1,71 @@
+﻿[<AutoOpen>]
+module FSharp.Benchmarks.Utils
+
+open System.IO
+open System.Xml
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Diagnostics
+open FSharp.Compiler.Text
+
+
+[<Literal>]
+let FSharpCategory = "fsharp"
+
+let (++) a b = Path.Combine(a, b)
+
+let prepareProject projectDirName =
+    let projectDir = __SOURCE_DIRECTORY__ ++ projectDirName
+
+    let projectFile =
+        projectDir
+        |> Directory.GetFiles
+        |> Seq.filter (fun f -> f.EndsWith ".fsproj")
+        |> Seq.toList
+        |> function
+            | [] -> failwith $"No .fsproj file found in {projectDir}"
+            | [x] -> x
+            | files -> failwith $"Multiple .fsproj files found in {projectDir}: {files}"
+
+    let fsproj = XmlDocument()
+    do fsproj.Load projectFile
+
+    let sourceFiles = [|for node in fsproj.DocumentElement.SelectNodes("//Compile") -> projectDir ++ node.Attributes["Include"].InnerText|]
+
+    let checker = FSharpChecker.Create(projectCacheSize=300)
+
+    let projectOptions, _diagnostics =
+        checker.GetProjectOptionsFromScript("file.fs", SourceText.ofString "", assumeDotNetFramework=false)
+        |> Async.RunSynchronously
+
+    let projectOptions =
+        { projectOptions with
+            OtherOptions = [|
+                yield! projectOptions.OtherOptions
+                "--optimize+"
+                "--target:library"
+            |]
+            UseScriptResolutionRules = false
+            ProjectFileName = projectFile
+            SourceFiles = sourceFiles }
+
+    projectDir, projectOptions, checker
+
+let parseAndTypeCheckProject (projectDir, projectOptions, checker: FSharpChecker)  =
+
+    let result = checker.ParseAndCheckProject(projectOptions) |> Async.RunSynchronously
+
+    match result.Diagnostics |> Seq.where (fun d -> d.Severity = FSharpDiagnosticSeverity.Error) |> Seq.toList with
+    | [] -> projectDir, projectOptions, checker
+    | errors ->
+        let errors = errors |> Seq.map (sprintf "%A") |> String.concat "\n"
+        failwith $"Type checking failed {errors}"
+
+let validateCheckResult (_parseResult, checkResult) =
+    match checkResult with
+    | FSharpCheckFileAnswer.Succeeded checkFileResults ->
+        match checkFileResults.Diagnostics |> Seq.where (fun d -> d.Severity = FSharpDiagnosticSeverity.Error) |> Seq.toList with
+        | [] -> checkFileResults
+        | errors ->
+            let errors = errors |> Seq.map (sprintf "%A") |> String.concat "\n"
+            failwith $"Type checking failed {errors}"
+    | FSharpCheckFileAnswer.Aborted -> failwith "Type checking aborted"


### PR DESCRIPTION
I'm trying to create benchmarks for a long running background compiler / `FSharpChecker` to be able to better validate changes such as https://github.com/dotnet/fsharp/pull/14076

The idea is to have some model for a project with different dependencies of files and measure how long it takes to type check after making changes to different files. Also when we just make changes in an editor vs saving the changed file to disk. 

It also covers changes to public APIs / signatures of files vs. changes to internals. 

The `SomethingToCompile` file is some code that should give the compiler a bit of work to do in each file when it re-checks it. Probably not the best example but that can be improved later. 