### PR TITLE
Do not check XmlDocs unless required [WIP]

### DIFF
--- a/src/Compiler/Checking/CheckBasics.fs
+++ b/src/Compiler/Checking/CheckBasics.fs
@@ -4,6 +4,7 @@ module internal FSharp.Compiler.CheckBasics
 
 open System.Collections.Generic
 
+open FSharp.Compiler.Diagnostics
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
 open FSharp.Compiler
@@ -310,6 +311,8 @@ type TcFileState =
 
       isInternalTestSpanStackReferring: bool
 
+      diagnosticOptions: FSharpDiagnosticOptions
+
       // forward call
       TcPat: WarnOnUpperFlag -> TcFileState -> TcEnv -> PrelimValReprInfo option -> TcPatValFlags -> TcPatLinearEnv -> TType -> SynPat -> (TcPatPhase2Input -> Pattern) * TcPatLinearEnv
 
@@ -328,7 +331,7 @@ type TcFileState =
 
     /// Create a new compilation environment
     static member Create
-         (g, isScript, amap, thisCcu, isSig, haveSig, conditionalDefines, tcSink, tcVal, isInternalTestSpanStackReferring,
+         (g, isScript, amap, thisCcu, isSig, haveSig, conditionalDefines, tcSink, tcVal, isInternalTestSpanStackReferring, diagnosticOptions,
           tcPat,
           tcSimplePats,
           tcSequenceExpressionEntry,
@@ -358,6 +361,7 @@ type TcFileState =
           compilingCanonicalFslibModuleType = (isSig || not haveSig) && g.compilingFSharpCore
           conditionalDefines = conditionalDefines
           isInternalTestSpanStackReferring = isInternalTestSpanStackReferring
+          diagnosticOptions = diagnosticOptions
           TcPat = tcPat
           TcSimplePats = tcSimplePats
           TcSequenceExpressionEntry = tcSequenceExpressionEntry

--- a/src/Compiler/Checking/CheckBasics.fsi
+++ b/src/Compiler/Checking/CheckBasics.fsi
@@ -3,6 +3,7 @@
 module internal FSharp.Compiler.CheckBasics
 
 open System.Collections.Generic
+open FSharp.Compiler.Diagnostics
 open Internal.Utilities.Library
 open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.CompilerGlobalState
@@ -260,6 +261,8 @@ type TcFileState =
 
         isInternalTestSpanStackReferring: bool
 
+        diagnosticOptions: FSharpDiagnosticOptions
+
         // forward call
         TcPat: WarnOnUpperFlag
             -> TcFileState
@@ -319,6 +322,7 @@ type TcFileState =
         tcSink: TcResultsSink *
         tcVal: TcValF *
         isInternalTestSpanStackReferring: bool *
+        diagnosticOptions: FSharpDiagnosticOptions *
         tcPat: (WarnOnUpperFlag -> TcFileState -> TcEnv -> PrelimValReprInfo option -> TcPatValFlags -> TcPatLinearEnv -> TType -> SynPat -> (TcPatPhase2Input -> Pattern) * TcPatLinearEnv) *
         tcSimplePats: (TcFileState -> bool -> CheckConstraints -> TType -> TcEnv -> TcPatLinearEnv -> SynSimplePats -> string list * TcPatLinearEnv) *
         tcSequenceExpressionEntry: (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv) *

--- a/src/Compiler/Checking/CheckDeclarations.fsi
+++ b/src/Compiler/Checking/CheckDeclarations.fsi
@@ -2,6 +2,7 @@
 
 module internal FSharp.Compiler.CheckDeclarations
 
+open FSharp.Compiler.Diagnostics
 open Internal.Utilities.Library
 open FSharp.Compiler.CheckBasics
 open FSharp.Compiler.CompilerGlobalState
@@ -58,11 +59,12 @@ val CheckOneImplFile:
     bool *
     TcEnv *
     ModuleOrNamespaceType option *
-    ParsedImplFileInput ->
+    ParsedImplFileInput *
+    FSharpDiagnosticOptions ->
         Cancellable<TopAttribs * CheckedImplFile * TcEnv * bool>
 
 val CheckOneSigFile:
-    TcGlobals * ImportMap * CcuThunk * (unit -> bool) * ConditionalDefines option * TcResultsSink * bool ->
+    TcGlobals * ImportMap * CcuThunk * (unit -> bool) * ConditionalDefines option * TcResultsSink * bool * FSharpDiagnosticOptions ->
         TcEnv ->
         ParsedSigFileInput ->
             Cancellable<TcEnv * ModuleOrNamespaceType * bool>

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -2430,7 +2430,8 @@ module BindingNormalization =
             let (NormalizedBindingPat(pat, rhsExpr, valSynData, typars)) =
                 NormalizeBindingPattern cenv cenv.nameResolver isObjExprBinding env valSynData headPat (NormalizedBindingRhs ([], retInfo, rhsExpr))
             let paramNames = Some valSynData.SynValInfo.ArgNames
-            let xmlDoc = xmlDoc.ToXmlDoc(true, paramNames)
+            let checkXmlDocs = cenv.diagnosticOptions.CheckXmlDocs
+            let xmlDoc = xmlDoc.ToXmlDoc(checkXmlDocs, paramNames)
             NormalizedBinding(vis, kind, isInline, isMutable, attrs, xmlDoc, typars, valSynData, pat, rhsExpr, mBinding, debugPoint)
 
 //-------------------------------------------------------------------------

--- a/src/Compiler/Checking/CheckIncrementalClasses.fs
+++ b/src/Compiler/Checking/CheckIncrementalClasses.fs
@@ -4,6 +4,7 @@ module internal FSharp.Compiler.CheckIncrementalClasses
 
 open System
 
+open FSharp.Compiler.Diagnostics
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -135,7 +136,9 @@ let TcImplicitCtorLhs_Phase2A(cenv: cenv, env, tpenv, tcref: TyconRef, vis, attr
         let varReprInfo = InferGenericArityFromTyScheme prelimTyschemeG prelimValReprInfo
         let ctorValScheme = ValScheme(id, prelimTyschemeG, Some varReprInfo, None, Some memberInfo, false, ValInline.Never, NormalVal, vis, false, true, false, false)
         let paramNames = varReprInfo.ArgNames
-        let xmlDoc = xmlDoc.ToXmlDoc(true, Some paramNames)
+
+        let checkXmlDocs = cenv.diagnosticOptions.CheckXmlDocs
+        let xmlDoc = xmlDoc.ToXmlDoc(checkXmlDocs, Some paramNames)
         let ctorVal = MakeAndPublishVal cenv env (Parent tcref, false, ModuleOrMemberBinding, ValInRecScope isComplete, ctorValScheme, attribs, xmlDoc, None, false) 
         ctorValScheme, ctorVal
 

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1228,7 +1228,8 @@ let CheckOneInputAux
                          checkForErrors,
                          conditionalDefines,
                          tcSink,
-                         tcConfig.internalTestSpanStackReferring)
+                         tcConfig.internalTestSpanStackReferring,
+                         tcConfig.diagnosticsOptions)
                         tcState.tcsTcSigEnv
                         file
 
@@ -1306,7 +1307,8 @@ let CheckOneInputAux
                             tcConfig.internalTestSpanStackReferring,
                             tcState.tcsTcImplEnv,
                             rootSigOpt,
-                            file
+                            file,
+                            tcConfig.diagnosticsOptions
                         )
 
                     let tcState =
@@ -1511,7 +1513,8 @@ let CheckMultipleInputsInParallel
                             tcConfig.internalTestSpanStackReferring,
                             tcStateForImplFile.tcsTcImplEnv,
                             Some rootSig,
-                            file
+                            file,
+                            tcConfig.diagnosticsOptions
                         )
                         |> Cancellable.runWithoutCancellation
 

--- a/src/Compiler/Facilities/DiagnosticOptions.fs
+++ b/src/Compiler/Facilities/DiagnosticOptions.fs
@@ -31,3 +31,7 @@ type FSharpDiagnosticOptions =
             WarnAsError = []
             WarnAsWarn = []
         }
+
+    member x.CheckXmlDocs =
+        // xmlDocBadlyFormed - off by default
+        List.contains 3390 x.WarnOn && not (List.contains 3390 x.WarnOff)

--- a/src/Compiler/Facilities/DiagnosticOptions.fs
+++ b/src/Compiler/Facilities/DiagnosticOptions.fs
@@ -33,5 +33,4 @@ type FSharpDiagnosticOptions =
         }
 
     member x.CheckXmlDocs =
-        // xmlDocBadlyFormed - off by default
         List.contains 3390 x.WarnOn && not (List.contains 3390 x.WarnOff)

--- a/src/Compiler/Facilities/DiagnosticOptions.fsi
+++ b/src/Compiler/Facilities/DiagnosticOptions.fsi
@@ -22,3 +22,5 @@ type FSharpDiagnosticOptions =
       WarnAsWarn: int list }
 
     static member Default: FSharpDiagnosticOptions
+
+    member CheckXmlDocs: bool


### PR DESCRIPTION
Currently, XmlDoc check is performed even if the corresponding diagnostic (3390) is not enabled in the .fsproj.

This PR suggests adding an option to DiagnosticOptions to not call analysis if not required.