### PR TITLE
Use recommended postfix notation for generics

### DIFF
--- a/src/Compiler/Driver/CompilerConfig.fs
+++ b/src/Compiler/Driver/CompilerConfig.fs
@@ -300,7 +300,7 @@ type ImportedAssembly =
         IsProviderGenerated: bool
         mutable TypeProviders: Tainted<ITypeProvider> list
 #endif
-        FSharpOptimizationData: Microsoft.FSharp.Control.Lazy<Option<Optimizer.LazyModuleInfo>>
+        FSharpOptimizationData: Microsoft.FSharp.Control.Lazy<Optimizer.LazyModuleInfo option>
     }
 
 type AvailableImportedAssembly =

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -338,7 +338,7 @@ type ImportedAssembly =
         IsProviderGenerated: bool
         mutable TypeProviders: Tainted<ITypeProvider> list
 #endif
-        FSharpOptimizationData: Microsoft.FSharp.Control.Lazy<Option<Optimizer.LazyModuleInfo>>
+        FSharpOptimizationData: Microsoft.FSharp.Control.Lazy<Optimizer.LazyModuleInfo option>
     }
 
 type AvailableImportedAssembly =

--- a/src/Compiler/Driver/CompilerImports.fsi
+++ b/src/Compiler/Driver/CompilerImports.fsi
@@ -116,7 +116,7 @@ type ImportedAssembly =
       IsProviderGenerated: bool
       mutable TypeProviders: Tainted<ITypeProvider> list
 #endif
-      FSharpOptimizationData: Lazy<Option<LazyModuleInfo>> }
+      FSharpOptimizationData: Lazy<LazyModuleInfo option> }
 
 /// Tables of assembly resolutions
 [<Sealed>]

--- a/src/Compiler/Driver/CompilerOptions.fs
+++ b/src/Compiler/Driver/CompilerOptions.fs
@@ -69,7 +69,7 @@ and CompilerOption =
         name: string *
         argumentDescriptionString: string *
         actionSpec: OptionSpec *
-        deprecationError: Option<exn> *
+        deprecationError: exn option *
         helpText: string option
 
 and CompilerOptionBlock =

--- a/src/Compiler/Driver/CompilerOptions.fsi
+++ b/src/Compiler/Driver/CompilerOptions.fsi
@@ -36,7 +36,7 @@ and CompilerOption =
         name: string *
         argumentDescriptionString: string *
         actionSpec: OptionSpec *
-        deprecationError: Option<exn> *
+        deprecationError: exn option *
         helpText: string option
 
 and CompilerOptionBlock =

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -834,7 +834,7 @@ type internal TypeCheckInfo
             if p >= 0 then Some p else None
 
     /// Build a CompetionItem
-    let CompletionItem (ty: ValueOption<TyconRef>) (assemblySymbol: ValueOption<AssemblySymbol>) (item: ItemWithInst) =
+    let CompletionItem (ty: TyconRef voption) (assemblySymbol: AssemblySymbol voption) (item: ItemWithInst) =
         let kind =
             match item.Item with
             | Item.FakeInterfaceCtor _

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -1604,13 +1604,13 @@ type TyconRefMultiMap<'T>(contents: TyconRefMap<'T list>) =
 //--------------------------------------------------------------------------
 
 /// Try to create a EntityRef suitable for accessing the given Entity from another assembly 
-let tryRescopeEntity viewedCcu (entity: Entity) : ValueOption<EntityRef> = 
+let tryRescopeEntity viewedCcu (entity: Entity) : EntityRef voption =
     match entity.PublicPath with 
     | Some pubpath -> ValueSome (ERefNonLocal (rescopePubPath viewedCcu pubpath))
     | None -> ValueNone
 
 /// Try to create a ValRef suitable for accessing the given Val from another assembly 
-let tryRescopeVal viewedCcu (entityRemap: Remap) (vspec: Val) : ValueOption<ValRef> =
+let tryRescopeVal viewedCcu (entityRemap: Remap) (vspec: Val) : ValRef voption =
     match vspec.PublicPath with 
     | Some (ValPubPath(p, fullLinkageKey)) -> 
         // The type information in the val linkage doesn't need to keep any information to trait solutions.

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -665,7 +665,7 @@ val isTyparTy: TcGlobals -> TType -> bool
 
 val isAnyParTy: TcGlobals -> TType -> bool
 
-val tryAnyParTy: TcGlobals -> TType -> ValueOption<Typar>
+val tryAnyParTy: TcGlobals -> TType -> Typar voption
 
 val tryAnyParTyOption: TcGlobals -> TType -> Typar option
 
@@ -679,26 +679,26 @@ val isProvenUnionCaseTy: TType -> bool
 
 val isAppTy: TcGlobals -> TType -> bool
 
-val tryAppTy: TcGlobals -> TType -> ValueOption<TyconRef * TypeInst>
+val tryAppTy: TcGlobals -> TType -> (TyconRef * TypeInst) voption
 
 val destAppTy: TcGlobals -> TType -> TyconRef * TypeInst
 
 val tcrefOfAppTy: TcGlobals -> TType -> TyconRef
 
-val tryTcrefOfAppTy: TcGlobals -> TType -> ValueOption<TyconRef>
+val tryTcrefOfAppTy: TcGlobals -> TType -> TyconRef voption
 
-val tryDestTyparTy: TcGlobals -> TType -> ValueOption<Typar>
+val tryDestTyparTy: TcGlobals -> TType -> Typar voption
 
-val tryDestFunTy: TcGlobals -> TType -> ValueOption<TType * TType>
+val tryDestFunTy: TcGlobals -> TType -> (TType * TType) voption
 
-val tryDestAnonRecdTy: TcGlobals -> TType -> ValueOption<AnonRecdTypeInfo * TType list>
+val tryDestAnonRecdTy: TcGlobals -> TType -> (AnonRecdTypeInfo * TType list) voption
 
 val argsOfAppTy: TcGlobals -> TType -> TypeInst
 
 val mkInstForAppTy: TcGlobals -> TType -> TyparInstantiation
 
 /// Try to get a TyconRef for a type without erasing type abbreviations
-val tryNiceEntityRefOfTy: TType -> ValueOption<TyconRef>
+val tryNiceEntityRefOfTy: TType -> TyconRef voption
 
 val tryNiceEntityRefOfTyOption: TType -> TyconRef option
 
@@ -1089,7 +1089,7 @@ val tagEntityRefName: xref: EntityRef -> name: string -> TaggedText
 /// Return the full text for an item as we want it displayed to the user as a fully qualified entity
 val fullDisplayTextOfModRef: ModuleOrNamespaceRef -> string
 
-val fullDisplayTextOfParentOfModRef: ModuleOrNamespaceRef -> ValueOption<string>
+val fullDisplayTextOfParentOfModRef: ModuleOrNamespaceRef -> string voption
 
 val fullDisplayTextOfValRef: ValRef -> string
 
@@ -1303,10 +1303,10 @@ val wrapModuleOrNamespaceTypeInNamespace:
 val wrapModuleOrNamespaceType: Ident -> CompilationPath -> ModuleOrNamespaceType -> ModuleOrNamespace
 
 /// Given a namespace, module or type definition, try to produce a reference to that entity.
-val tryRescopeEntity: CcuThunk -> Entity -> ValueOption<EntityRef>
+val tryRescopeEntity: CcuThunk -> Entity -> EntityRef voption
 
 /// Given a value definition, try to produce a reference to that value. Fails for local values.
-val tryRescopeVal: CcuThunk -> Remap -> Val -> ValueOption<ValRef>
+val tryRescopeVal: CcuThunk -> Remap -> Val -> ValRef voption
 
 /// Make the substitution (remapping) table for viewing a module or namespace 'from the outside'
 ///
@@ -1526,7 +1526,7 @@ val isOptionTy: TcGlobals -> TType -> bool
 val destOptionTy: TcGlobals -> TType -> TType
 
 /// Try to take apart an option type
-val tryDestOptionTy: TcGlobals -> TType -> ValueOption<TType>
+val tryDestOptionTy: TcGlobals -> TType -> TType voption
 
 /// Try to take apart an option type
 val destValueOptionTy: TcGlobals -> TType -> TType
@@ -1535,7 +1535,7 @@ val destValueOptionTy: TcGlobals -> TType -> TType
 val isNullableTy: TcGlobals -> TType -> bool
 
 /// Try to take apart a System.Nullable type
-val tryDestNullableTy: TcGlobals -> TType -> ValueOption<TType>
+val tryDestNullableTy: TcGlobals -> TType -> TType voption
 
 /// Take apart a System.Nullable type
 val destNullableTy: TcGlobals -> TType -> TType

--- a/src/FSharp.Core/result.fsi
+++ b/src/FSharp.Core/result.fsi
@@ -296,7 +296,7 @@ module Result =
     /// </code>
     /// </example>
     [<CompiledName("ToOption")>]
-    val toOption: result: Result<'T, 'Error> -> Option<'T>
+    val toOption: result: Result<'T, 'Error> -> 'T option
 
     /// <summary>Convert the result to an Option value.</summary>
     ///

--- a/src/FSharp.Core/result.fsi
+++ b/src/FSharp.Core/result.fsi
@@ -281,7 +281,7 @@ module Result =
     /// </code>
     /// </example>
     [<CompiledName("ToList")>]
-    val toList: result: Result<'T, 'Error> -> List<'T>
+    val toList: result: Result<'T, 'Error> -> 'T list
 
     /// <summary>Convert the result to an Option value.</summary>
     ///

--- a/src/FSharp.Core/result.fsi
+++ b/src/FSharp.Core/result.fsi
@@ -311,4 +311,4 @@ module Result =
     /// </code>
     /// </example>
     [<CompiledName("ToValueOption")>]
-    val toValueOption: result: Result<'T, 'Error> -> ValueOption<'T>
+    val toValueOption: result: Result<'T, 'Error> -> 'T voption


### PR DESCRIPTION
Fixes #14465

Uses postfix notation for types listed in the [F# code formatting guidelines](https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting#for-types-prefer-prefix-syntax-for-generics-foot-with-some-specific-exceptions):

> 1. For F# Lists, use the postfix form: `int list` rather than `list<int>`.
> 2. For F# Options, use the postfix form: `int option` rather than `option<int>`.
> 3. For F# Value Options, use the postfix form: `int voption` rather than `voption<int>`.
> 4. For F# arrays, use the syntactic name `int[]` rather than `int array` or `array<int>`.
> 5. For Reference Cells, use int ref rather than `ref<int>` or `Ref<int>`.