### PR TITLE
Fix build for sbom generation.

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -497,7 +497,10 @@ try {
     }
 
     if ($pack) {
+        $properties_storage = $properties
+        $properties += "/p:GenerateSbom=false"
         BuildSolution "Microsoft.FSharp.Compiler.sln"
+        $properties = $properties_storage
     }
     if ($build) {
         VerifyAssemblyVersionsAndSymbols


### PR DESCRIPTION
It appears that we  have been building vsix' twice.

So in order to ensure we are not so wasteful, and to ensure that the arcade team are not struggling with our wasteful build.  I have made it a tad more efficient.

O.K - so the above is rubbish:
- the real issue is that the build of ````Microsoft.FSharp.Compiler.sln```` is essential, and it needs separating from visualfsharp.sln somewhat, because of how and what we insert into the SDK.

The issue is that when arcade is building sbom's for the insertion phase (sbom means secure bill of materials) it generates them for each solution build, it performs.  Unfortunately it will have already done this for ````VisualFSharp.sln````, and so when it repeats this for ````Microsoft.FSharp.Compiler.sln```` this fails because it has already added the sbom's created by the previous solution.  The way the sbom tool works is to add a list of files generated by scanning the intermediate output directory for vsix'.

The fix presented here disables sbom generation when building ````Microsoft.FSharp.Compiler.sln````.  This is okay because ````Microsoft.FSharp.Compiler.sln```` will never generate a vsix for insertion into VS.
