### PR TITLE
Fixing Nan=Nan behavior for Set and Map collection types

### DIFF
--- a/src/FSharp.Core/map.fsi
+++ b/src/FSharp.Core/map.fsi
@@ -210,6 +210,7 @@ type Map<[<EqualityConditionalOn>] 'Key, [<EqualityConditionalOn; ComparisonCond
     interface ICollection<KeyValuePair<'Key, 'Value>>
     interface IEnumerable<KeyValuePair<'Key, 'Value>>
     interface System.IComparable
+    interface System.Collections.IStructuralEquatable
     interface System.Collections.IEnumerable
     interface IReadOnlyCollection<KeyValuePair<'Key, 'Value>>
     interface IReadOnlyDictionary<'Key, 'Value>

--- a/src/FSharp.Core/set.fs
+++ b/src/FSharp.Core/set.fs
@@ -872,7 +872,7 @@ type Set<[<EqualityConditionalOn>] 'T when 'T: comparison>(comparer: IComparer<'
     member x.ToArray() =
         SetTree.toArray x.Tree
 
-    member this.ComputeHashCode() =
+    member private this.ComputeHashCode() =
         let combineHash x y =
             (x <<< 1) + y + 631
 
@@ -903,6 +903,32 @@ type Set<[<EqualityConditionalOn>] 'T when 'T: comparison>(comparer: IComparer<'
     interface System.IComparable with
         member this.CompareTo(that: obj) =
             SetTree.compare this.Comparer this.Tree ((that :?> Set<'T>).Tree)
+
+    interface IStructuralEquatable with
+        member this.Equals(that, comparer) =
+            match that with
+            | :? Set<'T> as that ->
+                use e1 = (this :> seq<_>).GetEnumerator()
+                use e2 = (that :> seq<_>).GetEnumerator()
+
+                let rec loop () =
+                    let m1 = e1.MoveNext()
+                    let m2 = e2.MoveNext()
+                    (m1 = m2) && (not m1 || ((comparer.Equals(e1.Current, e2.Current)) && loop ()))
+
+                loop ()
+            | _ -> false
+
+        member this.GetHashCode(comparer) =
+            let combineHash x y =
+                (x <<< 1) + y + 631
+
+            let mutable res = 0
+
+            for x in this do
+                res <- combineHash res (comparer.GetHashCode(x))
+
+            res
 
     interface ICollection<'T> with
         member s.Add x =

--- a/src/FSharp.Core/set.fsi
+++ b/src/FSharp.Core/set.fsi
@@ -229,6 +229,7 @@ type Set<[<EqualityConditionalOn>] 'T when 'T: comparison> =
     interface IEnumerable<'T>
     interface System.Collections.IEnumerable
     interface System.IComparable
+    interface System.Collections.IStructuralEquatable
     interface IReadOnlyCollection<'T>
     override Equals: obj -> bool
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/PrimTypes.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/PrimTypes.fs
@@ -202,6 +202,45 @@ type LanguagePrimitivesModule() =
 
         let resultNul = LanguagePrimitives.GenericEquality "ABC" null
         Assert.False(resultNul)
+
+    [<Fact>]
+    member _.GenericEqualityForNans() = 
+        Assert.DoesNotContain(true,
+            [| LanguagePrimitives.GenericEquality nan nan
+               LanguagePrimitives.GenericEquality [nan] [nan]
+               LanguagePrimitives.GenericEquality [|nan|] [|nan|]
+               LanguagePrimitives.GenericEquality (Set.ofList [nan]) (Set.ofList [nan])       
+               LanguagePrimitives.GenericEquality (Map.ofList [1,nan]) (Map.ofList [1,nan])
+               LanguagePrimitives.GenericEquality (Map.ofList [nan,1]) (Map.ofList [nan,1])
+               LanguagePrimitives.GenericEquality (Map.ofList [nan,nan]) (Map.ofList [nan,nan])
+               
+               LanguagePrimitives.GenericEquality nanf nanf
+               LanguagePrimitives.GenericEquality [nanf] [nanf]
+               LanguagePrimitives.GenericEquality [|nanf|] [|nanf|]
+               LanguagePrimitives.GenericEquality (Set.ofList [nanf]) (Set.ofList [nanf])          
+               LanguagePrimitives.GenericEquality (Map.ofList [1,nanf]) (Map.ofList [1,nanf])
+               LanguagePrimitives.GenericEquality (Map.ofList [nanf,1]) (Map.ofList [nanf,1])
+               LanguagePrimitives.GenericEquality (Map.ofList [nanf,nanf]) (Map.ofList [nanf,nanf])|])
+
+    [<Fact>]
+    member _.GenericEqualityER() = 
+        Assert.DoesNotContain(false,
+            [| LanguagePrimitives.GenericEqualityER nan nan
+               LanguagePrimitives.GenericEqualityER [nan] [nan]
+               LanguagePrimitives.GenericEqualityER [|nan|] [|nan|]
+               LanguagePrimitives.GenericEqualityER (Set.ofList [nan]) (Set.ofList [nan])        
+               LanguagePrimitives.GenericEqualityER (Map.ofList [1,nan]) (Map.ofList [1,nan])
+               LanguagePrimitives.GenericEqualityER (Map.ofList [nan,1]) (Map.ofList [nan,1])
+               LanguagePrimitives.GenericEqualityER (Map.ofList [nan,nan]) (Map.ofList [nan,nan])
+               
+               LanguagePrimitives.GenericEqualityER nanf nanf
+               LanguagePrimitives.GenericEqualityER [nanf] [nanf]
+               LanguagePrimitives.GenericEqualityER [|nanf|] [|nanf|]
+               LanguagePrimitives.GenericEqualityER (Set.ofList [nanf]) (Set.ofList [nanf])        
+               LanguagePrimitives.GenericEqualityER (Map.ofList [1,nanf]) (Map.ofList [1,nanf])
+               LanguagePrimitives.GenericEqualityER (Map.ofList [nanf,1]) (Map.ofList [nanf,1])
+               LanguagePrimitives.GenericEqualityER (Map.ofList [nanf,nanf]) (Map.ofList [nanf,nanf])|])
+        
         
     [<Fact>]
     member this.GenericGreaterOrEqual() =

--- a/tests/projects/SelfContained_Trimming_Test/check.ps1
+++ b/tests/projects/SelfContained_Trimming_Test/check.ps1
@@ -14,7 +14,7 @@ if (-not ($output -eq $expected))
 }
 
 # Checking that FSharp.Core binary is of expected size (needs adjustments if test is updated).
-$expected_len = 245248 # In bytes
+$expected_len = 246272  # In bytes
 $file = Get-Item .\bin\Release\net7.0\win-x64\publish\FSharp.Core.dll
 $file_len = $file.Length
 if (-not ($file_len -eq $expected_len))

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/OptionParserTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/OptionParserTests.fs
@@ -22,7 +22,7 @@ module OptionParserTests =
 
         let actual = OptionParser.getHintKinds options
 
-        Assert.AreEqual(expected, actual)
+        CollectionAssert.AreEquivalent(expected, actual)
 
     [<Test>]
     let ``Type hints on, parameter name hints off`` () =
@@ -36,7 +36,7 @@ module OptionParserTests =
 
         let actual = OptionParser.getHintKinds options
 
-        Assert.AreEqual(expected, actual)
+        CollectionAssert.AreEquivalent(expected, actual)
 
     [<Test>]
     let ``Type hints off, parameter name hints on`` () =
@@ -50,7 +50,7 @@ module OptionParserTests =
 
         let actual = OptionParser.getHintKinds options
 
-        Assert.AreEqual(expected, actual)
+        CollectionAssert.AreEquivalent(expected, actual)
 
     [<Test>]
     let ``Type hints on, parameter name hints on`` () =
@@ -64,4 +64,4 @@ module OptionParserTests =
 
         let actual = OptionParser.getHintKinds options
 
-        Assert.AreEqual(expected, actual)
+        CollectionAssert.AreEquivalent(expected, actual)


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/14507 bug .

Per documentation, **GenericEqualityER** "Compare two values for equality using equivalence relation semantics (**[nan] = [nan]**)". It is a sibling to GenericEquality , which treats` nan<>nan`.

This `nan=nan` behaviour GenericEqualityER in should work for structural data, incl. collections, unions, records etc.
Summary of **existing  behavior** for various types, when holding nan (or nanf):
Scalar value = OK
Lists = OK (generated code coming from DU implementation)
Array = OK (special-cased in Fsharp.Core)
Sets = GenericEqualityER  behaves the same like GenericEquality , i.e. `set [nan] <> set [nan]` => **wrong**
Maps = fails just like it does for Sets, both for Keys and for values

An inconsistency between lists and Sets/Maps is considered a bug, because all 3 of them are typical F# constructs for data modelling.
The fact that they did not support GenericEqualityER out of the box was an implementation-detail-bug.


This PR addresses this by having both `Set<>` and `Map<,>` implement `interface System.Collections.IStructuralEquatable`.
For Maps, I decided to use the passed in comparer for both keys and values (one can argue about the logical validity of floats as keys in a map, but it is technically possible).

