### PR TITLE
Bump xcopy-msbuild + enable server gc

### DIFF
--- a/FSharp.Profiles.props
+++ b/FSharp.Profiles.props
@@ -14,4 +14,8 @@
     </Otherwise>
   </Choose>
 
+  <PropertyGroup>
+     <!-- Override the setting for the Arcade UserRuntimeConfig for fsc on .NET Core -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -12,7 +12,7 @@
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     },
-    "xcopy-msbuild": "17.2.1"
+    "xcopy-msbuild": "17.3.1"
   },
   "native-tools": {
     "perl": "5.32.1.1"


### PR DESCRIPTION
Fixes #14224 

When auto-merge to 17.5 happens, the CI will be failing building fslexyacc, when it happens, `global.json` needs to be updated to use rc2 (in the PR itself).