### PR TITLE
Updated devcontainer, tasks

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG VARIANT=7.0-bullseye-slim
+ARG VARIANT=7.0.100-bullseye-slim-amd64
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 
 # Avoid warnings by switching to noninteractive

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
         "args": {
             // Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0, 7.0
             // Append -bullseye(-slim), -focal, or -jammy to pin to an OS version.
-            "VARIANT": "7.0-bullseye-slim"
+            "VARIANT": "7.0.100-bullseye-slim-amd64"
         }
     },
     "hostRequirements": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,8 +3,14 @@
     "version": "0.2.0",
     "inputs": [
         {
-            "id": "argsPrompt",
+            "id": "fscArgsPrompt",
             "description": "Enter arguments for fsc",
+            "default": "",
+            "type": "promptString",
+        },
+        {
+            "id": "fssArgsPrompt",
+            "description": "Enter arguments for fsi (optional)",
             "default": "",
             "type": "promptString",
         }
@@ -18,6 +24,9 @@
             // "preLaunchTask": "Build (Debug)",
             // If you have changed target frameworks, make sure to update the program p
             "program": "${workspaceFolder}/artifacts/bin/fsi/Debug/net7.0/fsi.dll",
+            "args": [
+                "${input:fsiArgsPrompt}"
+            ],
             "cwd": "${workspaceFolder}/src",
             "console": "integratedTerminal", // This is the default to be able to run in Codespaces.
             "internalConsoleOptions": "neverOpen",
@@ -44,7 +53,7 @@
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/artifacts/bin/fsc/Debug/net7.0/fsc.dll",
             "args": [
-                "${input:argsPrompt}"
+                "${input:fscArgsPrompt}"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal", // This is the default to be able to run in Codespaces.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
     },
     "tasks": [
         {
-            "label": "Build (Debug)",
+            "label": "Full Build (Debug)",
             "command": "./build.sh",
             "type": "shell",
             "args": [
@@ -23,12 +23,16 @@
             ],
             "windows": {
                 "command": "${workspaceFolder}/Build.cmd",
+                "args": [
+                    "-c Debug",
+                    "-noVisualStudio"
+                ],
             },
             "problemMatcher": "$msCompile",
             "group": "build",
         },
         {
-            "label": "Build (Release)",
+            "label": "Full Build (Release)",
             "command": "./build.sh",
             "type": "shell",
             "args": [
@@ -36,7 +40,24 @@
             ],
             "windows": {
                 "command": "${workspaceFolder}/Build.cmd",
+                "args": [
+                    "-c Release",
+                    "-noVisualStudio"
+                ],
             },
+            "problemMatcher": "$msCompile",
+            "group": "build",
+        },
+        {
+            "label": "Rebuild (Debug)",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "-c",
+                "Debug",
+                "${workspaceFolder}/FSharp.sln"
+            ],
             "problemMatcher": "$msCompile",
             "group": "build",
         },


### PR DESCRIPTION
Updated Dockerfile to use slim debian sdk image, added a (quick) rebuild task - will use `dotnet build` for `FSharp.sln`, which is useful when you make small changes to compiler before you want to debug FSC/FSI.
