### PR TITLE
Don't emit IsReadOnlyAttribute if not available.

### DIFF
--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -611,7 +611,10 @@ let GenReadOnlyAttribute (g: TcGlobals) =
     mkILCustomAttribute (g.attrib_IsReadOnlyAttribute.TypeRef, [], [], [])
 
 let GenReadOnlyAttributeIfNecessary (g: TcGlobals) ty =
-    let add = isInByrefTy g ty && g.attrib_IsReadOnlyAttribute.TyconRef.CanDeref
+    let add =
+        g.isSystem_Runtime_CompilerServices_IsReadOnlyAttributeAvailable
+        && isInByrefTy g ty
+        && g.attrib_IsReadOnlyAttribute.TyconRef.CanDeref
 
     if add then
         let attr = GenReadOnlyAttribute g
@@ -2120,7 +2123,11 @@ type AssemblyBuilder(cenv: cenv, anonTypeTable: AnonTypeGenerationTable) as mgbu
             let ilMethods =
                 [
                     for propName, fldName, fldTy in flds ->
-                        let attrs = if isStruct then [ GenReadOnlyAttribute g ] else []
+                        let attrs =
+                            if g.isSystem_Runtime_CompilerServices_IsReadOnlyAttributeAvailable && isStruct then
+                                [ GenReadOnlyAttribute g ]
+                            else
+                                []
 
                         mkLdfldMethodDef ("get_" + propName, ILMemberAccess.Public, false, ilTy, fldName, fldTy, attrs)
                         |> g.AddMethodGeneratedAttributes
@@ -10878,7 +10885,11 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
                             let isStruct = isStructTyconRef tcref
 
                             let attrs =
-                                if isStruct && not isStatic then
+                                if
+                                    g.isSystem_Runtime_CompilerServices_IsReadOnlyAttributeAvailable
+                                    && isStruct
+                                    && not isStatic
+                                then
                                     [ GenReadOnlyAttribute g ]
                                 else
                                     []

--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -1719,6 +1719,9 @@ type TcGlobals(
   /// Indicates if we can use System.Array.Empty when emitting IL for empty array literals
   member val isArrayEmptyAvailable = v_Array_tcref.ILTyconRawMetadata.Methods.FindByName "Empty" |> List.isEmpty |> not
 
+  /// Indicates if we can emit the System.Runtime.CompilerServices.IsReadOnlyAttribute
+  member val isSystem_Runtime_CompilerServices_IsReadOnlyAttributeAvailable = tryFindSysTypeCcu sysCompilerServices "IsReadOnlyAttribute" |> Option.isSome
+
   member _.FindSysTyconRef path nm = findSysTyconRef path nm
 
   member _.TryFindSysTyconRef path nm = tryFindSysTyconRef path nm


### PR DESCRIPTION
Fixes #14275

I'm not sure how to add a test for this fix.
I believe [IsReadOnlyAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.isreadonlyattribute?view=netframework-4.7.2) is available for both `net472` and `net6.0`. Only when targeting `netstandard2.0` or lower can you come across the situation where it is not present.
I'm not sure how to add a test for that exact condition.

I was able to compile my [repro]
(https://github.com/nojaf/serialize-struct) with the local compiler and the test now passes.