### PR TITLE
Prevent StackoverflowException when hashing lists above ~30k elements

### DIFF
--- a/src/Compiler/Checking/AugmentWithHashCompare.fs
+++ b/src/Compiler/Checking/AugmentWithHashCompare.fs
@@ -996,7 +996,16 @@ let MakeBindingsForEqualityWithComparerAugmentation (g: TcGlobals) (tycon: Tycon
             // build the hash rhs
             let withcGetHashCodeExpr =
                 let compv, compe = mkCompGenLocal m "comp" g.IEqualityComparer_ty
-                let thisv, hashe = hashf g tcref tycon compe
+
+                // Special case List<T> type to avoid StackOverflow exception , call custom hash code instead
+                let thisv,hashe = 
+                    if tyconRefEq g tcref g.list_tcr_canon && tycon.HasMember g "CustomHashCode" [g.IEqualityComparer_ty] then
+                        let customCodeVal = (tycon.TryGetMember g "CustomHashCode" [g.IEqualityComparer_ty]).Value                  
+                        let tinst, ty = mkMinimalTy g tcref
+                        let thisv, thise = mkThisVar g m ty   
+                        thisv,mkApps g ((exprForValRef m customCodeVal, customCodeVal.Type), (if isNil tinst then [] else [tinst]), [thise; compe], m)
+                    else                     
+                        hashf g tcref tycon compe
                 mkLambdas g m tps [thisv; compv] (hashe, g.int_ty)
                 
             // build the equals rhs

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -9573,11 +9573,11 @@ type Entity with
                 List.lengthsEqAndForall2 (typeEquiv g) (List.map fst argInfos) argTys &&  
                 membInfo.MemberFlags.IsOverrideOrExplicitImpl
             | _ -> false) 
-    
-    member tycon.HasMember g nm argTys = 
+
+    member internal tycon.TryGetMember g nm argTys = 
         tycon.TypeContents.tcaug_adhoc 
         |> NameMultiMap.find nm
-        |> List.exists (fun vref -> 
+        |> List.tryFind (fun vref -> 
             match vref.MemberInfo with 
             | None -> false 
             | _ ->
@@ -9586,7 +9586,8 @@ type Entity with
             match argInfos with
             | [argInfos] -> List.lengthsEqAndForall2 (typeEquiv g) (List.map fst argInfos) argTys
             | _ -> false) 
-
+    
+    member tycon.HasMember g nm argTys = (tycon.TryGetMember g nm argTys).IsSome
 
 type EntityRef with 
     member tcref.HasInterface g ty = tcref.Deref.HasInterface g ty

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -2449,6 +2449,8 @@ type Entity with
 
     member HasMember: TcGlobals -> string -> TType list -> bool
 
+    member internal TryGetMember: TcGlobals -> string -> TType list -> ValRef option
+
 type EntityRef with
 
     member HasInterface: TcGlobals -> TType -> bool

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -3912,16 +3912,14 @@ namespace Microsoft.FSharp.Collections
     type List<'T> = 
        | ([])  :                  'T list
        | ( :: )  : Head: 'T * Tail: 'T list -> 'T list
-       member private this.CustomHashCode(c:IEqualityComparer) =
-            let upperBoundAllowedIterations = LanguagePrimitives.HashCompare.defaultHashNodes
-            let rec loop l acc remainingIterations =
+       member private this.CustomHashCode(c:IEqualityComparer) =        
+            let rec loop l acc position =
                 match l with
-                | [] -> acc
-                | _ when remainingIterations < 1 -> acc
+                | [] -> acc           
                 | h::t ->
-                    loop t  (LanguagePrimitives.HashCompare.HashCombine remainingIterations acc (c.GetHashCode(h))) (remainingIterations-1)
+                    loop t  (LanguagePrimitives.HashCompare.HashCombine position acc (c.GetHashCode(h))) (position+1)
 
-            loop this 0 upperBoundAllowedIterations
+            loop this 0 0
        interface IEnumerable<'T>
        interface IEnumerable
        interface IReadOnlyCollection<'T>

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -3912,6 +3912,16 @@ namespace Microsoft.FSharp.Collections
     type List<'T> = 
        | ([])  :                  'T list
        | ( :: )  : Head: 'T * Tail: 'T list -> 'T list
+       member private this.CustomHashCode(c:IEqualityComparer) =
+            let upperBoundAllowedIterations = LanguagePrimitives.HashCompare.defaultHashNodes
+            let rec loop l acc remainingIterations =
+                match l with
+                | [] -> acc
+                | _ when remainingIterations < 1 -> acc
+                | h::t ->
+                    loop t  (LanguagePrimitives.HashCompare.HashCombine remainingIterations acc (c.GetHashCode(h))) (remainingIterations-1)
+
+            loop this 0 upperBoundAllowedIterations
        interface IEnumerable<'T>
        interface IEnumerable
        interface IReadOnlyCollection<'T>

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -3917,7 +3917,9 @@ namespace Microsoft.FSharp.Collections
                 match l with
                 | [] -> acc           
                 | h::t ->
-                    loop t  (LanguagePrimitives.HashCompare.HashCombine position acc (c.GetHashCode(h))) (position+1)
+                    let hashOfH = GenericHashWithComparer c h
+                    let acc = LanguagePrimitives.HashCompare.HashCombine position acc hashOfH
+                    loop t acc (position+1)
 
             loop this 0 0
        interface IEnumerable<'T>

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListType.fs
@@ -120,6 +120,16 @@ type ListType() =
         Assert.AreEqual("[1; 2; 3]", [1; 2; 3].ToString())
         Assert.AreEqual("[]", [].ToString())
         Assert.AreEqual("[]", ([] : decimal list list).ToString())
+
+    [<Fact>]
+    member this.HashCodeNotThrowingStackOverflow() = 
+        let l = 1 :: 2 :: [0.. 35_000]
+        let hash = l.GetHashCode()
+
+        let l2 = [1;2] @ [0.. 35_000]
+        let hash2 = l.GetHashCode()
+
+        Assert.AreEqual(hash,hash2)
     
     [<Fact>]
     member this.ObjectEquals() =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListType.fs
@@ -130,6 +130,19 @@ type ListType() =
         let hash2 = l.GetHashCode()
 
         Assert.AreEqual(hash,hash2)
+
+    [<Fact>]
+    member this.HashCodeDoesNotThrowOnListOfNullStrings() = 
+        let l = ["1";"2";null;null]
+        Assert.AreEqual(l.GetHashCode(),l.GetHashCode())
+
+    [<Fact>]
+    member this.HashCodeIsDifferentForListsWithSamePrefix() = 
+        let sharedPrefix = [0..500]
+        let l1 = sharedPrefix @ [1]
+        let l2 = sharedPrefix @ [2]       
+
+        Assert.AreNotEqual(l1.GetHashCode(),l2.GetHashCode())
     
     [<Fact>]
     member this.ObjectEquals() =


### PR DESCRIPTION
This addresses https://github.com/dotnet/fsharp/issues/1838 and fixes **.GetHashCode()** for the built-in `List<T>` type.
List is internally implemented as a recursive DU, and existing codegen emits code which is not tail recursive. If the list gets bigger (~30K elements), StackoverflowException appears when hashing it.

While I understand the desire to find a general solution for all recursive DUs incl. custom ones, I consider a StackoverflowException on the main language's collection type more urgent.

This solution is therefore **special-cased only for the list type**.
@cartermp  tried to address this via standard F# attributes in https://github.com/dotnet/fsharp/pull/9070/files , but it affected the API shape of List<T> which is too dangerous of a change.

This PR solves this by:
- Adding a new private hashcode method on list
- Special-casing hashcode generation in the compiler, to understand the combination of `List<T>` and `.CustomHashCode(comparer)` member.
- If that is the case, the generated `.GetHashCode(comparer)` simply calls into `.CustomHashCode(comparer)`

As of now, I would tend against exploring on how to offer this mechanism for other types (e.g. a new CustomHashCodeOnlyAttribute), and for sure not part of this PR because the SO for list is much more visible.
Reason is, the existing mechanisms for custom types offer a solution and enforce treating GetHashCode and Equals together => for custom types which looser backwards compatibility limits, I believe it is sufficient..


The implementation follows the one for Array, which hashes based on the first 18 elements.
Note that this is not necessary, I only did it for consistency with array.
