### PR TITLE
Do not show type hints for optional parameters with manual type annotations

### DIFF
--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -33,7 +33,6 @@ module InlineParameterNameHints =
 
     let private getArgumentLocations
         (symbolUse: FSharpSymbolUse)
-        (longIdEndLocations: Position list)
         (parseResults: FSharpParseFileResults) =
 
         let position = Position.mkPos 
@@ -41,9 +40,9 @@ module InlineParameterNameHints =
                         (symbolUse.Range.End.Column + 1)
 
         parseResults.FindParameterLocations position
-        |> Option.filter (fun locations -> longIdEndLocations |> List.contains locations.LongIdEndLocation |> not)
-        |> Option.map (fun locations -> locations.ArgumentLocations)
-        |> Option.defaultValue [||]
+        |> Option.map (fun locations -> locations.ArgumentLocations |> Seq.filter (fun location -> Position.posGeq location.ArgumentRange.Start position))
+        |> Option.filter (not << Seq.isEmpty)
+        |> Option.defaultValue Seq.empty
 
     let private getTupleRanges =
         Seq.map (fun location -> location.ArgumentRange)
@@ -83,11 +82,10 @@ module InlineParameterNameHints =
     let getHintsForMemberOrFunctionOrValue
         (parseResults: FSharpParseFileResults) 
         (symbol: FSharpMemberOrFunctionOrValue) 
-        (symbolUse: FSharpSymbolUse)
-        (longIdEndLocations: Position list) =
+        (symbolUse: FSharpSymbolUse) =
 
         let parameters = symbol.CurriedParameterGroups |> Seq.concat
-        let argumentLocations = parseResults |> getArgumentLocations symbolUse longIdEndLocations
+        let argumentLocations = parseResults |> getArgumentLocations symbolUse
 
         let tupleRanges = argumentLocations |> getTupleRanges
         let curryRanges = parseResults |> getCurryRanges symbolUse

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
@@ -247,3 +247,21 @@ type Number<'T when IAddition<'T>>(value: 'T) =
         let actual = getTypeHints document
 
         CollectionAssert.AreEquivalent(expected, actual)
+
+
+    [<Test>]
+    let ``Hints are not shown when type is specified`` () =
+        let code =
+            """
+type MyType() =
+
+    member _.MyMethod(?beep: int, ?bap: int, ?boop: int) = ()
+
+    member this.Foo = this.MyMethod(bap = 3, boop = 4)
+"""
+
+        let document = getFsDocument code
+
+        let result = getTypeHints document
+
+        Assert.IsEmpty(result)


### PR DESCRIPTION
Another piece of [fsharp/issues/14459](https://github.com/dotnet/fsharp/issues/14459)

Inline type hints are still being shown for optional parameters, even when an explicit annotation is provided by the user:
![Screenshot 2022-12-29 at 10 34 39 AM](https://user-images.githubusercontent.com/94796738/209992917-af5ba508-2aaa-490b-81ba-f469b2098041.png)

Fixed:
![Screenshot 2022-12-29 at 12 56 37 PM](https://user-images.githubusercontent.com/94796738/209993056-349a88bd-c6a5-455c-a3d9-1458fe9dbb8b.png)

**Root cause:**
`IsTypeAnnotationGivenAtPosition` returns false when given the starting position of an optional parameter immediately following the `?` symbol

**Solution:**
Account for `?` and adjust column start by 1 for this check when detecting an optional parameter declaration

**Comments:**
This brings up another potential issue when manual annotations are subsequently removed; the parameter type is not resolved based on the usage below (see screenshot)

![Screenshot 2022-12-29 at 12 57 25 PM](https://user-images.githubusercontent.com/94796738/209993837-cd621260-b7c8-4e33-b259-a3381fcf72d9.png)
