### PR TITLE
Correct inline parameter hints for named optional arguments

### DIFF
--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -406,3 +406,45 @@ let x = "test".Split("").[0].Split("");
         let actual = getParameterNameHints document
 
         Assert.AreEqual(expected, actual)
+
+    [<Test>]
+    let ``Hints are not shown for optional parameters with specified names`` () =
+        let code =
+            """
+type MyType() =
+
+    member _.MyMethod(?beep: int, ?bap: int, ?boop: int) = ()
+
+    member this.Foo = this.MyMethod(3, boop = 4)
+"""
+
+        let document = getFsDocument code
+
+        let expected =
+            [
+                {
+                    Content = "beep = "
+                    Location = (5, 37)
+                }
+            ]
+
+        let actual = getParameterNameHints document
+
+        Assert.AreEqual(expected, actual)
+
+    [<Test>]
+    let ``Hints are not shown when all optional parameters are named`` () =
+        let code =
+            """
+type MyType() =
+
+    member _.MyMethod(?beep: int, ?bap : int, ?boop : int) = ()
+
+    member this.Foo = this.MyMethod(bap = 3, beep = 4)
+"""
+
+        let document = getFsDocument code
+
+        let actual = getParameterNameHints document
+
+        Assert.IsEmpty(actual)


### PR DESCRIPTION
Partially addresses #14459 (the parameter hint part)

![image](https://user-images.githubusercontent.com/5451366/208710396-4a69c61e-0034-4c64-bbce-879eebd94203.png)
