### PR TITLE
Bind of Async<> within task{} should start on the same thread

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- F# Version components -->
     <FSMajorVersion>7</FSMajorVersion>
-    <FSMinorVersion>0</FSMinorVersion>
+    <FSMinorVersion>1</FSMinorVersion>
     <FSBuildVersion>0</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- F# Version components -->
     <FSMajorVersion>7</FSMajorVersion>
-    <FSMinorVersion>1</FSMinorVersion>
+    <FSMinorVersion>0</FSMinorVersion>
     <FSBuildVersion>0</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->

--- a/src/FSharp.Core/tasks.fs
+++ b/src/FSharp.Core/tasks.fs
@@ -459,7 +459,7 @@ module MediumPriority =
                 computation: Async<'TResult1>,
                 continuation: ('TResult1 -> TaskCode<'TOverall, 'TResult2>)
             ) : TaskCode<'TOverall, 'TResult2> =
-            this.Bind(Async.StartAsTask computation, continuation)
+            this.Bind(Async.StartImmediateAsTask computation, continuation)
 
         member inline this.ReturnFrom(computation: Async<'T>) : TaskCode<'T, 'T> =
-            this.ReturnFrom(Async.StartAsTask computation)
+            this.ReturnFrom(Async.StartImmediateAsTask computation)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
@@ -1161,6 +1161,22 @@ type Basics() =
         require (result = 8) "something weird happened"
 
     [<Fact>]
+    member _.testAsyncsMixedWithTasks_ShouldNotSwitchContext() =
+        let t = task {
+            let a = Thread.CurrentThread.ManagedThreadId
+            let! b = async {
+                return Thread.CurrentThread.ManagedThreadId
+            }
+            let c = Thread.CurrentThread.ManagedThreadId
+            return $"Before: {a}, in async: {b}, after async: {c}"
+        }
+        let d = Thread.CurrentThread.ManagedThreadId
+        let actual = $"{t.Result}, after task: {d}"
+
+        require (actual = $"Before: {d}, in async: {d}, after async: {d}, after task: {d}") actual
+        
+
+    [<Fact>]
     // no need to call this, we just want to check that it compiles w/o warnings
     member _.testDefaultInferenceForReturnFrom() =
         let t = task { return Some "x" }
@@ -1391,4 +1407,3 @@ module Issue12184f =
             let! result = t
             return result
         }
-


### PR DESCRIPTION
This addresses https://github.com/dotnet/fsharp/issues/14490 .

I am now of the opinion of the current behavior being a bug, and this change should be treated like a bugfix.

None of the docs for task{} and async{} mention starting work on a new thread, this operation is considered to be done explicitly by user code instead.

The proposed change for 'async{} inside task{}'  is also consistent with 'async in async' situation, causing less surprises when moving between task{} and async{}.

When it comes to backwards compatibility issues, GUI/main thread involvement is one thing to have in mind.
In the actual behavior's, the code could start on main thread, do the inner async{} elsewhere, and then return.
The proposed change will keep the same context, which I again see as a bugfix - both for correctness sake, but especially for resource utilization.


