### PR TITLE
Bugfix: In CE's with .BindReturn(..), return inside if-then (without else) stopped working with F# 5.0. 

### DIFF
--- a/src/Compiler/Checking/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/CheckComputationExpressions.fs
@@ -1672,6 +1672,9 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
                 let bindCall = mkSynCall bindName bindRange (bindArgs @ [consumeExpr])
                 translatedCtxt (bindCall |> addBindDebugPoint))
 
+    /// This function is for desugaring into .Bind{N}Return calls if possible
+    /// The outer option indicates if .BindReturn is possible. When it returns None, .BindReturn cannot be used
+    /// The inner option indicates if a custom operation is involved inside
     and convertSimpleReturnToExpr varSpace innerComp =
         match innerComp with 
         | SynExpr.YieldOrReturn ((false, _), returnExpr, m) ->
@@ -1697,7 +1700,8 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
             | Some (thenExpr, None) ->
             let elseExprOptOpt  = 
                 match elseCompOpt with 
-                | None -> Some None 
+                // When we are missing an 'else' part alltogether in case of 'if cond then return exp', we fallback from BindReturn into regular Bind+Return
+                | None -> None 
                 | Some elseComp -> 
                     match convertSimpleReturnToExpr varSpace elseComp with
                     | None -> None // failure


### PR DESCRIPTION
See the added tests and the linked issue.
This has been introduced with the possibility to do a optimized .BindReturn (in one operation).

When used inside an if-then; without else; this started to fail with F# 5.0, but was working in F# 4.7.

After some attempts of making it go trough the .BindReturn even when conditional is used (by passing in the result of .Zero() into the 'then' expression, and letting it go via .BindReturn all the time), I did not manage to make it work.

Instead, if such situation is detected, the expression will fallback to using regular .Bind + .Return calls, just like it did in F# 4.7.


This affects code which was not compiling at F# 5.0 and later at all.

Summary of behavior depending on F# version:
1. Until 4.7: The code works in all circumstances, but never uses the .BindReturn optimized call
2. Before this fix: Code does not compile. If _.BindReturn is commented out, it starts working
3. After this fix: Code compiles. If return is used outside of conditional or other control flow, _.BindReturn is indeed used and classical _.Return is not even required (see added tests). If return is used within a conditinal, the flow fallbacks to using a combination of _.Return and _.Bind, and checks that both of them are present.


```
type Builder () =
   
    member inline __.Return (x: 'T) = Seq.singleton x                          : seq<'T>
    member inline __.Bind (p: seq<'T>, rest: 'T->seq<'U>) = Seq.collect rest p : seq<'U>
    member inline __.Zero () = Seq.empty : seq<'T>
    member inline __.BindReturn   (x : seq<'T>, f: 'T -> 'U) : seq<'U> = Seq.map f x

let seqbuilder= new Builder ()

let _pythags = seqbuilder {
  let! z = seq [5;10]
  let! x = seq [1..z]
  let! y = seq [x..z]
  if (x*x + y*y = z*z) then return (x, y, z) }
```

Why I agree with @gusty that **this was a bug+regression** and should be fixed:
- Libraries were offering CE to be consumed by 3rd parties, who's code inside the CE is out of control for the library authors. 
- The library, without any other changes, adds a single _.BindReturn   method. This is documented to be a performance optimization when applicable.
- Suddenly, 3rd party code is not compiling with new version of the CE/Builder under some circumstances, even though no breaking change happened (the older builder methods for regular .Bind and .Return are still there)
