### PR TITLE
Fix error reporting in fsi after a lexer error

### DIFF
--- a/src/Compiler/SyntaxTree/LexFilter.fs
+++ b/src/Compiler/SyntaxTree/LexFilter.fs
@@ -699,6 +699,8 @@ type LexFilterImpl (
     let mutable prevWasAtomicEnd = false
     
     let peekInitial() =
+        // Forget the lexbuf state we might have saved from previous input
+        haveLexbufState <- false
         let initialLookaheadTokenTup = popNextTokenTup()
         if debug then dprintf "first token: initialLookaheadTokenLexbufState = %a\n" outputPos (startPosOfTokenTup initialLookaheadTokenTup)
         


### PR DESCRIPTION
Fixes #13139, #9631

The problem was that we had some cached lexer state when reading new input during FSI session. If lexer threw an error on a very first token of new input, the cached lexer state would not get updated, so we would assosciate old lexer state with this new token that caused an error.

Now we will invalidate that cached state at the begining of reading new input.