### PR TITLE
Adding keywords for F# settings in VS options

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
@@ -159,8 +159,25 @@
   <data name="6008" xml:space="preserve">
     <value>IntelliSense</value>
   </data>
+  <data name="IntelliSensePageKeywords" xml:space="preserve">
+    <value>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</value>
+  </data>
   <data name="6009" xml:space="preserve">
     <value>QuickInfo</value>
+  </data>
+  <data name="QuickInfoPageKeywords" xml:space="preserve">
+    <value>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</value>
   </data>
   <data name="AddAssemblyReference" xml:space="preserve">
     <value>Add an assembly reference to '{0}'</value>
@@ -171,14 +188,43 @@
   <data name="6010" xml:space="preserve">
     <value>Code Fixes</value>
   </data>
+  <data name="CodeFixesPageKeywords" xml:space="preserve">
+    <value>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</value>
+  </data>
   <data name="6011" xml:space="preserve">
     <value>Performance</value>
+  </data>
+  <data name="PerformancePageKeywords" xml:space="preserve">
+    <value>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</value>
   </data>
   <data name="6012" xml:space="preserve">
     <value>Advanced</value>
   </data>
+  <data name="AdvancedPageKeywords" xml:space="preserve">
+    <value>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</value>
+  </data>
   <data name="6014" xml:space="preserve">
     <value>Formatting</value>
+  </data>
+  <data name="FormattingPageKeywords" xml:space="preserve">
+    <value>Re-format indentation on paste (Experimental)</value>
   </data>
   <data name="TheValueIsUnused" xml:space="preserve">
     <value>The value is unused</value>

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -193,12 +193,12 @@ type internal FSharpSettingsFactory
                     Width = 360,
                     Height = 120,
                     Window="34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3")>]
-[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.IntelliSenseOptionPage>, "F#", null, "IntelliSense", "6008")>]
-[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.QuickInfoOptionPage>, "F#", null, "QuickInfo", "6009")>]
-[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.CodeFixesOptionPage>, "F#", null, "Code Fixes", "6010")>]
-[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.LanguageServicePerformanceOptionPage>, "F#", null, "Performance", "6011")>]
-[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.AdvancedSettingsOptionPage>, "F#", null, "Advanced", "6012")>]
-[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.FormattingOptionPage>, "F#", null, "Formatting", "6014")>]
+[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.IntelliSenseOptionPage>, "F#", null, "IntelliSense", "6008", "IntelliSensePageKeywords")>]
+[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.QuickInfoOptionPage>, "F#", null, "QuickInfo", "6009", "QuickInfoPageKeywords")>]
+[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.CodeFixesOptionPage>, "F#", null, "Code Fixes", "6010", "CodeFixesPageKeywords")>]
+[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.LanguageServicePerformanceOptionPage>, "F#", null, "Performance", "6011", "PerformancePageKeywords")>]
+[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.AdvancedSettingsOptionPage>, "F#", null, "Advanced", "6012", "AdvancedPageKeywords")>]
+[<ProvideLanguageEditorOptionPage(typeof<OptionsUI.FormattingOptionPage>, "F#", null, "Formatting", "6014", "FormattingPageKeywords")>]
 [<ProvideFSharpVersionRegistration(FSharpConstants.projectPackageGuidString, "Microsoft Visual F#")>]
 // 64 represents a hex number. It needs to be greater than 37 so the TextMate editor will not be chosen as higher priority.
 [<ProvideEditorExtension(typeof<FSharpEditorFactory>, ".fs", 64)>]

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Přidat anotaci typu</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">Funkce jazyka F#</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Implementujte rozhraní.</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Implementujte rozhraní bez anotace typu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">Nastavit {0} jako rekurzivní</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">Před {0} vložte podtržítko.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Typanmerkung hinzufügen</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">F#-Funktionen</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Schnittstelle implementieren</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Schnittstelle ohne Typanmerkung implementieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">"{0}" als rekursiv festlegen</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">"{0}" einen Unterstrich voranstellen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Agregar una anotación de tipo</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">Funciones de F#</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Implementar interfaz</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Implementar interfaz sin anotación de tipos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">Convertir el elemento "{0}" en recursivo</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">Colocar un carácter de subrayado delante de "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Ajouter une annotation de type</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">Fonctions F#</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Implémenter l'interface</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Implémenter l'interface sans annotation de type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">Rendre '{0}' récursif</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">Faire précéder '{0}' d'un trait de soulignement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Aggiungere l'annotazione di tipo</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">Funzioni F#</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Implementa l'interfaccia</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Implementa l'interfaccia senza annotazione di tipo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">Imposta '{0}' come ricorsivo</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">Anteponi a '{0}' un carattere di sottolineatura</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
@@ -27,6 +27,36 @@
         <target state="translated">型の注釈の追加</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">F# 関数</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">インターフェイスを実装します。</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">型の注釈を指定しないでインターフェイスを実装する</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">'{0}' を再帰的にする</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">アンダースコアが含まれているプレフィックス '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
@@ -27,6 +27,36 @@
         <target state="translated">형식 주석 추가</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">F# 함수</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">인터페이스 구현</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">형식 주석 없이 인터페이스 구현</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">'{0}'을(를) 재귀적으로 만들기</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">밑줄이 있는 '{0}' 접두사</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Dodaj adnotację typu</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">Funkcje języka F#</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Zaimplementuj interfejs</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Zaimplementuj interfejs bez adnotacji typu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">Zmień element „{0}” w cykliczny</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">Prefiks „{0}” ze znakiem podkreślenia</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Adicionar uma anotação de tipo</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">Funções F#</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Implementar a interface</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Implementar a interface sem a anotação de tipo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">Tornar '{0}' recursiva</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">Prefixo '{0}' sem sublinhado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Добавить заметку типа</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">Функции F#</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Реализовать интерфейс</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Реализовать интерфейс без заметки с типом</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">Сделать "{0}" рекурсивным</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">Добавить символ подчеркивания как префикс "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
@@ -27,6 +27,36 @@
         <target state="translated">Tür ek açıklaması ekle</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">F# İşlevleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">Arabirimi uygula</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">Tür ek açıklaması olmadan arabirim uygulama</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">'{0}' bağlamasını özyinelemeli yap</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">'{0}' öğesinin önüne alt çizgi ekleme</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
@@ -27,6 +27,36 @@
         <target state="translated">添加类型注释</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">F# 函数</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">实现接口</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">无类型批注的实现接口</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">使 "{0}" 递归</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">带下划线的前缀“{0}”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
@@ -27,6 +27,36 @@
         <target state="translated">新增型別註解</target>
         <note />
       </trans-unit>
+      <trans-unit id="AdvancedPageKeywords">
+        <source>Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</source>
+        <target state="new">Block Structure Guides;
+Show structure guidelines for F# code;
+Outlining;
+Show outlining and collapsible nodes for F# code;
+Inline hints;
+Display inline type hints (experimental);
+Display inline parameter name hints (experimental);Beer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeFixesPageKeywords">
+        <source>Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</source>
+        <target state="new">Simplify names (remove unnecessary qualifiers);
+Always place open statements at the top level;
+Remove unused open statements;
+Analyze and suggest fixes for unused values;
+Suggest names for unresolved identifiers;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConvertCSharpUsingToFSharpOpen">
         <source>Convert C# 'using' to F# 'open'</source>
         <target state="new">Convert C# 'using' to F# 'open'</target>
@@ -72,6 +102,11 @@
         <target state="translated">F# 函式</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormattingPageKeywords">
+        <source>Re-format indentation on paste (Experimental)</source>
+        <target state="new">Re-format indentation on paste (Experimental)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ImplementInterface">
         <source>Implement interface</source>
         <target state="translated">實作介面</target>
@@ -80,6 +115,25 @@
       <trans-unit id="ImplementInterfaceWithoutTypeAnnotation">
         <source>Implement interface without type annotation</source>
         <target state="translated">實作沒有類型註釋的介面</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSensePageKeywords">
+        <source>Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</source>
+        <target state="new">Completion Lists;
+Show completion list after a character is deleted;
+Show completion list after a character is typed;
+Show symbols in unopened namespaces;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeDeclarationMutable">
@@ -92,9 +146,41 @@
         <target state="translated">將 '{0}' 設為遞迴</target>
         <note />
       </trans-unit>
+      <trans-unit id="PerformancePageKeywords">
+        <source>F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</source>
+        <target state="new">F# Project and Caching Performance Options;
+Enable in-memory cross project references;
+IntelliSense Performance Options;
+Enable stale data for IntelliSense features;
+Time until stale results are used (in milliseconds);
+Parallelization (requires restart);
+Enable parallel type checking with signature files;
+Enable parallel reference resolution</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PrefixValueNameWithUnderscore">
         <source>Prefix '{0}' with underscore</source>
         <target state="translated">有底線的前置詞 '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QuickInfoPageKeywords">
+        <source>Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</source>
+        <target state="new">Navigation links;
+Show navigation links as;
+Solid underline;
+Dot underline;
+Dash underline;</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveReturn">
@@ -164,7 +250,7 @@
       </trans-unit>
       <trans-unit id="6008">
         <source>IntelliSense</source>
-        <target state="translated">IntelliSense</target>
+        <target state="needs-review-translation">IntelliSense</target>
         <note />
       </trans-unit>
       <trans-unit id="6009">


### PR DESCRIPTION
closes #14369 

Before:

https://user-images.githubusercontent.com/5451366/203330864-019fa9b3-3815-4df6-acbb-048c41da7f70.mp4

After:

https://user-images.githubusercontent.com/5451366/203330880-9f34f7e0-175f-4bf2-b9a4-3324fd360d43.mp4

The implementation is based on the Roslyn approach [here](https://github.com/dotnet/roslyn/blob/main/src/VisualStudio/CSharp/Impl/CSharpPackage.cs#L46). Looking at their [resources](https://github.com/dotnet/roslyn/blob/main/src/VisualStudio/CSharp/Impl/VSPackage.resx#L144), it doesn't seem like there was much thought put into concrete keywords so I also just copypasted our string resources.

Note that VS is smart-ish in keyword processing, in that it doesn't require a full match, and IMO provides a good option search experience.

