### PR TITLE
Add parameter name hints for discriminated unions

### DIFF
--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -242,6 +242,8 @@ type FSharpSymbolUse(denv: DisplayEnv, symbol: FSharpSymbol, inst: TyparInstanti
 
     member _.IsFromDispatchSlotImplementation = itemOcc = ItemOccurence.Implemented
 
+    member _.IsFromUse = itemOcc = ItemOccurence.Use
+
     member _.IsFromComputationExpression =
         match symbol.Item, itemOcc with
         // 'seq' in 'seq { ... }' gets colored as keywords

--- a/src/Compiler/Service/FSharpCheckerResults.fsi
+++ b/src/Compiler/Service/FSharpCheckerResults.fsi
@@ -171,6 +171,9 @@ type public FSharpSymbolUse =
     /// Indicates if the reference is in open statement
     member IsFromOpenStatement: bool
 
+    /// Indicates if the reference is used??? eh, todo
+    member IsFromUse: bool
+
     /// The file name the reference occurs in
     member FileName: string
 

--- a/vsintegration/src/FSharp.Editor/Hints/HintService.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/HintService.fs
@@ -23,6 +23,12 @@ module HintService =
 
             InlineParameterNameHints.getHints parseResults symbol symbolUse
 
+        | :? FSharpUnionCase as symbol
+          when hintKinds |> Set.contains HintKind.ParameterNameHint
+            && symbolUse.IsFromUse ->
+
+          InlineParameterNameHints.getHintsForUnionCase parseResults symbol symbolUse
+
         // we'll be adding other stuff gradually here
         | _ -> 
             []


### PR DESCRIPTION
Implements https://github.com/dotnet/fsharp/issues/14257.

![devenv_D1Crt5TJD2](https://user-images.githubusercontent.com/5063478/200404191-540fd12f-91f5-4c56-9be4-dc9f6840d1e7.png)

Todo: don't show hints for compiler-generated field names, refactor, rename, reshuffle, test.