### PR TITLE
Extra tests for inline type hints

### DIFF
--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -260,12 +260,10 @@ module SyntaxTraversal =
             | [ x ] -> x ()
             | _ ->
 #if DEBUG
-                assert false
-                failwithf "multiple disjoint AST node ranges claimed to contain (%A) from %+A" pos debugObj
-#else
+                printf "multiple disjoint AST node ranges claimed to contain (%A) from %+A" pos debugObj
+#endif
                 ignore debugObj
                 None
-#endif
 
     /// traverse an implementation file walking all the way down to SynExpr or TypeAbbrev at a particular location
     ///

--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -31,9 +31,7 @@ module InlineParameterNameHints =
         not field.IsNameGenerated
 
     let isMemberOrFunctionOrValueValidForHint (symbol: FSharpMemberOrFunctionOrValue) (symbolUse: FSharpSymbolUse) =
-        // make sure we're looking at a call site and not the definition
         if symbolUse.IsFromUse then
-            // is there a better way?
             let isNotBuiltInOperator = 
                 symbol.DeclaringEntity 
                 |> Option.exists (fun entity -> entity.CompiledName <> "Operators")
@@ -45,7 +43,6 @@ module InlineParameterNameHints =
             false
 
     let isUnionCaseValidForHint (symbol: FSharpUnionCase) (symbolUse: FSharpSymbolUse) =
-        // is the union case being used as a constructor and is it not Cons
         symbolUse.IsFromUse
         && symbol.DisplayName <> "(::)"
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
@@ -145,3 +145,41 @@ type Song() as x =
         let result = getTypeHints document
 
         Assert.IsEmpty(result)
+
+    [<Test>]
+    let ``Hints are shown for lambdas`` () =
+        let code =
+            """
+let iamboring() =
+    fun x -> x
+"""
+
+        let document = getFsDocument code
+        let expected = [ { Content = ": 'a"; Location = (2, 10) } ]
+
+        let actual = getTypeHints document
+
+        Assert.AreEqual(expected, actual)
+
+    [<Test>]
+    let ``Hints are shown for lambdas with tuples`` () =
+        let code =
+            """
+let zip4 (l1: 'a list) (l2: 'b list) (l3: 'c list) (l4: 'd list) =
+    List.zip l1 (List.zip3 l2 l3 l4)
+    |> List.map (fun (x1, (x2, x3, x4)) -> (x1, x2, x3, x4))
+"""
+
+        let document = getFsDocument code
+
+        let expected =
+            [
+                { Content = ": 'a"; Location = (3, 25) }
+                { Content = ": 'b"; Location = (3, 30) }
+                { Content = ": 'c"; Location = (3, 34) }
+                { Content = ": 'd"; Location = (3, 38) }
+            ]
+
+        let actual = getTypeHints document
+
+        CollectionAssert.AreEquivalent(expected, actual)


### PR DESCRIPTION
The message will be properly addressed [here](https://github.com/dotnet/fsharp/pull/14292), for now just fixing #14269 and adding some tests.