### PR TITLE
Fix: Inline parameter hints for inner bindings

### DIFF
--- a/vsintegration/src/FSharp.Editor/Hints/HintService.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/HintService.fs
@@ -13,21 +13,21 @@ module HintService =
     let private getHintsForSymbol parseResults hintKinds (longIdEndLocations: Position list) (symbolUse: FSharpSymbolUse) =
         match symbolUse.Symbol with
         | :? FSharpMemberOrFunctionOrValue as symbol 
-            when hintKinds |> Set.contains HintKind.TypeHint 
+          when hintKinds |> Set.contains HintKind.TypeHint 
             && InlineTypeHints.isValidForHint parseResults symbol symbolUse ->
             
             InlineTypeHints.getHints symbol symbolUse, 
             longIdEndLocations
         
         | :? FSharpMemberOrFunctionOrValue as symbol
-            when hintKinds |> Set.contains HintKind.ParameterNameHint 
+          when hintKinds |> Set.contains HintKind.ParameterNameHint 
             && InlineParameterNameHints.isMemberOrFunctionOrValueValidForHint symbol symbolUse ->
 
             InlineParameterNameHints.getHintsForMemberOrFunctionOrValue parseResults symbol symbolUse longIdEndLocations, 
             symbolUse.Range.End :: longIdEndLocations
 
         | :? FSharpUnionCase as symbol
-            when hintKinds |> Set.contains HintKind.ParameterNameHint
+          when hintKinds |> Set.contains HintKind.ParameterNameHint
             && InlineParameterNameHints.isUnionCaseValidForHint symbol symbolUse ->
 
             InlineParameterNameHints.getHintsForUnionCase parseResults symbol symbolUse, 
@@ -35,7 +35,8 @@ module HintService =
 
         // we'll be adding other stuff gradually here
         | _ -> 
-            [], longIdEndLocations
+            [], 
+            longIdEndLocations
 
     let getHintsForDocument (document: Document) hintKinds userOpName cancellationToken = 
         async {

--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -87,7 +87,7 @@ module InlineParameterNameHints =
         (longIdEndLocations: Position list) =
 
         let parameters = symbol.CurriedParameterGroups |> Seq.concat
-        let argumentLocations = getArgumentLocations symbolUse parseResults longIdEndLocations
+        let argumentLocations = parseResults |> getArgumentLocations symbolUse longIdEndLocations
 
         let tupleRanges = argumentLocations |> getTupleRanges
         let curryRanges = parseResults |> getCurryRanges symbolUse

--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -87,9 +87,9 @@ module InlineParameterNameHints =
         (longIdEndLocations: Position list) =
 
         let parameters = symbol.CurriedParameterGroups |> Seq.concat
-        let argumentLocations = getArgumentLocations symbolUse parseResults
+        let argumentLocations = getArgumentLocations symbolUse parseResults longIdEndLocations
 
-        let tupleRanges = parseResults |> getTupleRanges symbolUse longIdEndLocations
+        let tupleRanges = argumentLocations |> getTupleRanges
         let curryRanges = parseResults |> getCurryRanges symbolUse
 
         let ranges = 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -406,13 +406,15 @@ let x = "test".Split("").[0].Split("");
         let actual = getParameterNameHints document
 
         Assert.AreEqual(expected, actual)
-        
+
     [<Test>]
     let ``Hints are not shown for optional parameters with specified names`` () =
         let code =
             """
 type MyType() =
+
     member _.MyMethod(?beep: int, ?bap: int, ?boop: int) = ()
+    
     member this.Foo = this.MyMethod(3, boop = 4)
 """
 
@@ -435,7 +437,9 @@ type MyType() =
         let code =
             """
 type MyType() =
+
     member _.MyMethod(?beep: int, ?bap : int, ?boop : int) = ()
+    
     member this.Foo = this.MyMethod(bap = 3, beep = 4)
 """
 
@@ -471,3 +475,7 @@ let test sequences =
                     Location = (3, 92)
                 }
             ]
+
+        let actual = getParameterNameHints document
+
+        Assert.AreEqual(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -406,3 +406,35 @@ let x = "test".Split("").[0].Split("");
         let actual = getParameterNameHints document
 
         Assert.AreEqual(expected, actual)
+
+    [<Test>]
+    let ``Hints are shown correctly for inner bindings`` () =
+        let code =
+            """
+let test sequences = 
+    sequences
+    |> Seq.map (fun sequence -> sequence |> Seq.map (fun sequence' -> sequence' |> Seq.map (fun item -> item)))
+"""
+
+        let document = getFsDocument code
+
+        let expected =
+            [
+                {
+                    Content = "mapping = "
+                    Location = (3, 16)
+                }
+                {
+                    Content = "mapping = "
+                    Location = (3, 53)
+                }
+                {
+                    Content = "mapping = "
+                    Location = (3, 92)
+                }
+            ]
+
+        let actual = getParameterNameHints document
+
+        Assert.AreEqual(expected, actual)
+        

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -414,7 +414,7 @@ let x = "test".Split("").[0].Split("");
 type MyType() =
 
     member _.MyMethod(?beep: int, ?bap: int, ?boop: int) = ()
-    
+
     member this.Foo = this.MyMethod(3, boop = 4)
 """
 
@@ -439,7 +439,7 @@ type MyType() =
 type MyType() =
 
     member _.MyMethod(?beep: int, ?bap : int, ?boop : int) = ()
-    
+
     member this.Foo = this.MyMethod(bap = 3, beep = 4)
 """
 


### PR DESCRIPTION
Fixes [fsharp/issues/14501 ](https://github.com/dotnet/fsharp/issues/14501)

By keeping track of long identifier ending positions for function calls, we can avoid recapturing parameters from the outer scope while traversing the syntax tree for hints.

There is likely a more efficient/direct way to patch this behavior, but this is a relatively simple change and appears to work as expected 👨‍🍳👍

**Screenshots**

Before
![Screenshot 2022-12-22 at 3 17 41 PM](https://user-images.githubusercontent.com/94796738/209219061-068265c4-6fa3-4d54-ba2a-b9ce5b569d55.png)

After
![Screenshot 2022-12-22 at 3 13 55 PM](https://user-images.githubusercontent.com/94796738/209218664-49ea9ba7-14a0-44af-ba8e-79581364f127.png)

