### PR TITLE
Ditch DictImp GetEnumerator<T> code that was needed because of a runtime bug

### DIFF
--- a/src/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/FSharp.Core/fslib-extra-pervasives.fs
@@ -51,10 +51,7 @@ module ExtraTopLevelOperators =
             makeSafeKey: 'Key -> 'SafeKey,
             getKey: 'SafeKey -> 'Key
         ) =
-#if NETSTANDARD
-        static let emptyEnumerator =
-            (Array.empty<KeyValuePair<'Key, 'T>> :> seq<_>).GetEnumerator()
-#endif
+
         member _.Count = t.Count
 
         // Give a read-only view of the dictionary
@@ -169,47 +166,8 @@ module ExtraTopLevelOperators =
             member _.GetEnumerator() =
                 // We use an array comprehension here instead of seq {} as otherwise we get incorrect
                 // IEnumerator.Reset() and IEnumerator.Current semantics.
-                // Coreclr has a bug with SZGenericEnumerators --- implement a correct enumerator.  On desktop use the desktop implementation because it's ngened.
-#if !NETSTANDARD
                 let kvps = [| for (KeyValue (k, v)) in t -> KeyValuePair(getKey k, v) |] :> seq<_>
                 kvps.GetEnumerator()
-#else
-                let endIndex = t.Count
-
-                if endIndex = 0 then
-                    emptyEnumerator
-                else
-                    let kvps = [| for (KeyValue (k, v)) in t -> KeyValuePair(getKey k, v) |]
-                    let mutable index = -1
-
-                    let current () =
-                        if index < 0 then
-                            raise <| InvalidOperationException(SR.GetString(SR.enumerationNotStarted))
-
-                        if index >= endIndex then
-                            raise <| InvalidOperationException(SR.GetString(SR.enumerationAlreadyFinished))
-
-                        kvps.[index]
-
-                    { new IEnumerator<_> with
-                        member _.Current = current ()
-                      interface System.Collections.IEnumerator with
-                          member _.Current = box (current ())
-
-                          member _.MoveNext() =
-                              if index < endIndex then
-                                  index <- index + 1
-                                  index < endIndex
-                              else
-                                  false
-
-                          member _.Reset() =
-                              index <- -1
-                      interface System.IDisposable with
-                          member _.Dispose() =
-                              ()
-                    }
-#endif
 
         interface System.Collections.IEnumerable with
             member _.GetEnumerator() =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Core/ExtraTopLevelOperatorsTests.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Core/ExtraTopLevelOperatorsTests.fs
@@ -8,7 +8,7 @@ open System.Collections.Generic
 type DictTests () =
 
     [<Fact>]
-    member this.IEnumerable() =
+    member this.IEnumerableOnDict() =
         // Legit IE
         let ie = (dict [|(1,1);(2,4);(3,9)|]) :> IEnumerable
         let enum = ie.GetEnumerator()
@@ -38,7 +38,7 @@ type DictTests () =
         CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
 
     [<Fact>]
-    member this.IEnumerable_T() =
+    member this.IEnumerable_T_OnDict() =
         // Legit IE
         let ie = (dict [|(1,1);(2,4);(3,9)|]) :> IEnumerable<KeyValuePair<_,_>>
         let enum = ie.GetEnumerator()


### PR DESCRIPTION
This bug has been fixed in the meantime.
Original issue:
F#: https://github.com/dotnet/fsharp/issues/5910 
Runtime: https://github.com/dotnet/runtime/issues/11488

Resolution in runtime repo:
https://github.com/dotnet/coreclr/pull/21368

Tests:
![image](https://user-images.githubusercontent.com/46543583/209152319-d6996feb-c29a-4585-a652-6d3bddff3ad9.png)
