### PR TITLE
Revert "Activate Server mode for .NET Core compiler (#13740)"

### DIFF
--- a/FSharp.Profiles.props
+++ b/FSharp.Profiles.props
@@ -14,8 +14,4 @@
     </Otherwise>
   </Choose>
 
-  <PropertyGroup>
-     <!-- Override the setting for the Arcade UserRuntimeConfig for fsc on .NET Core -->
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This reverts commit e6275e8054197ac24202b39230238fdc113aa17c.
The reason is:
rc1, which is used in 17.5 branch, has a GC bug with fslexyacc crashing, rc2 has a fix, but is not supported by signing gate, and was failing our signed builds.
So, if we upgrade 17.5 to rc2, we won't be able to insert into sdk or vs.