### PR TITLE
Fix: Inline parameter hints for inner bindings

### DIFF
--- a/src/Compiler/Service/ServiceParamInfoLocations.fs
+++ b/src/Compiler/Service/ServiceParamInfoLocations.fs
@@ -127,7 +127,7 @@ module internal ParameterLocationsImpl =
 
         match inner with
         | None ->
-            if SyntaxTraversal.rangeContainsPosLeftEdgeExclusiveAndRightEdgeInclusive parenRange pos then
+            if SyntaxTraversal.rangeContainsPosLeftEdgeInclusive parenRange pos then
                 let argRanges =
                     [
                         {

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -406,3 +406,35 @@ let x = "test".Split("").[0].Split("");
         let actual = getParameterNameHints document
 
         Assert.AreEqual(expected, actual)
+
+    [<Test>]
+    let ``Hints are shown correctly for inner bindings`` () =
+        let code =
+            """
+let test sequences = 
+    sequences
+    |> Seq.map (fun sequence -> sequence |> Seq.map (fun sequence' -> sequence' |> Seq.map (fun item -> item)))
+"""
+
+        let document = getFsDocument code
+
+        let expected =
+            [
+                {
+                    Content = "mapping = "
+                    Location = (3, 17)
+                }
+                {
+                    Content = "mapping = "
+                    Location = (3, 54)
+                }
+                {
+                    Content = "mapping = "
+                    Location = (3, 93)
+                }
+            ]
+
+        let actual = getParameterNameHints document
+
+        Assert.AreEqual(expected, actual)
+        


### PR DESCRIPTION
Fixes [fsharp/issues/14501](https://github.com/dotnet/fsharp/issues/14501)

A simple off by one error was causing the correct range to be ignored while traversing the syntax tree. 

`searchSynArgExpr` is the only remaining function that uses `SyntaxTraversal.rangeContainsPosLeftEdgeExclusiveAndRightEdgeInclusive`. Not sure if it is correct in this context or if it could potentially manifest as a similar bug later on down the road. I tried to avoid making too many assumptions since this is very new territory for me and I have a lot to wrap my head around. 😄 

![image](https://user-images.githubusercontent.com/94796738/208830612-0edff00e-630e-40b9-badf-e989ecfbdb7a.png)
