### PR TITLE
Use a more accurate range when reporting an error on delegate type declaration

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -3161,7 +3161,10 @@ module EstablishTypeDefinitionCores =
                 | None -> ()
                 | Some spats ->
                     let ctorArgNames, _ = TcSimplePatsOfUnknownType cenv true CheckCxs envinner tpenv spats
-                    if not ctorArgNames.IsEmpty then errorR (Error(FSComp.SR.parsOnlyClassCanTakeValueArguments(), m))
+                    if not ctorArgNames.IsEmpty then
+                        match spats with
+                        | SynSimplePats.SimplePats(_, m) -> errorR (Error(FSComp.SR.parsOnlyClassCanTakeValueArguments(), m))
+                        | SynSimplePats.Typed(_, _, m) -> errorR (Error(FSComp.SR.parsOnlyClassCanTakeValueArguments(), m))
                 
             let envinner = AddDeclaredTypars CheckForDuplicateTypars (tycon.Typars m) envinner
             let envinner = MakeInnerEnvForTyconRef envinner thisTyconRef false

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/DelegateTypes/DelegateDefinition.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/DelegateTypes/DelegateDefinition.fs
@@ -17,8 +17,9 @@ namespace FSharpTest
         """
         |> compile
         |> shouldFail
-        |> withErrorCode 552
-        |> withErrorMessage "Only class types may take value arguments"
+        |> withDiagnostics [
+            (Error 552, Line 3, Col 11, Line 3, Col 19, "Only class types may take value arguments")
+        ]
         
     [<Fact>]
     let ``Delegate definition with primary constructor no argument.`` () =
@@ -30,8 +31,10 @@ namespace FSharpTest
         """
         |> compile
         |> shouldFail
-        |> withErrorCode 552
-        |> withErrorMessage "Only class types may take value arguments"
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 552, Line 3, Col 11, Line 3, Col 13, "Only class types may take value arguments")
+        ]
 
     [<Fact>]
     let ``Delegate definition`` () =

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/DelegateTypes/invalid_delegate_definition.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/DelegateTypes/invalid_delegate_definition.fs
@@ -1,5 +1,0 @@
-﻿type T(x: int) =
-    delegate of int -> int
-
-type T() =
-    delegate of int -> int

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/DelegateTypes/invalid_delegate_definition.fs.err.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/DelegateTypes/invalid_delegate_definition.fs.err.bsl
@@ -1,3 +1,0 @@
-﻿invalid_delegate_definition.fs (1,6)-(1,15) Only class types may take value arguments
-invalid_delegate_definition.fs (4,6)-(1,9) Only class types may take value arguments
-


### PR DESCRIPTION
This PR improves one on first contribution to F# https://github.com/dotnet/fsharp/pull/13078 by:

- Using a more accurate range showing exactly the error occurs (parenthesis, and arguments)
- This will allow to use the quick fix (Remove argument from constructors in case of an error)
- Remove duplicated tests that were not use in any env.lst 