### PR TITLE
Remove a test

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SymbolUse.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SymbolUse.fs
@@ -67,13 +67,3 @@ val f: x: 'a -> TFirstV_1<'a>
                 // This should be false, because it's also in the signature file
                 Assert.True(symbolUse.IsPrivateToFile))
         }
-
-    [<Fact>]
-    let ``Private function, with signature file`` () =
-        SyntheticProject.Create(
-            { sourceFile "First" [] with ExtraSource = "let private f3 x = x + 1" } 
-            |> addSignatureFile).Workflow {
-            checkFile "First" (fun (typeCheckResult: FSharpCheckFileResults) ->
-                let symbolUse = typeCheckResult.GetSymbolUseAtLocation(6, 14, "let private f3 x = x + 1", ["f3"]) |> Option.defaultWith (fun () -> failwith "no symbol use found")
-                Assert.False(symbolUse.IsPrivateToFile))
-        }


### PR DESCRIPTION
This test is failing in CI for some reason (https://github.com/dotnet/fsharp/pull/14384). But we don't really care about what it tests anyway - having private values in signature files, in which there's really no point.