### PR TITLE
`WIP` VS Go to definition from C# to F#

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -95,11 +95,11 @@
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <!-- Versions for package groups -->
-    <RoslynVersion>4.4.0-3.22470.1</RoslynVersion>
-    <VisualStudioEditorPackagesVersion>17.4.196-preview</VisualStudioEditorPackagesVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.4.0-preview-3-32916-145</MicrosoftVisualStudioShellPackagesVersion>
-    <VisualStudioProjectSystemPackagesVersion>17.4.342-pre</VisualStudioProjectSystemPackagesVersion>
-    <MicrosoftVisualStudioThreadingPackagesVersion>17.4.23-alpha</MicrosoftVisualStudioThreadingPackagesVersion>
+    <RoslynVersion>4.5.0-1.22520.13</RoslynVersion>
+    <VisualStudioEditorPackagesVersion>17.5.49-preview</VisualStudioEditorPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.5.0-preview-1-33020-520</MicrosoftVisualStudioShellPackagesVersion>
+    <VisualStudioProjectSystemPackagesVersion>17.5.202-pre-g89e17c9f72</VisualStudioProjectSystemPackagesVersion>
+    <MicrosoftVisualStudioThreadingPackagesVersion>17.4.27</MicrosoftVisualStudioThreadingPackagesVersion>
     <MicrosoftBuildOverallPackagesVersion>17.4.0-preview-22469-04</MicrosoftBuildOverallPackagesVersion>
     <!-- Roslyn packages -->
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>
@@ -115,7 +115,7 @@
     <!-- Visual Studio Shell packages -->
     <MicrosoftVisualStudioInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropVersion>
     <MicrosoftInternalVisualStudioInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioInteropVersion>
-    <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>17.4.0-preview-3-32916-053</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
+    <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>17.5.0-preview-1-33019-447</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftVisualStudioShellInterop80Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellInterop80Version>
     <MicrosoftVisualStudioShellInterop90Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellInterop90Version>
     <MicrosoftVisualStudioShellInterop100Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellInterop100Version>
@@ -132,8 +132,8 @@
     <MicrosoftVisualStudioShellDesignVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellDesignVersion>
     <MicrosoftVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioPackageLanguageService150Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioPackageLanguageService150Version>
-    <MicrosoftVisualStudioManagedInterfacesVersion>17.4.0-preview-3-32916-053</MicrosoftVisualStudioManagedInterfacesVersion>
-    <MicrosoftVisualStudioProjectAggregatorVersion>17.4.0-preview-3-32916-053</MicrosoftVisualStudioProjectAggregatorVersion>
+    <MicrosoftVisualStudioManagedInterfacesVersion>17.5.0-preview-1-33019-447</MicrosoftVisualStudioManagedInterfacesVersion>
+    <MicrosoftVisualStudioProjectAggregatorVersion>17.5.0-preview-1-33019-447</MicrosoftVisualStudioProjectAggregatorVersion>
     <MicrosoftVisualStudioGraphModelVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImagingVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDesignerInterfacesVersion>
@@ -170,7 +170,7 @@
     <MicrosoftVisualStudioProjectSystemManagedVersion>2.3.6152103</MicrosoftVisualStudioProjectSystemManagedVersion>
     <!-- Misc. Visual Studio packages -->
     <MicrosoftVSSDKBuildToolsVersion>17.1.4054</MicrosoftVSSDKBuildToolsVersion>
-    <MicrosoftVisualStudioRpcContractsVersion>17.4.7-alpha</MicrosoftVisualStudioRpcContractsVersion>
+    <MicrosoftVisualStudioRpcContractsVersion>17.5.9-alpha-g84529e7115</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
     <MicrosoftVisualStudioValidationVersion>17.0.64</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioWCFReferenceInteropVersion>9.0.30729</MicrosoftVisualStudioWCFReferenceInteropVersion>
@@ -203,8 +203,8 @@
     <NUnitLiteVersion>3.11.0</NUnitLiteVersion>
     <NunitXmlTestLoggerVersion>2.1.80</NunitXmlTestLoggerVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
-    <StreamJsonRpcVersion>2.13.23-alpha</StreamJsonRpcVersion>
-    <NerdbankStreamsVersion>2.9.87-alpha</NerdbankStreamsVersion>
+    <StreamJsonRpcVersion>2.14.6-alpha</StreamJsonRpcVersion>
+    <NerdbankStreamsVersion>2.9.112</NerdbankStreamsVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVersion>2.4.2</XUnitRunnerVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -2818,6 +2818,19 @@ type FSharpAssemblySignature (cenv, topAttribs: TopAttribs option, optViewedCcu:
              |> Option.map (fun e -> FSharpEntity(cenv, rescopeEntity optViewedCcu e))
         | _ -> None
 
+    member _.FindMemberOrValByPath path =
+        let findNested name entity = 
+            match entity with
+            | Some (e: Entity) -> e.ModuleOrNamespaceType.AllEntitiesByCompiledAndLogicalMangledNames.TryFind name
+            | _ -> None
+
+        match path with
+        | hd :: tl ->
+             (mtyp.AllEntitiesByCompiledAndLogicalMangledNames.TryFind hd, tl) 
+             ||> List.fold (fun a x -> findNested x a)  
+             |> Option.map (fun e -> FSharpEntity(cenv, rescopeEntity optViewedCcu e))
+        | _ -> None
+
     member x.TryGetEntities() = try x.Entities :> _ seq with _ -> Seq.empty
 
     override x.ToString() = "<assembly signature>"

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -1777,7 +1777,7 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         if isUnresolved() then false else 
         match fsharpInfo() with 
         | None -> false
-        | Some v -> 
+        | Some v ->
         v.IsCompilerGenerated
 
     member _.InlineAnnotation = 
@@ -2809,19 +2809,6 @@ type FSharpAssemblySignature (cenv, topAttribs: TopAttribs option, optViewedCcu:
         let findNested name entity = 
             match entity with
             | Some (e: Entity) ->e.ModuleOrNamespaceType.AllEntitiesByCompiledAndLogicalMangledNames.TryFind name
-            | _ -> None
-
-        match path with
-        | hd :: tl ->
-             (mtyp.AllEntitiesByCompiledAndLogicalMangledNames.TryFind hd, tl) 
-             ||> List.fold (fun a x -> findNested x a)  
-             |> Option.map (fun e -> FSharpEntity(cenv, rescopeEntity optViewedCcu e))
-        | _ -> None
-
-    member _.FindMemberOrValByPath path =
-        let findNested name entity = 
-            match entity with
-            | Some (e: Entity) -> e.ModuleOrNamespaceType.AllEntitiesByCompiledAndLogicalMangledNames.TryFind name
             | _ -> None
 
         match path with

--- a/vsintegration/src/FSharp.Editor/LanguageService/MetadataAsSource.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/MetadataAsSource.fs
@@ -94,7 +94,7 @@ module internal MetadataAsSource =
 
 [<Sealed>]
 [<Export(typeof<FSharpMetadataAsSourceService>); Composition.Shared>]
-type internal FSharpMetadataAsSourceService() =
+type FSharpMetadataAsSourceService() =
 
     let serviceProvider = ServiceProvider.GlobalProvider
     let projs = System.Collections.Concurrent.ConcurrentDictionary<string, IFSharpWorkspaceProjectContext>()

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -7,6 +7,7 @@ open System.Threading
 open Microsoft.CodeAnalysis
 open FSharp.Compiler
 open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Symbols
 
 [<AutoOpen>]
 module private CheckerExtensions =
@@ -237,3 +238,16 @@ type Project with
             else
                 return raise(OperationCanceledException("Project is not a FSharp project."))
         }
+
+type FSharpEntity with
+    member this.TryFindValByName(name: string) =
+        match this.TryGetMembersFunctionsAndValues() with
+        | xs when xs.Count > 0 ->
+            xs 
+            |> Seq.filter (
+                fun x ->
+                    not x.IsPropertyGetterMethod 
+                    && not x.IsPropertySetterMethod
+                    && not x.IsCompilerGenerated
+                    && x.CompiledName = name)
+        | _ -> Seq.empty

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -842,8 +842,9 @@ type FSharpCrossLanguageSymbolNavigationService()  =
                     | _ -> ()
                 
                 // TODO: Figure out the way of giving the user choice where to navigate, if there are more than one result
-                // For now, for testing, we only take 1st one.
-                if locations.Count() > 1 then
+                // For now, we only take 1st one, since it's usually going to be only one result (given we process names correctly).
+                // More results can theoretically be returned in case of method overloads, or when we have both signature and implementation files.
+                if locations.Count() >= 1 then
                     let (location, project) = locations.First()
                     return FSharpNavigableLocation(statusBar, metadataAsSource, location, project) :> IFSharpNavigableLocation
                 else


### PR DESCRIPTION
This adds support for navigation to F# symbol from C# project, it selects target project based on assembly name, and searches symbol based on its DocumentCommentId, which has the following formats:

`T:` prefix for types
  - `T:N.X.Nested` - type
  - `T:N.X.D` - delegate

`M:` prefix is for methods
  - `M:N.X.#ctor` - constructor
  - `M:N.X.#ctor(System.Int32)` - constructor with one parameter
  - `M:N.X.f` - method with unit parameter
  - `M:N.X.bb(System.String,System.Int32@)` - method with two parameters
  - `M:N.X.gg(System.Int16[],System.Int32[0:,0:])` - method with two parameters, 1d and 2d array
  - `M:N.X.op_Addition(N.X,N.X)` - operator
  - `M:N.X.op_Explicit(N.X)~System.Int32` - operator with return type
  - `M:N.GenericMethod.WithNestedType``1(N.GenericType{``0}.NestedType)` - generic type with one parameter
  - `M:N.GenericMethod.WithIntOfNestedType``1(N.GenericType{System.Int32}.NestedType)` - generic type with one parameter
  - `M:N.X.N#IX{N#KVP{System#String,System#Int32}}#IXA(N.KVP{System.String,System.Int32})` - explicit interface implementation

`E:` prefix for events

  - `E:N.X.d`.

`F:` prefix for fields
  - `F:N.X.q` - field

`P:` prefix for properties
  - `P:N.X.prop` - property with getter and setter

TODO List:
- [x] Support for simple functions
- [ ] Support for generic functions
- [ ] Support for overloaded methods (+ match on type and method parameters)
- [ ] Support for types
- [ ] Support for events, fields and properties

Not entirely sure how to properly test it just yet.