### PR TITLE
tcglobals teeny tiny cleanup

### DIFF
--- a/src/Compiler/SyntaxTree/PrettyNaming.fs
+++ b/src/Compiler/SyntaxTree/PrettyNaming.fs
@@ -1075,13 +1075,6 @@ let mkExceptionFieldName =
 let FsiDynamicModulePrefix = "FSI_"
 
 [<RequireQualifiedAccess>]
-module FSharpLib =
-    let Root = "Microsoft.FSharp"
-    let RootPath = IL.splitNamespace Root
-    let Core = Root + ".Core"
-    let CorePath = IL.splitNamespace Core
-
-[<RequireQualifiedAccess>]
 module CustomOperations =
     [<Literal>]
     let Into = "into"

--- a/src/Compiler/SyntaxTree/PrettyNaming.fsi
+++ b/src/Compiler/SyntaxTree/PrettyNaming.fsi
@@ -255,12 +255,6 @@ val internal mkExceptionFieldName: (int -> string)
 /// The prefix of the names used for the fake namespace path added to all dynamic code entries in FSI.EXE
 val FsiDynamicModulePrefix: string
 
-module internal FSharpLib =
-    val Root: string
-    val RootPath: string list
-    val Core: string
-    val CorePath: string list
-
 module internal CustomOperations =
     [<Literal>]
     val Into: string = "into"

--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -51,33 +51,37 @@ let ValRefForIntrinsic (IntrinsicValRef(mvr, _, _, _, key))  = mkNonLocalValRef 
 [<AutoOpen>]
 module FSharpLib =
 
-    let CoreOperatorsCheckedName = FSharpLib.Root + ".Core.Operators.Checked"
-    let ControlName              = FSharpLib.Root + ".Control"
-    let LinqName                 = FSharpLib.Root + ".Linq"
-    let CollectionsName          = FSharpLib.Root + ".Collections"
-    let LanguagePrimitivesName   = FSharpLib.Root + ".Core.LanguagePrimitives"
-    let CompilerServicesName     = FSharpLib.Root + ".Core.CompilerServices"
-    let LinqRuntimeHelpersName   = FSharpLib.Root + ".Linq.RuntimeHelpers"
-    let RuntimeHelpersName       = FSharpLib.Root + ".Core.CompilerServices.RuntimeHelpers"
-    let ExtraTopLevelOperatorsName = FSharpLib.Root + ".Core.ExtraTopLevelOperators"
-    let NativeInteropName                 = FSharpLib.Root + ".NativeInterop"
+    let Root                       = "Microsoft.FSharp"
+    let RootPath                   = splitNamespace Root
+    let Core                       = Root + ".Core"
+    let CorePath                   = splitNamespace Core
+    let CoreOperatorsCheckedName   = Root + ".Core.Operators.Checked"
+    let ControlName                = Root + ".Control"
+    let LinqName                   = Root + ".Linq"
+    let CollectionsName            = Root + ".Collections"
+    let LanguagePrimitivesName     = Root + ".Core.LanguagePrimitives"
+    let CompilerServicesName       = Root + ".Core.CompilerServices"
+    let LinqRuntimeHelpersName     = Root + ".Linq.RuntimeHelpers"
+    let RuntimeHelpersName         = Root + ".Core.CompilerServices.RuntimeHelpers"
+    let ExtraTopLevelOperatorsName = Root + ".Core.ExtraTopLevelOperators"
+    let NativeInteropName          = Root + ".NativeInterop"
 
-    let QuotationsName             = FSharpLib.Root + ".Quotations"
+    let QuotationsName             = Root + ".Quotations"
 
-    let ControlPath                 = splitNamespace ControlName
-    let LinqPath                    = splitNamespace LinqName
-    let CollectionsPath             = splitNamespace CollectionsName
-    let NativeInteropPath           = splitNamespace NativeInteropName |> Array.ofList
-    let CompilerServicesPath        = splitNamespace CompilerServicesName |> Array.ofList
-    let LinqRuntimeHelpersPath      = splitNamespace LinqRuntimeHelpersName |> Array.ofList
-    let RuntimeHelpersPath          = splitNamespace RuntimeHelpersName |> Array.ofList
-    let QuotationsPath              = splitNamespace QuotationsName |> Array.ofList
+    let ControlPath                = splitNamespace ControlName
+    let LinqPath                   = splitNamespace LinqName
+    let CollectionsPath            = splitNamespace CollectionsName
+    let NativeInteropPath          = splitNamespace NativeInteropName |> Array.ofList
+    let CompilerServicesPath       = splitNamespace CompilerServicesName |> Array.ofList
+    let LinqRuntimeHelpersPath     = splitNamespace LinqRuntimeHelpersName |> Array.ofList
+    let RuntimeHelpersPath         = splitNamespace RuntimeHelpersName |> Array.ofList
+    let QuotationsPath             = splitNamespace QuotationsName |> Array.ofList
 
-    let RootPathArray                    = FSharpLib.RootPath |> Array.ofList
-    let CorePathArray                    = FSharpLib.CorePath |> Array.ofList
-    let LinqPathArray                    = LinqPath |> Array.ofList
-    let ControlPathArray                 = ControlPath |> Array.ofList
-    let CollectionsPathArray             = CollectionsPath |> Array.ofList
+    let RootPathArray              = RootPath |> Array.ofList
+    let CorePathArray              = CorePath |> Array.ofList
+    let LinqPathArray              = LinqPath |> Array.ofList
+    let ControlPathArray           = ControlPath |> Array.ofList
+    let CollectionsPathArray       = CollectionsPath |> Array.ofList
 
 //-------------------------------------------------------------------------
 // Access the initial environment: helpers to build references
@@ -90,13 +94,13 @@ let private mkNonGenericTy tcref = TType_app(tcref, [], v_knownWithoutNull)
 
 let mkNonLocalTyconRef2 ccu path n = mkNonLocalTyconRef (mkNonLocalEntityRef ccu path) n
 
-let mk_MFCore_tcref             ccu n = mkNonLocalTyconRef2 ccu FSharpLib.CorePathArray n
-let mk_MFQuotations_tcref       ccu n = mkNonLocalTyconRef2 ccu FSharpLib.QuotationsPath n
+let mk_MFCore_tcref             ccu n = mkNonLocalTyconRef2 ccu CorePathArray n
+let mk_MFQuotations_tcref       ccu n = mkNonLocalTyconRef2 ccu QuotationsPath n
 let mk_MFLinq_tcref             ccu n = mkNonLocalTyconRef2 ccu LinqPathArray n
-let mk_MFCollections_tcref      ccu n = mkNonLocalTyconRef2 ccu FSharpLib.CollectionsPathArray n
-let mk_MFCompilerServices_tcref ccu n = mkNonLocalTyconRef2 ccu FSharpLib.CompilerServicesPath n
-let mk_MFRuntimeHelpers_tcref   ccu n = mkNonLocalTyconRef2 ccu FSharpLib.RuntimeHelpersPath n
-let mk_MFControl_tcref          ccu n = mkNonLocalTyconRef2 ccu FSharpLib.ControlPathArray n
+let mk_MFCollections_tcref      ccu n = mkNonLocalTyconRef2 ccu CollectionsPathArray n
+let mk_MFCompilerServices_tcref ccu n = mkNonLocalTyconRef2 ccu CompilerServicesPath n
+let mk_MFRuntimeHelpers_tcref   ccu n = mkNonLocalTyconRef2 ccu RuntimeHelpersPath n
+let mk_MFControl_tcref          ccu n = mkNonLocalTyconRef2 ccu ControlPathArray n
 
 
 type
@@ -456,14 +460,14 @@ type TcGlobals(
 
   let v_nil_ucref  = mkUnionCaseRef v_list_tcr_canon "op_Nil"
 
-  let fslib_MF_nleref                   = mkNonLocalEntityRef fslibCcu FSharpLib.RootPathArray
-  let fslib_MFCore_nleref               = mkNonLocalEntityRef fslibCcu FSharpLib.CorePathArray
-  let fslib_MFLinq_nleref               = mkNonLocalEntityRef fslibCcu FSharpLib.LinqPathArray
-  let fslib_MFCollections_nleref        = mkNonLocalEntityRef fslibCcu FSharpLib.CollectionsPathArray
-  let fslib_MFCompilerServices_nleref   = mkNonLocalEntityRef fslibCcu FSharpLib.CompilerServicesPath
-  let fslib_MFLinqRuntimeHelpers_nleref = mkNonLocalEntityRef fslibCcu FSharpLib.LinqRuntimeHelpersPath
-  let fslib_MFControl_nleref            = mkNonLocalEntityRef fslibCcu FSharpLib.ControlPathArray
-  let fslib_MFNativeInterop_nleref      = mkNonLocalEntityRef fslibCcu FSharpLib.NativeInteropPath
+  let fslib_MF_nleref                   = mkNonLocalEntityRef fslibCcu RootPathArray
+  let fslib_MFCore_nleref               = mkNonLocalEntityRef fslibCcu CorePathArray
+  let fslib_MFLinq_nleref               = mkNonLocalEntityRef fslibCcu LinqPathArray
+  let fslib_MFCollections_nleref        = mkNonLocalEntityRef fslibCcu CollectionsPathArray
+  let fslib_MFCompilerServices_nleref   = mkNonLocalEntityRef fslibCcu CompilerServicesPath
+  let fslib_MFLinqRuntimeHelpers_nleref = mkNonLocalEntityRef fslibCcu LinqRuntimeHelpersPath
+  let fslib_MFControl_nleref            = mkNonLocalEntityRef fslibCcu ControlPathArray
+  let fslib_MFNativeInterop_nleref      = mkNonLocalEntityRef fslibCcu NativeInteropPath
 
   let fslib_MFLanguagePrimitives_nleref        = mkNestedNonLocalEntityRef fslib_MFCore_nleref "LanguagePrimitives"
   let fslib_MFIntrinsicOperators_nleref        = mkNestedNonLocalEntityRef fslib_MFLanguagePrimitives_nleref "IntrinsicOperators"
@@ -587,10 +591,10 @@ type TcGlobals(
       | None -> TType_app(tcref, l, v_knownWithoutNull)
 
   let mk_MFCore_attrib nm : BuiltinAttribInfo =
-      AttribInfo(mkILTyRef(ilg.fsharpCoreAssemblyScopeRef, FSharpLib.Core + "." + nm), mk_MFCore_tcref fslibCcu nm)
+      AttribInfo(mkILTyRef(ilg.fsharpCoreAssemblyScopeRef, Core + "." + nm), mk_MFCore_tcref fslibCcu nm)
 
   let mk_MFCompilerServices_attrib nm : BuiltinAttribInfo =
-      AttribInfo(mkILTyRef(ilg.fsharpCoreAssemblyScopeRef, FSharpLib.Core + "." + nm), mk_MFCompilerServices_tcref fslibCcu nm)
+      AttribInfo(mkILTyRef(ilg.fsharpCoreAssemblyScopeRef, Core + "." + nm), mk_MFCompilerServices_tcref fslibCcu nm)
 
   let mkSourceDoc fileName = ILSourceDocument.Create(language=None, vendor=None, documentType=None, file=fileName)
 


### PR DESCRIPTION
I'm looking at FSharp.Core compilation, and stumbled upon this.  It set my teeth on edge, and I think fixing it is beneficial.

Pretty naming has an internal module named FSharpLib, that it doesn't even use.

TcGlobals also has one, and this one uses functions from the pretty naming one, so I merged them.