### PR TITLE
Remove 'Compiling to a dynamic assembly' section from docs

### DIFF
--- a/docs/fcs/compiler.fsx
+++ b/docs/fcs/compiler.fsx
@@ -81,28 +81,3 @@ let x = 1.0 + "" // a type error
 let errors1b, exitCode1b = 
     checker.Compile([| "fsc.exe"; "-o"; fn3; "-a"; fn2 |])
     |> Async.RunSynchronously
-
-(**
-
-Compiling to a dynamic assembly
-===============================
-
-You can also compile to a dynamic assembly, which uses the F# Interactive code generator.
-This can be useful if you are, for example, in a situation where writing to the file system
-is not really an option.
-
-You still have to pass the "-o" option to name the output file, but the output file is not actually written to disk.
-
-The 'None' option indicates that the initialization code for the assembly is not executed. 
-*)
-let errors2, exitCode2, dynAssembly2 = 
-    checker.CompileToDynamicAssembly([| "-o"; fn3; "-a"; fn2 |], execute=None)
-     |> Async.RunSynchronously
-
-(*
-Passing 'Some' for the 'execute' parameter executes  the initialization code for the assembly.
-*)
-let errors3, exitCode3, dynAssembly3 = 
-    checker.CompileToDynamicAssembly([| "-o"; fn3; "-a"; fn2 |], Some(stdout,stderr))
-     |> Async.RunSynchronously
-


### PR DESCRIPTION
The codepath for 'Compiling to a dynamic assembly' mentioned in this doc has been removed to prevent newcomers to trying it.

As the original issue https://github.com/dotnet/fsharp/issues/13242 suggests, usage of this API was deemed to be zero (this turned out to be incorrect). In such a case, I believe leaving this section with commentary about removal and alternatives would do more harm than good.
Compilation to a file is already covered and is the commended way, alongside to hosted FSI API where that might be relevant.