### PR TITLE
Use InvariantCulture when running FSI scripts in tests

### DIFF
--- a/tests/FSharp.Test.Utilities/ScriptHelpers.fs
+++ b/tests/FSharp.Test.Utilities/ScriptHelpers.fs
@@ -108,9 +108,15 @@ type FSharpScript(?additionalArgs: string[], ?quiet: bool, ?langVersion: LangVer
 
     member _.Fsi = fsi
 
-    member _.Eval(code: string, ?cancellationToken: CancellationToken) =
+    member _.Eval(code: string, ?cancellationToken: CancellationToken, ?desiredCulture: Globalization.CultureInfo) =
+        let originalCulture = Thread.CurrentThread.CurrentCulture
+        Thread.CurrentThread.CurrentCulture <- Option.defaultValue Globalization.CultureInfo.InvariantCulture desiredCulture
+
         let cancellationToken = defaultArg cancellationToken CancellationToken.None
         let ch, errors = fsi.EvalInteractionNonThrowing(code, cancellationToken)
+
+        Thread.CurrentThread.CurrentCulture <- originalCulture
+
         match ch with
         | Choice1Of2 v -> Ok(v), errors
         | Choice2Of2 ex -> Error(ex), errors


### PR DESCRIPTION
This addresses failures where tests are culture-dependent, like here, where wrong column type is inferred because of decimal separator settings.

```
  Message:
System.ArgumentException : Provided label column 'median_house_value' was of type String, but only type Single is allowed.

  Stack Trace:
DependencyManagerInteractiveTests.getValue(FSharpResult`2 value, FSharpDiagnostic[] errors) line 34
DependencyManagerInteractiveTests.Use Dependency Manager to restore packages with native dependencies, build and run script that depends on the results() line 356
RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```