### PR TITLE
Parser: recover unfinished match clause at eof

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -4083,7 +4083,7 @@ patternClauses:
        fun _mBar ->
            (SynMatchClause(pat, guard, arbExpr ("patternClauses1", m.EndRange), m, DebugPointAtTarget.Yes, SynMatchClauseTrivia.Zero) :: clauses), mLast }
 
-  | patternAndGuard patternResult BAR error 
+  | patternAndGuard patternResult BAR recover 
      { let pat, guard = $1
        let mArrow, resultExpr = $2
        let mLast = rhs parseState 3 
@@ -4091,14 +4091,14 @@ patternClauses:
        fun mBar ->
            [SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = Some mArrow; BarRange = mBar })], mLast }
 
-  | patternAndGuard patternResult error
+  | patternAndGuard patternResult recover
      { let pat, guard = $1
        let mArrow, resultExpr = $2
        let m = unionRanges resultExpr.Range pat.Range
        fun mBar ->
            [SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = Some mArrow; BarRange = mBar })], m }
 
-  | patternAndGuard error
+  | patternAndGuard recover
      { let pat, guard = $1
        let patm = pat.Range
        let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -468,3 +468,16 @@ let (1,1,1) = ()
             [ p12; p13; p21; p23; p31; p32; p43; p51; p62 ] |> List.iter assertIsEmptyRange
 
     | _ -> failwith "Unexpected tree"
+
+
+[<Test>]
+let ``Match - Clause 01`` () =
+    let parseResults = getParseResults """
+match () with
+| _ -> ()
+| _, 
+    """
+    let exprs = getSingleModuleMemberDecls parseResults |> List.map getSingleParenInnerExpr
+    match exprs with
+    | [ SynExpr.Match(_, _, [_; _], _, _) ] -> ()
+    | _ -> failwith "Unexpected tree"

--- a/tests/service/ParserTests.fs
+++ b/tests/service/ParserTests.fs
@@ -477,7 +477,7 @@ match () with
 | _ -> ()
 | _, 
     """
-    let exprs = getSingleModuleMemberDecls parseResults |> List.map getSingleParenInnerExpr
+    let exprs = getSingleExprInModule parseResults
     match exprs with
-    | [ SynExpr.Match(_, _, [_; _], _, _) ] -> ()
+    | SynExpr.Match(_, _, [_; _], _, _) -> ()
     | _ -> failwith "Unexpected tree"


### PR DESCRIPTION
An fixup for #13985, which changed the recovery rules, and the following `match` expression wouldn't parse anymore when at EOF:
```fsharp
match () with
| _ -> ()
| _, 
```

Changes `error` to `recover` which also covers the EOF case.