### PR TITLE
Caching

### DIFF
--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -64,7 +64,6 @@ module internal Utilities =
         |> Array.filter (fun r ->
             not (String.IsNullOrEmpty(r.NugetPackageId) || String.IsNullOrEmpty(r.FullPath))
             && not (equals r.IsNotImplementationReference "true")
-            && File.Exists(r.FullPath)
             && equals r.AssetType "runtime")
         |> Array.map (fun r -> r.FullPath)
         |> Array.distinct
@@ -260,7 +259,7 @@ module internal Utilities =
         let resolutionsFile, resolutions, references, loads, includes =
             if success && File.Exists(outputFile) then
                 let resolutions = getResolutionsFromFile outputFile
-                let references = (findReferencesFromResolutions resolutions) |> Array.toList
+                let references = (findReferencesFromResolutions resolutions) |> Array.filter(File.Exists) |> Array.toList
                 let loads = (findLoadsFromResolutions resolutions) |> Array.toList
                 let includes = (findIncludesFromResolutions resolutions) |> Array.toList
                 (Some outputFile), resolutions, references, loads, includes

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -259,7 +259,12 @@ module internal Utilities =
         let resolutionsFile, resolutions, references, loads, includes =
             if success && File.Exists(outputFile) then
                 let resolutions = getResolutionsFromFile outputFile
-                let references = (findReferencesFromResolutions resolutions) |> Array.filter(File.Exists) |> Array.toList
+
+                let references =
+                    (findReferencesFromResolutions resolutions)
+                    |> Array.filter (File.Exists)
+                    |> Array.toList
+
                 let loads = (findLoadsFromResolutions resolutions) |> Array.toList
                 let includes = (findIncludesFromResolutions resolutions) |> Array.toList
                 (Some outputFile), resolutions, references, loads, includes


### PR DESCRIPTION
#r nuget has a package caching algorithm, that was broken.  The issue was that when determining the paths to verify if the cache was out of day, we removed paths that didn't exist.  Which obviously makes it a little tough if the cache invalidation consists of checking whether that path exists or not.

Anyway, this fixes that by not removing the path before checking cache validation.