### PR TITLE
Fix 14097

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -8540,7 +8540,12 @@ and TcTraitItemThen (cenv: cenv) overallTy env objOpt traitInfo tpenv mItem dela
             applicableExpr, exprTy
         | _ ->
             let vs, ves = argTys |> List.mapi (fun i ty -> mkCompGenLocal mItem ("arg" + string i) ty) |> List.unzip
-            let traitCall = Expr.Op (TOp.TraitCall traitInfo, [], objArgs@ves, mItem)
+            // Account for a unit mismtach in logical v. compiled arguments
+            let compiledArgExprs =
+                match argTys, traitInfo.GetCompiledArgumentTypes() with
+                | [_], [] -> []
+                | _ -> ves
+            let traitCall = Expr.Op (TOp.TraitCall traitInfo, [], objArgs@compiledArgExprs, mItem)
             let v, body = MultiLambdaToTupledLambda g vs traitCall
             let expr = mkLambda mItem v (body, retTy)
             let exprTy = tyOfExpr g expr

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/IWSAMsAndSRTPs/testFiles/CheckNewSyntax.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/IWSAMsAndSRTPs/testFiles/CheckNewSyntax.fs
@@ -4,7 +4,9 @@ module CheckNewSyntax =
 
     type MyType() = 
         static member val StaticProperty = 0 with get, set
-        static member StaticMethod x = x + 5
+        static member StaticMethod0 () = 5
+        static member StaticMethod1 x = x + 5
+        static member StaticMethod2 (x, y) = x + y + 5
         member val Length = 0 with get, set
         member _.Item with get x = "Hello"
         member _.InstanceMethod0 () = 5
@@ -14,7 +16,11 @@ module CheckNewSyntax =
     // Check that "property" and "get_ method" constraints are considered logically equivalent
     let inline f_StaticProperty<'T when 'T : (static member StaticProperty: int) >() : int = 'T.StaticProperty
 
-    let inline f_StaticMethod<'T when 'T : (static member StaticMethod: int -> int) >() : int = 'T.StaticMethod(3)
+    let inline f_StaticMethod0<'T when 'T : (static member StaticMethod0: unit -> int) >() : int = 'T.StaticMethod0()
+
+    let inline f_StaticMethod1<'T when 'T : (static member StaticMethod1: int -> int) >() : int = 'T.StaticMethod1(3)
+
+    let inline f_StaticMethod2<'T when 'T : (static member StaticMethod2: int * int -> int) >() : int = 'T.StaticMethod2(3, 3)
 
     let inline f_set_StaticProperty<'T when 'T : (static member StaticProperty: int with set) >() = 'T.set_StaticProperty(3)
 
@@ -39,7 +45,13 @@ module CheckNewSyntax =
     //let inline f_set_Length2<'T when 'T : (member Length: int with set) >(x: 'T) = x.Length <- 3
     //let inline f_Item2<'T when 'T : (member Item: int -> string with get) >(x: 'T) = x[3]
         
-    if f_StaticMethod<MyType>() <> 8 then
+    if f_StaticMethod0<MyType>() <> 5 then
+        failwith "Unexpected result"
+
+    if f_StaticMethod1<MyType>() <> 8 then
+        failwith "Unexpected result"
+
+    if f_StaticMethod2<MyType>() <> 11 then
         failwith "Unexpected result"
 
     if f_set_StaticProperty<MyType>() <> () then

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/IWSAMsAndSRTPs/testFiles/CheckNewSyntax.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/IWSAMsAndSRTPs/testFiles/CheckNewSyntax.fs
@@ -7,7 +7,9 @@ module CheckNewSyntax =
         static member StaticMethod x = x + 5
         member val Length = 0 with get, set
         member _.Item with get x = "Hello"
-        member _.InstanceMethod x = x + 5
+        member _.InstanceMethod0 () = 5
+        member _.InstanceMethod1 x = x + 5
+        member _.InstanceMethod2 (x, y) = x + y + 5
 
     // Check that "property" and "get_ method" constraints are considered logically equivalent
     let inline f_StaticProperty<'T when 'T : (static member StaticProperty: int) >() : int = 'T.StaticProperty
@@ -16,7 +18,11 @@ module CheckNewSyntax =
 
     let inline f_set_StaticProperty<'T when 'T : (static member StaticProperty: int with set) >() = 'T.set_StaticProperty(3)
 
-    let inline f_InstanceMethod<'T when 'T : (member InstanceMethod: int -> int) >(x: 'T) : int = x.InstanceMethod(3)
+    let inline f_InstanceMethod0<'T when 'T : (member InstanceMethod0: unit -> int) >(x: 'T) : int = x.InstanceMethod0()
+
+    let inline f_InstanceMethod1<'T when 'T : (member InstanceMethod1: int -> int) >(x: 'T) : int = x.InstanceMethod1(3)
+
+    let inline f_InstanceMethod2<'T when 'T : (member InstanceMethod2: int * int -> int) >(x: 'T) : int = x.InstanceMethod2(3, 3)
 
     let inline f_Length<'T when 'T : (member Length: int) >(x: 'T) = x.Length
 
@@ -47,7 +53,13 @@ module CheckNewSyntax =
     if f_Length(myInstance) <> 0 then
         failwith "Unexpected result"
 
-    if f_InstanceMethod(myInstance) <> 8 then
+    if f_InstanceMethod0(myInstance) <> 5 then
+        failwith "Unexpected result"
+
+    if f_InstanceMethod1(myInstance) <> 8 then
+        failwith "Unexpected result"
+
+    if f_InstanceMethod2(myInstance) <> 11 then
         failwith "Unexpected result"
 
     if f_set_Length(myInstance) <> () then


### PR DESCRIPTION
#14097 This was a unit-as-logical-argument v. empty-compiled-arguments-in-trait-call problem
