### PR TITLE
Add parameter name hints for methods and constructors

### DIFF
--- a/vsintegration/src/FSharp.Editor/Hints/HintService.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/HintService.fs
@@ -19,7 +19,7 @@ module HintService =
         
         | :? FSharpMemberOrFunctionOrValue as symbol
           when hintKinds |> Set.contains HintKind.ParameterNameHint 
-            && InlineParameterNameHints.isMemberOrFunctionOrValueValidForHint symbol ->
+            && InlineParameterNameHints.isMemberOrFunctionOrValueValidForHint symbol symbolUse ->
 
             InlineParameterNameHints.getHintsForMemberOrFunctionOrValue parseResults symbol symbolUse
 

--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -30,14 +30,19 @@ module InlineParameterNameHints =
     let private doesFieldNameExist (field: FSharpField) = 
         not field.IsNameGenerated
 
-    let isMemberOrFunctionOrValueValidForHint (symbol: FSharpMemberOrFunctionOrValue) =
-        // is there a better way?
-        let isNotBuiltInOperator = 
-            symbol.DeclaringEntity 
-            |> Option.exists (fun entity -> entity.CompiledName <> "Operators")
+    let isMemberOrFunctionOrValueValidForHint (symbol: FSharpMemberOrFunctionOrValue) (symbolUse: FSharpSymbolUse) =
+        // make sure we're looking at a call site and not the definition
+        if symbolUse.IsFromUse then
+            // is there a better way?
+            let isNotBuiltInOperator = 
+                symbol.DeclaringEntity 
+                |> Option.exists (fun entity -> entity.CompiledName <> "Operators")
 
-        symbol.IsFunction
-        && isNotBuiltInOperator // arguably, hints for those would be rather useless
+            (symbol.IsFunction && isNotBuiltInOperator) // arguably, hints for those would be rather useless
+            || symbol.IsConstructor
+            || symbol.IsMethod
+        else
+            false
 
     let isUnionCaseValidForHint (symbol: FSharpUnionCase) (symbolUse: FSharpSymbolUse) =
         // is the union case being used as a constructor and is it not Cons

--- a/vsintegration/tests/UnitTests/OverallHintExperienceTests.fs
+++ b/vsintegration/tests/UnitTests/OverallHintExperienceTests.fs
@@ -22,6 +22,12 @@ type Shape =
 
 let a = Square 1
 let b = Rectangle (1, 2)
+
+type C (blahFirst: int) =
+    member _.Normal (what: string) = 1 
+
+let a = C 1
+let cc = a.Normal "hmm"
 """
     let document = getFsDocument code
     let expected = [
@@ -33,6 +39,10 @@ let b = Rectangle (1, 2)
         { Content = "width = "; Location = (11, 20) }
         { Content = "height = "; Location = (11, 23) }
         { Content = ": Shape"; Location = (11, 6) }
+        { Content = "blahFirst = "; Location = (16, 11) }
+        { Content = ": C"; Location = (16, 6) }
+        { Content = "what = "; Location = (17, 19) }
+        { Content = ": int"; Location = (17, 7) }
     ]
 
     let actual = getAllHints document


### PR DESCRIPTION
Implements #14258, #14259.

![5Jo1YLTUmc](https://user-images.githubusercontent.com/5063478/200633027-9ab1af12-4d9e-4060-9c5a-ac61cff1b010.png)