### PR TITLE
Enable stream based strong signing

### DIFF
--- a/src/Compiler/AbstractIL/ilsign.fs
+++ b/src/Compiler/AbstractIL/ilsign.fs
@@ -297,12 +297,6 @@ let signStream stream keyBlob =
     let signature = createSignature hash keyBlob KeyType.KeyPair
     patchSignature stream peReader signature
 
-let signFile fileName keyBlob =
-    use fs =
-        FileSystem.OpenFileForWriteShim(fileName, FileMode.Open, FileAccess.ReadWrite)
-
-    signStream fs keyBlob
-
 let signatureSize (pk: byte[]) =
     if pk.Length < 25 then
         raise (CryptographicException(getResourceString (FSComp.SR.ilSignInvalidPKBlob ())))
@@ -339,18 +333,9 @@ let signerOpenKeyPairFile filePath =
 
 let signerGetPublicKeyForKeyPair (kp: keyPair) : pubkey = getPublicKeyForKeyPair kp
 
-let signerGetPublicKeyForKeyContainer (_kcName: keyContainerName) : pubkey =
-    raise (NotImplementedException("signerGetPublicKeyForKeyContainer is not yet implemented"))
-
-let signerCloseKeyContainer (_kc: keyContainerName) : unit =
-    raise (NotImplementedException("signerCloseKeyContainer is not yet implemented"))
-
 let signerSignatureSize (pk: pubkey) : int = signatureSize pk
 
-let signerSignFileWithKeyPair (fileName: string) (kp: keyPair) : unit = signFile fileName kp
-
-let signerSignFileWithKeyContainer (_fileName: string) (_kcName: keyContainerName) : unit =
-    raise (NotImplementedException("signerSignFileWithKeyContainer is not yet implemented"))
+let signerSignStreamWithKeyPair stream keyBlob = signStream stream keyBlob
 
 let failWithContainerSigningUnsupportedOnThisPlatform () =
     failwith (FSComp.SR.containerSigningUnsupportedOnThisPlatform () |> snd)
@@ -370,13 +355,6 @@ type ILStrongNameSigner =
     static member OpenPublicKey pubkey = PublicKeySigner pubkey
     static member OpenKeyPairFile s = KeyPair(signerOpenKeyPairFile s)
     static member OpenKeyContainer s = KeyContainer s
-
-    member s.Close() =
-        match s with
-        | PublicKeySigner _
-        | PublicKeyOptionsSigner _
-        | KeyPair _ -> ()
-        | KeyContainer _ -> failWithContainerSigningUnsupportedOnThisPlatform ()
 
     member s.IsFullySigned =
         match s with
@@ -412,9 +390,9 @@ type ILStrongNameSigner =
         | KeyPair kp -> pkSignatureSize (signerGetPublicKeyForKeyPair kp)
         | KeyContainer _ -> failWithContainerSigningUnsupportedOnThisPlatform ()
 
-    member s.SignFile file =
+    member s.SignStream stream =
         match s with
         | PublicKeySigner _ -> ()
         | PublicKeyOptionsSigner _ -> ()
-        | KeyPair kp -> signerSignFileWithKeyPair file kp
+        | KeyPair kp -> signerSignStreamWithKeyPair stream kp
         | KeyContainer _ -> failWithContainerSigningUnsupportedOnThisPlatform ()

--- a/src/Compiler/AbstractIL/ilsign.fsi
+++ b/src/Compiler/AbstractIL/ilsign.fsi
@@ -6,6 +6,7 @@
 ///
 
 module internal FSharp.Compiler.AbstractIL.StrongNameSign
+
 open System
 open System.IO
 

--- a/src/Compiler/AbstractIL/ilsign.fsi
+++ b/src/Compiler/AbstractIL/ilsign.fsi
@@ -6,6 +6,8 @@
 ///
 
 module internal FSharp.Compiler.AbstractIL.StrongNameSign
+open System
+open System.IO
 
 //---------------------------------------------------------------------
 // Strong name signing
@@ -17,8 +19,7 @@ type ILStrongNameSigner =
     static member OpenPublicKey: byte[] -> ILStrongNameSigner
     static member OpenKeyPairFile: string -> ILStrongNameSigner
     static member OpenKeyContainer: string -> ILStrongNameSigner
-    member Close: unit -> unit
     member IsFullySigned: bool
     member PublicKey: byte[]
     member SignatureSize: int
-    member SignFile: string -> unit
+    member SignStream: Stream -> unit

--- a/src/Compiler/AbstractIL/ilwrite.fs
+++ b/src/Compiler/AbstractIL/ilwrite.fs
@@ -3725,8 +3725,7 @@ let writePdb (
 
     // Now we've done the bulk of the binary, do the PDB file and fixup the binary.
     match pdbfile with
-    | None ->
-        signImage ()
+    | None -> signImage ()
 
     | Some pdbfile ->
         let idd =
@@ -4528,7 +4527,7 @@ let writeBinaryFiles (options: options, modul, normalizeAssemblyRefs) =
             reraise()
 
     let reopenOutput () =
-        FileSystem.OpenFileForWriteShim(options.outfile, FileMode.Open, FileAccess.Write, FileShare.Read)
+        FileSystem.OpenFileForWriteShim(options.outfile, FileMode.Open, FileAccess.ReadWrite, FileShare.Read)
 
     writePdb (options.dumpDebugInfo,
         options.showTimes,

--- a/src/Compiler/AbstractIL/ilwrite.fs
+++ b/src/Compiler/AbstractIL/ilwrite.fs
@@ -3775,14 +3775,11 @@ let writePdb (
     match signer with
     | None -> ()
     | Some s ->
+        use fs = reopenOutput()
         try
-            s.SignFile outfile
-            s.Close()
+            s.SignStream fs
         with exn ->
-            failwith ("Warning: A call to SignFile failed ("+exn.Message+")")
-            (try s.Close() with _ -> ())
-            (try FileSystem.FileDeleteShim outfile with _ -> ())
-            ()
+            failwith ($"Warning: A call to SignFile failed ({exn.Message})")
 
     reportTime showTimes "Signing Image"
     pdbBytes


### PR DESCRIPTION
While looking at some fsi issues, I came accross this little improvement.

Now that we are able to build assemblies into a stream, ensure that assembly signing operates without requiring a file on disk too.

Additionally remove a few unused values and Methods on ILStrongNameSigner class.