### PR TITLE
Fix handling % chars in interpolated strings

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -7165,13 +7165,14 @@ and TcInterpolatedStringExpr cenv (overallTy: OverallTy) env m tpenv (parts: Syn
         // Type check the expressions filling the holes
 
         if List.isEmpty synFillExprs then
-            let str = mkString g m printfFormatString
-
             if isString then
+                let sb = System.Text.StringBuilder(printfFormatString).Replace("%%", "%")
+                let str = mkString g m (sb.ToString())
                 TcPropagatingExprLeafThenConvert cenv overallTy g.string_ty env (* true *) m (fun () ->
                     str, tpenv
                 )
             else
+                let str = mkString g m printfFormatString
                 mkCallNewFormat g m printerTy printerArgTy printerResidueTy printerResultTy printerTupleTy str, tpenv
         else
             // Type check the expressions filling the holes

--- a/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
@@ -31,3 +31,9 @@ let c: System.IFormattable = $"string"
         """
         |> compile
         |> shouldSucceed
+
+    [<Fact>]
+    let ``Percent sign characters in interpolated strings`` () =
+        Assert.Equal("%", $"%%")
+        Assert.Equal("42%", $"{42}%%")
+        Assert.Equal("% 42", $"%%%3d{42}")


### PR DESCRIPTION
Interpolated strings require escaping '%' chars by doubling them, however if an interpolated string literal had no interpolation expressions, it would not drop extra '%' chars in the content.

Fixes: #14434