### PR TITLE
Don't show parameter name hints for basic types

### DIFF
--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -492,3 +492,18 @@ let q = query { for x in { 1 .. 10 } do select x }
         let actual = getParameterNameHints document
 
         Assert.IsEmpty actual
+
+    [<Test>]
+    let ``Hints are not shown for options and results`` () =
+        let code =
+            """
+let theAnswer1 = Some 42
+let theAnswer2 = Ok 42
+let theAnswer3 = Error 42
+"""
+
+        let document = getFsDocument code
+
+        let actual = getParameterNameHints document
+
+        Assert.IsEmpty actual


### PR DESCRIPTION
closes #14448 

Was:
![image](https://user-images.githubusercontent.com/5451366/210829559-c4706c63-442a-412b-a1ce-8a35fed14500.png)

Now:
![image](https://user-images.githubusercontent.com/5451366/210830610-23b69fb7-e2ce-4afd-90fe-d97f06c987ad.png)
