### PR TITLE
Fix IFSharpFindDefinitionService MEF export

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -86,6 +86,7 @@
     <Compile Include="Navigation\NavigationBarItemService.fs" />
     <Compile Include="Navigation\NavigateToSearchService.fs" />
     <Compile Include="Navigation\FindUsagesService.fs" />
+    <Compile Include="Navigation\FindDefinitionService.fs" />
     <Compile Include="QuickInfo\NavigableTextRun.fs" />
     <Compile Include="QuickInfo\WpfNagivableTextRunViewElementFactory.fs" />
     <Compile Include="QuickInfo\Views.fs" />

--- a/vsintegration/src/FSharp.Editor/Navigation/FindDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindDefinitionService.fs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System.Composition
+open System.Threading
+
+open FSharp.Compiler.Text.Range
+
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.ExternalAccess.FSharp.GoToDefinition
+
+open Microsoft.VisualStudio.Shell
+open Microsoft.VisualStudio.Shell.Interop
+open System.Collections.Immutable
+open System.Threading.Tasks
+
+[<Export(typeof<IFSharpFindDefinitionService>)>]
+[<Export(typeof<FSharpFindDefinitionService>)>]
+type internal FSharpFindDefinitionService 
+    [<ImportingConstructor>]
+    (metadataAsSource: FSharpMetadataAsSourceService) =
+
+    let statusBar = StatusBar(ServiceProvider.GlobalProvider.GetService<SVsStatusbar,IVsStatusbar>())
+ 
+    interface IFSharpFindDefinitionService with
+        member _.FindDefinitionsAsync (document: Document, position: int, cancellationToken: CancellationToken) =
+            let navigation = FSharpNavigation(statusBar, metadataAsSource, document, rangeStartup)
+            let definitions = navigation.FindDefinitions(position, cancellationToken)
+            ImmutableArray.CreateRange(definitions) |> Task.FromResult

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -699,7 +699,6 @@ type internal FSharpNavigation
             | FSharpGoToDefinitionResult.NavigableItem(navItem) -> Some navItem
             | _ -> None
         )
-        |> Task.FromResult
 
     member _.TryGoToDefinition(position, cancellationToken) =
         let gtd = GoToDefinition(metadataAsSource)

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
@@ -29,7 +29,7 @@ type internal FSharpGoToDefinitionService
         /// Invoked with Peek Definition.
         member _.FindDefinitionsAsync (document: Document, position: int, cancellationToken: CancellationToken) =
             let navigation = FSharpNavigation(statusBar, metadataAsSource, document, rangeStartup)
-            navigation.FindDefinitions(position, cancellationToken)
+            navigation.FindDefinitions(position, cancellationToken) |> Task.FromResult
 
         /// Invoked with Go to Definition.
         /// Try to navigate to the definiton of the symbol at the symbolRange in the originDocument


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/14053, more info in https://github.com/dotnet/roslyn/issues/50391, `IFSharpFindDefinitionService` will be replacing `IFSharpGoToDefinitionService`

@CyrusNajmabadi @333fred do we need to do anything else? When I remove the `FSharpGoToDefinitionService`, `FSharpFindDefinitionService` isn't getting called now in VS debug when I try to navigate to definition.

