### PR TITLE
fix TestSource structure in ComponentTests 

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -177,12 +177,6 @@
     <Compile Include="Language\ExtensionMethodTests.fs" />
     <Compile Include="ConstraintSolver\PrimitiveConstraints.fs" />
     <Compile Include="ConstraintSolver\MemberConstraints.fs" />
-    <None Include="**\*.cs;**\*.fs;**\*.fsx;**\*.fsi" Exclude="@(Compile)">
-      <Link>%(RelativeDir)\TestSource\%(Filename)%(Extension)</Link>
-    </None>
-    <None Include="**\*.cs;**\*.fs;**\*.fsx;**\*.fsi;" Exclude="@(Compile)">
-      <Link>%(RelativeDir)\TestSource\%(Filename)%(Extension)</Link>
-    </None>
     <Compile Include="Interop\SimpleInteropTests.fs" />
     <Compile Include="Interop\RequiredAndInitOnlyProperties.fs" />
     <Compile Include="Interop\StaticsInInterfaces.fs" />
@@ -210,13 +204,20 @@
     <Compile Include="Signatures\TypeTests.fs" />
     <Compile Include="FSharpChecker\CommonWorkflows.fs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="**\*.cs;**\*.fs;**\*.fsx;**\*.fsi" Exclude="@(Compile)">
+      <Link>%(RelativeDir)\TestSource\%(Filename)%(Extension)</Link>
+    </None>
+    <None Include="**\*.bsl">
+      <Link>%(RelativeDir)\BaseLine\%(Filename)%(Extension)</Link>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="resources\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="PreserveNewest" />
     <EmbeddedResource Remove="Properties\**" />
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="**\*.bsl">
-      <Link>%(RelativeDir)\BaseLine\%(Filename)%(Extension)</Link>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\Compiler\FSharp.Compiler.Service.fsproj" />


### PR DESCRIPTION
I was just about to convert more tests from fsharpqa to the ComponentTest suite .... because I am just that sort of "selfless soul".

 I noticed that the treeview does not display files correctly.   The goal is that source files included in the project by "Compile" are showed directly.  Whilst F# / C# source files that are discovered by the DirectoryAttribute appear as a link below TestSource and baseline files appear as links below 
 Currently it looks like this:
 ![image](https://user-images.githubusercontent.com/5175830/200095369-ad527680-a025-4205-be04-edabb59c1988.png)

This is how it looks after the fix:
![image](https://user-images.githubusercontent.com/5175830/200095481-3059b5d0-bf84-40c8-a935-8aa8fa622be0.png)
