### PR TITLE
Revert latest arcade changes, as they fail signed build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,14 +8,14 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.22579.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.22554.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>6b3bad6673f3ebe89ebe12ea7c4eff1705b893e6</Sha>
+      <Sha>80b6be47e1425ea90c5febffac119250043a0c92</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.22579.2">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.22554.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>6b3bad6673f3ebe89ebe12ea7c4eff1705b893e6</Sha>
+      <Sha>80b6be47e1425ea90c5febffac119250043a0c92</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -1,12 +1,5 @@
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})
 
-# reset platform variables (e.g. cmake 3.25 sets LINUX=1)
-unset(LINUX)
-unset(FREEBSD)
-unset(ILLUMOS)
-unset(ANDROID)
-unset(TIZEN)
-
 set(TARGET_ARCH_NAME $ENV{TARGET_BUILD_ARCH})
 if(EXISTS ${CROSS_ROOTFS}/bin/freebsd-version)
   set(CMAKE_SYSTEM_NAME FreeBSD)

--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -132,8 +132,8 @@ if [[ -z "$CC" ]]; then
     exit 1
 fi
 
-# Only lld version >= 9 can be considered stable. lld doesn't support s390x.
-if [[ "$compiler" == "clang" && "$majorVersion" -ge 9 && "$build_arch" != "s390x" ]]; then
+# Only lld version >= 9 can be considered stable
+if [[ "$compiler" == "clang" && "$majorVersion" -ge 9 ]]; then
     if "$CC" -fuse-ld=lld -Wl,--version >/dev/null 2>&1; then
         LDFLAGS="-fuse-ld=lld"
     fi

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.4.1" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.3.1" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -34,7 +34,6 @@ jobs:
 - job: Asset_Registry_Publish
 
   dependsOn: ${{ parameters.dependsOn }}
-  timeoutInMinutes: 150
 
   ${{ if eq(parameters.publishAssetsImmediately, 'true') }}:
     displayName: Publish Assets
@@ -73,6 +72,12 @@ jobs:
       continueOnError: ${{ parameters.continueOnError }}
     
     - task: NuGetAuthenticate@0
+
+    - task: PowerShell@2 
+      displayName: Enable cross-org NuGet feed authentication 
+      inputs: 
+        filePath: $(Build.SourcesDirectory)/eng/common/enable-cross-org-publishing.ps1 
+        arguments: -token $(dn-bot-all-orgs-artifact-feeds-rw) 
 
     - task: PowerShell@2
       displayName: Publish Build Assets

--- a/eng/common/templates/post-build/common-variables.yml
+++ b/eng/common/templates/post-build/common-variables.yml
@@ -1,4 +1,8 @@
 variables:
+  - group: AzureDevOps-Artifact-Feeds-Pats
+  - group: DotNet-Blob-Feed
+  - group: DotNet-DotNetCli-Storage
+  - group: DotNet-MSRC-Storage
   - group: Publish-Build-Assets
 
   # Whether the build is internal or not

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -172,6 +172,12 @@ stages:
         - task: NuGetAuthenticate@0
           displayName: 'Authenticate to AzDO Feeds'
 
+        - task: PowerShell@2
+          displayName: Enable cross-org publishing
+          inputs:
+            filePath: eng\common\enable-cross-org-publishing.ps1
+            arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
+
         # Signing validation will optionally work with the buildmanifest file which is downloaded from
         # Azure DevOps above.
         - task: PowerShell@2

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -365,8 +365,8 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-eng&package=RoslynTools.MSBuild&protocolType=NuGet&version=17.4.1&view=overview
-  $defaultXCopyMSBuildVersion = '17.4.1'
+  # https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-eng&package=RoslynTools.MSBuild&protocolType=NuGet&version=17.3.1view=overview
+  $defaultXCopyMSBuildVersion = '17.3.1'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {
@@ -413,7 +413,6 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       if($vsMinVersion -lt $vsMinVersionReqd){
         Write-Host "Using xcopy-msbuild version of $defaultXCopyMSBuildVersion since VS version $vsMinVersionStr provided in global.json is not compatible"
         $xcopyMSBuildVersion = $defaultXCopyMSBuildVersion
-        $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
       }
       else{
         # If the VS version IS compatible, look for an xcopy msbuild package

--- a/global.json
+++ b/global.json
@@ -1,24 +1,24 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "7.0.100-rc.2.22477.23",
     "allowPrerelease": true,
     "rollForward": "latestPatch"
   },
   "tools": {
-    "dotnet": "7.0.100",
+    "dotnet": "7.0.100-rc.2.22477.23",
     "vs": {
       "version": "17.2",
       "components": [
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     },
-    "xcopy-msbuild": "17.4.1"
+    "xcopy-msbuild": "17.3.1"
   },
   "native-tools": {
     "perl": "5.32.1.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22579.2",
-    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.22579.2"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22554.2",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.22554.2"
   }
 }

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SymbolUse.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SymbolUse.fs
@@ -67,3 +67,13 @@ val f: x: 'a -> TFirstV_1<'a>
                 // This should be false, because it's also in the signature file
                 Assert.True(symbolUse.IsPrivateToFile))
         }
+
+    [<Fact>]
+    let ``Private function, with signature file`` () =
+        SyntheticProject.Create(
+            { sourceFile "First" [] with ExtraSource = "let private f3 x = x + 1" } 
+            |> addSignatureFile).Workflow {
+            checkFile "First" (fun (typeCheckResult: FSharpCheckFileResults) ->
+                let symbolUse = typeCheckResult.GetSymbolUseAtLocation(6, 14, "let private f3 x = x + 1", ["f3"]) |> Option.defaultWith (fun () -> failwith "no symbol use found")
+                Assert.False(symbolUse.IsPrivateToFile))
+        }


### PR DESCRIPTION
Latest arcade changes made in https://github.com/dotnet/fsharp/pull/14384 result in signed builds failures, we'll need to revert it until we test signed pipeline.