### PR TITLE
improve text in FSI options

### DIFF
--- a/vsintegration/src/FSharp.VS.FSI/Properties.resx
+++ b/vsintegration/src/FSharp.VS.FSI/Properties.resx
@@ -121,7 +121,7 @@
     <value>Run as 64-bit</value>
   </data>
   <data name="FSharpInteractiveAnyCpuDescr" xml:space="preserve">
-    <value>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</value>
+    <value>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</value>
   </data>
   <data name="FSharpInteractiveOptions" xml:space="preserve">
     <value>F# Interactive options</value>

--- a/vsintegration/src/FSharp.VS.FSI/Properties.resx
+++ b/vsintegration/src/FSharp.VS.FSI/Properties.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FSharpInteractiveAnyCpu" xml:space="preserve">
-    <value>Use fsiAnyCpu.exe</value>
+    <value>Run as 64-bit</value>
   </data>
   <data name="FSharpInteractiveAnyCpuDescr" xml:space="preserve">
-    <value>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</value>
+    <value>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</value>
   </data>
   <data name="FSharpInteractiveOptions" xml:space="preserve">
     <value>F# Interactive options</value>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.cs.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.cs.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Když se nastaví na hodnotu true, 'fsiAnyCpu.exe' se spustí jako proces neutrální vzhledem k platformě. V opačném případě je F# Interactive 32bitový proces na platformě X86/X64 nebo nativní 64bitový proces v systémech založených na arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.cs.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.cs.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Když se nastaví na hodnotu true, 'fsiAnyCpu.exe' se spustí jako proces neutrální vzhledem k platformě. V opačném případě je F# Interactive 32bitový proces na platformě X86/X64 nebo nativní 64bitový proces v systémech založených na arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.de.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.de.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Wenn TRUE festgelegt ist, wird „fsiAnyCpu.exe“ als plattformneutraler Prozess ausgeführt. Andernfalls ist „F# Interactive“ ein 32-Bit-Prozess auf X86/X64 oder ein nativer 64-Bit-Prozess auf Arm64-basierten Systemen.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.de.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.de.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Wenn TRUE festgelegt ist, wird „fsiAnyCpu.exe“ als plattformneutraler Prozess ausgeführt. Andernfalls ist „F# Interactive“ ein 32-Bit-Prozess auf X86/X64 oder ein nativer 64-Bit-Prozess auf Arm64-basierten Systemen.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.es.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.es.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Si se establece en true, "fsiAnyCpu.exe" se ejecuta como un proceso neutro de la plataforma. De lo contrario, F# interactivo es un proceso de 32 bits en X86/X64 o un proceso nativo de 64 bits en sistemas basados en Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.es.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.es.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Si se establece en true, "fsiAnyCpu.exe" se ejecuta como un proceso neutro de la plataforma. De lo contrario, F# interactivo es un proceso de 32 bits en X86/X64 o un proceso nativo de 64 bits en sistemas basados en Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.fr.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.fr.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Si la valeur est true, 'fsiAnyCpu.exe' est exécuté en tant que processus indépendant de la plateforme. Sinon, F# Interactive est un processus 32 bits sur X86/X64 ou un processus natif 64 bits sur des systèmes Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.fr.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.fr.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Si la valeur est true, 'fsiAnyCpu.exe' est exécuté en tant que processus indépendant de la plateforme. Sinon, F# Interactive est un processus 32 bits sur X86/X64 ou un processus natif 64 bits sur des systèmes Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.it.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.it.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Se impostato su true, 'fsiAnyCpu.exe' viene eseguito come processo indipendente dalla piattaforma. In caso contrario, F# Interactive è un processo a 32 bit su X86/X64 o un processo nativo a 64 bit nei sistemi basati su Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.it.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.it.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Se impostato su true, 'fsiAnyCpu.exe' viene eseguito come processo indipendente dalla piattaforma. In caso contrario, F# Interactive è un processo a 32 bit su X86/X64 o un processo nativo a 64 bit nei sistemi basati su Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ja.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ja.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">true に設定すると、'fsiAnyCpu.exe' はプラットフォーム ニュートラル プロセスとして実行されます。それ以外の場合、F# インタラクティブ は X86 または X64 の 32 ビット プロセス、または Arm64 ベースのシステムでのネイティブ 64 ビット プロセスです。</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ja.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ja.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">true に設定すると、'fsiAnyCpu.exe' はプラットフォーム ニュートラル プロセスとして実行されます。それ以外の場合、F# インタラクティブ は X86 または X64 の 32 ビット プロセス、または Arm64 ベースのシステムでのネイティブ 64 ビット プロセスです。</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ko.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ko.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">true로 설정하면 'fsiAnyCpu.exe'가 플랫폼 중립 프로세스로 실행됩니다. 그렇지 않으면 F# 대화형이 X86/X64의 32비트 프로세스이거나 Arm64 기반 시스템의 네이티브 64비트 프로세스입니다.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ko.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ko.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">true로 설정하면 'fsiAnyCpu.exe'가 플랫폼 중립 프로세스로 실행됩니다. 그렇지 않으면 F# 대화형이 X86/X64의 32비트 프로세스이거나 Arm64 기반 시스템의 네이티브 64비트 프로세스입니다.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pl.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pl.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Jeśli ustawiono wartość „true”, 'fsiAnyCpu.exe' jest uruchamiany jako proces neutralny dla platformy. W przeciwnym razie F# Interactive jest procesem 32-bitowym w architekturze X86/X64 lub natywnym procesem 64-bitowym w systemach opartych na architekturze Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pl.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pl.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Jeśli ustawiono wartość „true”, 'fsiAnyCpu.exe' jest uruchamiany jako proces neutralny dla platformy. W przeciwnym razie F# Interactive jest procesem 32-bitowym w architekturze X86/X64 lub natywnym procesem 64-bitowym w systemach opartych na architekturze Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pt-BR.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pt-BR.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Se definido como true, 'fsiAnyCpu.exe' será executado como um processo neutro de plataforma. Caso contrário, F# Interativo é um processo de 32 bits em X86/X64 ou um processo nativo de 64 bits em sistemas baseados em Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pt-BR.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pt-BR.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Se definido como true, 'fsiAnyCpu.exe' será executado como um processo neutro de plataforma. Caso contrário, F# Interativo é um processo de 32 bits em X86/X64 ou um processo nativo de 64 bits em sistemas baseados em Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ru.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ru.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Если задано значение "true", "fsiAnyCpu.exe" выполняется как процесс, не зависящий от платформы. В противном случае F# Interactive — это 32-разрядный процесс на X86/X64 или собственный 64-разрядный процесс в системах на базе Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ru.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ru.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">Если задано значение "true", "fsiAnyCpu.exe" выполняется как процесс, не зависящий от платформы. В противном случае F# Interactive — это 32-разрядный процесс на X86/X64 или собственный 64-разрядный процесс в системах на базе Arm64.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.tr.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.tr.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">“True” olarak ayarlandığında, 'fsiAnyCpu.exe' platformdan bağımsız bir işlem olarak çalıştırılır. Aksi takdirde, F# Etkileşimli derleyici aracı X86/X64 üzerinde 32 bit bir işlem veya Arm64 tabanlı sistemlerde yerel bir 64 bit işlem olarak çalıştırılır.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.tr.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.tr.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">“True” olarak ayarlandığında, 'fsiAnyCpu.exe' platformdan bağımsız bir işlem olarak çalıştırılır. Aksi takdirde, F# Etkileşimli derleyici aracı X86/X64 üzerinde 32 bit bir işlem veya Arm64 tabanlı sistemlerde yerel bir 64 bit işlem olarak çalıştırılır.</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hans.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">如果设置为 true，"fsiAnyCpu.exe" 将作为平台非特定进程运行。否则，F# 交互窗口是 X86/X64 上的 32 位进程或基于 Arm64 的系统的本机 64 位进程。</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hans.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">如果设置为 true，"fsiAnyCpu.exe" 将作为平台非特定进程运行。否则，F# 交互窗口是 X86/X64 上的 32 位进程或基于 Arm64 的系统的本机 64 位进程。</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hant.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
+        <source>If set to true, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">如果設為 true，'fsiAnyCpu.exe' 會以平台中性流程執行。否則，F# 互動是 X86/X64 上的 32 位元流程或 Arm64 型系統上的原生 64 位元流程。</target>
         <note />
       </trans-unit>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hant.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpuDescr">
-        <source>If set to true, 'fsiAnyCpu.exe' is run as a platform neutral process. Otherwise, F# Interactive is a 32-bit process on X86/X64 or a native 64 bit process on Arm64 based systems.</source>
+        <source>If set, F# Interactive is a 64-bit process. Otherwise, F# Interactive is 32-bit on X86/X64 and 64-bit on Arm64.</source>
         <target state="translated">如果設為 true，'fsiAnyCpu.exe' 會以平台中性流程執行。否則，F# 互動是 X86/X64 上的 32 位元流程或 Arm64 型系統上的原生 64 位元流程。</target>
         <note />
       </trans-unit>


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/14101

@moloneymb initially thought the "run as 64-bit" option had been removed from Visual Studio. 

Because of this I think we should make the option text plainer, that enabling means we always run as 64-bit. The current text refers to "fsiAnyCpu.exe" and "platform neutral process" which doesn't mean anything to the user

cc @KevinRansom 

