### PR TITLE
FCS: enable cancelation of FSI-sessions by host.

### DIFF
--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -3560,6 +3560,8 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
             (tcImports :> IDisposable).Dispose()
             uninstallMagicAssemblyResolution.Dispose()
 
+    member _.TryAbort() = controlledExecution.TryAbort() 
+         
     /// Load the dummy interaction, load the initial files, and,
     /// if interacting, start the background thread to read the standard input.
     member _.Interrupt() = fsiInterruptController.Interrupt()

--- a/src/Compiler/Interactive/fsi.fsi
+++ b/src/Compiler/Interactive/fsi.fsi
@@ -160,6 +160,13 @@ type FsiEvaluationSession =
         ?legacyReferenceResolver: LegacyReferenceResolver ->
             FsiEvaluationSession
 
+    /// A host calls this to request an abort of the evaluation thread.
+    /// This works only on net framework and on net7.0 or later.
+    /// On net framework it calls thread.Abort(). 
+    /// On net7.0 or higher it cancels an internal cancellation token passed to System.Runtime.ControlledExecution.Run().
+    /// On net6.0 or lower it does nothing.
+    member TryAbort : unit -> unit  
+
     /// A host calls this to request an interrupt on the evaluation thread.
     member Interrupt: unit -> unit
 

--- a/src/Compiler/Interactive/fsi.fsi
+++ b/src/Compiler/Interactive/fsi.fsi
@@ -162,10 +162,10 @@ type FsiEvaluationSession =
 
     /// A host calls this to request an abort of the evaluation thread.
     /// This works only on net framework and on net7.0 or later.
-    /// On net framework it calls thread.Abort(). 
-    /// On net7.0 or higher it cancels an internal cancellation token passed to System.Runtime.ControlledExecution.Run().
-    /// On net6.0 or lower it does nothing.
-    member TryAbort : unit -> unit  
+    /// On .NET Framework it calls thread.Abort() on the current thread, it also does the required ResetAbort. It reports a OperationCanceledException for the fsi evaluation.
+    /// On .NET 7 or higher it cancels an internal cancellation token passed to System.Runtime.ControlledExecution.Run(). It reports a OperationCanceledException for the fsi evaluation.
+    /// On .NET 6 or lower it does nothing.
+    member TryAbort: unit -> unit
 
     /// A host calls this to request an interrupt on the evaluation thread.
     member Interrupt: unit -> unit

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.CompilerService.SurfaceArea.netstandard.expected
@@ -4292,6 +4292,7 @@ FSharp.Compiler.Interactive.Shell+FsiEvaluationSession: System.Tuple`3[FSharp.Co
 FSharp.Compiler.Interactive.Shell+FsiEvaluationSession: Void AddBoundValue(System.String, System.Object)
 FSharp.Compiler.Interactive.Shell+FsiEvaluationSession: Void EvalInteraction(System.String, Microsoft.FSharp.Core.FSharpOption`1[System.Threading.CancellationToken])
 FSharp.Compiler.Interactive.Shell+FsiEvaluationSession: Void EvalScript(System.String)
+FSharp.Compiler.Interactive.Shell+FsiEvaluationSession: Void TryAbort()
 FSharp.Compiler.Interactive.Shell+FsiEvaluationSession: Void Interrupt()
 FSharp.Compiler.Interactive.Shell+FsiEvaluationSession: Void ReportUnhandledException(System.Exception)
 FSharp.Compiler.Interactive.Shell+FsiEvaluationSession: Void Run()


### PR DESCRIPTION
Fix for https://github.com/dotnet/fsharp/issues/14489 
On net7 (and net48) this new member allows cancellation of FSI threads in a hosted context such as WPF or WinForms.  All fsi evaluations on net7 run under  `System.Runtime.ControlledExecution.Run()`. 
 Doing the cancellation myself by wrapping it into `System.Runtime.ControlledExecution.Run()`again does not work. It would fail with `Compiler Error:input.fsx (1,1)-(1,1) interactive error internal error: The thread is already executing the ControlledExecution.Run method.` 
So hosted evaluations can only be cancelled if this or a similar  new member is added.