### PR TITLE
Remove unused initialState in Observable.partition docs

### DIFF
--- a/src/FSharp.Core/observable.fsi
+++ b/src/FSharp.Core/observable.fsi
@@ -135,7 +135,6 @@ module Observable =
     /// let observableNumbers = Observable.ToObservable numbers
     ///
     /// let isEvenNumber = fun number -> number % 2 = 0
-    /// let initialState = 2
     ///
     /// let leftPartition, rightPartition =
     ///     Observable.partition isEvenNumber observableNumbers


### PR DESCRIPTION
In the docs, under [Observable.partition](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-control-observablemodule.html#partition), there is an `initialState` expression which seems to be unused. 

This PR removes this expression.