### PR TITLE
Allow the collapsing of single line match clauses

### DIFF
--- a/src/Compiler/Service/ServiceStructure.fs
+++ b/src/Compiler/Service/ServiceStructure.fs
@@ -493,9 +493,21 @@ module Structure =
                 | x -> x
 
             let synPat = getLastPat synPat
-            // Collapse the scope starting with `->`
-            let collapse = Range.endToEnd synPat.Range clause.Range
-            rcheck Scope.MatchClause Collapse.Same e.Range collapse
+            let synPatRange = synPat.Range
+            let resultExprRange = e.Range
+
+            // Avoid rcheck because we want to be able to collapse resultExpr even if it spans a single line
+            // but is not on the same one as the pattern
+            if synPatRange.EndLine <> resultExprRange.EndLine then
+                acc.Add
+                    {
+                        Scope = Scope.MatchClause
+                        Collapse = Collapse.Same
+                        Range = resultExprRange
+                        // Collapse the scope starting with `->`
+                        CollapseRange = Range.endToEnd synPatRange clause.Range
+                    }
+
             parseExpr e
 
         and parseAttributes (Attributes attrs) =


### PR DESCRIPTION
... but only when the match clause expression is on a different line than the pattern.

Before

![bGkG6Ublr0](https://user-images.githubusercontent.com/5063478/200165220-16c68d05-1fa7-4df6-bc12-013bf090883b.png)

After

![cSt0IeGfg7](https://user-images.githubusercontent.com/5063478/200165229-60a6619a-df58-49cd-a7f2-0bdec9ddb2df.png) ![jmh4KoOm9X](https://user-images.githubusercontent.com/5063478/200165232-9104c4f8-17bd-4096-9e2b-9a3103971d92.png)
