### PR TITLE
Disable two tests in `ExprTests` in DEBUG, non-NetFramework only - they fail due to `StackOverflow` exception on `NetCore`+DEBUG configuration..

### DIFF
--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -722,6 +722,13 @@ let test{0}ToStringOperator   (e1:{1}) = string e1
 
 """
 
+let ignoreTestInDebug () =
+#if DEBUG
+    Assert.Ignore("Test is known to fail in DEBUG. Use RELEASE configuration to run it.")
+#else
+    ()
+#endif
+
 /// This test is run in unison with its optimized counterpart below
 [<Test>]
 let ``Test Unoptimized Declarations Project1`` () =
@@ -3191,6 +3198,7 @@ let BigSequenceExpression(outFileOpt,docFileOpt,baseAddressOpt) =
 
 [<Test>]
 let ``Test expressions of declarations stress big expressions`` () =
+    ignoreTestInDebug ()
     let cleanup, options = ProjectStressBigExpressions.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
@@ -3207,6 +3215,7 @@ let ``Test expressions of declarations stress big expressions`` () =
 
 [<Test>]
 let ``Test expressions of optimized declarations stress big expressions`` () =
+    ignoreTestInDebug ()
     let cleanup, options = ProjectStressBigExpressions.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -722,9 +722,9 @@ let test{0}ToStringOperator   (e1:{1}) = string e1
 
 """
 
-let ignoreTestInDebug () =
-#if DEBUG
-    Assert.Ignore("Test is known to fail in DEBUG. Use RELEASE configuration to run it.")
+let ignoreTestIfStackOverflowExpected () =
+#if !NETFRAMEWORK && DEBUG
+    Assert.Ignore("Test is known to fail in DEBUG when not using NetFramework. Use RELEASE configuration or NetFramework to run it.")
 #else
     ()
 #endif
@@ -3198,7 +3198,7 @@ let BigSequenceExpression(outFileOpt,docFileOpt,baseAddressOpt) =
 
 [<Test>]
 let ``Test expressions of declarations stress big expressions`` () =
-    ignoreTestInDebug ()
+    ignoreTestIfStackOverflowExpected ()
     let cleanup, options = ProjectStressBigExpressions.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)
@@ -3215,7 +3215,7 @@ let ``Test expressions of declarations stress big expressions`` () =
 
 [<Test>]
 let ``Test expressions of optimized declarations stress big expressions`` () =
-    ignoreTestInDebug ()
+    ignoreTestIfStackOverflowExpected ()
     let cleanup, options = ProjectStressBigExpressions.createOptions()
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true)


### PR DESCRIPTION
These two tests fail due to StackOverflow on NetCore in DEBUG mode, because:
- NetCore has a smaller stack by default than NetFramework
- DEBUG does not optimise the expression traversal and generates very long stacktraces.

We use NUnit's [Assert.Ignore](https://docs.nunit.org/articles/nunit/writing-tests/assertions/classic-assertions/Assert.Ignore.html) to ignore tests dynamically, by calling this function:
```
let ignoreTestIfStackOverflowExpected () =
#if !NETFRAMEWORK && DEBUG
    Assert.Ignore("Test is known to fail in DEBUG when not using NetFramework. Use RELEASE configuration or NetFramework to run it.")
#else
    ()
#endif
```

With this change `./build -noVisualStudio -testCompilerService` no longer fails on my machine.

<details>
<summary>
Screenshot showing the tests being ignored in DEBUG NetCore, but not DEBUG NetFramework:
</summary>

<img width="849" alt="image" src="https://user-images.githubusercontent.com/2478401/213865122-16a1c68c-10b2-43d7-a0ea-296f10ee9de6.png">
</details>

<details>
<summary>
And tests running in RELEASE:
</summary>

<img width="517" alt="image" src="https://user-images.githubusercontent.com/2478401/213817056-20c9794b-9a2b-4f78-9901-1be70d5dc6d0.png">
</details>