### PR TITLE
Fix: Type checking behavior on interface extension members

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4378,7 +4378,7 @@ and CheckIWSAM (cenv: cenv) (env: TcEnv) checkConstraints iwsam m tcref =
     if iwsam = WarnOnIWSAM.Yes && isInterfaceTy g ty && checkConstraints = CheckCxs then
         let tcref = tcrefOfAppTy g ty
         let meths = AllMethInfosOfTypeInScope ResultCollectionSettings.AllResults cenv.infoReader env.NameEnv None ad IgnoreOverrides m ty
-        if meths |> List.exists (fun meth -> not meth.IsInstance && meth.IsDispatchSlot) then
+        if meths |> List.exists (fun meth -> not meth.IsInstance && meth.IsDispatchSlot && not meth.IsExtensionMember) then
             warning(Error(FSComp.SR.tcUsingInterfaceWithStaticAbstractMethodAsType(tcref.DisplayNameWithStaticParametersAndUnderscoreTypars), m))
 
 and TcLongIdentType kindOpt (cenv: cenv) newOk checkConstraints occ iwsam env tpenv synLongId =

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
@@ -320,6 +320,33 @@ module ``Equivalence of properties and getters`` =
             IL_000e:  ret
           }"""]
 
+module ``Type checking behavior`` =   
+
+    #if !NETCOREAPP
+    [<Theory(Skip = "IWSAMs are not supported by NET472.")>]
+    #else   
+    [<InlineData("""
+        type INormalInterface =
+            abstract member IntMember: int
+
+        module INormalInterfaceExtensions =
+            type INormalInterface with
+                static member ExtMethod (a: INormalInterface) =
+                    ()""")>]
+    [<Theory>]
+    #endif
+    let ``Extension method on interface without SAM does not produce a warning`` code =
+        Fsx code
+        |> withLangVersion60
+        |> compile
+        |> shouldSucceed
+        |> ignore
+
+        Fsx code
+        |> withLangVersion70
+        |> compile
+        |> shouldSucceed
+        |> ignore
 
 module Negative =
 
@@ -374,7 +401,6 @@ module Negative =
         |> withErrorCode 3537
         |> withDiagnosticMessage "The trait 'A' invoked by this call has multiple support types. This invocation syntax is not permitted for such traits. See https://aka.ms/fsharp-srtp for guidance."
         |> ignore
-
 
 module InvocationBehavior =
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/TypesAndTypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
@@ -325,28 +325,23 @@ module ``Type checking behavior`` =
     #if !NETCOREAPP
     [<Theory(Skip = "IWSAMs are not supported by NET472.")>]
     #else   
-    [<InlineData("""
+    [<InlineData("6.0")>]
+    [<InlineData("7.0")>]
+    [<Theory>]
+    #endif
+    let ``Extension method on interface without SAM does not produce a warning`` version =
+        Fsx """
         type INormalInterface =
             abstract member IntMember: int
 
         module INormalInterfaceExtensions =
             type INormalInterface with
                 static member ExtMethod (a: INormalInterface) =
-                    ()""")>]
-    [<Theory>]
-    #endif
-    let ``Extension method on interface without SAM does not produce a warning`` code =
-        Fsx code
-        |> withLangVersion60
+                    ()
+        """
+        |> withLangVersion version
         |> compile
         |> shouldSucceed
-        |> ignore
-
-        Fsx code
-        |> withLangVersion70
-        |> compile
-        |> shouldSucceed
-        |> ignore
 
 module Negative =
 

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -393,6 +393,9 @@ module rec Compiler =
 
     let withLangVersionPreview (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ "--langversion:preview" ] "withLangVersionPreview is only supported on F#" cUnit
+        
+    let withLangVersion (version: string) (cUnit: CompilationUnit) : CompilationUnit =
+        withOptionsHelper [ $"--langversion:{version}" ] "withLangVersion is only supported on F#" cUnit
 
     let withAssemblyVersion (version:string) (cUnit: CompilationUnit) : CompilationUnit =
         withOptionsHelper [ $"--version:{version}" ] "withAssemblyVersion is only supported on F#" cUnit


### PR DESCRIPTION
Resolves [fsharp/issues/14480](https://github.com/dotnet/fsharp/issues/14480)

![image](https://user-images.githubusercontent.com/94796738/208315782-e2b9495a-2a21-4cc4-b119-f9b322449183.png)

An FS3536 warning was being emitted for extension methods on interfaces without static abstract members (SAM). This was due to some of the `MethInfo` logic which classifies any method on an interface type to be an abstract method declaration or virtual dispatch slot. Adding an explicit extension member check to the `CheckIWSAM` function resolves the compiler warning issue.