### PR TITLE
Small command line Deprecations

### DIFF
--- a/src/Compiler/Driver/CompilerOptions.fs
+++ b/src/Compiler/Driver/CompilerOptions.fs
@@ -1770,13 +1770,31 @@ let compilingFsLibFlag (tcConfigB: TcConfigBuilder) =
     )
 
 let compilingFsLib20Flag =
-    CompilerOption("compiling-fslib-20", tagNone, OptionString(fun _ -> ()), Some (DeprecatedCommandLineOptionNoDescription("--compiling-fslib-20", rangeCmdArgs)), None)
+    CompilerOption(
+        "compiling-fslib-20",
+        tagNone,
+        OptionString(fun _ -> ()),
+        Some(DeprecatedCommandLineOptionNoDescription("--compiling-fslib-20", rangeCmdArgs)),
+        None
+    )
 
 let compilingFsLib40Flag =
-    CompilerOption("compiling-fslib-40", tagNone, OptionUnit(fun () -> ()), Some (DeprecatedCommandLineOptionNoDescription("--compiling-fslib-40", rangeCmdArgs)), None)
+    CompilerOption(
+        "compiling-fslib-40",
+        tagNone,
+        OptionUnit(fun () -> ()),
+        Some(DeprecatedCommandLineOptionNoDescription("--compiling-fslib-40", rangeCmdArgs)),
+        None
+    )
 
 let compilingFsLibNoBigIntFlag =
-    CompilerOption("compiling-fslib-nobigint", tagNone, OptionUnit(fun () -> ()), Some (DeprecatedCommandLineOptionNoDescription("compiling-fslib-nobigint", rangeCmdArgs)), None)
+    CompilerOption(
+        "compiling-fslib-nobigint",
+        tagNone,
+        OptionUnit(fun () -> ()),
+        Some(DeprecatedCommandLineOptionNoDescription("compiling-fslib-nobigint", rangeCmdArgs)),
+        None
+    )
 
 let mlKeywordsFlag =
     CompilerOption(

--- a/src/Compiler/Driver/CompilerOptions.fs
+++ b/src/Compiler/Driver/CompilerOptions.fs
@@ -1770,13 +1770,13 @@ let compilingFsLibFlag (tcConfigB: TcConfigBuilder) =
     )
 
 let compilingFsLib20Flag =
-    CompilerOption("compiling-fslib-20", tagNone, OptionString(fun _ -> ()), None, None)
+    CompilerOption("compiling-fslib-20", tagNone, OptionString(fun _ -> ()), Some (DeprecatedCommandLineOptionNoDescription("--compiling-fslib-20", rangeCmdArgs)), None)
 
 let compilingFsLib40Flag =
-    CompilerOption("compiling-fslib-40", tagNone, OptionUnit(fun () -> ()), None, None)
+    CompilerOption("compiling-fslib-40", tagNone, OptionUnit(fun () -> ()), Some (DeprecatedCommandLineOptionNoDescription("--compiling-fslib-40", rangeCmdArgs)), None)
 
 let compilingFsLibNoBigIntFlag =
-    CompilerOption("compiling-fslib-nobigint", tagNone, OptionUnit(fun () -> ()), None, None)
+    CompilerOption("compiling-fslib-nobigint", tagNone, OptionUnit(fun () -> ()), Some (DeprecatedCommandLineOptionNoDescription("compiling-fslib-nobigint", rangeCmdArgs)), None)
 
 let mlKeywordsFlag =
     CompilerOption(


### PR DESCRIPTION
Whilst looking at some refactorings in fsharp.core.dll I came across a few command line options, that do nothing.  So I deprecated them.

We haven't shipped a new build of fsharp.core relying on these options since 2012 ... really, if any one is using them, they are doing the wrong thing!!!!!

