### PR TITLE
New codefix provider to remove superflous binding for a Union case that has 0 fields.

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/CodeFixHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/CodeFixHelpers.fs
@@ -22,3 +22,18 @@ module internal CodeFixHelpers =
                     | Some textChanges -> return context.Document.WithText(sourceText.WithChanges(textChanges))
                 } |> RoslynHelpers.StartAsyncAsTask(cancellationToken)),
             title)
+
+[<AutoOpen>]
+module internal CodeFixExtensions =
+    type CodeFixProvider with
+        member this.GetPrunedDiagnostics(context: CodeFixContext) = 
+            context.Diagnostics.RemoveAll(fun x -> this.FixableDiagnosticIds.Contains(x.Id) |> not)
+            
+        member this.RegisterFix(context: CodeFixContext, fixName, fixChange) =
+            let replaceCodeFix =
+                CodeFixHelpers.createTextChangeCodeFix(
+                    fixName,
+                    context,
+                    (fun () -> asyncMaybe.Return [| fixChange |]))
+            context.RegisterCodeFix(replaceCodeFix, this.GetPrunedDiagnostics(context))
+                 

--- a/vsintegration/src/FSharp.Editor/CodeFix/RemoveSuperflousCaptureForUnionCaseWithNoData.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/RemoveSuperflousCaptureForUnionCaseWithNoData.fs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.Composition
+open System.Threading.Tasks
+
+open Microsoft.CodeAnalysis.Text
+open Microsoft.CodeAnalysis.CodeFixes
+
+open FSharp.Compiler
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Symbols
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.EditorServices
+
+[<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = "RemoveSuperflousCapture"); Shared>]
+type internal RemoveSuperflousCaptureForUnionCaseWithNoDataProvider
+    [<ImportingConstructor>]
+    (
+    ) =
+    
+    inherit CodeFixProvider()    
+
+    override _.FixableDiagnosticIds = Seq.toImmutableArray ["FS0725";"FS3548"]
+
+    override this.RegisterCodeFixesAsync context : Task =
+        asyncMaybe {           
+            do! Option.guard context.Document.Project.IsFSharpCodeFixesUnusedDeclarationsEnabled
+
+            let document = context.Document      
+            let! sourceText = document.GetTextAsync(context.CancellationToken)
+            let! _, checkResults = document.GetFSharpParseAndCheckResultsAsync(nameof(RemoveSuperflousCaptureForUnionCaseWithNoDataProvider)) |> liftAsync
+            let m = RoslynHelpers.TextSpanToFSharpRange(document.FilePath, context.Span, sourceText)
+            let classifications = checkResults.GetSemanticClassification(Some m)
+            let unionCaseItem = 
+                classifications
+                |> Array.tryFind (fun c -> c.Type = SemanticClassificationType.UnionCase)           
+
+            match unionCaseItem with
+            | None -> ()
+            | Some unionCaseItem ->
+                // The error/warning captures entire pattern match, like "Ns.Type.DuName bindingName". We want to keep type info when suggesting a replacement, and only remove "bindingName".
+                let typeInfoLength = unionCaseItem.Range.EndColumn - m.StartColumn
+                let reminderSpan = new TextSpan(context.Span.Start + typeInfoLength, context.Span.Length - typeInfoLength)                   
+                this.RegisterFix(context, SR.RemoveUnusedBinding(), TextChange(reminderSpan, ""))              
+        } 
+        |> Async.Ignore
+        |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -114,6 +114,7 @@
     <Compile Include="CodeFix\AddOpenCodeFixProvider.fs" />
     <Compile Include="CodeFix\ProposeUppercaseLabel.fs" />
     <Compile Include="CodeFix\ReplaceWithSuggestion.fs" />
+    <Compile Include="CodeFix\RemoveSuperflousCaptureForUnionCaseWithNoData.fs" />
     <Compile Include="CodeFix\RemoveUnusedBinding.fs" />
     <Compile Include="CodeFix\RenameUnusedValue.fs" />
     <Compile Include="CodeFix\ImplementInterfaceCodeFixProvider.fs" />


### PR DESCRIPTION
This kicks in when:
- DU case has 0 fields and _ is used to pattern match
- DU case has 0 fields and a named binding is used to pattern match

This builds on top of the new diagnostics added via https://github.com/dotnet/fsharp/pull/14055 

https://user-images.githubusercontent.com/46543583/200575149-1161693c-5650-4166-b5da-b76863e037e5.mp4


