### PR TITLE
Disallow explicit type parameters on getset properties

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -2169,7 +2169,8 @@ module GeneralizationHelpers =
             match memberFlags.MemberKind with
             // can't infer extra polymorphism for properties
             | SynMemberKind.PropertyGet
-            | SynMemberKind.PropertySet ->
+            | SynMemberKind.PropertySet
+            | SynMemberKind.PropertyGetSet ->
                  if not (isNil declaredTypars) then
                      errorR(Error(FSComp.SR.tcPropertyRequiresExplicitTypeParameters(), m))
             | SynMemberKind.Constructor ->

--- a/tests/fsharp/typecheck/sigs/neg32.bsl
+++ b/tests/fsharp/typecheck/sigs/neg32.bsl
@@ -37,11 +37,11 @@ neg32.fs(55,18,55,20): typecheck error FS0039: The type parameter 'T is not defi
 
 neg32.fs(56,18,56,20): typecheck error FS0039: The type parameter 'T is not defined.
 
-neg32.fs(57,22,57,24): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead.
+neg32.fs(57,4,57,38): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead.
 
-neg32.fs(58,22,58,24): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead.
+neg32.fs(58,4,58,33): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead.
 
-neg32.fs(59,22,59,24): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead..
+neg32.fs(59,4,59,33): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead..
 
 neg32.fs(62,10,62,12): typecheck error FS0039: The type parameter 'T is not defined.
 

--- a/tests/fsharp/typecheck/sigs/neg32.bsl
+++ b/tests/fsharp/typecheck/sigs/neg32.bsl
@@ -37,14 +37,20 @@ neg32.fs(55,18,55,20): typecheck error FS0039: The type parameter 'T is not defi
 
 neg32.fs(56,18,56,20): typecheck error FS0039: The type parameter 'T is not defined.
 
-neg32.fs(59,10,59,12): typecheck error FS0039: The type parameter 'T is not defined.
+neg32.fs(57,22,57,24): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead.
 
-neg32.fs(59,10,59,12): typecheck error FS0039: The type parameter 'T is not defined.
+neg32.fs(58,22,58,24): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead.
 
-neg32.fs(62,11,62,13): typecheck error FS0039: The type parameter 'T is not defined.
+neg32.fs(59,22,59,24): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead..
 
-neg32.fs(62,11,62,13): typecheck error FS0039: The type parameter 'T is not defined.
+neg32.fs(62,10,62,12): typecheck error FS0039: The type parameter 'T is not defined.
 
-neg32.fs(66,65,66,86): typecheck error FS0033: The non-generic type 'System.EventArgs' does not expect any type arguments, but here is given 1 type argument(s)
+neg32.fs(62,10,62,12): typecheck error FS0039: The type parameter 'T is not defined.
 
-neg32.fs(66,21,66,27): typecheck error FS1091: The event 'Event1' has a non-standard type. If this event is declared in another CLI language, you may need to access this event using the explicit add_Event1 and remove_Event1 methods for the event. If this event is declared in F#, make the type of the event an instantiation of either 'IDelegateEvent<_>' or 'IEvent<_,_>'.
+neg32.fs(65,11,65,13): typecheck error FS0039: The type parameter 'T is not defined.
+
+neg32.fs(65,11,65,13): typecheck error FS0039: The type parameter 'T is not defined.
+
+neg32.fs(69,65,69,86): typecheck error FS0033: The non-generic type 'System.EventArgs' does not expect any type arguments, but here is given 1 type argument(s)
+
+neg32.fs(69,21,69,27): typecheck error FS1091: The event 'Event1' has a non-standard type. If this event is declared in another CLI language, you may need to access this event using the explicit add_Event1 and remove_Event1 methods for the event. If this event is declared in F#, make the type of the event an instantiation of either 'IDelegateEvent<_>' or 'IEvent<_,_>'.

--- a/tests/fsharp/typecheck/sigs/neg32.bsl
+++ b/tests/fsharp/typecheck/sigs/neg32.bsl
@@ -41,7 +41,7 @@ neg32.fs(57,4,57,38): typecheck error FS0671: A property cannot have explicit ty
 
 neg32.fs(58,4,58,33): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead.
 
-neg32.fs(59,4,59,33): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead..
+neg32.fs(59,4,59,33): typecheck error FS0671: A property cannot have explicit type parameters. Consider using a method instead.
 
 neg32.fs(62,10,62,12): typecheck error FS0039: The type parameter 'T is not defined.
 

--- a/tests/fsharp/typecheck/sigs/neg32.fs
+++ b/tests/fsharp/typecheck/sigs/neg32.fs
@@ -54,6 +54,9 @@ type NegativeClass() =
    abstract M2 : 'T with get, set
    abstract M3 : 'T with set
    abstract M4 : 'T with get
+   abstract M5<'T> : 'T with get, set
+   abstract M6<'T> : 'T with set
+   abstract M7<'T> : 'T with get
 
 type NegativeRecord =
    { v : 'T }


### PR DESCRIPTION
Expanding on https://github.com/dotnet/fsharp/pull/13978, which only prevents inferring type parameters.