### PR TITLE
TypeDefn and NamespaceOrModule leading trivia

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -4558,7 +4558,7 @@ and TcSignatureElementsMutRec cenv parent typeNames m mutRecNSInfo envInitial (d
                 | SynModuleSigDecl.Exception (exnSig=SynExceptionSig(exnRepr=exnRepr; withKeyword=withKeyword; members=members)) ->
                       let ( SynExceptionDefnRepr(synAttrs, SynUnionCase(ident=SynIdent(id,_)), _, xmlDoc, vis, m)) = exnRepr
                       let compInfo = SynComponentInfo(synAttrs, None, [], [id], xmlDoc, false, vis, id.idRange)
-                      let decls = [ MutRecShape.Tycon(SynTypeDefnSig.SynTypeDefnSig(compInfo, SynTypeDefnSigRepr.Exception exnRepr, members, m, { TypeKeyword = None; WithKeyword = withKeyword; EqualsRange = None })) ]
+                      let decls = [ MutRecShape.Tycon(SynTypeDefnSig.SynTypeDefnSig(compInfo, SynTypeDefnSigRepr.Exception exnRepr, members, m, { LeadingKeyword = SynTypeDefnLeadingKeyword.Synthetic; WithKeyword = withKeyword; EqualsRange = None })) ]
                       decls, (false, false)
 
                 | SynModuleSigDecl.Val (vspec, _) -> 

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -148,8 +148,7 @@ let PostParseModuleImpl (_i, defaultNamespace, isLastCompiland, fileName, impl) 
 
         let trivia: SynModuleOrNamespaceTrivia =
             {
-                ModuleKeyword = None
-                NamespaceKeyword = None
+                LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.None
             }
 
         SynModuleOrNamespace(modname, false, SynModuleOrNamespaceKind.AnonModule, defs, PreXmlDoc.Empty, [], None, m, trivia)
@@ -194,8 +193,7 @@ let PostParseModuleSpec (_i, defaultNamespace, isLastCompiland, fileName, intf) 
 
         let trivia: SynModuleOrNamespaceSigTrivia =
             {
-                ModuleKeyword = None
-                NamespaceKeyword = None
+                LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.None
             }
 
         SynModuleOrNamespaceSig(modname, false, SynModuleOrNamespaceKind.AnonModule, defs, PreXmlDoc.Empty, [], None, m, trivia)

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -1847,7 +1847,7 @@ type internal FsiDynamicCompiler(
         let m = match defs with [] -> rangeStdin0 | _ -> List.reduce unionRanges [for d in defs -> d.Range] 
         let prefix = mkFragmentPath m i
         let prefixPath = pathOfLid prefix
-        let impl = SynModuleOrNamespace(prefix,false, SynModuleOrNamespaceKind.NamedModule,defs,PreXmlDoc.Empty,[],None,m, { ModuleKeyword = None; NamespaceKeyword = None })
+        let impl = SynModuleOrNamespace(prefix,false, SynModuleOrNamespaceKind.NamedModule,defs,PreXmlDoc.Empty,[],None,m, { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.None })
         let isLastCompiland = true
         let isExe = false
         let input = ParsedInput.ImplFile (ParsedImplFileInput (fileName,true, ComputeQualifiedNameOfFileFromUniquePath (m,prefixPath),[],[],[impl],(isLastCompiland, isExe), { ConditionalDirectives = []; CodeComments = [] }))

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -125,17 +125,24 @@ type SynPatOrTrivia = { BarRange: range }
 [<NoEquality; NoComparison>]
 type SynPatListConsTrivia = { ColonColonRange: range }
 
+[<NoEquality; NoComparison; RequireQualifiedAccess>]
+type SynTypeDefnLeadingKeyword =
+    | Type of range
+    | And of range
+    | StaticType of staticRange: range * typeRange: range
+    | Synthetic
+
 [<NoEquality; NoComparison>]
 type SynTypeDefnTrivia =
     {
-        TypeKeyword: range option
+        LeadingKeyword: SynTypeDefnLeadingKeyword
         EqualsRange: range option
         WithKeyword: range option
     }
 
     static member Zero: SynTypeDefnTrivia =
         {
-            TypeKeyword = None
+            LeadingKeyword = SynTypeDefnLeadingKeyword.Synthetic
             EqualsRange = None
             WithKeyword = None
         }
@@ -143,14 +150,14 @@ type SynTypeDefnTrivia =
 [<NoEquality; NoComparison>]
 type SynTypeDefnSigTrivia =
     {
-        TypeKeyword: range option
+        LeadingKeyword: SynTypeDefnLeadingKeyword
         EqualsRange: range option
         WithKeyword: range option
     }
 
     static member Zero: SynTypeDefnSigTrivia =
         {
-            TypeKeyword = None
+            LeadingKeyword = SynTypeDefnLeadingKeyword.Synthetic
             EqualsRange = None
             WithKeyword = None
         }

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -266,18 +266,22 @@ type SynModuleSigDeclNestedModuleTrivia =
             EqualsRange = None
         }
 
+[<NoEquality; NoComparison; RequireQualifiedAccess>]
+type SynModuleOrNamespaceLeadingKeyword =
+    | Module of moduleRange: range
+    | Namespace of namespaceRange: range
+    | None
+
 [<NoEquality; NoComparison>]
 type SynModuleOrNamespaceTrivia =
     {
-        ModuleKeyword: range option
-        NamespaceKeyword: range option
+        LeadingKeyword: SynModuleOrNamespaceLeadingKeyword
     }
 
 [<NoEquality; NoComparison>]
 type SynModuleOrNamespaceSigTrivia =
     {
-        ModuleKeyword: range option
-        NamespaceKeyword: range option
+        LeadingKeyword: SynModuleOrNamespaceLeadingKeyword
     }
 
 [<NoEquality; NoComparison>]

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -330,26 +330,27 @@ type SynModuleSigDeclNestedModuleTrivia =
 
     static member Zero: SynModuleSigDeclNestedModuleTrivia
 
+/// Represents the leading keyword in a SynModuleOrNamespace or SynModuleOrNamespaceSig
+[<NoEquality; NoComparison; RequireQualifiedAccess>]
+type SynModuleOrNamespaceLeadingKeyword =
+    | Module of moduleRange: range
+    | Namespace of namespaceRange: range
+    | None
+
 /// Represents additional information for SynModuleOrNamespace
 [<NoEquality; NoComparison>]
 type SynModuleOrNamespaceTrivia =
     {
-        /// The syntax range of the `module` keyword
-        ModuleKeyword: range option
-
-        /// The syntax range of the `namespace` keyword
-        NamespaceKeyword: range option
+        /// The syntax range of the `module` or `namespace` keyword
+        LeadingKeyword: SynModuleOrNamespaceLeadingKeyword
     }
 
 /// Represents additional information for SynModuleOrNamespaceSig
 [<NoEquality; NoComparison>]
 type SynModuleOrNamespaceSigTrivia =
     {
-        /// The syntax range of the `module` keyword
-        ModuleKeyword: range option
-
-        /// The syntax range of the `namespace` keyword
-        NamespaceKeyword: range option
+        /// The syntax range of the `module` or `namespace` keyword
+        LeadingKeyword: SynModuleOrNamespaceLeadingKeyword
     }
 
 /// Represents additional information for SynValSig

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -207,12 +207,21 @@ type SynPatListConsTrivia =
         ColonColonRange: range
     }
 
+/// Represents the leading keyword in a SynTypeDefn or SynTypeDefnSig
+[<NoEquality; NoComparison; RequireQualifiedAccess>]
+type SynTypeDefnLeadingKeyword =
+    | Type of range
+    | And of range
+    // Can happen in SynMemberDefn.NestedType or SynMemberSig.NestedType
+    | StaticType of staticRange: range * typeRange: range
+    | Synthetic
+
 /// Represents additional information for SynTypeDefn
 [<NoEquality; NoComparison>]
 type SynTypeDefnTrivia =
     {
-        /// The syntax range of the `type` keyword.
-        TypeKeyword: range option
+        /// The syntax range of the `type` or `and` keyword.
+        LeadingKeyword: SynTypeDefnLeadingKeyword
 
         /// The syntax range of the `=` token.
         EqualsRange: range option
@@ -227,8 +236,8 @@ type SynTypeDefnTrivia =
 [<NoEquality; NoComparison>]
 type SynTypeDefnSigTrivia =
     {
-        /// The syntax range of the `type` keyword.
-        TypeKeyword: range option
+        /// The syntax range of the `type` or `and` keyword.
+        LeadingKeyword: SynTypeDefnLeadingKeyword
 
         /// The syntax range of the `=` token.
         EqualsRange: range option

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -664,7 +664,8 @@ moduleSpfn:
 
   | opt_attributes opt_access typeKeyword tyconSpfn tyconSpfnList
       { if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
-        let (SynTypeDefnSig (SynComponentInfo (cas, a, cs, b, _xmlDoc, d, d2, d3), typeRepr, members, range, trivia)) = $4
+        let leadingKeyword = SynTypeDefnLeadingKeyword.Type (rhs parseState 3)
+        let (SynTypeDefnSig (SynComponentInfo (cas, a, cs, b, _xmlDoc, d, d2, d3), typeRepr, members, range, trivia)) = $4 leadingKeyword
         _xmlDoc.MarkAsInvalid()
         let attrs = $1 @ cas
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
@@ -672,7 +673,6 @@ moduleSpfn:
             (d3, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             |> unionRanges range
             |> unionRangeWithXmlDoc xmlDoc
-        let trivia = { trivia with TypeKeyword = Some (rhs parseState 3) }
         let tc = (SynTypeDefnSig(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), typeRepr, members, mDefn, trivia))
         let m = (mDefn, $5) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range) |> unionRanges (rhs parseState 3)
         SynModuleSigDecl.Types (tc :: $5, m) }
@@ -741,10 +741,11 @@ tyconSpfnList:
   | AND tyconSpfn tyconSpfnList
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        let tyconSpfn =
-           let (SynTypeDefnSig(componentInfo, typeRepr, members, range, trivia)) = $2
+           let leadingKeyword = SynTypeDefnLeadingKeyword.And(rhs parseState 1)
+           let (SynTypeDefnSig(componentInfo, typeRepr, members, range, trivia) as typeDefnSig) = $2 leadingKeyword
            let (SynComponentInfo(a, typars, c, lid, _xmlDoc, fixity, vis, mLongId)) = componentInfo
            if xmlDoc.IsEmpty then
-               if _xmlDoc.IsEmpty then $2 else
+               if _xmlDoc.IsEmpty then typeDefnSig else
                let range = unionRangeWithXmlDoc _xmlDoc range
                SynTypeDefnSig(componentInfo, typeRepr, members, range, trivia)
 
@@ -764,7 +765,7 @@ tyconSpfn:
   | typeNameInfo  EQUALS tyconSpfnRhsBlock 
       { let mLhs = rhs parseState 1 
         let mEquals = rhs parseState 2
-        $3 mLhs $1 (Some mEquals) }
+        fun leadingKeyword -> $3 leadingKeyword mLhs $1 (Some mEquals) }
   | typeNameInfo  opt_classSpfn       
       { let mWithKwd, members = $2
         let (SynComponentInfo(range=range)) = $1
@@ -776,8 +777,9 @@ tyconSpfn:
                 | Some mWithKwd -> unionRanges range mWithKwd
             | decls ->
                 (range, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
-        let trivia: SynTypeDefnSigTrivia = { TypeKeyword = None; EqualsRange = None; WithKeyword = mWithKwd }
-        SynTypeDefnSig($1, SynTypeDefnSigRepr.Simple (SynTypeDefnSimpleRepr.None m, m), members, m, trivia) }
+        fun leadingKeyword ->
+            let trivia: SynTypeDefnSigTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = None; WithKeyword = mWithKwd }
+            SynTypeDefnSig($1, SynTypeDefnSigRepr.Simple (SynTypeDefnSimpleRepr.None m, m), members, m, trivia) }
 
 
 /* The right-hand-side of a type definition in a signature */
@@ -792,24 +794,24 @@ tyconSpfnRhsBlock:
   /* representation. */
   | OBLOCKBEGIN  tyconSpfnRhs opt_OBLOCKSEP classSpfnMembers opt_classSpfn oblockend opt_classSpfn  
      { let m = lhs parseState 
-       (fun mLhs nameInfo mEquals -> 
+       (fun leadingKeyword mLhs nameInfo mEquals -> 
            let members = $4 @ (snd $5)
-           $2 mLhs nameInfo mEquals (checkForMultipleAugmentations m members (snd $7))) }
+           $2 leadingKeyword mLhs nameInfo mEquals (checkForMultipleAugmentations m members (snd $7))) }
 
   | tyconSpfnRhs opt_classSpfn
      { let m = lhs parseState 
-       (fun mLhs nameInfo mEquals ->
+       (fun leadingKeyword mLhs nameInfo mEquals ->
            let _, members = $2 
-           $1 mLhs nameInfo mEquals members) }
+           $1 leadingKeyword mLhs nameInfo mEquals members) }
 
 
 /* The right-hand-side of a type definition in a signature */
 tyconSpfnRhs: 
   | tyconDefnOrSpfnSimpleRepr 
-     { (fun mLhs nameInfo mEquals augmentation -> 
+     { (fun leadingKeyword mLhs nameInfo mEquals augmentation -> 
            let declRange = unionRanges mLhs $1.Range
            let mWhole = (declRange, augmentation) ||> unionRangeWithListBy (fun (mem: SynMemberSig) -> mem.Range)
-           let trivia: SynTypeDefnSigTrivia = { TypeKeyword = None; WithKeyword = None; EqualsRange = mEquals }
+           let trivia: SynTypeDefnSigTrivia = { LeadingKeyword = leadingKeyword; WithKeyword = None; EqualsRange = mEquals }
            SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.Simple ($1, $1.Range), augmentation, mWhole, trivia)) }
 
   | tyconClassSpfn 
@@ -821,13 +823,13 @@ tyconSpfnRhs:
                 let start = mkSynRange parseState.ResultStartPosition parseState.ResultStartPosition
                 (start, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
 
-       (fun nameRange nameInfo mEquals augmentation -> 
+       (fun leadingKeyword nameRange nameInfo mEquals augmentation -> 
            if needsCheck && isNil decls then
               reportParseErrorAt nameRange (FSComp.SR.parsEmptyTypeDefinition())
            
            let declRange = unionRanges nameRange objectModelRange
            let mWhole = (declRange, augmentation) ||> unionRangeWithListBy (fun (mem: SynMemberSig) -> mem.Range)
-           let trivia: SynTypeDefnSigTrivia = { TypeKeyword = None; WithKeyword = None; EqualsRange = mEquals }
+           let trivia: SynTypeDefnSigTrivia = { LeadingKeyword = leadingKeyword; WithKeyword = None; EqualsRange = mEquals }
            SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.ObjectModel (kind, decls, objectModelRange), augmentation, mWhole, trivia)) }
 
   | DELEGATE OF topType
@@ -836,10 +838,10 @@ tyconSpfnRhs:
        let flags = AbstractMemberFlags true SynMemberKind.Member
        let valSig = SynValSig([], (SynIdent(mkSynId m "Invoke", None)), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, m, SynValSigTrivia.Zero)
        let invoke = SynMemberSig.Member(valSig, flags, m) 
-       (fun nameRange nameInfo mEquals augmentation -> 
+       (fun leadingKeyword nameRange nameInfo mEquals augmentation -> 
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
            let mWhole = unionRanges nameRange m
-           let trivia: SynTypeDefnSigTrivia = { TypeKeyword = None; WithKeyword = None; EqualsRange = mEquals }
+           let trivia: SynTypeDefnSigTrivia = { LeadingKeyword = leadingKeyword; WithKeyword = None; EqualsRange = mEquals }
            SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.ObjectModel (SynTypeDefnKind.Delegate (ty, arity), [invoke], m), [], mWhole, trivia)) }
 
 
@@ -955,8 +957,9 @@ classMemberSpfn:
        SynMemberSig.ValField(field, mWhole) }
 
   | opt_attributes  opt_access STATIC typeKeyword tyconSpfn 
-     { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-       SynMemberSig.NestedType($5, rhs2 parseState 1 5) }
+     { let leadingKeyword = SynTypeDefnLeadingKeyword.StaticType(rhs parseState 3, rhs parseState 4)
+       if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
+       SynMemberSig.NestedType($5 leadingKeyword, rhs2 parseState 1 5) }
 
   | opt_attributes opt_access NEW COLON topTypeWithTypeConstraints  
      { let vis, doc, (ty, valSynInfo) = $2, grabXmlDoc(parseState, $1, 1), $5
@@ -1221,12 +1224,12 @@ moduleDefn:
   | opt_attributes opt_access typeKeyword tyconDefn tyconDefnList
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
-        let (SynTypeDefn(SynComponentInfo(cas, a, cs, b, _xmlDoc, d, d2, d3), e, f, g, h, trivia)) = $4
+        let leadingKeyword = SynTypeDefnLeadingKeyword.Type(rhs parseState 3)
+        let (SynTypeDefn(SynComponentInfo(cas, a, cs, b, _xmlDoc, d, d2, d3), e, f, g, h, trivia)) = $4 leadingKeyword
         _xmlDoc.MarkAsInvalid()
         let attrs = $1@cas
         let mDefn = (h, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range) |> unionRangeWithXmlDoc xmlDoc
-        let mType = rhs parseState 3
-        let tc = SynTypeDefn(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), e, f, g, mDefn, { trivia with TypeKeyword = Some mType })
+        let tc = SynTypeDefn(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), e, f, g, mDefn, trivia)
         let types = tc :: $5
         [ SynModuleDecl.Types(types, (rhs parseState 3, types) ||> unionRangeWithListBy (fun t -> t.Range) ) ] }
 
@@ -1469,10 +1472,11 @@ tyconDefnList:
   | AND tyconDefn tyconDefnList 
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        let tyconDefn =
-           let (SynTypeDefn(componentInfo, typeRepr, members, implicitConstructor, range, trivia)) = $2
+           let leadingKeyword = SynTypeDefnLeadingKeyword.And(rhs parseState 1)
+           let (SynTypeDefn(componentInfo, typeRepr, members, implicitConstructor, range, trivia) as typeDefn) = $2 leadingKeyword
            let (SynComponentInfo(a, typars, c, lid, _xmlDoc, fixity, vis, mLongId)) = componentInfo
            if xmlDoc.IsEmpty then
-               if _xmlDoc.IsEmpty then $2 else
+               if _xmlDoc.IsEmpty then typeDefn else
                let range = unionRangeWithXmlDoc _xmlDoc range
                SynTypeDefn(componentInfo, typeRepr, members, implicitConstructor, range, trivia)
 
@@ -1488,7 +1492,9 @@ tyconDefnList:
 /* A type definition */
 tyconDefn: 
   | typeNameInfo 
-     { SynTypeDefn($1, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range), $1.Range), [], None, $1.Range, SynTypeDefnTrivia.Zero) }
+     { fun leadingKeyword ->
+           let trivia: SynTypeDefnTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = None; WithKeyword = None }
+           SynTypeDefn($1, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range), $1.Range), [], None, $1.Range, trivia) }
 
   | typeNameInfo opt_equals tyconDefnRhsBlock 
      { match $2 with
@@ -1503,13 +1509,17 @@ tyconDefn:
        let (tcDefRepr:SynTypeDefnRepr), mWith ,members = $3 nameRange
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
        let mWhole = (declRange, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
-       let trivia: SynTypeDefnTrivia = { TypeKeyword = None; EqualsRange = $2; WithKeyword = mWith }
-       SynTypeDefn($1, tcDefRepr, members, None, mWhole, trivia) }
+
+       fun leadingKeyword ->
+           let trivia: SynTypeDefnTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = $2; WithKeyword = mWith }
+           SynTypeDefn($1, tcDefRepr, members, None, mWhole, trivia) }
 
   | typeNameInfo tyconDefnAugmentation
      { let mWithKwd, classDefns = $2
        let m = (rhs parseState 1, classDefns) ||> unionRangeWithListBy (fun mem -> mem.Range)
-       SynTypeDefn($1, SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Augmentation mWithKwd, [], m), classDefns, None, m, SynTypeDefnTrivia.Zero) }
+       fun leadingKeyword ->
+           let trivia: SynTypeDefnTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = None; WithKeyword = None }
+           SynTypeDefn($1, SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Augmentation mWithKwd, [], m), classDefns, None, m, trivia) }
 
   | typeNameInfo opt_attributes opt_access opt_HIGH_PRECEDENCE_APP  simplePatterns optAsSpec EQUALS tyconDefnRhsBlock
      { let vis, spats, az = $3, $5, $6
@@ -1528,8 +1538,9 @@ tyconDefn:
        let mWhole = (declRange, members)
                     ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
                     |> unionRangeWithXmlDoc xmlDoc
-       let trivia: SynTypeDefnTrivia = { TypeKeyword = None; EqualsRange = Some mEquals; WithKeyword = mWith }
-       SynTypeDefn($1, tcDefRepr, members, Some memberCtorPattern, mWhole, trivia) }
+       fun leadingKeyword ->
+           let trivia: SynTypeDefnTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = Some mEquals; WithKeyword = mWith }
+           SynTypeDefn($1, tcDefRepr, members, Some memberCtorPattern, mWhole, trivia) }
 
 
 /* The right-hand-side of a type definition */
@@ -1850,7 +1861,8 @@ classDefnMember:
         
   | opt_attributes opt_access STATIC typeKeyword tyconDefn 
      {  if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        [ SynMemberDefn.NestedType($5, None, rhs2 parseState 1 5) ] }
+        let leadingKeyword = SynTypeDefnLeadingKeyword.StaticType(rhs parseState 3, rhs parseState 4)
+        [ SynMemberDefn.NestedType($5 leadingKeyword, None, rhs2 parseState 1 5) ] }
 
 
 /* A 'val' definition in an object type definition */

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -576,7 +576,7 @@ fileModuleSpec:
       (fun (mNamespaceOpt, isRec2, path, _) ->
         if not (isNil path) then errorR(Error(FSComp.SR.parsNamespaceOrModuleNotBoth(), m2))
         let lid = path@path2
-        let trivia: SynModuleOrNamespaceSigTrivia = { ModuleKeyword = Some mModule; NamespaceKeyword = mNamespaceOpt }
+        let trivia: SynModuleOrNamespaceSigTrivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Module mModule }
         ParsedSigFileFragment.NamedModule(SynModuleOrNamespaceSig(lid, (isRec || isRec2), SynModuleOrNamespaceKind.NamedModule, $4, xmlDoc, $1 @ attribs2, vis, m, trivia)))  }
 
   | moduleSpfnsPossiblyEmptyBlock 
@@ -588,7 +588,10 @@ fileModuleSpec:
             let lastDeclRange = List.tryLast $1 |> Option.map (fun decl -> decl.Range) |> Option.defaultValue (rhs parseState 1)
             let m = mkRange lastDeclRange.FileName (lhs parseState).Start lastDeclRange.End
             xml.MarkAsInvalid()
-            let trivia = { ModuleKeyword = None; NamespaceKeyword = mNamespaceOpt }
+            let trivia: SynModuleOrNamespaceSigTrivia = 
+                match mNamespaceOpt with
+                | None -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.None }
+                | Some mNamespace -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace }
             ParsedSigFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m, trivia))  } 
 
 
@@ -1096,7 +1099,7 @@ fileModuleImpl:
       (fun (mNamespaceOpt, isRec, path, _) ->
         if not (isNil path) then errorR(Error(FSComp.SR.parsNamespaceOrModuleNotBoth(), m2))
         let lid = path@path2
-        let trivia: SynModuleOrNamespaceTrivia = { ModuleKeyword = Some mModule; NamespaceKeyword = mNamespaceOpt }
+        let trivia: SynModuleOrNamespaceTrivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Module mModule }
         ParsedImplFileFragment.NamedModule(SynModuleOrNamespace(lid, (isRec || isRec2), SynModuleOrNamespaceKind.NamedModule, $4, xmlDoc, $1@attribs2, vis, m, trivia))) }
 
   | moduleDefnsOrExprPossiblyEmptyOrBlock 
@@ -1108,7 +1111,10 @@ fileModuleImpl:
             let lastDeclRange = List.tryLast $1 |> Option.map (fun decl -> decl.Range) |> Option.defaultValue (rhs parseState 1)
             let m = mkRange lastDeclRange.FileName (lhs parseState).Start lastDeclRange.End
             xml.MarkAsInvalid()
-            let trivia: SynModuleOrNamespaceTrivia = { ModuleKeyword = None; NamespaceKeyword = mNamespaceOpt }
+            let trivia: SynModuleOrNamespaceTrivia = 
+                match mNamespaceOpt with
+                 | None -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.None }
+                 | Some mNamespace -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace }
             ParsedImplFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m, trivia)) } 
 
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -9805,28 +9805,61 @@ FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia: FSharp.Compiler.Text.Range BarRange
 FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia: FSharp.Compiler.Text.Range get_BarRange()
 FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynPatOrTrivia: Void .ctor(FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+And: FSharp.Compiler.Text.Range Item
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+And: FSharp.Compiler.Text.Range get_Item()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType: FSharp.Compiler.Text.Range get_staticRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType: FSharp.Compiler.Text.Range get_typeRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType: FSharp.Compiler.Text.Range staticRange
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType: FSharp.Compiler.Text.Range typeRange
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Tags: Int32 And
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Tags: Int32 StaticType
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Tags: Int32 Synthetic
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Tags: Int32 Type
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Type: FSharp.Compiler.Text.Range Item
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Type: FSharp.Compiler.Text.Range get_Item()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Boolean IsAnd
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Boolean IsStaticType
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Boolean IsSynthetic
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Boolean IsType
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Boolean get_IsAnd()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Boolean get_IsStaticType()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Boolean get_IsSynthetic()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Boolean get_IsType()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword NewAnd(FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword NewStaticType(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword NewType(FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword Synthetic
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword get_Synthetic()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+And
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Tags
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Type
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Int32 Tag
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Int32 get_Tag()
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword LeadingKeyword
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword get_LeadingKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia Zero
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia get_Zero()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] EqualsRange
-FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] TypeKeyword
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] WithKeyword
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_EqualsRange()
-FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_TypeKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_WithKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: System.String ToString()
-FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnSigTrivia: Void .ctor(FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword LeadingKeyword
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword get_LeadingKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia Zero
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia get_Zero()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] EqualsRange
-FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] TypeKeyword
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] WithKeyword
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_EqualsRange()
-FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_TypeKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_WithKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: System.String ToString()
-FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnTrivia: Void .ctor(FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
 FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia
 FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia: FSharp.Compiler.Text.Range ArrowRange
 FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia: FSharp.Compiler.Text.Range get_ArrowRange()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -9772,20 +9772,40 @@ FSharp.Compiler.SyntaxTrivia.SynModuleDeclNestedModuleTrivia: Microsoft.FSharp.C
 FSharp.Compiler.SyntaxTrivia.SynModuleDeclNestedModuleTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_ModuleKeyword()
 FSharp.Compiler.SyntaxTrivia.SynModuleDeclNestedModuleTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynModuleDeclNestedModuleTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Module: FSharp.Compiler.Text.Range get_moduleRange()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Module: FSharp.Compiler.Text.Range moduleRange
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Namespace: FSharp.Compiler.Text.Range get_namespaceRange()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Namespace: FSharp.Compiler.Text.Range namespaceRange
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Tags: Int32 Module
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Tags: Int32 Namespace
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Tags: Int32 None
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: Boolean IsModule
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: Boolean IsNamespace
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: Boolean IsNone
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: Boolean get_IsModule()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: Boolean get_IsNamespace()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: Boolean get_IsNone()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword NewModule(FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword NewNamespace(FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword None
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword get_None()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Module
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Namespace
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword+Tags
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: Int32 Tag
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: Int32 get_Tag()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] ModuleKeyword
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] NamespaceKeyword
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_ModuleKeyword()
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_NamespaceKeyword()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword LeadingKeyword
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword get_LeadingKeyword()
 FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: System.String ToString()
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceSigTrivia: Void .ctor(FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword)
 FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] ModuleKeyword
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] NamespaceKeyword
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_ModuleKeyword()
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_NamespaceKeyword()
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword LeadingKeyword
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword get_LeadingKeyword()
 FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: System.String ToString()
-FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceTrivia: Void .ctor(FSharp.Compiler.SyntaxTrivia.SynModuleOrNamespaceLeadingKeyword)
 FSharp.Compiler.SyntaxTrivia.SynModuleSigDeclNestedModuleTrivia
 FSharp.Compiler.SyntaxTrivia.SynModuleSigDeclNestedModuleTrivia: FSharp.Compiler.SyntaxTrivia.SynModuleSigDeclNestedModuleTrivia Zero
 FSharp.Compiler.SyntaxTrivia.SynModuleSigDeclNestedModuleTrivia: FSharp.Compiler.SyntaxTrivia.SynModuleSigDeclNestedModuleTrivia get_Zero()

--- a/tests/service/SyntaxTreeTests/ModuleOrNamespaceSigTests.fs
+++ b/tests/service/SyntaxTreeTests/ModuleOrNamespaceSigTests.fs
@@ -2,6 +2,7 @@ module FSharp.Compiler.Service.Tests.SyntaxTreeTests.ModuleOrNamespaceSigTests
 
 open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.SyntaxTrivia
 open NUnit.Framework
 
 [<Test>]
@@ -67,7 +68,9 @@ val a: int
 
     match parseResults with
     | ParsedInput.SigFile (ParsedSigFileInput (contents = [
-        SynModuleOrNamespaceSig(kind = SynModuleOrNamespaceKind.NamedModule; trivia = { ModuleKeyword = Some mModule; NamespaceKeyword = None }) ])) ->
+        SynModuleOrNamespaceSig(
+            kind = SynModuleOrNamespaceKind.NamedModule
+            trivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Module mModule }) ])) ->
         assertRange (2, 0) (2, 6) mModule
     | _ -> Assert.Fail "Could not get valid AST"
 
@@ -83,6 +86,8 @@ val a: int
 
     match parseResults with
     | ParsedInput.SigFile (ParsedSigFileInput (contents = [
-        SynModuleOrNamespaceSig(kind = SynModuleOrNamespaceKind.DeclaredNamespace; trivia = { ModuleKeyword = None; NamespaceKeyword = Some mNamespace }) ])) ->
+        SynModuleOrNamespaceSig(
+            kind = SynModuleOrNamespaceKind.DeclaredNamespace
+            trivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace }) ])) ->
         assertRange (2, 0) (2, 9) mNamespace
     | _ -> Assert.Fail "Could not get valid AST"

--- a/tests/service/SyntaxTreeTests/ModuleOrNamespaceTests.fs
+++ b/tests/service/SyntaxTreeTests/ModuleOrNamespaceTests.fs
@@ -97,7 +97,9 @@ let a = 42
 
     match parseResults with
     | ParsedInput.ImplFile (ParsedImplFileInput (contents = [
-        SynModuleOrNamespace.SynModuleOrNamespace(kind = SynModuleOrNamespaceKind.NamedModule; trivia = { ModuleKeyword = Some mModule; NamespaceKeyword = None }) ])) ->
+        SynModuleOrNamespace.SynModuleOrNamespace(
+            kind = SynModuleOrNamespaceKind.NamedModule
+            trivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Module mModule }) ])) ->
         assertRange (5, 0) (5, 6) mModule
     | _ -> Assert.Fail "Could not get valid AST"
 
@@ -113,7 +115,9 @@ let a = 42
 
     match parseResults with
     | ParsedInput.ImplFile (ParsedImplFileInput (contents = [
-        SynModuleOrNamespace.SynModuleOrNamespace(kind = SynModuleOrNamespaceKind.DeclaredNamespace; trivia = { ModuleKeyword = None; NamespaceKeyword = Some mNamespace }) ])) ->
+        SynModuleOrNamespace.SynModuleOrNamespace(
+            kind = SynModuleOrNamespaceKind.DeclaredNamespace
+            trivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace }) ])) ->
         assertRange (2, 0) (2, 9) mNamespace
     | _ -> Assert.Fail $"Could not get valid AST, got {parseResults}"
 

--- a/tests/service/SyntaxTreeTests/SignatureTypeTests.fs
+++ b/tests/service/SyntaxTreeTests/SignatureTypeTests.fs
@@ -452,15 +452,15 @@ type Z with
     | ParsedInput.SigFile (ParsedSigFileInput (contents=[
         SynModuleOrNamespaceSig(decls=[
             SynModuleSigDecl.Types(types = [
-                SynTypeDefnSig(trivia = { TypeKeyword = Some mType1
+                SynTypeDefnSig(trivia = { LeadingKeyword = SynTypeDefnLeadingKeyword.Type mType1
                                           EqualsRange = Some mEq1
                                           WithKeyword = None }) ])
             SynModuleSigDecl.Types(types = [
-                SynTypeDefnSig(trivia = { TypeKeyword = Some mType2
+                SynTypeDefnSig(trivia = { LeadingKeyword = SynTypeDefnLeadingKeyword.Type mType2
                                           EqualsRange = Some mEq2
                                           WithKeyword = None  }) ])
             SynModuleSigDecl.Types(types = [
-                SynTypeDefnSig(trivia = { TypeKeyword = Some mType3
+                SynTypeDefnSig(trivia = { LeadingKeyword = SynTypeDefnLeadingKeyword.Type mType3
                                           EqualsRange = None
                                           WithKeyword = Some mWith3 }) ])
         ] ) ])) ->
@@ -512,4 +512,55 @@ val InferSynValData:
         Assert.AreEqual("pat", pat.idText)
         Assert.AreEqual("origRhsExpr", origRhsExpr.idText)
         Assert.AreEqual("x", x.idText)
+    | _ -> Assert.Fail $"Could not get valid AST, got {parseResults}"
+
+[<Test>]
+let ``Leading keyword in recursive types`` () =
+    let parseResults =
+        getParseResultsOfSignatureFile
+             """
+type A = obj
+and B = int
+ """
+
+    match parseResults with
+    | ParsedInput.SigFile (ParsedSigFileInput(contents = [
+        SynModuleOrNamespaceSig(decls = [
+            SynModuleSigDecl.Types(types = [
+                SynTypeDefnSig(trivia = { LeadingKeyword = SynTypeDefnLeadingKeyword.Type mType })
+                SynTypeDefnSig(trivia = { LeadingKeyword = SynTypeDefnLeadingKeyword.And mAnd })
+            ])
+        ])
+    ])) ->
+        assertRange (2, 0) (2, 4) mType
+        assertRange (3, 0) (3, 3) mAnd
+    | _ -> Assert.Fail $"Could not get valid AST, got {parseResults}"
+
+
+[<Test>]
+let ``Nested type has static type as leading keyword`` () =
+    let parseResults =
+        getParseResultsOfSignatureFile
+             """
+type A =
+    static type B =
+                    class
+                    end
+ """
+
+    match parseResults with
+    | ParsedInput.SigFile (ParsedSigFileInput(contents = [
+        SynModuleOrNamespaceSig(decls = [
+            SynModuleSigDecl.Types(types = [
+                SynTypeDefnSig(typeRepr = SynTypeDefnSigRepr.ObjectModel(
+                    memberSigs = [
+                        SynMemberSig.NestedType(nestedType =
+                            SynTypeDefnSig(trivia = { LeadingKeyword = SynTypeDefnLeadingKeyword.StaticType(mStatic, mType) }))
+                    ]
+                ))
+            ])
+        ])
+    ])) ->
+        assertRange (3, 4) (3, 10) mStatic
+        assertRange (3, 11) (3, 15) mType
     | _ -> Assert.Fail $"Could not get valid AST, got {parseResults}"


### PR DESCRIPTION
This streamlines a couple of the previous trivia captures.
For example, you cannot both have the `module` and `namespace` keywords at the same time.

