### PR TITLE
Update ComponentTest baselines

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/CompiledNameAttribute/CompiledNameAttribute04.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/CompiledNameAttribute/CompiledNameAttribute04.fs.il.net472.debug.bsl
@@ -12,7 +12,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly CompiledNameAttribute04
 {
@@ -21,29 +21,29 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.CompiledNameAttribute04
 {
-  // Offset: 0x00000000 Length: 0x00000D2D
+  // Offset: 0x00000000 Length: 0x00000D1B
   // WARNING: managed resource file FSharpSignatureData.CompiledNameAttribute04 created
 }
 .mresource public FSharpOptimizationData.CompiledNameAttribute04
 {
-  // Offset: 0x00000D38 Length: 0x000002BB
+  // Offset: 0x00000D20 Length: 0x000002BB
   // WARNING: managed resource file FSharpOptimizationData.CompiledNameAttribute04 created
 }
 .module CompiledNameAttribute04.exe
-// MVID: {623F5F36-34DF-584F-A745-0383365F3F62}
+// MVID: {63E6EA31-0A9C-B06D-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x053F0000
+// Image base: 0x000002358DD80000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -142,8 +142,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype Program/S obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       5 (0x5)
       .maxstack  3
       .locals init (valuetype Program/S& V_0)
@@ -156,8 +155,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -171,8 +169,7 @@
             instance int32  CompareTo(object obj,
                                       class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  3
       .locals init (valuetype Program/S V_0,
@@ -189,8 +186,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       2 (0x2)
       .maxstack  8
       IL_0000:  ldc.i4.0
@@ -200,8 +196,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -214,8 +209,7 @@
             instance bool  Equals(object obj,
                                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       27 (0x1b)
       .maxstack  3
       .locals init (object V_0,
@@ -253,8 +247,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype Program/S obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       5 (0x5)
       .maxstack  3
       .locals init (valuetype Program/S& V_0)
@@ -267,8 +260,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/CompiledNameAttribute/CompiledNameAttribute04.fs.il.netcore.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/CompiledNameAttribute/CompiledNameAttribute04.fs.il.netcore.debug.bsl
@@ -7,17 +7,17 @@
 .assembly extern System.Runtime
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern System.Runtime.InteropServices
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly CompiledNameAttribute04
 {
@@ -26,29 +26,29 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.CompiledNameAttribute04
 {
-  // Offset: 0x00000000 Length: 0x00000D69
+  // Offset: 0x00000000 Length: 0x00000D57
   // WARNING: managed resource file FSharpSignatureData.CompiledNameAttribute04 created
 }
 .mresource public FSharpOptimizationData.CompiledNameAttribute04
 {
-  // Offset: 0x00000D70 Length: 0x000002C1
+  // Offset: 0x00000D60 Length: 0x000002C1
   // WARNING: managed resource file FSharpOptimizationData.CompiledNameAttribute04 created
 }
 .module CompiledNameAttribute04.exe
-// MVID: {623F5E75-0386-3430-A745-0383755E3F62}
+// MVID: {63E6ED0E-F6F2-C3F7-A745-03830EEDE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000023C6AAC0000
+// Image base: 0x0000027A45420000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -147,8 +147,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype Program/S obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       5 (0x5)
       .maxstack  3
       .locals init (valuetype Program/S& V_0)
@@ -161,8 +160,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -176,8 +174,7 @@
             instance int32  CompareTo(object obj,
                                       class [System.Runtime]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  3
       .locals init (valuetype Program/S V_0,
@@ -194,8 +191,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       2 (0x2)
       .maxstack  8
       IL_0000:  ldc.i4.0
@@ -205,8 +201,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -219,8 +214,7 @@
             instance bool  Equals(object obj,
                                   class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       27 (0x1b)
       .maxstack  3
       .locals init (object V_0,
@@ -258,8 +252,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype Program/S obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       5 (0x5)
       .maxstack  3
       .locals init (valuetype Program/S& V_0)
@@ -272,8 +265,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,
@@ -406,4 +398,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\CompiledNameAttribute\CompiledNameAttribute04_fs\CompiledNameAttribute04.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net7.0\tests\EmittedIL\CompiledNameAttribute\CompiledNameAttribute04_fs\CompiledNameAttribute04.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly Match01
 {
@@ -21,50 +21,50 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 00 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 00 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Match01
 {
-  // Offset: 0x00000000 Length: 0x00000718
+  // Offset: 0x00000000 Length: 0x00000722
   // WARNING: managed resource file FSharpSignatureData.Match01 created
 }
 .mresource public FSharpOptimizationData.Match01
 {
-  // Offset: 0x00000720 Length: 0x000003C3
+  // Offset: 0x00000728 Length: 0x000003B7
   // WARNING: managed resource file FSharpOptimizationData.Match01 created
 }
 .module Match01.exe
-// MVID: {628F4C90-D9D6-6143-A745-0383904C8F62}
+// MVID: {63E6EA31-8A6A-D886-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000019CC0BB0000
+// Image base: 0x00000181091D0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed Match01
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class abstract auto autochar serializable nested public beforefieldinit Test1
-         extends [System.Runtime]System.Object
-         implements class [System.Runtime]System.IEquatable`1<class Match01/Test1>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<class Match01/Test1>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IEquatable`1<class Match01/Test1>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<class Match01/Test1>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                         61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                   61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
     .class abstract auto ansi sealed nested public Tags
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .field public static literal int32 X11 = int32(0x00000000)
       .field public static literal int32 X12 = int32(0x00000001)
@@ -75,20 +75,20 @@
     .class auto ansi serializable nested public beforefieldinit specialname X11
            extends Match01/Test1
     {
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [System.Runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   // .. Match01+Test1
-                                                                                                                                        2B 58 31 31 40 44 65 62 75 67 54 79 70 65 50 72   // +X11@DebugTypePr
-                                                                                                                                        6F 78 79 00 00 )                                  // oxy..
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                           61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   // .. Match01+Test1
+                                                                                                                            2B 58 31 31 40 44 65 62 75 67 54 79 70 65 50 72   // +X11@DebugTypePr
+                                                                                                                            6F 78 79 00 00 )                                  // oxy..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                     61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
       .field assembly initonly int32 item
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method assembly specialname rtspecialname 
               instance void  .ctor(int32 item) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       15 (0xf)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -103,8 +103,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -117,8 +117,8 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 Match01/Test1/X11::get_Item()
       } // end of property X11::Item
     } // end of class X11
@@ -126,20 +126,20 @@
     .class auto ansi serializable nested public beforefieldinit specialname X12
            extends Match01/Test1
     {
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [System.Runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   // .. Match01+Test1
-                                                                                                                                        2B 58 31 32 40 44 65 62 75 67 54 79 70 65 50 72   // +X12@DebugTypePr
-                                                                                                                                        6F 78 79 00 00 )                                  // oxy..
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                           61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   // .. Match01+Test1
+                                                                                                                            2B 58 31 32 40 44 65 62 75 67 54 79 70 65 50 72   // +X12@DebugTypePr
+                                                                                                                            6F 78 79 00 00 )                                  // oxy..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                     61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
       .field assembly initonly int32 item
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method assembly specialname rtspecialname 
               instance void  .ctor(int32 item) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       15 (0xf)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -154,8 +154,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -168,8 +168,8 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 01 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 Match01/Test1/X12::get_Item()
       } // end of property X12::Item
     } // end of class X12
@@ -177,20 +177,20 @@
     .class auto ansi serializable nested public beforefieldinit specialname X13
            extends Match01/Test1
     {
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [System.Runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   // .. Match01+Test1
-                                                                                                                                        2B 58 31 33 40 44 65 62 75 67 54 79 70 65 50 72   // +X13@DebugTypePr
-                                                                                                                                        6F 78 79 00 00 )                                  // oxy..
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                           61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   // .. Match01+Test1
+                                                                                                                            2B 58 31 33 40 44 65 62 75 67 54 79 70 65 50 72   // +X13@DebugTypePr
+                                                                                                                            6F 78 79 00 00 )                                  // oxy..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                     61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
       .field assembly initonly int32 item
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method assembly specialname rtspecialname 
               instance void  .ctor(int32 item) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       15 (0xf)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -205,8 +205,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -219,8 +219,8 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 02 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 Match01/Test1/X13::get_Item()
       } // end of property X13::Item
     } // end of class X13
@@ -228,20 +228,20 @@
     .class auto ansi serializable nested public beforefieldinit specialname X14
            extends Match01/Test1
     {
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [System.Runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   // .. Match01+Test1
-                                                                                                                                        2B 58 31 34 40 44 65 62 75 67 54 79 70 65 50 72   // +X14@DebugTypePr
-                                                                                                                                        6F 78 79 00 00 )                                  // oxy..
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                           61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   // .. Match01+Test1
+                                                                                                                            2B 58 31 34 40 44 65 62 75 67 54 79 70 65 50 72   // +X14@DebugTypePr
+                                                                                                                            6F 78 79 00 00 )                                  // oxy..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                     61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
       .field assembly initonly int32 item
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method assembly specialname rtspecialname 
               instance void  .ctor(int32 item) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       15 (0xf)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -256,8 +256,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -270,28 +270,28 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 03 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 Match01/Test1/X14::get_Item()
       } // end of property X14::Item
     } // end of class X14
 
     .class auto ansi nested assembly beforefieldinit specialname X11@DebugTypeProxy
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .field assembly class Match01/Test1/X11 _obj
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method public specialname rtspecialname 
               instance void  .ctor(class Match01/Test1/X11 obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      class Match01/Test1/X11 Match01/Test1/X11@DebugTypeProxy::_obj
@@ -301,8 +301,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -316,28 +316,28 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 Match01/Test1/X11@DebugTypeProxy::get_Item()
       } // end of property X11@DebugTypeProxy::Item
     } // end of class X11@DebugTypeProxy
 
     .class auto ansi nested assembly beforefieldinit specialname X12@DebugTypeProxy
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .field assembly class Match01/Test1/X12 _obj
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method public specialname rtspecialname 
               instance void  .ctor(class Match01/Test1/X12 obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      class Match01/Test1/X12 Match01/Test1/X12@DebugTypeProxy::_obj
@@ -347,8 +347,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -362,28 +362,28 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 01 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 Match01/Test1/X12@DebugTypeProxy::get_Item()
       } // end of property X12@DebugTypeProxy::Item
     } // end of class X12@DebugTypeProxy
 
     .class auto ansi nested assembly beforefieldinit specialname X13@DebugTypeProxy
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .field assembly class Match01/Test1/X13 _obj
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method public specialname rtspecialname 
               instance void  .ctor(class Match01/Test1/X13 obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      class Match01/Test1/X13 Match01/Test1/X13@DebugTypeProxy::_obj
@@ -393,8 +393,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -408,28 +408,28 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 02 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 Match01/Test1/X13@DebugTypeProxy::get_Item()
       } // end of property X13@DebugTypeProxy::Item
     } // end of class X13@DebugTypeProxy
 
     .class auto ansi nested assembly beforefieldinit specialname X14@DebugTypeProxy
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .field assembly class Match01/Test1/X14 _obj
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method public specialname rtspecialname 
               instance void  .ctor(class Match01/Test1/X14 obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      class Match01/Test1/X14 Match01/Test1/X14@DebugTypeProxy::_obj
@@ -439,8 +439,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -454,25 +454,25 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 03 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 Match01/Test1/X14@DebugTypeProxy::get_Item()
       } // end of property X14@DebugTypeProxy::Item
     } // end of class X14@DebugTypeProxy
 
     .field assembly initonly int32 _tag
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .method assembly specialname rtspecialname 
             instance void  .ctor(int32 _tag) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 Match01/Test1::_tag
@@ -494,8 +494,8 @@
     .method public hidebysig instance bool 
             get_IsX11() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       10 (0xa)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -520,8 +520,8 @@
     .method public hidebysig instance bool 
             get_IsX12() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       10 (0xa)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -546,8 +546,8 @@
     .method public hidebysig instance bool 
             get_IsX13() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       10 (0xa)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -572,8 +572,8 @@
     .method public hidebysig instance bool 
             get_IsX14() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       10 (0xa)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -586,8 +586,8 @@
     .method public hidebysig instance int32 
             get_Tag() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -598,8 +598,8 @@
     .method assembly hidebysig specialname 
             instance object  __DebugDisplay() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
@@ -613,7 +613,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -627,8 +627,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class Match01/Test1 obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       24 (0x18)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -661,8 +660,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -674,10 +672,9 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       41 (0x29)
       .maxstack  5
       .locals init (class Match01/Test1 V_0)
@@ -714,10 +711,9 @@
     } // end of method Test1::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       167 (0xa7)
       .maxstack  7
       .locals init (int32 V_0,
@@ -828,22 +824,20 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 Match01/Test1::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 Match01/Test1::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method Test1::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       209 (0xd1)
       .maxstack  4
       .locals init (class Match01/Test1 V_0,
@@ -952,8 +946,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class Match01/Test1 obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       200 (0xc8)
       .maxstack  4
       .locals init (int32 V_0,
@@ -1058,8 +1051,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class Match01/Test1 V_0)
@@ -1080,37 +1072,37 @@
 
     .property instance int32 Tag()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance int32 Match01/Test1::get_Tag()
     } // end of property Test1::Tag
     .property instance bool IsX11()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance bool Match01/Test1::get_IsX11()
     } // end of property Test1::IsX11
     .property instance bool IsX12()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance bool Match01/Test1::get_IsX12()
     } // end of property Test1::IsX12
     .property instance bool IsX13()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance bool Match01/Test1::get_IsX13()
     } // end of property Test1::IsX13
     .property instance bool IsX14()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance bool Match01/Test1::get_IsX14()
     } // end of property Test1::IsX14
   } // end of class Test1
@@ -1119,15 +1111,14 @@
                                                   class Match01/Test1 obj,
                                                   class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       268 (0x10c)
     .maxstack  5
     .locals init (int32 V_0,
              int32 V_1,
              class Match01/Test1/X11 V_2,
              class Match01/Test1/X11 V_3,
-             class [System.Runtime]System.Collections.IComparer V_4,
+             class [mscorlib]System.Collections.IComparer V_4,
              int32 V_5,
              int32 V_6,
              class Match01/Test1/X12 V_7,
@@ -1159,7 +1150,7 @@
     IL_0037:  ldarg.1
     IL_0038:  castclass  Match01/Test1/X11
     IL_003d:  stloc.3
-    IL_003e:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+    IL_003e:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_0043:  stloc.s    V_4
     IL_0045:  ldloc.2
     IL_0046:  ldfld      int32 Match01/Test1/X11::item
@@ -1182,7 +1173,7 @@
     IL_006b:  ldarg.1
     IL_006c:  castclass  Match01/Test1/X12
     IL_0071:  stloc.s    V_8
-    IL_0073:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+    IL_0073:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_0078:  stloc.s    V_4
     IL_007a:  ldloc.s    V_7
     IL_007c:  ldfld      int32 Match01/Test1/X12::item
@@ -1205,7 +1196,7 @@
     IL_00a2:  ldarg.1
     IL_00a3:  castclass  Match01/Test1/X13
     IL_00a8:  stloc.s    V_10
-    IL_00aa:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+    IL_00aa:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_00af:  stloc.s    V_4
     IL_00b1:  ldloc.s    V_9
     IL_00b3:  ldfld      int32 Match01/Test1/X13::item
@@ -1228,7 +1219,7 @@
     IL_00d9:  ldarg.1
     IL_00da:  castclass  Match01/Test1/X14
     IL_00df:  stloc.s    V_12
-    IL_00e1:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+    IL_00e1:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_00e6:  stloc.s    V_4
     IL_00e8:  ldloc.s    V_11
     IL_00ea:  ldfld      int32 Match01/Test1/X14::item
@@ -1255,8 +1246,7 @@
                                                       class Match01/Test1 objTemp,
                                                       class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       240 (0xf0)
     .maxstack  5
     .locals init (int32 V_0,
@@ -1417,7 +1407,7 @@
 } // end of class Match01
 
 .class private abstract auto ansi sealed '<StartupCode$Match01>'.$Match01
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .method public static void  main@() cil managed
   {
@@ -1433,4 +1423,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\Inlining\Match01_fs\Match01.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\Inlining\Match01_fs\Match01.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/EqualsOnUnions01.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/EqualsOnUnions01.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly EqualsOnUnions01
 {
@@ -21,50 +21,50 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.EqualsOnUnions01
 {
-  // Offset: 0x00000000 Length: 0x00000673
+  // Offset: 0x00000000 Length: 0x0000067D
   // WARNING: managed resource file FSharpSignatureData.EqualsOnUnions01 created
 }
 .mresource public FSharpOptimizationData.EqualsOnUnions01
 {
-  // Offset: 0x00000678 Length: 0x000001CD
+  // Offset: 0x00000688 Length: 0x000001C7
   // WARNING: managed resource file FSharpOptimizationData.EqualsOnUnions01 created
 }
 .module EqualsOnUnions01.exe
-// MVID: {628F4C90-3A79-D23A-A745-0383904C8F62}
+// MVID: {63E6EA31-3FB9-D1D2-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000002A4D8200000
+// Image base: 0x000001B6817C0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed EqualsOnUnions01
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class abstract auto autochar serializable nested public beforefieldinit U
-         extends [System.Runtime]System.Object
-         implements class [System.Runtime]System.IEquatable`1<class EqualsOnUnions01/U>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<class EqualsOnUnions01/U>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IEquatable`1<class EqualsOnUnions01/U>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<class EqualsOnUnions01/U>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                         61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                   61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
     .class abstract auto ansi sealed nested public Tags
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .field public static literal int32 A = int32(0x00000000)
       .field public static literal int32 B = int32(0x00000001)
@@ -73,16 +73,16 @@
     .class auto ansi serializable nested assembly beforefieldinit specialname _A
            extends EqualsOnUnions01/U
     {
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [System.Runtime]System.Type) = ( 01 00 24 45 71 75 61 6C 73 4F 6E 55 6E 69 6F 6E   // ..$EqualsOnUnion
-                                                                                                                                        73 30 31 2B 55 2B 5F 41 40 44 65 62 75 67 54 79   // s01+U+_A@DebugTy
-                                                                                                                                        70 65 50 72 6F 78 79 00 00 )                      // peProxy..
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                           61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 24 45 71 75 61 6C 73 4F 6E 55 6E 69 6F 6E   // ..$EqualsOnUnion
+                                                                                                                            73 30 31 2B 55 2B 5F 41 40 44 65 62 75 67 54 79   // s01+U+_A@DebugTy
+                                                                                                                            70 65 50 72 6F 78 79 00 00 )                      // peProxy..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                     61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
       .method assembly specialname rtspecialname 
               instance void  .ctor() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -95,20 +95,20 @@
     .class auto ansi serializable nested public beforefieldinit specialname B
            extends EqualsOnUnions01/U
     {
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [System.Runtime]System.Type) = ( 01 00 23 45 71 75 61 6C 73 4F 6E 55 6E 69 6F 6E   // ..#EqualsOnUnion
-                                                                                                                                        73 30 31 2B 55 2B 42 40 44 65 62 75 67 54 79 70   // s01+U+B@DebugTyp
-                                                                                                                                        65 50 72 6F 78 79 00 00 )                         // eProxy..
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                           61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [mscorlib]System.Type) = ( 01 00 23 45 71 75 61 6C 73 4F 6E 55 6E 69 6F 6E   // ..#EqualsOnUnion
+                                                                                                                            73 30 31 2B 55 2B 42 40 44 65 62 75 67 54 79 70   // s01+U+B@DebugTyp
+                                                                                                                            65 50 72 6F 78 79 00 00 )                         // eProxy..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                     61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
       .field assembly initonly int32 item
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method assembly specialname rtspecialname 
               instance void  .ctor(int32 item) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -122,8 +122,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -136,28 +136,28 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 01 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 EqualsOnUnions01/U/B::get_Item()
       } // end of property B::Item
     } // end of class B
 
     .class auto ansi nested assembly beforefieldinit specialname _A@DebugTypeProxy
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .field assembly class EqualsOnUnions01/U/_A _obj
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method public specialname rtspecialname 
               instance void  .ctor(class EqualsOnUnions01/U/_A obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      class EqualsOnUnions01/U/_A EqualsOnUnions01/U/_A@DebugTypeProxy::_obj
@@ -167,21 +167,21 @@
     } // end of class _A@DebugTypeProxy
 
     .class auto ansi nested assembly beforefieldinit specialname B@DebugTypeProxy
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .field assembly class EqualsOnUnions01/U/B _obj
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method public specialname rtspecialname 
               instance void  .ctor(class EqualsOnUnions01/U/B obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      class EqualsOnUnions01/U/B EqualsOnUnions01/U/B@DebugTypeProxy::_obj
@@ -191,8 +191,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -206,16 +206,16 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 01 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 EqualsOnUnions01/U/B@DebugTypeProxy::get_Item()
       } // end of property B@DebugTypeProxy::Item
     } // end of class B@DebugTypeProxy
 
     .field static assembly initonly class EqualsOnUnions01/U _unique_A
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .method private specialname rtspecialname static 
             void  .cctor() cil managed
     {
@@ -229,12 +229,12 @@
     .method assembly specialname rtspecialname 
             instance void  .ctor() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ret
     } // end of method U::.ctor
 
@@ -252,8 +252,8 @@
     .method public hidebysig instance bool 
             get_IsA() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       10 (0xa)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -278,8 +278,8 @@
     .method public hidebysig instance bool 
             get_IsB() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       10 (0xa)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -292,8 +292,8 @@
     .method public hidebysig instance int32 
             get_Tag() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -310,8 +310,8 @@
     .method assembly hidebysig specialname 
             instance object  __DebugDisplay() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
@@ -325,7 +325,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -339,8 +339,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class EqualsOnUnions01/U obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       136 (0x88)
       .maxstack  5
       .locals init (int32 V_0,
@@ -349,10 +348,10 @@
                class EqualsOnUnions01/U V_3,
                class EqualsOnUnions01/U/B V_4,
                class EqualsOnUnions01/U/B V_5,
-               class [System.Runtime]System.Collections.IComparer V_6,
+               class [mscorlib]System.Collections.IComparer V_6,
                int32 V_7,
                int32 V_8,
-               class [System.Runtime]System.Collections.IComparer V_9,
+               class [mscorlib]System.Collections.IComparer V_9,
                int32 V_10,
                int32 V_11)
       IL_0000:  ldarg.0
@@ -397,7 +396,7 @@
       IL_003e:  ldarg.1
       IL_003f:  castclass  EqualsOnUnions01/U/B
       IL_0044:  stloc.s    V_5
-      IL_0046:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0046:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_004b:  stloc.s    V_6
       IL_004d:  ldloc.s    V_4
       IL_004f:  ldfld      int32 EqualsOnUnions01/U/B::item
@@ -444,8 +443,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -457,10 +455,9 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       151 (0x97)
       .maxstack  5
       .locals init (class EqualsOnUnions01/U V_0,
@@ -470,10 +467,10 @@
                class EqualsOnUnions01/U V_4,
                class EqualsOnUnions01/U/B V_5,
                class EqualsOnUnions01/U/B V_6,
-               class [System.Runtime]System.Collections.IComparer V_7,
+               class [mscorlib]System.Collections.IComparer V_7,
                int32 V_8,
                int32 V_9,
-               class [System.Runtime]System.Collections.IComparer V_10,
+               class [mscorlib]System.Collections.IComparer V_10,
                int32 V_11,
                int32 V_12)
       IL_0000:  ldarg.1
@@ -568,17 +565,16 @@
     } // end of method U::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       71 (0x47)
       .maxstack  7
       .locals init (int32 V_0,
                class EqualsOnUnions01/U/B V_1,
-               class [System.Runtime]System.Collections.IEqualityComparer V_2,
+               class [mscorlib]System.Collections.IEqualityComparer V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
                class EqualsOnUnions01/U V_5)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0045
@@ -635,22 +631,20 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 EqualsOnUnions01/U::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 EqualsOnUnions01/U::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method U::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       126 (0x7e)
       .maxstack  4
       .locals init (class EqualsOnUnions01/U V_0,
@@ -661,10 +655,10 @@
                class EqualsOnUnions01/U V_5,
                class EqualsOnUnions01/U/B V_6,
                class EqualsOnUnions01/U/B V_7,
-               class [System.Runtime]System.Collections.IEqualityComparer V_8,
+               class [mscorlib]System.Collections.IEqualityComparer V_8,
                int32 V_9,
                int32 V_10,
-               class [System.Runtime]System.Collections.IEqualityComparer V_11)
+               class [mscorlib]System.Collections.IEqualityComparer V_11)
       IL_0000:  ldarg.0
       IL_0001:  brfalse    IL_0076
 
@@ -747,8 +741,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class EqualsOnUnions01/U obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       95 (0x5f)
       .maxstack  4
       .locals init (int32 V_0,
@@ -826,8 +819,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class EqualsOnUnions01/U V_0)
@@ -848,30 +840,30 @@
 
     .property instance int32 Tag()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance int32 EqualsOnUnions01/U::get_Tag()
     } // end of property U::Tag
     .property class EqualsOnUnions01/U A()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get class EqualsOnUnions01/U EqualsOnUnions01/U::get_A()
     } // end of property U::A
     .property instance bool IsA()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance bool EqualsOnUnions01/U::get_IsA()
     } // end of property U::IsA
     .property instance bool IsB()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance bool EqualsOnUnions01/U::get_IsB()
     } // end of property U::IsB
   } // end of class U
@@ -879,7 +871,7 @@
 } // end of class EqualsOnUnions01
 
 .class private abstract auto ansi sealed '<StartupCode$EqualsOnUnions01>'.$EqualsOnUnions01
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .method public static void  main@() cil managed
   {
@@ -895,4 +887,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\Misc\EqualsOnUnions01_fs\EqualsOnUnions01.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\Misc\EqualsOnUnions01_fs\EqualsOnUnions01.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/Structs01.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/Structs01.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly Structs01
 {
@@ -21,64 +21,63 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Structs01
 {
-  // Offset: 0x00000000 Length: 0x0000076D
+  // Offset: 0x00000000 Length: 0x00000777
   // WARNING: managed resource file FSharpSignatureData.Structs01 created
 }
 .mresource public FSharpOptimizationData.Structs01
 {
-  // Offset: 0x00000778 Length: 0x00000237
+  // Offset: 0x00000780 Length: 0x00000231
   // WARNING: managed resource file FSharpOptimizationData.Structs01 created
 }
 .module Structs01.exe
-// MVID: {628F4C90-ED12-88DB-A745-0383904C8F62}
+// MVID: {63E6EA31-A153-39D7-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000015E059D0000
+// Image base: 0x00000246C2230000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed Experiment.Test
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class sequential ansi serializable sealed nested public Test
-         extends [System.Runtime]System.ValueType
-         implements class [System.Runtime]System.IEquatable`1<valuetype Experiment.Test/Test>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<valuetype Experiment.Test/Test>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.ValueType
+         implements class [mscorlib]System.IEquatable`1<valuetype Experiment.Test/Test>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<valuetype Experiment.Test/Test>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
     .field public int32 Field
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype Experiment.Test/Test obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       46 (0x2e)
       .maxstack  5
       .locals init (valuetype Experiment.Test/Test& V_0,
-               class [System.Runtime]System.Collections.IComparer V_1,
+               class [mscorlib]System.Collections.IComparer V_1,
                int32 V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IComparer V_4,
+               class [mscorlib]System.Collections.IComparer V_4,
                int32 V_5,
                int32 V_6)
       IL_0000:  ldarga.s   obj
       IL_0002:  stloc.0
-      IL_0003:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0003:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0008:  stloc.1
       IL_0009:  ldarg.0
       IL_000a:  ldfld      int32 Experiment.Test/Test::Field
@@ -105,8 +104,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -118,18 +116,17 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       51 (0x33)
       .maxstack  5
       .locals init (valuetype Experiment.Test/Test V_0,
                valuetype Experiment.Test/Test& V_1,
-               class [System.Runtime]System.Collections.IComparer V_2,
+               class [mscorlib]System.Collections.IComparer V_2,
                int32 V_3,
                int32 V_4,
-               class [System.Runtime]System.Collections.IComparer V_5,
+               class [mscorlib]System.Collections.IComparer V_5,
                int32 V_6,
                int32 V_7)
       IL_0000:  ldarg.1
@@ -162,16 +159,15 @@
     } // end of method Test::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       31 (0x1f)
       .maxstack  7
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IEqualityComparer V_1,
+               class [mscorlib]System.Collections.IEqualityComparer V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3)
+               class [mscorlib]System.Collections.IEqualityComparer V_3)
       IL_0000:  ldc.i4.0
       IL_0001:  stloc.0
       IL_0002:  ldc.i4     0x9e3779b9
@@ -200,31 +196,29 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  call       instance int32 Experiment.Test/Test::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  call       instance int32 Experiment.Test/Test::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method Test::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       53 (0x35)
       .maxstack  4
       .locals init (object V_0,
                valuetype Experiment.Test/Test V_1,
                valuetype Experiment.Test/Test& V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3,
+               class [mscorlib]System.Collections.IEqualityComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6)
+               class [mscorlib]System.Collections.IEqualityComparer V_6)
       IL_0000:  ldarg.1
       IL_0001:  stloc.0
       IL_0002:  ldloc.0
@@ -271,8 +265,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype Experiment.Test/Test obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       18 (0x12)
       .maxstack  4
       .locals init (valuetype Experiment.Test/Test& V_0)
@@ -289,8 +282,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,
@@ -333,7 +325,7 @@
 } // end of class Experiment.Test
 
 .class private abstract auto ansi sealed '<StartupCode$Structs01>.$Experiment'.Test
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .method public static void  main@() cil managed
   {
@@ -349,4 +341,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\Misc\Structs01_fs\Structs01.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\Misc\Structs01_fs\Structs01.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/Structs02.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/Structs02.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly Structs02
 {
@@ -21,44 +21,44 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Structs02
 {
-  // Offset: 0x00000000 Length: 0x000007A7
+  // Offset: 0x00000000 Length: 0x000007B1
   // WARNING: managed resource file FSharpSignatureData.Structs02 created
 }
 .mresource public FSharpOptimizationData.Structs02
 {
-  // Offset: 0x000007B0 Length: 0x0000023D
+  // Offset: 0x000007B8 Length: 0x00000237
   // WARNING: managed resource file FSharpOptimizationData.Structs02 created
 }
 .module Structs02.exe
-// MVID: {628F4C90-A85C-11CB-A745-0383904C8F62}
+// MVID: {63E6EA31-BE14-39D7-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00000200752B0000
+// Image base: 0x000002A17A200000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed Experiment.Test
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class sequential ansi serializable sealed nested public Repro
-         extends [System.Runtime]System.ValueType
-         implements class [System.Runtime]System.IEquatable`1<valuetype Experiment.Test/Repro>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<valuetype Experiment.Test/Repro>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.ValueType
+         implements class [mscorlib]System.IEquatable`1<valuetype Experiment.Test/Repro>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<valuetype Experiment.Test/Repro>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.StructAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
@@ -66,8 +66,8 @@
     .method public hidebysig specialname 
             instance int32  get_hash() cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -78,20 +78,19 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype Experiment.Test/Repro obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       46 (0x2e)
       .maxstack  5
       .locals init (valuetype Experiment.Test/Repro& V_0,
-               class [System.Runtime]System.Collections.IComparer V_1,
+               class [mscorlib]System.Collections.IComparer V_1,
                int32 V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IComparer V_4,
+               class [mscorlib]System.Collections.IComparer V_4,
                int32 V_5,
                int32 V_6)
       IL_0000:  ldarga.s   obj
       IL_0002:  stloc.0
-      IL_0003:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0003:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0008:  stloc.1
       IL_0009:  ldarg.0
       IL_000a:  ldfld      int32 Experiment.Test/Repro::hash@
@@ -118,8 +117,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -131,18 +129,17 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       51 (0x33)
       .maxstack  5
       .locals init (valuetype Experiment.Test/Repro V_0,
                valuetype Experiment.Test/Repro& V_1,
-               class [System.Runtime]System.Collections.IComparer V_2,
+               class [mscorlib]System.Collections.IComparer V_2,
                int32 V_3,
                int32 V_4,
-               class [System.Runtime]System.Collections.IComparer V_5,
+               class [mscorlib]System.Collections.IComparer V_5,
                int32 V_6,
                int32 V_7)
       IL_0000:  ldarg.1
@@ -175,16 +172,15 @@
     } // end of method Repro::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       31 (0x1f)
       .maxstack  7
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IEqualityComparer V_1,
+               class [mscorlib]System.Collections.IEqualityComparer V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3)
+               class [mscorlib]System.Collections.IEqualityComparer V_3)
       IL_0000:  ldc.i4.0
       IL_0001:  stloc.0
       IL_0002:  ldc.i4     0x9e3779b9
@@ -213,31 +209,29 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  call       instance int32 Experiment.Test/Repro::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  call       instance int32 Experiment.Test/Repro::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method Repro::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       53 (0x35)
       .maxstack  4
       .locals init (object V_0,
                valuetype Experiment.Test/Repro V_1,
                valuetype Experiment.Test/Repro& V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3,
+               class [mscorlib]System.Collections.IEqualityComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6)
+               class [mscorlib]System.Collections.IEqualityComparer V_6)
       IL_0000:  ldarg.1
       IL_0001:  stloc.0
       IL_0002:  ldloc.0
@@ -316,8 +310,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype Experiment.Test/Repro obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       18 (0x12)
       .maxstack  4
       .locals init (valuetype Experiment.Test/Repro& V_0)
@@ -334,8 +327,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,
@@ -384,7 +376,7 @@
 } // end of class Experiment.Test
 
 .class private abstract auto ansi sealed '<StartupCode$Structs02>.$Experiment'.Test
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .method public static void  main@() cil managed
   {
@@ -400,4 +392,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\Misc\Structs02_fs\Structs02.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\Misc\Structs02_fs\Structs02.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/StructsAsArrayElements01.fs.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/StructsAsArrayElements01.fs.il.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly StructsAsArrayElements01
 {
@@ -21,44 +21,44 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.StructsAsArrayElements01
 {
-  // Offset: 0x00000000 Length: 0x00000794
+  // Offset: 0x00000000 Length: 0x0000079E
   // WARNING: managed resource file FSharpSignatureData.StructsAsArrayElements01 created
 }
 .mresource public FSharpOptimizationData.StructsAsArrayElements01
 {
-  // Offset: 0x00000798 Length: 0x00000232
+  // Offset: 0x000007A8 Length: 0x0000022C
   // WARNING: managed resource file FSharpOptimizationData.StructsAsArrayElements01 created
 }
 .module StructsAsArrayElements01.exe
-// MVID: {628F4C90-460B-6F2F-A745-0383904C8F62}
+// MVID: {63E6EA31-4431-B514-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000002012B2F0000
+// Image base: 0x0000020299950000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed StructsAsArrayElements01
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class sequential ansi serializable sealed nested public T
-         extends [System.Runtime]System.ValueType
-         implements class [System.Runtime]System.IEquatable`1<valuetype StructsAsArrayElements01/T>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<valuetype StructsAsArrayElements01/T>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.ValueType
+         implements class [mscorlib]System.IEquatable`1<valuetype StructsAsArrayElements01/T>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<valuetype StructsAsArrayElements01/T>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.StructAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
@@ -66,20 +66,19 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype StructsAsArrayElements01/T obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       46 (0x2e)
       .maxstack  5
       .locals init (valuetype StructsAsArrayElements01/T& V_0,
-               class [System.Runtime]System.Collections.IComparer V_1,
+               class [mscorlib]System.Collections.IComparer V_1,
                int32 V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IComparer V_4,
+               class [mscorlib]System.Collections.IComparer V_4,
                int32 V_5,
                int32 V_6)
       IL_0000:  ldarga.s   obj
       IL_0002:  stloc.0
-      IL_0003:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0003:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0008:  stloc.1
       IL_0009:  ldarg.0
       IL_000a:  ldfld      int32 StructsAsArrayElements01/T::i
@@ -106,8 +105,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -119,18 +117,17 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       51 (0x33)
       .maxstack  5
       .locals init (valuetype StructsAsArrayElements01/T V_0,
                valuetype StructsAsArrayElements01/T& V_1,
-               class [System.Runtime]System.Collections.IComparer V_2,
+               class [mscorlib]System.Collections.IComparer V_2,
                int32 V_3,
                int32 V_4,
-               class [System.Runtime]System.Collections.IComparer V_5,
+               class [mscorlib]System.Collections.IComparer V_5,
                int32 V_6,
                int32 V_7)
       IL_0000:  ldarg.1
@@ -163,16 +160,15 @@
     } // end of method T::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       31 (0x1f)
       .maxstack  7
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IEqualityComparer V_1,
+               class [mscorlib]System.Collections.IEqualityComparer V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3)
+               class [mscorlib]System.Collections.IEqualityComparer V_3)
       IL_0000:  ldc.i4.0
       IL_0001:  stloc.0
       IL_0002:  ldc.i4     0x9e3779b9
@@ -201,31 +197,29 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  call       instance int32 StructsAsArrayElements01/T::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  call       instance int32 StructsAsArrayElements01/T::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method T::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       53 (0x35)
       .maxstack  4
       .locals init (object V_0,
                valuetype StructsAsArrayElements01/T V_1,
                valuetype StructsAsArrayElements01/T& V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3,
+               class [mscorlib]System.Collections.IEqualityComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6)
+               class [mscorlib]System.Collections.IEqualityComparer V_6)
       IL_0000:  ldarg.1
       IL_0001:  stloc.0
       IL_0002:  ldloc.0
@@ -272,8 +266,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype StructsAsArrayElements01/T obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       18 (0x12)
       .maxstack  4
       .locals init (valuetype StructsAsArrayElements01/T& V_0)
@@ -290,8 +283,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,
@@ -336,14 +328,14 @@
 } // end of class StructsAsArrayElements01
 
 .class private abstract auto ansi sealed '<StartupCode$StructsAsArrayElements01>'.$StructsAsArrayElements01
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .field static assembly valuetype StructsAsArrayElements01/T[] a@11
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly int32 init@
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public static void  main@() cil managed
   {
     .entrypoint
@@ -373,4 +365,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\Misc\StructsAsArrayElements01_fs\StructsAsArrayElements01.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\Misc\StructsAsArrayElements01_fs\StructsAsArrayElements01.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule.fs.il.debug.bsl
@@ -37,13 +37,13 @@
   // WARNING: managed resource file FSharpOptimizationData.ToplevelModule created
 }
 .module ToplevelModule.exe
-// MVID: {62F987D1-3E21-F1E3-A745-0383D187F962}
+// MVID: {63E6EA31-3E21-F1E3-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000001EAC2450000
+// Image base: 0x00000154AC310000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -152,7 +152,6 @@
             instance int32  CompareTo(class ABC/Expr obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       66 (0x42)
       .maxstack  5
       .locals init (class ABC/Expr V_0,
@@ -215,7 +214,6 @@
             instance int32  CompareTo(object obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -230,7 +228,6 @@
                                       class [mscorlib]System.Collections.IComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       81 (0x51)
       .maxstack  5
       .locals init (class ABC/Expr V_0,
@@ -299,7 +296,6 @@
             instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       43 (0x2b)
       .maxstack  7
       .locals init (int32 V_0,
@@ -348,7 +344,6 @@
             instance int32  GetHashCode() cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -362,7 +357,6 @@
                                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       61 (0x3d)
       .maxstack  4
       .locals init (class ABC/Expr V_0,
@@ -420,7 +414,6 @@
             instance bool  Equals(class ABC/Expr obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       37 (0x25)
       .maxstack  4
       .locals init (class ABC/Expr V_0,
@@ -459,7 +452,6 @@
             instance bool  Equals(object obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class ABC/Expr V_0)
@@ -567,7 +559,6 @@
             GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       41 (0x29)
       .maxstack  7
       .locals init (int32 V_0,
@@ -610,7 +601,6 @@
             GetHashCode() cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -624,7 +614,6 @@
                    class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       78 (0x4e)
       .maxstack  4
       .locals init (class [mscorlib]System.Exception V_0,
@@ -688,7 +677,6 @@
             Equals(class [mscorlib]System.Exception obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (object V_0)
@@ -733,7 +721,6 @@
             Equals(object obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class [mscorlib]System.Exception V_0)
@@ -900,7 +887,6 @@
               instance int32  CompareTo(class ABC/ABC/Expr obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       66 (0x42)
         .maxstack  5
         .locals init (class ABC/ABC/Expr V_0,
@@ -963,7 +949,6 @@
               instance int32  CompareTo(object obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       13 (0xd)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -978,7 +963,6 @@
                                         class [mscorlib]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       81 (0x51)
         .maxstack  5
         .locals init (class ABC/ABC/Expr V_0,
@@ -1047,7 +1031,6 @@
               instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       43 (0x2b)
         .maxstack  7
         .locals init (int32 V_0,
@@ -1096,7 +1079,6 @@
               instance int32  GetHashCode() cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -1110,7 +1092,6 @@
                                     class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       61 (0x3d)
         .maxstack  4
         .locals init (class ABC/ABC/Expr V_0,
@@ -1168,7 +1149,6 @@
               instance bool  Equals(class ABC/ABC/Expr obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       37 (0x25)
         .maxstack  4
         .locals init (class ABC/ABC/Expr V_0,
@@ -1207,7 +1187,6 @@
               instance bool  Equals(object obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       20 (0x14)
         .maxstack  4
         .locals init (class ABC/ABC/Expr V_0)
@@ -1315,7 +1294,6 @@
               GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       41 (0x29)
         .maxstack  7
         .locals init (int32 V_0,
@@ -1358,7 +1336,6 @@
               GetHashCode() cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -1372,7 +1349,6 @@
                      class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       78 (0x4e)
         .maxstack  4
         .locals init (class [mscorlib]System.Exception V_0,
@@ -1436,7 +1412,6 @@
               Equals(class [mscorlib]System.Exception obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       56 (0x38)
         .maxstack  4
         .locals init (object V_0)
@@ -1481,7 +1456,6 @@
               Equals(object obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       20 (0x14)
         .maxstack  4
         .locals init (class [mscorlib]System.Exception V_0)

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule60.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule60.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly ToplevelModule60
 {
@@ -21,52 +21,52 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.ToplevelModule60
 {
-  // Offset: 0x00000000 Length: 0x00001176
+  // Offset: 0x00000000 Length: 0x00001180
   // WARNING: managed resource file FSharpSignatureData.ToplevelModule60 created
 }
 .mresource public FSharpOptimizationData.ToplevelModule60
 {
-  // Offset: 0x00001180 Length: 0x00000405
+  // Offset: 0x00001188 Length: 0x000003FF
   // WARNING: managed resource file FSharpOptimizationData.ToplevelModule60 created
 }
 .module ToplevelModule60.exe
-// MVID: {628F4C90-79E1-223C-A745-0383904C8F62}
+// MVID: {63E6EA31-CF43-E5D9-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000021A85AA0000
+// Image base: 0x000002381F1F0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed ABC
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class auto autochar serializable sealed nested public beforefieldinit Expr
-         extends [System.Runtime]System.Object
-         implements class [System.Runtime]System.IEquatable`1<class ABC/Expr>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<class ABC/Expr>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IEquatable`1<class ABC/Expr>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<class ABC/Expr>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                         61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                   61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
     .field assembly initonly int32 item
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .method public static class ABC/Expr 
             NewNum(int32 item) cil managed
     {
@@ -82,12 +82,12 @@
     .method assembly specialname rtspecialname 
             instance void  .ctor(int32 item) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 ABC/Expr::item
@@ -97,8 +97,8 @@
     .method public hidebysig instance int32 
             get_Item() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -109,8 +109,8 @@
     .method public hidebysig instance int32 
             get_Tag() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       4 (0x4)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -122,8 +122,8 @@
     .method assembly hidebysig specialname 
             instance object  __DebugDisplay() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
@@ -137,7 +137,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -151,16 +151,15 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class ABC/Expr obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       66 (0x42)
       .maxstack  5
       .locals init (class ABC/Expr V_0,
                class ABC/Expr V_1,
-               class [System.Runtime]System.Collections.IComparer V_2,
+               class [mscorlib]System.Collections.IComparer V_2,
                int32 V_3,
                int32 V_4,
-               class [System.Runtime]System.Collections.IComparer V_5,
+               class [mscorlib]System.Collections.IComparer V_5,
                int32 V_6,
                int32 V_7)
       IL_0000:  ldarg.0
@@ -175,7 +174,7 @@
       IL_0009:  stloc.0
       IL_000a:  ldarg.1
       IL_000b:  stloc.1
-      IL_000c:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_000c:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0011:  stloc.2
       IL_0012:  ldloc.0
       IL_0013:  ldfld      int32 ABC/Expr::item
@@ -214,8 +213,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -227,19 +225,18 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       81 (0x51)
       .maxstack  5
       .locals init (class ABC/Expr V_0,
                class ABC/Expr V_1,
                class ABC/Expr V_2,
-               class [System.Runtime]System.Collections.IComparer V_3,
+               class [mscorlib]System.Collections.IComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IComparer V_6,
+               class [mscorlib]System.Collections.IComparer V_6,
                int32 V_7,
                int32 V_8)
       IL_0000:  ldarg.1
@@ -296,17 +293,16 @@
     } // end of method Expr::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       43 (0x2b)
       .maxstack  7
       .locals init (int32 V_0,
                class ABC/Expr V_1,
-               class [System.Runtime]System.Collections.IEqualityComparer V_2,
+               class [mscorlib]System.Collections.IEqualityComparer V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4)
+               class [mscorlib]System.Collections.IEqualityComparer V_4)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0029
 
@@ -347,32 +343,30 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 ABC/Expr::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 ABC/Expr::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method Expr::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       61 (0x3d)
       .maxstack  4
       .locals init (class ABC/Expr V_0,
                class ABC/Expr V_1,
                class ABC/Expr V_2,
                class ABC/Expr V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
                int32 V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IEqualityComparer V_7)
+               class [mscorlib]System.Collections.IEqualityComparer V_7)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0035
 
@@ -419,8 +413,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class ABC/Expr obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       37 (0x25)
       .maxstack  4
       .locals init (class ABC/Expr V_0,
@@ -458,8 +451,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class ABC/Expr V_0)
@@ -480,9 +472,9 @@
 
     .property instance int32 Tag()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance int32 ABC/Expr::get_Tag()
     } // end of property Expr::Tag
     .property instance int32 Item()
@@ -490,15 +482,15 @@
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32,
                                                                                                   int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .get instance int32 ABC/Expr::get_Item()
     } // end of property Expr::Item
   } // end of class Expr
 
   .class auto ansi serializable nested public beforefieldinit MyExn
-         extends [System.Runtime]System.Exception
-         implements [System.Runtime]System.Collections.IStructuralEquatable
+         extends [mscorlib]System.Exception
+         implements [mscorlib]System.Collections.IStructuralEquatable
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 05 00 00 00 00 00 ) 
     .field assembly int32 Data0@
@@ -508,7 +500,7 @@
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 ABC/MyExn::Data0@
@@ -521,21 +513,21 @@
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
       IL_0006:  ret
     } // end of method MyExn::.ctor
 
     .method family specialname rtspecialname 
-            instance void  .ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo info,
-                                 valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext context) cil managed
+            instance void  .ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo info,
+                                 valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
     {
       // Code size       9 (0x9)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
-      IL_0003:  call       instance void [System.Runtime]System.Exception::.ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo,
-                                                                                 valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext)
+      IL_0003:  call       instance void [mscorlib]System.Exception::.ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo,
+                                                                           valuetype [mscorlib]System.Runtime.Serialization.StreamingContext)
       IL_0008:  ret
     } // end of method MyExn::.ctor
 
@@ -550,16 +542,15 @@
     } // end of method MyExn::get_Data0
 
     .method public hidebysig virtual instance int32 
-            GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       41 (0x29)
       .maxstack  7
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IEqualityComparer V_1,
+               class [mscorlib]System.Collections.IEqualityComparer V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3)
+               class [mscorlib]System.Collections.IEqualityComparer V_3)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0027
 
@@ -595,36 +586,34 @@
     .method public hidebysig virtual instance int32 
             GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 ABC/MyExn::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 ABC/MyExn::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method MyExn::GetHashCode
 
     .method public hidebysig virtual instance bool 
             Equals(object obj,
-                   class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       78 (0x4e)
       .maxstack  4
-      .locals init (class [System.Runtime]System.Exception V_0,
-               class [System.Runtime]System.Exception V_1,
+      .locals init (class [mscorlib]System.Exception V_0,
+               class [mscorlib]System.Exception V_1,
                object V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3,
+               class [mscorlib]System.Collections.IEqualityComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6)
+               class [mscorlib]System.Collections.IEqualityComparer V_6)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0046
 
       IL_0003:  ldarg.1
-      IL_0004:  isinst     [System.Runtime]System.Exception
+      IL_0004:  isinst     [mscorlib]System.Exception
       IL_0009:  stloc.0
       IL_000a:  ldloc.0
       IL_000b:  brfalse.s  IL_0044
@@ -671,10 +660,9 @@
     } // end of method MyExn::Equals
 
     .method public hidebysig instance bool 
-            Equals(class [System.Runtime]System.Exception obj) cil managed
+            Equals(class [mscorlib]System.Exception obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (object V_0)
@@ -718,20 +706,19 @@
     .method public hidebysig virtual instance bool 
             Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
-      .locals init (class [System.Runtime]System.Exception V_0)
+      .locals init (class [mscorlib]System.Exception V_0)
       IL_0000:  ldarg.1
-      IL_0001:  isinst     [System.Runtime]System.Exception
+      IL_0001:  isinst     [mscorlib]System.Exception
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
       IL_0008:  brfalse.s  IL_0012
 
       IL_000a:  ldarg.0
       IL_000b:  ldloc.0
-      IL_000c:  callvirt   instance bool ABC/MyExn::Equals(class [System.Runtime]System.Exception)
+      IL_000c:  callvirt   instance bool ABC/MyExn::Equals(class [mscorlib]System.Exception)
       IL_0011:  ret
 
       IL_0012:  ldc.i4.0
@@ -747,7 +734,7 @@
   } // end of class MyExn
 
   .class auto ansi serializable nested public A
-         extends [System.Runtime]System.Object
+         extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
     .field assembly string x
@@ -757,7 +744,7 @@
       // Code size       16 (0x10)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  callvirt   instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  callvirt   instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  pop
       IL_0008:  ldarg.0
@@ -783,24 +770,24 @@
   } // end of class A
 
   .class abstract auto ansi sealed nested public ABC
-         extends [System.Runtime]System.Object
+         extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
     .class auto autochar serializable sealed nested public beforefieldinit Expr
-           extends [System.Runtime]System.Object
-           implements class [System.Runtime]System.IEquatable`1<class ABC/ABC/Expr>,
-                      [System.Runtime]System.Collections.IStructuralEquatable,
-                      class [System.Runtime]System.IComparable`1<class ABC/ABC/Expr>,
-                      [System.Runtime]System.IComparable,
-                      [System.Runtime]System.Collections.IStructuralComparable
+           extends [mscorlib]System.Object
+           implements class [mscorlib]System.IEquatable`1<class ABC/ABC/Expr>,
+                      [mscorlib]System.Collections.IStructuralEquatable,
+                      class [mscorlib]System.IComparable`1<class ABC/ABC/Expr>,
+                      [mscorlib]System.IComparable,
+                      [mscorlib]System.Collections.IStructuralComparable
     {
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                           61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                     61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
       .field assembly initonly int32 item
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method public static class ABC/ABC/Expr 
               NewNum(int32 item) cil managed
       {
@@ -816,12 +803,12 @@
       .method assembly specialname rtspecialname 
               instance void  .ctor(int32 item) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      int32 ABC/ABC/Expr::item
@@ -831,8 +818,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -843,8 +830,8 @@
       .method public hidebysig instance int32 
               get_Tag() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       4 (0x4)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -856,8 +843,8 @@
       .method assembly hidebysig specialname 
               instance object  __DebugDisplay() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       22 (0x16)
         .maxstack  8
         IL_0000:  ldstr      "%+0.8A"
@@ -871,7 +858,7 @@
       .method public strict virtual instance string 
               ToString() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       22 (0x16)
         .maxstack  8
         IL_0000:  ldstr      "%+A"
@@ -885,16 +872,15 @@
       .method public hidebysig virtual final 
               instance int32  CompareTo(class ABC/ABC/Expr obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       66 (0x42)
         .maxstack  5
         .locals init (class ABC/ABC/Expr V_0,
                  class ABC/ABC/Expr V_1,
-                 class [System.Runtime]System.Collections.IComparer V_2,
+                 class [mscorlib]System.Collections.IComparer V_2,
                  int32 V_3,
                  int32 V_4,
-                 class [System.Runtime]System.Collections.IComparer V_5,
+                 class [mscorlib]System.Collections.IComparer V_5,
                  int32 V_6,
                  int32 V_7)
         IL_0000:  ldarg.0
@@ -909,7 +895,7 @@
         IL_0009:  stloc.0
         IL_000a:  ldarg.1
         IL_000b:  stloc.1
-        IL_000c:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+        IL_000c:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
         IL_0011:  stloc.2
         IL_0012:  ldloc.0
         IL_0013:  ldfld      int32 ABC/ABC/Expr::item
@@ -948,8 +934,7 @@
       .method public hidebysig virtual final 
               instance int32  CompareTo(object obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       13 (0xd)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -961,19 +946,18 @@
 
       .method public hidebysig virtual final 
               instance int32  CompareTo(object obj,
-                                        class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                        class [mscorlib]System.Collections.IComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       81 (0x51)
         .maxstack  5
         .locals init (class ABC/ABC/Expr V_0,
                  class ABC/ABC/Expr V_1,
                  class ABC/ABC/Expr V_2,
-                 class [System.Runtime]System.Collections.IComparer V_3,
+                 class [mscorlib]System.Collections.IComparer V_3,
                  int32 V_4,
                  int32 V_5,
-                 class [System.Runtime]System.Collections.IComparer V_6,
+                 class [mscorlib]System.Collections.IComparer V_6,
                  int32 V_7,
                  int32 V_8)
         IL_0000:  ldarg.1
@@ -1030,17 +1014,16 @@
       } // end of method Expr::CompareTo
 
       .method public hidebysig virtual final 
-              instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+              instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       43 (0x2b)
         .maxstack  7
         .locals init (int32 V_0,
                  class ABC/ABC/Expr V_1,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_2,
+                 class [mscorlib]System.Collections.IEqualityComparer V_2,
                  int32 V_3,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_4)
+                 class [mscorlib]System.Collections.IEqualityComparer V_4)
         IL_0000:  ldarg.0
         IL_0001:  brfalse.s  IL_0029
 
@@ -1081,32 +1064,30 @@
       .method public hidebysig virtual final 
               instance int32  GetHashCode() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-        IL_0006:  callvirt   instance int32 ABC/ABC/Expr::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+        IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+        IL_0006:  callvirt   instance int32 ABC/ABC/Expr::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
         IL_000b:  ret
       } // end of method Expr::GetHashCode
 
       .method public hidebysig virtual final 
               instance bool  Equals(object obj,
-                                    class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                    class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       61 (0x3d)
         .maxstack  4
         .locals init (class ABC/ABC/Expr V_0,
                  class ABC/ABC/Expr V_1,
                  class ABC/ABC/Expr V_2,
                  class ABC/ABC/Expr V_3,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_4,
+                 class [mscorlib]System.Collections.IEqualityComparer V_4,
                  int32 V_5,
                  int32 V_6,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_7)
+                 class [mscorlib]System.Collections.IEqualityComparer V_7)
         IL_0000:  ldarg.0
         IL_0001:  brfalse.s  IL_0035
 
@@ -1153,8 +1134,7 @@
       .method public hidebysig virtual final 
               instance bool  Equals(class ABC/ABC/Expr obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       37 (0x25)
         .maxstack  4
         .locals init (class ABC/ABC/Expr V_0,
@@ -1192,8 +1172,7 @@
       .method public hidebysig virtual final 
               instance bool  Equals(object obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       20 (0x14)
         .maxstack  4
         .locals init (class ABC/ABC/Expr V_0)
@@ -1214,9 +1193,9 @@
 
       .property instance int32 Tag()
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
         .get instance int32 ABC/ABC/Expr::get_Tag()
       } // end of property Expr::Tag
       .property instance int32 Item()
@@ -1224,15 +1203,15 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 ABC/ABC/Expr::get_Item()
       } // end of property Expr::Item
     } // end of class Expr
 
     .class auto ansi serializable nested public beforefieldinit MyExn
-           extends [System.Runtime]System.Exception
-           implements [System.Runtime]System.Collections.IStructuralEquatable
+           extends [mscorlib]System.Exception
+           implements [mscorlib]System.Collections.IStructuralEquatable
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 05 00 00 00 00 00 ) 
       .field assembly int32 Data0@
@@ -1242,7 +1221,7 @@
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      int32 ABC/ABC/MyExn::Data0@
@@ -1255,21 +1234,21 @@
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
         IL_0006:  ret
       } // end of method MyExn::.ctor
 
       .method family specialname rtspecialname 
-              instance void  .ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo info,
-                                   valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext context) cil managed
+              instance void  .ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo info,
+                                   valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
       {
         // Code size       9 (0x9)
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldarg.1
         IL_0002:  ldarg.2
-        IL_0003:  call       instance void [System.Runtime]System.Exception::.ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo,
-                                                                                   valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext)
+        IL_0003:  call       instance void [mscorlib]System.Exception::.ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo,
+                                                                             valuetype [mscorlib]System.Runtime.Serialization.StreamingContext)
         IL_0008:  ret
       } // end of method MyExn::.ctor
 
@@ -1284,16 +1263,15 @@
       } // end of method MyExn::get_Data0
 
       .method public hidebysig virtual instance int32 
-              GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+              GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       41 (0x29)
         .maxstack  7
         .locals init (int32 V_0,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_1,
+                 class [mscorlib]System.Collections.IEqualityComparer V_1,
                  int32 V_2,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_3)
+                 class [mscorlib]System.Collections.IEqualityComparer V_3)
         IL_0000:  ldarg.0
         IL_0001:  brfalse.s  IL_0027
 
@@ -1329,36 +1307,34 @@
       .method public hidebysig virtual instance int32 
               GetHashCode() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-        IL_0006:  callvirt   instance int32 ABC/ABC/MyExn::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+        IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+        IL_0006:  callvirt   instance int32 ABC/ABC/MyExn::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
         IL_000b:  ret
       } // end of method MyExn::GetHashCode
 
       .method public hidebysig virtual instance bool 
               Equals(object obj,
-                     class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                     class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       78 (0x4e)
         .maxstack  4
-        .locals init (class [System.Runtime]System.Exception V_0,
-                 class [System.Runtime]System.Exception V_1,
+        .locals init (class [mscorlib]System.Exception V_0,
+                 class [mscorlib]System.Exception V_1,
                  object V_2,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_3,
+                 class [mscorlib]System.Collections.IEqualityComparer V_3,
                  int32 V_4,
                  int32 V_5,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_6)
+                 class [mscorlib]System.Collections.IEqualityComparer V_6)
         IL_0000:  ldarg.0
         IL_0001:  brfalse.s  IL_0046
 
         IL_0003:  ldarg.1
-        IL_0004:  isinst     [System.Runtime]System.Exception
+        IL_0004:  isinst     [mscorlib]System.Exception
         IL_0009:  stloc.0
         IL_000a:  ldloc.0
         IL_000b:  brfalse.s  IL_0044
@@ -1405,10 +1381,9 @@
       } // end of method MyExn::Equals
 
       .method public hidebysig instance bool 
-              Equals(class [System.Runtime]System.Exception obj) cil managed
+              Equals(class [mscorlib]System.Exception obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       56 (0x38)
         .maxstack  4
         .locals init (object V_0)
@@ -1452,20 +1427,19 @@
       .method public hidebysig virtual instance bool 
               Equals(object obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       20 (0x14)
         .maxstack  4
-        .locals init (class [System.Runtime]System.Exception V_0)
+        .locals init (class [mscorlib]System.Exception V_0)
         IL_0000:  ldarg.1
-        IL_0001:  isinst     [System.Runtime]System.Exception
+        IL_0001:  isinst     [mscorlib]System.Exception
         IL_0006:  stloc.0
         IL_0007:  ldloc.0
         IL_0008:  brfalse.s  IL_0012
 
         IL_000a:  ldarg.0
         IL_000b:  ldloc.0
-        IL_000c:  callvirt   instance bool ABC/ABC/MyExn::Equals(class [System.Runtime]System.Exception)
+        IL_000c:  callvirt   instance bool ABC/ABC/MyExn::Equals(class [mscorlib]System.Exception)
         IL_0011:  ret
 
         IL_0012:  ldc.i4.0
@@ -1481,7 +1455,7 @@
     } // end of class MyExn
 
     .class auto ansi serializable nested public A
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
       .field assembly string x
@@ -1491,7 +1465,7 @@
         // Code size       16 (0x10)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  callvirt   instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  callvirt   instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  pop
         IL_0008:  ldarg.0
@@ -1531,8 +1505,8 @@
     .method public specialname static string 
             get_greeting() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       6 (0x6)
       .maxstack  8
       IL_0000:  ldstr      "hello"
@@ -1560,8 +1534,8 @@
   .method public specialname static string 
           get_greeting() cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       6 (0x6)
     .maxstack  8
     IL_0000:  ldstr      "hello"
@@ -1575,12 +1549,12 @@
 } // end of class ABC
 
 .class private abstract auto ansi sealed '<StartupCode$ToplevelModule60>'.$ABC
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .field static assembly int32 init@
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public static void  main@() cil managed
   {
     .entrypoint
@@ -1601,4 +1575,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\SerializableAttribute\ToplevelModule_LangVersion60_fs\ToplevelModule60.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\SerializableAttribute\ToplevelModule_LangVersion60_fs\ToplevelModule60.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace.fs.il.debug.bsl
@@ -37,13 +37,13 @@
   // WARNING: managed resource file FSharpOptimizationData.ToplevelNamespace created
 }
 .module ToplevelNamespace.exe
-// MVID: {62F98081-3EC6-FDC1-A745-03838180F962}
+// MVID: {63E6EA31-3EC6-FDC1-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000001C2AAA90000
+// Image base: 0x000002285CC80000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -147,7 +147,6 @@
           instance int32  CompareTo(class XYZ.Expr obj) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       66 (0x42)
     .maxstack  5
     .locals init (class XYZ.Expr V_0,
@@ -210,7 +209,6 @@
           instance int32  CompareTo(object obj) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       13 (0xd)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -225,7 +223,6 @@
                                     class [mscorlib]System.Collections.IComparer comp) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       81 (0x51)
     .maxstack  5
     .locals init (class XYZ.Expr V_0,
@@ -294,7 +291,6 @@
           instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       43 (0x2b)
     .maxstack  7
     .locals init (int32 V_0,
@@ -343,7 +339,6 @@
           instance int32  GetHashCode() cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       12 (0xc)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -357,7 +352,6 @@
                                 class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       61 (0x3d)
     .maxstack  4
     .locals init (class XYZ.Expr V_0,
@@ -415,7 +409,6 @@
           instance bool  Equals(class XYZ.Expr obj) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       37 (0x25)
     .maxstack  4
     .locals init (class XYZ.Expr V_0,
@@ -454,7 +447,6 @@
           instance bool  Equals(object obj) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       20 (0x14)
     .maxstack  4
     .locals init (class XYZ.Expr V_0)
@@ -562,7 +554,6 @@
           GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       41 (0x29)
     .maxstack  7
     .locals init (int32 V_0,
@@ -605,7 +596,6 @@
           GetHashCode() cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       12 (0xc)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -619,7 +609,6 @@
                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       78 (0x4e)
     .maxstack  4
     .locals init (class [mscorlib]System.Exception V_0,
@@ -683,7 +672,6 @@
           Equals(class [mscorlib]System.Exception obj) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       56 (0x38)
     .maxstack  4
     .locals init (object V_0)
@@ -728,7 +716,6 @@
           Equals(object obj) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       20 (0x14)
     .maxstack  4
     .locals init (class [mscorlib]System.Exception V_0)
@@ -895,7 +882,6 @@
             instance int32  CompareTo(class XYZ.ABC/Expr obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       66 (0x42)
       .maxstack  5
       .locals init (class XYZ.ABC/Expr V_0,
@@ -958,7 +944,6 @@
             instance int32  CompareTo(object obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -973,7 +958,6 @@
                                       class [mscorlib]System.Collections.IComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       81 (0x51)
       .maxstack  5
       .locals init (class XYZ.ABC/Expr V_0,
@@ -1042,7 +1026,6 @@
             instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       43 (0x2b)
       .maxstack  7
       .locals init (int32 V_0,
@@ -1091,7 +1074,6 @@
             instance int32  GetHashCode() cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -1105,7 +1087,6 @@
                                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       61 (0x3d)
       .maxstack  4
       .locals init (class XYZ.ABC/Expr V_0,
@@ -1163,7 +1144,6 @@
             instance bool  Equals(class XYZ.ABC/Expr obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       37 (0x25)
       .maxstack  4
       .locals init (class XYZ.ABC/Expr V_0,
@@ -1202,7 +1182,6 @@
             instance bool  Equals(object obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class XYZ.ABC/Expr V_0)
@@ -1310,7 +1289,6 @@
             GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       41 (0x29)
       .maxstack  7
       .locals init (int32 V_0,
@@ -1353,7 +1331,6 @@
             GetHashCode() cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -1367,7 +1344,6 @@
                    class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       78 (0x4e)
       .maxstack  4
       .locals init (class [mscorlib]System.Exception V_0,
@@ -1431,7 +1407,6 @@
             Equals(class [mscorlib]System.Exception obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (object V_0)
@@ -1476,7 +1451,6 @@
             Equals(object obj) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class [mscorlib]System.Exception V_0)
@@ -1643,7 +1617,6 @@
               instance int32  CompareTo(class XYZ.ABC/ABC/Expr obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       66 (0x42)
         .maxstack  5
         .locals init (class XYZ.ABC/ABC/Expr V_0,
@@ -1706,7 +1679,6 @@
               instance int32  CompareTo(object obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       13 (0xd)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -1721,7 +1693,6 @@
                                         class [mscorlib]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       81 (0x51)
         .maxstack  5
         .locals init (class XYZ.ABC/ABC/Expr V_0,
@@ -1790,7 +1761,6 @@
               instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       43 (0x2b)
         .maxstack  7
         .locals init (int32 V_0,
@@ -1839,7 +1809,6 @@
               instance int32  GetHashCode() cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -1853,7 +1822,6 @@
                                     class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       61 (0x3d)
         .maxstack  4
         .locals init (class XYZ.ABC/ABC/Expr V_0,
@@ -1911,7 +1879,6 @@
               instance bool  Equals(class XYZ.ABC/ABC/Expr obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       37 (0x25)
         .maxstack  4
         .locals init (class XYZ.ABC/ABC/Expr V_0,
@@ -1950,7 +1917,6 @@
               instance bool  Equals(object obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       20 (0x14)
         .maxstack  4
         .locals init (class XYZ.ABC/ABC/Expr V_0)
@@ -2058,7 +2024,6 @@
               GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       41 (0x29)
         .maxstack  7
         .locals init (int32 V_0,
@@ -2101,7 +2066,6 @@
               GetHashCode() cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -2115,7 +2079,6 @@
                      class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       78 (0x4e)
         .maxstack  4
         .locals init (class [mscorlib]System.Exception V_0,
@@ -2179,7 +2142,6 @@
               Equals(class [mscorlib]System.Exception obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       56 (0x38)
         .maxstack  4
         .locals init (object V_0)
@@ -2224,7 +2186,6 @@
               Equals(object obj) cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       20 (0x14)
         .maxstack  4
         .locals init (class [mscorlib]System.Exception V_0)

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace60.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace60.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly ToplevelNamespace60
 {
@@ -21,48 +21,48 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.ToplevelNamespace60
 {
-  // Offset: 0x00000000 Length: 0x00001884
+  // Offset: 0x00000000 Length: 0x0000188E
   // WARNING: managed resource file FSharpSignatureData.ToplevelNamespace60 created
 }
 .mresource public FSharpOptimizationData.ToplevelNamespace60
 {
-  // Offset: 0x00001888 Length: 0x00000564
+  // Offset: 0x00001898 Length: 0x0000055E
   // WARNING: managed resource file FSharpOptimizationData.ToplevelNamespace60 created
 }
 .module ToplevelNamespace60.exe
-// MVID: {628F4C90-D42A-0CFD-A745-0383904C8F62}
+// MVID: {63E6EA31-711C-7A79-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00000172650D0000
+// Image base: 0x0000029372210000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public auto autochar serializable sealed beforefieldinit XYZ.Expr
-       extends [System.Runtime]System.Object
-       implements class [System.Runtime]System.IEquatable`1<class XYZ.Expr>,
-                  [System.Runtime]System.Collections.IStructuralEquatable,
-                  class [System.Runtime]System.IComparable`1<class XYZ.Expr>,
-                  [System.Runtime]System.IComparable,
-                  [System.Runtime]System.Collections.IStructuralComparable
+       extends [mscorlib]System.Object
+       implements class [mscorlib]System.IEquatable`1<class XYZ.Expr>,
+                  [mscorlib]System.Collections.IStructuralEquatable,
+                  class [mscorlib]System.IComparable`1<class XYZ.Expr>,
+                  [mscorlib]System.IComparable,
+                  [mscorlib]System.Collections.IStructuralComparable
 {
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                       61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                 61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
   .field assembly initonly int32 item
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public static class XYZ.Expr  NewNum(int32 item) cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
@@ -77,12 +77,12 @@
   .method assembly specialname rtspecialname 
           instance void  .ctor(int32 item) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       14 (0xe)
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ldarg.0
     IL_0007:  ldarg.1
     IL_0008:  stfld      int32 XYZ.Expr::item
@@ -92,8 +92,8 @@
   .method public hidebysig instance int32 
           get_Item() cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -104,8 +104,8 @@
   .method public hidebysig instance int32 
           get_Tag() cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       4 (0x4)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -117,8 +117,8 @@
   .method assembly hidebysig specialname 
           instance object  __DebugDisplay() cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       22 (0x16)
     .maxstack  8
     IL_0000:  ldstr      "%+0.8A"
@@ -132,7 +132,7 @@
   .method public strict virtual instance string 
           ToString() cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       22 (0x16)
     .maxstack  8
     IL_0000:  ldstr      "%+A"
@@ -146,16 +146,15 @@
   .method public hidebysig virtual final 
           instance int32  CompareTo(class XYZ.Expr obj) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       66 (0x42)
     .maxstack  5
     .locals init (class XYZ.Expr V_0,
              class XYZ.Expr V_1,
-             class [System.Runtime]System.Collections.IComparer V_2,
+             class [mscorlib]System.Collections.IComparer V_2,
              int32 V_3,
              int32 V_4,
-             class [System.Runtime]System.Collections.IComparer V_5,
+             class [mscorlib]System.Collections.IComparer V_5,
              int32 V_6,
              int32 V_7)
     IL_0000:  ldarg.0
@@ -170,7 +169,7 @@
     IL_0009:  stloc.0
     IL_000a:  ldarg.1
     IL_000b:  stloc.1
-    IL_000c:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+    IL_000c:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_0011:  stloc.2
     IL_0012:  ldloc.0
     IL_0013:  ldfld      int32 XYZ.Expr::item
@@ -209,8 +208,7 @@
   .method public hidebysig virtual final 
           instance int32  CompareTo(object obj) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       13 (0xd)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -222,19 +220,18 @@
 
   .method public hidebysig virtual final 
           instance int32  CompareTo(object obj,
-                                    class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                    class [mscorlib]System.Collections.IComparer comp) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       81 (0x51)
     .maxstack  5
     .locals init (class XYZ.Expr V_0,
              class XYZ.Expr V_1,
              class XYZ.Expr V_2,
-             class [System.Runtime]System.Collections.IComparer V_3,
+             class [mscorlib]System.Collections.IComparer V_3,
              int32 V_4,
              int32 V_5,
-             class [System.Runtime]System.Collections.IComparer V_6,
+             class [mscorlib]System.Collections.IComparer V_6,
              int32 V_7,
              int32 V_8)
     IL_0000:  ldarg.1
@@ -291,17 +288,16 @@
   } // end of method Expr::CompareTo
 
   .method public hidebysig virtual final 
-          instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+          instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       43 (0x2b)
     .maxstack  7
     .locals init (int32 V_0,
              class XYZ.Expr V_1,
-             class [System.Runtime]System.Collections.IEqualityComparer V_2,
+             class [mscorlib]System.Collections.IEqualityComparer V_2,
              int32 V_3,
-             class [System.Runtime]System.Collections.IEqualityComparer V_4)
+             class [mscorlib]System.Collections.IEqualityComparer V_4)
     IL_0000:  ldarg.0
     IL_0001:  brfalse.s  IL_0029
 
@@ -342,32 +338,30 @@
   .method public hidebysig virtual final 
           instance int32  GetHashCode() cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       12 (0xc)
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-    IL_0006:  callvirt   instance int32 XYZ.Expr::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+    IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+    IL_0006:  callvirt   instance int32 XYZ.Expr::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
     IL_000b:  ret
   } // end of method Expr::GetHashCode
 
   .method public hidebysig virtual final 
           instance bool  Equals(object obj,
-                                class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       61 (0x3d)
     .maxstack  4
     .locals init (class XYZ.Expr V_0,
              class XYZ.Expr V_1,
              class XYZ.Expr V_2,
              class XYZ.Expr V_3,
-             class [System.Runtime]System.Collections.IEqualityComparer V_4,
+             class [mscorlib]System.Collections.IEqualityComparer V_4,
              int32 V_5,
              int32 V_6,
-             class [System.Runtime]System.Collections.IEqualityComparer V_7)
+             class [mscorlib]System.Collections.IEqualityComparer V_7)
     IL_0000:  ldarg.0
     IL_0001:  brfalse.s  IL_0035
 
@@ -414,8 +408,7 @@
   .method public hidebysig virtual final 
           instance bool  Equals(class XYZ.Expr obj) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       37 (0x25)
     .maxstack  4
     .locals init (class XYZ.Expr V_0,
@@ -453,8 +446,7 @@
   .method public hidebysig virtual final 
           instance bool  Equals(object obj) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       20 (0x14)
     .maxstack  4
     .locals init (class XYZ.Expr V_0)
@@ -475,9 +467,9 @@
 
   .property instance int32 Tag()
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .get instance int32 XYZ.Expr::get_Tag()
   } // end of property Expr::Tag
   .property instance int32 Item()
@@ -485,15 +477,15 @@
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                 int32,
                                                                                                 int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .get instance int32 XYZ.Expr::get_Item()
   } // end of property Expr::Item
 } // end of class XYZ.Expr
 
 .class public auto ansi serializable beforefieldinit XYZ.MyExn
-       extends [System.Runtime]System.Exception
-       implements [System.Runtime]System.Collections.IStructuralEquatable
+       extends [mscorlib]System.Exception
+       implements [mscorlib]System.Collections.IStructuralEquatable
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 05 00 00 00 00 00 ) 
   .field assembly int32 Data0@
@@ -503,7 +495,7 @@
     // Code size       14 (0xe)
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+    IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
     IL_0006:  ldarg.0
     IL_0007:  ldarg.1
     IL_0008:  stfld      int32 XYZ.MyExn::Data0@
@@ -516,21 +508,21 @@
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+    IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
     IL_0006:  ret
   } // end of method MyExn::.ctor
 
   .method family specialname rtspecialname 
-          instance void  .ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo info,
-                               valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext context) cil managed
+          instance void  .ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo info,
+                               valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
   {
     // Code size       9 (0x9)
     .maxstack  8
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
     IL_0002:  ldarg.2
-    IL_0003:  call       instance void [System.Runtime]System.Exception::.ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo,
-                                                                               valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext)
+    IL_0003:  call       instance void [mscorlib]System.Exception::.ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo,
+                                                                         valuetype [mscorlib]System.Runtime.Serialization.StreamingContext)
     IL_0008:  ret
   } // end of method MyExn::.ctor
 
@@ -545,16 +537,15 @@
   } // end of method MyExn::get_Data0
 
   .method public hidebysig virtual instance int32 
-          GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+          GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       41 (0x29)
     .maxstack  7
     .locals init (int32 V_0,
-             class [System.Runtime]System.Collections.IEqualityComparer V_1,
+             class [mscorlib]System.Collections.IEqualityComparer V_1,
              int32 V_2,
-             class [System.Runtime]System.Collections.IEqualityComparer V_3)
+             class [mscorlib]System.Collections.IEqualityComparer V_3)
     IL_0000:  ldarg.0
     IL_0001:  brfalse.s  IL_0027
 
@@ -590,36 +581,34 @@
   .method public hidebysig virtual instance int32 
           GetHashCode() cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       12 (0xc)
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-    IL_0006:  callvirt   instance int32 XYZ.MyExn::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+    IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+    IL_0006:  callvirt   instance int32 XYZ.MyExn::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
     IL_000b:  ret
   } // end of method MyExn::GetHashCode
 
   .method public hidebysig virtual instance bool 
           Equals(object obj,
-                 class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                 class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       78 (0x4e)
     .maxstack  4
-    .locals init (class [System.Runtime]System.Exception V_0,
-             class [System.Runtime]System.Exception V_1,
+    .locals init (class [mscorlib]System.Exception V_0,
+             class [mscorlib]System.Exception V_1,
              object V_2,
-             class [System.Runtime]System.Collections.IEqualityComparer V_3,
+             class [mscorlib]System.Collections.IEqualityComparer V_3,
              int32 V_4,
              int32 V_5,
-             class [System.Runtime]System.Collections.IEqualityComparer V_6)
+             class [mscorlib]System.Collections.IEqualityComparer V_6)
     IL_0000:  ldarg.0
     IL_0001:  brfalse.s  IL_0046
 
     IL_0003:  ldarg.1
-    IL_0004:  isinst     [System.Runtime]System.Exception
+    IL_0004:  isinst     [mscorlib]System.Exception
     IL_0009:  stloc.0
     IL_000a:  ldloc.0
     IL_000b:  brfalse.s  IL_0044
@@ -666,10 +655,9 @@
   } // end of method MyExn::Equals
 
   .method public hidebysig instance bool 
-          Equals(class [System.Runtime]System.Exception obj) cil managed
+          Equals(class [mscorlib]System.Exception obj) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       56 (0x38)
     .maxstack  4
     .locals init (object V_0)
@@ -713,20 +701,19 @@
   .method public hidebysig virtual instance bool 
           Equals(object obj) cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       20 (0x14)
     .maxstack  4
-    .locals init (class [System.Runtime]System.Exception V_0)
+    .locals init (class [mscorlib]System.Exception V_0)
     IL_0000:  ldarg.1
-    IL_0001:  isinst     [System.Runtime]System.Exception
+    IL_0001:  isinst     [mscorlib]System.Exception
     IL_0006:  stloc.0
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_0012
 
     IL_000a:  ldarg.0
     IL_000b:  ldloc.0
-    IL_000c:  callvirt   instance bool XYZ.MyExn::Equals(class [System.Runtime]System.Exception)
+    IL_000c:  callvirt   instance bool XYZ.MyExn::Equals(class [mscorlib]System.Exception)
     IL_0011:  ret
 
     IL_0012:  ldc.i4.0
@@ -742,7 +729,7 @@
 } // end of class XYZ.MyExn
 
 .class public auto ansi serializable XYZ.A
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
   .field assembly string x
@@ -752,7 +739,7 @@
     // Code size       16 (0x10)
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  callvirt   instance void [System.Runtime]System.Object::.ctor()
+    IL_0001:  callvirt   instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ldarg.0
     IL_0007:  pop
     IL_0008:  ldarg.0
@@ -778,24 +765,24 @@
 } // end of class XYZ.A
 
 .class public abstract auto ansi sealed XYZ.ABC
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class auto autochar serializable sealed nested public beforefieldinit Expr
-         extends [System.Runtime]System.Object
-         implements class [System.Runtime]System.IEquatable`1<class XYZ.ABC/Expr>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<class XYZ.ABC/Expr>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IEquatable`1<class XYZ.ABC/Expr>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<class XYZ.ABC/Expr>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                         61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                   61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
     .field assembly initonly int32 item
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .method public static class XYZ.ABC/Expr 
             NewNum(int32 item) cil managed
     {
@@ -811,12 +798,12 @@
     .method assembly specialname rtspecialname 
             instance void  .ctor(int32 item) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 XYZ.ABC/Expr::item
@@ -826,8 +813,8 @@
     .method public hidebysig instance int32 
             get_Item() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -838,8 +825,8 @@
     .method public hidebysig instance int32 
             get_Tag() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       4 (0x4)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -851,8 +838,8 @@
     .method assembly hidebysig specialname 
             instance object  __DebugDisplay() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
@@ -866,7 +853,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -880,16 +867,15 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class XYZ.ABC/Expr obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       66 (0x42)
       .maxstack  5
       .locals init (class XYZ.ABC/Expr V_0,
                class XYZ.ABC/Expr V_1,
-               class [System.Runtime]System.Collections.IComparer V_2,
+               class [mscorlib]System.Collections.IComparer V_2,
                int32 V_3,
                int32 V_4,
-               class [System.Runtime]System.Collections.IComparer V_5,
+               class [mscorlib]System.Collections.IComparer V_5,
                int32 V_6,
                int32 V_7)
       IL_0000:  ldarg.0
@@ -904,7 +890,7 @@
       IL_0009:  stloc.0
       IL_000a:  ldarg.1
       IL_000b:  stloc.1
-      IL_000c:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_000c:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0011:  stloc.2
       IL_0012:  ldloc.0
       IL_0013:  ldfld      int32 XYZ.ABC/Expr::item
@@ -943,8 +929,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -956,19 +941,18 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       81 (0x51)
       .maxstack  5
       .locals init (class XYZ.ABC/Expr V_0,
                class XYZ.ABC/Expr V_1,
                class XYZ.ABC/Expr V_2,
-               class [System.Runtime]System.Collections.IComparer V_3,
+               class [mscorlib]System.Collections.IComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IComparer V_6,
+               class [mscorlib]System.Collections.IComparer V_6,
                int32 V_7,
                int32 V_8)
       IL_0000:  ldarg.1
@@ -1025,17 +1009,16 @@
     } // end of method Expr::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       43 (0x2b)
       .maxstack  7
       .locals init (int32 V_0,
                class XYZ.ABC/Expr V_1,
-               class [System.Runtime]System.Collections.IEqualityComparer V_2,
+               class [mscorlib]System.Collections.IEqualityComparer V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4)
+               class [mscorlib]System.Collections.IEqualityComparer V_4)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0029
 
@@ -1076,32 +1059,30 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 XYZ.ABC/Expr::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 XYZ.ABC/Expr::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method Expr::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       61 (0x3d)
       .maxstack  4
       .locals init (class XYZ.ABC/Expr V_0,
                class XYZ.ABC/Expr V_1,
                class XYZ.ABC/Expr V_2,
                class XYZ.ABC/Expr V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
                int32 V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IEqualityComparer V_7)
+               class [mscorlib]System.Collections.IEqualityComparer V_7)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0035
 
@@ -1148,8 +1129,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class XYZ.ABC/Expr obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       37 (0x25)
       .maxstack  4
       .locals init (class XYZ.ABC/Expr V_0,
@@ -1187,8 +1167,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class XYZ.ABC/Expr V_0)
@@ -1209,9 +1188,9 @@
 
     .property instance int32 Tag()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance int32 XYZ.ABC/Expr::get_Tag()
     } // end of property Expr::Tag
     .property instance int32 Item()
@@ -1219,15 +1198,15 @@
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32,
                                                                                                   int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .get instance int32 XYZ.ABC/Expr::get_Item()
     } // end of property Expr::Item
   } // end of class Expr
 
   .class auto ansi serializable nested public beforefieldinit MyExn
-         extends [System.Runtime]System.Exception
-         implements [System.Runtime]System.Collections.IStructuralEquatable
+         extends [mscorlib]System.Exception
+         implements [mscorlib]System.Collections.IStructuralEquatable
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 05 00 00 00 00 00 ) 
     .field assembly int32 Data0@
@@ -1237,7 +1216,7 @@
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 XYZ.ABC/MyExn::Data0@
@@ -1250,21 +1229,21 @@
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
       IL_0006:  ret
     } // end of method MyExn::.ctor
 
     .method family specialname rtspecialname 
-            instance void  .ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo info,
-                                 valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext context) cil managed
+            instance void  .ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo info,
+                                 valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
     {
       // Code size       9 (0x9)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
-      IL_0003:  call       instance void [System.Runtime]System.Exception::.ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo,
-                                                                                 valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext)
+      IL_0003:  call       instance void [mscorlib]System.Exception::.ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo,
+                                                                           valuetype [mscorlib]System.Runtime.Serialization.StreamingContext)
       IL_0008:  ret
     } // end of method MyExn::.ctor
 
@@ -1279,16 +1258,15 @@
     } // end of method MyExn::get_Data0
 
     .method public hidebysig virtual instance int32 
-            GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       41 (0x29)
       .maxstack  7
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IEqualityComparer V_1,
+               class [mscorlib]System.Collections.IEqualityComparer V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3)
+               class [mscorlib]System.Collections.IEqualityComparer V_3)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0027
 
@@ -1324,36 +1302,34 @@
     .method public hidebysig virtual instance int32 
             GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 XYZ.ABC/MyExn::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 XYZ.ABC/MyExn::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method MyExn::GetHashCode
 
     .method public hidebysig virtual instance bool 
             Equals(object obj,
-                   class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       78 (0x4e)
       .maxstack  4
-      .locals init (class [System.Runtime]System.Exception V_0,
-               class [System.Runtime]System.Exception V_1,
+      .locals init (class [mscorlib]System.Exception V_0,
+               class [mscorlib]System.Exception V_1,
                object V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3,
+               class [mscorlib]System.Collections.IEqualityComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6)
+               class [mscorlib]System.Collections.IEqualityComparer V_6)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0046
 
       IL_0003:  ldarg.1
-      IL_0004:  isinst     [System.Runtime]System.Exception
+      IL_0004:  isinst     [mscorlib]System.Exception
       IL_0009:  stloc.0
       IL_000a:  ldloc.0
       IL_000b:  brfalse.s  IL_0044
@@ -1400,10 +1376,9 @@
     } // end of method MyExn::Equals
 
     .method public hidebysig instance bool 
-            Equals(class [System.Runtime]System.Exception obj) cil managed
+            Equals(class [mscorlib]System.Exception obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (object V_0)
@@ -1447,20 +1422,19 @@
     .method public hidebysig virtual instance bool 
             Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
-      .locals init (class [System.Runtime]System.Exception V_0)
+      .locals init (class [mscorlib]System.Exception V_0)
       IL_0000:  ldarg.1
-      IL_0001:  isinst     [System.Runtime]System.Exception
+      IL_0001:  isinst     [mscorlib]System.Exception
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
       IL_0008:  brfalse.s  IL_0012
 
       IL_000a:  ldarg.0
       IL_000b:  ldloc.0
-      IL_000c:  callvirt   instance bool XYZ.ABC/MyExn::Equals(class [System.Runtime]System.Exception)
+      IL_000c:  callvirt   instance bool XYZ.ABC/MyExn::Equals(class [mscorlib]System.Exception)
       IL_0011:  ret
 
       IL_0012:  ldc.i4.0
@@ -1476,7 +1450,7 @@
   } // end of class MyExn
 
   .class auto ansi serializable nested public A
-         extends [System.Runtime]System.Object
+         extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
     .field assembly string x
@@ -1486,7 +1460,7 @@
       // Code size       16 (0x10)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  callvirt   instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  callvirt   instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  pop
       IL_0008:  ldarg.0
@@ -1512,24 +1486,24 @@
   } // end of class A
 
   .class abstract auto ansi sealed nested public ABC
-         extends [System.Runtime]System.Object
+         extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
     .class auto autochar serializable sealed nested public beforefieldinit Expr
-           extends [System.Runtime]System.Object
-           implements class [System.Runtime]System.IEquatable`1<class XYZ.ABC/ABC/Expr>,
-                      [System.Runtime]System.Collections.IStructuralEquatable,
-                      class [System.Runtime]System.IComparable`1<class XYZ.ABC/ABC/Expr>,
-                      [System.Runtime]System.IComparable,
-                      [System.Runtime]System.Collections.IStructuralComparable
+           extends [mscorlib]System.Object
+           implements class [mscorlib]System.IEquatable`1<class XYZ.ABC/ABC/Expr>,
+                      [mscorlib]System.Collections.IStructuralEquatable,
+                      class [mscorlib]System.IComparable`1<class XYZ.ABC/ABC/Expr>,
+                      [mscorlib]System.IComparable,
+                      [mscorlib]System.Collections.IStructuralComparable
     {
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                           61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                     61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
       .field assembly initonly int32 item
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .method public static class XYZ.ABC/ABC/Expr 
               NewNum(int32 item) cil managed
       {
@@ -1545,12 +1519,12 @@
       .method assembly specialname rtspecialname 
               instance void  .ctor(int32 item) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      int32 XYZ.ABC/ABC/Expr::item
@@ -1560,8 +1534,8 @@
       .method public hidebysig instance int32 
               get_Item() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -1572,8 +1546,8 @@
       .method public hidebysig instance int32 
               get_Tag() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       4 (0x4)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -1585,8 +1559,8 @@
       .method assembly hidebysig specialname 
               instance object  __DebugDisplay() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       22 (0x16)
         .maxstack  8
         IL_0000:  ldstr      "%+0.8A"
@@ -1600,7 +1574,7 @@
       .method public strict virtual instance string 
               ToString() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       22 (0x16)
         .maxstack  8
         IL_0000:  ldstr      "%+A"
@@ -1614,16 +1588,15 @@
       .method public hidebysig virtual final 
               instance int32  CompareTo(class XYZ.ABC/ABC/Expr obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       66 (0x42)
         .maxstack  5
         .locals init (class XYZ.ABC/ABC/Expr V_0,
                  class XYZ.ABC/ABC/Expr V_1,
-                 class [System.Runtime]System.Collections.IComparer V_2,
+                 class [mscorlib]System.Collections.IComparer V_2,
                  int32 V_3,
                  int32 V_4,
-                 class [System.Runtime]System.Collections.IComparer V_5,
+                 class [mscorlib]System.Collections.IComparer V_5,
                  int32 V_6,
                  int32 V_7)
         IL_0000:  ldarg.0
@@ -1638,7 +1611,7 @@
         IL_0009:  stloc.0
         IL_000a:  ldarg.1
         IL_000b:  stloc.1
-        IL_000c:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+        IL_000c:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
         IL_0011:  stloc.2
         IL_0012:  ldloc.0
         IL_0013:  ldfld      int32 XYZ.ABC/ABC/Expr::item
@@ -1677,8 +1650,7 @@
       .method public hidebysig virtual final 
               instance int32  CompareTo(object obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       13 (0xd)
         .maxstack  8
         IL_0000:  ldarg.0
@@ -1690,19 +1662,18 @@
 
       .method public hidebysig virtual final 
               instance int32  CompareTo(object obj,
-                                        class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                        class [mscorlib]System.Collections.IComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       81 (0x51)
         .maxstack  5
         .locals init (class XYZ.ABC/ABC/Expr V_0,
                  class XYZ.ABC/ABC/Expr V_1,
                  class XYZ.ABC/ABC/Expr V_2,
-                 class [System.Runtime]System.Collections.IComparer V_3,
+                 class [mscorlib]System.Collections.IComparer V_3,
                  int32 V_4,
                  int32 V_5,
-                 class [System.Runtime]System.Collections.IComparer V_6,
+                 class [mscorlib]System.Collections.IComparer V_6,
                  int32 V_7,
                  int32 V_8)
         IL_0000:  ldarg.1
@@ -1759,17 +1730,16 @@
       } // end of method Expr::CompareTo
 
       .method public hidebysig virtual final 
-              instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+              instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       43 (0x2b)
         .maxstack  7
         .locals init (int32 V_0,
                  class XYZ.ABC/ABC/Expr V_1,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_2,
+                 class [mscorlib]System.Collections.IEqualityComparer V_2,
                  int32 V_3,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_4)
+                 class [mscorlib]System.Collections.IEqualityComparer V_4)
         IL_0000:  ldarg.0
         IL_0001:  brfalse.s  IL_0029
 
@@ -1810,32 +1780,30 @@
       .method public hidebysig virtual final 
               instance int32  GetHashCode() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-        IL_0006:  callvirt   instance int32 XYZ.ABC/ABC/Expr::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+        IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+        IL_0006:  callvirt   instance int32 XYZ.ABC/ABC/Expr::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
         IL_000b:  ret
       } // end of method Expr::GetHashCode
 
       .method public hidebysig virtual final 
               instance bool  Equals(object obj,
-                                    class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                    class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       61 (0x3d)
         .maxstack  4
         .locals init (class XYZ.ABC/ABC/Expr V_0,
                  class XYZ.ABC/ABC/Expr V_1,
                  class XYZ.ABC/ABC/Expr V_2,
                  class XYZ.ABC/ABC/Expr V_3,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_4,
+                 class [mscorlib]System.Collections.IEqualityComparer V_4,
                  int32 V_5,
                  int32 V_6,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_7)
+                 class [mscorlib]System.Collections.IEqualityComparer V_7)
         IL_0000:  ldarg.0
         IL_0001:  brfalse.s  IL_0035
 
@@ -1882,8 +1850,7 @@
       .method public hidebysig virtual final 
               instance bool  Equals(class XYZ.ABC/ABC/Expr obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       37 (0x25)
         .maxstack  4
         .locals init (class XYZ.ABC/ABC/Expr V_0,
@@ -1921,8 +1888,7 @@
       .method public hidebysig virtual final 
               instance bool  Equals(object obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       20 (0x14)
         .maxstack  4
         .locals init (class XYZ.ABC/ABC/Expr V_0)
@@ -1943,9 +1909,9 @@
 
       .property instance int32 Tag()
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
         .get instance int32 XYZ.ABC/ABC/Expr::get_Tag()
       } // end of property Expr::Tag
       .property instance int32 Item()
@@ -1953,15 +1919,15 @@
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32,
                                                                                                     int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         .get instance int32 XYZ.ABC/ABC/Expr::get_Item()
       } // end of property Expr::Item
     } // end of class Expr
 
     .class auto ansi serializable nested public beforefieldinit MyExn
-           extends [System.Runtime]System.Exception
-           implements [System.Runtime]System.Collections.IStructuralEquatable
+           extends [mscorlib]System.Exception
+           implements [mscorlib]System.Collections.IStructuralEquatable
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 05 00 00 00 00 00 ) 
       .field assembly int32 Data0@
@@ -1971,7 +1937,7 @@
         // Code size       14 (0xe)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
         IL_0008:  stfld      int32 XYZ.ABC/ABC/MyExn::Data0@
@@ -1984,21 +1950,21 @@
         // Code size       7 (0x7)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       instance void [System.Runtime]System.Exception::.ctor()
+        IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
         IL_0006:  ret
       } // end of method MyExn::.ctor
 
       .method family specialname rtspecialname 
-              instance void  .ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo info,
-                                   valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext context) cil managed
+              instance void  .ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo info,
+                                   valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
       {
         // Code size       9 (0x9)
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldarg.1
         IL_0002:  ldarg.2
-        IL_0003:  call       instance void [System.Runtime]System.Exception::.ctor(class [System.Runtime]System.Runtime.Serialization.SerializationInfo,
-                                                                                   valuetype [System.Runtime]System.Runtime.Serialization.StreamingContext)
+        IL_0003:  call       instance void [mscorlib]System.Exception::.ctor(class [mscorlib]System.Runtime.Serialization.SerializationInfo,
+                                                                             valuetype [mscorlib]System.Runtime.Serialization.StreamingContext)
         IL_0008:  ret
       } // end of method MyExn::.ctor
 
@@ -2013,16 +1979,15 @@
       } // end of method MyExn::get_Data0
 
       .method public hidebysig virtual instance int32 
-              GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+              GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       41 (0x29)
         .maxstack  7
         .locals init (int32 V_0,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_1,
+                 class [mscorlib]System.Collections.IEqualityComparer V_1,
                  int32 V_2,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_3)
+                 class [mscorlib]System.Collections.IEqualityComparer V_3)
         IL_0000:  ldarg.0
         IL_0001:  brfalse.s  IL_0027
 
@@ -2058,36 +2023,34 @@
       .method public hidebysig virtual instance int32 
               GetHashCode() cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-        IL_0006:  callvirt   instance int32 XYZ.ABC/ABC/MyExn::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+        IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+        IL_0006:  callvirt   instance int32 XYZ.ABC/ABC/MyExn::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
         IL_000b:  ret
       } // end of method MyExn::GetHashCode
 
       .method public hidebysig virtual instance bool 
               Equals(object obj,
-                     class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                     class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       78 (0x4e)
         .maxstack  4
-        .locals init (class [System.Runtime]System.Exception V_0,
-                 class [System.Runtime]System.Exception V_1,
+        .locals init (class [mscorlib]System.Exception V_0,
+                 class [mscorlib]System.Exception V_1,
                  object V_2,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_3,
+                 class [mscorlib]System.Collections.IEqualityComparer V_3,
                  int32 V_4,
                  int32 V_5,
-                 class [System.Runtime]System.Collections.IEqualityComparer V_6)
+                 class [mscorlib]System.Collections.IEqualityComparer V_6)
         IL_0000:  ldarg.0
         IL_0001:  brfalse.s  IL_0046
 
         IL_0003:  ldarg.1
-        IL_0004:  isinst     [System.Runtime]System.Exception
+        IL_0004:  isinst     [mscorlib]System.Exception
         IL_0009:  stloc.0
         IL_000a:  ldloc.0
         IL_000b:  brfalse.s  IL_0044
@@ -2134,10 +2097,9 @@
       } // end of method MyExn::Equals
 
       .method public hidebysig instance bool 
-              Equals(class [System.Runtime]System.Exception obj) cil managed
+              Equals(class [mscorlib]System.Exception obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       56 (0x38)
         .maxstack  4
         .locals init (object V_0)
@@ -2181,20 +2143,19 @@
       .method public hidebysig virtual instance bool 
               Equals(object obj) cil managed
       {
-        .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-        .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       20 (0x14)
         .maxstack  4
-        .locals init (class [System.Runtime]System.Exception V_0)
+        .locals init (class [mscorlib]System.Exception V_0)
         IL_0000:  ldarg.1
-        IL_0001:  isinst     [System.Runtime]System.Exception
+        IL_0001:  isinst     [mscorlib]System.Exception
         IL_0006:  stloc.0
         IL_0007:  ldloc.0
         IL_0008:  brfalse.s  IL_0012
 
         IL_000a:  ldarg.0
         IL_000b:  ldloc.0
-        IL_000c:  callvirt   instance bool XYZ.ABC/ABC/MyExn::Equals(class [System.Runtime]System.Exception)
+        IL_000c:  callvirt   instance bool XYZ.ABC/ABC/MyExn::Equals(class [mscorlib]System.Exception)
         IL_0011:  ret
 
         IL_0012:  ldc.i4.0
@@ -2210,7 +2171,7 @@
     } // end of class MyExn
 
     .class auto ansi serializable nested public A
-           extends [System.Runtime]System.Object
+           extends [mscorlib]System.Object
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
       .field assembly string x
@@ -2220,7 +2181,7 @@
         // Code size       16 (0x10)
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  callvirt   instance void [System.Runtime]System.Object::.ctor()
+        IL_0001:  callvirt   instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  pop
         IL_0008:  ldarg.0
@@ -2260,8 +2221,8 @@
     .method public specialname static string 
             get_greeting() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       6 (0x6)
       .maxstack  8
       IL_0000:  ldstr      "hello"
@@ -2289,8 +2250,8 @@
   .method public specialname static string 
           get_greeting() cil managed
   {
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       6 (0x6)
     .maxstack  8
     IL_0000:  ldstr      "hello"
@@ -2304,12 +2265,12 @@
 } // end of class XYZ.ABC
 
 .class private abstract auto ansi sealed '<StartupCode$ToplevelNamespace60>'.$ToplevelNamespace60
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .field static assembly int32 init@
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-  .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public static void  main@() cil managed
   {
     .entrypoint
@@ -2330,4 +2291,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\SerializableAttribute\ToplevelNamespace_LangVersion60_fs\ToplevelNamespace60.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\SerializableAttribute\ToplevelNamespace_LangVersion60_fs\ToplevelNamespace60.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.net472.debug.bsl
@@ -12,7 +12,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern netstandard
 {
@@ -26,7 +26,7 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
@@ -42,13 +42,13 @@
   // WARNING: managed resource file FSharpOptimizationData.StaticInit_Struct01 created
 }
 .module StaticInit_Struct01.exe
-// MVID: {624CCAB9-1F68-8E9A-A745-0383B9CA4C62}
+// MVID: {63E6EA31-3DFD-FC11-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x034B0000
+// Image base: 0x0000014A80D90000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -72,8 +72,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype StaticInit_Struct01/C obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       34 (0x22)
       .maxstack  4
       .locals init (valuetype StaticInit_Struct01/C& V_0,
@@ -103,8 +102,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -118,8 +116,7 @@
             instance int32  CompareTo(object obj,
                                       class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       39 (0x27)
       .maxstack  4
       .locals init (valuetype StaticInit_Struct01/C V_0,
@@ -153,8 +150,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       31 (0x1f)
       .maxstack  7
       .locals init (int32 V_0)
@@ -183,8 +179,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -197,8 +192,7 @@
             instance bool  Equals(object obj,
                                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (object V_0,
@@ -254,8 +248,7 @@
 
     .method assembly static int32  f() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       38 (0x26)
       .maxstack  8
       IL_0000:  nop
@@ -280,8 +273,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype StaticInit_Struct01/C obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       21 (0x15)
       .maxstack  4
       .locals init (valuetype StaticInit_Struct01/C& V_0)
@@ -299,8 +291,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,
@@ -368,4 +359,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file c:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\StaticInit\StaticInit_Struct01_fs\StaticInit_Struct01.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\StaticInit\StaticInit_Struct01_fs\StaticInit_Struct01.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.netcore.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.netcore.debug.bsl
@@ -7,12 +7,12 @@
 .assembly extern System.Runtime
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern netstandard
 {
@@ -26,7 +26,7 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
@@ -42,13 +42,13 @@
   // WARNING: managed resource file FSharpOptimizationData.StaticInit_Struct01 created
 }
 .module StaticInit_Struct01.exe
-// MVID: {624CCF56-BD47-E55D-A745-038356CF4C62}
+// MVID: {63E6ED0E-02AC-6EA3-A745-03830EEDE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00000159C0660000
+// Image base: 0x000001452EA90000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -72,8 +72,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype StaticInit_Struct01/C obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       34 (0x22)
       .maxstack  4
       .locals init (valuetype StaticInit_Struct01/C& V_0,
@@ -103,8 +102,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -118,8 +116,7 @@
             instance int32  CompareTo(object obj,
                                       class [System.Runtime]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       39 (0x27)
       .maxstack  4
       .locals init (valuetype StaticInit_Struct01/C V_0,
@@ -153,8 +150,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       31 (0x1f)
       .maxstack  7
       .locals init (int32 V_0)
@@ -183,8 +179,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -197,8 +192,7 @@
             instance bool  Equals(object obj,
                                   class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (object V_0,
@@ -254,8 +248,7 @@
 
     .method assembly static int32  f() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       38 (0x26)
       .maxstack  8
       IL_0000:  nop
@@ -280,8 +273,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype StaticInit_Struct01/C obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       21 (0x15)
       .maxstack  4
       .locals init (valuetype StaticInit_Struct01/C& V_0)
@@ -299,8 +291,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,
@@ -368,4 +359,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file c:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\StaticInit\StaticInit_Struct01_fs\StaticInit_Struct01.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net7.0\tests\EmittedIL\StaticInit\StaticInit_Struct01_fs\StaticInit_Struct01.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch06.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch06.fs.il.net472.debug.bsl
@@ -12,7 +12,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly SteppingMatch06
 {
@@ -21,7 +21,7 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
@@ -37,13 +37,13 @@
   // WARNING: managed resource file FSharpOptimizationData.SteppingMatch06 created
 }
 .module SteppingMatch06.exe
-// MVID: {624CDC8C-1F70-8A79-A745-03838CDC4C62}
+// MVID: {63E6EA31-9101-9725-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x053D0000
+// Image base: 0x000002279C690000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -191,7 +191,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -205,8 +205,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class SteppingMatch06/Discr obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       39 (0x27)
       .maxstack  4
       .locals init (int32 V_0,
@@ -251,8 +250,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -266,8 +264,7 @@
             instance int32  CompareTo(object obj,
                                       class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (class SteppingMatch06/Discr V_0,
@@ -318,8 +315,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  3
       .locals init (int32 V_0)
@@ -339,8 +335,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -353,8 +348,7 @@
             instance bool  Equals(object obj,
                                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       44 (0x2c)
       .maxstack  4
       .locals init (class SteppingMatch06/Discr V_0,
@@ -397,8 +391,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class SteppingMatch06/Discr obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       35 (0x23)
       .maxstack  4
       .locals init (int32 V_0,
@@ -434,8 +427,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class SteppingMatch06/Discr V_0)
@@ -533,4 +525,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file c:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\SteppingMatch\SteppingMatch06_fs\SteppingMatch06.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\SteppingMatch\SteppingMatch06_fs\SteppingMatch06.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch06.fs.il.netcore.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch06.fs.il.netcore.debug.bsl
@@ -7,17 +7,17 @@
 .assembly extern System.Runtime
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly SteppingMatch06
 {
@@ -26,7 +26,7 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
@@ -42,13 +42,13 @@
   // WARNING: managed resource file FSharpOptimizationData.SteppingMatch06 created
 }
 .module SteppingMatch06.exe
-// MVID: {624CDD14-B96B-6A0F-A745-038314DD4C62}
+// MVID: {63E6ED0E-1172-D583-A745-03830EEDE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000001FACE210000
+// Image base: 0x00000225CA990000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -196,7 +196,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -210,8 +210,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class SteppingMatch06/Discr obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       39 (0x27)
       .maxstack  4
       .locals init (int32 V_0,
@@ -256,8 +255,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -271,8 +269,7 @@
             instance int32  CompareTo(object obj,
                                       class [System.Runtime]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (class SteppingMatch06/Discr V_0,
@@ -323,8 +320,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  3
       .locals init (int32 V_0)
@@ -344,8 +340,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -358,8 +353,7 @@
             instance bool  Equals(object obj,
                                   class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       44 (0x2c)
       .maxstack  4
       .locals init (class SteppingMatch06/Discr V_0,
@@ -402,8 +396,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class SteppingMatch06/Discr obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       35 (0x23)
       .maxstack  4
       .locals init (int32 V_0,
@@ -439,8 +432,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class SteppingMatch06/Discr V_0)
@@ -538,4 +530,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file c:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\SteppingMatch\SteppingMatch06_fs\SteppingMatch06.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net7.0\tests\EmittedIL\SteppingMatch\SteppingMatch06_fs\SteppingMatch06.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch07.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch07.fs.il.net472.debug.bsl
@@ -12,7 +12,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly SteppingMatch07
 {
@@ -21,7 +21,7 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
@@ -37,13 +37,13 @@
   // WARNING: managed resource file FSharpOptimizationData.SteppingMatch07 created
 }
 .module SteppingMatch07.exe
-// MVID: {624CDC8C-B9FF-4FFC-A745-03838CDC4C62}
+// MVID: {63E6EA31-8C42-9725-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x053D0000
+// Image base: 0x000002ADA0930000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -191,7 +191,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -205,8 +205,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class SteppingMatch07/Discr obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       39 (0x27)
       .maxstack  4
       .locals init (int32 V_0,
@@ -251,8 +250,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -266,8 +264,7 @@
             instance int32  CompareTo(object obj,
                                       class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (class SteppingMatch07/Discr V_0,
@@ -318,8 +315,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  3
       .locals init (int32 V_0)
@@ -339,8 +335,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -353,8 +348,7 @@
             instance bool  Equals(object obj,
                                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       44 (0x2c)
       .maxstack  4
       .locals init (class SteppingMatch07/Discr V_0,
@@ -397,8 +391,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class SteppingMatch07/Discr obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       35 (0x23)
       .maxstack  4
       .locals init (int32 V_0,
@@ -434,8 +427,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class SteppingMatch07/Discr V_0)
@@ -533,4 +525,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file c:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\SteppingMatch\SteppingMatch07_fs\SteppingMatch07.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\SteppingMatch\SteppingMatch07_fs\SteppingMatch07.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch07.fs.il.netcore.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch07.fs.il.netcore.debug.bsl
@@ -7,17 +7,17 @@
 .assembly extern System.Runtime
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly SteppingMatch07
 {
@@ -26,7 +26,7 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
@@ -42,13 +42,13 @@
   // WARNING: managed resource file FSharpOptimizationData.SteppingMatch07 created
 }
 .module SteppingMatch07.exe
-// MVID: {624CDD14-9CCD-48CC-A745-038314DD4C62}
+// MVID: {63E6ED0E-1DAF-2380-A745-03830EEDE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000002870BC60000
+// Image base: 0x000002334E4B0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -196,7 +196,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -210,8 +210,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class SteppingMatch07/Discr obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       39 (0x27)
       .maxstack  4
       .locals init (int32 V_0,
@@ -256,8 +255,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -271,8 +269,7 @@
             instance int32  CompareTo(object obj,
                                       class [System.Runtime]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       56 (0x38)
       .maxstack  4
       .locals init (class SteppingMatch07/Discr V_0,
@@ -323,8 +320,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  3
       .locals init (int32 V_0)
@@ -344,8 +340,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -358,8 +353,7 @@
             instance bool  Equals(object obj,
                                   class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       44 (0x2c)
       .maxstack  4
       .locals init (class SteppingMatch07/Discr V_0,
@@ -402,8 +396,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class SteppingMatch07/Discr obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       35 (0x23)
       .maxstack  4
       .locals init (int32 V_0,
@@ -439,8 +432,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class SteppingMatch07/Discr V_0)
@@ -538,4 +530,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file c:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\SteppingMatch\SteppingMatch07_fs\SteppingMatch07.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net7.0\tests\EmittedIL\SteppingMatch\SteppingMatch07_fs\SteppingMatch07.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Structure/FloatsAndDoubles.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Structure/FloatsAndDoubles.fs.il.debug.bsl
@@ -12,7 +12,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly FloatsAndDoubles
 {
@@ -21,7 +21,7 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
@@ -37,13 +37,13 @@
   // WARNING: managed resource file FSharpOptimizationData.FloatsAndDoubles created
 }
 .module FloatsAndDoubles.exe
-// MVID: {62505A27-906B-9AD0-A745-0383275A5062}
+// MVID: {63E6EA31-274A-A48B-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x030C0000
+// Image base: 0x0000015AA6730000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -65,8 +65,8 @@
     .method public hidebysig specialname 
             instance float64  get_F() cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -77,8 +77,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype floatsanddoubles/Float obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       76 (0x4c)
       .maxstack  5
       .locals init (valuetype floatsanddoubles/Float& V_0,
@@ -141,8 +140,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -156,8 +154,7 @@
             instance int32  CompareTo(object obj,
                                       class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       81 (0x51)
       .maxstack  5
       .locals init (valuetype floatsanddoubles/Float V_0,
@@ -224,8 +221,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       31 (0x1f)
       .maxstack  7
       .locals init (int32 V_0)
@@ -254,8 +250,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -268,8 +263,7 @@
             instance bool  Equals(object obj,
                                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       53 (0x35)
       .maxstack  4
       .locals init (object V_0,
@@ -325,8 +319,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype floatsanddoubles/Float obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       47 (0x2f)
       .maxstack  4
       .locals init (valuetype floatsanddoubles/Float& V_0,
@@ -372,8 +365,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,
@@ -419,8 +411,8 @@
     .method public hidebysig specialname 
             instance float64  get_D() cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -431,8 +423,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(valuetype floatsanddoubles/Double obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       76 (0x4c)
       .maxstack  5
       .locals init (valuetype floatsanddoubles/Double& V_0,
@@ -495,8 +486,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -510,8 +500,7 @@
             instance int32  CompareTo(object obj,
                                       class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       81 (0x51)
       .maxstack  5
       .locals init (valuetype floatsanddoubles/Double V_0,
@@ -578,8 +567,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       31 (0x1f)
       .maxstack  7
       .locals init (int32 V_0)
@@ -608,8 +596,7 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -622,8 +609,7 @@
             instance bool  Equals(object obj,
                                   class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       53 (0x35)
       .maxstack  4
       .locals init (object V_0,
@@ -679,8 +665,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(valuetype floatsanddoubles/Double obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       47 (0x2f)
       .maxstack  4
       .locals init (valuetype floatsanddoubles/Double& V_0,
@@ -726,8 +711,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       30 (0x1e)
       .maxstack  4
       .locals init (object V_0,

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction16.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction16.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly TestFunction16
 {
@@ -21,56 +21,56 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction16
 {
-  // Offset: 0x00000000 Length: 0x000006B0
+  // Offset: 0x00000000 Length: 0x000006BA
   // WARNING: managed resource file FSharpSignatureData.TestFunction16 created
 }
 .mresource public FSharpOptimizationData.TestFunction16
 {
-  // Offset: 0x000006B8 Length: 0x000001D3
+  // Offset: 0x000006C0 Length: 0x000001CD
   // WARNING: managed resource file FSharpOptimizationData.TestFunction16 created
 }
 .module TestFunction16.exe
-// MVID: {628F4C90-4649-1055-A745-0383904C8F62}
+// MVID: {63E6EA31-12D5-E97E-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000001ECE7610000
+// Image base: 0x0000028D85740000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed TestFunction16
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class auto autochar serializable sealed nested public beforefieldinit U
-         extends [System.Runtime]System.Object
-         implements class [System.Runtime]System.IEquatable`1<class TestFunction16/U>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<class TestFunction16/U>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IEquatable`1<class TestFunction16/U>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<class TestFunction16/U>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                         61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                   61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
     .field assembly initonly int32 item1
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .field assembly initonly int32 item2
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .method public static class TestFunction16/U 
             NewU(int32 item1,
                  int32 item2) cil managed
@@ -90,12 +90,12 @@
             instance void  .ctor(int32 item1,
                                  int32 item2) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       21 (0x15)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 TestFunction16/U::item1
@@ -108,8 +108,8 @@
     .method public hidebysig instance int32 
             get_Item1() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -120,8 +120,8 @@
     .method public hidebysig instance int32 
             get_Item2() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -132,8 +132,8 @@
     .method public hidebysig instance int32 
             get_Tag() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       4 (0x4)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -145,8 +145,8 @@
     .method assembly hidebysig specialname 
             instance object  __DebugDisplay() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
@@ -160,7 +160,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -174,23 +174,22 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class TestFunction16/U obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       132 (0x84)
       .maxstack  5
       .locals init (class TestFunction16/U V_0,
                class TestFunction16/U V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IComparer V_3,
+               class [mscorlib]System.Collections.IComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IComparer V_6,
+               class [mscorlib]System.Collections.IComparer V_6,
                int32 V_7,
                int32 V_8,
-               class [System.Runtime]System.Collections.IComparer V_9,
+               class [mscorlib]System.Collections.IComparer V_9,
                int32 V_10,
                int32 V_11,
-               class [System.Runtime]System.Collections.IComparer V_12,
+               class [mscorlib]System.Collections.IComparer V_12,
                int32 V_13,
                int32 V_14)
       IL_0000:  ldarg.0
@@ -205,7 +204,7 @@
       IL_000c:  stloc.0
       IL_000d:  ldarg.1
       IL_000e:  stloc.1
-      IL_000f:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_000f:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0014:  stloc.3
       IL_0015:  ldloc.0
       IL_0016:  ldfld      int32 TestFunction16/U::item1
@@ -241,7 +240,7 @@
       IL_0048:  ldloc.2
       IL_0049:  ret
 
-      IL_004a:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_004a:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_004f:  stloc.s    V_9
       IL_0051:  ldloc.0
       IL_0052:  ldfld      int32 TestFunction16/U::item2
@@ -280,8 +279,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -293,26 +291,25 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       140 (0x8c)
       .maxstack  5
       .locals init (class TestFunction16/U V_0,
                class TestFunction16/U V_1,
                class TestFunction16/U V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IComparer V_4,
+               class [mscorlib]System.Collections.IComparer V_4,
                int32 V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IComparer V_7,
+               class [mscorlib]System.Collections.IComparer V_7,
                int32 V_8,
                int32 V_9,
-               class [System.Runtime]System.Collections.IComparer V_10,
+               class [mscorlib]System.Collections.IComparer V_10,
                int32 V_11,
                int32 V_12,
-               class [System.Runtime]System.Collections.IComparer V_13,
+               class [mscorlib]System.Collections.IComparer V_13,
                int32 V_14,
                int32 V_15)
       IL_0000:  ldarg.1
@@ -405,20 +402,19 @@
     } // end of method U::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       75 (0x4b)
       .maxstack  7
       .locals init (int32 V_0,
                class TestFunction16/U V_1,
-               class [System.Runtime]System.Collections.IEqualityComparer V_2,
+               class [mscorlib]System.Collections.IEqualityComparer V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
-               class [System.Runtime]System.Collections.IEqualityComparer V_5,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IEqualityComparer V_7)
+               class [mscorlib]System.Collections.IEqualityComparer V_7)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0049
 
@@ -478,36 +474,34 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 TestFunction16/U::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 TestFunction16/U::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method U::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       94 (0x5e)
       .maxstack  4
       .locals init (class TestFunction16/U V_0,
                class TestFunction16/U V_1,
                class TestFunction16/U V_2,
                class TestFunction16/U V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
                int32 V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IEqualityComparer V_7,
-               class [System.Runtime]System.Collections.IEqualityComparer V_8,
+               class [mscorlib]System.Collections.IEqualityComparer V_7,
+               class [mscorlib]System.Collections.IEqualityComparer V_8,
                int32 V_9,
                int32 V_10,
-               class [System.Runtime]System.Collections.IEqualityComparer V_11)
+               class [mscorlib]System.Collections.IEqualityComparer V_11)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0056
 
@@ -572,8 +566,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class TestFunction16/U obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       53 (0x35)
       .maxstack  4
       .locals init (class TestFunction16/U V_0,
@@ -620,8 +613,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class TestFunction16/U V_0)
@@ -642,9 +634,9 @@
 
     .property instance int32 Tag()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance int32 TestFunction16/U::get_Tag()
     } // end of property U::Tag
     .property instance int32 Item1()
@@ -652,8 +644,8 @@
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32,
                                                                                                   int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .get instance int32 TestFunction16/U::get_Item1()
     } // end of property U::Item1
     .property instance int32 Item2()
@@ -661,13 +653,13 @@
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32,
                                                                                                   int32) = ( 01 00 04 00 00 00 00 00 00 00 01 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .get instance int32 TestFunction16/U::get_Item2()
     } // end of property U::Item2
   } // end of class U
 
-  .method public static class [System.Runtime]System.Tuple`2<class TestFunction16/U,class TestFunction16/U> 
+  .method public static class [mscorlib]System.Tuple`2<class TestFunction16/U,class TestFunction16/U> 
           TestFunction16(int32 inp) cil managed
   {
     // Code size       16 (0x10)
@@ -680,15 +672,15 @@
     IL_0007:  stloc.0
     IL_0008:  ldloc.0
     IL_0009:  ldloc.0
-    IL_000a:  newobj     instance void class [System.Runtime]System.Tuple`2<class TestFunction16/U,class TestFunction16/U>::.ctor(!0,
-                                                                                                                                  !1)
+    IL_000a:  newobj     instance void class [mscorlib]System.Tuple`2<class TestFunction16/U,class TestFunction16/U>::.ctor(!0,
+                                                                                                                            !1)
     IL_000f:  ret
   } // end of method TestFunction16::TestFunction16
 
 } // end of class TestFunction16
 
 .class private abstract auto ansi sealed '<StartupCode$TestFunction16>'.$TestFunction16
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .method public static void  main@() cil managed
   {
@@ -704,4 +696,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\TestFunctions\TestFunction16_fs\TestFunction16.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\TestFunctions\TestFunction16_fs\TestFunction16.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly TestFunction17
 {
@@ -21,57 +21,57 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction17
 {
-  // Offset: 0x00000000 Length: 0x0000069B
+  // Offset: 0x00000000 Length: 0x000006A5
   // WARNING: managed resource file FSharpSignatureData.TestFunction17 created
 }
 .mresource public FSharpOptimizationData.TestFunction17
 {
-  // Offset: 0x000006A0 Length: 0x000001D3
+  // Offset: 0x000006B0 Length: 0x000001CD
   // WARNING: managed resource file FSharpOptimizationData.TestFunction17 created
 }
 .module TestFunction17.exe
-// MVID: {628F4C90-9846-1B91-A745-0383904C8F62}
+// MVID: {63E6EA31-3D30-2E38-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000001E4B3470000
+// Image base: 0x000002115FE10000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed TestFunction17
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class auto ansi serializable sealed nested public R
-         extends [System.Runtime]System.Object
-         implements class [System.Runtime]System.IEquatable`1<class TestFunction17/R>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<class TestFunction17/R>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IEquatable`1<class TestFunction17/R>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<class TestFunction17/R>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 02 00 00 00 00 00 ) 
     .field assembly int32 x@
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .field assembly int32 y@
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .method public hidebysig specialname 
             instance int32  get_x() cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -82,8 +82,8 @@
     .method public hidebysig specialname 
             instance int32  get_y() cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -98,7 +98,7 @@
       // Code size       21 (0x15)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 TestFunction17/R::x@
@@ -111,7 +111,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -125,21 +125,20 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class TestFunction17/R obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       119 (0x77)
       .maxstack  5
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IComparer V_1,
+               class [mscorlib]System.Collections.IComparer V_1,
                int32 V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IComparer V_4,
+               class [mscorlib]System.Collections.IComparer V_4,
                int32 V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IComparer V_7,
+               class [mscorlib]System.Collections.IComparer V_7,
                int32 V_8,
                int32 V_9,
-               class [System.Runtime]System.Collections.IComparer V_10,
+               class [mscorlib]System.Collections.IComparer V_10,
                int32 V_11,
                int32 V_12)
       IL_0000:  ldarg.0
@@ -148,7 +147,7 @@
       IL_0003:  ldarg.1
       IL_0004:  brfalse.s  IL_006e
 
-      IL_0006:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0006:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_000b:  stloc.1
       IL_000c:  ldarg.0
       IL_000d:  ldfld      int32 TestFunction17/R::x@
@@ -184,7 +183,7 @@
       IL_003b:  ldloc.0
       IL_003c:  ret
 
-      IL_003d:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_003d:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0042:  stloc.s    V_7
       IL_0044:  ldarg.0
       IL_0045:  ldfld      int32 TestFunction17/R::y@
@@ -223,8 +222,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -236,25 +234,24 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       134 (0x86)
       .maxstack  5
       .locals init (class TestFunction17/R V_0,
                class TestFunction17/R V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IComparer V_3,
+               class [mscorlib]System.Collections.IComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IComparer V_6,
+               class [mscorlib]System.Collections.IComparer V_6,
                int32 V_7,
                int32 V_8,
-               class [System.Runtime]System.Collections.IComparer V_9,
+               class [mscorlib]System.Collections.IComparer V_9,
                int32 V_10,
                int32 V_11,
-               class [System.Runtime]System.Collections.IComparer V_12,
+               class [mscorlib]System.Collections.IComparer V_12,
                int32 V_13,
                int32 V_14)
       IL_0000:  ldarg.1
@@ -343,19 +340,18 @@
     } // end of method R::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       68 (0x44)
       .maxstack  7
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IEqualityComparer V_1,
+               class [mscorlib]System.Collections.IEqualityComparer V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_3,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6)
+               class [mscorlib]System.Collections.IEqualityComparer V_6)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0042
 
@@ -409,34 +405,32 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 TestFunction17/R::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 TestFunction17/R::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method R::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       84 (0x54)
       .maxstack  4
       .locals init (class TestFunction17/R V_0,
                class TestFunction17/R V_1,
-               class [System.Runtime]System.Collections.IEqualityComparer V_2,
+               class [mscorlib]System.Collections.IEqualityComparer V_2,
                int32 V_3,
                int32 V_4,
-               class [System.Runtime]System.Collections.IEqualityComparer V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6,
+               class [mscorlib]System.Collections.IEqualityComparer V_5,
+               class [mscorlib]System.Collections.IEqualityComparer V_6,
                int32 V_7,
                int32 V_8,
-               class [System.Runtime]System.Collections.IEqualityComparer V_9)
+               class [mscorlib]System.Collections.IEqualityComparer V_9)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_004c
 
@@ -495,8 +489,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class TestFunction17/R obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       47 (0x2f)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -535,8 +528,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class TestFunction17/R V_0)
@@ -569,7 +561,7 @@
     } // end of property R::y
   } // end of class R
 
-  .method public static class [System.Runtime]System.Tuple`2<class TestFunction17/R,class TestFunction17/R> 
+  .method public static class [mscorlib]System.Tuple`2<class TestFunction17/R,class TestFunction17/R> 
           TestFunction17(int32 inp) cil managed
   {
     // Code size       16 (0x10)
@@ -582,15 +574,15 @@
     IL_0007:  stloc.0
     IL_0008:  ldloc.0
     IL_0009:  ldloc.0
-    IL_000a:  newobj     instance void class [System.Runtime]System.Tuple`2<class TestFunction17/R,class TestFunction17/R>::.ctor(!0,
-                                                                                                                                  !1)
+    IL_000a:  newobj     instance void class [mscorlib]System.Tuple`2<class TestFunction17/R,class TestFunction17/R>::.ctor(!0,
+                                                                                                                            !1)
     IL_000f:  ret
   } // end of method TestFunction17::TestFunction17
 
 } // end of class TestFunction17
 
 .class private abstract auto ansi sealed '<StartupCode$TestFunction17>'.$TestFunction17
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .method public static void  main@() cil managed
   {
@@ -606,4 +598,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\TestFunctions\TestFunction17_fs\TestFunction17.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\TestFunctions\TestFunction17_fs\TestFunction17.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction21.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction21.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly TestFunction21
 {
@@ -21,56 +21,56 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction21
 {
-  // Offset: 0x00000000 Length: 0x000006A2
+  // Offset: 0x00000000 Length: 0x000006AC
   // WARNING: managed resource file FSharpSignatureData.TestFunction21 created
 }
 .mresource public FSharpOptimizationData.TestFunction21
 {
-  // Offset: 0x000006A8 Length: 0x000001D3
+  // Offset: 0x000006B0 Length: 0x000001CD
   // WARNING: managed resource file FSharpOptimizationData.TestFunction21 created
 }
 .module TestFunction21.exe
-// MVID: {628F4C90-83B6-1458-A745-0383904C8F62}
+// MVID: {63E6EA31-CFF9-35FA-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000001767E840000
+// Image base: 0x000001A8B7EB0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed TestFunction21
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class auto autochar serializable sealed nested public beforefieldinit U
-         extends [System.Runtime]System.Object
-         implements class [System.Runtime]System.IEquatable`1<class TestFunction21/U>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<class TestFunction21/U>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IEquatable`1<class TestFunction21/U>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<class TestFunction21/U>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
-                                                                                                         61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   // ...{__DebugDispl
+                                                                                                   61 79 28 29 2C 6E 71 7D 00 00 )                   // ay(),nq}..
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 01 00 00 00 00 00 ) 
     .field assembly initonly int32 item1
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .field assembly initonly int32 item2
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .method public static class TestFunction21/U 
             NewU(int32 item1,
                  int32 item2) cil managed
@@ -90,12 +90,12 @@
             instance void  .ctor(int32 item1,
                                  int32 item2) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       21 (0x15)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 TestFunction21/U::item1
@@ -108,8 +108,8 @@
     .method public hidebysig instance int32 
             get_Item1() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -120,8 +120,8 @@
     .method public hidebysig instance int32 
             get_Item2() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -132,8 +132,8 @@
     .method public hidebysig instance int32 
             get_Tag() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       4 (0x4)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -145,8 +145,8 @@
     .method assembly hidebysig specialname 
             instance object  __DebugDisplay() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
@@ -160,7 +160,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -174,23 +174,22 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class TestFunction21/U obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       132 (0x84)
       .maxstack  5
       .locals init (class TestFunction21/U V_0,
                class TestFunction21/U V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IComparer V_3,
+               class [mscorlib]System.Collections.IComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IComparer V_6,
+               class [mscorlib]System.Collections.IComparer V_6,
                int32 V_7,
                int32 V_8,
-               class [System.Runtime]System.Collections.IComparer V_9,
+               class [mscorlib]System.Collections.IComparer V_9,
                int32 V_10,
                int32 V_11,
-               class [System.Runtime]System.Collections.IComparer V_12,
+               class [mscorlib]System.Collections.IComparer V_12,
                int32 V_13,
                int32 V_14)
       IL_0000:  ldarg.0
@@ -205,7 +204,7 @@
       IL_000c:  stloc.0
       IL_000d:  ldarg.1
       IL_000e:  stloc.1
-      IL_000f:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_000f:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0014:  stloc.3
       IL_0015:  ldloc.0
       IL_0016:  ldfld      int32 TestFunction21/U::item1
@@ -241,7 +240,7 @@
       IL_0048:  ldloc.2
       IL_0049:  ret
 
-      IL_004a:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_004a:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_004f:  stloc.s    V_9
       IL_0051:  ldloc.0
       IL_0052:  ldfld      int32 TestFunction21/U::item2
@@ -280,8 +279,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -293,26 +291,25 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       140 (0x8c)
       .maxstack  5
       .locals init (class TestFunction21/U V_0,
                class TestFunction21/U V_1,
                class TestFunction21/U V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IComparer V_4,
+               class [mscorlib]System.Collections.IComparer V_4,
                int32 V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IComparer V_7,
+               class [mscorlib]System.Collections.IComparer V_7,
                int32 V_8,
                int32 V_9,
-               class [System.Runtime]System.Collections.IComparer V_10,
+               class [mscorlib]System.Collections.IComparer V_10,
                int32 V_11,
                int32 V_12,
-               class [System.Runtime]System.Collections.IComparer V_13,
+               class [mscorlib]System.Collections.IComparer V_13,
                int32 V_14,
                int32 V_15)
       IL_0000:  ldarg.1
@@ -405,20 +402,19 @@
     } // end of method U::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       75 (0x4b)
       .maxstack  7
       .locals init (int32 V_0,
                class TestFunction21/U V_1,
-               class [System.Runtime]System.Collections.IEqualityComparer V_2,
+               class [mscorlib]System.Collections.IEqualityComparer V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
-               class [System.Runtime]System.Collections.IEqualityComparer V_5,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IEqualityComparer V_7)
+               class [mscorlib]System.Collections.IEqualityComparer V_7)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0049
 
@@ -478,36 +474,34 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 TestFunction21/U::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 TestFunction21/U::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method U::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       94 (0x5e)
       .maxstack  4
       .locals init (class TestFunction21/U V_0,
                class TestFunction21/U V_1,
                class TestFunction21/U V_2,
                class TestFunction21/U V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
                int32 V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IEqualityComparer V_7,
-               class [System.Runtime]System.Collections.IEqualityComparer V_8,
+               class [mscorlib]System.Collections.IEqualityComparer V_7,
+               class [mscorlib]System.Collections.IEqualityComparer V_8,
                int32 V_9,
                int32 V_10,
-               class [System.Runtime]System.Collections.IEqualityComparer V_11)
+               class [mscorlib]System.Collections.IEqualityComparer V_11)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0056
 
@@ -572,8 +566,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class TestFunction21/U obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       53 (0x35)
       .maxstack  4
       .locals init (class TestFunction21/U V_0,
@@ -620,8 +613,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class TestFunction21/U V_0)
@@ -642,9 +634,9 @@
 
     .property instance int32 Tag()
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance int32 TestFunction21/U::get_Tag()
     } // end of property U::Tag
     .property instance int32 Item1()
@@ -652,8 +644,8 @@
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32,
                                                                                                   int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .get instance int32 TestFunction21/U::get_Item1()
     } // end of property U::Item1
     .property instance int32 Item2()
@@ -661,8 +653,8 @@
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32,
                                                                                                   int32) = ( 01 00 04 00 00 00 00 00 00 00 01 00 00 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .get instance int32 TestFunction21/U::get_Item2()
     } // end of property U::Item2
   } // end of class U
@@ -671,14 +663,14 @@
          extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>
   {
     .field public class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit> clo2
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .method assembly specialname rtspecialname 
             instance void  .ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit> clo2) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -708,14 +700,14 @@
          extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>
   {
     .field public class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>> clo1
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
     .method assembly specialname rtspecialname 
             instance void  .ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>> clo1) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [System.Runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -761,8 +753,8 @@
     IL_000a:  ldfld      int32 TestFunction21/U::item1
     IL_000f:  stloc.2
     IL_0010:  ldstr      "a = %A, a = %A"
-    IL_0015:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [System.Runtime]System.Tuple`2<int32,int32>>::.ctor(string)
-    IL_001a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [System.Runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0015:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.Tuple`2<int32,int32>>::.ctor(string)
+    IL_001a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_001f:  stloc.3
     IL_0020:  ldloc.3
     IL_0021:  newobj     instance void TestFunction21/TestFunction21@7::.ctor(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>)
@@ -778,7 +770,7 @@
 } // end of class TestFunction21
 
 .class private abstract auto ansi sealed '<StartupCode$TestFunction21>'.$TestFunction21
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .method public static void  main@() cil managed
   {
@@ -794,4 +786,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\TestFunctions\TestFunction21_fs\TestFunction21.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\TestFunctions\TestFunction21_fs\TestFunction21.res

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.debug.bsl
@@ -4,15 +4,15 @@
 
 
 // Metadata version: v4.0.30319
-.assembly extern System.Runtime
+.assembly extern mscorlib
 {
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 6:0:0:0
+  .ver 7:0:0:0
 }
 .assembly TestFunction24
 {
@@ -21,57 +21,57 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 03 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction24
 {
-  // Offset: 0x00000000 Length: 0x0000076F
+  // Offset: 0x00000000 Length: 0x00000779
   // WARNING: managed resource file FSharpSignatureData.TestFunction24 created
 }
 .mresource public FSharpOptimizationData.TestFunction24
 {
-  // Offset: 0x00000778 Length: 0x0000022E
+  // Offset: 0x00000780 Length: 0x00000228
   // WARNING: managed resource file FSharpOptimizationData.TestFunction24 created
 }
 .module TestFunction24.exe
-// MVID: {628F4C90-2576-C1EA-A745-0383904C8F62}
+// MVID: {63E6EA31-230A-8930-A745-038331EAE663}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000018C43700000
+// Image base: 0x000001EF57F40000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
 .class public abstract auto ansi sealed TestFunction24
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class auto ansi serializable sealed nested public Point
-         extends [System.Runtime]System.Object
-         implements class [System.Runtime]System.IEquatable`1<class TestFunction24/Point>,
-                    [System.Runtime]System.Collections.IStructuralEquatable,
-                    class [System.Runtime]System.IComparable`1<class TestFunction24/Point>,
-                    [System.Runtime]System.IComparable,
-                    [System.Runtime]System.Collections.IStructuralComparable
+         extends [mscorlib]System.Object
+         implements class [mscorlib]System.IEquatable`1<class TestFunction24/Point>,
+                    [mscorlib]System.Collections.IStructuralEquatable,
+                    class [mscorlib]System.IComparable`1<class TestFunction24/Point>,
+                    [mscorlib]System.IComparable,
+                    [mscorlib]System.Collections.IStructuralComparable
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 02 00 00 00 00 00 ) 
     .field public int32 x@
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .field public int32 y@
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [System.Runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .method public hidebysig specialname 
             instance int32  get_x() cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -82,8 +82,8 @@
     .method public hidebysig specialname 
             instance int32  get_y() cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -94,8 +94,8 @@
     .method public hidebysig specialname 
             instance void  set_x(int32 'value') cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       8 (0x8)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -107,8 +107,8 @@
     .method public hidebysig specialname 
             instance void  set_y(int32 'value') cil managed
     {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       8 (0x8)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -124,7 +124,7 @@
       // Code size       21 (0x15)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  stfld      int32 TestFunction24/Point::x@
@@ -137,7 +137,7 @@
     .method public strict virtual instance string 
             ToString() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
       .maxstack  8
       IL_0000:  ldstr      "%+A"
@@ -151,21 +151,20 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(class TestFunction24/Point obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       119 (0x77)
       .maxstack  5
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IComparer V_1,
+               class [mscorlib]System.Collections.IComparer V_1,
                int32 V_2,
                int32 V_3,
-               class [System.Runtime]System.Collections.IComparer V_4,
+               class [mscorlib]System.Collections.IComparer V_4,
                int32 V_5,
                int32 V_6,
-               class [System.Runtime]System.Collections.IComparer V_7,
+               class [mscorlib]System.Collections.IComparer V_7,
                int32 V_8,
                int32 V_9,
-               class [System.Runtime]System.Collections.IComparer V_10,
+               class [mscorlib]System.Collections.IComparer V_10,
                int32 V_11,
                int32 V_12)
       IL_0000:  ldarg.0
@@ -174,7 +173,7 @@
       IL_0003:  ldarg.1
       IL_0004:  brfalse.s  IL_006e
 
-      IL_0006:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0006:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_000b:  stloc.1
       IL_000c:  ldarg.0
       IL_000d:  ldfld      int32 TestFunction24/Point::x@
@@ -210,7 +209,7 @@
       IL_003b:  ldloc.0
       IL_003c:  ret
 
-      IL_003d:  call       class [System.Runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_003d:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
       IL_0042:  stloc.s    V_7
       IL_0044:  ldarg.0
       IL_0045:  ldfld      int32 TestFunction24/Point::y@
@@ -249,8 +248,7 @@
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -262,25 +260,24 @@
 
     .method public hidebysig virtual final 
             instance int32  CompareTo(object obj,
-                                      class [System.Runtime]System.Collections.IComparer comp) cil managed
+                                      class [mscorlib]System.Collections.IComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       134 (0x86)
       .maxstack  5
       .locals init (class TestFunction24/Point V_0,
                class TestFunction24/Point V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IComparer V_3,
+               class [mscorlib]System.Collections.IComparer V_3,
                int32 V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IComparer V_6,
+               class [mscorlib]System.Collections.IComparer V_6,
                int32 V_7,
                int32 V_8,
-               class [System.Runtime]System.Collections.IComparer V_9,
+               class [mscorlib]System.Collections.IComparer V_9,
                int32 V_10,
                int32 V_11,
-               class [System.Runtime]System.Collections.IComparer V_12,
+               class [mscorlib]System.Collections.IComparer V_12,
                int32 V_13,
                int32 V_14)
       IL_0000:  ldarg.1
@@ -369,19 +366,18 @@
     } // end of method Point::CompareTo
 
     .method public hidebysig virtual final 
-            instance int32  GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+            instance int32  GetHashCode(class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       68 (0x44)
       .maxstack  7
       .locals init (int32 V_0,
-               class [System.Runtime]System.Collections.IEqualityComparer V_1,
+               class [mscorlib]System.Collections.IEqualityComparer V_1,
                int32 V_2,
-               class [System.Runtime]System.Collections.IEqualityComparer V_3,
-               class [System.Runtime]System.Collections.IEqualityComparer V_4,
+               class [mscorlib]System.Collections.IEqualityComparer V_3,
+               class [mscorlib]System.Collections.IEqualityComparer V_4,
                int32 V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6)
+               class [mscorlib]System.Collections.IEqualityComparer V_6)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_0042
 
@@ -435,34 +431,32 @@
     .method public hidebysig virtual final 
             instance int32  GetHashCode() cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       12 (0xc)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       class [System.Runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 TestFunction24/Point::GetHashCode(class [System.Runtime]System.Collections.IEqualityComparer)
+      IL_0001:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+      IL_0006:  callvirt   instance int32 TestFunction24/Point::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } // end of method Point::GetHashCode
 
     .method public hidebysig virtual final 
             instance bool  Equals(object obj,
-                                  class [System.Runtime]System.Collections.IEqualityComparer comp) cil managed
+                                  class [mscorlib]System.Collections.IEqualityComparer comp) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       84 (0x54)
       .maxstack  4
       .locals init (class TestFunction24/Point V_0,
                class TestFunction24/Point V_1,
-               class [System.Runtime]System.Collections.IEqualityComparer V_2,
+               class [mscorlib]System.Collections.IEqualityComparer V_2,
                int32 V_3,
                int32 V_4,
-               class [System.Runtime]System.Collections.IEqualityComparer V_5,
-               class [System.Runtime]System.Collections.IEqualityComparer V_6,
+               class [mscorlib]System.Collections.IEqualityComparer V_5,
+               class [mscorlib]System.Collections.IEqualityComparer V_6,
                int32 V_7,
                int32 V_8,
-               class [System.Runtime]System.Collections.IEqualityComparer V_9)
+               class [mscorlib]System.Collections.IEqualityComparer V_9)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_004c
 
@@ -521,8 +515,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(class TestFunction24/Point obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       47 (0x2f)
       .maxstack  8
       IL_0000:  ldarg.0
@@ -561,8 +554,7 @@
     .method public hidebysig virtual final 
             instance bool  Equals(object obj) cil managed
     {
-      .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       20 (0x14)
       .maxstack  4
       .locals init (class TestFunction24/Point V_0)
@@ -634,10 +626,10 @@
     IL_001e:  ldloc.s    V_5
     IL_0020:  ldloc.s    V_6
     IL_0022:  conv.i
-    IL_0023:  sizeof     [System.Runtime]System.Int32
+    IL_0023:  sizeof     [mscorlib]System.Int32
     IL_0029:  mul
     IL_002a:  add
-    IL_002b:  ldobj      [System.Runtime]System.Int32
+    IL_002b:  ldobj      [mscorlib]System.Int32
     IL_0030:  ldloc.1
     IL_0031:  stloc.s    V_7
     IL_0033:  ldc.i4.1
@@ -649,10 +641,10 @@
     IL_003e:  ldloc.s    V_9
     IL_0040:  ldloc.s    V_10
     IL_0042:  conv.i
-    IL_0043:  sizeof     [System.Runtime]System.Int32
+    IL_0043:  sizeof     [mscorlib]System.Int32
     IL_0049:  mul
     IL_004a:  add
-    IL_004b:  ldobj      [System.Runtime]System.Int32
+    IL_004b:  ldobj      [mscorlib]System.Int32
     IL_0050:  add
     IL_0051:  ret
   } // end of method TestFunction24::pinObject
@@ -674,9 +666,9 @@
     IL_0010:  conv.i
     IL_0011:  stloc.1
     IL_0012:  ldloc.1
-    IL_0013:  ldobj      [System.Runtime]System.Int32
+    IL_0013:  ldobj      [mscorlib]System.Int32
     IL_0018:  ldloc.1
-    IL_0019:  ldobj      [System.Runtime]System.Int32
+    IL_0019:  ldobj      [mscorlib]System.Int32
     IL_001e:  add
     IL_001f:  ret
   } // end of method TestFunction24::pinRef
@@ -698,31 +690,31 @@
              native int V_10,
              int32 V_11)
     IL_0000:  ldc.i4.6
-    IL_0001:  newarr     [System.Runtime]System.Double
+    IL_0001:  newarr     [mscorlib]System.Double
     IL_0006:  dup
     IL_0007:  ldc.i4.0
     IL_0008:  ldc.r8     0.0
-    IL_0011:  stelem     [System.Runtime]System.Double
+    IL_0011:  stelem     [mscorlib]System.Double
     IL_0016:  dup
     IL_0017:  ldc.i4.1
     IL_0018:  ldc.r8     1.5
-    IL_0021:  stelem     [System.Runtime]System.Double
+    IL_0021:  stelem     [mscorlib]System.Double
     IL_0026:  dup
     IL_0027:  ldc.i4.2
     IL_0028:  ldc.r8     2.2999999999999998
-    IL_0031:  stelem     [System.Runtime]System.Double
+    IL_0031:  stelem     [mscorlib]System.Double
     IL_0036:  dup
     IL_0037:  ldc.i4.3
     IL_0038:  ldc.r8     3.3999999999999999
-    IL_0041:  stelem     [System.Runtime]System.Double
+    IL_0041:  stelem     [mscorlib]System.Double
     IL_0046:  dup
     IL_0047:  ldc.i4.4
     IL_0048:  ldc.r8     4.0999999999999996
-    IL_0051:  stelem     [System.Runtime]System.Double
+    IL_0051:  stelem     [mscorlib]System.Double
     IL_0056:  dup
     IL_0057:  ldc.i4.5
     IL_0058:  ldc.r8     5.9000000000000004
-    IL_0061:  stelem     [System.Runtime]System.Double
+    IL_0061:  stelem     [mscorlib]System.Double
     IL_0066:  stloc.0
     IL_0067:  ldloc.0
     IL_0068:  stloc.2
@@ -735,7 +727,7 @@
 
     IL_0074:  ldloc.2
     IL_0075:  ldc.i4.0
-    IL_0076:  ldelema    [System.Runtime]System.Double
+    IL_0076:  ldelema    [mscorlib]System.Double
     IL_007b:  stloc.3
     IL_007c:  ldloc.3
     IL_007d:  conv.i
@@ -762,10 +754,10 @@
     IL_0098:  ldloc.s    V_6
     IL_009a:  ldloc.s    V_7
     IL_009c:  conv.i
-    IL_009d:  sizeof     [System.Runtime]System.Double
+    IL_009d:  sizeof     [mscorlib]System.Double
     IL_00a3:  mul
     IL_00a4:  add
-    IL_00a5:  ldobj      [System.Runtime]System.Double
+    IL_00a5:  ldobj      [mscorlib]System.Double
     IL_00aa:  ldloc.1
     IL_00ab:  stloc.s    V_8
     IL_00ad:  ldc.i4.1
@@ -777,10 +769,10 @@
     IL_00b8:  ldloc.s    V_10
     IL_00ba:  ldloc.s    V_11
     IL_00bc:  conv.i
-    IL_00bd:  sizeof     [System.Runtime]System.Double
+    IL_00bd:  sizeof     [mscorlib]System.Double
     IL_00c3:  mul
     IL_00c4:  add
-    IL_00c5:  ldobj      [System.Runtime]System.Double
+    IL_00c5:  ldobj      [mscorlib]System.Double
     IL_00ca:  add
     IL_00cb:  ret
   } // end of method TestFunction24::pinArray1
@@ -801,35 +793,35 @@
              native int V_9,
              int32 V_10)
     IL_0000:  ldc.i4.6
-    IL_0001:  newarr     [System.Runtime]System.Double
+    IL_0001:  newarr     [mscorlib]System.Double
     IL_0006:  dup
     IL_0007:  ldc.i4.0
     IL_0008:  ldc.r8     0.0
-    IL_0011:  stelem     [System.Runtime]System.Double
+    IL_0011:  stelem     [mscorlib]System.Double
     IL_0016:  dup
     IL_0017:  ldc.i4.1
     IL_0018:  ldc.r8     1.5
-    IL_0021:  stelem     [System.Runtime]System.Double
+    IL_0021:  stelem     [mscorlib]System.Double
     IL_0026:  dup
     IL_0027:  ldc.i4.2
     IL_0028:  ldc.r8     2.2999999999999998
-    IL_0031:  stelem     [System.Runtime]System.Double
+    IL_0031:  stelem     [mscorlib]System.Double
     IL_0036:  dup
     IL_0037:  ldc.i4.3
     IL_0038:  ldc.r8     3.3999999999999999
-    IL_0041:  stelem     [System.Runtime]System.Double
+    IL_0041:  stelem     [mscorlib]System.Double
     IL_0046:  dup
     IL_0047:  ldc.i4.4
     IL_0048:  ldc.r8     4.0999999999999996
-    IL_0051:  stelem     [System.Runtime]System.Double
+    IL_0051:  stelem     [mscorlib]System.Double
     IL_0056:  dup
     IL_0057:  ldc.i4.5
     IL_0058:  ldc.r8     5.9000000000000004
-    IL_0061:  stelem     [System.Runtime]System.Double
+    IL_0061:  stelem     [mscorlib]System.Double
     IL_0066:  stloc.0
     IL_0067:  ldloc.0
     IL_0068:  ldc.i4.0
-    IL_0069:  ldelema    [System.Runtime]System.Double
+    IL_0069:  ldelema    [mscorlib]System.Double
     IL_006e:  stloc.2
     IL_006f:  ldloc.2
     IL_0070:  conv.i
@@ -845,10 +837,10 @@
     IL_007e:  ldloc.s    V_5
     IL_0080:  ldloc.s    V_6
     IL_0082:  conv.i
-    IL_0083:  sizeof     [System.Runtime]System.Double
+    IL_0083:  sizeof     [mscorlib]System.Double
     IL_0089:  mul
     IL_008a:  add
-    IL_008b:  ldobj      [System.Runtime]System.Double
+    IL_008b:  ldobj      [mscorlib]System.Double
     IL_0090:  ldloc.1
     IL_0091:  stloc.s    V_7
     IL_0093:  ldc.i4.1
@@ -860,15 +852,15 @@
     IL_009e:  ldloc.s    V_9
     IL_00a0:  ldloc.s    V_10
     IL_00a2:  conv.i
-    IL_00a3:  sizeof     [System.Runtime]System.Double
+    IL_00a3:  sizeof     [mscorlib]System.Double
     IL_00a9:  mul
     IL_00aa:  add
-    IL_00ab:  ldobj      [System.Runtime]System.Double
+    IL_00ab:  ldobj      [mscorlib]System.Double
     IL_00b0:  add
     IL_00b1:  ret
   } // end of method TestFunction24::pinArray2
 
-  .method public static class [System.Runtime]System.Tuple`2<char,char> 
+  .method public static class [mscorlib]System.Tuple`2<char,char> 
           pinString() cil managed
   {
     // Code size       93 (0x5d)
@@ -893,7 +885,7 @@
 
     IL_000b:  ldloc.2
     IL_000c:  conv.i
-    IL_000d:  call       int32 [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::get_OffsetToStringData()
+    IL_000d:  call       int32 [mscorlib]System.Runtime.CompilerServices.RuntimeHelpers::get_OffsetToStringData()
     IL_0012:  add
     IL_0013:  nop
     IL_0014:  br.s       IL_0018
@@ -912,10 +904,10 @@
     IL_0025:  ldloc.s    V_5
     IL_0027:  ldloc.s    V_6
     IL_0029:  conv.i
-    IL_002a:  sizeof     [System.Runtime]System.Char
+    IL_002a:  sizeof     [mscorlib]System.Char
     IL_0030:  mul
     IL_0031:  add
-    IL_0032:  ldobj      [System.Runtime]System.Char
+    IL_0032:  ldobj      [mscorlib]System.Char
     IL_0037:  ldloc.1
     IL_0038:  stloc.s    V_7
     IL_003a:  ldc.i4.1
@@ -927,19 +919,19 @@
     IL_0045:  ldloc.s    V_9
     IL_0047:  ldloc.s    V_10
     IL_0049:  conv.i
-    IL_004a:  sizeof     [System.Runtime]System.Char
+    IL_004a:  sizeof     [mscorlib]System.Char
     IL_0050:  mul
     IL_0051:  add
-    IL_0052:  ldobj      [System.Runtime]System.Char
-    IL_0057:  newobj     instance void class [System.Runtime]System.Tuple`2<char,char>::.ctor(!0,
-                                                                                              !1)
+    IL_0052:  ldobj      [mscorlib]System.Char
+    IL_0057:  newobj     instance void class [mscorlib]System.Tuple`2<char,char>::.ctor(!0,
+                                                                                        !1)
     IL_005c:  ret
   } // end of method TestFunction24::pinString
 
 } // end of class TestFunction24
 
 .class private abstract auto ansi sealed '<StartupCode$TestFunction24>'.$TestFunction24
-       extends [System.Runtime]System.Object
+       extends [mscorlib]System.Object
 {
   .method public static void  main@() cil managed
   {
@@ -955,4 +947,4 @@
 // =============================================================
 
 // *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file C:\dev\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net6.0\tests\EmittedIL\TestFunctions\TestFunction24_fs\TestFunction24.res
+// WARNING: Created Win32 resource file C:\kevinransom\fsharp\artifacts\bin\FSharp.Compiler.ComponentTests\Debug\net472\tests\EmittedIL\TestFunctions\TestFunction24_fs\TestFunction24.res


### PR DESCRIPTION
Recent PR's have required updated baselines, these were done for the release build because that's what the CI needs, however, various debug build baselines were overlooked.

This fixes that.