### PR TITLE
Update nuget versioning for fsharp.core and fcs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>7</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>1</FSBuildVersion>
+    <FSBuildVersion>200</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->
@@ -33,7 +33,7 @@
     <!-- FSharp.Compiler.Service version -->
     <FCSMajorVersion>43</FCSMajorVersion>
     <FCSMinorVersion>7</FCSMinorVersion>
-    <FCSBuildVersion>200</FCSBuildVersion>
+    <FCSBuildVersion>$(FSBuildVersion)</FCSBuildVersion>
     <FCSRevisionVersion>$(FSRevisionVersion)</FCSRevisionVersion>
     <FSharpCompilerServicePackageVersion>$(FCSMajorVersion).$(FCSMinorVersion).$(FCSBuildVersion)</FSharpCompilerServicePackageVersion>
     <FSharpCompilerServiceVersion>$(FCSMajorVersion).$(FCSMinorVersion).$(FCSBuildVersion).$(FCSRevisionVersion)</FSharpCompilerServiceVersion>


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/14618

Okay ... It turns out that we rebuild the fsharp.core nuget package every time we service fsharp, whether there are deliberate FSharp.Core changes or not.  This impacts the fsharp.core.nuget package that is embedded in the dotnet sdk, it causes the package to be different from the package previously shipped to nuget.  This means that we must revise the version number every time we service a branch.  Currently we may have to service the LTS branches and the current release branch as well as preview branches.

So, we will adopt a similarbuild numbering system to the dotnet sdk.
The build revision will start at 100 and increment by 1 for each subsequent release.  We will align the start to match the release of the SDK.  Ie.  sdk 7.0.300 we will ship fsharp.core 7.0.300 etc... However, we will only rev the version number if there is a servicing event.  So 7.0.300 of the SDK may ship 7.0.200 of FSharp.Core if no changes occurred in any of the binaries.

Note this PR targets main branch which aligns with the current preview release\dev17.5 branch which will ship

- FCS 43.7.200 

and 

- FSharp.Core 7.0.200

May I please never have to think about versioning again.
