### PR TITLE
Fixes #14613

### DIFF
--- a/src/Compiler/Checking/InfoReader.fs
+++ b/src/Compiler/Checking/InfoReader.fs
@@ -564,12 +564,12 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
     /// Filter the overrides of methods or properties, either keeping the overrides or keeping the dispatch slots.
     static let FilterOverrides findFlag (isVirt:'a->bool, isNewSlot, isDefiniteOverride, isFinal, equivSigs, nmf:'a->string) items = 
         let equivVirts x y = isVirt x && isVirt y && equivSigs x y
-        let filterDefiniteOverride = List.filter(not << isDefiniteOverride)
+        let filterDefiniteOverrides = List.filter(not << isDefiniteOverride)
 
         match findFlag with
         | DiscardOnFirstNonOverride ->
             items
-            |> List.map filterDefiniteOverride
+            |> List.map filterDefiniteOverrides
             |> ExcludeItemsInSuperTypesBasedOnEquivTestWithItemsInSubTypes nmf (fun newItem priorItem ->
                 equivSigs newItem priorItem &&
                 isVirt newItem && not (isVirt priorItem)
@@ -594,7 +594,7 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
             items
               // Remove any F#-declared overrides. These may occur in the same type as the abstract member (unlike with .NET metadata)
               // Include any 'newslot' declared methods.
-              |> List.map filterDefiniteOverride
+              |> List.map filterDefiniteOverrides
 
               // Remove any virtuals that are signature-equivalent to virtuals in subtypes, except for newslots
               // That is, keep if it's 

--- a/src/Compiler/Checking/InfoReader.fs
+++ b/src/Compiler/Checking/InfoReader.fs
@@ -564,16 +564,17 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
     /// Filter the overrides of methods or properties, either keeping the overrides or keeping the dispatch slots.
     static let FilterOverrides findFlag (isVirt:'a->bool, isNewSlot, isDefiniteOverride, isFinal, equivSigs, nmf:'a->string) items = 
         let equivVirts x y = isVirt x && isVirt y && equivSigs x y
-        let filterDifiniteOverrides x = not (isDefiniteOverride x)
+        let filterDifiniteOverride = List.filter(not << isDefiniteOverride)
 
         match findFlag with
         | DiscardOnFirstNonOverride ->
             items
-            |> List.map (List.filter filterDifiniteOverrides)
+            |> List.map filterDifiniteOverride
             |> ExcludeItemsInSuperTypesBasedOnEquivTestWithItemsInSubTypes nmf (fun newItem priorItem ->
+                equivSigs newItem priorItem &&
                 isVirt newItem && not (isVirt priorItem)
             ) 
-        | PreferOverrides -> 
+        | PreferOverrides ->
             items
             // For each F#-declared override, get rid of any equivalent abstract member in the same type
             // This is because F# abstract members with default overrides give rise to two members with the
@@ -593,7 +594,7 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
             items
               // Remove any F#-declared overrides. These may occur in the same type as the abstract member (unlike with .NET metadata)
               // Include any 'newslot' declared methods.
-              |> List.map (List.filter filterDifiniteOverrides) 
+              |> List.map filterDifiniteOverride
 
               // Remove any virtuals that are signature-equivalent to virtuals in subtypes, except for newslots
               // That is, keep if it's 

--- a/src/Compiler/Checking/InfoReader.fs
+++ b/src/Compiler/Checking/InfoReader.fs
@@ -311,6 +311,9 @@ type FindMemberFlag =
     | IgnoreOverrides 
     /// Get overrides instead of abstract slots when measuring whether a class/interface implements all its required slots. 
     | PreferOverrides
+    /// Similar to "IgnoreOverrides", but filters the items bottom-to-top,
+    /// and discards all when finds first non-virtual member which hides one above it in hirearchy.
+    | DiscardOnFirstNonOverride
 
 /// The input list is sorted from most-derived to least-derived type, so any System.Object methods 
 /// are at the end of the list. Return a filtered list where prior/subsequent members matching by name and 
@@ -561,8 +564,15 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
     /// Filter the overrides of methods or properties, either keeping the overrides or keeping the dispatch slots.
     static let FilterOverrides findFlag (isVirt:'a->bool, isNewSlot, isDefiniteOverride, isFinal, equivSigs, nmf:'a->string) items = 
         let equivVirts x y = isVirt x && isVirt y && equivSigs x y
+        let filterDifiniteOverrides x = not (isDefiniteOverride x)
 
-        match findFlag with 
+        match findFlag with
+        | DiscardOnFirstNonOverride ->
+            items
+            |> List.map (List.filter filterDifiniteOverrides)
+            |> ExcludeItemsInSuperTypesBasedOnEquivTestWithItemsInSubTypes nmf (fun newItem priorItem ->
+                isVirt newItem && not (isVirt priorItem)
+            ) 
         | PreferOverrides -> 
             items
             // For each F#-declared override, get rid of any equivalent abstract member in the same type
@@ -583,7 +593,7 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
             items
               // Remove any F#-declared overrides. These may occur in the same type as the abstract member (unlike with .NET metadata)
               // Include any 'newslot' declared methods.
-              |> List.map (List.filter (fun x -> not (isDefiniteOverride x))) 
+              |> List.map (List.filter filterDifiniteOverrides) 
 
               // Remove any virtuals that are signature-equivalent to virtuals in subtypes, except for newslots
               // That is, keep if it's 

--- a/src/Compiler/Checking/InfoReader.fs
+++ b/src/Compiler/Checking/InfoReader.fs
@@ -564,12 +564,12 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
     /// Filter the overrides of methods or properties, either keeping the overrides or keeping the dispatch slots.
     static let FilterOverrides findFlag (isVirt:'a->bool, isNewSlot, isDefiniteOverride, isFinal, equivSigs, nmf:'a->string) items = 
         let equivVirts x y = isVirt x && isVirt y && equivSigs x y
-        let filterDifiniteOverride = List.filter(not << isDefiniteOverride)
+        let filterDefiniteOverride = List.filter(not << isDefiniteOverride)
 
         match findFlag with
         | DiscardOnFirstNonOverride ->
             items
-            |> List.map filterDifiniteOverride
+            |> List.map filterDefiniteOverride
             |> ExcludeItemsInSuperTypesBasedOnEquivTestWithItemsInSubTypes nmf (fun newItem priorItem ->
                 equivSigs newItem priorItem &&
                 isVirt newItem && not (isVirt priorItem)
@@ -594,7 +594,7 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
             items
               // Remove any F#-declared overrides. These may occur in the same type as the abstract member (unlike with .NET metadata)
               // Include any 'newslot' declared methods.
-              |> List.map filterDifiniteOverride
+              |> List.map filterDefiniteOverride
 
               // Remove any virtuals that are signature-equivalent to virtuals in subtypes, except for newslots
               // That is, keep if it's 

--- a/src/Compiler/Checking/InfoReader.fs
+++ b/src/Compiler/Checking/InfoReader.fs
@@ -564,7 +564,7 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
     /// Filter the overrides of methods or properties, either keeping the overrides or keeping the dispatch slots.
     static let FilterOverrides findFlag (isVirt:'a->bool, isNewSlot, isDefiniteOverride, isFinal, equivSigs, nmf:'a->string) items = 
         let equivVirts x y = isVirt x && isVirt y && equivSigs x y
-        let filterDefiniteOverrides = List.filter(not << isDefiniteOverride)
+        let filterDefiniteOverrides = List.filter(isDefiniteOverride >> not)
 
         match findFlag with
         | DiscardOnFirstNonOverride ->

--- a/src/Compiler/Checking/InfoReader.fsi
+++ b/src/Compiler/Checking/InfoReader.fsi
@@ -89,6 +89,10 @@ type FindMemberFlag =
     /// Get overrides instead of abstract slots when measuring whether a class/interface implements all its required slots.
     | PreferOverrides
 
+    /// Similar to "IgnoreOverrides", but filters the items bottom-to-top,
+    /// and discards all when finds first non-virtual member which hides one above it in hirearchy.
+    | DiscardOnFirstNonOverride
+
 /// An InfoReader is an object to help us read and cache infos.
 /// We create one of these for each file we typecheck.
 type InfoReader =

--- a/src/Compiler/Checking/MethodOverrides.fs
+++ b/src/Compiler/Checking/MethodOverrides.fs
@@ -927,7 +927,7 @@ let FinalTypeDefinitionChecksAtEndOfInferenceScope (infoReader: InfoReader, nenv
 
 /// Get the methods relevant to determining if a uniquely-identified-override exists based on the syntactic information 
 /// at the member signature prior to type inference. This is used to pre-assign type information if it does 
-let GetAbstractMethInfosForSynMethodDecl(infoReader: InfoReader, ad, memberName: Ident, bindm, typToSearchForAbstractMembers, valSynData, memberFlags: SynMemberFlags) =
+let GetAbstractMethInfosForSynMethodDecl(infoReader: InfoReader, ad, memberName: Ident, bindm, typToSearchForAbstractMembers, valSynData, memberFlags: SynMemberFlags, findFlag: FindMemberFlag) =
 
     let g = infoReader.g
     if not memberFlags.IsInstance && memberFlags.IsOverrideOrExplicitImpl then
@@ -939,7 +939,7 @@ let GetAbstractMethInfosForSynMethodDecl(infoReader: InfoReader, ad, memberName:
         | _, Some(SlotImplSet(_, dispatchSlotsKeyed, _, _)) -> 
             NameMultiMap.find  memberName.idText dispatchSlotsKeyed |> List.map (fun reqdSlot -> reqdSlot.MethodInfo)
         | ty, None -> 
-            GetIntrinsicMethInfosOfType infoReader (Some memberName.idText) ad AllowMultiIntfInstantiations.Yes IgnoreOverrides bindm ty
+            GetIntrinsicMethInfosOfType infoReader (Some memberName.idText) ad AllowMultiIntfInstantiations.Yes findFlag bindm ty
     let dispatchSlots = minfos |> List.filter (fun minfo -> minfo.IsDispatchSlot)
     let valReprSynArities = SynInfo.AritiesOfArgs valSynData
 

--- a/src/Compiler/Checking/MethodOverrides.fsi
+++ b/src/Compiler/Checking/MethodOverrides.fsi
@@ -156,7 +156,8 @@ val GetAbstractMethInfosForSynMethodDecl:
     bindm: range *
     typToSearchForAbstractMembers: (TType * SlotImplSet option) *
     valSynData: SynValInfo *
-    memberFlags: SynMemberFlags ->
+    memberFlags: SynMemberFlags *
+    findFlag: FindMemberFlag ->
         MethInfo list * MethInfo list
 
 /// Get the properties relevant to determining if a uniquely-identified-override exists based on the syntactic information

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -3868,7 +3868,8 @@ let ResolveExprDotLongIdentAndComputeRange (sink: TcResultsSink) (ncenv: NameRes
                 match findFlag, item with
                 | FindMemberFlag.PreferOverrides, _
                 | _, NonOverridable() -> item, itemRange, false
-                | FindMemberFlag.IgnoreOverrides, _ ->
+                | FindMemberFlag.IgnoreOverrides, _
+                | FindMemberFlag.DiscardOnFirstNonOverride, _ ->
                     let _, item, _, itemRange = resolveExpr FindMemberFlag.PreferOverrides
                     item, itemRange, true
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
@@ -545,6 +545,62 @@ type C() =
         ]
 
     [<Fact>]
+    let ``Virtual members were found with multiple types in hierarchy with different overloads langversionPreview`` () =
+        let CSLib =
+            CSharp """
+public class A
+{
+    public virtual void M1(string s) { }
+}
+
+public class B : A
+{
+    public virtual void M1(int i) { }
+}
+        """ |> withName "CSLib"
+
+        let app =
+            FSharp """
+module ClassTests
+type C() =
+    inherit B ()
+    override _.M1 (i: string) = ()
+    override _.M1 (i: int) = ()
+        """ |> withReferences [CSLib]
+        app
+        |> withLangVersionPreview
+        |> compile
+        |> shouldSucceed
+
+    [<Fact>]
+    let ``Virtual member was found with multiple types in hierarchy with different overloads langversionPreview`` () =
+        let CSLib =
+            CSharp """
+public class A
+{
+    public virtual void M1(string s) { }
+}
+
+public class B : A
+{
+    public void M1(int i) { }
+}
+        """ |> withName "CSLib"
+
+        let app =
+            FSharp """
+module ClassTests
+type C() =
+    inherit B ()
+    override _.M1 (i: string) = ()
+        """ |> withReferences [CSLib]
+        app
+        |> withLangVersionPreview
+        |> compile
+        |> shouldSucceed
+
+
+    [<Fact>]
     let ``Virtual member was found among virtual and non-virtual overloads with lang preview`` () =
         let CSLib =
             CSharp """

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
@@ -543,3 +543,30 @@ type C() =
             (Error 855, Line 7, Col 19, Line 7, Col 21, "No abstract or interface member was found that corresponds to this override")
             (Error 855, Line 9, Col 19, Line 9, Col 21, "No abstract or interface member was found that corresponds to this override")
         ]
+
+    [<Fact>]
+    let ``Virtual member was found among virtual and non-virtual overloads with lang preview`` () =
+        let CSLib =
+            CSharp """
+public class A
+{
+    public void M1(int i) { }
+    public virtual void M1(string s) { }
+}
+        """ |> withName "CSLib"
+
+        let app =
+            FSharp """
+module ClassTests
+
+type Over () =
+    inherit A ()
+
+    override _.M1 (s: string) = ()
+        """
+        
+        app
+        |> withReferences [CSLib]
+        |> withLangVersionPreview
+        |> compile
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
@@ -654,4 +654,4 @@ type PD() =
         |> withLangVersionPreview
         |> compile
         |> shouldFail
-        |> withSingleDiagnostic (Error 361, Line 19, Col 18, Line 19, Col 19, "The override 'M: int -> unit' implements more than one abstract slot, e.g. 'abstract PB.M: 'a -> unit' and 'abstract PA.M: int -> unit'")
+        |> withSingleDiagnostic (Error 361, Line 19, Col 19, Line 19, Col 20, "The override 'M: int -> unit' implements more than one abstract slot, e.g. 'abstract PB.M: 'a -> unit' and 'abstract PA.M: int -> unit'")


### PR DESCRIPTION
Fixes #14613 (an issue in preview version of F# which was introduced in https://github.com/dotnet/fsharp/pull/14263)

Adds another `FindMemberFlag` "strategy", which folds over type hierarchy bottom-to-top (from parent up) and discards all members if it detects that a non-virtual member with same signature hides virtual one.

@kerams @auduchinok if you have any more tests in mind, I'll gladly add it.

cc @edgarfgp 