### PR TITLE
SyntaxTreeTests: use short ranges

### DIFF
--- a/src/Compiler/Optimize/LowerStateMachines.fs
+++ b/src/Compiler/Optimize/LowerStateMachines.fs
@@ -447,7 +447,7 @@ type LowerStateMachine(g: TcGlobals) =
         let res = 
             match expr with 
             | ResumableCodeInvoke g (_, _, _, m, _) ->
-                Result.Error (FSComp.SR.reprResumableCodeInvokeNotReduced(m.ToShortString()))
+                Result.Error (FSComp.SR.reprResumableCodeInvokeNotReduced(m.ToString()))
 
             // Eliminate 'if __useResumableCode ...' within.  
             | IfUseResumableStateMachinesExpr g (thenExpr, _) -> 

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -220,7 +220,7 @@ module SyntaxTraversal =
 #endif
             if not isOrdered then
                 let s =
-                    sprintf "ServiceParseTreeWalk: not isOrdered: %A" (diveResults |> List.map (fun (r, _) -> r.ToShortString()))
+                    sprintf "ServiceParseTreeWalk: not isOrdered: %A" (diveResults |> List.map (fun (r, _) -> r.ToString()))
 
                 ignore s
             //System.Diagnostics.Debug.Assert(false, s)
@@ -237,8 +237,8 @@ module SyntaxTraversal =
                 let s =
                     sprintf
                         "ServiceParseTreeWalk: not outerContainsInner: %A : %A"
-                        (outerRange.ToShortString())
-                        (diveResults |> List.map (fun (r, _) -> r.ToShortString()))
+                        (outerRange.ToString())
+                        (diveResults |> List.map (fun (r, _) -> r.ToString()))
 
                 ignore s
             //System.Diagnostics.Debug.Assert(false, s)

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -4831,7 +4831,7 @@ type Expr =
         | WitnessArg _  -> "WitnessArg(..)"
         | TyChoose _ -> "TyChoose(..)"
         | Link e -> "Link(" + e.Value.ToDebugString(depth) + ")"
-        | DebugPoint (DebugPointAtLeafExpr.Yes m, e) -> sprintf "DebugPoint(%s, " (m.ToShortString()) + e.ToDebugString(depth) + ")"
+        | DebugPoint (DebugPointAtLeafExpr.Yes m, e) -> sprintf "DebugPoint(%s, " (m.ToString()) + e.ToDebugString(depth) + ")"
 
     /// Get the mark/range/position information from an expression
     member expr.Range =

--- a/src/Compiler/Utilities/range.fs
+++ b/src/Compiler/Utilities/range.fs
@@ -387,7 +387,7 @@ type Range(code1: int64, code2: int64) =
         hash code1 + hash code2
 
     override r.ToString() =
-        sprintf "%s (%d,%d--%d,%d)" r.FileName r.StartLine r.StartColumn r.EndLine r.EndColumn
+        sprintf "(%d,%d--%d,%d)" r.StartLine r.StartColumn r.EndLine r.EndColumn
 
 and range = Range
 

--- a/src/Compiler/Utilities/range.fs
+++ b/src/Compiler/Utilities/range.fs
@@ -369,9 +369,6 @@ type Range(code1: int64, code2: int64) =
             with e ->
                 e.ToString()
 
-    member m.ToShortString() =
-        sprintf "(%d,%d--%d,%d)" m.StartLine m.StartColumn m.EndLine m.EndColumn
-
     member _.Equals(m2: range) =
         let code2 = code2 &&& ~~~(debugPointKindMask ||| isSyntheticMask)
         let rcode2 = m2.Code2 &&& ~~~(debugPointKindMask ||| isSyntheticMask)

--- a/src/Compiler/Utilities/range.fsi
+++ b/src/Compiler/Utilities/range.fsi
@@ -120,9 +120,6 @@ type Range =
     /// Check if the range is adjacent to another range
     member internal IsAdjacentTo: otherRange: Range -> bool
 
-    /// Convert a range to string
-    member internal ToShortString: unit -> string
-
     /// The range where all values are zero
     static member Zero: range
   

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -372,7 +372,7 @@ let inline dumpDiagnostics (results: FSharpCheckFileResults) =
             e.Message.Split('\n')
             |> Array.map (fun s -> s.Trim())
             |> String.concat " "
-        sprintf "%s: %s" (e.Range.ToShortString()) message)
+        sprintf "%s: %s" (e.Range.ToString()) message)
     |> List.ofArray
 
 let getSymbolUses (results: FSharpCheckFileResults) =

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -215,9 +215,9 @@ module internal Utils =
                     //printfn "%s" v.CompiledName
 //                 try
                     if v.IsMember then
-                        sprintf "member %s%s = %s @ %s" v.CompiledName (printCurriedParams vs)  (printExpr 0 e) (e.Range.ToShortString())
+                        sprintf "member %s%s = %s @ %s" v.CompiledName (printCurriedParams vs)  (printExpr 0 e) (e.Range.ToString())
                     else
-                        sprintf "let %s%s = %s @ %s" v.CompiledName (printCurriedParams vs) (printExpr 0 e) (e.Range.ToShortString())
+                        sprintf "let %s%s = %s @ %s" v.CompiledName (printCurriedParams vs) (printExpr 0 e) (e.Range.ToString())
 //                 with e ->
 //                     printfn "FAILURE STACK: %A" e
 //                     sprintf "!!!!!!!!!! FAILED on %s @ %s, message: %s" v.CompiledName (v.DeclarationLocation.ToString()) e.Message

--- a/tests/service/data/SyntaxTree/Attribute/RangeOfAttribute.fs.bsl
+++ b/tests/service/data/SyntaxTree/Attribute/RangeOfAttribute.fs.bsl
@@ -18,29 +18,16 @@ ImplFile
                                   SynLongIdent
                                     ([op_Equality], [],
                                      [Some (OriginalNotation "=")]), None,
-                                  /root/Attribute/RangeOfAttribute.fs (2,18--2,19)),
-                               Ident foo,
-                               /root/Attribute/RangeOfAttribute.fs (2,14--2,19)),
+                                  (2,18--2,19)), Ident foo, (2,14--2,19)),
                             Const
-                              (String
-                                 ("bar", Regular,
-                                  /root/Attribute/RangeOfAttribute.fs (2,19--2,24)),
-                               /root/Attribute/RangeOfAttribute.fs (2,19--2,24)),
-                            /root/Attribute/RangeOfAttribute.fs (2,14--2,24)),
-                         /root/Attribute/RangeOfAttribute.fs (2,13--2,14),
-                         Some /root/Attribute/RangeOfAttribute.fs (2,24--2,25),
-                         /root/Attribute/RangeOfAttribute.fs (2,13--2,25))
+                              (String ("bar", Regular, (2,19--2,24)),
+                               (2,19--2,24)), (2,14--2,24)), (2,13--2,14),
+                         Some (2,24--2,25), (2,13--2,25))
                      Target = None
                      AppliesToGetterAndSetter = false
-                     Range = /root/Attribute/RangeOfAttribute.fs (2,2--2,25) }]
-                 Range = /root/Attribute/RangeOfAttribute.fs (2,0--2,27) }],
-              /root/Attribute/RangeOfAttribute.fs (2,0--2,27));
-           Expr
-             (Do
-                (Const (Unit, /root/Attribute/RangeOfAttribute.fs (3,3--3,5)),
-                 /root/Attribute/RangeOfAttribute.fs (3,0--3,5)),
-              /root/Attribute/RangeOfAttribute.fs (3,0--3,5))], PreXmlDocEmpty,
-          [], None, /root/Attribute/RangeOfAttribute.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                     Range = (2,2--2,25) }]
+                 Range = (2,0--2,27) }], (2,0--2,27));
+           Expr (Do (Const (Unit, (3,3--3,5)), (3,0--3,5)), (3,0--3,5))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Attribute/RangeOfAttributeWithPath.fs.bsl
+++ b/tests/service/data/SyntaxTree/Attribute/RangeOfAttributeWithPath.fs.bsl
@@ -8,9 +8,7 @@ ImplFile
              ([{ Attributes =
                   [{ TypeName =
                       SynLongIdent
-                        ([Prefix; MyAttribute],
-                         [/root/Attribute/RangeOfAttributeWithPath.fs (2,8--2,9)],
-                         [None; None])
+                        ([Prefix; MyAttribute], [(2,8--2,9)], [None; None])
                      ArgExpr =
                       Paren
                         (App
@@ -22,33 +20,16 @@ ImplFile
                                   SynLongIdent
                                     ([op_Equality], [],
                                      [Some (OriginalNotation "=")]), None,
-                                  /root/Attribute/RangeOfAttributeWithPath.fs (2,25--2,26)),
-                               Ident foo,
-                               /root/Attribute/RangeOfAttributeWithPath.fs (2,21--2,26)),
+                                  (2,25--2,26)), Ident foo, (2,21--2,26)),
                             Const
-                              (String
-                                 ("bar", Regular,
-                                  /root/Attribute/RangeOfAttributeWithPath.fs (2,26--2,31)),
-                               /root/Attribute/RangeOfAttributeWithPath.fs (2,26--2,31)),
-                            /root/Attribute/RangeOfAttributeWithPath.fs (2,21--2,31)),
-                         /root/Attribute/RangeOfAttributeWithPath.fs (2,20--2,21),
-                         Some
-                           /root/Attribute/RangeOfAttributeWithPath.fs (2,31--2,32),
-                         /root/Attribute/RangeOfAttributeWithPath.fs (2,20--2,32))
+                              (String ("bar", Regular, (2,26--2,31)),
+                               (2,26--2,31)), (2,21--2,31)), (2,20--2,21),
+                         Some (2,31--2,32), (2,20--2,32))
                      Target = None
                      AppliesToGetterAndSetter = false
-                     Range =
-                      /root/Attribute/RangeOfAttributeWithPath.fs (2,2--2,32) }]
-                 Range = /root/Attribute/RangeOfAttributeWithPath.fs (2,0--2,34) }],
-              /root/Attribute/RangeOfAttributeWithPath.fs (2,0--2,34));
-           Expr
-             (Do
-                (Const
-                   (Unit, /root/Attribute/RangeOfAttributeWithPath.fs (3,3--3,5)),
-                 /root/Attribute/RangeOfAttributeWithPath.fs (3,0--3,5)),
-              /root/Attribute/RangeOfAttributeWithPath.fs (3,0--3,5))],
-          PreXmlDocEmpty, [], None,
-          /root/Attribute/RangeOfAttributeWithPath.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                     Range = (2,2--2,32) }]
+                 Range = (2,0--2,34) }], (2,0--2,34));
+           Expr (Do (Const (Unit, (3,3--3,5)), (3,0--3,5)), (3,0--3,5))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Attribute/RangeOfAttributeWithTarget.fs.bsl
+++ b/tests/service/data/SyntaxTree/Attribute/RangeOfAttributeWithTarget.fs.bsl
@@ -18,35 +18,16 @@ ImplFile
                                   SynLongIdent
                                     ([op_Equality], [],
                                      [Some (OriginalNotation "=")]), None,
-                                  /root/Attribute/RangeOfAttributeWithTarget.fs (2,28--2,29)),
-                               Ident foo,
-                               /root/Attribute/RangeOfAttributeWithTarget.fs (2,24--2,29)),
+                                  (2,28--2,29)), Ident foo, (2,24--2,29)),
                             Const
-                              (String
-                                 ("bar", Regular,
-                                  /root/Attribute/RangeOfAttributeWithTarget.fs (2,29--2,34)),
-                               /root/Attribute/RangeOfAttributeWithTarget.fs (2,29--2,34)),
-                            /root/Attribute/RangeOfAttributeWithTarget.fs (2,24--2,34)),
-                         /root/Attribute/RangeOfAttributeWithTarget.fs (2,23--2,24),
-                         Some
-                           /root/Attribute/RangeOfAttributeWithTarget.fs (2,34--2,35),
-                         /root/Attribute/RangeOfAttributeWithTarget.fs (2,23--2,35))
+                              (String ("bar", Regular, (2,29--2,34)),
+                               (2,29--2,34)), (2,24--2,34)), (2,23--2,24),
+                         Some (2,34--2,35), (2,23--2,35))
                      Target = Some assembly
                      AppliesToGetterAndSetter = false
-                     Range =
-                      /root/Attribute/RangeOfAttributeWithTarget.fs (2,2--2,35) }]
-                 Range =
-                  /root/Attribute/RangeOfAttributeWithTarget.fs (2,0--2,37) }],
-              /root/Attribute/RangeOfAttributeWithTarget.fs (2,0--2,37));
-           Expr
-             (Do
-                (Const
-                   (Unit,
-                    /root/Attribute/RangeOfAttributeWithTarget.fs (3,3--3,5)),
-                 /root/Attribute/RangeOfAttributeWithTarget.fs (3,0--3,5)),
-              /root/Attribute/RangeOfAttributeWithTarget.fs (3,0--3,5))],
-          PreXmlDocEmpty, [], None,
-          /root/Attribute/RangeOfAttributeWithTarget.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                     Range = (2,2--2,35) }]
+                 Range = (2,0--2,37) }], (2,0--2,37));
+           Expr (Do (Const (Unit, (3,3--3,5)), (3,0--3,5)), (3,0--3,5))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs.bsl
@@ -16,43 +16,23 @@ ImplFile
                         SynArgInfo ([], false, None)), None),
                   LongIdent
                     (SynLongIdent ([x], [], [None]), None, None,
-                     Pats
-                       [Named
-                          (SynIdent (y, None), false, None,
-                           /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,6--2,7))],
-                     None,
-                     /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,4--2,7)),
+                     Pats [Named (SynIdent (y, None), false, None, (2,6--2,7))],
+                     None, (2,4--2,7)),
                   Some
                     (SynBindingReturnInfo
                        (LongIdent (SynLongIdent ([int], [], [None])),
-                        /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,10--2,13),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,8--2,9) })),
+                        (2,10--2,13), [], { ColonRange = Some (2,8--2,9) })),
                   Typed
                     (App
                        (NonAtomic, false, Ident failwith,
                         Const
-                          (String
-                             ("todo", Regular,
-                              /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,25--2,31)),
-                           /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,25--2,31)),
-                        /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,16--2,31)),
-                     LongIdent (SynLongIdent ([int], [], [None])),
-                     /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,16--2,31)),
-                  /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,4--2,7),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,14--2,15) })],
-              /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,0--2,31))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/ColonBeforeReturnTypeIsPartOfTrivia.fs (2,0--3,0),
+                          (String ("todo", Regular, (2,25--2,31)), (2,25--2,31)),
+                        (2,16--2,31)),
+                     LongIdent (SynLongIdent ([int], [], [None])), (2,16--2,31)),
+                  (2,4--2,7), NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                                           InlineKeyword = None
+                                           EqualsRange = Some (2,14--2,15) })],
+              (2,0--2,31))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs.bsl
@@ -10,8 +10,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [GetSetMember
@@ -33,41 +32,25 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; Y],
-                                     [/root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,15--3,16)],
-                                     [None; None]), Some get, None,
+                                    ([this; Y], [(3,15--3,16)], [None; None]),
+                                  Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,26--3,28)),
-                                        /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,26--3,28))],
-                                  None,
-                                  /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,23--3,28)),
+                                       (Const (Unit, (3,26--3,28)), (3,26--3,28))],
+                                  None, (3,23--3,28)),
                                Some
                                  (SynBindingReturnInfo
                                     (LongIdent
                                        (SynLongIdent ([int], [], [None])),
-                                     /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,29--3,32),
-                                     [],
-                                     { ColonRange =
-                                        Some
-                                          /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,28--3,29) })),
+                                     (3,29--3,32), [],
+                                     { ColonRange = Some (3,28--3,29) })),
                                Typed
-                                 (Const
-                                    (Int32 1,
-                                     /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,35--3,36)),
+                                 (Const (Int32 1, (3,35--3,36)),
                                   LongIdent (SynLongIdent ([int], [], [None])),
-                                  /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,35--3,36)),
-                               /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,23--3,28),
-                               NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,4--3,10)
+                                  (3,35--3,36)), (3,23--3,28), NoneAtInvisible,
+                               { LeadingKeyword = Member (3,4--3,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,33--3,34) })),
+                                 EqualsRange = Some (3,33--3,34) })),
                          Some
                            (SynBinding
                               (None, Normal, false, false, [],
@@ -87,70 +70,38 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; Y],
-                                     [/root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,15--3,16)],
-                                     [None; None]), Some set, None,
+                                    ([this; Y], [(3,15--3,16)], [None; None]),
+                                  Some set, None,
                                   Pats
                                     [Paren
                                        (Typed
-                                          (Wild
-                                             /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,46--3,47),
+                                          (Wild (3,46--3,47),
                                            LongIdent
                                              (SynLongIdent ([int], [], [None])),
-                                           /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,46--3,51)),
-                                        /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,45--3,52))],
-                                  None,
-                                  /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,41--3,52)),
+                                           (3,46--3,51)), (3,45--3,52))], None,
+                                  (3,41--3,52)),
                                Some
                                  (SynBindingReturnInfo
                                     (LongIdent
                                        (SynLongIdent ([unit], [], [None])),
-                                     /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,53--3,57),
-                                     [],
-                                     { ColonRange =
-                                        Some
-                                          /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,52--3,53) })),
+                                     (3,53--3,57), [],
+                                     { ColonRange = Some (3,52--3,53) })),
                                Typed
-                                 (Const
-                                    (Unit,
-                                     /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,60--3,62)),
+                                 (Const (Unit, (3,60--3,62)),
                                   LongIdent (SynLongIdent ([unit], [], [None])),
-                                  /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,60--3,62)),
-                               /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,41--3,52),
-                               NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,4--3,10)
+                                  (3,60--3,62)), (3,41--3,52), NoneAtInvisible,
+                               { LeadingKeyword = Member (3,4--3,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,58--3,59) })),
-                         /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,4--3,62),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,18--3,22)
-                           GetKeyword =
-                            Some
-                              /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,23--3,26)
-                           AndKeyword =
-                            Some
-                              /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,37--3,40)
-                           SetKeyword =
-                            Some
-                              /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,41--3,44) })],
-                     /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (3,4--3,62)),
-                  [], None,
-                  /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (2,5--3,62),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (2,0--3,62))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/ColonBeforeReturnTypeIsPartOfTriviaInProperties.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                                 EqualsRange = Some (3,58--3,59) })),
+                         (3,4--3,62), { InlineKeyword = None
+                                        WithKeyword = (3,18--3,22)
+                                        GetKeyword = Some (3,23--3,26)
+                                        AndKeyword = Some (3,37--3,40)
+                                        SetKeyword = Some (3,41--3,44) })],
+                     (3,4--3,62)), [], None, (2,5--3,62),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,62))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/ConditionalDirectiveAroundInlineKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/ConditionalDirectiveAroundInlineKeyword.fs.bsl
@@ -18,15 +18,9 @@ ImplFile
                   LongIdent
                     (SynLongIdent ([map], [], [None]), None, None,
                      Pats
-                       [Named
-                          (SynIdent (f, None), false, None,
-                           /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,8--6,9));
-                        Named
-                          (SynIdent (ar, None), false, None,
-                           /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,10--6,12))],
-                     None,
-                     /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,4--6,12)),
-                  None,
+                       [Named (SynIdent (f, None), false, None, (6,8--6,9));
+                        Named (SynIdent (ar, None), false, None, (6,10--6,12))],
+                     None, (6,4--6,12)), None,
                   App
                     (NonAtomic, false,
                      App
@@ -34,48 +28,23 @@ ImplFile
                         LongIdent
                           (false,
                            SynLongIdent
-                             ([Async; map],
-                              [/root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,20--6,21)],
-                              [None; None]), None,
-                           /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,15--6,24)),
+                             ([Async; map], [(6,20--6,21)], [None; None]), None,
+                           (6,15--6,24)),
                         Paren
                           (App
                              (NonAtomic, false,
                               LongIdent
                                 (false,
                                  SynLongIdent
-                                   ([Result; map],
-                                    [/root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,32--6,33)],
-                                    [None; None]), None,
-                                 /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,26--6,36)),
-                              Ident f,
-                              /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,26--6,38)),
-                           /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,25--6,26),
-                           Some
-                             /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,38--6,39),
-                           /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,25--6,39)),
-                        /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,15--6,39)),
-                     Ident ar,
-                     /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,15--6,42)),
-                  /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,4--6,12),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (2,0--2,3)
-                    InlineKeyword =
-                     Some
-                       /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (4,4--4,10)
-                    EqualsRange =
-                     Some
-                       /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (6,13--6,14) })],
-              /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (2,0--6,42))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
+                                   ([Result; map], [(6,32--6,33)], [None; None]),
+                                 None, (6,26--6,36)), Ident f, (6,26--6,38)),
+                           (6,25--6,26), Some (6,38--6,39), (6,25--6,39)),
+                        (6,15--6,39)), Ident ar, (6,15--6,42)), (6,4--6,12),
+                  NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                               InlineKeyword = Some (4,4--4,10)
+                               EqualsRange = Some (6,13--6,14) })], (2,0--6,42))],
+          PreXmlDocEmpty, [], None, (2,0--7,0), { LeadingKeyword = None })],
+      (true, false),
       { ConditionalDirectives =
-         [If
-            (Not (Ident "FOO"),
-             /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (3,0--3,8));
-          EndIf
-            /root/Binding/ConditionalDirectiveAroundInlineKeyword.fs (5,0--5,6)]
+         [If (Not (Ident "FOO"), (3,0--3,8)); EndIf (5,0--5,6)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/InlineKeywordInBinding.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/InlineKeywordInBinding.fs.bsl
@@ -18,14 +18,9 @@ ImplFile
                   LongIdent
                     (SynLongIdent ([x], [], [None]), None, None,
                      Pats
-                       [Named
-                          (SynIdent (y, None), false, None,
-                           /root/Binding/InlineKeywordInBinding.fs (2,13--2,14));
-                        Named
-                          (SynIdent (z, None), false, None,
-                           /root/Binding/InlineKeywordInBinding.fs (2,15--2,16))],
-                     None, /root/Binding/InlineKeywordInBinding.fs (2,11--2,16)),
-                  None,
+                       [Named (SynIdent (y, None), false, None, (2,13--2,14));
+                        Named (SynIdent (z, None), false, None, (2,15--2,16))],
+                     None, (2,11--2,16)), None,
                   LetOrUse
                     (false, false,
                      [SynBinding
@@ -41,43 +36,19 @@ ImplFile
                            (SynLongIdent ([a], [], [None]), None, None,
                             Pats
                               [Named
-                                 (SynIdent (b, None), false, None,
-                                  /root/Binding/InlineKeywordInBinding.fs (3,17--3,18));
+                                 (SynIdent (b, None), false, None, (3,17--3,18));
                                Named
-                                 (SynIdent (c, None), false, None,
-                                  /root/Binding/InlineKeywordInBinding.fs (3,19--3,20))],
-                            None,
-                            /root/Binding/InlineKeywordInBinding.fs (3,15--3,20)),
-                         None,
-                         Const
-                           (Unit,
-                            /root/Binding/InlineKeywordInBinding.fs (3,23--3,25)),
-                         /root/Binding/InlineKeywordInBinding.fs (3,15--3,20),
-                         NoneAtLet,
-                         { LeadingKeyword =
-                            Let
-                              /root/Binding/InlineKeywordInBinding.fs (3,4--3,7)
-                           InlineKeyword =
-                            Some
-                              /root/Binding/InlineKeywordInBinding.fs (3,8--3,14)
-                           EqualsRange =
-                            Some
-                              /root/Binding/InlineKeywordInBinding.fs (3,21--3,22) })],
-                     Const
-                       (Unit, /root/Binding/InlineKeywordInBinding.fs (4,4--4,6)),
-                     /root/Binding/InlineKeywordInBinding.fs (3,4--4,6),
-                     { InKeyword = None }),
-                  /root/Binding/InlineKeywordInBinding.fs (2,11--2,16),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let /root/Binding/InlineKeywordInBinding.fs (2,0--2,3)
-                    InlineKeyword =
-                     Some /root/Binding/InlineKeywordInBinding.fs (2,4--2,10)
-                    EqualsRange =
-                     Some /root/Binding/InlineKeywordInBinding.fs (2,17--2,18) })],
-              /root/Binding/InlineKeywordInBinding.fs (2,0--4,6))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/InlineKeywordInBinding.fs (2,0--5,0),
+                                 (SynIdent (c, None), false, None, (3,19--3,20))],
+                            None, (3,15--3,20)), None,
+                         Const (Unit, (3,23--3,25)), (3,15--3,20), NoneAtLet,
+                         { LeadingKeyword = Let (3,4--3,7)
+                           InlineKeyword = Some (3,8--3,14)
+                           EqualsRange = Some (3,21--3,22) })],
+                     Const (Unit, (4,4--4,6)), (3,4--4,6), { InKeyword = None }),
+                  (2,11--2,16), NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                                             InlineKeyword = Some (2,4--2,10)
+                                             EqualsRange = Some (2,17--2,18) })],
+              (2,0--4,6))], PreXmlDocEmpty, [], None, (2,0--5,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs.bsl
@@ -14,16 +14,11 @@ ImplFile
                  (None, Normal, false, false,
                   [{ Attributes =
                       [{ TypeName = SynLongIdent ([Literal], [], [None])
-                         ArgExpr =
-                          Const
-                            (Unit,
-                             /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,6--2,13))
+                         ArgExpr = Const (Unit, (2,6--2,13))
                          Target = None
                          AppliesToGetterAndSetter = false
-                         Range =
-                          /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,6--2,13) }]
-                     Range =
-                      /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,4--2,15) }],
+                         Range = (2,6--2,13) }]
+                     Range = (2,4--2,15) }],
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
@@ -31,29 +26,12 @@ ImplFile
                     (LongIdent
                        (SynLongIdent ([A], [], [None]), None, None,
                         Pats
-                          [Named
-                             (SynIdent (x, None), false, None,
-                              /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,19--2,20))],
-                        None,
-                        /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,17--2,20)),
-                     /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,16--2,21)),
-                  None,
-                  Const
-                    (Int32 1,
-                     /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,24--2,25)),
-                  /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,4--2,21),
-                  Yes
-                    /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,0--2,25),
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,0--2,3)
+                          [Named (SynIdent (x, None), false, None, (2,19--2,20))],
+                        None, (2,17--2,20)), (2,16--2,21)), None,
+                  Const (Int32 1, (2,24--2,25)), (2,4--2,21), Yes (2,0--2,25),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,22--2,23) })],
-              /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,0--2,25))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeBetweenLetKeywordAndPatternShouldBeIncludedInSynModuleDeclLet.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,22--2,23) })], (2,0--2,25))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs.bsl
@@ -11,32 +11,18 @@ ImplFile
              (ObjExpr
                 (LongIdent
                    (SynLongIdent
-                      ([System; Object],
-                       [/root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (2,12--2,13)],
-                       [None; None])),
-                 Some
-                   (Const
-                      (Unit,
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (2,19--2,21)),
-                    None),
-                 Some
-                   /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (2,22--2,26),
-                 [],
+                      ([System; Object], [(2,12--2,13)], [None; None])),
+                 Some (Const (Unit, (2,19--2,21)), None), Some (2,22--2,26), [],
                  [Member
                     (SynBinding
                        (None, Normal, false, false,
                         [{ Attributes =
                             [{ TypeName = SynLongIdent ([Foo], [], [None])
-                               ArgExpr =
-                                Const
-                                  (Unit,
-                                   /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (3,6--3,9))
+                               ArgExpr = Const (Unit, (3,6--3,9))
                                Target = None
                                AppliesToGetterAndSetter = false
-                               Range =
-                                /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (3,6--3,9) }]
-                           Range =
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (3,4--3,11) }],
+                               Range = (3,6--3,9) }]
+                           Range = (3,4--3,11) }],
                         PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
                         SynValData
                           (Some { IsInstance = true
@@ -50,39 +36,18 @@ ImplFile
                               SynArgInfo ([], false, None)), None),
                         LongIdent
                           (SynLongIdent
-                             ([x; ToString],
-                              [/root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (4,12--4,13)],
-                              [None; None]), None, None,
-                           Pats
-                             [Paren
-                                (Const
-                                   (Unit,
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (4,21--4,23)),
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (4,21--4,23))],
+                             ([x; ToString], [(4,12--4,13)], [None; None]), None,
                            None,
-                           /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (4,11--4,23)),
-                        None,
+                           Pats
+                             [Paren (Const (Unit, (4,21--4,23)), (4,21--4,23))],
+                           None, (4,11--4,23)), None,
                         Const
-                          (String
-                             ("F#", Regular,
-                              /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (4,26--4,30)),
-                           /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (4,26--4,30)),
-                        /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (3,4--4,23),
-                        NoneAtInvisible,
-                        { LeadingKeyword =
-                           Member
-                             /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (4,4--4,10)
+                          (String ("F#", Regular, (4,26--4,30)), (4,26--4,30)),
+                        (3,4--4,23), NoneAtInvisible,
+                        { LeadingKeyword = Member (4,4--4,10)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (4,24--4,25) }),
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (3,4--4,30))],
-                 [],
-                 /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (2,2--2,21),
-                 /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (2,0--4,32)),
-              /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (2,0--4,32))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInBindingOfSynExprObjExpr.fs (2,0--4,32),
-          { LeadingKeyword = None })], (true, false),
+                          EqualsRange = Some (4,24--4,25) }), (3,4--4,30))], [],
+                 (2,2--2,21), (2,0--4,32)), (2,0--4,32))], PreXmlDocEmpty, [],
+          None, (2,0--4,32), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs.bsl
@@ -12,8 +12,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Tiger],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (2,5--2,10)),
+                     false, None, (2,5--2,10)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -21,16 +20,11 @@ ImplFile
                            (None, Normal, false, false,
                             [{ Attributes =
                                 [{ TypeName = SynLongIdent ([Foo], [], [None])
-                                   ArgExpr =
-                                    Const
-                                      (Unit,
-                                       /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (3,6--3,9))
+                                   ArgExpr = Const (Unit, (3,6--3,9))
                                    Target = None
                                    AppliesToGetterAndSetter = false
-                                   Range =
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (3,6--3,9) }]
-                               Range =
-                                /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (3,4--3,11) }],
+                                   Range = (3,6--3,9) }]
+                               Range = (3,4--3,11) }],
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
                             SynValData
                               (Some { IsInstance = false
@@ -45,40 +39,16 @@ ImplFile
                               (SynLongIdent ([new], [], [None]), None,
                                Some (SynValTyparDecls (None, false)),
                                Pats
-                                 [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (4,8--4,10)),
-                                     /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (4,8--4,10))],
-                               None,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (4,4--4,7)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (4,13--4,15)),
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (3,4--4,10),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               New
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (4,4--4,7)
-                              InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (4,11--4,12) }),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (3,4--4,15))],
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (3,4--4,15)),
-                  [], None,
-                  /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (2,5--4,15),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (2,0--4,15))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMember.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                                 [Paren (Const (Unit, (4,8--4,10)), (4,8--4,10))],
+                               None, (4,4--4,7)), None,
+                            Const (Unit, (4,13--4,15)), (3,4--4,10),
+                            NoneAtInvisible, { LeadingKeyword = New (4,4--4,7)
+                                               InlineKeyword = None
+                                               EqualsRange = Some (4,11--4,12) }),
+                         (3,4--4,15))], (3,4--4,15)), [], None, (2,5--4,15),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--4,15))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs.bsl
@@ -13,8 +13,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Tiger],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (2,5--2,10)),
+                     false, None, (2,5--2,10)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -22,16 +21,11 @@ ImplFile
                            (None, Normal, false, false,
                             [{ Attributes =
                                 [{ TypeName = SynLongIdent ([Foo], [], [None])
-                                   ArgExpr =
-                                    Const
-                                      (Unit,
-                                       /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (3,6--3,9))
+                                   ArgExpr = Const (Unit, (3,6--3,9))
                                    Target = None
                                    AppliesToGetterAndSetter = false
-                                   Range =
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (3,6--3,9) }]
-                               Range =
-                                /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (3,4--3,11) }],
+                                   Range = (3,6--3,9) }]
+                               Range = (3,4--3,11) }],
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
                             SynValData
                               (Some { IsInstance = false
@@ -46,40 +40,16 @@ ImplFile
                               (SynLongIdent ([new], [], [None]), None,
                                Some (SynValTyparDecls (None, false)),
                                Pats
-                                 [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (4,8--4,10)),
-                                     /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (4,8--4,10))],
-                               None,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (4,4--4,7)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (4,21--4,23)),
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (3,4--4,18),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               New
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (4,4--4,7)
-                              InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (4,19--4,20) }),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (3,4--4,23))],
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (3,4--4,23)),
-                  [], None,
-                  /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (2,5--4,23),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (2,0--4,23))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInConstructorSynMemberDefnMemberOptAsSpec.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                                 [Paren (Const (Unit, (4,8--4,10)), (4,8--4,10))],
+                               None, (4,4--4,7)), None,
+                            Const (Unit, (4,21--4,23)), (3,4--4,18),
+                            NoneAtInvisible, { LeadingKeyword = New (4,4--4,7)
+                                               InlineKeyword = None
+                                               EqualsRange = Some (4,19--4,20) }),
+                         (3,4--4,23))], (3,4--4,23)), [], None, (2,5--4,23),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--4,23))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs.bsl
@@ -13,8 +13,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Bird],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (2,5--2,9)),
+                     false, None, (2,5--2,9)),
                   ObjectModel
                     (Unspecified,
                      [GetSetMember
@@ -24,16 +23,11 @@ ImplFile
                                [{ Attributes =
                                    [{ TypeName =
                                        SynLongIdent ([Foo], [], [None])
-                                      ArgExpr =
-                                       Const
-                                         (Unit,
-                                          /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,6--3,9))
+                                      ArgExpr = Const (Unit, (3,6--3,9))
                                       Target = None
                                       AppliesToGetterAndSetter = false
-                                      Range =
-                                       /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,6--3,9) }]
-                                  Range =
-                                   /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,4--3,11) }],
+                                      Range = (3,6--3,9) }]
+                                  Range = (3,4--3,11) }],
                                PreXmlMerge
   (PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector), PreXmlDocEmpty),
                                SynValData
@@ -49,43 +43,28 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; TheWord],
-                                     [/root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (4,15--4,16)],
+                                    ([this; TheWord], [(4,15--4,16)],
                                      [None; None]), Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (5,17--5,19)),
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (5,17--5,19))],
-                                  None,
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (5,13--5,19)),
-                               None, Ident myInternalValue,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,4--5,19),
+                                       (Const (Unit, (5,17--5,19)), (5,17--5,19))],
+                                  None, (5,13--5,19)), None,
+                               Ident myInternalValue, (3,4--5,19),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (5,20--5,21) })),
+                                 EqualsRange = Some (5,20--5,21) })),
                          Some
                            (SynBinding
                               (None, Normal, false, false,
                                [{ Attributes =
                                    [{ TypeName =
                                        SynLongIdent ([Foo], [], [None])
-                                      ArgExpr =
-                                       Const
-                                         (Unit,
-                                          /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,6--3,9))
+                                      ArgExpr = Const (Unit, (3,6--3,9))
                                       Target = None
                                       AppliesToGetterAndSetter = false
-                                      Range =
-                                       /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,6--3,9) }]
-                                  Range =
-                                   /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,4--3,11) }],
+                                      Range = (3,6--3,9) }]
+                                  Range = (3,4--3,11) }],
                                PreXmlMerge
   (PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector), PreXmlDocEmpty),
                                SynValData
@@ -102,57 +81,30 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; TheWord],
-                                     [/root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (4,15--4,16)],
+                                    ([this; TheWord], [(4,15--4,16)],
                                      [None; None]), Some set, None,
                                   Pats
                                     [Paren
                                        (Named
                                           (SynIdent (value, None), false, None,
-                                           /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (6,17--6,22)),
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (6,16--6,23))],
-                                  None,
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (6,12--6,23)),
-                               None,
+                                           (6,17--6,22)), (6,16--6,23))], None,
+                                  (6,12--6,23)), None,
                                LongIdentSet
                                  (SynLongIdent ([myInternalValue], [], [None]),
-                                  Ident value,
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (6,26--6,50)),
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,4--6,23),
+                                  Ident value, (6,26--6,50)), (3,4--6,23),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (6,24--6,25) })),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,4--6,50),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (5,8--5,12)
-                           GetKeyword =
-                            Some
-                              /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (5,13--5,16)
-                           AndKeyword =
-                            Some
-                              /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (6,8--6,11)
-                           SetKeyword =
-                            Some
-                              /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (6,12--6,15) })],
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (3,4--6,50)),
-                  [], None,
-                  /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (2,5--6,50),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (2,10--2,11)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (2,0--6,50))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInFullSynMemberDefnMemberProperty.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
+                                 EqualsRange = Some (6,24--6,25) })),
+                         (3,4--6,50), { InlineKeyword = None
+                                        WithKeyword = (5,8--5,12)
+                                        GetKeyword = Some (5,13--5,16)
+                                        AndKeyword = Some (6,8--6,11)
+                                        SetKeyword = Some (6,12--6,15) })],
+                     (3,4--6,50)), [], None, (2,5--6,50),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,10--2,11)
+                    WithKeyword = None })], (2,0--6,50))], PreXmlDocEmpty, [],
+          None, (2,0--7,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs.bsl
@@ -12,19 +12,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [T],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -42,30 +36,15 @@ ImplFile
                               (SynLongIdent ([new], [], [None]), None,
                                Some (SynValTyparDecls (None, false)),
                                Pats
-                                 [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (3,8--3,10)),
-                                     /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (3,8--3,10))],
-                               None,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (3,4--3,7)),
-                            None,
+                                 [Paren (Const (Unit, (3,8--3,10)), (3,8--3,10))],
+                               None, (3,4--3,7)), None,
                             App
                               (NonAtomic, false, Ident T,
-                               Const
-                                 (Unit,
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (4,10--4,12)),
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (4,8--4,12)),
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (3,4--3,10),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               New
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (3,4--3,7)
+                               Const (Unit, (4,10--4,12)), (4,8--4,12)),
+                            (3,4--3,10), NoneAtInvisible,
+                            { LeadingKeyword = New (3,4--3,7)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (3,11--3,12) }),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (3,4--4,12));
+                              EqualsRange = Some (3,11--3,12) }), (3,4--4,12));
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -84,46 +63,25 @@ ImplFile
                                Some (SynValTyparDecls (None, false)),
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (6,17--6,19)),
-                                     /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (6,17--6,19))],
-                               Some
-                                 (Internal
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (6,4--6,12)),
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (6,13--6,16)),
-                            None,
+                                    (Const (Unit, (6,17--6,19)), (6,17--6,19))],
+                               Some (Internal (6,4--6,12)), (6,13--6,16)), None,
                             App
                               (NonAtomic, false, Ident T,
-                               Const
-                                 (Unit,
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (7,10--7,12)),
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (7,8--7,12)),
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (6,4--6,19),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               New
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (6,13--6,16)
+                               Const (Unit, (7,10--7,12)), (7,8--7,12)),
+                            (6,4--6,19), NoneAtInvisible,
+                            { LeadingKeyword = New (6,13--6,16)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (6,20--6,21) }),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (6,4--7,12));
+                              EqualsRange = Some (6,20--6,21) }), (6,4--7,12));
                       Member
                         (SynBinding
                            (None, Normal, false, false,
                             [{ Attributes =
                                 [{ TypeName = SynLongIdent ([Foo], [], [None])
-                                   ArgExpr =
-                                    Const
-                                      (Unit,
-                                       /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (9,6--9,9))
+                                   ArgExpr = Const (Unit, (9,6--9,9))
                                    Target = None
                                    AppliesToGetterAndSetter = false
-                                   Range =
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (9,6--9,9) }]
-                               Range =
-                                /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (9,4--9,11) }],
+                                   Range = (9,6--9,9) }]
+                               Range = (9,4--9,11) }],
                             PreXmlDoc ((9,4), FSharp.Compiler.Xml.XmlDocCollector),
                             SynValData
                               (Some { IsInstance = false
@@ -139,52 +97,24 @@ ImplFile
                                Some (SynValTyparDecls (None, false)),
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (10,8--10,10)),
-                                     /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (10,8--10,10))],
-                               None,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (10,4--10,7)),
-                            None,
+                                    (Const (Unit, (10,8--10,10)), (10,8--10,10))],
+                               None, (10,4--10,7)), None,
                             App
                               (NonAtomic, false, Ident T,
-                               Const
-                                 (Unit,
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (11,10--11,12)),
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (11,8--11,12)),
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (9,4--10,10),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               New
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (10,4--10,7)
+                               Const (Unit, (11,10--11,12)), (11,8--11,12)),
+                            (9,4--10,10), NoneAtInvisible,
+                            { LeadingKeyword = New (10,4--10,7)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (10,11--10,12) }),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (9,4--11,12))],
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (3,4--11,12)),
-                  [],
+                              EqualsRange = Some (10,11--10,12) }), (9,4--11,12))],
+                     (3,4--11,12)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,5--11,12),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,0--11,12))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInSecondaryConstructor.fs (2,0--12,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--11,12),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--11,12))], PreXmlDocEmpty, [],
+          None, (2,0--12,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs.bsl
@@ -12,8 +12,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Bar],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [LetBindings
@@ -21,53 +20,26 @@ ImplFile
                             (None, Normal, false, false,
                              [{ Attributes =
                                  [{ TypeName = SynLongIdent ([Foo], [], [None])
-                                    ArgExpr =
-                                     Const
-                                       (Unit,
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (3,6--3,9))
+                                    ArgExpr = Const (Unit, (3,6--3,9))
                                     Target = None
                                     AppliesToGetterAndSetter = false
-                                    Range =
-                                     /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (3,6--3,9) }]
-                                Range =
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (3,4--3,11) }],
+                                    Range = (3,6--3,9) }]
+                                Range = (3,4--3,11) }],
                              PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
                              SynValData
                                (None,
                                 SynValInfo ([], SynArgInfo ([], false, None)),
                                 None),
-                             Named
-                               (SynIdent (x, None), false, None,
-                                /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (4,8--4,9)),
-                             None,
-                             Const
-                               (Int32 8,
-                                /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (4,12--4,13)),
-                             /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (3,4--4,9),
-                             Yes
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (3,4--4,13),
-                             { LeadingKeyword =
-                                Let
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (4,4--4,7)
+                             Named (SynIdent (x, None), false, None, (4,8--4,9)),
+                             None, Const (Int32 8, (4,12--4,13)), (3,4--4,9),
+                             Yes (3,4--4,13),
+                             { LeadingKeyword = Let (4,4--4,7)
                                InlineKeyword = None
-                               EqualsRange =
-                                Some
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (4,10--4,11) })],
-                         false, false,
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (3,4--4,13))],
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (3,4--4,13)),
-                  [], None,
-                  /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (2,5--4,13),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (2,0--4,13))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnLetBindings.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                               EqualsRange = Some (4,10--4,11) })], false, false,
+                         (3,4--4,13))], (3,4--4,13)), [], None, (2,5--4,13),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--4,13))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs.bsl
@@ -12,8 +12,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Bar],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -21,16 +20,11 @@ ImplFile
                            (None, Normal, false, false,
                             [{ Attributes =
                                 [{ TypeName = SynLongIdent ([Foo], [], [None])
-                                   ArgExpr =
-                                    Const
-                                      (Unit,
-                                       /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (3,6--3,9))
+                                   ArgExpr = Const (Unit, (3,6--3,9))
                                    Target = None
                                    AppliesToGetterAndSetter = false
-                                   Range =
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (3,6--3,9) }]
-                               Range =
-                                /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (3,4--3,11) }],
+                                   Range = (3,6--3,9) }]
+                               Range = (3,4--3,11) }],
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
                             SynValData
                               (Some { IsInstance = true
@@ -44,44 +38,21 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; Something],
-                                  [/root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (4,15--4,16)],
+                                 ([this; Something], [(4,15--4,16)],
                                   [None; None]), None, None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (4,26--4,28)),
-                                     /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (4,26--4,28))],
-                               None,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (4,11--4,28)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (4,31--4,33)),
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (3,4--4,28),
+                                    (Const (Unit, (4,26--4,28)), (4,26--4,28))],
+                               None, (4,11--4,28)), None,
+                            Const (Unit, (4,31--4,33)), (3,4--4,28),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (4,4--4,10)
+                            { LeadingKeyword = Member (4,4--4,10)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (4,29--4,30) }),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (3,4--4,33))],
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (3,4--4,33)),
-                  [], None,
-                  /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (2,5--4,33),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (2,0--4,33))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInSynMemberDefnMember.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                              EqualsRange = Some (4,29--4,30) }), (3,4--4,33))],
+                     (3,4--4,33)), [], None, (2,5--4,33),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--4,33))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs.bsl
@@ -11,41 +11,20 @@ ImplFile
              (false,
               [SynBinding
                  (None, Normal, false, false,
-                  [{ Attributes =
-                      [{ TypeName = SynLongIdent ([Foo], [], [None])
-                         ArgExpr =
-                          Const
-                            (Unit,
-                             /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (2,2--2,5))
-                         Target = None
-                         AppliesToGetterAndSetter = false
-                         Range =
-                          /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (2,2--2,5) }]
-                     Range =
-                      /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (2,0--2,7) }],
+                  [{ Attributes = [{ TypeName = SynLongIdent ([Foo], [], [None])
+                                     ArgExpr = Const (Unit, (2,2--2,5))
+                                     Target = None
+                                     AppliesToGetterAndSetter = false
+                                     Range = (2,2--2,5) }]
+                     Range = (2,0--2,7) }],
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (a, None), false, None,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (3,4--3,5)),
-                  None,
-                  Const
-                    (Int32 0,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (3,8--3,9)),
-                  /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (2,0--3,5),
-                  Yes
-                    /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (2,0--3,9),
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (3,0--3,3)
+                  Named (SynIdent (a, None), false, None, (3,4--3,5)), None,
+                  Const (Int32 0, (3,8--3,9)), (2,0--3,5), Yes (2,0--3,9),
+                  { LeadingKeyword = Let (3,0--3,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (3,6--3,7) })],
-              /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (2,0--3,9))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInSynModuleDeclLet.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (3,6--3,7) })], (2,0--3,9))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs.bsl
@@ -13,8 +13,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Crane],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (2,5--2,10)),
+                     false, None, (2,5--2,10)),
                   ObjectModel
                     (Unspecified,
                      [GetSetMember
@@ -25,16 +24,11 @@ ImplFile
                                [{ Attributes =
                                    [{ TypeName =
                                        SynLongIdent ([Foo], [], [None])
-                                      ArgExpr =
-                                       Const
-                                         (Unit,
-                                          /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (3,6--3,9))
+                                      ArgExpr = Const (Unit, (3,6--3,9))
                                       Target = None
                                       AppliesToGetterAndSetter = false
-                                      Range =
-                                       /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (3,6--3,9) }]
-                                  Range =
-                                   /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (3,4--3,11) }],
+                                      Range = (3,6--3,9) }]
+                                  Range = (3,4--3,11) }],
                                PreXmlMerge
   (PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector), PreXmlDocEmpty),
                                SynValData
@@ -51,53 +45,30 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; MyWriteOnlyProperty],
-                                     [/root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,15--4,16)],
+                                    ([this; MyWriteOnlyProperty], [(4,15--4,16)],
                                      [None; None]), Some set, None,
                                   Pats
                                     [Paren
                                        (Named
                                           (SynIdent (value, None), false, None,
-                                           /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,46--4,51)),
-                                        /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,45--4,52))],
-                                  None,
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,41--4,52)),
-                               None,
+                                           (4,46--4,51)), (4,45--4,52))], None,
+                                  (4,41--4,52)), None,
                                LongIdentSet
                                  (SynLongIdent ([myInternalValue], [], [None]),
-                                  Ident value,
-                                  /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,55--4,79)),
-                               /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (3,4--4,52),
+                                  Ident value, (4,55--4,79)), (3,4--4,52),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,53--4,54) })),
-                         /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (3,4--4,79),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,36--4,40)
-                           GetKeyword = None
-                           AndKeyword = None
-                           SetKeyword =
-                            Some
-                              /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (4,41--4,44) })],
-                     /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (3,4--4,79)),
-                  [], None,
-                  /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (2,5--4,79),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (2,0--4,79))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfAttributeShouldBeIncludedInWriteOnlySynMemberDefnMemberProperty.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                                 EqualsRange = Some (4,53--4,54) })),
+                         (3,4--4,79), { InlineKeyword = None
+                                        WithKeyword = (4,36--4,40)
+                                        GetKeyword = None
+                                        AndKeyword = None
+                                        SetKeyword = Some (4,41--4,44) })],
+                     (3,4--4,79)), [], None, (2,5--4,79),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--4,79))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs.bsl
@@ -15,32 +15,13 @@ ImplFile
                         SynValData
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
-                        Named
-                          (SynIdent (z, None), false, None,
-                           /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (3,8--3,9)),
-                        None,
-                        Const
-                          (Int32 2,
-                           /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (3,12--3,13)),
-                        /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (3,8--3,9),
-                        Yes
-                          /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (3,4--3,13),
-                        { LeadingKeyword =
-                           Let
-                             /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (3,4--3,7)
-                          InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (3,10--3,11) })],
-                    Const
-                      (Unit,
-                       /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (4,4--4,6)),
-                    /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (3,4--4,6),
-                    { InKeyword = None }),
-                 /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (2,0--4,6)),
-              /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (2,0--4,6))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBinding.fs (2,0--5,0),
+                        Named (SynIdent (z, None), false, None, (3,8--3,9)),
+                        None, Const (Int32 2, (3,12--3,13)), (3,8--3,9),
+                        Yes (3,4--3,13), { LeadingKeyword = Let (3,4--3,7)
+                                           InlineKeyword = None
+                                           EqualsRange = Some (3,10--3,11) })],
+                    Const (Unit, (4,4--4,6)), (3,4--4,6), { InKeyword = None }),
+                 (2,0--4,6)), (2,0--4,6))], PreXmlDocEmpty, [], None, (2,0--5,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs.bsl
@@ -17,42 +17,21 @@ ImplFile
                         SynValData
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
-                        Named
-                          (SynIdent (z, None), false, None,
-                           /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,8--3,9)),
+                        Named (SynIdent (z, None), false, None, (3,8--3,9)),
                         Some
                           (SynBindingReturnInfo
                              (LongIdent (SynLongIdent ([int], [], [None])),
-                              /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,11--3,14),
-                              [],
-                              { ColonRange =
-                                 Some
-                                   /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,9--3,10) })),
+                              (3,11--3,14), [],
+                              { ColonRange = Some (3,9--3,10) })),
                         Typed
-                          (Const
-                             (Int32 2,
-                              /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,17--3,18)),
+                          (Const (Int32 2, (3,17--3,18)),
                            LongIdent (SynLongIdent ([int], [], [None])),
-                           /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,17--3,18)),
-                        /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,8--3,9),
-                        Yes
-                          /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,4--3,18),
-                        { LeadingKeyword =
-                           Let
-                             /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,4--3,7)
+                           (3,17--3,18)), (3,8--3,9), Yes (3,4--3,18),
+                        { LeadingKeyword = Let (3,4--3,7)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,15--3,16) })],
-                    Const
-                      (Unit,
-                       /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (4,4--4,6)),
-                    /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (3,4--4,6),
-                    { InKeyword = None }),
-                 /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (2,0--4,6)),
-              /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (2,0--4,6))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfEqualSignShouldBePresentInLocalLetBindingTyped.fs (2,0--5,0),
+                          EqualsRange = Some (3,15--3,16) })],
+                    Const (Unit, (4,4--4,6)), (3,4--4,6), { InKeyword = None }),
+                 (2,0--4,6)), (2,0--4,6))], PreXmlDocEmpty, [], None, (2,0--5,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs.bsl
@@ -9,19 +9,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -38,44 +32,21 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; Y],
-                                  [/root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (3,15--3,16)],
-                                  [None; None]), None, None, Pats [], None,
-                               /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (3,11--3,17)),
-                            None, Ident z,
-                            /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (3,11--3,17),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (3,4--3,10)
+                                 ([this; Y], [(3,15--3,16)], [None; None]), None,
+                               None, Pats [], None, (3,11--3,17)), None, Ident z,
+                            (3,11--3,17), NoneAtInvisible,
+                            { LeadingKeyword = Member (3,4--3,10)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (3,18--3,19) }),
-                         /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (3,4--3,21))],
-                     /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (3,4--3,21)),
-                  [],
+                              EqualsRange = Some (3,18--3,19) }), (3,4--3,21))],
+                     (3,4--3,21)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,5--3,21),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,0--3,21))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfEqualSignShouldBePresentInMemberBinding.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--3,21),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--3,21))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs.bsl
@@ -12,19 +12,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -41,51 +35,25 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; Y],
-                                  [/root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,15--3,16)],
-                                  [None; None]), None, None,
+                                 ([this; Y], [(3,15--3,16)], [None; None]), None,
+                               None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,18--3,20)),
-                                     /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,18--3,20))],
-                               None,
-                               /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,11--3,20)),
-                            None, Ident z,
-                            /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,11--3,20),
+                                    (Const (Unit, (3,18--3,20)), (3,18--3,20))],
+                               None, (3,11--3,20)), None, Ident z, (3,11--3,20),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,4--3,10)
+                            { LeadingKeyword = Member (3,4--3,10)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,21--3,22) }),
-                         /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,4--3,24))],
-                     /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (3,4--3,24)),
-                  [],
+                              EqualsRange = Some (3,21--3,22) }), (3,4--3,24))],
+                     (3,4--3,24)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,5--3,24),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,0--3,24))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithParameters.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--3,24),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--3,24))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs.bsl
@@ -12,19 +12,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -41,63 +35,34 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; Y],
-                                  [/root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,15--3,16)],
-                                  [None; None]), None, None,
+                                 ([this; Y], [(3,15--3,16)], [None; None]), None,
+                               None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,18--3,20)),
-                                     /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,18--3,20))],
-                               None,
-                               /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,11--3,20)),
+                                    (Const (Unit, (3,18--3,20)), (3,18--3,20))],
+                               None, (3,11--3,20)),
                             Some
                               (SynBindingReturnInfo
                                  (LongIdent
                                     (SynLongIdent ([string], [], [None])),
-                                  /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,23--3,29),
-                                  [],
-                                  { ColonRange =
-                                     Some
-                                       /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,21--3,22) })),
+                                  (3,23--3,29), [],
+                                  { ColonRange = Some (3,21--3,22) })),
                             Typed
                               (Ident z,
                                LongIdent (SynLongIdent ([string], [], [None])),
-                               /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,32--3,33)),
-                            /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,11--3,20),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,4--3,10)
+                               (3,32--3,33)), (3,11--3,20), NoneAtInvisible,
+                            { LeadingKeyword = Member (3,4--3,10)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,30--3,31) }),
-                         /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,4--3,33))],
-                     /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (3,4--3,33)),
-                  [],
+                              EqualsRange = Some (3,30--3,31) }), (3,4--3,33))],
+                     (3,4--3,33)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,5--3,33),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,0--3,33))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfEqualSignShouldBePresentInMemberBindingWithReturnType.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--3,33),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--3,33))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInProperty.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInProperty.fs.bsl
@@ -9,19 +9,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Y],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       GetSetMember
                         (Some
                            (SynBinding
@@ -41,27 +35,17 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; MyReadWriteProperty],
-                                     [/root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (3,15--3,16)],
+                                    ([this; MyReadWriteProperty], [(3,15--3,16)],
                                      [None; None]), Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (4,17--4,19)),
-                                        /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (4,17--4,19))],
-                                  None,
-                                  /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (4,13--4,19)),
-                               None, Ident myInternalValue,
-                               /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (4,13--4,19),
+                                       (Const (Unit, (4,17--4,19)), (4,17--4,19))],
+                                  None, (4,13--4,19)), None,
+                               Ident myInternalValue, (4,13--4,19),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (3,4--3,10)
+                               { LeadingKeyword = Member (3,4--3,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (4,20--4,21) })),
+                                 EqualsRange = Some (4,20--4,21) })),
                          Some
                            (SynBinding
                               (None, Normal, false, false, [],
@@ -81,67 +65,35 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; MyReadWriteProperty],
-                                     [/root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (3,15--3,16)],
+                                    ([this; MyReadWriteProperty], [(3,15--3,16)],
                                      [None; None]), Some set, None,
                                   Pats
                                     [Paren
                                        (Named
                                           (SynIdent (value, None), false, None,
-                                           /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (5,17--5,22)),
-                                        /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (5,16--5,23))],
-                                  None,
-                                  /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (5,12--5,23)),
-                               None,
+                                           (5,17--5,22)), (5,16--5,23))], None,
+                                  (5,12--5,23)), None,
                                LongIdentSet
                                  (SynLongIdent ([myInternalValue], [], [None]),
-                                  Ident value,
-                                  /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (5,26--5,50)),
-                               /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (5,12--5,23),
+                                  Ident value, (5,26--5,50)), (5,12--5,23),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (3,4--3,10)
+                               { LeadingKeyword = Member (3,4--3,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (5,24--5,25) })),
-                         /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (3,4--5,50),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (4,8--4,12)
-                           GetKeyword =
-                            Some
-                              /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (4,13--4,16)
-                           AndKeyword =
-                            Some
-                              /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (5,8--5,11)
-                           SetKeyword =
-                            Some
-                              /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (5,12--5,15) })],
-                     /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (3,4--5,50)),
-                  [],
+                                 EqualsRange = Some (5,24--5,25) })),
+                         (3,4--5,50), { InlineKeyword = None
+                                        WithKeyword = (4,8--4,12)
+                                        GetKeyword = Some (4,13--4,16)
+                                        AndKeyword = Some (5,8--5,11)
+                                        SetKeyword = Some (5,12--5,15) })],
+                     (3,4--5,50)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,5--5,50),
-                  { LeadingKeyword =
-                     Type
-                       /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,0--5,50))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfEqualSignShouldBePresentInProperty.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--5,50),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--5,50))], PreXmlDocEmpty, [],
+          None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs.bsl
@@ -14,26 +14,11 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs (2,4--2,5)),
-                  None,
-                  Const
-                    (Int32 12,
-                     /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs (2,8--2,10)),
-                  /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs (2,4--2,5),
-                  Yes
-                    /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs (2,0--2,10),
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs (2,0--2,3)
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)), None,
+                  Const (Int32 12, (2,8--2,10)), (2,4--2,5), Yes (2,0--2,10),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs (2,6--2,7) })],
-              /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs (2,0--2,10))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBinding.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,6--2,7) })], (2,0--2,10))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs.bsl
@@ -14,36 +14,18 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,4--2,5)),
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)),
                   Some
                     (SynBindingReturnInfo
                        (LongIdent (SynLongIdent ([int], [], [None])),
-                        /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,8--2,11),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,6--2,7) })),
+                        (2,8--2,11), [], { ColonRange = Some (2,6--2,7) })),
                   Typed
-                    (Const
-                       (Int32 12,
-                        /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,14--2,16)),
-                     LongIdent (SynLongIdent ([int], [], [None])),
-                     /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,14--2,16)),
-                  /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,4--2,5),
-                  Yes
-                    /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,0--2,16),
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,0--2,3)
+                    (Const (Int32 12, (2,14--2,16)),
+                     LongIdent (SynLongIdent ([int], [], [None])), (2,14--2,16)),
+                  (2,4--2,5), Yes (2,0--2,16),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,12--2,13) })],
-              /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,0--2,16))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfEqualSignShouldBePresentInSynModuleDeclLetBindingTyped.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,12--2,13) })], (2,0--2,16))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs.bsl
@@ -14,10 +14,7 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (a, None), false, None,
-                     /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (2,4--2,5)),
-                  None,
+                  Named (SynIdent (a, None), false, None, (2,4--2,5)), None,
                   LetOrUse
                     (false, false,
                      [SynBinding
@@ -32,37 +29,16 @@ ImplFile
                            (SynLongIdent ([b], [], [None]), None, None,
                             Pats
                               [Named
-                                 (SynIdent (c, None), false, None,
-                                  /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (3,10--3,11))],
-                            None,
-                            /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (3,8--3,11)),
-                         None, Ident d,
-                         /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (3,8--3,11),
-                         NoneAtLet,
-                         { LeadingKeyword =
-                            Let
-                              /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (3,4--3,7)
-                           InlineKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (3,12--3,13) })],
-                     Const
-                       (Unit,
-                        /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (4,4--4,6)),
-                     /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (3,4--4,6),
-                     { InKeyword = None }),
-                  /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (2,4--2,5),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (2,6--2,7) })],
-              /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (2,0--4,6))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfLetKeywordShouldBePresentInSynExprLetOrUseBinding.fs (2,0--5,0),
+                                 (SynIdent (c, None), false, None, (3,10--3,11))],
+                            None, (3,8--3,11)), None, Ident d, (3,8--3,11),
+                         NoneAtLet, { LeadingKeyword = Let (3,4--3,7)
+                                      InlineKeyword = None
+                                      EqualsRange = Some (3,12--3,13) })],
+                     Const (Unit, (4,4--4,6)), (3,4--4,6), { InKeyword = None }),
+                  (2,4--2,5), NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                                           InlineKeyword = None
+                                           EqualsRange = Some (2,6--2,7) })],
+              (2,0--4,6))], PreXmlDocEmpty, [], None, (2,0--5,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs.bsl
@@ -14,26 +14,11 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs (2,4--2,5)),
-                  None,
-                  Const
-                    (Int32 12,
-                     /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs (2,8--2,10)),
-                  /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs (2,4--2,5),
-                  Yes
-                    /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs (2,0--2,10),
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs (2,0--2,3)
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)), None,
+                  Const (Int32 12, (2,8--2,10)), (2,4--2,5), Yes (2,0--2,10),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs (2,6--2,7) })],
-              /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs (2,0--2,10))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBinding.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,6--2,7) })], (2,0--2,10))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs.bsl
@@ -14,42 +14,19 @@ ImplFile
                  (None, Normal, false, false,
                   [{ Attributes =
                       [{ TypeName = SynLongIdent ([SomeAttribute], [], [None])
-                         ArgExpr =
-                          Const
-                            (Unit,
-                             /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (3,2--3,15))
+                         ArgExpr = Const (Unit, (3,2--3,15))
                          Target = None
                          AppliesToGetterAndSetter = false
-                         Range =
-                          /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (3,2--3,15) }]
-                     Range =
-                      /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (3,0--3,17) }],
+                         Range = (3,2--3,15) }]
+                     Range = (3,0--3,17) }],
                   PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (5,4--5,5)),
-                  None,
-                  Const
-                    (Int32 12,
-                     /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (5,8--5,10)),
-                  /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (2,0--5,5),
-                  Yes
-                    /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (3,0--5,10),
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (5,0--5,3)
+                  Named (SynIdent (v, None), false, None, (5,4--5,5)), None,
+                  Const (Int32 12, (5,8--5,10)), (2,0--5,5), Yes (3,0--5,10),
+                  { LeadingKeyword = Let (5,0--5,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (5,6--5,7) })],
-              /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (2,0--5,10))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (3,0--6,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Binding/RangeOfLetKeywordShouldBePresentInSynModuleDeclLetBindingWithAttributes.fs (4,0--4,15)] },
-      set []))
+                    EqualsRange = Some (5,6--5,7) })], (2,0--5,10))],
+          PreXmlDocEmpty, [], None, (3,0--6,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [LineComment (4,0--4,15)] }, set []))

--- a/tests/service/data/SyntaxTree/Binding/TupleReturnTypeOfBindingShouldContainStars.fs.bsl
+++ b/tests/service/data/SyntaxTree/Binding/TupleReturnTypeOfBindingShouldContainStars.fs.bsl
@@ -11,52 +11,32 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (a, None), false, None,
-                     /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,4--2,5)),
+                  Named (SynIdent (a, None), false, None, (2,4--2,5)),
                   Some
                     (SynBindingReturnInfo
                        (Tuple
                           (false,
                            [Type (LongIdent (SynLongIdent ([int], [], [None])));
-                            Star
-                              /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,12--2,13);
+                            Star (2,12--2,13);
                             Type
                               (LongIdent (SynLongIdent ([string], [], [None])))],
-                           /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,8--2,20)),
-                        /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,8--2,20),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,6--2,7) })),
+                           (2,8--2,20)), (2,8--2,20), [],
+                        { ColonRange = Some (2,6--2,7) })),
                   Typed
                     (App
                        (NonAtomic, false, Ident failwith,
                         Const
-                          (String
-                             ("todo", Regular,
-                              /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,32--2,38)),
-                           /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,32--2,38)),
-                        /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,23--2,38)),
+                          (String ("todo", Regular, (2,32--2,38)), (2,32--2,38)),
+                        (2,23--2,38)),
                      Tuple
                        (false,
                         [Type (LongIdent (SynLongIdent ([int], [], [None])));
-                         Star
-                           /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,12--2,13);
+                         Star (2,12--2,13);
                          Type (LongIdent (SynLongIdent ([string], [], [None])))],
-                        /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,8--2,20)),
-                     /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,23--2,38)),
-                  /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,4--2,5),
-                  Yes
-                    /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,0--2,38),
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,0--2,3)
+                        (2,8--2,20)), (2,23--2,38)), (2,4--2,5), Yes (2,0--2,38),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,21--2,22) })],
-              /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,0--2,38));
+                    EqualsRange = Some (2,21--2,22) })], (2,0--2,38));
            Let
              (false,
               [SynBinding
@@ -64,68 +44,38 @@ ImplFile
                   PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (b, None), false, None,
-                     /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,4--3,5)),
+                  Named (SynIdent (b, None), false, None, (3,4--3,5)),
                   Some
                     (SynBindingReturnInfo
                        (Tuple
                           (false,
                            [Type (LongIdent (SynLongIdent ([int], [], [None])));
-                            Star
-                              /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,12--3,13);
+                            Star (3,12--3,13);
                             Type
                               (LongIdent (SynLongIdent ([string], [], [None])));
-                            Star
-                              /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,21--3,22);
+                            Star (3,21--3,22);
                             Type (LongIdent (SynLongIdent ([bool], [], [None])))],
-                           /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,8--3,27)),
-                        /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,8--3,27),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,6--3,7) })),
+                           (3,8--3,27)), (3,8--3,27), [],
+                        { ColonRange = Some (3,6--3,7) })),
                   Typed
                     (Tuple
                        (false,
-                        [Const
-                           (Int32 1,
-                            /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,30--3,31));
+                        [Const (Int32 1, (3,30--3,31));
                          Const
-                           (String
-                              ("", Regular,
-                               /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,33--3,35)),
-                            /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,33--3,35));
-                         Const
-                           (Bool false,
-                            /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,37--3,42))],
-                        [/root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,31--3,32);
-                         /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,35--3,36)],
-                        /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,30--3,42)),
+                           (String ("", Regular, (3,33--3,35)), (3,33--3,35));
+                         Const (Bool false, (3,37--3,42))],
+                        [(3,31--3,32); (3,35--3,36)], (3,30--3,42)),
                      Tuple
                        (false,
                         [Type (LongIdent (SynLongIdent ([int], [], [None])));
-                         Star
-                           /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,12--3,13);
+                         Star (3,12--3,13);
                          Type (LongIdent (SynLongIdent ([string], [], [None])));
-                         Star
-                           /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,21--3,22);
+                         Star (3,21--3,22);
                          Type (LongIdent (SynLongIdent ([bool], [], [None])))],
-                        /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,8--3,27)),
-                     /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,30--3,42)),
-                  /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,4--3,5),
-                  Yes
-                    /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,0--3,42),
-                  { LeadingKeyword =
-                     Let
-                       /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,0--3,3)
+                        (3,8--3,27)), (3,30--3,42)), (3,4--3,5), Yes (3,0--3,42),
+                  { LeadingKeyword = Let (3,0--3,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,28--3,29) })],
-              /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (3,0--3,42))],
-          PreXmlDocEmpty, [], None,
-          /root/Binding/TupleReturnTypeOfBindingShouldContainStars.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (3,28--3,29) })], (3,0--3,42))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/BlockCommentInSourceCode.fs.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/BlockCommentInSourceCode.fs.bsl
@@ -17,12 +17,8 @@ ImplFile
                   LongIdent
                     (SynLongIdent ([a], [], [None]), None, None,
                      Pats
-                       [Named
-                          (SynIdent (c, None), false, None,
-                           /root/CodeComment/BlockCommentInSourceCode.fs (2,15--2,16))],
-                     None,
-                     /root/CodeComment/BlockCommentInSourceCode.fs (2,4--2,16)),
-                  None,
+                       [Named (SynIdent (c, None), false, None, (2,15--2,16))],
+                     None, (2,4--2,16)), None,
                   App
                     (NonAtomic, false,
                      App
@@ -31,28 +27,11 @@ ImplFile
                           (false,
                            SynLongIdent
                              ([op_Addition], [], [Some (OriginalNotation "+")]),
-                           None,
-                           /root/CodeComment/BlockCommentInSourceCode.fs (2,21--2,22)),
-                        Ident c,
-                        /root/CodeComment/BlockCommentInSourceCode.fs (2,19--2,22)),
-                     Const
-                       (Int32 42,
-                        /root/CodeComment/BlockCommentInSourceCode.fs (2,23--2,25)),
-                     /root/CodeComment/BlockCommentInSourceCode.fs (2,19--2,25)),
-                  /root/CodeComment/BlockCommentInSourceCode.fs (2,4--2,16),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/CodeComment/BlockCommentInSourceCode.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/CodeComment/BlockCommentInSourceCode.fs (2,17--2,18) })],
-              /root/CodeComment/BlockCommentInSourceCode.fs (2,0--2,25))],
-          PreXmlDocEmpty, [], None,
-          /root/CodeComment/BlockCommentInSourceCode.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments =
-         [BlockComment /root/CodeComment/BlockCommentInSourceCode.fs (2,6--2,13)] },
-      set []))
+                           None, (2,21--2,22)), Ident c, (2,19--2,22)),
+                     Const (Int32 42, (2,23--2,25)), (2,19--2,25)), (2,4--2,16),
+                  NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                               InlineKeyword = None
+                               EqualsRange = Some (2,17--2,18) })], (2,0--2,25))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [BlockComment (2,6--2,13)] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/BlockCommentInSourceCodeSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/BlockCommentInSourceCodeSignatureFile.fsi.bsl
@@ -10,22 +10,11 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None,
-                 /root/CodeComment/BlockCommentInSourceCodeSignatureFile.fsi (4,0--4,19),
-                 { LeadingKeyword =
-                    Val
-                      /root/CodeComment/BlockCommentInSourceCodeSignatureFile.fsi (4,0--4,3)
-                   InlineKeyword = None
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/CodeComment/BlockCommentInSourceCodeSignatureFile.fsi (4,0--4,19))],
-          PreXmlDocEmpty, [], None,
-          /root/CodeComment/BlockCommentInSourceCodeSignatureFile.fsi (2,0--4,19),
-          { LeadingKeyword =
-             Namespace
-               /root/CodeComment/BlockCommentInSourceCodeSignatureFile.fsi (2,0--2,9) })],
+                 None, (4,0--4,19), { LeadingKeyword = Val (4,0--4,3)
+                                      InlineKeyword = None
+                                      WithKeyword = None
+                                      EqualsRange = None }), (4,0--4,19))],
+          PreXmlDocEmpty, [], None, (2,0--4,19),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [BlockComment
-            /root/CodeComment/BlockCommentInSourceCodeSignatureFile.fsi (4,6--4,13)] },
-      set []))
+        CodeComments = [BlockComment (4,6--4,13)] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/CommentAfterSourceCode.fs.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/CommentAfterSourceCode.fs.bsl
@@ -6,15 +6,8 @@ ImplFile
          ([CommentAfterSourceCode], false, AnonModule,
           [Expr
              (App
-                (Atomic, false, Ident foo,
-                 Const
-                   (Unit, /root/CodeComment/CommentAfterSourceCode.fs (2,3--2,5)),
-                 /root/CodeComment/CommentAfterSourceCode.fs (2,0--2,5)),
-              /root/CodeComment/CommentAfterSourceCode.fs (2,0--2,5))],
-          PreXmlDocEmpty, [], None,
-          /root/CodeComment/CommentAfterSourceCode.fs (2,0--2,5),
+                (Atomic, false, Ident foo, Const (Unit, (2,3--2,5)), (2,0--2,5)),
+              (2,0--2,5))], PreXmlDocEmpty, [], None, (2,0--2,5),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment /root/CodeComment/CommentAfterSourceCode.fs (2,6--2,17)] },
-      set []))
+        CodeComments = [LineComment (2,6--2,17)] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/CommentAfterSourceCodeSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/CommentAfterSourceCodeSignatureFile.fsi.bsl
@@ -10,22 +10,11 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None,
-                 /root/CodeComment/CommentAfterSourceCodeSignatureFile.fsi (4,0--4,13),
-                 { LeadingKeyword =
-                    Val
-                      /root/CodeComment/CommentAfterSourceCodeSignatureFile.fsi (4,0--4,3)
-                   InlineKeyword = None
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/CodeComment/CommentAfterSourceCodeSignatureFile.fsi (4,0--4,13))],
-          PreXmlDocEmpty, [], None,
-          /root/CodeComment/CommentAfterSourceCodeSignatureFile.fsi (2,0--4,13),
-          { LeadingKeyword =
-             Namespace
-               /root/CodeComment/CommentAfterSourceCodeSignatureFile.fsi (2,0--2,9) })],
+                 None, (4,0--4,13), { LeadingKeyword = Val (4,0--4,3)
+                                      InlineKeyword = None
+                                      WithKeyword = None
+                                      EqualsRange = None }), (4,0--4,13))],
+          PreXmlDocEmpty, [], None, (2,0--4,13),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/CodeComment/CommentAfterSourceCodeSignatureFile.fsi (4,14--4,25)] },
-      set []))
+        CodeComments = [LineComment (4,14--4,25)] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/CommentAtEndOfFile.fs.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/CommentAtEndOfFile.fs.bsl
@@ -3,12 +3,7 @@ ImplFile
      ("/root/CodeComment/CommentAtEndOfFile.fs", false,
       QualifiedNameOfFile CommentAtEndOfFile, [], [],
       [SynModuleOrNamespace
-         ([CommentAtEndOfFile], false, AnonModule,
-          [Expr (Ident x, /root/CodeComment/CommentAtEndOfFile.fs (2,0--2,1))],
-          PreXmlDocEmpty, [], None,
-          /root/CodeComment/CommentAtEndOfFile.fs (2,0--2,1),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments =
-         [LineComment /root/CodeComment/CommentAtEndOfFile.fs (2,2--2,6)] },
-      set []))
+         ([CommentAtEndOfFile], false, AnonModule, [Expr (Ident x, (2,0--2,1))],
+          PreXmlDocEmpty, [], None, (2,0--2,1), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [LineComment (2,2--2,6)] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/CommentOnSingleLine.fs.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/CommentOnSingleLine.fs.bsl
@@ -6,15 +6,8 @@ ImplFile
          ([CommentOnSingleLine], false, AnonModule,
           [Expr
              (App
-                (Atomic, false, Ident foo,
-                 Const
-                   (Unit, /root/CodeComment/CommentOnSingleLine.fs (3,3--3,5)),
-                 /root/CodeComment/CommentOnSingleLine.fs (3,0--3,5)),
-              /root/CodeComment/CommentOnSingleLine.fs (3,0--3,5))],
-          PreXmlDocEmpty, [], None,
-          /root/CodeComment/CommentOnSingleLine.fs (3,0--3,5),
+                (Atomic, false, Ident foo, Const (Unit, (3,3--3,5)), (3,0--3,5)),
+              (3,0--3,5))], PreXmlDocEmpty, [], None, (3,0--3,5),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment /root/CodeComment/CommentOnSingleLine.fs (2,0--2,11)] },
-      set []))
+        CodeComments = [LineComment (2,0--2,11)] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/CommentOnSingleLineSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/CommentOnSingleLineSignatureFile.fsi.bsl
@@ -4,12 +4,6 @@ SigFile
       QualifiedNameOfFile CommentOnSingleLineSignatureFile, [], [],
       [SynModuleOrNamespaceSig
          ([Meh], false, DeclaredNamespace, [], PreXmlDocEmpty, [], None,
-          /root/CodeComment/CommentOnSingleLineSignatureFile.fsi (2,0--2,13),
-          { LeadingKeyword =
-             Namespace
-               /root/CodeComment/CommentOnSingleLineSignatureFile.fsi (2,0--2,9) })],
+          (2,0--2,13), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/CodeComment/CommentOnSingleLineSignatureFile.fsi (3,0--3,11)] },
-      set []))
+        CodeComments = [LineComment (3,0--3,11)] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs.bsl
@@ -14,22 +14,12 @@ ImplFile
                   PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (x, None), false, None,
-                     /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (3,4--3,5)),
-                  None,
+                  Named (SynIdent (x, None), false, None, (3,4--3,5)), None,
                   Sequential
                     (SuppressNeither, true,
                      While
-                       (Yes
-                          /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (8,4--8,14),
-                        Const
-                          (Bool true,
-                           /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (8,10--8,14)),
-                        Const
-                          (Unit,
-                           /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (8,18--8,20)),
-                        /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (8,4--8,20)),
+                       (Yes (8,4--8,14), Const (Bool true, (8,10--8,14)),
+                        Const (Unit, (8,18--8,20)), (8,4--8,20)),
                      App
                        (NonAtomic, false,
                         App
@@ -39,33 +29,14 @@ ImplFile
                               SynLongIdent
                                 ([op_Addition], [],
                                  [Some (OriginalNotation "+")]), None,
-                              /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (9,6--9,7)),
-                           Ident a,
-                           /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (9,4--9,7)),
-                        Const
-                          (Int32 1,
-                           /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (9,8--9,9)),
-                        /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (9,4--9,9)),
-                     /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (8,4--9,9)),
-                  /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (2,0--3,5),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (3,0--3,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (3,6--3,7) })],
-              /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (2,0--9,9))],
-          PreXmlDocEmpty, [], None,
-          /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (3,0--10,0),
+                              (9,6--9,7)), Ident a, (9,4--9,7)),
+                        Const (Int32 1, (9,8--9,9)), (9,4--9,9)), (8,4--9,9)),
+                  (2,0--3,5), NoneAtLet, { LeadingKeyword = Let (3,0--3,3)
+                                           InlineKeyword = None
+                                           EqualsRange = Some (3,6--3,7) })],
+              (2,0--9,9))], PreXmlDocEmpty, [], None, (3,0--10,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments =
-         [LineComment
-            /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (4,4--4,40);
-          LineComment
-            /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (6,4--6,36);
-          LineComment
-            /root/CodeComment/TripleSlashCommentShouldBeCapturedIfUsedInAnInvalidLocation.fs (7,4--7,27)] },
-      set []))
+         [LineComment (4,4--4,40); LineComment (6,4--6,36);
+          LineComment (7,4--7,27)] }, set []))

--- a/tests/service/data/SyntaxTree/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs.bsl
+++ b/tests/service/data/SyntaxTree/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs.bsl
@@ -11,26 +11,11 @@ ImplFile
                   PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (x, None), false, None,
-                     /root/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs (3,4--3,5)),
-                  None,
-                  Const
-                    (Int32 0,
-                     /root/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs (3,8--3,9)),
-                  /root/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs (2,0--3,5),
-                  Yes
-                    /root/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs (3,0--3,9),
-                  { LeadingKeyword =
-                     Let
-                       /root/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs (3,0--3,3)
+                  Named (SynIdent (x, None), false, None, (3,4--3,5)), None,
+                  Const (Int32 0, (3,8--3,9)), (2,0--3,5), Yes (3,0--3,9),
+                  { LeadingKeyword = Let (3,0--3,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs (3,6--3,7) })],
-              /root/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs (2,0--3,9))],
-          PreXmlDocEmpty, [], None,
-          /root/CodeComment/TripleSlashCommentShouldNotBeCaptured.fs (3,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (3,6--3,7) })], (2,0--3,9))],
+          PreXmlDocEmpty, [], None, (3,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs.bsl
+++ b/tests/service/data/SyntaxTree/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs.bsl
@@ -14,66 +14,32 @@ ImplFile
                  ComputationExpr
                    (false,
                     LetOrUseBang
-                      (Yes
-                         /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (3,4--3,24),
-                       false, true,
-                       Named
-                         (SynIdent (bar, None), false, None,
-                          /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (3,9--3,12)),
+                      (Yes (3,4--3,24), false, true,
+                       Named (SynIdent (bar, None), false, None, (3,9--3,12)),
                        App
                          (NonAtomic, false, Ident getBar,
-                          Const
-                            (Unit,
-                             /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (3,22--3,24)),
-                          /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (3,15--3,24)),
+                          Const (Unit, (3,22--3,24)), (3,15--3,24)),
                        [SynExprAndBang
-                          (Yes
-                             /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (4,4--4,27),
-                           false, true,
+                          (Yes (4,4--4,27), false, true,
                            Named
-                             (SynIdent (foo, None), false, None,
-                              /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (4,9--4,12)),
+                             (SynIdent (foo, None), false, None, (4,9--4,12)),
                            App
                              (NonAtomic, false, Ident getFoo,
-                              Const
-                                (Unit,
-                                 /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (4,22--4,24)),
-                              /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (4,15--4,24)),
-                           /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (4,4--4,24),
-                           { EqualsRange =
-                              /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (4,13--4,14)
-                             InKeyword =
-                              Some
-                                /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (4,25--4,27) });
+                              Const (Unit, (4,22--4,24)), (4,15--4,24)),
+                           (4,4--4,24), { EqualsRange = (4,13--4,14)
+                                          InKeyword = Some (4,25--4,27) });
                         SynExprAndBang
-                          (Yes
-                             /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (5,4--6,10),
-                           false, true,
+                          (Yes (5,4--6,10), false, true,
                            Named
-                             (SynIdent (meh, None), false, None,
-                              /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (5,9--5,12)),
+                             (SynIdent (meh, None), false, None, (5,9--5,12)),
                            App
                              (NonAtomic, false, Ident getMeh,
-                              Const
-                                (Unit,
-                                 /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (5,22--5,24)),
-                              /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (5,15--5,24)),
-                           /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (5,4--5,24),
-                           { EqualsRange =
-                              /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (5,13--5,14)
-                             InKeyword = None })],
-                       YieldOrReturn
-                         ((false, true), Ident bar,
-                          /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (6,4--6,14)),
-                       /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (3,4--6,14),
-                       { EqualsRange =
-                          Some
-                            /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (3,13--3,14) }),
-                    /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (2,6--7,1)),
-                 /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (2,0--7,1)),
-              /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (2,0--7,1))],
-          PreXmlDocEmpty, [], None,
-          /root/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs (2,0--7,1),
-          { LeadingKeyword = None })], (true, false),
+                              Const (Unit, (5,22--5,24)), (5,15--5,24)),
+                           (5,4--5,24), { EqualsRange = (5,13--5,14)
+                                          InKeyword = None })],
+                       YieldOrReturn ((false, true), Ident bar, (6,4--6,14)),
+                       (3,4--6,14), { EqualsRange = Some (3,13--3,14) }),
+                    (2,6--7,1)), (2,0--7,1)), (2,0--7,1))], PreXmlDocEmpty, [],
+          None, (2,0--7,1), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs.bsl
+++ b/tests/service/data/SyntaxTree/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs.bsl
@@ -13,47 +13,23 @@ ImplFile
                  ComputationExpr
                    (false,
                     LetOrUseBang
-                      (Yes
-                         /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (3,4--3,24),
-                       false, true,
-                       Named
-                         (SynIdent (bar, None), false, None,
-                          /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (3,9--3,12)),
+                      (Yes (3,4--3,24), false, true,
+                       Named (SynIdent (bar, None), false, None, (3,9--3,12)),
                        App
                          (NonAtomic, false, Ident getBar,
-                          Const
-                            (Unit,
-                             /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (3,22--3,24)),
-                          /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (3,15--3,24)),
+                          Const (Unit, (3,22--3,24)), (3,15--3,24)),
                        [SynExprAndBang
-                          (Yes
-                             /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (5,4--7,10),
-                           false, true,
+                          (Yes (5,4--7,10), false, true,
                            Named
-                             (SynIdent (foo, None), false, None,
-                              /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (5,9--5,12)),
+                             (SynIdent (foo, None), false, None, (5,9--5,12)),
                            App
                              (NonAtomic, false, Ident getFoo,
-                              Const
-                                (Unit,
-                                 /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (5,22--5,24)),
-                              /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (5,15--5,24)),
-                           /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (5,4--5,24),
-                           { EqualsRange =
-                              /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (5,13--5,14)
-                             InKeyword = None })],
-                       YieldOrReturn
-                         ((false, true), Ident bar,
-                          /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (7,4--7,14)),
-                       /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (3,4--7,14),
-                       { EqualsRange =
-                          Some
-                            /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (3,13--3,14) }),
-                    /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (2,6--8,1)),
-                 /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (2,0--8,1)),
-              /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (2,0--8,1))],
-          PreXmlDocEmpty, [], None,
-          /root/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs (2,0--8,1),
-          { LeadingKeyword = None })], (true, false),
+                              Const (Unit, (5,22--5,24)), (5,15--5,24)),
+                           (5,4--5,24), { EqualsRange = (5,13--5,14)
+                                          InKeyword = None })],
+                       YieldOrReturn ((false, true), Ident bar, (7,4--7,14)),
+                       (3,4--7,14), { EqualsRange = Some (3,13--3,14) }),
+                    (2,6--8,1)), (2,0--8,1)), (2,0--8,1))], PreXmlDocEmpty, [],
+          None, (2,0--8,1), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs.bsl
@@ -14,29 +14,11 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (2,4--2,5)),
-                  None,
-                  Const
-                    (Int32 42,
-                     /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (8,0--8,2)),
-                  /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (2,4--2,5),
-                  Yes
-                    /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (2,0--8,2),
-                  { LeadingKeyword =
-                     Let
-                       /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (2,0--2,3)
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)), None,
+                  Const (Int32 42, (8,0--8,2)), (2,4--2,5), Yes (2,0--8,2),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (2,6--2,7) })],
-              /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (2,0--8,2))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (2,0--9,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments =
-         [BlockComment
-            /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTrivia.fs (3,0--7,2)] },
-      set []))
+                    EqualsRange = Some (2,6--2,7) })], (2,0--8,2))],
+          PreXmlDocEmpty, [], None, (2,0--9,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [BlockComment (3,0--7,2)] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi.bsl
@@ -11,27 +11,12 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 Some
-                   (Const
-                      (Int32 42,
-                       /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi (10,0--10,2))),
-                 /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi (4,0--10,2),
-                 { LeadingKeyword =
-                    Val
-                      /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi (4,0--4,3)
+                 Some (Const (Int32 42, (10,0--10,2))), (4,0--10,2),
+                 { LeadingKeyword = Val (4,0--4,3)
                    InlineKeyword = None
                    WithKeyword = None
-                   EqualsRange =
-                    Some
-                      /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi (4,12--4,13) }),
-              /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi (4,0--10,2))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi (2,0--10,2),
-          { LeadingKeyword =
-             Namespace
-               /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi (2,0--2,9) })],
+                   EqualsRange = Some (4,12--4,13) }), (4,0--10,2))],
+          PreXmlDocEmpty, [], None, (2,0--10,2),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [BlockComment
-            /root/ConditionalDirective/DirectivesInMultilineCommentAreNotReportedAsTriviaSignatureFile.fsi (5,0--9,2)] },
-      set []))
+        CodeComments = [BlockComment (5,0--9,2)] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs.bsl
@@ -13,26 +13,12 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs (2,4--2,5)),
-                  None,
-                  ArbitraryAfterError
-                    ("localBinding1",
-                     /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs (2,7--2,7)),
-                  /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs (2,4--2,5),
-                  Yes
-                    /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs (2,4--2,7),
-                  { LeadingKeyword =
-                     Let
-                       /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs (2,6--2,7) })],
-              /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs (2,0--2,7))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTrivia.fs (2,0--8,0),
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)), None,
+                  ArbitraryAfterError ("localBinding1", (2,7--2,7)), (2,4--2,5),
+                  Yes (2,4--2,7), { LeadingKeyword = Let (2,0--2,3)
+                                    InlineKeyword = None
+                                    EqualsRange = Some (2,6--2,7) })],
+              (2,0--2,7))], PreXmlDocEmpty, [], None, (2,0--8,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTriviaSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTriviaSignatureFile.fsi.bsl
@@ -5,9 +5,6 @@ SigFile
         DirectivesInMultilineStringAreNotReportedAsTriviaSignatureFile, [], [],
       [SynModuleOrNamespaceSig
          ([Foobar], false, DeclaredNamespace, [], PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTriviaSignatureFile.fsi (2,0--2,16),
-          { LeadingKeyword =
-             Namespace
-               /root/ConditionalDirective/DirectivesInMultilineStringAreNotReportedAsTriviaSignatureFile.fsi (2,0--2,9) })],
+          (2,0--2,16), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/NestedIfElseEndif.fs.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/NestedIfElseEndif.fs.bsl
@@ -11,36 +11,15 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/ConditionalDirective/NestedIfElseEndif.fs (2,4--2,5)),
-                  None,
-                  Const
-                    (Int32 3,
-                     /root/ConditionalDirective/NestedIfElseEndif.fs (10,8--10,9)),
-                  /root/ConditionalDirective/NestedIfElseEndif.fs (2,4--2,5),
-                  Yes
-                    /root/ConditionalDirective/NestedIfElseEndif.fs (2,0--10,9),
-                  { LeadingKeyword =
-                     Let
-                       /root/ConditionalDirective/NestedIfElseEndif.fs (2,0--2,3)
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)), None,
+                  Const (Int32 3, (10,8--10,9)), (2,4--2,5), Yes (2,0--10,9),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/ConditionalDirective/NestedIfElseEndif.fs (2,6--2,7) })],
-              /root/ConditionalDirective/NestedIfElseEndif.fs (2,0--10,9))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/NestedIfElseEndif.fs (2,0--12,0),
-          { LeadingKeyword = None })], (true, false),
+                    EqualsRange = Some (2,6--2,7) })], (2,0--10,9))],
+          PreXmlDocEmpty, [], None, (2,0--12,0), { LeadingKeyword = None })],
+      (true, false),
       { ConditionalDirectives =
-         [If
-            (Ident "FOO",
-             /root/ConditionalDirective/NestedIfElseEndif.fs (3,4--3,11));
-          If
-            (Ident "MEH",
-             /root/ConditionalDirective/NestedIfElseEndif.fs (4,8--4,15));
-          Else /root/ConditionalDirective/NestedIfElseEndif.fs (6,8--6,13);
-          EndIf /root/ConditionalDirective/NestedIfElseEndif.fs (8,8--8,14);
-          Else /root/ConditionalDirective/NestedIfElseEndif.fs (9,4--9,9);
-          EndIf /root/ConditionalDirective/NestedIfElseEndif.fs (11,4--11,10)]
+         [If (Ident "FOO", (3,4--3,11)); If (Ident "MEH", (4,8--4,15));
+          Else (6,8--6,13); EndIf (8,8--8,14); Else (9,4--9,9);
+          EndIf (11,4--11,10)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi.bsl
@@ -10,38 +10,15 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 Some
-                   (Const
-                      (Int32 3,
-                       /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (12,8--12,9))),
-                 /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (4,0--12,9),
-                 { LeadingKeyword =
-                    Val
-                      /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (4,0--4,3)
+                 Some (Const (Int32 3, (12,8--12,9))), (4,0--12,9),
+                 { LeadingKeyword = Val (4,0--4,3)
                    InlineKeyword = None
                    WithKeyword = None
-                   EqualsRange =
-                    Some
-                      /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (4,12--4,13) }),
-              /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (4,0--12,9))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (2,0--12,9),
-          { LeadingKeyword =
-             Namespace
-               /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (2,0--2,9) })],
+                   EqualsRange = Some (4,12--4,13) }), (4,0--12,9))],
+          PreXmlDocEmpty, [], None, (2,0--12,9),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives =
-         [If
-            (Ident "FOO",
-             /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (5,4--5,11));
-          If
-            (Ident "MEH",
-             /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (6,8--6,15));
-          Else
-            /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (8,8--8,13);
-          EndIf
-            /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (10,8--10,14);
-          Else
-            /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (11,4--11,9);
-          EndIf
-            /root/ConditionalDirective/NestedIfElseEndifSignatureFile.fsi (13,4--13,10)]
+         [If (Ident "FOO", (5,4--5,11)); If (Ident "MEH", (6,8--6,15));
+          Else (8,8--8,13); EndIf (10,8--10,14); Else (11,4--11,9);
+          EndIf (13,4--13,10)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs.bsl
@@ -11,41 +11,16 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (2,4--2,5)),
-                  None,
-                  ArbitraryAfterError
-                    ("localBinding1",
-                     /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (2,7--2,7)),
-                  /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (2,4--2,5),
-                  Yes
-                    /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (2,4--2,7),
-                  { LeadingKeyword =
-                     Let
-                       /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (2,6--2,7) })],
-              /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (2,0--2,7))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (2,0--10,0),
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)), None,
+                  ArbitraryAfterError ("localBinding1", (2,7--2,7)), (2,4--2,5),
+                  Yes (2,4--2,7), { LeadingKeyword = Let (2,0--2,3)
+                                    InlineKeyword = None
+                                    EqualsRange = Some (2,6--2,7) })],
+              (2,0--2,7))], PreXmlDocEmpty, [], None, (2,0--10,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives =
-         [If
-            (Not (Ident "DEBUG"),
-             /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (3,4--3,14));
-          If
-            (And (Ident "FOO", Ident "BAR"),
-             /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (4,8--4,22));
-          If
-            (Or (Ident "MEH", Ident "HMM"),
-             /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (5,12--5,26));
-          EndIf
-            /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (7,12--7,18);
-          EndIf
-            /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (8,8--8,14);
-          EndIf
-            /root/ConditionalDirective/NestedIfEndifWithComplexExpressions.fs (9,4--9,10)]
+         [If (Not (Ident "DEBUG"), (3,4--3,14));
+          If (And (Ident "FOO", Ident "BAR"), (4,8--4,22));
+          If (Or (Ident "MEH", Ident "HMM"), (5,12--5,26)); EndIf (7,12--7,18);
+          EndIf (8,8--8,14); EndIf (9,4--9,10)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi.bsl
@@ -11,39 +11,16 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 Some
-                   (Const
-                      (Int32 10,
-                       /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (12,4--12,6))),
-                 /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (4,0--12,6),
-                 { LeadingKeyword =
-                    Val
-                      /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (4,0--4,3)
+                 Some (Const (Int32 10, (12,4--12,6))), (4,0--12,6),
+                 { LeadingKeyword = Val (4,0--4,3)
                    InlineKeyword = None
                    WithKeyword = None
-                   EqualsRange =
-                    Some
-                      /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (4,12--4,13) }),
-              /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (4,0--12,6))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (2,0--12,6),
-          { LeadingKeyword =
-             Namespace
-               /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (2,0--2,9) })],
+                   EqualsRange = Some (4,12--4,13) }), (4,0--12,6))],
+          PreXmlDocEmpty, [], None, (2,0--12,6),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives =
-         [If
-            (Not (Ident "DEBUG"),
-             /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (5,4--5,14));
-          If
-            (And (Ident "FOO", Ident "BAR"),
-             /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (6,8--6,22));
-          If
-            (Or (Ident "MEH", Ident "HMM"),
-             /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (7,12--7,26));
-          EndIf
-            /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (9,12--9,18);
-          EndIf
-            /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (10,8--10,14);
-          EndIf
-            /root/ConditionalDirective/NestedIfEndifWithComplexExpressionsSignatureFile.fsi (11,4--11,10)]
+         [If (Not (Ident "DEBUG"), (5,4--5,14));
+          If (And (Ident "FOO", Ident "BAR"), (6,8--6,22));
+          If (Or (Ident "MEH", Ident "HMM"), (7,12--7,26)); EndIf (9,12--9,18);
+          EndIf (10,8--10,14); EndIf (11,4--11,10)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/SingleIfElseEndif.fs.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/SingleIfElseEndif.fs.bsl
@@ -11,30 +11,13 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/ConditionalDirective/SingleIfElseEndif.fs (2,4--2,5)),
-                  None,
-                  Const
-                    (Int32 42,
-                     /root/ConditionalDirective/SingleIfElseEndif.fs (6,4--6,6)),
-                  /root/ConditionalDirective/SingleIfElseEndif.fs (2,4--2,5),
-                  Yes /root/ConditionalDirective/SingleIfElseEndif.fs (2,0--6,6),
-                  { LeadingKeyword =
-                     Let
-                       /root/ConditionalDirective/SingleIfElseEndif.fs (2,0--2,3)
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)), None,
+                  Const (Int32 42, (6,4--6,6)), (2,4--2,5), Yes (2,0--6,6),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/ConditionalDirective/SingleIfElseEndif.fs (2,6--2,7) })],
-              /root/ConditionalDirective/SingleIfElseEndif.fs (2,0--6,6))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/SingleIfElseEndif.fs (2,0--8,0),
-          { LeadingKeyword = None })], (true, false),
+                    EqualsRange = Some (2,6--2,7) })], (2,0--6,6))],
+          PreXmlDocEmpty, [], None, (2,0--8,0), { LeadingKeyword = None })],
+      (true, false),
       { ConditionalDirectives =
-         [If
-            (Ident "DEBUG",
-             /root/ConditionalDirective/SingleIfElseEndif.fs (3,4--3,13));
-          Else /root/ConditionalDirective/SingleIfElseEndif.fs (5,4--5,9);
-          EndIf /root/ConditionalDirective/SingleIfElseEndif.fs (7,4--7,10)]
+         [If (Ident "DEBUG", (3,4--3,13)); Else (5,4--5,9); EndIf (7,4--7,10)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi.bsl
@@ -10,31 +10,13 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 Some
-                   (Const
-                      (Int32 42,
-                       /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (8,4--8,6))),
-                 /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (4,0--8,6),
-                 { LeadingKeyword =
-                    Val
-                      /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (4,0--4,3)
+                 Some (Const (Int32 42, (8,4--8,6))), (4,0--8,6),
+                 { LeadingKeyword = Val (4,0--4,3)
                    InlineKeyword = None
                    WithKeyword = None
-                   EqualsRange =
-                    Some
-                      /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (4,12--4,13) }),
-              /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (4,0--8,6))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (2,0--8,6),
-          { LeadingKeyword =
-             Namespace
-               /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (2,0--2,9) })],
+                   EqualsRange = Some (4,12--4,13) }), (4,0--8,6))],
+          PreXmlDocEmpty, [], None, (2,0--8,6),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives =
-         [If
-            (Ident "DEBUG",
-             /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (5,4--5,13));
-          Else
-            /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (7,4--7,9);
-          EndIf
-            /root/ConditionalDirective/SingleIfElseEndifSignatureFile.fsi (9,4--9,10)]
+         [If (Ident "DEBUG", (5,4--5,13)); Else (7,4--7,9); EndIf (9,4--9,10)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/SingleIfEndif.fs.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/SingleIfEndif.fs.bsl
@@ -11,27 +11,13 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (v, None), false, None,
-                     /root/ConditionalDirective/SingleIfEndif.fs (2,4--2,5)),
-                  None,
-                  Const
-                    (Int32 42,
-                     /root/ConditionalDirective/SingleIfEndif.fs (6,4--6,6)),
-                  /root/ConditionalDirective/SingleIfEndif.fs (2,4--2,5),
-                  Yes /root/ConditionalDirective/SingleIfEndif.fs (2,0--6,6),
-                  { LeadingKeyword =
-                     Let /root/ConditionalDirective/SingleIfEndif.fs (2,0--2,3)
+                  Named (SynIdent (v, None), false, None, (2,4--2,5)), None,
+                  Const (Int32 42, (6,4--6,6)), (2,4--2,5), Yes (2,0--6,6),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some /root/ConditionalDirective/SingleIfEndif.fs (2,6--2,7) })],
-              /root/ConditionalDirective/SingleIfEndif.fs (2,0--6,6))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/SingleIfEndif.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
+                    EqualsRange = Some (2,6--2,7) })], (2,0--6,6))],
+          PreXmlDocEmpty, [], None, (2,0--7,0), { LeadingKeyword = None })],
+      (true, false),
       { ConditionalDirectives =
-         [If
-            (Ident "DEBUG",
-             /root/ConditionalDirective/SingleIfEndif.fs (3,4--3,13));
-          EndIf /root/ConditionalDirective/SingleIfEndif.fs (5,4--5,10)]
+         [If (Ident "DEBUG", (3,4--3,13)); EndIf (5,4--5,10)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ConditionalDirective/SingleIfEndifSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ConditionalDirective/SingleIfEndifSignatureFile.fsi.bsl
@@ -10,29 +10,13 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 Some
-                   (Const
-                      (Int32 42,
-                       /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (8,4--8,6))),
-                 /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (4,0--8,6),
-                 { LeadingKeyword =
-                    Val
-                      /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (4,0--4,3)
+                 Some (Const (Int32 42, (8,4--8,6))), (4,0--8,6),
+                 { LeadingKeyword = Val (4,0--4,3)
                    InlineKeyword = None
                    WithKeyword = None
-                   EqualsRange =
-                    Some
-                      /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (4,11--4,12) }),
-              /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (4,0--8,6))],
-          PreXmlDocEmpty, [], None,
-          /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (2,0--8,6),
-          { LeadingKeyword =
-             Namespace
-               /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (2,0--2,9) })],
+                   EqualsRange = Some (4,11--4,12) }), (4,0--8,6))],
+          PreXmlDocEmpty, [], None, (2,0--8,6),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives =
-         [If
-            (Ident "DEBUG",
-             /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (5,4--5,13));
-          EndIf
-            /root/ConditionalDirective/SingleIfEndifSignatureFile.fsi (7,4--7,10)]
+         [If (Ident "DEBUG", (5,4--5,13)); EndIf (7,4--7,10)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/EnumCase/MultipleSynEnumCasesHaveBarRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/EnumCase/MultipleSynEnumCasesHaveBarRange.fs.bsl
@@ -9,48 +9,25 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Enum
                        ([SynEnumCase
                            ([], SynIdent (Bar, None),
-                            Const
-                              (Int32 1,
-                               /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (3,12--3,13)),
+                            Const (Int32 1, (3,12--3,13)),
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (3,6--3,13),
-                            { BarRange =
-                               Some
-                                 /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (3,4--3,5)
-                              EqualsRange =
-                               /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (3,10--3,11) });
+                            (3,6--3,13), { BarRange = Some (3,4--3,5)
+                                           EqualsRange = (3,10--3,11) });
                          SynEnumCase
                            ([], SynIdent (Bear, None),
-                            Const
-                              (Int32 2,
-                               /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (4,13--4,14)),
+                            Const (Int32 2, (4,13--4,14)),
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (4,6--4,14),
-                            { BarRange =
-                               Some
-                                 /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (4,4--4,5)
-                              EqualsRange =
-                               /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (4,11--4,12) })],
-                        /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (3,4--4,14)),
-                     /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (3,4--4,14)),
-                  [], None,
-                  /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (2,5--4,14),
-                  { LeadingKeyword =
-                     Type
-                       /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (2,0--4,14))],
-          PreXmlDocEmpty, [], None,
-          /root/EnumCase/MultipleSynEnumCasesHaveBarRange.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                            (4,6--4,14), { BarRange = Some (4,4--4,5)
+                                           EqualsRange = (4,11--4,12) })],
+                        (3,4--4,14)), (3,4--4,14)), [], None, (2,5--4,14),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--4,14))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/EnumCase/SingleSynEnumCaseHasBarRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/EnumCase/SingleSynEnumCaseHasBarRange.fs.bsl
@@ -9,36 +9,19 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Enum
                        ([SynEnumCase
                            ([], SynIdent (Bar, None),
-                            Const
-                              (Int32 1,
-                               /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,19--2,20)),
+                            Const (Int32 1, (2,19--2,20)),
                             PreXmlDoc ((2,11), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,13--2,20),
-                            { BarRange =
-                               Some
-                                 /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,11--2,12)
-                              EqualsRange =
-                               /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,17--2,18) })],
-                        /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,11--2,20)),
-                     /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,11--2,20)),
-                  [], None,
-                  /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,5--2,20),
-                  { LeadingKeyword =
-                     Type
-                       /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,0--2,20))],
-          PreXmlDocEmpty, [], None,
-          /root/EnumCase/SingleSynEnumCaseHasBarRange.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
+                            (2,13--2,20), { BarRange = Some (2,11--2,12)
+                                            EqualsRange = (2,17--2,18) })],
+                        (2,11--2,20)), (2,11--2,20)), [], None, (2,5--2,20),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--2,20))], PreXmlDocEmpty, [],
+          None, (2,0--3,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/EnumCase/SingleSynEnumCaseWithoutBar.fs.bsl
+++ b/tests/service/data/SyntaxTree/EnumCase/SingleSynEnumCaseWithoutBar.fs.bsl
@@ -9,34 +9,19 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Enum
                        ([SynEnumCase
                            ([], SynIdent (Bar, None),
-                            Const
-                              (Int32 1,
-                               /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,17--2,18)),
+                            Const (Int32 1, (2,17--2,18)),
                             PreXmlDoc ((2,11), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,11--2,18),
-                            { BarRange = None
-                              EqualsRange =
-                               /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,15--2,16) })],
-                        /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,11--2,18)),
-                     /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,11--2,18)),
-                  [], None,
-                  /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,5--2,18),
-                  { LeadingKeyword =
-                     Type
-                       /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,0--2,18))],
-          PreXmlDocEmpty, [], None,
-          /root/EnumCase/SingleSynEnumCaseWithoutBar.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
+                            (2,11--2,18), { BarRange = None
+                                            EqualsRange = (2,15--2,16) })],
+                        (2,11--2,18)), (2,11--2,18)), [], None, (2,5--2,18),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--2,18))], PreXmlDocEmpty, [],
+          None, (2,0--3,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -12,12 +12,9 @@ ImplFile
                    ([],
                     SynUnionCase
                       ([], SynIdent (Foo, None), Fields [], PreXmlDocEmpty, None,
-                       /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (4,10--4,13),
-                       { BarRange = None }), None,
+                       (4,10--4,13), { BarRange = None }), None,
                     PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                    /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (4,0--4,13)),
-                 Some
-                   /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (4,14--4,18),
+                    (4,0--4,13)), Some (4,14--4,18),
                  [Member
                     (SynBinding
                        (None, Normal, false, false, [],
@@ -35,33 +32,13 @@ ImplFile
                         LongIdent
                           (SynLongIdent ([Meh], [], [None]), None, None,
                            Pats
-                             [Paren
-                                (Const
-                                   (Unit,
-                                    /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (5,15--5,17)),
-                                 /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (5,15--5,17))],
-                           None,
-                           /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (5,11--5,17)),
-                        None,
-                        Const
-                          (Unit,
-                           /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (5,20--5,22)),
-                        /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (5,11--5,17),
-                        NoneAtInvisible,
-                        { LeadingKeyword =
-                           Member
-                             /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (5,4--5,10)
+                             [Paren (Const (Unit, (5,15--5,17)), (5,15--5,17))],
+                           None, (5,11--5,17)), None, Const (Unit, (5,20--5,22)),
+                        (5,11--5,17), NoneAtInvisible,
+                        { LeadingKeyword = Member (5,4--5,10)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (5,18--5,19) }),
-                     /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (5,4--5,22))],
-                 /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (4,0--5,22)),
-              /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (4,0--5,22))],
-          PreXmlDocEmpty, [], None,
-          /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (2,0--5,22),
-          { LeadingKeyword =
-             Namespace
-               /root/Exception/SynExceptionDefnShouldContainsTheRangeOfTheWithKeyword.fs (2,0--2,9) })],
+                          EqualsRange = Some (5,18--5,19) }), (5,4--5,22))],
+                 (4,0--5,22)), (4,0--5,22))], PreXmlDocEmpty, [], None,
+          (2,0--5,22), { LeadingKeyword = Namespace (2,0--2,9) })],
       (true, false), { ConditionalDirectives = []
                        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/AnonymousRecords-01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/AnonymousRecords-01.fs.bsl
@@ -7,51 +7,23 @@ ImplFile
           [Expr
              (AnonRecd
                 (false, None,
-                 [(X, Some /root/Expression/AnonymousRecords-01.fs (1,5--1,6),
-                   Const
-                     (Int32 1,
-                      /root/Expression/AnonymousRecords-01.fs (1,7--1,8)))],
-                 /root/Expression/AnonymousRecords-01.fs (1,0--1,11),
-                 { OpeningBraceRange =
-                    /root/Expression/AnonymousRecords-01.fs (1,0--1,2) }),
-              /root/Expression/AnonymousRecords-01.fs (1,0--1,11));
+                 [(X, Some (1,5--1,6), Const (Int32 1, (1,7--1,8)))],
+                 (1,0--1,11), { OpeningBraceRange = (1,0--1,2) }), (1,0--1,11));
            Expr
              (AnonRecd
                 (true, None,
-                 [(Y, Some /root/Expression/AnonymousRecords-01.fs (2,12--2,13),
-                   Const
-                     (Int32 2,
-                      /root/Expression/AnonymousRecords-01.fs (2,14--2,15)))],
-                 /root/Expression/AnonymousRecords-01.fs (2,0--2,18),
-                 { OpeningBraceRange =
-                    /root/Expression/AnonymousRecords-01.fs (2,7--2,9) }),
-              /root/Expression/AnonymousRecords-01.fs (2,0--2,18));
+                 [(Y, Some (2,12--2,13), Const (Int32 2, (2,14--2,15)))],
+                 (2,0--2,18), { OpeningBraceRange = (2,7--2,9) }), (2,0--2,18));
            Expr
              (AnonRecd
-                (false, None, [],
-                 /root/Expression/AnonymousRecords-01.fs (3,0--3,5),
-                 { OpeningBraceRange =
-                    /root/Expression/AnonymousRecords-01.fs (3,0--3,2) }),
-              /root/Expression/AnonymousRecords-01.fs (3,0--3,5));
+                (false, None, [], (3,0--3,5), { OpeningBraceRange = (3,0--3,2) }),
+              (3,0--3,5));
            Expr
              (AnonRecd
-                (true, None, [],
-                 /root/Expression/AnonymousRecords-01.fs (4,0--4,12),
-                 { OpeningBraceRange =
-                    /root/Expression/AnonymousRecords-01.fs (4,7--4,9) }),
-              /root/Expression/AnonymousRecords-01.fs (4,0--4,12));
-           Expr
-             (ArbitraryAfterError
-                ("braceBarExpr",
-                 /root/Expression/AnonymousRecords-01.fs (5,0--5,10)),
-              /root/Expression/AnonymousRecords-01.fs (5,0--5,10));
-           Expr
-             (ArbitraryAfterError
-                ("braceBarExpr",
-                 /root/Expression/AnonymousRecords-01.fs (6,0--6,17)),
-              /root/Expression/AnonymousRecords-01.fs (6,0--6,17))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/AnonymousRecords-01.fs (1,0--6,17),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                (true, None, [], (4,0--4,12), { OpeningBraceRange = (4,7--4,9) }),
+              (4,0--4,12));
+           Expr (ArbitraryAfterError ("braceBarExpr", (5,0--5,10)), (5,0--5,10));
+           Expr (ArbitraryAfterError ("braceBarExpr", (6,0--6,17)), (6,0--6,17))],
+          PreXmlDocEmpty, [], None, (1,0--6,17), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/AnonymousRecords-02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/AnonymousRecords-02.fs.bsl
@@ -7,16 +7,8 @@ ImplFile
           [Expr
              (AnonRecd
                 (false, None,
-                 [(X, Some /root/Expression/AnonymousRecords-02.fs (1,5--1,6),
-                   Const
-                     (Int32 0,
-                      /root/Expression/AnonymousRecords-02.fs (1,7--1,8)))],
-                 /root/Expression/AnonymousRecords-02.fs (1,0--2,0),
-                 { OpeningBraceRange =
-                    /root/Expression/AnonymousRecords-02.fs (1,0--1,2) }),
-              /root/Expression/AnonymousRecords-02.fs (1,0--2,0))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/AnonymousRecords-02.fs (1,0--2,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                 [(X, Some (1,5--1,6), Const (Int32 0, (1,7--1,8)))], (1,0--2,0),
+                 { OpeningBraceRange = (1,0--1,2) }), (1,0--2,0))],
+          PreXmlDocEmpty, [], None, (1,0--2,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/AnonymousRecords-03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/AnonymousRecords-03.fs.bsl
@@ -7,16 +7,8 @@ ImplFile
           [Expr
              (AnonRecd
                 (true, None,
-                 [(X, Some /root/Expression/AnonymousRecords-03.fs (1,12--1,13),
-                   Const
-                     (Int32 0,
-                      /root/Expression/AnonymousRecords-03.fs (1,14--1,15)))],
-                 /root/Expression/AnonymousRecords-03.fs (1,0--2,0),
-                 { OpeningBraceRange =
-                    /root/Expression/AnonymousRecords-03.fs (1,7--1,9) }),
-              /root/Expression/AnonymousRecords-03.fs (1,0--2,0))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/AnonymousRecords-03.fs (1,0--2,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                 [(X, Some (1,12--1,13), Const (Int32 0, (1,14--1,15)))],
+                 (1,0--2,0), { OpeningBraceRange = (1,7--1,9) }), (1,0--2,0))],
+          PreXmlDocEmpty, [], None, (1,0--2,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/AnonymousRecords-04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/AnonymousRecords-04.fs.bsl
@@ -6,13 +6,8 @@ ImplFile
          ([AnonymousRecords-04], false, AnonModule,
           [Expr
              (AnonRecd
-                (false, None, [],
-                 /root/Expression/AnonymousRecords-04.fs (1,0--1,2),
-                 { OpeningBraceRange =
-                    /root/Expression/AnonymousRecords-04.fs (1,0--1,2) }),
-              /root/Expression/AnonymousRecords-04.fs (1,0--1,2))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/AnonymousRecords-04.fs (1,0--2,0),
+                (false, None, [], (1,0--1,2), { OpeningBraceRange = (1,0--1,2) }),
+              (1,0--1,2))], PreXmlDocEmpty, [], None, (1,0--2,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/AnonymousRecords-05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/AnonymousRecords-05.fs.bsl
@@ -6,13 +6,8 @@ ImplFile
          ([AnonymousRecords-05], false, AnonModule,
           [Expr
              (AnonRecd
-                (true, None, [],
-                 /root/Expression/AnonymousRecords-05.fs (1,0--1,9),
-                 { OpeningBraceRange =
-                    /root/Expression/AnonymousRecords-05.fs (1,7--1,9) }),
-              /root/Expression/AnonymousRecords-05.fs (1,0--1,9))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/AnonymousRecords-05.fs (1,0--2,0),
+                (true, None, [], (1,0--1,9), { OpeningBraceRange = (1,7--1,9) }),
+              (1,0--1,9))], PreXmlDocEmpty, [], None, (1,0--2,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
@@ -10,24 +10,11 @@ ImplFile
           false, AnonModule,
           [Expr
              (Record
-                (None,
-                 Some
-                   (Ident foo,
-                    (/root/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,6--2,10),
-                     None)),
+                (None, Some (Ident foo, ((2,6--2,10), None)),
                  [SynExprRecordField
-                    ((SynLongIdent ([X], [], [None]), true),
-                     Some
-                       /root/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (4,12--4,13),
-                     Some
-                       (Const
-                          (Int32 12,
-                           /root/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (5,16--5,18))),
-                     None)],
-                 /root/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--5,20)),
-              /root/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--5,20))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--5,20),
+                    ((SynLongIdent ([X], [], [None]), true), Some (4,12--4,13),
+                     Some (Const (Int32 12, (5,16--5,18))), None)], (2,0--5,20)),
+              (2,0--5,20))], PreXmlDocEmpty, [], None, (2,0--5,20),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/GlobalKeywordAsSynExpr.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/GlobalKeywordAsSynExpr.fs.bsl
@@ -9,10 +9,7 @@ ImplFile
                 (false,
                  SynLongIdent
                    ([`global`], [], [Some (OriginalNotation "global")]), None,
-                 /root/Expression/GlobalKeywordAsSynExpr.fs (2,0--2,6)),
-              /root/Expression/GlobalKeywordAsSynExpr.fs (2,0--2,6))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/GlobalKeywordAsSynExpr.fs (2,0--2,6),
+                 (2,0--2,6)), (2,0--2,6))], PreXmlDocEmpty, [], None, (2,0--2,6),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
@@ -13,32 +13,14 @@ ImplFile
                 (Some
                    (LongIdent (SynLongIdent ([Exception], [], [None])),
                     Paren
-                      (Ident msg,
-                       /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,19--2,20),
-                       Some
-                         /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,23--2,24),
-                       /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,19--2,24)),
-                    /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,10--2,24),
-                    Some
-                      (/root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,24--2,25),
-                       Some (2,25)),
-                    /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,2--2,9)),
+                      (Ident msg, (2,19--2,20), Some (2,23--2,24), (2,19--2,24)),
+                    (2,10--2,24), Some ((2,24--2,25), Some (2,25)), (2,2--2,9)),
                  None,
                  [SynExprRecordField
-                    ((SynLongIdent ([X], [], [None]), true),
-                     Some
-                       /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,28--2,29),
-                     Some
-                       (Const
-                          (Int32 1,
-                           /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,30--2,31))),
-                     Some
-                       (/root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,31--2,32),
-                        Some (2,32)))],
-                 /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--2,34)),
-              /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--2,34))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--2,34),
+                    ((SynLongIdent ([X], [], [None]), true), Some (2,28--2,29),
+                     Some (Const (Int32 1, (2,30--2,31))),
+                     Some ((2,31--2,32), Some (2,32)))], (2,0--2,34)),
+              (2,0--2,34))], PreXmlDocEmpty, [], None, (2,0--2,34),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs.bsl
@@ -15,15 +15,8 @@ ImplFile
                     (None, SynValInfo ([[]], SynArgInfo ([], false, None)), None),
                   LongIdent
                     (SynLongIdent ([f], [], [None]), None, None,
-                     Pats
-                       [Paren
-                          (Const
-                             (Unit,
-                              /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,6--2,8)),
-                           /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,6--2,8))],
-                     None,
-                     /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,4--2,8)),
-                  None,
+                     Pats [Paren (Const (Unit, (2,6--2,8)), (2,6--2,8))], None,
+                     (2,4--2,8)), None,
                   LetOrUse
                     (false, false,
                      [SynBinding
@@ -32,23 +25,11 @@ ImplFile
                          SynValData
                            (None, SynValInfo ([], SynArgInfo ([], false, None)),
                             None),
-                         Named
-                           (SynIdent (x, None), false, None,
-                            /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,8--3,9)),
-                         None,
-                         Const
-                           (Int32 1,
-                            /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,12--3,13)),
-                         /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,8--3,9),
-                         Yes
-                           /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,4--3,13),
-                         { LeadingKeyword =
-                            Let
-                              /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,4--3,7)
-                           InlineKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,10--3,11) })],
+                         Named (SynIdent (x, None), false, None, (3,8--3,9)),
+                         None, Const (Int32 1, (3,12--3,13)), (3,8--3,9),
+                         Yes (3,4--3,13), { LeadingKeyword = Let (3,4--3,7)
+                                            InlineKeyword = None
+                                            EqualsRange = Some (3,10--3,11) })],
                      LetOrUse
                        (false, false,
                         [SynBinding
@@ -58,23 +39,11 @@ ImplFile
                               (None,
                                SynValInfo ([], SynArgInfo ([], false, None)),
                                None),
-                            Named
-                              (SynIdent (y, None), false, None,
-                               /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (4,8--4,9)),
-                            None,
-                            Const
-                              (Int32 2,
-                               /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (4,12--4,13)),
-                            /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (4,8--4,9),
-                            Yes
-                              /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (4,4--4,13),
-                            { LeadingKeyword =
-                               Let
-                                 /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (4,4--4,7)
-                              InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (4,10--4,11) })],
+                            Named (SynIdent (y, None), false, None, (4,8--4,9)),
+                            None, Const (Int32 2, (4,12--4,13)), (4,8--4,9),
+                            Yes (4,4--4,13), { LeadingKeyword = Let (4,4--4,7)
+                                               InlineKeyword = None
+                                               EqualsRange = Some (4,10--4,11) })],
                         App
                           (NonAtomic, false,
                            App
@@ -84,34 +53,13 @@ ImplFile
                                  SynLongIdent
                                    ([op_Addition], [],
                                     [Some (OriginalNotation "+")]), None,
-                                 /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (5,6--5,7)),
-                              Ident x,
-                              /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (5,4--5,7)),
-                           Ident y,
-                           /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (5,4--5,9)),
-                        /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (4,4--5,9),
-                        { InKeyword =
-                           Some
-                             /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (4,14--4,16) }),
-                     /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,4--5,9),
-                     { InKeyword =
-                        Some
-                          /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,14--3,16) }),
-                  /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,4--2,8),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,0--2,3)
+                                 (5,6--5,7)), Ident x, (5,4--5,7)), Ident y,
+                           (5,4--5,9)), (4,4--5,9),
+                        { InKeyword = Some (4,14--4,16) }), (3,4--5,9),
+                     { InKeyword = Some (3,14--3,16) }), (2,4--2,8), NoneAtLet,
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,9--2,10) })],
-              /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,0--5,9))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Expression/NestedSynExprLetOrUseContainsTheRangeOfInKeyword.fs (3,17--3,55)] },
-      set []))
+                    EqualsRange = Some (2,9--2,10) })], (2,0--5,9))],
+          PreXmlDocEmpty, [], None, (2,0--6,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [LineComment (3,17--3,55)] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprAnonRecdWithStructKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprAnonRecdWithStructKeyword.fs.bsl
@@ -6,27 +6,12 @@ ImplFile
          ([SynExprAnonRecdWithStructKeyword], false, AnonModule,
           [Expr
              (AnonRecd
-                (true, None,
-                 [(Foo,
-                   Some
-                     /root/Expression/SynExprAnonRecdWithStructKeyword.fs (3,11--3,12),
-                   Ident someValue)],
-                 /root/Expression/SynExprAnonRecdWithStructKeyword.fs (2,0--5,16),
-                 { OpeningBraceRange =
-                    /root/Expression/SynExprAnonRecdWithStructKeyword.fs (3,4--3,6) }),
-              /root/Expression/SynExprAnonRecdWithStructKeyword.fs (2,0--5,16));
+                (true, None, [(Foo, Some (3,11--3,12), Ident someValue)],
+                 (2,0--5,16), { OpeningBraceRange = (3,4--3,6) }), (2,0--5,16));
            Expr
              (AnonRecd
-                (true, None, [],
-                 /root/Expression/SynExprAnonRecdWithStructKeyword.fs (7,0--7,12),
-                 { OpeningBraceRange =
-                    /root/Expression/SynExprAnonRecdWithStructKeyword.fs (7,7--7,9) }),
-              /root/Expression/SynExprAnonRecdWithStructKeyword.fs (7,0--7,12))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprAnonRecdWithStructKeyword.fs (2,0--7,12),
+                (true, None, [], (7,0--7,12), { OpeningBraceRange = (7,7--7,9) }),
+              (7,0--7,12))], PreXmlDocEmpty, [], None, (2,0--7,12),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Expression/SynExprAnonRecdWithStructKeyword.fs (4,4--4,11)] },
-      set []))
+        CodeComments = [LineComment (4,4--4,11)] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs.bsl
@@ -10,30 +10,10 @@ ImplFile
           [Expr
              (AnonRecd
                 (false, None,
-                 [(X,
-                   Some
-                     /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (2,5--2,6),
-                   Const
-                     (Int32 5,
-                      /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (2,7--2,8)));
-                  (Y,
-                   Some
-                     /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (3,8--3,9),
-                   Const
-                     (Int32 6,
-                      /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (3,10--3,11)));
-                  (Z,
-                   Some
-                     /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (4,12--4,13),
-                   Const
-                     (Int32 7,
-                      /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (4,14--4,15)))],
-                 /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (2,0--4,18),
-                 { OpeningBraceRange =
-                    /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (2,0--2,2) }),
-              /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (2,0--4,18))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprAnonRecordContainsTheRangeOfTheEqualsSignInTheFields.fs (2,0--4,18),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                 [(X, Some (2,5--2,6), Const (Int32 5, (2,7--2,8)));
+                  (Y, Some (3,8--3,9), Const (Int32 6, (3,10--3,11)));
+                  (Z, Some (4,12--4,13), Const (Int32 7, (4,14--4,15)))],
+                 (2,0--4,18), { OpeningBraceRange = (2,0--2,2) }), (2,0--4,18))],
+          PreXmlDocEmpty, [], None, (2,0--4,18), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs.bsl
@@ -11,31 +11,14 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (a, None), false, None,
-                     /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (2,4--2,5)),
-                  None,
+                  Named (SynIdent (a, None), false, None, (2,4--2,5)), None,
                   Sequential
-                    (SuppressNeither, true,
-                     Do
-                       (Ident foobar,
-                        /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (3,4--4,14)),
-                     DoBang
-                       (Ident foobarBang,
-                        /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (5,4--6,18)),
-                     /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (3,4--6,18)),
-                  /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (2,4--2,5),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (2,6--2,7) })],
-              /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (2,0--6,18))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprDoContainsTheRangeOfTheDoKeyword.fs (2,0--7,0),
+                    (SuppressNeither, true, Do (Ident foobar, (3,4--4,14)),
+                     DoBang (Ident foobarBang, (5,4--6,18)), (3,4--6,18)),
+                  (2,4--2,5), NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                                           InlineKeyword = None
+                                           EqualsRange = Some (2,6--2,7) })],
+              (2,0--6,18))], PreXmlDocEmpty, [], None, (2,0--7,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprDynamicDoesContainIdent.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprDynamicDoesContainIdent.fs.bsl
@@ -4,15 +4,7 @@ ImplFile
       QualifiedNameOfFile SynExprDynamicDoesContainIdent, [], [],
       [SynModuleOrNamespace
          ([SynExprDynamicDoesContainIdent], false, AnonModule,
-          [Expr
-             (Dynamic
-                (Ident x,
-                 /root/Expression/SynExprDynamicDoesContainIdent.fs (2,1--2,2),
-                 Ident k,
-                 /root/Expression/SynExprDynamicDoesContainIdent.fs (2,0--2,3)),
-              /root/Expression/SynExprDynamicDoesContainIdent.fs (2,0--2,3))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprDynamicDoesContainIdent.fs (2,0--2,3),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+          [Expr (Dynamic (Ident x, (2,1--2,2), Ident k, (2,0--2,3)), (2,0--2,3))],
+          PreXmlDocEmpty, [], None, (2,0--2,3), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprDynamicDoesContainParentheses.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprDynamicDoesContainParentheses.fs.bsl
@@ -6,18 +6,9 @@ ImplFile
          ([SynExprDynamicDoesContainParentheses], false, AnonModule,
           [Expr
              (Dynamic
-                (Ident x,
-                 /root/Expression/SynExprDynamicDoesContainParentheses.fs (2,1--2,2),
-                 Paren
-                   (Ident g,
-                    /root/Expression/SynExprDynamicDoesContainParentheses.fs (2,2--2,3),
-                    Some
-                      /root/Expression/SynExprDynamicDoesContainParentheses.fs (2,4--2,5),
-                    /root/Expression/SynExprDynamicDoesContainParentheses.fs (2,2--2,5)),
-                 /root/Expression/SynExprDynamicDoesContainParentheses.fs (2,0--2,5)),
-              /root/Expression/SynExprDynamicDoesContainParentheses.fs (2,0--2,5))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprDynamicDoesContainParentheses.fs (2,0--2,5),
+                (Ident x, (2,1--2,2),
+                 Paren (Ident g, (2,2--2,3), Some (2,4--2,5), (2,2--2,5)),
+                 (2,0--2,5)), (2,0--2,5))], PreXmlDocEmpty, [], None, (2,0--2,5),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -6,36 +6,16 @@ ImplFile
          ([SynExprForContainsTheRangeOfTheEqualsSign], false, AnonModule,
           [Expr
              (For
-                (Yes
-                   /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (2,0--2,3),
-                 Yes
-                   /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (2,10--2,12),
-                 i,
-                 Some
-                   /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (2,6--2,7),
-                 Const
-                   (Int32 1,
-                    /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (2,8--2,9)),
-                 true,
-                 Const
-                   (Int32 10,
-                    /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (2,13--2,15)),
+                (Yes (2,0--2,3), Yes (2,10--2,12), i, Some (2,6--2,7),
+                 Const (Int32 1, (2,8--2,9)), true,
+                 Const (Int32 10, (2,13--2,15)),
                  App
                    (NonAtomic, false,
                     App
                       (NonAtomic, false, Ident printf,
-                       Const
-                         (String
-                            ("%d ", Regular,
-                             /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (3,7--3,12)),
-                          /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (3,7--3,12)),
-                       /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (3,0--3,12)),
-                    Ident i,
-                    /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (3,0--3,14)),
-                 /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (2,0--3,14)),
-              /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (2,0--3,14))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprForContainsTheRangeOfTheEqualsSign.fs (2,0--4,0),
+                       Const (String ("%d ", Regular, (3,7--3,12)), (3,7--3,12)),
+                       (3,0--3,12)), Ident i, (3,0--3,14)), (2,0--3,14)),
+              (2,0--3,14))], PreXmlDocEmpty, [], None, (2,0--4,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -13,45 +13,21 @@ ImplFile
                  ComputationExpr
                    (false,
                     LetOrUseBang
-                      (Yes
-                         /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (3,4--3,14),
-                       false, true,
-                       Named
-                         (SynIdent (x, None), false, None,
-                          /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (3,9--3,10)),
+                      (Yes (3,4--3,14), false, true,
+                       Named (SynIdent (x, None), false, None, (3,9--3,10)),
                        Ident y,
                        [SynExprAndBang
-                          (Yes
-                             /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (4,4--5,10),
-                           false, true,
-                           Named
-                             (SynIdent (z, None), false, None,
-                              /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (4,9--4,10)),
+                          (Yes (4,4--5,10), false, true,
+                           Named (SynIdent (z, None), false, None, (4,9--4,10)),
                            App
                              (NonAtomic, false, Ident someFunction,
-                              Const
-                                (Unit,
-                                 /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (4,26--4,28)),
-                              /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (4,13--4,28)),
-                           /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (4,4--4,28),
-                           { EqualsRange =
-                              /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (4,11--4,12)
-                             InKeyword = None })],
+                              Const (Unit, (4,26--4,28)), (4,13--4,28)),
+                           (4,4--4,28), { EqualsRange = (4,11--4,12)
+                                          InKeyword = None })],
                        YieldOrReturn
-                         ((false, true),
-                          Const
-                            (Unit,
-                             /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (5,11--5,13)),
-                          /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (5,4--5,13)),
-                       /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (3,4--5,13),
-                       { EqualsRange =
-                          Some
-                            /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (3,11--3,12) }),
-                    /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (2,5--6,1)),
-                 /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (2,0--6,1)),
-              /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (2,0--6,1))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs (2,0--6,1),
-          { LeadingKeyword = None })], (true, false),
+                         ((false, true), Const (Unit, (5,11--5,13)), (5,4--5,13)),
+                       (3,4--5,13), { EqualsRange = Some (3,11--3,12) }),
+                    (2,5--6,1)), (2,0--6,1)), (2,0--6,1))], PreXmlDocEmpty, [],
+          None, (2,0--6,1), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs.bsl
@@ -13,33 +13,13 @@ ImplFile
                      SynValData
                        (None, SynValInfo ([], SynArgInfo ([], false, None)),
                         None),
-                     Named
-                       (SynIdent (x, None), false, None,
-                        /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,4--2,5)),
-                     None,
-                     Const
-                       (Int32 1,
-                        /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,8--2,9)),
-                     /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,4--2,5),
-                     Yes
-                       /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,0--2,9),
-                     { LeadingKeyword =
-                        Let
-                          /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,0--2,3)
+                     Named (SynIdent (x, None), false, None, (2,4--2,5)), None,
+                     Const (Int32 1, (2,8--2,9)), (2,4--2,5), Yes (2,0--2,9),
+                     { LeadingKeyword = Let (2,0--2,3)
                        InlineKeyword = None
-                       EqualsRange =
-                        Some
-                          /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,6--2,7) })],
-                 Const
-                   (Unit,
-                    /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,13--2,15)),
-                 /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,0--2,15),
-                 { InKeyword =
-                    Some
-                      /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,10--2,12) }),
-              /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,0--2,15))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprLetOrUseContainsTheRangeOfInKeyword.fs (2,0--2,15),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                       EqualsRange = Some (2,6--2,7) })],
+                 Const (Unit, (2,13--2,15)), (2,0--2,15),
+                 { InKeyword = Some (2,10--2,12) }), (2,0--2,15))],
+          PreXmlDocEmpty, [], None, (2,0--2,15), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs.bsl
@@ -16,32 +16,13 @@ ImplFile
                         SynValData
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
-                        Named
-                          (SynIdent (x, None), false, None,
-                           /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (3,4--3,5)),
-                        None,
-                        Const
-                          (Int32 1,
-                           /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (3,8--3,9)),
-                        /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (3,4--3,5),
-                        Yes
-                          /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (3,0--3,9),
-                        { LeadingKeyword =
-                           Let
-                             /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (3,0--3,3)
-                          InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (3,6--3,7) })],
-                    Const
-                      (Unit,
-                       /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (4,0--4,2)),
-                    /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (3,0--4,2),
-                    { InKeyword = None }),
-                 /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (2,0--4,2)),
-              /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (2,0--4,2))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprLetOrUseDoesNotContainTheRangeOfInKeyword.fs (2,0--5,0),
+                        Named (SynIdent (x, None), false, None, (3,4--3,5)),
+                        None, Const (Int32 1, (3,8--3,9)), (3,4--3,5),
+                        Yes (3,0--3,9), { LeadingKeyword = Let (3,0--3,3)
+                                          InlineKeyword = None
+                                          EqualsRange = Some (3,6--3,7) })],
+                    Const (Unit, (4,0--4,2)), (3,0--4,2), { InKeyword = None }),
+                 (2,0--4,2)), (2,0--4,2))], PreXmlDocEmpty, [], None, (2,0--5,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs.bsl
@@ -18,52 +18,30 @@ ImplFile
                         SynValData
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
-                        Named
-                          (SynIdent (e1, None), false, None,
-                           /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (3,4--3,6)),
+                        Named (SynIdent (e1, None), false, None, (3,4--3,6)),
                         None,
                         Downcast
                           (Ident e,
                            LongIdent
                              (SynLongIdent
-                                ([Collections; DictionaryEntry],
-                                 [/root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (3,26--3,27)],
-                                 [None; None])),
-                           /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (3,9--3,42)),
-                        /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (3,4--3,6),
-                        Yes
-                          /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (3,0--3,42),
-                        { LeadingKeyword =
-                           Let
-                             /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (3,0--3,3)
-                          InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (3,7--3,8) })],
+                                ([Collections; DictionaryEntry], [(3,26--3,27)],
+                                 [None; None])), (3,9--3,42)), (3,4--3,6),
+                        Yes (3,0--3,42), { LeadingKeyword = Let (3,0--3,3)
+                                           InlineKeyword = None
+                                           EqualsRange = Some (3,7--3,8) })],
                     Tuple
                       (false,
                        [LongIdent
                           (false,
-                           SynLongIdent
-                             ([e1; Key],
-                              [/root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (4,2--4,3)],
-                              [None; None]), None,
-                           /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (4,0--4,6));
+                           SynLongIdent ([e1; Key], [(4,2--4,3)], [None; None]),
+                           None, (4,0--4,6));
                         LongIdent
                           (false,
                            SynLongIdent
-                             ([e1; Value],
-                              [/root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (4,10--4,11)],
-                              [None; None]), None,
-                           /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (4,8--4,16))],
-                       [/root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (4,6--4,7)],
-                       /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (4,0--4,16)),
-                    /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (3,0--4,16),
-                    { InKeyword = None }),
-                 /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (2,0--4,16)),
-              /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (2,0--4,16))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprLetOrUseWhereBodyExprStartsWithTokenOfTwoCharactersDoesNotContainTheRangeOfInKeyword.fs (2,0--5,0),
+                             ([e1; Value], [(4,10--4,11)], [None; None]), None,
+                           (4,8--4,16))], [(4,6--4,7)], (4,0--4,16)),
+                    (3,0--4,16), { InKeyword = None }), (2,0--4,16)),
+              (2,0--4,16))], PreXmlDocEmpty, [], None, (2,0--5,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs.bsl
@@ -17,58 +17,25 @@ ImplFile
                         SynValData
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
-                        Named
-                          (SynIdent (f, None), false, None,
-                           /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (3,12--3,13)),
-                        None,
-                        Const
-                          (Unit,
-                           /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (3,16--3,18)),
-                        /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (3,12--3,13),
-                        Yes
-                          /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (3,4--3,18),
-                        { LeadingKeyword =
-                           LetRec
-                             (/root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (3,4--3,7),
-                              /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (3,8--3,11))
+                        Named (SynIdent (f, None), false, None, (3,12--3,13)),
+                        None, Const (Unit, (3,16--3,18)), (3,12--3,13),
+                        Yes (3,4--3,18),
+                        { LeadingKeyword = LetRec ((3,4--3,7), (3,8--3,11))
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (3,14--3,15) });
+                          EqualsRange = Some (3,14--3,15) });
                      SynBinding
                        (None, Normal, false, false, [],
                         PreXmlDoc ((4,8), FSharp.Compiler.Xml.XmlDocCollector),
                         SynValData
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
-                        Named
-                          (SynIdent (g, None), false, None,
-                           /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (4,8--4,9)),
-                        None,
-                        Const
-                          (Unit,
-                           /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (4,12--4,14)),
-                        /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (4,8--4,9),
-                        Yes
-                          /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (4,4--4,14),
-                        { LeadingKeyword =
-                           And
-                             /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (4,4--4,7)
-                          InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (4,10--4,11) })],
-                    Const
-                      (Unit,
-                       /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (5,4--5,6)),
-                    /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (3,4--5,6),
-                    { InKeyword =
-                       Some
-                         /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (4,15--4,17) }),
-                 /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (2,0--5,6)),
-              /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (2,0--5,6))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprLetOrUseWithRecursiveBindingContainsTheRangeOfInKeyword.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                        Named (SynIdent (g, None), false, None, (4,8--4,9)),
+                        None, Const (Unit, (4,12--4,14)), (4,8--4,9),
+                        Yes (4,4--4,14), { LeadingKeyword = And (4,4--4,7)
+                                           InlineKeyword = None
+                                           EqualsRange = Some (4,10--4,11) })],
+                    Const (Unit, (5,4--5,6)), (3,4--5,6),
+                    { InKeyword = Some (4,15--4,17) }), (2,0--5,6)), (2,0--5,6))],
+          PreXmlDocEmpty, [], None, (2,0--6,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs.bsl
@@ -9,30 +9,13 @@ ImplFile
           AnonModule,
           [Expr
              (MatchBang
-                (Yes
-                   /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--2,13),
-                 Ident x,
+                (Yes (2,0--2,13), Ident x,
                  [SynMatchClause
-                    (Named
-                       (SynIdent (y, None), false, None,
-                        /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (3,2--3,3)),
-                     None, Ident z,
-                     /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (3,2--3,8),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (3,4--3,6)
-                       BarRange =
-                        Some
-                          /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (3,0--3,1) })],
-                 /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--3,8),
-                 { MatchBangKeyword =
-                    /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--2,6)
-                   WithKeyword =
-                    /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (2,9--2,13) }),
-              /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--3,8))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprMatchBangContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    (Named (SynIdent (y, None), false, None, (3,2--3,3)), None,
+                     Ident z, (3,2--3,8), Yes, { ArrowRange = Some (3,4--3,6)
+                                                 BarRange = Some (3,0--3,1) })],
+                 (2,0--3,8), { MatchBangKeyword = (2,0--2,6)
+                               WithKeyword = (2,9--2,13) }), (2,0--3,8))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs.bsl
@@ -9,30 +9,13 @@ ImplFile
           AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--2,12),
-                 Ident x,
+                (Yes (2,0--2,12), Ident x,
                  [SynMatchClause
-                    (Named
-                       (SynIdent (y, None), false, None,
-                        /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (3,2--3,3)),
-                     None, Ident z,
-                     /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (3,2--3,8),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (3,4--3,6)
-                       BarRange =
-                        Some
-                          /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (3,0--3,1) })],
-                 /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--3,8),
-                 { MatchKeyword =
-                    /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (2,8--2,12) }),
-              /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--3,8))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprMatchContainsTheRangeOfTheMatchAndWithKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    (Named (SynIdent (y, None), false, None, (3,2--3,3)), None,
+                     Ident z, (3,2--3,8), Yes, { ArrowRange = Some (3,4--3,6)
+                                                 BarRange = Some (3,0--3,1) })],
+                 (2,0--3,8), { MatchKeyword = (2,0--2,5)
+                               WithKeyword = (2,8--2,12) }), (2,0--3,8))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs.bsl
@@ -7,14 +7,7 @@ ImplFile
           [Expr
              (ObjExpr
                 (LongIdent (SynLongIdent ([obj], [], [None])),
-                 Some
-                   (Const
-                      (Unit,
-                       /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (2,9--2,11)),
-                    None),
-                 Some
-                   /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (2,12--2,16),
-                 [],
+                 Some (Const (Unit, (2,9--2,11)), None), Some (2,12--2,16), [],
                  [Member
                     (SynBinding
                        (None, Normal, false, false, [],
@@ -31,65 +24,33 @@ ImplFile
                               SynArgInfo ([], false, None)), None),
                         LongIdent
                           (SynLongIdent
-                             ([x; ToString],
-                              [/root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,12--3,13)],
-                              [None; None]), None, None,
-                           Pats
-                             [Paren
-                                (Const
-                                   (Unit,
-                                    /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,21--3,23)),
-                                 /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,21--3,23))],
+                             ([x; ToString], [(3,12--3,13)], [None; None]), None,
                            None,
-                           /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,11--3,23)),
-                        None,
+                           Pats
+                             [Paren (Const (Unit, (3,21--3,23)), (3,21--3,23))],
+                           None, (3,11--3,23)), None,
                         Const
                           (String
-                             ("INotifyEnumerableInternal", Regular,
-                              /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,26--3,53)),
-                           /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,26--3,53)),
-                        /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,11--3,23),
-                        NoneAtInvisible,
-                        { LeadingKeyword =
-                           Member
-                             /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,4--3,10)
+                             ("INotifyEnumerableInternal", Regular, (3,26--3,53)),
+                           (3,26--3,53)), (3,11--3,23), NoneAtInvisible,
+                        { LeadingKeyword = Member (3,4--3,10)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,24--3,25) }),
-                     /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (3,4--3,53))],
+                          EqualsRange = Some (3,24--3,25) }), (3,4--3,53))],
                  [SynInterfaceImpl
                     (App
                        (LongIdent
                           (SynLongIdent
                              ([INotifyEnumerableInternal], [], [None])),
-                        Some
-                          /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (4,37--4,38),
-                        [Var
-                           (SynTypar (T, None, false),
-                            /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (4,38--4,40))],
-                        [],
-                        Some
-                          /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (4,40--4,41),
-                        false,
-                        /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (4,12--4,41)),
-                     None, [], [],
-                     /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (4,2--5,2));
+                        Some (4,37--4,38),
+                        [Var (SynTypar (T, None, false), (4,38--4,40))], [],
+                        Some (4,40--4,41), false, (4,12--4,41)), None, [], [],
+                     (4,2--5,2));
                   SynInterfaceImpl
                     (App
                        (LongIdent (SynLongIdent ([IEnumerable], [], [None])),
-                        Some
-                          /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (5,23--5,24),
-                        [Anon
-                           /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (5,24--5,25)],
-                        [],
-                        Some
-                          /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (5,25--5,26),
-                        false,
-                        /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (5,12--5,26)),
-                     Some
-                       /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (5,27--5,31),
-                     [],
+                        Some (5,23--5,24), [Anon (5,24--5,25)], [],
+                        Some (5,25--5,26), false, (5,12--5,26)),
+                     Some (5,27--5,31), [],
                      [Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -106,36 +67,17 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([x; GetEnumerator],
-                                  [/root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,12--6,13)],
+                                 ([x; GetEnumerator], [(6,12--6,13)],
                                   [None; None]), None, None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,26--6,28)),
-                                     /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,26--6,28))],
-                               None,
-                               /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,11--6,28)),
-                            None,
-                            Null
-                              /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,31--6,35),
-                            /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,11--6,28),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,4--6,10)
+                                    (Const (Unit, (6,26--6,28)), (6,26--6,28))],
+                               None, (6,11--6,28)), None, Null (6,31--6,35),
+                            (6,11--6,28), NoneAtInvisible,
+                            { LeadingKeyword = Member (6,4--6,10)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,29--6,30) }),
-                         /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (6,4--6,35))],
-                     /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (5,2--6,37))],
-                 /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (2,2--2,11),
-                 /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (2,0--6,37)),
-              /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (2,0--6,37))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprObjExprContainsTheRangeOfWithKeyword.fs (2,0--6,37),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                              EqualsRange = Some (6,29--6,30) }), (6,4--6,35))],
+                     (5,2--6,37))], (2,2--2,11), (2,0--6,37)), (2,0--6,37))],
+          PreXmlDocEmpty, [], None, (2,0--6,37), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprObjWithSetter.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprObjWithSetter.fs.bsl
@@ -10,31 +10,19 @@ ImplFile
                     ([{ Attributes =
                          [{ TypeName =
                              SynLongIdent ([AbstractClass], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Expression/SynExprObjWithSetter.fs (2,2--2,15))
+                            ArgExpr = Const (Unit, (2,2--2,15))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Expression/SynExprObjWithSetter.fs (2,2--2,15) }]
-                        Range =
-                         /root/Expression/SynExprObjWithSetter.fs (2,0--2,17) }],
-                     None, [], [CFoo],
+                            Range = (2,2--2,15) }]
+                        Range = (2,0--2,17) }], None, [], [CFoo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Expression/SynExprObjWithSetter.fs (3,5--3,9)),
+                     false, None, (3,5--3,9)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Expression/SynExprObjWithSetter.fs (3,9--3,11)),
-                         None,
+                        (None, [], SimplePats ([], (3,9--3,11)), None,
                          PreXmlDoc ((3,9), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Expression/SynExprObjWithSetter.fs (3,5--3,9),
-                         { AsKeyword = None });
+                         (3,5--3,9), { AsKeyword = None });
                       AbstractSlot
                         (SynValSig
                            ([], SynIdent (AbstractClassPropertySet, None),
@@ -43,54 +31,31 @@ ImplFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/Expression/SynExprObjWithSetter.fs (4,4--4,54),
-                            { LeadingKeyword =
-                               Abstract
-                                 /root/Expression/SynExprObjWithSetter.fs (4,4--4,12)
+                            None, None, (4,4--4,54),
+                            { LeadingKeyword = Abstract (4,4--4,12)
                               InlineKeyword = None
-                              WithKeyword =
-                               Some
-                                 /root/Expression/SynExprObjWithSetter.fs (4,46--4,50)
+                              WithKeyword = Some (4,46--4,50)
                               EqualsRange = None }),
                          { IsInstance = true
                            IsDispatchSlot = true
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertySet },
-                         /root/Expression/SynExprObjWithSetter.fs (4,4--4,54),
-                         { GetSetKeywords =
-                            Some
-                              (Set
-                                 /root/Expression/SynExprObjWithSetter.fs (4,51--4,54)) })],
-                     /root/Expression/SynExprObjWithSetter.fs (4,4--4,54)), [],
+                           MemberKind = PropertySet }, (4,4--4,54),
+                         { GetSetKeywords = Some (Set (4,51--4,54)) })],
+                     (4,4--4,54)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Expression/SynExprObjWithSetter.fs (3,9--3,11)),
-                        None,
+                       (None, [], SimplePats ([], (3,9--3,11)), None,
                         PreXmlDoc ((3,9), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Expression/SynExprObjWithSetter.fs (3,5--3,9),
-                        { AsKeyword = None })),
-                  /root/Expression/SynExprObjWithSetter.fs (2,0--4,54),
-                  { LeadingKeyword =
-                     Type /root/Expression/SynExprObjWithSetter.fs (3,0--3,4)
-                    EqualsRange =
-                     Some /root/Expression/SynExprObjWithSetter.fs (3,12--3,13)
-                    WithKeyword = None })],
-              /root/Expression/SynExprObjWithSetter.fs (2,0--4,54));
+                        (3,5--3,9), { AsKeyword = None })), (2,0--4,54),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,12--3,13)
+                    WithKeyword = None })], (2,0--4,54));
            Expr
              (ObjExpr
                 (LongIdent (SynLongIdent ([CFoo], [], [None])),
-                 Some
-                   (Const
-                      (Unit,
-                       /root/Expression/SynExprObjWithSetter.fs (6,10--6,12)),
-                    None),
-                 Some /root/Expression/SynExprObjWithSetter.fs (6,13--6,17), [],
+                 Some (Const (Unit, (6,10--6,12)), None), Some (6,13--6,17), [],
                  [GetSetMember
                     (None,
                      Some
@@ -112,47 +77,27 @@ ImplFile
                            LongIdent
                              (SynLongIdent
                                 ([this; AbstractClassPropertySet],
-                                 [/root/Expression/SynExprObjWithSetter.fs (7,17--7,18)],
-                                 [None; None]), Some set, None,
+                                 [(7,17--7,18)], [None; None]), Some set, None,
                               Pats
                                 [Paren
                                    (Typed
                                       (Named
                                          (SynIdent (v, None), false, None,
-                                          /root/Expression/SynExprObjWithSetter.fs (7,53--7,54)),
+                                          (7,53--7,54)),
                                        LongIdent
                                          (SynLongIdent ([string], [], [None])),
-                                       /root/Expression/SynExprObjWithSetter.fs (7,53--7,61)),
-                                    /root/Expression/SynExprObjWithSetter.fs (7,52--7,62))],
-                              None,
-                              /root/Expression/SynExprObjWithSetter.fs (7,48--7,62)),
-                           None,
-                           Const
-                             (Unit,
-                              /root/Expression/SynExprObjWithSetter.fs (7,65--7,67)),
-                           /root/Expression/SynExprObjWithSetter.fs (7,48--7,62),
-                           NoneAtInvisible,
-                           { LeadingKeyword =
-                              Override
-                                /root/Expression/SynExprObjWithSetter.fs (7,4--7,12)
+                                       (7,53--7,61)), (7,52--7,62))], None,
+                              (7,48--7,62)), None, Const (Unit, (7,65--7,67)),
+                           (7,48--7,62), NoneAtInvisible,
+                           { LeadingKeyword = Override (7,4--7,12)
                              InlineKeyword = None
-                             EqualsRange =
-                              Some
-                                /root/Expression/SynExprObjWithSetter.fs (7,63--7,64) })),
-                     /root/Expression/SynExprObjWithSetter.fs (7,4--7,67),
+                             EqualsRange = Some (7,63--7,64) })), (7,4--7,67),
                      { InlineKeyword = None
-                       WithKeyword =
-                        /root/Expression/SynExprObjWithSetter.fs (7,43--7,47)
+                       WithKeyword = (7,43--7,47)
                        GetKeyword = None
                        AndKeyword = None
-                       SetKeyword =
-                        Some
-                          /root/Expression/SynExprObjWithSetter.fs (7,48--7,51) })],
-                 [], /root/Expression/SynExprObjWithSetter.fs (6,2--6,12),
-                 /root/Expression/SynExprObjWithSetter.fs (6,0--7,69)),
-              /root/Expression/SynExprObjWithSetter.fs (6,0--7,69))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprObjWithSetter.fs (2,0--7,69),
-          { LeadingKeyword = None })], (true, false),
+                       SetKeyword = Some (7,48--7,51) })], [], (6,2--6,12),
+                 (6,0--7,69)), (6,0--7,69))], PreXmlDocEmpty, [], None,
+          (2,0--7,69), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
@@ -11,17 +11,10 @@ ImplFile
              (Record
                 (None, None,
                  [SynExprRecordField
-                    ((SynLongIdent ([V], [], [None]), true),
-                     Some
-                       /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,4--2,5),
-                     Some (Ident v),
-                     Some
-                       (/root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,8--3,2),
-                        None));
+                    ((SynLongIdent ([V], [], [None]), true), Some (2,4--2,5),
+                     Some (Ident v), Some ((2,8--3,2), None));
                   SynExprRecordField
-                    ((SynLongIdent ([X], [], [None]), true),
-                     Some
-                       /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (3,9--3,10),
+                    ((SynLongIdent ([X], [], [None]), true), Some (3,9--3,10),
                      Some
                        (App
                           (NonAtomic, false,
@@ -29,20 +22,9 @@ ImplFile
                              (NonAtomic, false,
                               App
                                 (NonAtomic, false, Ident someLongFunctionCall,
-                                 Ident a,
-                                 /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (4,16--5,21)),
-                              Ident b,
-                              /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (4,16--6,21)),
-                           Ident c,
-                           /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (4,16--7,21))),
-                     None)],
-                 /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--7,23)),
-              /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--7,23))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (2,0--7,23),
+                                 Ident a, (4,16--5,21)), Ident b, (4,16--6,21)),
+                           Ident c, (4,16--7,21))), None)], (2,0--7,23)),
+              (2,0--7,23))], PreXmlDocEmpty, [], None, (2,0--7,23),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs (3,13--3,28)] },
-      set []))
+        CodeComments = [LineComment (3,13--3,28)] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs.bsl
@@ -10,8 +10,7 @@ ImplFile
                 (None, None,
                  [SynExprRecordField
                     ((SynLongIdent ([JobType], [], [None]), true),
-                     Some
-                       /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,10--2,11),
+                     Some (2,10--2,11),
                      Some
                        (App
                           (NonAtomic, false,
@@ -22,7 +21,7 @@ ImplFile
                                  SynLongIdent
                                    ([op_Equality], [],
                                     [Some (OriginalNotation "=")]), None,
-                                 /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (5,13--5,14)),
+                                 (5,13--5,14)),
                               App
                                 (NonAtomic, false,
                                  App
@@ -32,7 +31,7 @@ ImplFile
                                        SynLongIdent
                                          ([op_Equality], [],
                                           [Some (OriginalNotation "=")]), None,
-                                       /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (4,12--4,13)),
+                                       (4,12--4,13)),
                                     App
                                       (NonAtomic, false,
                                        App
@@ -42,38 +41,25 @@ ImplFile
                                              SynLongIdent
                                                ([op_Equality], [],
                                                 [Some (OriginalNotation "=")]),
-                                             None,
-                                             /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (3,19--3,20)),
+                                             None, (3,19--3,20)),
                                           App
                                             (NonAtomic, false,
                                              Ident EsriBoundaryImport,
-                                             Ident FileToImport,
-                                             /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,12--3,18)),
-                                          /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,12--3,20)),
+                                             Ident FileToImport, (2,12--3,18)),
+                                          (2,12--3,20)),
                                        App
                                          (NonAtomic, false, Ident filePath,
-                                          Ident State,
-                                          /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (3,21--4,11)),
-                                       /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,12--4,11)),
-                                    /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,12--4,13)),
+                                          Ident State, (3,21--4,11)),
+                                       (2,12--4,11)), (2,12--4,13)),
                                  App
                                    (NonAtomic, false, Ident state, Ident DryRun,
-                                    /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (4,14--5,12)),
-                                 /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,12--5,12)),
-                              /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,12--5,14)),
+                                    (4,14--5,12)), (2,12--5,12)), (2,12--5,14)),
                            LongIdent
                              (false,
                               SynLongIdent
-                                ([args; DryRun],
-                                 [/root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (5,19--5,20)],
-                                 [None; None]), None,
-                              /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (5,15--5,26)),
-                           /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,12--5,26))),
-                     None)],
-                 /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,0--5,28)),
-              /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,0--5,28))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprRecordFieldsContainCorrectAmountOfTrivia.fs (2,0--5,28),
-          { LeadingKeyword = None })], (true, false),
+                                ([args; DryRun], [(5,19--5,20)], [None; None]),
+                              None, (5,15--5,26)), (2,12--5,26))), None)],
+                 (2,0--5,28)), (2,0--5,28))], PreXmlDocEmpty, [], None,
+          (2,0--5,28), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprSetWithSynExprDynamic.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprSetWithSynExprDynamic.fs.bsl
@@ -6,18 +6,8 @@ ImplFile
          ([SynExprSetWithSynExprDynamic], false, AnonModule,
           [Expr
              (Set
-                (Dynamic
-                   (Ident x,
-                    /root/Expression/SynExprSetWithSynExprDynamic.fs (2,1--2,2),
-                    Ident v,
-                    /root/Expression/SynExprSetWithSynExprDynamic.fs (2,0--2,3)),
-                 Const
-                   (Int32 2,
-                    /root/Expression/SynExprSetWithSynExprDynamic.fs (2,7--2,8)),
-                 /root/Expression/SynExprSetWithSynExprDynamic.fs (2,0--2,8)),
-              /root/Expression/SynExprSetWithSynExprDynamic.fs (2,0--2,8))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprSetWithSynExprDynamic.fs (2,0--2,8),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                (Dynamic (Ident x, (2,1--2,2), Ident v, (2,0--2,3)),
+                 Const (Int32 2, (2,7--2,8)), (2,0--2,8)), (2,0--2,8))],
+          PreXmlDocEmpty, [], None, (2,0--2,8), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs.bsl
@@ -9,22 +9,9 @@ ImplFile
           AnonModule,
           [Expr
              (TryFinally
-                (Ident x,
-                 Const
-                   (Unit,
-                    /root/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs (5,0--5,2)),
-                 /root/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--5,2),
-                 Yes
-                   /root/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--2,3),
-                 Yes
-                   /root/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs (4,0--4,7),
-                 { TryKeyword =
-                    /root/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--2,3)
-                   FinallyKeyword =
-                    /root/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs (4,0--4,7) }),
-              /root/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--5,2))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprTryFinallyContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                (Ident x, Const (Unit, (5,0--5,2)), (2,0--5,2), Yes (2,0--2,3),
+                 Yes (4,0--4,7), { TryKeyword = (2,0--2,3)
+                                   FinallyKeyword = (4,0--4,7) }), (2,0--5,2))],
+          PreXmlDocEmpty, [], None, (2,0--6,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs.bsl
@@ -11,34 +11,14 @@ ImplFile
              (TryWith
                 (Ident x,
                  [SynMatchClause
-                    (Named
-                       (SynIdent (ex, None), false, None,
-                        /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (5,2--5,4)),
-                     None, Ident y,
-                     /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (5,2--5,9),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (5,5--5,7)
-                       BarRange =
-                        Some
-                          /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (5,0--5,1) })],
-                 /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--5,9),
-                 Yes
-                   /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--2,3),
-                 Yes
-                   /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (4,0--4,4),
-                 { TryKeyword =
-                    /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--4,4)
-                   WithKeyword =
-                    /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (4,0--4,4)
-                   WithToEndRange =
-                    /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (4,0--5,9) }),
-              /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--5,9))],
-          PreXmlDocEmpty, [], None,
-          /root/Expression/SynExprTryWithContainsTheRangeOfTheTryAndWithKeyword.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                    (Named (SynIdent (ex, None), false, None, (5,2--5,4)), None,
+                     Ident y, (5,2--5,9), Yes, { ArrowRange = Some (5,5--5,7)
+                                                 BarRange = Some (5,0--5,1) })],
+                 (2,0--5,9), Yes (2,0--2,3), Yes (4,0--4,4),
+                 { TryKeyword = (2,0--2,3)
+                   TryToWithRange = (2,0--4,4)
+                   WithKeyword = (4,0--4,4)
+                   WithToEndRange = (4,0--5,9) }), (2,0--5,9))], PreXmlDocEmpty,
+          [], None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Extern/ExternKeywordIsPresentInTrivia.fs.bsl
+++ b/tests/service/data/SyntaxTree/Extern/ExternKeywordIsPresentInTrivia.fs.bsl
@@ -14,21 +14,14 @@ ImplFile
                   LongIdent
                     (SynLongIdent ([GetProcessHeap], [], [None]), None,
                      Some (SynValTyparDecls (None, false)),
-                     Pats
-                       [Tuple
-                          (false, [],
-                           /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,26--2,27))],
-                     None,
-                     /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,12--2,26)),
+                     Pats [Tuple (false, [], (2,26--2,27))], None, (2,12--2,26)),
                   Some
                     (SynBindingReturnInfo
                        (App
                           (LongIdent
                              (SynLongIdent
                                 ([unit], [], [Some (OriginalNotation "void")])),
-                           None, [], [], None, false,
-                           /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,7--2,11)),
-                        /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,7--2,11),
+                           None, [], [], None, false, (2,7--2,11)), (2,7--2,11),
                         [], { ColonRange = None })),
                   Typed
                     (App
@@ -36,27 +29,16 @@ ImplFile
                         Const
                           (String
                              ("extern was not given a DllImport attribute",
-                              Regular,
-                              /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,27--2,28)),
-                           /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,27--2,28)),
-                        /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,0--2,28)),
+                              Regular, (2,27--2,28)), (2,27--2,28)), (2,0--2,28)),
                      App
                        (LongIdent
                           (SynLongIdent
                              ([unit], [], [Some (OriginalNotation "void")])),
-                        None, [], [], None, false,
-                        /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,7--2,11)),
-                     /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,0--2,28)),
-                  /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,0--2,28),
-                  NoneAtInvisible,
-                  { LeadingKeyword =
-                     Extern
-                       /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,0--2,6)
+                        None, [], [], None, false, (2,7--2,11)), (2,0--2,28)),
+                  (2,0--2,28), NoneAtInvisible,
+                  { LeadingKeyword = Extern (2,0--2,6)
                     InlineKeyword = None
-                    EqualsRange = None })],
-              /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,0--2,28))],
-          PreXmlDocEmpty, [], None,
-          /root/Extern/ExternKeywordIsPresentInTrivia.fs (2,0--2,28),
-          { LeadingKeyword = None })], (true, false),
+                    EqualsRange = None })], (2,0--2,28))], PreXmlDocEmpty, [],
+          None, (2,0--2,28), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/IfThenElse/CommentBetweenElseAndIf.fs.bsl
+++ b/tests/service/data/SyntaxTree/IfThenElse/CommentBetweenElseAndIf.fs.bsl
@@ -9,35 +9,18 @@ ImplFile
                 (Ident a, Ident b,
                  Some
                    (IfThenElse
-                      (Ident c, Ident d, None,
-                       Yes
-                         /root/IfThenElse/CommentBetweenElseAndIf.fs (4,34--4,43),
-                       false,
-                       /root/IfThenElse/CommentBetweenElseAndIf.fs (4,34--5,1),
-                       { IfKeyword =
-                          /root/IfThenElse/CommentBetweenElseAndIf.fs (4,34--4,36)
-                         IsElif = false
-                         ThenKeyword =
-                          /root/IfThenElse/CommentBetweenElseAndIf.fs (4,39--4,43)
-                         ElseKeyword = None
-                         IfToThenRange =
-                          /root/IfThenElse/CommentBetweenElseAndIf.fs (4,34--4,43) })),
-                 Yes /root/IfThenElse/CommentBetweenElseAndIf.fs (2,0--2,9),
-                 false, /root/IfThenElse/CommentBetweenElseAndIf.fs (2,0--5,1),
-                 { IfKeyword =
-                    /root/IfThenElse/CommentBetweenElseAndIf.fs (2,0--2,2)
+                      (Ident c, Ident d, None, Yes (4,34--4,43), false,
+                       (4,34--5,1), { IfKeyword = (4,34--4,36)
+                                      IsElif = false
+                                      ThenKeyword = (4,39--4,43)
+                                      ElseKeyword = None
+                                      IfToThenRange = (4,34--4,43) })),
+                 Yes (2,0--2,9), false, (2,0--5,1),
+                 { IfKeyword = (2,0--2,2)
                    IsElif = false
-                   ThenKeyword =
-                    /root/IfThenElse/CommentBetweenElseAndIf.fs (2,5--2,9)
-                   ElseKeyword =
-                    Some /root/IfThenElse/CommentBetweenElseAndIf.fs (4,0--4,4)
-                   IfToThenRange =
-                    /root/IfThenElse/CommentBetweenElseAndIf.fs (2,0--2,9) }),
-              /root/IfThenElse/CommentBetweenElseAndIf.fs (2,0--5,1))],
-          PreXmlDocEmpty, [], None,
-          /root/IfThenElse/CommentBetweenElseAndIf.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                   ThenKeyword = (2,5--2,9)
+                   ElseKeyword = Some (4,0--4,4)
+                   IfToThenRange = (2,0--2,9) }), (2,0--5,1))], PreXmlDocEmpty,
+          [], None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [BlockComment /root/IfThenElse/CommentBetweenElseAndIf.fs (4,5--4,33)] },
-      set []))
+        CodeComments = [BlockComment (4,5--4,33)] }, set []))

--- a/tests/service/data/SyntaxTree/IfThenElse/DeeplyNestedIfThenElse.fs.bsl
+++ b/tests/service/data/SyntaxTree/IfThenElse/DeeplyNestedIfThenElse.fs.bsl
@@ -12,48 +12,24 @@ ImplFile
                       (Ident c, Ident d,
                        Some
                          (IfThenElse
-                            (Ident e, Ident f, Some (Ident g),
-                             Yes
-                               /root/IfThenElse/DeeplyNestedIfThenElse.fs (7,8--7,17),
-                             false,
-                             /root/IfThenElse/DeeplyNestedIfThenElse.fs (7,8--10,13),
-                             { IfKeyword =
-                                /root/IfThenElse/DeeplyNestedIfThenElse.fs (7,8--7,10)
+                            (Ident e, Ident f, Some (Ident g), Yes (7,8--7,17),
+                             false, (7,8--10,13),
+                             { IfKeyword = (7,8--7,10)
                                IsElif = false
-                               ThenKeyword =
-                                /root/IfThenElse/DeeplyNestedIfThenElse.fs (7,13--7,17)
-                               ElseKeyword =
-                                Some
-                                  /root/IfThenElse/DeeplyNestedIfThenElse.fs (9,8--9,12)
-                               IfToThenRange =
-                                /root/IfThenElse/DeeplyNestedIfThenElse.fs (7,8--7,17) })),
-                       Yes
-                         /root/IfThenElse/DeeplyNestedIfThenElse.fs (4,0--4,11),
-                       false,
-                       /root/IfThenElse/DeeplyNestedIfThenElse.fs (4,0--10,13),
-                       { IfKeyword =
-                          /root/IfThenElse/DeeplyNestedIfThenElse.fs (4,0--4,4)
-                         IsElif = true
-                         ThenKeyword =
-                          /root/IfThenElse/DeeplyNestedIfThenElse.fs (4,7--4,11)
-                         ElseKeyword =
-                          Some
-                            /root/IfThenElse/DeeplyNestedIfThenElse.fs (6,0--6,4)
-                         IfToThenRange =
-                          /root/IfThenElse/DeeplyNestedIfThenElse.fs (4,0--4,11) })),
-                 Yes /root/IfThenElse/DeeplyNestedIfThenElse.fs (2,0--2,9),
-                 false, /root/IfThenElse/DeeplyNestedIfThenElse.fs (2,0--10,13),
-                 { IfKeyword =
-                    /root/IfThenElse/DeeplyNestedIfThenElse.fs (2,0--2,2)
+                               ThenKeyword = (7,13--7,17)
+                               ElseKeyword = Some (9,8--9,12)
+                               IfToThenRange = (7,8--7,17) })), Yes (4,0--4,11),
+                       false, (4,0--10,13), { IfKeyword = (4,0--4,4)
+                                              IsElif = true
+                                              ThenKeyword = (4,7--4,11)
+                                              ElseKeyword = Some (6,0--6,4)
+                                              IfToThenRange = (4,0--4,11) })),
+                 Yes (2,0--2,9), false, (2,0--10,13),
+                 { IfKeyword = (2,0--2,2)
                    IsElif = false
-                   ThenKeyword =
-                    /root/IfThenElse/DeeplyNestedIfThenElse.fs (2,5--2,9)
+                   ThenKeyword = (2,5--2,9)
                    ElseKeyword = None
-                   IfToThenRange =
-                    /root/IfThenElse/DeeplyNestedIfThenElse.fs (2,0--2,9) }),
-              /root/IfThenElse/DeeplyNestedIfThenElse.fs (2,0--10,13))],
-          PreXmlDocEmpty, [], None,
-          /root/IfThenElse/DeeplyNestedIfThenElse.fs (2,0--11,0),
-          { LeadingKeyword = None })], (true, false),
+                   IfToThenRange = (2,0--2,9) }), (2,0--10,13))], PreXmlDocEmpty,
+          [], None, (2,0--11,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/IfThenElse/ElseKeywordInSimpleIfThenElse.fs.bsl
+++ b/tests/service/data/SyntaxTree/IfThenElse/ElseKeywordInSimpleIfThenElse.fs.bsl
@@ -6,24 +6,12 @@ ImplFile
          ([ElseKeywordInSimpleIfThenElse], false, AnonModule,
           [Expr
              (IfThenElse
-                (Ident a, Ident b, Some (Ident c),
-                 Yes
-                   /root/IfThenElse/ElseKeywordInSimpleIfThenElse.fs (2,0--2,9),
-                 false,
-                 /root/IfThenElse/ElseKeywordInSimpleIfThenElse.fs (2,0--2,18),
-                 { IfKeyword =
-                    /root/IfThenElse/ElseKeywordInSimpleIfThenElse.fs (2,0--2,2)
-                   IsElif = false
-                   ThenKeyword =
-                    /root/IfThenElse/ElseKeywordInSimpleIfThenElse.fs (2,5--2,9)
-                   ElseKeyword =
-                    Some
-                      /root/IfThenElse/ElseKeywordInSimpleIfThenElse.fs (2,12--2,16)
-                   IfToThenRange =
-                    /root/IfThenElse/ElseKeywordInSimpleIfThenElse.fs (2,0--2,9) }),
-              /root/IfThenElse/ElseKeywordInSimpleIfThenElse.fs (2,0--2,18))],
-          PreXmlDocEmpty, [], None,
-          /root/IfThenElse/ElseKeywordInSimpleIfThenElse.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                (Ident a, Ident b, Some (Ident c), Yes (2,0--2,9), false,
+                 (2,0--2,18), { IfKeyword = (2,0--2,2)
+                                IsElif = false
+                                ThenKeyword = (2,5--2,9)
+                                ElseKeyword = Some (2,12--2,16)
+                                IfToThenRange = (2,0--2,9) }), (2,0--2,18))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/IfThenElse/IfKeywordInIfThenElse.fs.bsl
+++ b/tests/service/data/SyntaxTree/IfThenElse/IfKeywordInIfThenElse.fs.bsl
@@ -6,20 +6,12 @@ ImplFile
          ([IfKeywordInIfThenElse], false, AnonModule,
           [Expr
              (IfThenElse
-                (Ident a, Ident b, None,
-                 Yes /root/IfThenElse/IfKeywordInIfThenElse.fs (2,0--2,9), false,
-                 /root/IfThenElse/IfKeywordInIfThenElse.fs (2,0--2,11),
-                 { IfKeyword =
-                    /root/IfThenElse/IfKeywordInIfThenElse.fs (2,0--2,2)
+                (Ident a, Ident b, None, Yes (2,0--2,9), false, (2,0--2,11),
+                 { IfKeyword = (2,0--2,2)
                    IsElif = false
-                   ThenKeyword =
-                    /root/IfThenElse/IfKeywordInIfThenElse.fs (2,5--2,9)
+                   ThenKeyword = (2,5--2,9)
                    ElseKeyword = None
-                   IfToThenRange =
-                    /root/IfThenElse/IfKeywordInIfThenElse.fs (2,0--2,9) }),
-              /root/IfThenElse/IfKeywordInIfThenElse.fs (2,0--2,11))],
-          PreXmlDocEmpty, [], None,
-          /root/IfThenElse/IfKeywordInIfThenElse.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
+                   IfToThenRange = (2,0--2,9) }), (2,0--2,11))], PreXmlDocEmpty,
+          [], None, (2,0--3,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs.bsl
+++ b/tests/service/data/SyntaxTree/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs.bsl
@@ -6,24 +6,12 @@ ImplFile
          ([IfThenAndElseKeywordOnSeparateLines], false, AnonModule,
           [Expr
              (IfThenElse
-                (Ident a, Ident b, Some (Ident c),
-                 Yes
-                   /root/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs (2,0--3,4),
-                 false,
-                 /root/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs (2,0--4,6),
-                 { IfKeyword =
-                    /root/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs (2,0--2,2)
-                   IsElif = false
-                   ThenKeyword =
-                    /root/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs (3,0--3,4)
-                   ElseKeyword =
-                    Some
-                      /root/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs (4,0--4,4)
-                   IfToThenRange =
-                    /root/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs (2,0--3,4) }),
-              /root/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs (2,0--4,6))],
-          PreXmlDocEmpty, [], None,
-          /root/IfThenElse/IfThenAndElseKeywordOnSeparateLines.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                (Ident a, Ident b, Some (Ident c), Yes (2,0--3,4), false,
+                 (2,0--4,6), { IfKeyword = (2,0--2,2)
+                               IsElif = false
+                               ThenKeyword = (3,0--3,4)
+                               ElseKeyword = Some (4,0--4,4)
+                               IfToThenRange = (2,0--3,4) }), (2,0--4,6))],
+          PreXmlDocEmpty, [], None, (2,0--5,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/IfThenElse/NestedElifInIfThenElse.fs.bsl
+++ b/tests/service/data/SyntaxTree/IfThenElse/NestedElifInIfThenElse.fs.bsl
@@ -9,32 +9,18 @@ ImplFile
                 (Ident a, Ident b,
                  Some
                    (IfThenElse
-                      (Ident c, Ident d, None,
-                       Yes
-                         /root/IfThenElse/NestedElifInIfThenElse.fs (4,0--4,11),
-                       false,
-                       /root/IfThenElse/NestedElifInIfThenElse.fs (4,0--4,13),
-                       { IfKeyword =
-                          /root/IfThenElse/NestedElifInIfThenElse.fs (4,0--4,4)
-                         IsElif = true
-                         ThenKeyword =
-                          /root/IfThenElse/NestedElifInIfThenElse.fs (4,7--4,11)
-                         ElseKeyword = None
-                         IfToThenRange =
-                          /root/IfThenElse/NestedElifInIfThenElse.fs (4,0--4,11) })),
-                 Yes /root/IfThenElse/NestedElifInIfThenElse.fs (2,0--2,9),
-                 false, /root/IfThenElse/NestedElifInIfThenElse.fs (2,0--4,13),
-                 { IfKeyword =
-                    /root/IfThenElse/NestedElifInIfThenElse.fs (2,0--2,2)
+                      (Ident c, Ident d, None, Yes (4,0--4,11), false,
+                       (4,0--4,13), { IfKeyword = (4,0--4,4)
+                                      IsElif = true
+                                      ThenKeyword = (4,7--4,11)
+                                      ElseKeyword = None
+                                      IfToThenRange = (4,0--4,11) })),
+                 Yes (2,0--2,9), false, (2,0--4,13),
+                 { IfKeyword = (2,0--2,2)
                    IsElif = false
-                   ThenKeyword =
-                    /root/IfThenElse/NestedElifInIfThenElse.fs (2,5--2,9)
+                   ThenKeyword = (2,5--2,9)
                    ElseKeyword = None
-                   IfToThenRange =
-                    /root/IfThenElse/NestedElifInIfThenElse.fs (2,0--2,9) }),
-              /root/IfThenElse/NestedElifInIfThenElse.fs (2,0--4,13))],
-          PreXmlDocEmpty, [], None,
-          /root/IfThenElse/NestedElifInIfThenElse.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                   IfToThenRange = (2,0--2,9) }), (2,0--4,13))], PreXmlDocEmpty,
+          [], None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/IfThenElse/NestedElseIfInIfThenElse.fs.bsl
+++ b/tests/service/data/SyntaxTree/IfThenElse/NestedElseIfInIfThenElse.fs.bsl
@@ -9,33 +9,18 @@ ImplFile
                 (Ident a, Ident b,
                  Some
                    (IfThenElse
-                      (Ident c, Ident d, None,
-                       Yes
-                         /root/IfThenElse/NestedElseIfInIfThenElse.fs (5,4--5,13),
-                       false,
-                       /root/IfThenElse/NestedElseIfInIfThenElse.fs (5,4--5,15),
-                       { IfKeyword =
-                          /root/IfThenElse/NestedElseIfInIfThenElse.fs (5,4--5,6)
-                         IsElif = false
-                         ThenKeyword =
-                          /root/IfThenElse/NestedElseIfInIfThenElse.fs (5,9--5,13)
-                         ElseKeyword = None
-                         IfToThenRange =
-                          /root/IfThenElse/NestedElseIfInIfThenElse.fs (5,4--5,13) })),
-                 Yes /root/IfThenElse/NestedElseIfInIfThenElse.fs (2,0--2,9),
-                 false, /root/IfThenElse/NestedElseIfInIfThenElse.fs (2,0--5,15),
-                 { IfKeyword =
-                    /root/IfThenElse/NestedElseIfInIfThenElse.fs (2,0--2,2)
+                      (Ident c, Ident d, None, Yes (5,4--5,13), false,
+                       (5,4--5,15), { IfKeyword = (5,4--5,6)
+                                      IsElif = false
+                                      ThenKeyword = (5,9--5,13)
+                                      ElseKeyword = None
+                                      IfToThenRange = (5,4--5,13) })),
+                 Yes (2,0--2,9), false, (2,0--5,15),
+                 { IfKeyword = (2,0--2,2)
                    IsElif = false
-                   ThenKeyword =
-                    /root/IfThenElse/NestedElseIfInIfThenElse.fs (2,5--2,9)
-                   ElseKeyword =
-                    Some /root/IfThenElse/NestedElseIfInIfThenElse.fs (4,0--4,4)
-                   IfToThenRange =
-                    /root/IfThenElse/NestedElseIfInIfThenElse.fs (2,0--2,9) }),
-              /root/IfThenElse/NestedElseIfInIfThenElse.fs (2,0--5,15))],
-          PreXmlDocEmpty, [], None,
-          /root/IfThenElse/NestedElseIfInIfThenElse.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                   ThenKeyword = (2,5--2,9)
+                   ElseKeyword = Some (4,0--4,4)
+                   IfToThenRange = (2,0--2,9) }), (2,0--5,15))], PreXmlDocEmpty,
+          [], None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs.bsl
+++ b/tests/service/data/SyntaxTree/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs.bsl
@@ -9,36 +9,18 @@ ImplFile
                 (Ident a, Ident b,
                  Some
                    (IfThenElse
-                      (Ident c, Ident d, None,
-                       Yes
-                         /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (4,5--4,14),
-                       false,
-                       /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (4,5--5,1),
-                       { IfKeyword =
-                          /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (4,5--4,7)
-                         IsElif = false
-                         ThenKeyword =
-                          /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (4,10--4,14)
-                         ElseKeyword = None
-                         IfToThenRange =
-                          /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (4,5--4,14) })),
-                 Yes
-                   /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (2,0--2,9),
-                 false,
-                 /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (2,0--5,1),
-                 { IfKeyword =
-                    /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (2,0--2,2)
+                      (Ident c, Ident d, None, Yes (4,5--4,14), false,
+                       (4,5--5,1), { IfKeyword = (4,5--4,7)
+                                     IsElif = false
+                                     ThenKeyword = (4,10--4,14)
+                                     ElseKeyword = None
+                                     IfToThenRange = (4,5--4,14) })),
+                 Yes (2,0--2,9), false, (2,0--5,1),
+                 { IfKeyword = (2,0--2,2)
                    IsElif = false
-                   ThenKeyword =
-                    /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (2,5--2,9)
-                   ElseKeyword =
-                    Some
-                      /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (4,0--4,4)
-                   IfToThenRange =
-                    /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (2,0--2,9) }),
-              /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (2,0--5,1))],
-          PreXmlDocEmpty, [], None,
-          /root/IfThenElse/NestedElseIfOnTheSameLineInIfThenElse.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                   ThenKeyword = (2,5--2,9)
+                   ElseKeyword = Some (4,0--4,4)
+                   IfToThenRange = (2,0--2,9) }), (2,0--5,1))], PreXmlDocEmpty,
+          [], None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/ComplexArgumentsLambdaHasArrowRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/ComplexArgumentsLambdaHasArrowRange.fs.bsl
@@ -8,44 +8,31 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (x, None, false, false, false,
-                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,5--2,6));
-                     Id
-                       (_arg3, None, true, false, false,
-                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,8--2,9))],
-                    /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,4--2,10)),
+                   ([Id (x, None, false, false, false, (2,5--2,6));
+                     Id (_arg3, None, true, false, false, (2,8--2,9))],
+                    (2,4--2,10)),
                  Lambda
                    (false, true,
                     SimplePats
-                      ([Id
-                          (_arg2, None, true, false, false,
-                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--3,17))],
-                       /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,4--3,18)),
+                      ([Id (_arg2, None, true, false, false, (3,5--3,17))],
+                       (3,4--3,18)),
                     Lambda
                       (false, true,
                        SimplePats
-                         ([Id
-                             (_arg1, None, true, false, false,
-                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--4,19))],
-                          /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,4--4,20)),
+                         ([Id (_arg1, None, true, false, false, (4,5--4,19))],
+                          (4,4--4,20)),
                        Match
                          (NoneAtInvisible, Ident _arg2,
                           [SynMatchClause
                              (Record
-                                ([(([], Y),
-                                   /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,9--3,10),
+                                ([(([], Y), (3,9--3,10),
                                    ListCons
                                      (Named
                                         (SynIdent (h, None), false, None,
-                                         /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,11--3,12)),
-                                      Wild
-                                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,14--3,15),
-                                      /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,11--3,15),
-                                      { ColonColonRange =
-                                         /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,12--3,14) }))],
-                                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--3,17)),
-                              None,
+                                         (3,11--3,12)), Wild (3,14--3,15),
+                                      (3,11--3,15),
+                                      { ColonColonRange = (3,12--3,14) }))],
+                                 (3,5--3,17)), None,
                               Match
                                 (NoneAtInvisible, Ident _arg1,
                                  [SynMatchClause
@@ -56,11 +43,8 @@ ImplFile
                                           [Paren
                                              (Named
                                                 (SynIdent (z, None), false, None,
-                                                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,17--4,18)),
-                                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,16--4,19))],
-                                        None,
-                                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--4,19)),
-                                     None,
+                                                 (4,17--4,18)), (4,16--4,19))],
+                                        None, (4,5--4,19)), None,
                                      App
                                        (NonAtomic, false,
                                         App
@@ -70,8 +54,7 @@ ImplFile
                                               SynLongIdent
                                                 ([op_Addition], [],
                                                  [Some (OriginalNotation "+")]),
-                                              None,
-                                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,10--6,11)),
+                                              None, (6,10--6,11)),
                                            App
                                              (NonAtomic, false,
                                               App
@@ -82,67 +65,35 @@ ImplFile
                                                       ([op_Multiply], [],
                                                        [Some
                                                           (OriginalNotation "*")]),
-                                                    None,
-                                                    /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,6--6,7)),
-                                                 Ident x,
-                                                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,4--6,7)),
-                                              Ident y,
-                                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,4--6,9)),
-                                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,4--6,11)),
-                                        Ident z,
-                                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,4--6,13)),
-                                     /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--4,19),
-                                     No, { ArrowRange = None
-                                           BarRange = None })],
-                                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--6,13),
-                                 { MatchKeyword =
-                                    /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--6,13)
-                                   WithKeyword =
-                                    /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--6,13) }),
-                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--3,17),
-                              No, { ArrowRange = None
-                                    BarRange = None })],
-                          /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--6,13),
-                          { MatchKeyword =
-                             /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--6,13)
-                            WithKeyword =
-                             /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--6,13) }),
-                       None,
-                       /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,0--6,13),
-                       { ArrowRange =
-                          Some
-                            /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (5,4--5,6) }),
-                    None,
-                    /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,0--6,13),
-                    { ArrowRange =
-                       Some
-                         /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (5,4--5,6) }),
+                                                    None, (6,6--6,7)), Ident x,
+                                                 (6,4--6,7)), Ident y,
+                                              (6,4--6,9)), (6,4--6,11)), Ident z,
+                                        (6,4--6,13)), (4,5--4,19), No,
+                                     { ArrowRange = None
+                                       BarRange = None })], (4,5--6,13),
+                                 { MatchKeyword = (4,5--6,13)
+                                   WithKeyword = (4,5--6,13) }), (3,5--3,17), No,
+                              { ArrowRange = None
+                                BarRange = None })], (3,5--6,13),
+                          { MatchKeyword = (3,5--6,13)
+                            WithKeyword = (3,5--6,13) }), None, (2,0--6,13),
+                       { ArrowRange = Some (5,4--5,6) }), None, (2,0--6,13),
+                    { ArrowRange = Some (5,4--5,6) }),
                  Some
                    ([Paren
                        (Tuple
                           (false,
-                           [Named
-                              (SynIdent (x, None), false, None,
-                               /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,5--2,6));
-                            Wild
-                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,8--2,9)],
-                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,5--2,9)),
-                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,4--2,10));
+                           [Named (SynIdent (x, None), false, None, (2,5--2,6));
+                            Wild (2,8--2,9)], (2,5--2,9)), (2,4--2,10));
                      Paren
                        (Record
-                          ([(([], Y),
-                             /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,9--3,10),
+                          ([(([], Y), (3,9--3,10),
                              ListCons
                                (Named
-                                  (SynIdent (h, None), false, None,
-                                   /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,11--3,12)),
-                                Wild
-                                  /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,14--3,15),
-                                /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,11--3,15),
-                                { ColonColonRange =
-                                   /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,12--3,14) }))],
-                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--3,17)),
-                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,4--3,18));
+                                  (SynIdent (h, None), false, None, (3,11--3,12)),
+                                Wild (3,14--3,15), (3,11--3,15),
+                                { ColonColonRange = (3,12--3,14) }))],
+                           (3,5--3,17)), (3,4--3,18));
                      Paren
                        (LongIdent
                           (SynLongIdent ([SomePattern], [], [None]), None, None,
@@ -150,28 +101,20 @@ ImplFile
                              [Paren
                                 (Named
                                    (SynIdent (z, None), false, None,
-                                    /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,17--4,18)),
-                                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,16--4,19))],
-                           None,
-                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--4,19)),
-                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,4--4,20))],
+                                    (4,17--4,18)), (4,16--4,19))], None,
+                           (4,5--4,19)), (4,4--4,20))],
                     Match
                       (NoneAtInvisible, Ident _arg2,
                        [SynMatchClause
                           (Record
-                             ([(([], Y),
-                                /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,9--3,10),
+                             ([(([], Y), (3,9--3,10),
                                 ListCons
                                   (Named
                                      (SynIdent (h, None), false, None,
-                                      /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,11--3,12)),
-                                   Wild
-                                     /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,14--3,15),
-                                   /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,11--3,15),
-                                   { ColonColonRange =
-                                      /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,12--3,14) }))],
-                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--3,17)),
-                           None,
+                                      (3,11--3,12)), Wild (3,14--3,15),
+                                   (3,11--3,15),
+                                   { ColonColonRange = (3,12--3,14) }))],
+                              (3,5--3,17)), None,
                            Match
                              (NoneAtInvisible, Ident _arg1,
                               [SynMatchClause
@@ -182,11 +125,8 @@ ImplFile
                                        [Paren
                                           (Named
                                              (SynIdent (z, None), false, None,
-                                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,17--4,18)),
-                                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,16--4,19))],
-                                     None,
-                                     /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--4,19)),
-                                  None,
+                                              (4,17--4,18)), (4,16--4,19))],
+                                     None, (4,5--4,19)), None,
                                   App
                                     (NonAtomic, false,
                                      App
@@ -196,8 +136,7 @@ ImplFile
                                            SynLongIdent
                                              ([op_Addition], [],
                                               [Some (OriginalNotation "+")]),
-                                           None,
-                                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,10--6,11)),
+                                           None, (6,10--6,11)),
                                         App
                                           (NonAtomic, false,
                                            App
@@ -207,38 +146,18 @@ ImplFile
                                                  SynLongIdent
                                                    ([op_Multiply], [],
                                                     [Some (OriginalNotation "*")]),
-                                                 None,
-                                                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,6--6,7)),
-                                              Ident x,
-                                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,4--6,7)),
-                                           Ident y,
-                                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,4--6,9)),
-                                        /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,4--6,11)),
-                                     Ident z,
-                                     /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (6,4--6,13)),
-                                  /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--4,19),
-                                  No, { ArrowRange = None
-                                        BarRange = None })],
-                              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--6,13),
-                              { MatchKeyword =
-                                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--6,13)
-                                WithKeyword =
-                                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (4,5--6,13) }),
-                           /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--3,17),
-                           No, { ArrowRange = None
-                                 BarRange = None })],
-                       /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--6,13),
-                       { MatchKeyword =
-                          /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--6,13)
-                         WithKeyword =
-                          /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (3,5--6,13) })),
-                 /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,0--6,13),
-                 { ArrowRange =
-                    Some
-                      /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (5,4--5,6) }),
-              /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,0--6,13))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/ComplexArgumentsLambdaHasArrowRange.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                                 None, (6,6--6,7)), Ident x,
+                                              (6,4--6,7)), Ident y, (6,4--6,9)),
+                                        (6,4--6,11)), Ident z, (6,4--6,13)),
+                                  (4,5--4,19), No, { ArrowRange = None
+                                                     BarRange = None })],
+                              (4,5--6,13), { MatchKeyword = (4,5--6,13)
+                                             WithKeyword = (4,5--6,13) }),
+                           (3,5--3,17), No, { ArrowRange = None
+                                              BarRange = None })], (3,5--6,13),
+                       { MatchKeyword = (3,5--6,13)
+                         WithKeyword = (3,5--6,13) })), (2,0--6,13),
+                 { ArrowRange = Some (5,4--5,6) }), (2,0--6,13))],
+          PreXmlDocEmpty, [], None, (2,0--7,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/DestructedLambdaHasArrowRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/DestructedLambdaHasArrowRange.fs.bsl
@@ -8,21 +8,16 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (_arg1, None, true, false, false,
-                        /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,13))],
-                    /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,13)),
+                   ([Id (_arg1, None, true, false, false, (2,4--2,13))],
+                    (2,4--2,13)),
                  Match
                    (NoneAtInvisible, Ident _arg1,
                     [SynMatchClause
                        (Record
-                          ([(([], X),
-                             /root/Lambda/DestructedLambdaHasArrowRange.fs (2,8--2,9),
+                          ([(([], X), (2,8--2,9),
                              Named
-                               (SynIdent (x, None), false, None,
-                                /root/Lambda/DestructedLambdaHasArrowRange.fs (2,10--2,11)))],
-                           /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,13)),
-                        None,
+                               (SynIdent (x, None), false, None, (2,10--2,11)))],
+                           (2,4--2,13)), None,
                         App
                           (NonAtomic, false,
                            App
@@ -32,40 +27,25 @@ ImplFile
                                  SynLongIdent
                                    ([op_Multiply], [],
                                     [Some (OriginalNotation "*")]), None,
-                                 /root/Lambda/DestructedLambdaHasArrowRange.fs (2,19--2,20)),
-                              Ident x,
-                              /root/Lambda/DestructedLambdaHasArrowRange.fs (2,17--2,20)),
-                           Const
-                             (Int32 2,
-                              /root/Lambda/DestructedLambdaHasArrowRange.fs (2,21--2,22)),
-                           /root/Lambda/DestructedLambdaHasArrowRange.fs (2,17--2,22)),
-                        /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,13),
-                        No, { ArrowRange = None
-                              BarRange = None })],
-                    /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,22),
-                    { MatchKeyword =
-                       /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,22)
-                      WithKeyword =
-                       /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,22) }),
+                                 (2,19--2,20)), Ident x, (2,17--2,20)),
+                           Const (Int32 2, (2,21--2,22)), (2,17--2,22)),
+                        (2,4--2,13), No, { ArrowRange = None
+                                           BarRange = None })], (2,4--2,22),
+                    { MatchKeyword = (2,4--2,22)
+                      WithKeyword = (2,4--2,22) }),
                  Some
                    ([Record
-                       ([(([], X),
-                          /root/Lambda/DestructedLambdaHasArrowRange.fs (2,8--2,9),
-                          Named
-                            (SynIdent (x, None), false, None,
-                             /root/Lambda/DestructedLambdaHasArrowRange.fs (2,10--2,11)))],
-                        /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,13))],
+                       ([(([], X), (2,8--2,9),
+                          Named (SynIdent (x, None), false, None, (2,10--2,11)))],
+                        (2,4--2,13))],
                     Match
                       (NoneAtInvisible, Ident _arg1,
                        [SynMatchClause
                           (Record
-                             ([(([], X),
-                                /root/Lambda/DestructedLambdaHasArrowRange.fs (2,8--2,9),
+                             ([(([], X), (2,8--2,9),
                                 Named
-                                  (SynIdent (x, None), false, None,
-                                   /root/Lambda/DestructedLambdaHasArrowRange.fs (2,10--2,11)))],
-                              /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,13)),
-                           None,
+                                  (SynIdent (x, None), false, None, (2,10--2,11)))],
+                              (2,4--2,13)), None,
                            App
                              (NonAtomic, false,
                               App
@@ -75,28 +55,13 @@ ImplFile
                                     SynLongIdent
                                       ([op_Multiply], [],
                                        [Some (OriginalNotation "*")]), None,
-                                    /root/Lambda/DestructedLambdaHasArrowRange.fs (2,19--2,20)),
-                                 Ident x,
-                                 /root/Lambda/DestructedLambdaHasArrowRange.fs (2,17--2,20)),
-                              Const
-                                (Int32 2,
-                                 /root/Lambda/DestructedLambdaHasArrowRange.fs (2,21--2,22)),
-                              /root/Lambda/DestructedLambdaHasArrowRange.fs (2,17--2,22)),
-                           /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,13),
-                           No, { ArrowRange = None
-                                 BarRange = None })],
-                       /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,22),
-                       { MatchKeyword =
-                          /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,22)
-                         WithKeyword =
-                          /root/Lambda/DestructedLambdaHasArrowRange.fs (2,4--2,22) })),
-                 /root/Lambda/DestructedLambdaHasArrowRange.fs (2,0--2,22),
-                 { ArrowRange =
-                    Some
-                      /root/Lambda/DestructedLambdaHasArrowRange.fs (2,14--2,16) }),
-              /root/Lambda/DestructedLambdaHasArrowRange.fs (2,0--2,22))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/DestructedLambdaHasArrowRange.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                    (2,19--2,20)), Ident x, (2,17--2,20)),
+                              Const (Int32 2, (2,21--2,22)), (2,17--2,22)),
+                           (2,4--2,13), No, { ArrowRange = None
+                                              BarRange = None })], (2,4--2,22),
+                       { MatchKeyword = (2,4--2,22)
+                         WithKeyword = (2,4--2,22) })), (2,0--2,22),
+                 { ArrowRange = Some (2,14--2,16) }), (2,0--2,22))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs.bsl
@@ -11,62 +11,30 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (a, None, false, false, false,
-                        /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,4--2,5))],
-                    /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,4--2,5)),
+                   ([Id (a, None, false, false, false, (2,4--2,5))], (2,4--2,5)),
                  Lambda
                    (false, true,
                     SimplePats
-                      ([Id
-                          (b, None, false, false, false,
-                           /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,7--2,8));
-                        Id
-                          (_arg1, None, true, false, false,
-                           /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,10--2,11))],
-                       /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,6--2,12)),
+                      ([Id (b, None, false, false, false, (2,7--2,8));
+                        Id (_arg1, None, true, false, false, (2,10--2,11))],
+                       (2,6--2,12)),
                     Lambda
                       (false, true,
                        SimplePats
-                         ([Id
-                             (c, None, false, false, false,
-                              /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,13--2,14))],
-                          /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,13--2,14)),
-                       Ident x, None,
-                       /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,0--2,19),
-                       { ArrowRange =
-                          Some
-                            /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,15--2,17) }),
-                    None,
-                    /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,0--2,19),
-                    { ArrowRange =
-                       Some
-                         /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,15--2,17) }),
+                         ([Id (c, None, false, false, false, (2,13--2,14))],
+                          (2,13--2,14)), Ident x, None, (2,0--2,19),
+                       { ArrowRange = Some (2,15--2,17) }), None, (2,0--2,19),
+                    { ArrowRange = Some (2,15--2,17) }),
                  Some
-                   ([Named
-                       (SynIdent (a, None), false, None,
-                        /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,4--2,5));
+                   ([Named (SynIdent (a, None), false, None, (2,4--2,5));
                      Paren
                        (Tuple
                           (false,
-                           [Named
-                              (SynIdent (b, None), false, None,
-                               /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,7--2,8));
-                            Wild
-                              /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,10--2,11)],
-                           /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,7--2,11)),
-                        /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,6--2,12));
-                     Named
-                       (SynIdent (c, None), false, None,
-                        /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,13--2,14))],
-                    Ident x),
-                 /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,0--2,19),
-                 { ArrowRange =
-                    Some
-                      /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,15--2,17) }),
-              /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,0--2,19))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/LambdaWithTupleParameterWithWildCardGivesCorrectBody.fs (2,0--3,0),
+                           [Named (SynIdent (b, None), false, None, (2,7--2,8));
+                            Wild (2,10--2,11)], (2,7--2,11)), (2,6--2,12));
+                     Named (SynIdent (c, None), false, None, (2,13--2,14))],
+                    Ident x), (2,0--2,19), { ArrowRange = Some (2,15--2,17) }),
+              (2,0--2,19))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs.bsl
@@ -8,37 +8,18 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (a, None, false, false, false,
-                        /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,4--2,5))],
-                    /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,4--2,5)),
+                   ([Id (a, None, false, false, false, (2,4--2,5))], (2,4--2,5)),
                  Lambda
                    (false, true,
                     SimplePats
-                      ([Id
-                          (b, None, false, false, false,
-                           /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,6--2,7))],
-                       /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,6--2,7)),
-                    Ident x, None,
-                    /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,0--2,12),
-                    { ArrowRange =
-                       Some
-                         /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,8--2,10) }),
+                      ([Id (b, None, false, false, false, (2,6--2,7))],
+                       (2,6--2,7)), Ident x, None, (2,0--2,12),
+                    { ArrowRange = Some (2,8--2,10) }),
                  Some
-                   ([Named
-                       (SynIdent (a, None), false, None,
-                        /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,4--2,5));
-                     Named
-                       (SynIdent (b, None), false, None,
-                        /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,6--2,7))],
-                    Ident x),
-                 /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,0--2,12),
-                 { ArrowRange =
-                    Some
-                      /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,8--2,10) }),
-              /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,0--2,12))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/LambdaWithTwoParametersGivesCorrectBody.fs (2,0--3,0),
+                   ([Named (SynIdent (a, None), false, None, (2,4--2,5));
+                     Named (SynIdent (b, None), false, None, (2,6--2,7))],
+                    Ident x), (2,0--2,12), { ArrowRange = Some (2,8--2,10) }),
+              (2,0--2,12))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs.bsl
@@ -8,51 +8,25 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (a, None, false, false, false,
-                        /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,4--2,5))],
-                    /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,4--2,5)),
+                   ([Id (a, None, false, false, false, (2,4--2,5))], (2,4--2,5)),
                  Lambda
                    (false, true,
                     SimplePats
-                      ([Id
-                          (_arg1, None, true, false, false,
-                           /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,6--2,7))],
-                       /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,6--2,7)),
+                      ([Id (_arg1, None, true, false, false, (2,6--2,7))],
+                       (2,6--2,7)),
                     Lambda
                       (false, true,
                        SimplePats
-                         ([Id
-                             (b, None, false, false, false,
-                              /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,8--2,9))],
-                          /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,8--2,9)),
-                       Ident x, None,
-                       /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,0--2,14),
-                       { ArrowRange =
-                          Some
-                            /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,10--2,12) }),
-                    None,
-                    /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,0--2,14),
-                    { ArrowRange =
-                       Some
-                         /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,10--2,12) }),
+                         ([Id (b, None, false, false, false, (2,8--2,9))],
+                          (2,8--2,9)), Ident x, None, (2,0--2,14),
+                       { ArrowRange = Some (2,10--2,12) }), None, (2,0--2,14),
+                    { ArrowRange = Some (2,10--2,12) }),
                  Some
-                   ([Named
-                       (SynIdent (a, None), false, None,
-                        /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,4--2,5));
-                     Wild
-                       /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,6--2,7);
-                     Named
-                       (SynIdent (b, None), false, None,
-                        /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,8--2,9))],
-                    Ident x),
-                 /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,0--2,14),
-                 { ArrowRange =
-                    Some
-                      /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,10--2,12) }),
-              /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,0--2,14))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/LambdaWithWildCardParameterGivesCorrectBody.fs (2,0--3,0),
+                   ([Named (SynIdent (a, None), false, None, (2,4--2,5));
+                     Wild (2,6--2,7);
+                     Named (SynIdent (b, None), false, None, (2,8--2,9))],
+                    Ident x), (2,0--2,14), { ArrowRange = Some (2,10--2,12) }),
+              (2,0--2,14))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs.bsl
@@ -11,52 +11,25 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (_arg2, None, true, false, false,
-                        /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,4--2,5))],
-                    /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,4--2,5)),
+                   ([Id (_arg2, None, true, false, false, (2,4--2,5))],
+                    (2,4--2,5)),
                  Lambda
                    (false, false,
                     SimplePats
-                      ([Id
-                          (_arg1, None, true, false, false,
-                           /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,13--2,14))],
-                       /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,13--2,14)),
-                    Ident x,
-                    Some
-                      ([Wild
-                          /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,13--2,14)],
-                       Ident x),
-                    /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,9--2,19),
-                    { ArrowRange =
-                       Some
-                         /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,15--2,17) }),
+                      ([Id (_arg1, None, true, false, false, (2,13--2,14))],
+                       (2,13--2,14)), Ident x,
+                    Some ([Wild (2,13--2,14)], Ident x), (2,9--2,19),
+                    { ArrowRange = Some (2,15--2,17) }),
                  Some
-                   ([Wild
-                       /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,4--2,5)],
+                   ([Wild (2,4--2,5)],
                     Lambda
                       (false, false,
                        SimplePats
-                         ([Id
-                             (_arg1, None, true, false, false,
-                              /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,13--2,14))],
-                          /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,13--2,14)),
-                       Ident x,
-                       Some
-                         ([Wild
-                             /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,13--2,14)],
-                          Ident x),
-                       /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,9--2,19),
-                       { ArrowRange =
-                          Some
-                            /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,15--2,17) })),
-                 /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,0--2,19),
-                 { ArrowRange =
-                    Some
-                      /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,6--2,8) }),
-              /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,0--2,19))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/LambdaWithWildCardThatReturnsALambdaGivesCorrectBody.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                         ([Id (_arg1, None, true, false, false, (2,13--2,14))],
+                          (2,13--2,14)), Ident x,
+                       Some ([Wild (2,13--2,14)], Ident x), (2,9--2,19),
+                       { ArrowRange = Some (2,15--2,17) })), (2,0--2,19),
+                 { ArrowRange = Some (2,6--2,8) }), (2,0--2,19))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/MultilineLambdaHasArrowRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/MultilineLambdaHasArrowRange.fs.bsl
@@ -8,24 +8,17 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (x, None, false, false, false,
-                        /root/Lambda/MultilineLambdaHasArrowRange.fs (2,4--2,5))],
-                    /root/Lambda/MultilineLambdaHasArrowRange.fs (2,4--2,5)),
+                   ([Id (x, None, false, false, false, (2,4--2,5))], (2,4--2,5)),
                  Lambda
                    (false, true,
                     SimplePats
-                      ([Id
-                          (y, None, false, false, false,
-                           /root/Lambda/MultilineLambdaHasArrowRange.fs (2,6--2,7))],
-                       /root/Lambda/MultilineLambdaHasArrowRange.fs (2,6--2,7)),
+                      ([Id (y, None, false, false, false, (2,6--2,7))],
+                       (2,6--2,7)),
                     Lambda
                       (false, true,
                        SimplePats
-                         ([Id
-                             (z, None, false, false, false,
-                              /root/Lambda/MultilineLambdaHasArrowRange.fs (2,8--2,9))],
-                          /root/Lambda/MultilineLambdaHasArrowRange.fs (2,8--2,9)),
+                         ([Id (z, None, false, false, false, (2,8--2,9))],
+                          (2,8--2,9)),
                        App
                          (NonAtomic, false,
                           App
@@ -35,7 +28,7 @@ ImplFile
                                 SynLongIdent
                                   ([op_Multiply], [],
                                    [Some (OriginalNotation "*")]), None,
-                                /root/Lambda/MultilineLambdaHasArrowRange.fs (4,38--4,39)),
+                                (4,38--4,39)),
                              App
                                (NonAtomic, false,
                                 App
@@ -45,34 +38,15 @@ ImplFile
                                       SynLongIdent
                                         ([op_Multiply], [],
                                          [Some (OriginalNotation "*")]), None,
-                                      /root/Lambda/MultilineLambdaHasArrowRange.fs (4,34--4,35)),
-                                   Ident x,
-                                   /root/Lambda/MultilineLambdaHasArrowRange.fs (4,32--4,35)),
-                                Ident y,
-                                /root/Lambda/MultilineLambdaHasArrowRange.fs (4,32--4,37)),
-                             /root/Lambda/MultilineLambdaHasArrowRange.fs (4,32--4,39)),
-                          Ident z,
-                          /root/Lambda/MultilineLambdaHasArrowRange.fs (4,32--4,41)),
-                       None,
-                       /root/Lambda/MultilineLambdaHasArrowRange.fs (2,0--4,41),
-                       { ArrowRange =
-                          Some
-                            /root/Lambda/MultilineLambdaHasArrowRange.fs (3,28--3,30) }),
-                    None,
-                    /root/Lambda/MultilineLambdaHasArrowRange.fs (2,0--4,41),
-                    { ArrowRange =
-                       Some
-                         /root/Lambda/MultilineLambdaHasArrowRange.fs (3,28--3,30) }),
+                                      (4,34--4,35)), Ident x, (4,32--4,35)),
+                                Ident y, (4,32--4,37)), (4,32--4,39)), Ident z,
+                          (4,32--4,41)), None, (2,0--4,41),
+                       { ArrowRange = Some (3,28--3,30) }), None, (2,0--4,41),
+                    { ArrowRange = Some (3,28--3,30) }),
                  Some
-                   ([Named
-                       (SynIdent (x, None), false, None,
-                        /root/Lambda/MultilineLambdaHasArrowRange.fs (2,4--2,5));
-                     Named
-                       (SynIdent (y, None), false, None,
-                        /root/Lambda/MultilineLambdaHasArrowRange.fs (2,6--2,7));
-                     Named
-                       (SynIdent (z, None), false, None,
-                        /root/Lambda/MultilineLambdaHasArrowRange.fs (2,8--2,9))],
+                   ([Named (SynIdent (x, None), false, None, (2,4--2,5));
+                     Named (SynIdent (y, None), false, None, (2,6--2,7));
+                     Named (SynIdent (z, None), false, None, (2,8--2,9))],
                     App
                       (NonAtomic, false,
                        App
@@ -81,8 +55,7 @@ ImplFile
                             (false,
                              SynLongIdent
                                ([op_Multiply], [], [Some (OriginalNotation "*")]),
-                             None,
-                             /root/Lambda/MultilineLambdaHasArrowRange.fs (4,38--4,39)),
+                             None, (4,38--4,39)),
                           App
                             (NonAtomic, false,
                              App
@@ -92,21 +65,10 @@ ImplFile
                                    SynLongIdent
                                      ([op_Multiply], [],
                                       [Some (OriginalNotation "*")]), None,
-                                   /root/Lambda/MultilineLambdaHasArrowRange.fs (4,34--4,35)),
-                                Ident x,
-                                /root/Lambda/MultilineLambdaHasArrowRange.fs (4,32--4,35)),
-                             Ident y,
-                             /root/Lambda/MultilineLambdaHasArrowRange.fs (4,32--4,37)),
-                          /root/Lambda/MultilineLambdaHasArrowRange.fs (4,32--4,39)),
-                       Ident z,
-                       /root/Lambda/MultilineLambdaHasArrowRange.fs (4,32--4,41))),
-                 /root/Lambda/MultilineLambdaHasArrowRange.fs (2,0--4,41),
-                 { ArrowRange =
-                    Some
-                      /root/Lambda/MultilineLambdaHasArrowRange.fs (3,28--3,30) }),
-              /root/Lambda/MultilineLambdaHasArrowRange.fs (2,0--4,41))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/MultilineLambdaHasArrowRange.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                   (4,34--4,35)), Ident x, (4,32--4,35)),
+                             Ident y, (4,32--4,37)), (4,32--4,39)), Ident z,
+                       (4,32--4,41))), (2,0--4,41),
+                 { ArrowRange = Some (3,28--3,30) }), (2,0--4,41))],
+          PreXmlDocEmpty, [], None, (2,0--5,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/SimpleLambdaHasArrowRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/SimpleLambdaHasArrowRange.fs.bsl
@@ -8,22 +8,12 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (x, None, false, false, false,
-                        /root/Lambda/SimpleLambdaHasArrowRange.fs (2,4--2,5))],
-                    /root/Lambda/SimpleLambdaHasArrowRange.fs (2,4--2,5)),
+                   ([Id (x, None, false, false, false, (2,4--2,5))], (2,4--2,5)),
                  Ident x,
                  Some
-                   ([Named
-                       (SynIdent (x, None), false, None,
-                        /root/Lambda/SimpleLambdaHasArrowRange.fs (2,4--2,5))],
-                    Ident x),
-                 /root/Lambda/SimpleLambdaHasArrowRange.fs (2,0--2,10),
-                 { ArrowRange =
-                    Some /root/Lambda/SimpleLambdaHasArrowRange.fs (2,6--2,8) }),
-              /root/Lambda/SimpleLambdaHasArrowRange.fs (2,0--2,10))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/SimpleLambdaHasArrowRange.fs (2,0--3,0),
+                   ([Named (SynIdent (x, None), false, None, (2,4--2,5))],
+                    Ident x), (2,0--2,10), { ArrowRange = Some (2,6--2,8) }),
+              (2,0--2,10))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Lambda/TupleInLambdaHasArrowRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/TupleInLambdaHasArrowRange.fs.bsl
@@ -8,13 +8,9 @@ ImplFile
              (Lambda
                 (false, false,
                  SimplePats
-                   ([Id
-                       (x, None, false, false, false,
-                        /root/Lambda/TupleInLambdaHasArrowRange.fs (2,5--2,6));
-                     Id
-                       (_arg1, None, true, false, false,
-                        /root/Lambda/TupleInLambdaHasArrowRange.fs (2,8--2,9))],
-                    /root/Lambda/TupleInLambdaHasArrowRange.fs (2,4--2,10)),
+                   ([Id (x, None, false, false, false, (2,5--2,6));
+                     Id (_arg1, None, true, false, false, (2,8--2,9))],
+                    (2,4--2,10)),
                  App
                    (NonAtomic, false,
                     App
@@ -23,25 +19,14 @@ ImplFile
                          (false,
                           SynLongIdent
                             ([op_Multiply], [], [Some (OriginalNotation "*")]),
-                          None,
-                          /root/Lambda/TupleInLambdaHasArrowRange.fs (2,16--2,17)),
-                       Ident x,
-                       /root/Lambda/TupleInLambdaHasArrowRange.fs (2,14--2,17)),
-                    Const
-                      (Int32 3,
-                       /root/Lambda/TupleInLambdaHasArrowRange.fs (2,18--2,19)),
-                    /root/Lambda/TupleInLambdaHasArrowRange.fs (2,14--2,19)),
+                          None, (2,16--2,17)), Ident x, (2,14--2,17)),
+                    Const (Int32 3, (2,18--2,19)), (2,14--2,19)),
                  Some
                    ([Paren
                        (Tuple
                           (false,
-                           [Named
-                              (SynIdent (x, None), false, None,
-                               /root/Lambda/TupleInLambdaHasArrowRange.fs (2,5--2,6));
-                            Wild
-                              /root/Lambda/TupleInLambdaHasArrowRange.fs (2,8--2,9)],
-                           /root/Lambda/TupleInLambdaHasArrowRange.fs (2,5--2,9)),
-                        /root/Lambda/TupleInLambdaHasArrowRange.fs (2,4--2,10))],
+                           [Named (SynIdent (x, None), false, None, (2,5--2,6));
+                            Wild (2,8--2,9)], (2,5--2,9)), (2,4--2,10))],
                     App
                       (NonAtomic, false,
                        App
@@ -50,20 +35,9 @@ ImplFile
                             (false,
                              SynLongIdent
                                ([op_Multiply], [], [Some (OriginalNotation "*")]),
-                             None,
-                             /root/Lambda/TupleInLambdaHasArrowRange.fs (2,16--2,17)),
-                          Ident x,
-                          /root/Lambda/TupleInLambdaHasArrowRange.fs (2,14--2,17)),
-                       Const
-                         (Int32 3,
-                          /root/Lambda/TupleInLambdaHasArrowRange.fs (2,18--2,19)),
-                       /root/Lambda/TupleInLambdaHasArrowRange.fs (2,14--2,19))),
-                 /root/Lambda/TupleInLambdaHasArrowRange.fs (2,0--2,19),
-                 { ArrowRange =
-                    Some /root/Lambda/TupleInLambdaHasArrowRange.fs (2,11--2,13) }),
-              /root/Lambda/TupleInLambdaHasArrowRange.fs (2,0--2,19))],
-          PreXmlDocEmpty, [], None,
-          /root/Lambda/TupleInLambdaHasArrowRange.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                             None, (2,16--2,17)), Ident x, (2,14--2,17)),
+                       Const (Int32 3, (2,18--2,19)), (2,14--2,19))),
+                 (2,0--2,19), { ArrowRange = Some (2,11--2,13) }), (2,0--2,19))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/AbstractKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/AbstractKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/AbstractKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [AbstractSlot
@@ -21,11 +20,8 @@ ImplFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/LeadingKeyword/AbstractKeyword.fs (3,4--3,20),
-                            { LeadingKeyword =
-                               Abstract
-                                 /root/LeadingKeyword/AbstractKeyword.fs (3,4--3,12)
+                            None, None, (3,4--3,20),
+                            { LeadingKeyword = Abstract (3,4--3,12)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -34,19 +30,11 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/LeadingKeyword/AbstractKeyword.fs (3,4--3,20),
-                         { GetSetKeywords = None })],
-                     /root/LeadingKeyword/AbstractKeyword.fs (3,4--3,20)), [],
-                  None, /root/LeadingKeyword/AbstractKeyword.fs (2,5--3,20),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/AbstractKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/AbstractKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/AbstractKeyword.fs (2,0--3,20))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/AbstractKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           MemberKind = PropertyGet }, (3,4--3,20),
+                         { GetSetKeywords = None })], (3,4--3,20)), [], None,
+                  (2,5--3,20), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,20))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/AbstractMemberKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/AbstractMemberKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/AbstractMemberKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [AbstractSlot
@@ -21,12 +20,9 @@ ImplFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/LeadingKeyword/AbstractMemberKeyword.fs (3,4--3,27),
+                            None, None, (3,4--3,27),
                             { LeadingKeyword =
-                               AbstractMember
-                                 (/root/LeadingKeyword/AbstractMemberKeyword.fs (3,4--3,12),
-                                  /root/LeadingKeyword/AbstractMemberKeyword.fs (3,13--3,19))
+                               AbstractMember ((3,4--3,12), (3,13--3,19))
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -35,22 +31,11 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/LeadingKeyword/AbstractMemberKeyword.fs (3,4--3,27),
-                         { GetSetKeywords = None })],
-                     /root/LeadingKeyword/AbstractMemberKeyword.fs (3,4--3,27)),
-                  [], None,
-                  /root/LeadingKeyword/AbstractMemberKeyword.fs (2,5--3,27),
-                  { LeadingKeyword =
-                     Type
-                       /root/LeadingKeyword/AbstractMemberKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/LeadingKeyword/AbstractMemberKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/AbstractMemberKeyword.fs (2,0--3,27))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/AbstractMemberKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           MemberKind = PropertyGet }, (3,4--3,27),
+                         { GetSetKeywords = None })], (3,4--3,27)), [], None,
+                  (2,5--3,27), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,27))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/AndKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/AndKeyword.fs.bsl
@@ -17,10 +17,8 @@ ImplFile
                   LongIdent
                     (SynLongIdent ([a], [], [None]), None, None,
                      Pats
-                       [Named
-                          (SynIdent (b, None), false, None,
-                           /root/LeadingKeyword/AndKeyword.fs (2,10--2,11))],
-                     None, /root/LeadingKeyword/AndKeyword.fs (2,8--2,11)), None,
+                       [Named (SynIdent (b, None), false, None, (2,10--2,11))],
+                     None, (2,8--2,11)), None,
                   App
                     (NonAtomic, false,
                      App
@@ -29,19 +27,11 @@ ImplFile
                           (false,
                            SynLongIdent
                              ([op_Addition], [], [Some (OriginalNotation "+")]),
-                           None, /root/LeadingKeyword/AndKeyword.fs (2,16--2,17)),
-                        Ident b, /root/LeadingKeyword/AndKeyword.fs (2,14--2,17)),
-                     Const
-                       (Int32 1, /root/LeadingKeyword/AndKeyword.fs (2,18--2,19)),
-                     /root/LeadingKeyword/AndKeyword.fs (2,14--2,19)),
-                  /root/LeadingKeyword/AndKeyword.fs (2,8--2,11), NoneAtLet,
-                  { LeadingKeyword =
-                     LetRec
-                       (/root/LeadingKeyword/AndKeyword.fs (2,0--2,3),
-                        /root/LeadingKeyword/AndKeyword.fs (2,4--2,7))
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some /root/LeadingKeyword/AndKeyword.fs (2,12--2,13) });
+                           None, (2,16--2,17)), Ident b, (2,14--2,17)),
+                     Const (Int32 1, (2,18--2,19)), (2,14--2,19)), (2,8--2,11),
+                  NoneAtLet, { LeadingKeyword = LetRec ((2,0--2,3), (2,4--2,7))
+                               InlineKeyword = None
+                               EqualsRange = Some (2,12--2,13) });
                SynBinding
                  (None, Normal, false, false, [],
                   PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
@@ -52,11 +42,8 @@ ImplFile
                         SynArgInfo ([], false, None)), None),
                   LongIdent
                     (SynLongIdent ([d], [], [None]), None, None,
-                     Pats
-                       [Named
-                          (SynIdent (e, None), false, None,
-                           /root/LeadingKeyword/AndKeyword.fs (3,6--3,7))], None,
-                     /root/LeadingKeyword/AndKeyword.fs (3,4--3,7)), None,
+                     Pats [Named (SynIdent (e, None), false, None, (3,6--3,7))],
+                     None, (3,4--3,7)), None,
                   App
                     (NonAtomic, false,
                      App
@@ -65,19 +52,11 @@ ImplFile
                           (false,
                            SynLongIdent
                              ([op_Addition], [], [Some (OriginalNotation "+")]),
-                           None, /root/LeadingKeyword/AndKeyword.fs (3,12--3,13)),
-                        Ident e, /root/LeadingKeyword/AndKeyword.fs (3,10--3,13)),
-                     Const
-                       (Int32 1, /root/LeadingKeyword/AndKeyword.fs (3,14--3,15)),
-                     /root/LeadingKeyword/AndKeyword.fs (3,10--3,15)),
-                  /root/LeadingKeyword/AndKeyword.fs (3,4--3,7), NoneAtLet,
-                  { LeadingKeyword =
-                     And /root/LeadingKeyword/AndKeyword.fs (3,0--3,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some /root/LeadingKeyword/AndKeyword.fs (3,8--3,9) })],
-              /root/LeadingKeyword/AndKeyword.fs (2,0--3,15))], PreXmlDocEmpty,
-          [], None, /root/LeadingKeyword/AndKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           None, (3,12--3,13)), Ident e, (3,10--3,13)),
+                     Const (Int32 1, (3,14--3,15)), (3,10--3,15)), (3,4--3,7),
+                  NoneAtLet, { LeadingKeyword = And (3,0--3,3)
+                               InlineKeyword = None
+                               EqualsRange = Some (3,8--3,9) })], (2,0--3,15))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/DefaultKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/DefaultKeyword.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Y],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/DefaultKeyword.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -21,11 +20,8 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/LeadingKeyword/DefaultKeyword.fsi (5,4--5,19),
-                            { LeadingKeyword =
-                               Default
-                                 /root/LeadingKeyword/DefaultKeyword.fsi (5,4--5,11)
+                            None, None, (5,4--5,19),
+                            { LeadingKeyword = Default (5,4--5,11)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -34,20 +30,12 @@ SigFile
                            IsOverrideOrExplicitImpl = true
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/LeadingKeyword/DefaultKeyword.fsi (5,4--5,19),
-                         { GetSetKeywords = None })],
-                     /root/LeadingKeyword/DefaultKeyword.fsi (5,4--5,19)), [],
-                  /root/LeadingKeyword/DefaultKeyword.fsi (4,5--5,19),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/DefaultKeyword.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/DefaultKeyword.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/DefaultKeyword.fsi (4,0--5,19))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/DefaultKeyword.fsi (2,0--5,19),
-          { LeadingKeyword =
-             Namespace /root/LeadingKeyword/DefaultKeyword.fsi (2,0--2,9) })],
+                           MemberKind = PropertyGet }, (5,4--5,19),
+                         { GetSetKeywords = None })], (5,4--5,19)), [],
+                  (4,5--5,19), { LeadingKeyword = Type (4,0--4,4)
+                                 EqualsRange = Some (4,7--4,8)
+                                 WithKeyword = None })], (4,0--5,19))],
+          PreXmlDocEmpty, [], None, (2,0--5,19),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/DefaultValKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/DefaultValKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/DefaultValKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [AutoProperty
@@ -29,30 +28,15 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         Const
-                           (Int32 1,
-                            /root/LeadingKeyword/DefaultValKeyword.fs (3,26--3,27)),
-                         /root/LeadingKeyword/DefaultValKeyword.fs (3,4--3,27),
+                         None, Const (Int32 1, (3,26--3,27)), (3,4--3,27),
                          { LeadingKeyword =
-                            DefaultVal
-                              (/root/LeadingKeyword/DefaultValKeyword.fs (3,4--3,11),
-                               /root/LeadingKeyword/DefaultValKeyword.fs (3,12--3,15))
+                            DefaultVal ((3,4--3,11), (3,12--3,15))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/LeadingKeyword/DefaultValKeyword.fs (3,24--3,25)
-                           GetSetKeywords = None })],
-                     /root/LeadingKeyword/DefaultValKeyword.fs (3,4--3,27)), [],
-                  None, /root/LeadingKeyword/DefaultValKeyword.fs (2,5--3,27),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/DefaultValKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/DefaultValKeyword.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/DefaultValKeyword.fs (2,0--3,27))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/DefaultValKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           EqualsRange = Some (3,24--3,25)
+                           GetSetKeywords = None })], (3,4--3,27)), [], None,
+                  (2,5--3,27), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,9--2,10)
+                                 WithKeyword = None })], (2,0--3,27))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/DoKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/DoKeyword.fs.bsl
@@ -9,7 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None, /root/LeadingKeyword/DoKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [LetBindings
@@ -18,30 +18,15 @@ ImplFile
                              SynValData
                                (None,
                                 SynValInfo ([], SynArgInfo ([], false, None)),
-                                None),
-                             Const
-                               (Unit,
-                                /root/LeadingKeyword/DoKeyword.fs (3,4--3,9)),
-                             None,
-                             Const
-                               (Unit,
-                                /root/LeadingKeyword/DoKeyword.fs (3,7--3,9)),
-                             /root/LeadingKeyword/DoKeyword.fs (3,4--3,9),
-                             NoneAtDo,
-                             { LeadingKeyword =
-                                Do /root/LeadingKeyword/DoKeyword.fs (3,4--3,6)
+                                None), Const (Unit, (3,4--3,9)), None,
+                             Const (Unit, (3,7--3,9)), (3,4--3,9), NoneAtDo,
+                             { LeadingKeyword = Do (3,4--3,6)
                                InlineKeyword = None
-                               EqualsRange = None })], false, false,
-                         /root/LeadingKeyword/DoKeyword.fs (3,4--3,9))],
-                     /root/LeadingKeyword/DoKeyword.fs (3,4--3,9)), [], None,
-                  /root/LeadingKeyword/DoKeyword.fs (2,5--3,9),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/DoKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/DoKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/DoKeyword.fs (2,0--3,9))], PreXmlDocEmpty, [],
-          None, /root/LeadingKeyword/DoKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                               EqualsRange = None })], false, false, (3,4--3,9))],
+                     (3,4--3,9)), [], None, (2,5--3,9),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,9))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/DoStaticKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/DoStaticKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/DoStaticKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [LetBindings
@@ -19,33 +18,16 @@ ImplFile
                              SynValData
                                (None,
                                 SynValInfo ([], SynArgInfo ([], false, None)),
-                                None),
-                             Const
-                               (Unit,
-                                /root/LeadingKeyword/DoStaticKeyword.fs (3,11--3,16)),
-                             None,
-                             Const
-                               (Unit,
-                                /root/LeadingKeyword/DoStaticKeyword.fs (3,14--3,16)),
-                             /root/LeadingKeyword/DoStaticKeyword.fs (3,11--3,16),
-                             NoneAtDo,
+                                None), Const (Unit, (3,11--3,16)), None,
+                             Const (Unit, (3,14--3,16)), (3,11--3,16), NoneAtDo,
                              { LeadingKeyword =
-                                StaticDo
-                                  (/root/LeadingKeyword/DoStaticKeyword.fs (3,4--3,10),
-                                   /root/LeadingKeyword/DoStaticKeyword.fs (3,11--3,13))
+                                StaticDo ((3,4--3,10), (3,11--3,13))
                                InlineKeyword = None
-                               EqualsRange = None })], true, false,
-                         /root/LeadingKeyword/DoStaticKeyword.fs (3,4--3,16))],
-                     /root/LeadingKeyword/DoStaticKeyword.fs (3,4--3,16)), [],
-                  None, /root/LeadingKeyword/DoStaticKeyword.fs (2,5--3,16),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/DoStaticKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/DoStaticKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/DoStaticKeyword.fs (2,0--3,16))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/DoStaticKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                               EqualsRange = None })], true, false, (3,4--3,16))],
+                     (3,4--3,16)), [], None, (2,5--3,16),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,16))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/ExternKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/ExternKeyword.fs.bsl
@@ -14,47 +14,31 @@ ImplFile
                   LongIdent
                     (SynLongIdent ([Meh], [], [None]), None,
                      Some (SynValTyparDecls (None, false)),
-                     Pats
-                       [Tuple
-                          (false, [],
-                           /root/LeadingKeyword/ExternKeyword.fs (2,15--2,16))],
-                     None, /root/LeadingKeyword/ExternKeyword.fs (2,12--2,15)),
+                     Pats [Tuple (false, [], (2,15--2,16))], None, (2,12--2,15)),
                   Some
                     (SynBindingReturnInfo
                        (App
                           (LongIdent
                              (SynLongIdent
                                 ([unit], [], [Some (OriginalNotation "void")])),
-                           None, [], [], None, false,
-                           /root/LeadingKeyword/ExternKeyword.fs (2,7--2,11)),
-                        /root/LeadingKeyword/ExternKeyword.fs (2,7--2,11), [],
-                        { ColonRange = None })),
+                           None, [], [], None, false, (2,7--2,11)), (2,7--2,11),
+                        [], { ColonRange = None })),
                   Typed
                     (App
                        (NonAtomic, false, Ident failwith,
                         Const
                           (String
                              ("extern was not given a DllImport attribute",
-                              Regular,
-                              /root/LeadingKeyword/ExternKeyword.fs (2,16--2,17)),
-                           /root/LeadingKeyword/ExternKeyword.fs (2,16--2,17)),
-                        /root/LeadingKeyword/ExternKeyword.fs (2,0--2,17)),
+                              Regular, (2,16--2,17)), (2,16--2,17)), (2,0--2,17)),
                      App
                        (LongIdent
                           (SynLongIdent
                              ([unit], [], [Some (OriginalNotation "void")])),
-                        None, [], [], None, false,
-                        /root/LeadingKeyword/ExternKeyword.fs (2,7--2,11)),
-                     /root/LeadingKeyword/ExternKeyword.fs (2,0--2,17)),
-                  /root/LeadingKeyword/ExternKeyword.fs (2,0--2,17),
-                  NoneAtInvisible,
-                  { LeadingKeyword =
-                     Extern /root/LeadingKeyword/ExternKeyword.fs (2,0--2,6)
+                        None, [], [], None, false, (2,7--2,11)), (2,0--2,17)),
+                  (2,0--2,17), NoneAtInvisible,
+                  { LeadingKeyword = Extern (2,0--2,6)
                     InlineKeyword = None
-                    EqualsRange = None })],
-              /root/LeadingKeyword/ExternKeyword.fs (2,0--2,17))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/ExternKeyword.fs (2,0--2,17),
-          { LeadingKeyword = None })], (true, false),
+                    EqualsRange = None })], (2,0--2,17))], PreXmlDocEmpty, [],
+          None, (2,0--2,17), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/LetKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/LetKeyword.fs.bsl
@@ -16,11 +16,8 @@ ImplFile
                         SynArgInfo ([], false, None)), None),
                   LongIdent
                     (SynLongIdent ([a], [], [None]), None, None,
-                     Pats
-                       [Named
-                          (SynIdent (b, None), false, None,
-                           /root/LeadingKeyword/LetKeyword.fs (2,6--2,7))], None,
-                     /root/LeadingKeyword/LetKeyword.fs (2,4--2,7)), None,
+                     Pats [Named (SynIdent (b, None), false, None, (2,6--2,7))],
+                     None, (2,4--2,7)), None,
                   App
                     (NonAtomic, false,
                      App
@@ -29,19 +26,11 @@ ImplFile
                           (false,
                            SynLongIdent
                              ([op_Addition], [], [Some (OriginalNotation "+")]),
-                           None, /root/LeadingKeyword/LetKeyword.fs (2,12--2,13)),
-                        Ident b, /root/LeadingKeyword/LetKeyword.fs (2,10--2,13)),
-                     Const
-                       (Int32 1, /root/LeadingKeyword/LetKeyword.fs (2,14--2,15)),
-                     /root/LeadingKeyword/LetKeyword.fs (2,10--2,15)),
-                  /root/LeadingKeyword/LetKeyword.fs (2,4--2,7), NoneAtLet,
-                  { LeadingKeyword =
-                     Let /root/LeadingKeyword/LetKeyword.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some /root/LeadingKeyword/LetKeyword.fs (2,8--2,9) })],
-              /root/LeadingKeyword/LetKeyword.fs (2,0--2,15))], PreXmlDocEmpty,
-          [], None, /root/LeadingKeyword/LetKeyword.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           None, (2,12--2,13)), Ident b, (2,10--2,13)),
+                     Const (Int32 1, (2,14--2,15)), (2,10--2,15)), (2,4--2,7),
+                  NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                               InlineKeyword = None
+                               EqualsRange = Some (2,8--2,9) })], (2,0--2,15))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/LetRecKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/LetRecKeyword.fs.bsl
@@ -17,11 +17,8 @@ ImplFile
                   LongIdent
                     (SynLongIdent ([a], [], [None]), None, None,
                      Pats
-                       [Named
-                          (SynIdent (b, None), false, None,
-                           /root/LeadingKeyword/LetRecKeyword.fs (2,10--2,11))],
-                     None, /root/LeadingKeyword/LetRecKeyword.fs (2,8--2,11)),
-                  None,
+                       [Named (SynIdent (b, None), false, None, (2,10--2,11))],
+                     None, (2,8--2,11)), None,
                   App
                     (NonAtomic, false,
                      App
@@ -30,25 +27,11 @@ ImplFile
                           (false,
                            SynLongIdent
                              ([op_Addition], [], [Some (OriginalNotation "+")]),
-                           None,
-                           /root/LeadingKeyword/LetRecKeyword.fs (2,16--2,17)),
-                        Ident b,
-                        /root/LeadingKeyword/LetRecKeyword.fs (2,14--2,17)),
-                     Const
-                       (Int32 1,
-                        /root/LeadingKeyword/LetRecKeyword.fs (2,18--2,19)),
-                     /root/LeadingKeyword/LetRecKeyword.fs (2,14--2,19)),
-                  /root/LeadingKeyword/LetRecKeyword.fs (2,8--2,11), NoneAtLet,
-                  { LeadingKeyword =
-                     LetRec
-                       (/root/LeadingKeyword/LetRecKeyword.fs (2,0--2,3),
-                        /root/LeadingKeyword/LetRecKeyword.fs (2,4--2,7))
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some /root/LeadingKeyword/LetRecKeyword.fs (2,12--2,13) })],
-              /root/LeadingKeyword/LetRecKeyword.fs (2,0--2,19))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/LetRecKeyword.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           None, (2,16--2,17)), Ident b, (2,14--2,17)),
+                     Const (Int32 1, (2,18--2,19)), (2,14--2,19)), (2,8--2,11),
+                  NoneAtLet, { LeadingKeyword = LetRec ((2,0--2,3), (2,4--2,7))
+                               InlineKeyword = None
+                               EqualsRange = Some (2,12--2,13) })], (2,0--2,19))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/MemberKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/MemberKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/MemberKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -29,41 +28,21 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; Y],
-                                  [/root/LeadingKeyword/MemberKeyword.fs (3,15--3,16)],
-                                  [None; None]), None, None,
+                                 ([this; Y], [(3,15--3,16)], [None; None]), None,
+                               None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/LeadingKeyword/MemberKeyword.fs (3,18--3,20)),
-                                     /root/LeadingKeyword/MemberKeyword.fs (3,18--3,20))],
-                               None,
-                               /root/LeadingKeyword/MemberKeyword.fs (3,11--3,20)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/LeadingKeyword/MemberKeyword.fs (3,24--3,26)),
-                            /root/LeadingKeyword/MemberKeyword.fs (3,11--3,20),
+                                    (Const (Unit, (3,18--3,20)), (3,18--3,20))],
+                               None, (3,11--3,20)), None,
+                            Const (Unit, (3,24--3,26)), (3,11--3,20),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/LeadingKeyword/MemberKeyword.fs (3,4--3,10)
+                            { LeadingKeyword = Member (3,4--3,10)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/LeadingKeyword/MemberKeyword.fs (3,22--3,23) }),
-                         /root/LeadingKeyword/MemberKeyword.fs (3,4--3,26))],
-                     /root/LeadingKeyword/MemberKeyword.fs (3,4--3,26)), [],
-                  None, /root/LeadingKeyword/MemberKeyword.fs (2,5--3,26),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/MemberKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/MemberKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/MemberKeyword.fs (2,0--3,26))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/MemberKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                              EqualsRange = Some (3,22--3,23) }), (3,4--3,26))],
+                     (3,4--3,26)), [], None, (2,5--3,26),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,26))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/MemberValKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/MemberValKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/MemberValKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [AutoProperty
@@ -29,30 +28,15 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         Const
-                           (Int32 1,
-                            /root/LeadingKeyword/MemberValKeyword.fs (3,25--3,26)),
-                         /root/LeadingKeyword/MemberValKeyword.fs (3,4--3,26),
+                         None, Const (Int32 1, (3,25--3,26)), (3,4--3,26),
                          { LeadingKeyword =
-                            MemberVal
-                              (/root/LeadingKeyword/MemberValKeyword.fs (3,4--3,10),
-                               /root/LeadingKeyword/MemberValKeyword.fs (3,11--3,14))
+                            MemberVal ((3,4--3,10), (3,11--3,14))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/LeadingKeyword/MemberValKeyword.fs (3,23--3,24)
-                           GetSetKeywords = None })],
-                     /root/LeadingKeyword/MemberValKeyword.fs (3,4--3,26)), [],
-                  None, /root/LeadingKeyword/MemberValKeyword.fs (2,5--3,26),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/MemberValKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/MemberValKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/MemberValKeyword.fs (2,0--3,26))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/MemberValKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           EqualsRange = Some (3,23--3,24)
+                           GetSetKeywords = None })], (3,4--3,26)), [], None,
+                  (2,5--3,26), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,26))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/NewKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/NewKeyword.fs.bsl
@@ -9,17 +9,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Y],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None, /root/LeadingKeyword/NewKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([], /root/LeadingKeyword/NewKeyword.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/LeadingKeyword/NewKeyword.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -42,47 +38,27 @@ ImplFile
                                     (Typed
                                        (Named
                                           (SynIdent (message, None), false, None,
-                                           /root/LeadingKeyword/NewKeyword.fs (3,9--3,16)),
+                                           (3,9--3,16)),
                                         LongIdent
                                           (SynLongIdent ([string], [], [None])),
-                                        /root/LeadingKeyword/NewKeyword.fs (3,9--3,23)),
-                                     /root/LeadingKeyword/NewKeyword.fs (3,8--3,24))],
-                               None,
-                               /root/LeadingKeyword/NewKeyword.fs (3,4--3,7)),
-                            None,
+                                        (3,9--3,23)), (3,8--3,24))], None,
+                               (3,4--3,7)), None,
                             App
                               (Atomic, false, Ident Y,
-                               Const
-                                 (Unit,
-                                  /root/LeadingKeyword/NewKeyword.fs (3,28--3,30)),
-                               /root/LeadingKeyword/NewKeyword.fs (3,27--3,30)),
-                            /root/LeadingKeyword/NewKeyword.fs (3,4--3,24),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               New /root/LeadingKeyword/NewKeyword.fs (3,4--3,7)
+                               Const (Unit, (3,28--3,30)), (3,27--3,30)),
+                            (3,4--3,24), NoneAtInvisible,
+                            { LeadingKeyword = New (3,4--3,7)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/LeadingKeyword/NewKeyword.fs (3,25--3,26) }),
-                         /root/LeadingKeyword/NewKeyword.fs (3,4--3,30))],
-                     /root/LeadingKeyword/NewKeyword.fs (3,4--3,30)), [],
+                              EqualsRange = Some (3,25--3,26) }), (3,4--3,30))],
+                     (3,4--3,30)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([], /root/LeadingKeyword/NewKeyword.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/LeadingKeyword/NewKeyword.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/LeadingKeyword/NewKeyword.fs (2,5--3,30),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/NewKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/NewKeyword.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/NewKeyword.fs (2,0--3,30))], PreXmlDocEmpty,
-          [], None, /root/LeadingKeyword/NewKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--3,30),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--3,30))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/OverrideKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/OverrideKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [D],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/OverrideKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -29,45 +28,26 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent ([E], [], [None]), None, None,
-                               Pats [], None,
-                               /root/LeadingKeyword/OverrideKeyword.fs (3,13--3,14)),
+                               Pats [], None, (3,13--3,14)),
                             Some
                               (SynBindingReturnInfo
                                  (LongIdent
                                     (SynLongIdent ([string], [], [None])),
-                                  /root/LeadingKeyword/OverrideKeyword.fs (3,17--3,23),
-                                  [],
-                                  { ColonRange =
-                                     Some
-                                       /root/LeadingKeyword/OverrideKeyword.fs (3,15--3,16) })),
+                                  (3,17--3,23), [],
+                                  { ColonRange = Some (3,15--3,16) })),
                             Typed
                               (Const
-                                 (String
-                                    ("", Regular,
-                                     /root/LeadingKeyword/OverrideKeyword.fs (3,26--3,28)),
-                                  /root/LeadingKeyword/OverrideKeyword.fs (3,26--3,28)),
+                                 (String ("", Regular, (3,26--3,28)),
+                                  (3,26--3,28)),
                                LongIdent (SynLongIdent ([string], [], [None])),
-                               /root/LeadingKeyword/OverrideKeyword.fs (3,26--3,28)),
-                            /root/LeadingKeyword/OverrideKeyword.fs (3,13--3,14),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               Override
-                                 /root/LeadingKeyword/OverrideKeyword.fs (3,4--3,12)
+                               (3,26--3,28)), (3,13--3,14), NoneAtInvisible,
+                            { LeadingKeyword = Override (3,4--3,12)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/LeadingKeyword/OverrideKeyword.fs (3,24--3,25) }),
-                         /root/LeadingKeyword/OverrideKeyword.fs (3,4--3,28))],
-                     /root/LeadingKeyword/OverrideKeyword.fs (3,4--3,28)), [],
-                  None, /root/LeadingKeyword/OverrideKeyword.fs (2,5--3,28),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/OverrideKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/OverrideKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/OverrideKeyword.fs (2,0--3,28))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/OverrideKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                              EqualsRange = Some (3,24--3,25) }), (3,4--3,28))],
+                     (3,4--3,28)), [], None, (2,5--3,28),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,28))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/OverrideValKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/OverrideValKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/OverrideValKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [AutoProperty
@@ -29,30 +28,15 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         Const
-                           (Int32 1,
-                            /root/LeadingKeyword/OverrideValKeyword.fs (3,27--3,28)),
-                         /root/LeadingKeyword/OverrideValKeyword.fs (3,4--3,28),
+                         None, Const (Int32 1, (3,27--3,28)), (3,4--3,28),
                          { LeadingKeyword =
-                            OverrideVal
-                              (/root/LeadingKeyword/OverrideValKeyword.fs (3,4--3,12),
-                               /root/LeadingKeyword/OverrideValKeyword.fs (3,13--3,16))
+                            OverrideVal ((3,4--3,12), (3,13--3,16))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/LeadingKeyword/OverrideValKeyword.fs (3,25--3,26)
-                           GetSetKeywords = None })],
-                     /root/LeadingKeyword/OverrideValKeyword.fs (3,4--3,28)), [],
-                  None, /root/LeadingKeyword/OverrideValKeyword.fs (2,5--3,28),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/OverrideValKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/OverrideValKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/OverrideValKeyword.fs (2,0--3,28))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/OverrideValKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           EqualsRange = Some (3,25--3,26)
+                           GetSetKeywords = None })], (3,4--3,28)), [], None,
+                  (2,5--3,28), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,28))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/StaticAbstractKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/StaticAbstractKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/StaticAbstractKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [AbstractSlot
@@ -20,19 +19,14 @@ ImplFile
                             Fun
                               (LongIdent (SynLongIdent ([int], [], [None])),
                                LongIdent (SynLongIdent ([int], [], [None])),
-                               /root/LeadingKeyword/StaticAbstractKeyword.fs (3,24--3,34),
-                               { ArrowRange =
-                                  /root/LeadingKeyword/StaticAbstractKeyword.fs (3,28--3,30) }),
+                               (3,24--3,34), { ArrowRange = (3,28--3,30) }),
                             SynValInfo
                               ([[SynArgInfo ([], false, None)]],
                                SynArgInfo ([], false, None)), false, false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/LeadingKeyword/StaticAbstractKeyword.fs (3,4--3,34),
+                            None, None, (3,4--3,34),
                             { LeadingKeyword =
-                               StaticAbstract
-                                 (/root/LeadingKeyword/StaticAbstractKeyword.fs (3,4--3,10),
-                                  /root/LeadingKeyword/StaticAbstractKeyword.fs (3,11--3,19))
+                               StaticAbstract ((3,4--3,10), (3,11--3,19))
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -41,22 +35,11 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/LeadingKeyword/StaticAbstractKeyword.fs (3,4--3,34),
-                         { GetSetKeywords = None })],
-                     /root/LeadingKeyword/StaticAbstractKeyword.fs (3,4--3,34)),
-                  [], None,
-                  /root/LeadingKeyword/StaticAbstractKeyword.fs (2,5--3,34),
-                  { LeadingKeyword =
-                     Type
-                       /root/LeadingKeyword/StaticAbstractKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/LeadingKeyword/StaticAbstractKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/StaticAbstractKeyword.fs (2,0--3,34))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/StaticAbstractKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           MemberKind = Member }, (3,4--3,34),
+                         { GetSetKeywords = None })], (3,4--3,34)), [], None,
+                  (2,5--3,34), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,34))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/StaticAbstractMemberKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/StaticAbstractMemberKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [AbstractSlot
@@ -20,20 +19,15 @@ ImplFile
                             Fun
                               (LongIdent (SynLongIdent ([int], [], [None])),
                                LongIdent (SynLongIdent ([int], [], [None])),
-                               /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (3,31--3,41),
-                               { ArrowRange =
-                                  /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (3,35--3,37) }),
+                               (3,31--3,41), { ArrowRange = (3,35--3,37) }),
                             SynValInfo
                               ([[SynArgInfo ([], false, None)]],
                                SynArgInfo ([], false, None)), false, false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (3,4--3,41),
+                            None, None, (3,4--3,41),
                             { LeadingKeyword =
                                StaticAbstractMember
-                                 (/root/LeadingKeyword/StaticAbstractMemberKeyword.fs (3,4--3,10),
-                                  /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (3,11--3,19),
-                                  /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (3,20--3,26))
+                                 ((3,4--3,10), (3,11--3,19), (3,20--3,26))
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -42,22 +36,11 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (3,4--3,41),
-                         { GetSetKeywords = None })],
-                     /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (3,4--3,41)),
-                  [], None,
-                  /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (2,5--3,41),
-                  { LeadingKeyword =
-                     Type
-                       /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (2,0--3,41))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/StaticAbstractMemberKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           MemberKind = Member }, (3,4--3,41),
+                         { GetSetKeywords = None })], (3,4--3,41)), [], None,
+                  (2,5--3,41), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,41))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/StaticLetKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/StaticLetKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/StaticLetKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [LetBindings
@@ -23,35 +22,17 @@ ImplFile
                                 None),
                              LongIdent
                                (SynLongIdent ([PI], [], [None]), None, None,
-                                Pats [], None,
-                                /root/LeadingKeyword/StaticLetKeyword.fs (3,15--3,17)),
-                             None,
-                             Const
-                               (Double 3.14,
-                                /root/LeadingKeyword/StaticLetKeyword.fs (3,20--3,24)),
-                             /root/LeadingKeyword/StaticLetKeyword.fs (3,15--3,17),
-                             Yes
-                               /root/LeadingKeyword/StaticLetKeyword.fs (3,11--3,24),
+                                Pats [], None, (3,15--3,17)), None,
+                             Const (Double 3.14, (3,20--3,24)), (3,15--3,17),
+                             Yes (3,11--3,24),
                              { LeadingKeyword =
-                                StaticLet
-                                  (/root/LeadingKeyword/StaticLetKeyword.fs (3,4--3,10),
-                                   /root/LeadingKeyword/StaticLetKeyword.fs (3,11--3,14))
+                                StaticLet ((3,4--3,10), (3,11--3,14))
                                InlineKeyword = None
-                               EqualsRange =
-                                Some
-                                  /root/LeadingKeyword/StaticLetKeyword.fs (3,18--3,19) })],
-                         true, false,
-                         /root/LeadingKeyword/StaticLetKeyword.fs (3,4--3,24))],
-                     /root/LeadingKeyword/StaticLetKeyword.fs (3,4--3,24)), [],
-                  None, /root/LeadingKeyword/StaticLetKeyword.fs (2,5--3,24),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/StaticLetKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/StaticLetKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/StaticLetKeyword.fs (2,0--3,24))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/StaticLetKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                               EqualsRange = Some (3,18--3,19) })], true, false,
+                         (3,4--3,24))], (3,4--3,24)), [], None, (2,5--3,24),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,24))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/StaticLetRecKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/StaticLetRecKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/StaticLetRecKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [LetBindings
@@ -25,43 +24,21 @@ ImplFile
                                (SynLongIdent ([forever], [], [None]), None, None,
                                 Pats
                                   [Paren
-                                     (Const
-                                        (Unit,
-                                         /root/LeadingKeyword/StaticLetRecKeyword.fs (3,27--3,29)),
-                                      /root/LeadingKeyword/StaticLetRecKeyword.fs (3,27--3,29))],
-                                None,
-                                /root/LeadingKeyword/StaticLetRecKeyword.fs (3,19--3,29)),
-                             None,
+                                     (Const (Unit, (3,27--3,29)), (3,27--3,29))],
+                                None, (3,19--3,29)), None,
                              App
                                (Atomic, false, Ident forever,
-                                Const
-                                  (Unit,
-                                   /root/LeadingKeyword/StaticLetRecKeyword.fs (3,39--3,41)),
-                                /root/LeadingKeyword/StaticLetRecKeyword.fs (3,32--3,41)),
-                             /root/LeadingKeyword/StaticLetRecKeyword.fs (3,19--3,29),
-                             NoneAtLet,
+                                Const (Unit, (3,39--3,41)), (3,32--3,41)),
+                             (3,19--3,29), NoneAtLet,
                              { LeadingKeyword =
                                 StaticLetRec
-                                  (/root/LeadingKeyword/StaticLetRecKeyword.fs (3,4--3,10),
-                                   /root/LeadingKeyword/StaticLetRecKeyword.fs (3,11--3,14),
-                                   /root/LeadingKeyword/StaticLetRecKeyword.fs (3,15--3,18))
+                                  ((3,4--3,10), (3,11--3,14), (3,15--3,18))
                                InlineKeyword = None
-                               EqualsRange =
-                                Some
-                                  /root/LeadingKeyword/StaticLetRecKeyword.fs (3,30--3,31) })],
-                         true, true,
-                         /root/LeadingKeyword/StaticLetRecKeyword.fs (3,4--3,41))],
-                     /root/LeadingKeyword/StaticLetRecKeyword.fs (3,4--3,41)),
-                  [], None,
-                  /root/LeadingKeyword/StaticLetRecKeyword.fs (2,5--3,41),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/StaticLetRecKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/StaticLetRecKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/StaticLetRecKeyword.fs (2,0--3,41))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/StaticLetRecKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                               EqualsRange = Some (3,30--3,31) })], true, true,
+                         (3,4--3,41))], (3,4--3,41)), [], None, (2,5--3,41),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,41))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/StaticMemberKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/StaticMemberKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/StaticMemberKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -28,44 +27,24 @@ ImplFile
                                None),
                             LongIdent
                               (SynLongIdent ([Y], [], [None]), None, None,
-                               Pats [], None,
-                               /root/LeadingKeyword/StaticMemberKeyword.fs (3,18--3,19)),
+                               Pats [], None, (3,18--3,19)),
                             Some
                               (SynBindingReturnInfo
                                  (LongIdent (SynLongIdent ([int], [], [None])),
-                                  /root/LeadingKeyword/StaticMemberKeyword.fs (3,22--3,25),
-                                  [],
-                                  { ColonRange =
-                                     Some
-                                       /root/LeadingKeyword/StaticMemberKeyword.fs (3,20--3,21) })),
+                                  (3,22--3,25), [],
+                                  { ColonRange = Some (3,20--3,21) })),
                             Typed
-                              (Const
-                                 (Int32 1,
-                                  /root/LeadingKeyword/StaticMemberKeyword.fs (3,28--3,29)),
+                              (Const (Int32 1, (3,28--3,29)),
                                LongIdent (SynLongIdent ([int], [], [None])),
-                               /root/LeadingKeyword/StaticMemberKeyword.fs (3,28--3,29)),
-                            /root/LeadingKeyword/StaticMemberKeyword.fs (3,18--3,19),
-                            NoneAtInvisible,
+                               (3,28--3,29)), (3,18--3,19), NoneAtInvisible,
                             { LeadingKeyword =
-                               StaticMember
-                                 (/root/LeadingKeyword/StaticMemberKeyword.fs (3,4--3,10),
-                                  /root/LeadingKeyword/StaticMemberKeyword.fs (3,11--3,17))
+                               StaticMember ((3,4--3,10), (3,11--3,17))
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/LeadingKeyword/StaticMemberKeyword.fs (3,26--3,27) }),
-                         /root/LeadingKeyword/StaticMemberKeyword.fs (3,4--3,29))],
-                     /root/LeadingKeyword/StaticMemberKeyword.fs (3,4--3,29)),
-                  [], None,
-                  /root/LeadingKeyword/StaticMemberKeyword.fs (2,5--3,29),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/StaticMemberKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/StaticMemberKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/StaticMemberKeyword.fs (2,0--3,29))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/StaticMemberKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                              EqualsRange = Some (3,26--3,27) }), (3,4--3,29))],
+                     (3,4--3,29)), [], None, (2,5--3,29),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,29))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/StaticMemberValKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/StaticMemberValKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/StaticMemberValKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [AutoProperty
@@ -29,34 +28,16 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         Const
-                           (Int32 1,
-                            /root/LeadingKeyword/StaticMemberValKeyword.fs (3,32--3,33)),
-                         /root/LeadingKeyword/StaticMemberValKeyword.fs (3,4--3,33),
+                         None, Const (Int32 1, (3,32--3,33)), (3,4--3,33),
                          { LeadingKeyword =
                             StaticMemberVal
-                              (/root/LeadingKeyword/StaticMemberValKeyword.fs (3,4--3,10),
-                               /root/LeadingKeyword/StaticMemberValKeyword.fs (3,11--3,17),
-                               /root/LeadingKeyword/StaticMemberValKeyword.fs (3,18--3,21))
+                              ((3,4--3,10), (3,11--3,17), (3,18--3,21))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/LeadingKeyword/StaticMemberValKeyword.fs (3,30--3,31)
-                           GetSetKeywords = None })],
-                     /root/LeadingKeyword/StaticMemberValKeyword.fs (3,4--3,33)),
-                  [], None,
-                  /root/LeadingKeyword/StaticMemberValKeyword.fs (2,5--3,33),
-                  { LeadingKeyword =
-                     Type
-                       /root/LeadingKeyword/StaticMemberValKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/LeadingKeyword/StaticMemberValKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/StaticMemberValKeyword.fs (2,0--3,33))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/StaticMemberValKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           EqualsRange = Some (3,30--3,31)
+                           GetSetKeywords = None })], (3,4--3,33)), [], None,
+                  (2,5--3,33), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,33))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/StaticValKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/StaticValKeyword.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/LeadingKeyword/StaticValKeyword.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [ValField
@@ -19,30 +18,16 @@ SigFile
                             Fun
                               (LongIdent (SynLongIdent ([int], [], [None])),
                                LongIdent (SynLongIdent ([int], [], [None])),
-                               /root/LeadingKeyword/StaticValKeyword.fsi (5,19--5,29),
-                               { ArrowRange =
-                                  /root/LeadingKeyword/StaticValKeyword.fsi (5,23--5,25) }),
+                               (5,19--5,29), { ArrowRange = (5,23--5,25) }),
                             false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/LeadingKeyword/StaticValKeyword.fsi (5,4--5,29),
+                            None, (5,4--5,29),
                             { LeadingKeyword =
-                               Some
-                                 (StaticVal
-                                    (/root/LeadingKeyword/StaticValKeyword.fsi (5,4--5,10),
-                                     /root/LeadingKeyword/StaticValKeyword.fsi (5,11--5,14))) }),
-                         /root/LeadingKeyword/StaticValKeyword.fsi (5,4--5,29))],
-                     /root/LeadingKeyword/StaticValKeyword.fsi (5,4--5,29)), [],
-                  /root/LeadingKeyword/StaticValKeyword.fsi (4,5--5,29),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/StaticValKeyword.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/StaticValKeyword.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/StaticValKeyword.fsi (4,0--5,29))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/StaticValKeyword.fsi (2,0--5,29),
-          { LeadingKeyword =
-             Namespace /root/LeadingKeyword/StaticValKeyword.fsi (2,0--2,9) })],
+                               Some (StaticVal ((5,4--5,10), (5,11--5,14))) }),
+                         (5,4--5,29))], (5,4--5,29)), [], (4,5--5,29),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,7--4,8)
+                    WithKeyword = None })], (4,0--5,29))], PreXmlDocEmpty, [],
+          None, (2,0--5,29), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/SyntheticKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/SyntheticKeyword.fs.bsl
@@ -7,30 +7,18 @@ ImplFile
           [Expr
              (ObjExpr
                 (LongIdent (SynLongIdent ([ISomething], [], [None])), None,
-                 Some /root/LeadingKeyword/SyntheticKeyword.fs (2,17--2,21),
+                 Some (2,17--2,21),
                  [SynBinding
                     (None, Normal, false, false, [], PreXmlDocEmpty,
                      SynValData
                        (None, SynValInfo ([], SynArgInfo ([], false, None)),
                         None),
-                     Named
-                       (SynIdent (a, None), false, None,
-                        /root/LeadingKeyword/SyntheticKeyword.fs (3,4--3,5)),
-                     None,
-                     Const
-                       (Unit,
-                        /root/LeadingKeyword/SyntheticKeyword.fs (3,8--3,10)),
-                     /root/LeadingKeyword/SyntheticKeyword.fs (3,4--3,5),
-                     Yes /root/LeadingKeyword/SyntheticKeyword.fs (3,8--3,10),
+                     Named (SynIdent (a, None), false, None, (3,4--3,5)), None,
+                     Const (Unit, (3,8--3,10)), (3,4--3,5), Yes (3,8--3,10),
                      { LeadingKeyword = Synthetic
                        InlineKeyword = None
-                       EqualsRange =
-                        Some /root/LeadingKeyword/SyntheticKeyword.fs (3,6--3,7) })],
-                 [], [], /root/LeadingKeyword/SyntheticKeyword.fs (2,2--2,16),
-                 /root/LeadingKeyword/SyntheticKeyword.fs (2,0--3,12)),
-              /root/LeadingKeyword/SyntheticKeyword.fs (2,0--3,12))],
-          PreXmlDocEmpty, [], None,
-          /root/LeadingKeyword/SyntheticKeyword.fs (2,0--3,12),
-          { LeadingKeyword = None })], (true, false),
+                       EqualsRange = Some (3,6--3,7) })], [], [], (2,2--2,16),
+                 (2,0--3,12)), (2,0--3,12))], PreXmlDocEmpty, [], None,
+          (2,0--3,12), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/UseKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/UseKeyword.fs.bsl
@@ -14,28 +14,16 @@ ImplFile
                         SynValData
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
-                        Named
-                          (SynIdent (x, None), false, None,
-                           /root/LeadingKeyword/UseKeyword.fs (3,8--3,9)), None,
+                        Named (SynIdent (x, None), false, None, (3,8--3,9)),
+                        None,
                         App
-                          (Atomic, false, Ident X,
-                           Const
-                             (Unit,
-                              /root/LeadingKeyword/UseKeyword.fs (3,13--3,15)),
-                           /root/LeadingKeyword/UseKeyword.fs (3,12--3,15)),
-                        /root/LeadingKeyword/UseKeyword.fs (3,8--3,9),
-                        Yes /root/LeadingKeyword/UseKeyword.fs (3,4--3,15),
-                        { LeadingKeyword =
-                           Use /root/LeadingKeyword/UseKeyword.fs (3,4--3,7)
+                          (Atomic, false, Ident X, Const (Unit, (3,13--3,15)),
+                           (3,12--3,15)), (3,8--3,9), Yes (3,4--3,15),
+                        { LeadingKeyword = Use (3,4--3,7)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some /root/LeadingKeyword/UseKeyword.fs (3,10--3,11) })],
-                    Const (Unit, /root/LeadingKeyword/UseKeyword.fs (4,4--4,6)),
-                    /root/LeadingKeyword/UseKeyword.fs (3,4--4,6),
-                    { InKeyword = None }),
-                 /root/LeadingKeyword/UseKeyword.fs (2,0--4,6)),
-              /root/LeadingKeyword/UseKeyword.fs (2,0--4,6))], PreXmlDocEmpty,
-          [], None, /root/LeadingKeyword/UseKeyword.fs (2,0--5,0),
+                          EqualsRange = Some (3,10--3,11) })],
+                    Const (Unit, (4,4--4,6)), (3,4--4,6), { InKeyword = None }),
+                 (2,0--4,6)), (2,0--4,6))], PreXmlDocEmpty, [], None, (2,0--5,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/UseRecKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/UseRecKeyword.fs.bsl
@@ -14,33 +14,16 @@ ImplFile
                         SynValData
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
-                        Named
-                          (SynIdent (x, None), false, None,
-                           /root/LeadingKeyword/UseRecKeyword.fs (3,12--3,13)),
+                        Named (SynIdent (x, None), false, None, (3,12--3,13)),
                         None,
                         App
-                          (Atomic, false, Ident X,
-                           Const
-                             (Unit,
-                              /root/LeadingKeyword/UseRecKeyword.fs (3,17--3,19)),
-                           /root/LeadingKeyword/UseRecKeyword.fs (3,16--3,19)),
-                        /root/LeadingKeyword/UseRecKeyword.fs (3,12--3,13),
-                        Yes /root/LeadingKeyword/UseRecKeyword.fs (3,4--3,19),
-                        { LeadingKeyword =
-                           UseRec
-                             (/root/LeadingKeyword/UseRecKeyword.fs (3,4--3,7),
-                              /root/LeadingKeyword/UseRecKeyword.fs (3,8--3,11))
+                          (Atomic, false, Ident X, Const (Unit, (3,17--3,19)),
+                           (3,16--3,19)), (3,12--3,13), Yes (3,4--3,19),
+                        { LeadingKeyword = UseRec ((3,4--3,7), (3,8--3,11))
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/LeadingKeyword/UseRecKeyword.fs (3,14--3,15) })],
-                    Const
-                      (Unit, /root/LeadingKeyword/UseRecKeyword.fs (4,4--4,6)),
-                    /root/LeadingKeyword/UseRecKeyword.fs (3,4--4,6),
-                    { InKeyword = None }),
-                 /root/LeadingKeyword/UseRecKeyword.fs (2,0--4,6)),
-              /root/LeadingKeyword/UseRecKeyword.fs (2,0--4,6))], PreXmlDocEmpty,
-          [], None, /root/LeadingKeyword/UseRecKeyword.fs (2,0--5,0),
+                          EqualsRange = Some (3,14--3,15) })],
+                    Const (Unit, (4,4--4,6)), (3,4--4,6), { InKeyword = None }),
+                 (2,0--4,6)), (2,0--4,6))], PreXmlDocEmpty, [], None, (2,0--5,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/LeadingKeyword/ValKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/ValKeyword.fsi.bsl
@@ -9,7 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Y],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None, /root/LeadingKeyword/ValKeyword.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [ValField
@@ -17,23 +17,12 @@ SigFile
                            ([], false, Some F,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/LeadingKeyword/ValKeyword.fsi (5,4--5,15),
-                            { LeadingKeyword =
-                               Some
-                                 (Val
-                                    /root/LeadingKeyword/ValKeyword.fsi (5,4--5,7)) }),
-                         /root/LeadingKeyword/ValKeyword.fsi (5,4--5,15))],
-                     /root/LeadingKeyword/ValKeyword.fsi (5,4--5,15)), [],
-                  /root/LeadingKeyword/ValKeyword.fsi (4,5--5,15),
-                  { LeadingKeyword =
-                     Type /root/LeadingKeyword/ValKeyword.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some /root/LeadingKeyword/ValKeyword.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/LeadingKeyword/ValKeyword.fsi (4,0--5,15))], PreXmlDocEmpty,
-          [], None, /root/LeadingKeyword/ValKeyword.fsi (2,0--5,15),
-          { LeadingKeyword =
-             Namespace /root/LeadingKeyword/ValKeyword.fsi (2,0--2,9) })],
+                            None, (5,4--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                         (5,4--5,15))], (5,4--5,15)), [], (4,5--5,15),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,7--4,8)
+                    WithKeyword = None })], (4,0--5,15))], PreXmlDocEmpty, [],
+          None, (2,0--5,15), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs.bsl
@@ -10,44 +10,17 @@ ImplFile
           [Expr
              (TryWith
                 (App
-                   (NonAtomic, false, Ident foo,
-                    Const
-                      (Unit,
-                       /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (3,8--3,10)),
-                    /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (3,4--3,10)),
+                   (NonAtomic, false, Ident foo, Const (Unit, (3,8--3,10)),
+                    (3,4--3,10)),
                  [SynMatchClause
-                    (Named
-                       (SynIdent (exn, None), false, None,
-                        /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,5--4,8)),
-                     None,
-                     Const
-                       (Unit,
-                        /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (6,4--6,6)),
-                     /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,5--6,6),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,9--4,11)
-                       BarRange = None })],
-                 /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--6,6),
-                 Yes
-                   /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--2,3),
-                 Yes
-                   /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,0--4,4),
-                 { TryKeyword =
-                    /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--4,4)
-                   WithKeyword =
-                    /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,0--4,4)
-                   WithToEndRange =
-                    /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,0--6,6) }),
-              /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--6,6))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/MatchClause/NoRangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (5,4--5,19)] },
-      set []))
+                    (Named (SynIdent (exn, None), false, None, (4,5--4,8)), None,
+                     Const (Unit, (6,4--6,6)), (4,5--6,6), Yes,
+                     { ArrowRange = Some (4,9--4,11)
+                       BarRange = None })], (2,0--6,6), Yes (2,0--2,3),
+                 Yes (4,0--4,4), { TryKeyword = (2,0--2,3)
+                                   TryToWithRange = (2,0--4,4)
+                                   WithKeyword = (4,0--4,4)
+                                   WithToEndRange = (4,0--6,6) }), (2,0--6,6))],
+          PreXmlDocEmpty, [], None, (2,0--7,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [LineComment (5,4--5,19)] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfArrowInSynMatchClause.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfArrowInSynMatchClause.fs.bsl
@@ -6,38 +6,17 @@ ImplFile
          ([RangeOfArrowInSynMatchClause], false, AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/MatchClause/RangeOfArrowInSynMatchClause.fs (2,0--2,14),
-                 Ident foo,
+                (Yes (2,0--2,14), Ident foo,
                  [SynMatchClause
                     (LongIdent
                        (SynLongIdent ([Bar], [], [None]), None, None,
                         Pats
-                          [Named
-                             (SynIdent (bar, None), false, None,
-                              /root/MatchClause/RangeOfArrowInSynMatchClause.fs (3,6--3,9))],
-                        None,
-                        /root/MatchClause/RangeOfArrowInSynMatchClause.fs (3,2--3,9)),
-                     None,
-                     Const
-                       (Unit,
-                        /root/MatchClause/RangeOfArrowInSynMatchClause.fs (3,13--3,15)),
-                     /root/MatchClause/RangeOfArrowInSynMatchClause.fs (3,2--3,15),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfArrowInSynMatchClause.fs (3,10--3,12)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfArrowInSynMatchClause.fs (3,0--3,1) })],
-                 /root/MatchClause/RangeOfArrowInSynMatchClause.fs (2,0--3,15),
-                 { MatchKeyword =
-                    /root/MatchClause/RangeOfArrowInSynMatchClause.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfArrowInSynMatchClause.fs (2,10--2,14) }),
-              /root/MatchClause/RangeOfArrowInSynMatchClause.fs (2,0--3,15))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfArrowInSynMatchClause.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                          [Named (SynIdent (bar, None), false, None, (3,6--3,9))],
+                        None, (3,2--3,9)), None, Const (Unit, (3,13--3,15)),
+                     (3,2--3,15), Yes, { ArrowRange = Some (3,10--3,12)
+                                         BarRange = Some (3,0--3,1) })],
+                 (2,0--3,15), { MatchKeyword = (2,0--2,5)
+                                WithKeyword = (2,10--2,14) }), (2,0--3,15))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs.bsl
@@ -6,46 +6,23 @@ ImplFile
          ([RangeOfArrowInSynMatchClauseWithWhenClause], false, AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (2,0--2,14),
-                 Ident foo,
+                (Yes (2,0--2,14), Ident foo,
                  [SynMatchClause
                     (LongIdent
                        (SynLongIdent ([Bar], [], [None]), None, None,
                         Pats
-                          [Named
-                             (SynIdent (bar, None), false, None,
-                              /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,6--3,9))],
-                        None,
-                        /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,2--3,9)),
+                          [Named (SynIdent (bar, None), false, None, (3,6--3,9))],
+                        None, (3,2--3,9)),
                      Some
                        (Paren
                           (App
                              (NonAtomic, false, Ident someCheck, Ident bar,
-                              /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,16--3,29)),
-                           /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,15--3,16),
-                           Some
-                             /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,29--3,30),
-                           /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,15--3,30))),
-                     Const
-                       (Unit,
-                        /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,34--3,36)),
-                     /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,2--3,36),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,31--3,33)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (3,0--3,1) })],
-                 /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (2,0--3,36),
-                 { MatchKeyword =
-                    /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (2,10--2,14) }),
-              /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (2,0--3,36))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfArrowInSynMatchClauseWithWhenClause.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                              (3,16--3,29)), (3,15--3,16), Some (3,29--3,30),
+                           (3,15--3,30))), Const (Unit, (3,34--3,36)),
+                     (3,2--3,36), Yes, { ArrowRange = Some (3,31--3,33)
+                                         BarRange = Some (3,0--3,1) })],
+                 (2,0--3,36), { MatchKeyword = (2,0--2,5)
+                                WithKeyword = (2,10--2,14) }), (2,0--3,36))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs.bsl
@@ -10,68 +10,27 @@ ImplFile
           [Expr
              (TryWith
                 (App
-                   (NonAtomic, false, Ident foo,
-                    Const
-                      (Unit,
-                       /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (3,8--3,10)),
-                    /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (3,4--3,10)),
+                   (NonAtomic, false, Ident foo, Const (Unit, (3,8--3,10)),
+                    (3,4--3,10)),
                  [SynMatchClause
                     (As
                        (LongIdent
                           (SynLongIdent ([IOException], [], [None]), None, None,
-                           Pats [], None,
-                           /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (5,2--5,13)),
-                        Named
-                          (SynIdent (ioex, None), false, None,
-                           /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (5,17--5,21)),
-                        /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (5,2--5,21)),
-                     None,
-                     Const
-                       (Unit,
-                        /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (7,4--7,6)),
-                     /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (5,2--7,6),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (5,22--5,24)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (5,0--5,1) });
+                           Pats [], None, (5,2--5,13)),
+                        Named (SynIdent (ioex, None), false, None, (5,17--5,21)),
+                        (5,2--5,21)), None, Const (Unit, (7,4--7,6)), (5,2--7,6),
+                     Yes, { ArrowRange = Some (5,22--5,24)
+                            BarRange = Some (5,0--5,1) });
                   SynMatchClause
-                    (Named
-                       (SynIdent (ex, None), false, None,
-                        /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (8,2--8,4)),
-                     None,
-                     Const
-                       (Unit,
-                        /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (8,8--8,10)),
-                     /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (8,2--8,10),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (8,5--8,7)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (8,0--8,1) })],
-                 /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (2,0--8,10),
-                 Yes
-                   /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (2,0--2,3),
-                 Yes
-                   /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (4,0--4,4),
-                 { TryKeyword =
-                    /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (2,0--4,4)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (4,0--4,4)
-                   WithToEndRange =
-                    /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (4,0--8,10) }),
-              /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (2,0--8,10))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (2,0--9,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/MatchClause/RangeOfBarInAMultipleSynMatchClausesInSynExprTryWith.fs (6,4--6,19)] },
-      set []))
+                    (Named (SynIdent (ex, None), false, None, (8,2--8,4)), None,
+                     Const (Unit, (8,8--8,10)), (8,2--8,10), Yes,
+                     { ArrowRange = Some (8,5--8,7)
+                       BarRange = Some (8,0--8,1) })], (2,0--8,10),
+                 Yes (2,0--2,3), Yes (4,0--4,4),
+                 { TryKeyword = (2,0--2,3)
+                   TryToWithRange = (2,0--4,4)
+                   WithKeyword = (4,0--4,4)
+                   WithToEndRange = (4,0--8,10) }), (2,0--8,10))],
+          PreXmlDocEmpty, [], None, (2,0--9,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [LineComment (6,4--6,19)] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs.bsl
@@ -7,46 +7,23 @@ ImplFile
          ([RangeOfBarInASingleSynMatchClauseInSynExprMatch], false, AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (2,0--2,14),
-                 Ident foo,
+                (Yes (2,0--2,14), Ident foo,
                  [SynMatchClause
                     (LongIdent
                        (SynLongIdent ([Bar], [], [None]), None, None,
                         Pats
-                          [Named
-                             (SynIdent (bar, None), false, None,
-                              /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,6--3,9))],
-                        None,
-                        /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,2--3,9)),
+                          [Named (SynIdent (bar, None), false, None, (3,6--3,9))],
+                        None, (3,2--3,9)),
                      Some
                        (Paren
                           (App
                              (NonAtomic, false, Ident someCheck, Ident bar,
-                              /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,16--3,29)),
-                           /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,15--3,16),
-                           Some
-                             /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,29--3,30),
-                           /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,15--3,30))),
-                     Const
-                       (Unit,
-                        /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,34--3,36)),
-                     /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,2--3,36),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,31--3,33)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (3,0--3,1) })],
-                 /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (2,0--3,36),
-                 { MatchKeyword =
-                    /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (2,10--2,14) }),
-              /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (2,0--3,36))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprMatch.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                              (3,16--3,29)), (3,15--3,16), Some (3,29--3,30),
+                           (3,15--3,30))), Const (Unit, (3,34--3,36)),
+                     (3,2--3,36), Yes, { ArrowRange = Some (3,31--3,33)
+                                         BarRange = Some (3,0--3,1) })],
+                 (2,0--3,36), { MatchKeyword = (2,0--2,5)
+                                WithKeyword = (2,10--2,14) }), (2,0--3,36))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs.bsl
@@ -9,43 +9,18 @@ ImplFile
           [Expr
              (TryWith
                 (App
-                   (NonAtomic, false, Ident foo,
-                    Const
-                      (Unit,
-                       /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (3,8--3,10)),
-                    /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (3,4--3,10)),
+                   (NonAtomic, false, Ident foo, Const (Unit, (3,8--3,10)),
+                    (3,4--3,10)),
                  [SynMatchClause
-                    (Named
-                       (SynIdent (exn, None), false, None,
-                        /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (5,2--5,5)),
-                     None,
-                     Const
-                       (Unit,
-                        /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (5,9--5,11)),
-                     /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (5,2--5,11),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (5,6--5,8)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (5,0--5,1) })],
-                 /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--5,11),
-                 Yes
-                   /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--2,3),
-                 Yes
-                   /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,0--4,4),
-                 { TryKeyword =
-                    /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--4,4)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,0--4,4)
-                   WithToEndRange =
-                    /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (4,0--5,11) }),
-              /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--5,11))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfBarInASingleSynMatchClauseInSynExprTryWith.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    (Named (SynIdent (exn, None), false, None, (5,2--5,5)), None,
+                     Const (Unit, (5,9--5,11)), (5,2--5,11), Yes,
+                     { ArrowRange = Some (5,6--5,8)
+                       BarRange = Some (5,0--5,1) })], (2,0--5,11),
+                 Yes (2,0--2,3), Yes (4,0--4,4),
+                 { TryKeyword = (2,0--2,3)
+                   TryToWithRange = (2,0--4,4)
+                   WithKeyword = (4,0--4,4)
+                   WithToEndRange = (4,0--5,11) }), (2,0--5,11))],
+          PreXmlDocEmpty, [], None, (2,0--6,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs.bsl
@@ -8,70 +8,34 @@ ImplFile
          ([RangeOfBarInMultipleSynMatchClausesInSynExprMatch], false, AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (2,0--2,14),
-                 Ident foo,
+                (Yes (2,0--2,14), Ident foo,
                  [SynMatchClause
                     (LongIdent
                        (SynLongIdent ([Bar], [], [None]), None, None,
                         Pats
-                          [Named
-                             (SynIdent (bar, None), false, None,
-                              /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,6--3,9))],
-                        None,
-                        /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,2--3,9)),
+                          [Named (SynIdent (bar, None), false, None, (3,6--3,9))],
+                        None, (3,2--3,9)),
                      Some
                        (Paren
                           (App
                              (NonAtomic, false, Ident someCheck, Ident bar,
-                              /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,16--3,29)),
-                           /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,15--3,16),
-                           Some
-                             /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,29--3,30),
-                           /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,15--3,30))),
-                     Const
-                       (Unit,
-                        /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,34--3,36)),
-                     /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,2--3,36),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,31--3,33)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (3,0--3,1) });
+                              (3,16--3,29)), (3,15--3,16), Some (3,29--3,30),
+                           (3,15--3,30))), Const (Unit, (3,34--3,36)),
+                     (3,2--3,36), Yes, { ArrowRange = Some (3,31--3,33)
+                                         BarRange = Some (3,0--3,1) });
                   SynMatchClause
                     (LongIdent
                        (SynLongIdent ([Far], [], [None]), None, None,
                         Pats
-                          [Named
-                             (SynIdent (too, None), false, None,
-                              /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (4,6--4,9))],
-                        None,
-                        /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (4,2--4,9)),
-                     None,
+                          [Named (SynIdent (too, None), false, None, (4,6--4,9))],
+                        None, (4,2--4,9)), None,
                      App
-                       (NonAtomic, false, Ident near,
-                        Const
-                          (Unit,
-                           /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (4,18--4,20)),
-                        /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (4,13--4,20)),
-                     /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (4,2--4,20),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (4,10--4,12)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (4,0--4,1) })],
-                 /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (2,0--4,20),
-                 { MatchKeyword =
-                    /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (2,10--2,14) }),
-              /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (2,0--4,20))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfBarInMultipleSynMatchClausesInSynExprMatch.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                       (NonAtomic, false, Ident near, Const (Unit, (4,18--4,20)),
+                        (4,13--4,20)), (4,2--4,20), Yes,
+                     { ArrowRange = Some (4,10--4,12)
+                       BarRange = Some (4,0--4,1) })], (2,0--4,20),
+                 { MatchKeyword = (2,0--2,5)
+                   WithKeyword = (2,10--2,14) }), (2,0--4,20))], PreXmlDocEmpty,
+          [], None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfMultipleSynMatchClause.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfMultipleSynMatchClause.fs.bsl
@@ -15,32 +15,19 @@ ImplFile
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
                         Named
-                          (SynIdent (content, None), false, None,
-                           /root/MatchClause/RangeOfMultipleSynMatchClause.fs (3,8--3,15)),
+                          (SynIdent (content, None), false, None, (3,8--3,15)),
                         None,
                         App
                           (NonAtomic, false, Ident tryDownloadFile, Ident url,
-                           /root/MatchClause/RangeOfMultipleSynMatchClause.fs (3,18--3,37)),
-                        /root/MatchClause/RangeOfMultipleSynMatchClause.fs (3,8--3,15),
-                        Yes
-                          /root/MatchClause/RangeOfMultipleSynMatchClause.fs (3,4--3,37),
-                        { LeadingKeyword =
-                           Let
-                             /root/MatchClause/RangeOfMultipleSynMatchClause.fs (3,4--3,7)
+                           (3,18--3,37)), (3,8--3,15), Yes (3,4--3,37),
+                        { LeadingKeyword = Let (3,4--3,7)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/MatchClause/RangeOfMultipleSynMatchClause.fs (3,16--3,17) })],
+                          EqualsRange = Some (3,16--3,17) })],
                     App
-                      (NonAtomic, false, Ident Some, Ident content,
-                       /root/MatchClause/RangeOfMultipleSynMatchClause.fs (4,4--4,16)),
-                    /root/MatchClause/RangeOfMultipleSynMatchClause.fs (3,4--4,16),
-                    { InKeyword = None }),
+                      (NonAtomic, false, Ident Some, Ident content, (4,4--4,16)),
+                    (3,4--4,16), { InKeyword = None }),
                  [SynMatchClause
-                    (Named
-                       (SynIdent (ex, None), false, None,
-                        /root/MatchClause/RangeOfMultipleSynMatchClause.fs (6,2--6,4)),
-                     None,
+                    (Named (SynIdent (ex, None), false, None, (6,2--6,4)), None,
                      Sequential
                        (SuppressNeither, true,
                         App
@@ -48,51 +35,21 @@ ImplFile
                            LongIdent
                              (false,
                               SynLongIdent
-                                ([Infrastructure; ReportWarning],
-                                 [/root/MatchClause/RangeOfMultipleSynMatchClause.fs (7,18--7,19)],
-                                 [None; None]), None,
-                              /root/MatchClause/RangeOfMultipleSynMatchClause.fs (7,4--7,32)),
-                           Ident ex,
-                           /root/MatchClause/RangeOfMultipleSynMatchClause.fs (7,4--7,35)),
-                        Ident None,
-                        /root/MatchClause/RangeOfMultipleSynMatchClause.fs (7,4--8,8)),
-                     /root/MatchClause/RangeOfMultipleSynMatchClause.fs (6,2--8,8),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfMultipleSynMatchClause.fs (6,5--6,7)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfMultipleSynMatchClause.fs (6,0--6,1) });
+                                ([Infrastructure; ReportWarning], [(7,18--7,19)],
+                                 [None; None]), None, (7,4--7,32)), Ident ex,
+                           (7,4--7,35)), Ident None, (7,4--8,8)), (6,2--8,8),
+                     Yes, { ArrowRange = Some (6,5--6,7)
+                            BarRange = Some (6,0--6,1) });
                   SynMatchClause
-                    (Named
-                       (SynIdent (exx, None), false, None,
-                        /root/MatchClause/RangeOfMultipleSynMatchClause.fs (9,2--9,5)),
-                     None, Ident None,
-                     /root/MatchClause/RangeOfMultipleSynMatchClause.fs (9,2--10,8),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfMultipleSynMatchClause.fs (9,6--9,8)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfMultipleSynMatchClause.fs (9,0--9,1) })],
-                 /root/MatchClause/RangeOfMultipleSynMatchClause.fs (2,0--10,8),
-                 Yes
-                   /root/MatchClause/RangeOfMultipleSynMatchClause.fs (2,0--2,3),
-                 Yes
-                   /root/MatchClause/RangeOfMultipleSynMatchClause.fs (5,0--5,4),
-                 { TryKeyword =
-                    /root/MatchClause/RangeOfMultipleSynMatchClause.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/MatchClause/RangeOfMultipleSynMatchClause.fs (2,0--5,4)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfMultipleSynMatchClause.fs (5,0--5,4)
-                   WithToEndRange =
-                    /root/MatchClause/RangeOfMultipleSynMatchClause.fs (5,0--10,8) }),
-              /root/MatchClause/RangeOfMultipleSynMatchClause.fs (2,0--10,8))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfMultipleSynMatchClause.fs (2,0--11,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    (Named (SynIdent (exx, None), false, None, (9,2--9,5)), None,
+                     Ident None, (9,2--10,8), Yes,
+                     { ArrowRange = Some (9,6--9,8)
+                       BarRange = Some (9,0--9,1) })], (2,0--10,8),
+                 Yes (2,0--2,3), Yes (5,0--5,4),
+                 { TryKeyword = (2,0--2,3)
+                   TryToWithRange = (2,0--5,4)
+                   WithKeyword = (5,0--5,4)
+                   WithToEndRange = (5,0--10,8) }), (2,0--10,8))],
+          PreXmlDocEmpty, [], None, (2,0--11,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfSingleSynMatchClause.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfSingleSynMatchClause.fs.bsl
@@ -15,32 +15,19 @@ ImplFile
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
                         Named
-                          (SynIdent (content, None), false, None,
-                           /root/MatchClause/RangeOfSingleSynMatchClause.fs (3,8--3,15)),
+                          (SynIdent (content, None), false, None, (3,8--3,15)),
                         None,
                         App
                           (NonAtomic, false, Ident tryDownloadFile, Ident url,
-                           /root/MatchClause/RangeOfSingleSynMatchClause.fs (3,18--3,37)),
-                        /root/MatchClause/RangeOfSingleSynMatchClause.fs (3,8--3,15),
-                        Yes
-                          /root/MatchClause/RangeOfSingleSynMatchClause.fs (3,4--3,37),
-                        { LeadingKeyword =
-                           Let
-                             /root/MatchClause/RangeOfSingleSynMatchClause.fs (3,4--3,7)
+                           (3,18--3,37)), (3,8--3,15), Yes (3,4--3,37),
+                        { LeadingKeyword = Let (3,4--3,7)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/MatchClause/RangeOfSingleSynMatchClause.fs (3,16--3,17) })],
+                          EqualsRange = Some (3,16--3,17) })],
                     App
-                      (NonAtomic, false, Ident Some, Ident content,
-                       /root/MatchClause/RangeOfSingleSynMatchClause.fs (4,4--4,16)),
-                    /root/MatchClause/RangeOfSingleSynMatchClause.fs (3,4--4,16),
-                    { InKeyword = None }),
+                      (NonAtomic, false, Ident Some, Ident content, (4,4--4,16)),
+                    (3,4--4,16), { InKeyword = None }),
                  [SynMatchClause
-                    (Named
-                       (SynIdent (ex, None), false, None,
-                        /root/MatchClause/RangeOfSingleSynMatchClause.fs (5,5--5,7)),
-                     None,
+                    (Named (SynIdent (ex, None), false, None, (5,5--5,7)), None,
                      Sequential
                        (SuppressNeither, true,
                         App
@@ -48,34 +35,15 @@ ImplFile
                            LongIdent
                              (false,
                               SynLongIdent
-                                ([Infrastructure; ReportWarning],
-                                 [/root/MatchClause/RangeOfSingleSynMatchClause.fs (6,18--6,19)],
-                                 [None; None]), None,
-                              /root/MatchClause/RangeOfSingleSynMatchClause.fs (6,4--6,32)),
-                           Ident ex,
-                           /root/MatchClause/RangeOfSingleSynMatchClause.fs (6,4--6,35)),
-                        Ident None,
-                        /root/MatchClause/RangeOfSingleSynMatchClause.fs (6,4--7,8)),
-                     /root/MatchClause/RangeOfSingleSynMatchClause.fs (5,5--7,8),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfSingleSynMatchClause.fs (5,8--5,10)
-                       BarRange = None })],
-                 /root/MatchClause/RangeOfSingleSynMatchClause.fs (2,0--7,8),
-                 Yes /root/MatchClause/RangeOfSingleSynMatchClause.fs (2,0--2,3),
-                 Yes /root/MatchClause/RangeOfSingleSynMatchClause.fs (5,0--5,4),
-                 { TryKeyword =
-                    /root/MatchClause/RangeOfSingleSynMatchClause.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/MatchClause/RangeOfSingleSynMatchClause.fs (2,0--5,4)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfSingleSynMatchClause.fs (5,0--5,4)
-                   WithToEndRange =
-                    /root/MatchClause/RangeOfSingleSynMatchClause.fs (5,0--7,8) }),
-              /root/MatchClause/RangeOfSingleSynMatchClause.fs (2,0--7,8))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfSingleSynMatchClause.fs (2,0--8,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                ([Infrastructure; ReportWarning], [(6,18--6,19)],
+                                 [None; None]), None, (6,4--6,32)), Ident ex,
+                           (6,4--6,35)), Ident None, (6,4--7,8)), (5,5--7,8),
+                     Yes, { ArrowRange = Some (5,8--5,10)
+                            BarRange = None })], (2,0--7,8), Yes (2,0--2,3),
+                 Yes (5,0--5,4), { TryKeyword = (2,0--2,3)
+                                   TryToWithRange = (2,0--5,4)
+                                   WithKeyword = (5,0--5,4)
+                                   WithToEndRange = (5,0--7,8) }), (2,0--7,8))],
+          PreXmlDocEmpty, [], None, (2,0--8,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs.bsl
@@ -15,59 +15,27 @@ ImplFile
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
                         Named
-                          (SynIdent (content, None), false, None,
-                           /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (3,8--3,15)),
+                          (SynIdent (content, None), false, None, (3,8--3,15)),
                         None,
                         App
                           (NonAtomic, false, Ident tryDownloadFile, Ident url,
-                           /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (3,18--3,37)),
-                        /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (3,8--3,15),
-                        Yes
-                          /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (3,4--3,37),
-                        { LeadingKeyword =
-                           Let
-                             /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (3,4--3,7)
+                           (3,18--3,37)), (3,8--3,15), Yes (3,4--3,37),
+                        { LeadingKeyword = Let (3,4--3,7)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (3,16--3,17) })],
+                          EqualsRange = Some (3,16--3,17) })],
                     App
-                      (NonAtomic, false, Ident Some, Ident content,
-                       /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (4,4--4,16)),
-                    /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (3,4--4,16),
-                    { InKeyword = None }),
+                      (NonAtomic, false, Ident Some, Ident content, (4,4--4,16)),
+                    (3,4--4,16), { InKeyword = None }),
                  [SynMatchClause
-                    (Named
-                       (SynIdent (ex, None), false, None,
-                        /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (6,2--6,4)),
-                     None,
-                     Const
-                       (Unit,
-                        /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (7,4--7,6)),
-                     /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (6,2--7,6),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (6,5--6,7)
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (6,0--6,1) })],
-                 /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (2,0--8,1),
-                 Yes
-                   /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (2,0--2,3),
-                 Yes
-                   /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (5,0--5,4),
-                 { TryKeyword =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (2,0--5,4)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (5,0--5,4)
-                   WithToEndRange =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (5,0--8,1) }),
-              /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (2,0--8,1))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfSingleSynMatchClauseFollowedByBar.fs (2,0--9,0),
+                    (Named (SynIdent (ex, None), false, None, (6,2--6,4)), None,
+                     Const (Unit, (7,4--7,6)), (6,2--7,6), Yes,
+                     { ArrowRange = Some (6,5--6,7)
+                       BarRange = Some (6,0--6,1) })], (2,0--8,1),
+                 Yes (2,0--2,3), Yes (5,0--5,4), { TryKeyword = (2,0--2,3)
+                                                   TryToWithRange = (2,0--5,4)
+                                                   WithKeyword = (5,0--5,4)
+                                                   WithToEndRange = (5,0--8,1) }),
+              (2,0--8,1))], PreXmlDocEmpty, [], None, (2,0--9,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs.bsl
@@ -15,57 +15,27 @@ ImplFile
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
                         Named
-                          (SynIdent (content, None), false, None,
-                           /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (3,8--3,15)),
+                          (SynIdent (content, None), false, None, (3,8--3,15)),
                         None,
                         App
                           (NonAtomic, false, Ident tryDownloadFile, Ident url,
-                           /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (3,18--3,37)),
-                        /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (3,8--3,15),
-                        Yes
-                          /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (3,4--3,37),
-                        { LeadingKeyword =
-                           Let
-                             /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (3,4--3,7)
+                           (3,18--3,37)), (3,8--3,15), Yes (3,4--3,37),
+                        { LeadingKeyword = Let (3,4--3,7)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (3,16--3,17) })],
+                          EqualsRange = Some (3,16--3,17) })],
                     App
-                      (NonAtomic, false, Ident Some, Ident content,
-                       /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (4,4--4,16)),
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (3,4--4,16),
-                    { InKeyword = None }),
+                      (NonAtomic, false, Ident Some, Ident content, (4,4--4,16)),
+                    (3,4--4,16), { InKeyword = None }),
                  [SynMatchClause
-                    (Named
-                       (SynIdent (ex, None), false, None,
-                        /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (6,2--6,4)),
-                     None,
-                     ArbitraryAfterError
-                       ("patternClauses2",
-                        /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (6,4--6,4)),
-                     /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (6,2--6,4),
-                     Yes,
-                     { ArrowRange = None
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (6,0--6,1) })],
-                 /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (2,0--6,4),
-                 Yes
-                   /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (2,0--2,3),
-                 Yes
-                   /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (5,0--5,4),
-                 { TryKeyword =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (2,0--5,4)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (5,0--5,4)
-                   WithToEndRange =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (5,0--6,4) }),
-              /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (2,0--6,4))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBody.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
+                    (Named (SynIdent (ex, None), false, None, (6,2--6,4)), None,
+                     ArbitraryAfterError ("patternClauses2", (6,4--6,4)),
+                     (6,2--6,4), Yes, { ArrowRange = None
+                                        BarRange = Some (6,0--6,1) })],
+                 (2,0--6,4), Yes (2,0--2,3), Yes (5,0--5,4),
+                 { TryKeyword = (2,0--2,3)
+                   TryToWithRange = (2,0--5,4)
+                   WithKeyword = (5,0--5,4)
+                   WithToEndRange = (5,0--6,4) }), (2,0--6,4))], PreXmlDocEmpty,
+          [], None, (2,0--7,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs.bsl
@@ -18,65 +18,33 @@ ImplFile
                           (None, SynValInfo ([], SynArgInfo ([], false, None)),
                            None),
                         Named
-                          (SynIdent (content, None), false, None,
-                           /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (3,8--3,15)),
+                          (SynIdent (content, None), false, None, (3,8--3,15)),
                         None,
                         App
                           (NonAtomic, false, Ident tryDownloadFile, Ident url,
-                           /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (3,18--3,37)),
-                        /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (3,8--3,15),
-                        Yes
-                          /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (3,4--3,37),
-                        { LeadingKeyword =
-                           Let
-                             /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (3,4--3,7)
+                           (3,18--3,37)), (3,8--3,15), Yes (3,4--3,37),
+                        { LeadingKeyword = Let (3,4--3,7)
                           InlineKeyword = None
-                          EqualsRange =
-                           Some
-                             /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (3,16--3,17) })],
+                          EqualsRange = Some (3,16--3,17) })],
                     App
-                      (NonAtomic, false, Ident Some, Ident content,
-                       /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (4,4--4,16)),
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (3,4--4,16),
-                    { InKeyword = None }),
+                      (NonAtomic, false, Ident Some, Ident content, (4,4--4,16)),
+                    (3,4--4,16), { InKeyword = None }),
                  [SynMatchClause
-                    (Named
-                       (SynIdent (ex, None), false, None,
-                        /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (6,2--6,4)),
+                    (Named (SynIdent (ex, None), false, None, (6,2--6,4)),
                      Some
                        (Paren
                           (App
                              (NonAtomic, false, Ident isNull, Ident ex,
-                              /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (6,11--6,20)),
-                           /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (6,10--6,11),
-                           Some
-                             /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (6,20--6,21),
-                           /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (6,10--6,21))),
-                     ArbitraryAfterError
-                       ("patternClauses2",
-                        /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (6,21--6,21)),
-                     /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (6,2--6,21),
-                     Yes,
-                     { ArrowRange = None
-                       BarRange =
-                        Some
-                          /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (6,0--6,1) })],
-                 /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (2,0--6,21),
-                 Yes
-                   /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (2,0--2,3),
-                 Yes
-                   /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (5,0--5,4),
-                 { TryKeyword =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (2,0--2,3)
-                   TryToWithRange =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (2,0--5,4)
-                   WithKeyword =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (5,0--5,4)
-                   WithToEndRange =
-                    /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (5,0--6,21) }),
-              /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (2,0--6,21))],
-          PreXmlDocEmpty, [], None,
-          /root/MatchClause/RangeOfSingleSynMatchClauseWithMissingBodyAndWhenExpr.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                              (6,11--6,20)), (6,10--6,11), Some (6,20--6,21),
+                           (6,10--6,21))),
+                     ArbitraryAfterError ("patternClauses2", (6,21--6,21)),
+                     (6,2--6,21), Yes, { ArrowRange = None
+                                         BarRange = Some (6,0--6,1) })],
+                 (2,0--6,21), Yes (2,0--2,3), Yes (5,0--5,4),
+                 { TryKeyword = (2,0--2,3)
+                   TryToWithRange = (2,0--5,4)
+                   WithKeyword = (5,0--5,4)
+                   WithToEndRange = (5,0--6,21) }), (2,0--6,21))],
+          PreXmlDocEmpty, [], None, (2,0--7,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Measure/MeasureContainsTheRangeOfTheConstant.fs.bsl
+++ b/tests/service/data/SyntaxTree/Measure/MeasureContainsTheRangeOfTheConstant.fs.bsl
@@ -11,31 +11,15 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (n, None), false, None,
-                     /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,4--2,5)),
-                  None,
+                  Named (SynIdent (n, None), false, None, (2,4--2,5)), None,
                   Const
                     (Measure
-                       (Decimal 1.0M,
-                        /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,8--2,12),
-                        Seq
-                          ([Named
-                              ([cm],
-                               /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,13--2,15))],
-                           /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,13--2,15))),
-                     /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,8--2,16)),
-                  /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,4--2,5),
-                  Yes
-                    /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,0--2,16),
-                  { LeadingKeyword =
-                     Let
-                       /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,0--2,3)
+                       (Decimal 1.0M, (2,8--2,12),
+                        Seq ([Named ([cm], (2,13--2,15))], (2,13--2,15))),
+                     (2,8--2,16)), (2,4--2,5), Yes (2,0--2,16),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,6--2,7) })],
-              /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,0--2,16));
+                    EqualsRange = Some (2,6--2,7) })], (2,0--2,16));
            Let
              (false,
               [SynBinding
@@ -43,33 +27,15 @@ ImplFile
                   PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (m, None), false, None,
-                     /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,4--3,5)),
-                  None,
+                  Named (SynIdent (m, None), false, None, (3,4--3,5)), None,
                   Const
                     (Measure
-                       (Double 7.0,
-                        /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,8--3,13),
-                        Seq
-                          ([Named
-                              ([cm],
-                               /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,14--3,16))],
-                           /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,14--3,16))),
-                     /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,8--3,17)),
-                  /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,4--3,5),
-                  Yes
-                    /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,0--3,17),
-                  { LeadingKeyword =
-                     Let
-                       /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,0--3,3)
+                       (Double 7.0, (3,8--3,13),
+                        Seq ([Named ([cm], (3,14--3,16))], (3,14--3,16))),
+                     (3,8--3,17)), (3,4--3,5), Yes (3,0--3,17),
+                  { LeadingKeyword = Let (3,0--3,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,6--3,7) })],
-              /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (3,0--3,17))],
-          PreXmlDocEmpty, [], None,
-          /root/Measure/MeasureContainsTheRangeOfTheConstant.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (3,6--3,7) })], (3,0--3,17))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Measure/SynMeasureParenHasCorrectRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/Measure/SynMeasureParenHasCorrectRange.fs.bsl
@@ -7,31 +7,16 @@ ImplFile
           [Expr
              (Const
                 (Measure
-                   (UInt32 40u,
-                    /root/Measure/SynMeasureParenHasCorrectRange.fs (2,0--2,3),
+                   (UInt32 40u, (2,0--2,3),
                     Divide
-                      (Seq
-                         ([Named
-                             ([hr],
-                              /root/Measure/SynMeasureParenHasCorrectRange.fs (2,4--2,6))],
-                          /root/Measure/SynMeasureParenHasCorrectRange.fs (2,4--2,6)),
+                      (Seq ([Named ([hr], (2,4--2,6))], (2,4--2,6)),
                        Seq
                          ([Paren
                              (Seq
-                                ([Named
-                                    ([staff],
-                                     /root/Measure/SynMeasureParenHasCorrectRange.fs (2,10--2,15));
-                                  Named
-                                    ([weeks],
-                                     /root/Measure/SynMeasureParenHasCorrectRange.fs (2,16--2,21))],
-                                 /root/Measure/SynMeasureParenHasCorrectRange.fs (2,10--2,21)),
-                              /root/Measure/SynMeasureParenHasCorrectRange.fs (2,9--2,22))],
-                          /root/Measure/SynMeasureParenHasCorrectRange.fs (2,9--2,22)),
-                       /root/Measure/SynMeasureParenHasCorrectRange.fs (2,4--2,22))),
-                 /root/Measure/SynMeasureParenHasCorrectRange.fs (2,0--2,23)),
-              /root/Measure/SynMeasureParenHasCorrectRange.fs (2,0--2,23))],
-          PreXmlDocEmpty, [], None,
-          /root/Measure/SynMeasureParenHasCorrectRange.fs (2,0--2,23),
-          { LeadingKeyword = None })], (true, false),
+                                ([Named ([staff], (2,10--2,15));
+                                  Named ([weeks], (2,16--2,21))], (2,10--2,21)),
+                              (2,9--2,22))], (2,9--2,22)), (2,4--2,22))),
+                 (2,0--2,23)), (2,0--2,23))], PreXmlDocEmpty, [], None,
+          (2,0--2,23), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs.bsl
+++ b/tests/service/data/SyntaxTree/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs.bsl
@@ -9,44 +9,25 @@ ImplFile
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName = SynLongIdent ([Measure], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,2--2,9))
+                            ArgExpr = Const (Unit, (2,2--2,9))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,2--2,9) }]
-                        Range =
-                         /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,0--2,11) }],
-                     None, [], [X],
+                            Range = (2,2--2,9) }]
+                        Range = (2,0--2,11) }], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,17--2,18)),
+                     false, None, (2,17--2,18)),
                   Simple
                     (TypeAbbrev
                        (Ok,
                         Tuple
                           (false,
-                           [Slash
-                              /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,21--2,22);
+                           [Slash (2,21--2,22);
                             Type
                               (LongIdent (SynLongIdent ([second], [], [None])))],
-                           /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,21--2,29)),
-                        /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,21--2,29)),
-                     /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,21--2,29)),
-                  [], None,
-                  /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,0--2,29),
-                  { LeadingKeyword =
-                     Type
-                       /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,12--2,16)
-                    EqualsRange =
-                     Some
-                       /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,19--2,20)
-                    WithKeyword = None })],
-              /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,0--2,29))],
-          PreXmlDocEmpty, [], None,
-          /root/Measure/SynTypeTupleInMeasureTypeWithLeadingSlash.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           (2,21--2,29)), (2,21--2,29)), (2,21--2,29)), [], None,
+                  (2,0--2,29), { LeadingKeyword = Type (2,12--2,16)
+                                 EqualsRange = Some (2,19--2,20)
+                                 WithKeyword = None })], (2,0--2,29))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs.bsl
+++ b/tests/service/data/SyntaxTree/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs.bsl
@@ -9,44 +9,25 @@ ImplFile
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName = SynLongIdent ([Measure], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,2--2,9))
+                            ArgExpr = Const (Unit, (2,2--2,9))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,2--2,9) }]
-                        Range =
-                         /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,0--2,11) }],
-                     None, [], [X],
+                            Range = (2,2--2,9) }]
+                        Range = (2,0--2,11) }], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,17--2,18)),
+                     false, None, (2,17--2,18)),
                   Simple
                     (TypeAbbrev
                        (Ok,
                         Tuple
                           (false,
                            [Type (LongIdent (SynLongIdent ([Y], [], [None])));
-                            Star
-                              /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,23--2,24);
+                            Star (2,23--2,24);
                             Type (LongIdent (SynLongIdent ([Z], [], [None])))],
-                           /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,21--2,26)),
-                        /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,21--2,26)),
-                     /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,21--2,26)),
-                  [], None,
-                  /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,0--2,26),
-                  { LeadingKeyword =
-                     Type
-                       /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,12--2,16)
-                    EqualsRange =
-                     Some
-                       /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,19--2,20)
-                    WithKeyword = None })],
-              /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,0--2,26))],
-          PreXmlDocEmpty, [], None,
-          /root/Measure/SynTypeTupleInMeasureTypeWithNoSlashes.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           (2,21--2,26)), (2,21--2,26)), (2,21--2,26)), [], None,
+                  (2,0--2,26), { LeadingKeyword = Type (2,12--2,16)
+                                 EqualsRange = Some (2,19--2,20)
+                                 WithKeyword = None })], (2,0--2,26))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs.bsl
+++ b/tests/service/data/SyntaxTree/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs.bsl
@@ -9,47 +9,27 @@ ImplFile
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName = SynLongIdent ([Measure], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,2--2,9))
+                            ArgExpr = Const (Unit, (2,2--2,9))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,2--2,9) }]
-                        Range =
-                         /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,0--2,11) }],
-                     None, [], [R],
+                            Range = (2,2--2,9) }]
+                        Range = (2,0--2,11) }], None, [], [R],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,17--2,18)),
+                     false, None, (2,17--2,18)),
                   Simple
                     (TypeAbbrev
                        (Ok,
                         Tuple
                           (false,
                            [Type (LongIdent (SynLongIdent ([X], [], [None])));
-                            Star
-                              /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,23--2,24);
+                            Star (2,23--2,24);
                             Type (LongIdent (SynLongIdent ([Y], [], [None])));
-                            Slash
-                              /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,27--2,28);
+                            Slash (2,27--2,28);
                             Type (LongIdent (SynLongIdent ([Z], [], [None])))],
-                           /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,21--2,30)),
-                        /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,21--2,30)),
-                     /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,21--2,30)),
-                  [], None,
-                  /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,0--2,30),
-                  { LeadingKeyword =
-                     Type
-                       /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,12--2,16)
-                    EqualsRange =
-                     Some
-                       /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,19--2,20)
-                    WithKeyword = None })],
-              /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,0--2,30))],
-          PreXmlDocEmpty, [], None,
-          /root/Measure/SynTypeTupleInMeasureTypeWithStartAndSlash.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           (2,21--2,30)), (2,21--2,30)), (2,21--2,30)), [], None,
+                  (2,0--2,30), { LeadingKeyword = Type (2,12--2,16)
+                                 EqualsRange = Some (2,19--2,20)
+                                 WithKeyword = None })], (2,0--2,30))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/GetSetMemberWithInlineKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/GetSetMemberWithInlineKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/GetSetMemberWithInlineKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [GetSetMember
@@ -32,32 +31,17 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([x; Y],
-                                     [/root/Member/GetSetMemberWithInlineKeyword.fs (3,19--3,20)],
-                                     [None; None]), Some get, None,
+                                    ([x; Y], [(3,19--3,20)], [None; None]),
+                                  Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Member/GetSetMemberWithInlineKeyword.fs (4,24--4,26)),
-                                        /root/Member/GetSetMemberWithInlineKeyword.fs (4,24--4,26))],
-                                  None,
-                                  /root/Member/GetSetMemberWithInlineKeyword.fs (4,20--4,26)),
-                               None,
-                               Const
-                                 (Int32 4,
-                                  /root/Member/GetSetMemberWithInlineKeyword.fs (4,29--4,30)),
-                               /root/Member/GetSetMemberWithInlineKeyword.fs (4,20--4,26),
+                                       (Const (Unit, (4,24--4,26)), (4,24--4,26))],
+                                  None, (4,20--4,26)), None,
+                               Const (Int32 4, (4,29--4,30)), (4,20--4,26),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/GetSetMemberWithInlineKeyword.fs (3,4--3,10)
-                                 InlineKeyword =
-                                  Some
-                                    /root/Member/GetSetMemberWithInlineKeyword.fs (4,13--4,19)
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/GetSetMemberWithInlineKeyword.fs (4,27--4,28) })),
+                               { LeadingKeyword = Member (3,4--3,10)
+                                 InlineKeyword = Some (4,13--4,19)
+                                 EqualsRange = Some (4,27--4,28) })),
                          Some
                            (SynBinding
                               (None, Normal, true, false, [],
@@ -77,58 +61,26 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([x; Y],
-                                     [/root/Member/GetSetMemberWithInlineKeyword.fs (3,19--3,20)],
-                                     [None; None]), Some set, None,
+                                    ([x; Y], [(3,19--3,20)], [None; None]),
+                                  Some set, None,
                                   Pats
                                     [Named
                                        (SynIdent (y, None), false, None,
-                                        /root/Member/GetSetMemberWithInlineKeyword.fs (5,23--5,24))],
-                                  None,
-                                  /root/Member/GetSetMemberWithInlineKeyword.fs (5,19--5,24)),
-                               None,
-                               Const
-                                 (Unit,
-                                  /root/Member/GetSetMemberWithInlineKeyword.fs (5,27--5,29)),
-                               /root/Member/GetSetMemberWithInlineKeyword.fs (5,19--5,24),
+                                        (5,23--5,24))], None, (5,19--5,24)),
+                               None, Const (Unit, (5,27--5,29)), (5,19--5,24),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/GetSetMemberWithInlineKeyword.fs (3,4--3,10)
-                                 InlineKeyword =
-                                  Some
-                                    /root/Member/GetSetMemberWithInlineKeyword.fs (5,12--5,18)
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/GetSetMemberWithInlineKeyword.fs (5,25--5,26) })),
-                         /root/Member/GetSetMemberWithInlineKeyword.fs (3,4--5,29),
-                         { InlineKeyword =
-                            Some
-                              /root/Member/GetSetMemberWithInlineKeyword.fs (3,11--3,17)
-                           WithKeyword =
-                            /root/Member/GetSetMemberWithInlineKeyword.fs (4,8--4,12)
-                           GetKeyword =
-                            Some
-                              /root/Member/GetSetMemberWithInlineKeyword.fs (4,20--4,23)
-                           AndKeyword =
-                            Some
-                              /root/Member/GetSetMemberWithInlineKeyword.fs (5,8--5,11)
-                           SetKeyword =
-                            Some
-                              /root/Member/GetSetMemberWithInlineKeyword.fs (5,19--5,22) })],
-                     /root/Member/GetSetMemberWithInlineKeyword.fs (3,4--5,29)),
-                  [], None,
-                  /root/Member/GetSetMemberWithInlineKeyword.fs (2,5--5,29),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/GetSetMemberWithInlineKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/GetSetMemberWithInlineKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/Member/GetSetMemberWithInlineKeyword.fs (2,0--5,29))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/GetSetMemberWithInlineKeyword.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                               { LeadingKeyword = Member (3,4--3,10)
+                                 InlineKeyword = Some (5,12--5,18)
+                                 EqualsRange = Some (5,25--5,26) })),
+                         (3,4--5,29), { InlineKeyword = Some (3,11--3,17)
+                                        WithKeyword = (4,8--4,12)
+                                        GetKeyword = Some (4,20--4,23)
+                                        AndKeyword = Some (5,8--5,11)
+                                        SetKeyword = Some (5,19--5,22) })],
+                     (3,4--5,29)), [], None, (2,5--5,29),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--5,29))], PreXmlDocEmpty, [],
+          None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/ImplicitCtorWithAsKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/ImplicitCtorWithAsKeyword.fs.bsl
@@ -9,11 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [CompilerStateCache],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false,
-                     Some
-                       (Internal
-                          /root/Member/ImplicitCtorWithAsKeyword.fs (2,5--2,13)),
-                     /root/Member/ImplicitCtorWithAsKeyword.fs (2,14--2,32)),
+                     false, Some (Internal (2,5--2,13)), (2,14--2,32)),
                   ObjectModel
                     (Class,
                      [ImplicitCtor
@@ -22,7 +18,7 @@ ImplFile
                            ([Typed
                                (Id
                                   (readAllBytes, None, false, false, false,
-                                   /root/Member/ImplicitCtorWithAsKeyword.fs (2,33--2,45)),
+                                   (2,33--2,45)),
                                 Fun
                                   (LongIdent
                                      (SynLongIdent ([string], [], [None])),
@@ -30,27 +26,19 @@ ImplFile
                                      (1,
                                       LongIdent
                                         (SynLongIdent ([byte], [], [None])),
-                                      /root/Member/ImplicitCtorWithAsKeyword.fs (2,57--2,63)),
-                                   /root/Member/ImplicitCtorWithAsKeyword.fs (2,47--2,63),
-                                   { ArrowRange =
-                                      /root/Member/ImplicitCtorWithAsKeyword.fs (2,54--2,56) }),
-                                /root/Member/ImplicitCtorWithAsKeyword.fs (2,33--2,63));
+                                      (2,57--2,63)), (2,47--2,63),
+                                   { ArrowRange = (2,54--2,56) }), (2,33--2,63));
                              Typed
                                (Id
                                   (projectOptions, None, false, false, false,
-                                   /root/Member/ImplicitCtorWithAsKeyword.fs (2,65--2,79)),
+                                   (2,65--2,79)),
                                 LongIdent
                                   (SynLongIdent
                                      ([FSharpProjectOptions], [], [None])),
-                                /root/Member/ImplicitCtorWithAsKeyword.fs (2,65--2,101))],
-                            /root/Member/ImplicitCtorWithAsKeyword.fs (2,32--2,102)),
-                         Some this,
+                                (2,65--2,101))], (2,32--2,102)), Some this,
                          PreXmlDoc ((2,32), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Member/ImplicitCtorWithAsKeyword.fs (2,14--2,32),
-                         { AsKeyword =
-                            Some
-                              /root/Member/ImplicitCtorWithAsKeyword.fs (4,4--4,6) })],
-                     /root/Member/ImplicitCtorWithAsKeyword.fs (8,4--8,13)), [],
+                         (2,14--2,32), { AsKeyword = Some (4,4--4,6) })],
+                     (8,4--8,13)), [],
                   Some
                     (ImplicitCtor
                        (None, [],
@@ -58,7 +46,7 @@ ImplFile
                           ([Typed
                               (Id
                                  (readAllBytes, None, false, false, false,
-                                  /root/Member/ImplicitCtorWithAsKeyword.fs (2,33--2,45)),
+                                  (2,33--2,45)),
                                Fun
                                  (LongIdent
                                     (SynLongIdent ([string], [], [None])),
@@ -66,40 +54,24 @@ ImplFile
                                     (1,
                                      LongIdent
                                        (SynLongIdent ([byte], [], [None])),
-                                     /root/Member/ImplicitCtorWithAsKeyword.fs (2,57--2,63)),
-                                  /root/Member/ImplicitCtorWithAsKeyword.fs (2,47--2,63),
-                                  { ArrowRange =
-                                     /root/Member/ImplicitCtorWithAsKeyword.fs (2,54--2,56) }),
-                               /root/Member/ImplicitCtorWithAsKeyword.fs (2,33--2,63));
+                                     (2,57--2,63)), (2,47--2,63),
+                                  { ArrowRange = (2,54--2,56) }), (2,33--2,63));
                             Typed
                               (Id
                                  (projectOptions, None, false, false, false,
-                                  /root/Member/ImplicitCtorWithAsKeyword.fs (2,65--2,79)),
+                                  (2,65--2,79)),
                                LongIdent
                                  (SynLongIdent
                                     ([FSharpProjectOptions], [], [None])),
-                               /root/Member/ImplicitCtorWithAsKeyword.fs (2,65--2,101))],
-                           /root/Member/ImplicitCtorWithAsKeyword.fs (2,32--2,102)),
-                        Some this,
+                               (2,65--2,101))], (2,32--2,102)), Some this,
                         PreXmlDoc ((2,32), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Member/ImplicitCtorWithAsKeyword.fs (2,14--2,32),
-                        { AsKeyword =
-                           Some
-                             /root/Member/ImplicitCtorWithAsKeyword.fs (4,4--4,6) })),
-                  /root/Member/ImplicitCtorWithAsKeyword.fs (2,5--8,13),
-                  { LeadingKeyword =
-                     Type /root/Member/ImplicitCtorWithAsKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/Member/ImplicitCtorWithAsKeyword.fs (4,12--4,13)
-                    WithKeyword = None })],
-              /root/Member/ImplicitCtorWithAsKeyword.fs (2,0--8,13))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/ImplicitCtorWithAsKeyword.fs (2,0--9,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,14--2,32), { AsKeyword = Some (4,4--4,6) })),
+                  (2,5--8,13), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (4,12--4,13)
+                                 WithKeyword = None })], (2,0--8,13))],
+          PreXmlDocEmpty, [], None, (2,0--9,0), { LeadingKeyword = None })],
+      (true, false),
       { ConditionalDirectives = []
         CodeComments =
-         [LineComment /root/Member/ImplicitCtorWithAsKeyword.fs (3,0--3,23);
-          LineComment /root/Member/ImplicitCtorWithAsKeyword.fs (5,0--5,7);
-          LineComment /root/Member/ImplicitCtorWithAsKeyword.fs (6,0--6,8);
-          LineComment /root/Member/ImplicitCtorWithAsKeyword.fs (7,0--7,9)] },
-      set []))
+         [LineComment (3,0--3,23); LineComment (5,0--5,7);
+          LineComment (6,0--6,8); LineComment (7,0--7,9)] }, set []))

--- a/tests/service/data/SyntaxTree/Member/MemberWithInlineKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/MemberWithInlineKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/MemberWithInlineKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -29,43 +28,21 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([x; Y],
-                                  [/root/Member/MemberWithInlineKeyword.fs (3,19--3,20)],
-                                  [None; None]), None, None,
+                                 ([x; Y], [(3,19--3,20)], [None; None]), None,
+                               None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/Member/MemberWithInlineKeyword.fs (3,22--3,24)),
-                                     /root/Member/MemberWithInlineKeyword.fs (3,22--3,24))],
-                               None,
-                               /root/Member/MemberWithInlineKeyword.fs (3,18--3,24)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/Member/MemberWithInlineKeyword.fs (3,27--3,29)),
-                            /root/Member/MemberWithInlineKeyword.fs (3,18--3,24),
+                                    (Const (Unit, (3,22--3,24)), (3,22--3,24))],
+                               None, (3,18--3,24)), None,
+                            Const (Unit, (3,27--3,29)), (3,18--3,24),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/Member/MemberWithInlineKeyword.fs (3,4--3,10)
-                              InlineKeyword =
-                               Some
-                                 /root/Member/MemberWithInlineKeyword.fs (3,11--3,17)
-                              EqualsRange =
-                               Some
-                                 /root/Member/MemberWithInlineKeyword.fs (3,25--3,26) }),
-                         /root/Member/MemberWithInlineKeyword.fs (3,4--3,29))],
-                     /root/Member/MemberWithInlineKeyword.fs (3,4--3,29)), [],
-                  None, /root/Member/MemberWithInlineKeyword.fs (2,5--3,29),
-                  { LeadingKeyword =
-                     Type /root/Member/MemberWithInlineKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/Member/MemberWithInlineKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/Member/MemberWithInlineKeyword.fs (2,0--3,29))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/MemberWithInlineKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                            { LeadingKeyword = Member (3,4--3,10)
+                              InlineKeyword = Some (3,11--3,17)
+                              EqualsRange = Some (3,25--3,26) }), (3,4--3,29))],
+                     (3,4--3,29)), [], None, (2,5--3,29),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,29))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -13,19 +13,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                         None,
+                        (None, [], SimplePats ([], (2,8--2,10)), None,
                          PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                         { AsKeyword = None });
+                         (2,5--2,8), { AsKeyword = None });
                       GetSetMember
                         (Some
                            (SynBinding
@@ -45,63 +39,30 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; MyReadProperty],
-                                     [/root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,15--4,16)],
+                                    ([this; MyReadProperty], [(4,15--4,16)],
                                      [None; None]), Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,40--4,42)),
-                                        /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,40--4,42))],
-                                  None,
-                                  /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,36--4,42)),
-                               None, Ident myInternalValue,
-                               /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,36--4,42),
+                                       (Const (Unit, (4,40--4,42)), (4,40--4,42))],
+                                  None, (4,36--4,42)), None,
+                               Ident myInternalValue, (4,36--4,42),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,43--4,44) })),
-                         None,
-                         /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--4,60),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,31--4,35)
-                           GetKeyword =
-                            Some
-                              /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,36--4,39)
-                           AndKeyword = None
-                           SetKeyword = None })],
-                     /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--4,60)),
-                  [],
+                                 EqualsRange = Some (4,43--4,44) })), None,
+                         (4,4--4,60), { InlineKeyword = None
+                                        WithKeyword = (4,31--4,35)
+                                        GetKeyword = Some (4,36--4,39)
+                                        AndKeyword = None
+                                        SetKeyword = None })], (4,4--4,60)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                        None,
+                       (None, [], SimplePats ([], (2,8--2,10)), None,
                         PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                        { AsKeyword = None })),
-                  /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--4,60),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--4,60))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,8), { AsKeyword = None })), (2,5--4,60),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--4,60))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Member/Read-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (3,4--3,28)] },
-      set []))
+        CodeComments = [LineComment (3,4--3,28)] }, set []))

--- a/tests/service/data/SyntaxTree/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -13,19 +13,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                         None,
+                        (None, [], SimplePats ([], (2,8--2,10)), None,
                          PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                         { AsKeyword = None });
+                         (2,5--2,8), { AsKeyword = None });
                       GetSetMember
                         (Some
                            (SynBinding
@@ -45,27 +39,17 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; MyReadWriteProperty],
-                                     [/root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,15--4,16)],
+                                    ([this; MyReadWriteProperty], [(4,15--4,16)],
                                      [None; None]), Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (5,17--5,19)),
-                                        /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (5,17--5,19))],
-                                  None,
-                                  /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (5,13--5,19)),
-                               None, Ident myInternalValue,
-                               /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (5,13--5,19),
+                                       (Const (Unit, (5,17--5,19)), (5,17--5,19))],
+                                  None, (5,13--5,19)), None,
+                               Ident myInternalValue, (5,13--5,19),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (5,20--5,21) })),
+                                 EqualsRange = Some (5,20--5,21) })),
                          Some
                            (SynBinding
                               (None, Normal, false, false, [],
@@ -85,70 +69,35 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; MyReadWriteProperty],
-                                     [/root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,15--4,16)],
+                                    ([this; MyReadWriteProperty], [(4,15--4,16)],
                                      [None; None]), Some set, None,
                                   Pats
                                     [Paren
                                        (Named
                                           (SynIdent (value, None), false, None,
-                                           /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (6,17--6,22)),
-                                        /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (6,16--6,23))],
-                                  None,
-                                  /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (6,12--6,23)),
-                               None,
+                                           (6,17--6,22)), (6,16--6,23))], None,
+                                  (6,12--6,23)), None,
                                LongIdentSet
                                  (SynLongIdent ([myInternalValue], [], [None]),
-                                  Ident value,
-                                  /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (6,26--6,50)),
-                               /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (6,12--6,23),
+                                  Ident value, (6,26--6,50)), (6,12--6,23),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (6,24--6,25) })),
-                         /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--6,50),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (5,8--5,12)
-                           GetKeyword =
-                            Some
-                              /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (5,13--5,16)
-                           AndKeyword =
-                            Some
-                              /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (6,8--6,11)
-                           SetKeyword =
-                            Some
-                              /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (6,12--6,15) })],
-                     /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--6,50)),
-                  [],
+                                 EqualsRange = Some (6,24--6,25) })),
+                         (4,4--6,50), { InlineKeyword = None
+                                        WithKeyword = (5,8--5,12)
+                                        GetKeyword = Some (5,13--5,16)
+                                        AndKeyword = Some (6,8--6,11)
+                                        SetKeyword = Some (6,12--6,15) })],
+                     (4,4--6,50)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                        None,
+                       (None, [], SimplePats ([], (2,8--2,10)), None,
                         PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                        { AsKeyword = None })),
-                  /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--6,50),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--6,50))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,8), { AsKeyword = None })), (2,5--6,50),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--6,50))], PreXmlDocEmpty, [],
+          None, (2,0--7,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Member/ReadwritePropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (3,4--3,29)] },
-      set []))
+        CodeComments = [LineComment (3,4--3,29)] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SignatureMemberWithGet.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Member/SignatureMemberWithGet.fsi.bsl
@@ -8,8 +8,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SignatureMemberWithGet.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -20,40 +19,23 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/Member/SignatureMemberWithGet.fsi (6,4--8,35),
-                            { LeadingKeyword =
-                               Member
-                                 /root/Member/SignatureMemberWithGet.fsi (6,4--6,10)
+                            None, None, (6,4--8,35),
+                            { LeadingKeyword = Member (6,4--6,10)
                               InlineKeyword = None
-                              WithKeyword =
-                               Some
-                                 /root/Member/SignatureMemberWithGet.fsi (7,20--7,24)
+                              WithKeyword = Some (7,20--7,24)
                               EqualsRange = None }),
                          { IsInstance = true
                            IsDispatchSlot = false
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/Member/SignatureMemberWithGet.fsi (6,4--8,35),
-                         { GetSetKeywords =
-                            Some
-                              (Get
-                                 /root/Member/SignatureMemberWithGet.fsi (8,32--8,35)) })],
-                     /root/Member/SignatureMemberWithGet.fsi (6,4--8,35)), [],
-                  /root/Member/SignatureMemberWithGet.fsi (4,5--8,35),
-                  { LeadingKeyword =
-                     Type /root/Member/SignatureMemberWithGet.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some /root/Member/SignatureMemberWithGet.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/Member/SignatureMemberWithGet.fsi (4,0--8,35))],
+                           MemberKind = PropertyGet }, (6,4--8,35),
+                         { GetSetKeywords = Some (Get (8,32--8,35)) })],
+                     (6,4--8,35)), [], (4,5--8,35),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,7--4,8)
+                    WithKeyword = None })], (4,0--8,35))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/Member/SignatureMemberWithGet.fsi (2,0--8,35),
-          { LeadingKeyword =
-             Module /root/Member/SignatureMemberWithGet.fsi (2,0--2,6) })],
+          (2,0--8,35), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment /root/Member/SignatureMemberWithGet.fsi (5,4--5,23)] },
-      set []))
+        CodeComments = [LineComment (5,4--5,23)] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SignatureMemberWithSet.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Member/SignatureMemberWithSet.fsi.bsl
@@ -8,8 +8,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SignatureMemberWithSet.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -20,40 +19,23 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/Member/SignatureMemberWithSet.fsi (6,4--8,31),
-                            { LeadingKeyword =
-                               Member
-                                 /root/Member/SignatureMemberWithSet.fsi (6,4--6,10)
+                            None, None, (6,4--8,31),
+                            { LeadingKeyword = Member (6,4--6,10)
                               InlineKeyword = None
-                              WithKeyword =
-                               Some
-                                 /root/Member/SignatureMemberWithSet.fsi (7,20--7,24)
+                              WithKeyword = Some (7,20--7,24)
                               EqualsRange = None }),
                          { IsInstance = true
                            IsDispatchSlot = false
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertySet },
-                         /root/Member/SignatureMemberWithSet.fsi (6,4--8,31),
-                         { GetSetKeywords =
-                            Some
-                              (Set
-                                 /root/Member/SignatureMemberWithSet.fsi (8,28--8,31)) })],
-                     /root/Member/SignatureMemberWithSet.fsi (6,4--8,31)), [],
-                  /root/Member/SignatureMemberWithSet.fsi (4,5--8,31),
-                  { LeadingKeyword =
-                     Type /root/Member/SignatureMemberWithSet.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some /root/Member/SignatureMemberWithSet.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/Member/SignatureMemberWithSet.fsi (4,0--8,31))],
+                           MemberKind = PropertySet }, (6,4--8,31),
+                         { GetSetKeywords = Some (Set (8,28--8,31)) })],
+                     (6,4--8,31)), [], (4,5--8,31),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,7--4,8)
+                    WithKeyword = None })], (4,0--8,31))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/Member/SignatureMemberWithSet.fsi (2,0--8,31),
-          { LeadingKeyword =
-             Module /root/Member/SignatureMemberWithSet.fsi (2,0--2,6) })],
+          (2,0--8,31), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment /root/Member/SignatureMemberWithSet.fsi (5,4--5,23)] },
-      set []))
+        CodeComments = [LineComment (5,4--5,23)] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SignatureMemberWithSetget.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Member/SignatureMemberWithSetget.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SignatureMemberWithSetget.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -21,41 +20,24 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/Member/SignatureMemberWithSetget.fsi (6,4--8,39),
-                            { LeadingKeyword =
-                               Member
-                                 /root/Member/SignatureMemberWithSetget.fsi (6,4--6,10)
+                            None, None, (6,4--8,39),
+                            { LeadingKeyword = Member (6,4--6,10)
                               InlineKeyword = None
-                              WithKeyword =
-                               Some
-                                 /root/Member/SignatureMemberWithSetget.fsi (7,20--7,24)
+                              WithKeyword = Some (7,20--7,24)
                               EqualsRange = None }),
                          { IsInstance = true
                            IsDispatchSlot = false
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGetSet },
-                         /root/Member/SignatureMemberWithSetget.fsi (6,4--8,39),
+                           MemberKind = PropertyGetSet }, (6,4--8,39),
                          { GetSetKeywords =
-                            Some
-                              (GetSet
-                                 (/root/Member/SignatureMemberWithSetget.fsi (8,36--8,39),
-                                  /root/Member/SignatureMemberWithSetget.fsi (8,28--8,31))) })],
-                     /root/Member/SignatureMemberWithSetget.fsi (6,4--8,39)), [],
-                  /root/Member/SignatureMemberWithSetget.fsi (4,5--8,39),
-                  { LeadingKeyword =
-                     Type /root/Member/SignatureMemberWithSetget.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some /root/Member/SignatureMemberWithSetget.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/Member/SignatureMemberWithSetget.fsi (4,0--8,39))],
+                            Some (GetSet ((8,36--8,39), (8,28--8,31))) })],
+                     (6,4--8,39)), [], (4,5--8,39),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,7--4,8)
+                    WithKeyword = None })], (4,0--8,39))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/Member/SignatureMemberWithSetget.fsi (2,0--8,39),
-          { LeadingKeyword =
-             Module /root/Member/SignatureMemberWithSetget.fsi (2,0--2,6) })],
+          (2,0--8,39), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment /root/Member/SignatureMemberWithSetget.fsi (5,4--5,23)] },
-      set []))
+        CodeComments = [LineComment (5,4--5,23)] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -12,19 +12,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                         None,
+                        (None, [], SimplePats ([], (2,8--2,10)), None,
                          PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                         { AsKeyword = None });
+                         (2,5--2,8), { AsKeyword = None });
                       AbstractSlot
                         (SynValSig
                            ([], SynIdent (Bar, None),
@@ -33,52 +27,29 @@ ImplFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (3,4--3,42),
+                            None, None, (3,4--3,42),
                             { LeadingKeyword =
-                               AbstractMember
-                                 (/root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (3,4--3,12),
-                                  /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (3,13--3,19))
+                               AbstractMember ((3,4--3,12), (3,13--3,19))
                               InlineKeyword = None
-                              WithKeyword =
-                               Some
-                                 /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (3,30--3,34)
+                              WithKeyword = Some (3,30--3,34)
                               EqualsRange = None }),
                          { IsInstance = true
                            IsDispatchSlot = true
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGetSet },
-                         /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (3,4--3,42),
+                           MemberKind = PropertyGetSet }, (3,4--3,42),
                          { GetSetKeywords =
-                            Some
-                              (GetSet
-                                 (/root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (3,35--3,38),
-                                  /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (3,39--3,42))) })],
-                     /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (3,4--3,42)),
-                  [],
+                            Some (GetSet ((3,35--3,38), (3,39--3,42))) })],
+                     (3,4--3,42)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                        None,
+                       (None, [], SimplePats ([], (2,8--2,10)), None,
                         PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                        { AsKeyword = None })),
-                  /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,5--3,42),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,0--3,42))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/SynTypeDefnWithAbstractSlotContainsTheRangeOfTheWithKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,8), { AsKeyword = None })), (2,5--3,42),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--3,42))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -12,8 +12,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Person],
                      PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,5--3,11)),
+                     false, None, (3,5--3,11)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
@@ -21,21 +20,16 @@ ImplFile
                          SimplePats
                            ([Typed
                                (Id
-                                  (name, None, false, false, false,
-                                   /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,12--3,16)),
+                                  (name, None, false, false, false, (3,12--3,16)),
                                 LongIdent (SynLongIdent ([string], [], [None])),
-                                /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,12--3,25));
+                                (3,12--3,25));
                              Typed
                                (Id
-                                  (age, None, false, false, false,
-                                   /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,27--3,30)),
+                                  (age, None, false, false, false, (3,27--3,30)),
                                 LongIdent (SynLongIdent ([int], [], [None])),
-                                /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,27--3,36))],
-                            /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,11--3,37)),
-                         None,
+                                (3,27--3,36))], (3,11--3,37)), None,
                          PreXmlDoc ((3,11), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,5--3,11),
-                         { AsKeyword = None });
+                         (3,5--3,11), { AsKeyword = None });
                       AutoProperty
                         ([], false, Name, None, PropertyGetSet,
                          { IsInstance = true
@@ -51,57 +45,32 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, Ident name,
-                         /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (4,4--5,26),
+                         None, Ident name, (4,4--5,26),
                          { LeadingKeyword =
-                            MemberVal
-                              (/root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (5,4--5,10),
-                               /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (5,11--5,14))
-                           WithKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (5,27--5,31)
-                           EqualsRange =
-                            Some
-                              /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (5,20--5,21)
+                            MemberVal ((5,4--5,10), (5,11--5,14))
+                           WithKeyword = Some (5,27--5,31)
+                           EqualsRange = Some (5,20--5,21)
                            GetSetKeywords =
-                            Some
-                              (GetSet
-                                 (/root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (5,32--5,35),
-                                  /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (5,37--5,40))) })],
-                     /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (4,4--5,26)),
-                  [],
+                            Some (GetSet ((5,32--5,35), (5,37--5,40))) })],
+                     (4,4--5,26)), [],
                   Some
                     (ImplicitCtor
                        (None, [],
                         SimplePats
                           ([Typed
                               (Id
-                                 (name, None, false, false, false,
-                                  /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,12--3,16)),
+                                 (name, None, false, false, false, (3,12--3,16)),
                                LongIdent (SynLongIdent ([string], [], [None])),
-                               /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,12--3,25));
+                               (3,12--3,25));
                             Typed
-                              (Id
-                                 (age, None, false, false, false,
-                                  /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,27--3,30)),
+                              (Id (age, None, false, false, false, (3,27--3,30)),
                                LongIdent (SynLongIdent ([int], [], [None])),
-                               /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,27--3,36))],
-                           /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,11--3,37)),
-                        None,
+                               (3,27--3,36))], (3,11--3,37)), None,
                         PreXmlDoc ((3,11), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,5--3,11),
-                        { AsKeyword = None })),
-                  /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (2,0--5,26),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,0--3,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,38--3,39)
-                    WithKeyword = None })],
-              /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (2,0--5,26))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs (3,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                        (3,5--3,11), { AsKeyword = None })), (2,0--5,26),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,38--3,39)
+                    WithKeyword = None })], (2,0--5,26))], PreXmlDocEmpty, [],
+          None, (3,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -12,19 +12,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                         None,
+                        (None, [], SimplePats ([], (2,8--2,10)), None,
                          PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                         { AsKeyword = None });
+                         (2,5--2,8), { AsKeyword = None });
                       AutoProperty
                         ([], false, AutoProperty, None, PropertyGetSet,
                          { IsInstance = true
@@ -40,23 +34,13 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, Ident autoProp,
-                         /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (3,4--3,38),
+                         None, Ident autoProp, (3,4--3,38),
                          { LeadingKeyword =
-                            MemberVal
-                              (/root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (3,4--3,10),
-                               /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (3,11--3,14))
-                           WithKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (3,39--3,43)
-                           EqualsRange =
-                            Some
-                              /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (3,28--3,29)
+                            MemberVal ((3,4--3,10), (3,11--3,14))
+                           WithKeyword = Some (3,39--3,43)
+                           EqualsRange = Some (3,28--3,29)
                            GetSetKeywords =
-                            Some
-                              (GetSet
-                                 (/root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (3,44--3,47),
-                                  /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (3,49--3,52))) });
+                            Some (GetSet ((3,44--3,47), (3,49--3,52))) });
                       AutoProperty
                         ([], false, AutoProperty2, None, Member,
                          { IsInstance = true
@@ -72,40 +56,20 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, Ident autoProp,
-                         /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (4,4--4,39),
+                         None, Ident autoProp, (4,4--4,39),
                          { LeadingKeyword =
-                            MemberVal
-                              (/root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (4,4--4,10),
-                               /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (4,11--4,14))
+                            MemberVal ((4,4--4,10), (4,11--4,14))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (4,29--4,30)
-                           GetSetKeywords = None })],
-                     /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (3,4--4,39)),
-                  [],
+                           EqualsRange = Some (4,29--4,30)
+                           GetSetKeywords = None })], (3,4--4,39)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                        None,
+                       (None, [], SimplePats ([], (2,8--2,10)), None,
                         PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                        { AsKeyword = None })),
-                  /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,5--4,39),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,0--4,39))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,8), { AsKeyword = None })), (2,5--4,39),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--4,39))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [A],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [GetSetMember
@@ -32,53 +31,25 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([x; B],
-                                     [/root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,12--4,13)],
-                                     [None; None]), Some get, None,
+                                    ([x; B], [(4,12--4,13)], [None; None]),
+                                  Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,23--4,25)),
-                                        /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,23--4,25))],
-                                  None,
-                                  /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,20--4,25)),
-                               None,
-                               Const
-                                 (Int32 5,
-                                  /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,28--4,29)),
-                               /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (3,4--4,25),
+                                       (Const (Unit, (4,23--4,25)), (4,23--4,25))],
+                                  None, (4,20--4,25)), None,
+                               Const (Int32 5, (4,28--4,29)), (3,4--4,25),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,26--4,27) })),
-                         None,
-                         /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (3,4--4,29),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,15--4,19)
-                           GetKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (4,20--4,23)
-                           AndKeyword = None
-                           SetKeyword = None })],
-                     /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (3,4--4,29)),
-                  [], None,
-                  /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (2,5--4,29),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (2,0--4,29))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/SynTypeDefnWithMemberWithGetHasXmlComment.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                 EqualsRange = Some (4,26--4,27) })), None,
+                         (3,4--4,29), { InlineKeyword = None
+                                        WithKeyword = (4,15--4,19)
+                                        GetKeyword = Some (4,20--4,23)
+                                        AndKeyword = None
+                                        SetKeyword = None })], (3,4--4,29)), [],
+                  None, (2,5--4,29), { LeadingKeyword = Type (2,0--2,4)
+                                       EqualsRange = Some (2,7--2,8)
+                                       WithKeyword = None })], (2,0--4,29))],
+          PreXmlDocEmpty, [], None, (2,0--5,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SynTypeDefnWithMemberWithSetget.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/SynTypeDefnWithMemberWithSetget.fs.bsl
@@ -9,19 +9,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [A],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       GetSetMember
                         (Some
                            (SynBinding
@@ -41,41 +35,25 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; Z],
-                                     [/root/Member/SynTypeDefnWithMemberWithSetget.fs (3,15--3,16)],
-                                     [None; None]), Some get, None,
+                                    ([this; Z], [(3,15--3,16)], [None; None]),
+                                  Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,52--3,54)),
-                                        /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,52--3,54))],
-                                  None,
-                                  /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,49--3,54)),
+                                       (Const (Unit, (3,52--3,54)), (3,52--3,54))],
+                                  None, (3,49--3,54)),
                                Some
                                  (SynBindingReturnInfo
                                     (LongIdent
                                        (SynLongIdent ([int], [], [None])),
-                                     /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,55--3,58),
-                                     [],
-                                     { ColonRange =
-                                        Some
-                                          /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,54--3,55) })),
+                                     (3,55--3,58), [],
+                                     { ColonRange = Some (3,54--3,55) })),
                                Typed
-                                 (Const
-                                    (Int32 1,
-                                     /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,61--3,62)),
+                                 (Const (Int32 1, (3,61--3,62)),
                                   LongIdent (SynLongIdent ([int], [], [None])),
-                                  /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,61--3,62)),
-                               /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,49--3,54),
-                               NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,4--3,10)
+                                  (3,61--3,62)), (3,49--3,54), NoneAtInvisible,
+                               { LeadingKeyword = Member (3,4--3,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,59--3,60) })),
+                                 EqualsRange = Some (3,59--3,60) })),
                          Some
                            (SynBinding
                               (None, Normal, false, false, [],
@@ -95,80 +73,43 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; Z],
-                                     [/root/Member/SynTypeDefnWithMemberWithSetget.fs (3,15--3,16)],
-                                     [None; None]), Some set, None,
+                                    ([this; Z], [(3,15--3,16)], [None; None]),
+                                  Some set, None,
                                   Pats
                                     [Paren
                                        (Typed
-                                          (Wild
-                                             /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,28--3,29),
+                                          (Wild (3,28--3,29),
                                            LongIdent
                                              (SynLongIdent ([int], [], [None])),
-                                           /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,28--3,33)),
-                                        /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,27--3,34))],
-                                  None,
-                                  /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,23--3,34)),
+                                           (3,28--3,33)), (3,27--3,34))], None,
+                                  (3,23--3,34)),
                                Some
                                  (SynBindingReturnInfo
                                     (LongIdent
                                        (SynLongIdent ([unit], [], [None])),
-                                     /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,35--3,39),
-                                     [],
-                                     { ColonRange =
-                                        Some
-                                          /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,34--3,35) })),
+                                     (3,35--3,39), [],
+                                     { ColonRange = Some (3,34--3,35) })),
                                Typed
-                                 (Const
-                                    (Unit,
-                                     /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,42--3,44)),
+                                 (Const (Unit, (3,42--3,44)),
                                   LongIdent (SynLongIdent ([unit], [], [None])),
-                                  /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,42--3,44)),
-                               /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,23--3,34),
-                               NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,4--3,10)
+                                  (3,42--3,44)), (3,23--3,34), NoneAtInvisible,
+                               { LeadingKeyword = Member (3,4--3,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,40--3,41) })),
-                         /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,4--3,62),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,18--3,22)
-                           GetKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,49--3,52)
-                           AndKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,45--3,48)
-                           SetKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,23--3,26) })],
-                     /root/Member/SynTypeDefnWithMemberWithSetget.fs (3,4--3,62)),
-                  [],
+                                 EqualsRange = Some (3,40--3,41) })),
+                         (3,4--3,62), { InlineKeyword = None
+                                        WithKeyword = (3,18--3,22)
+                                        GetKeyword = Some (3,49--3,52)
+                                        AndKeyword = Some (3,45--3,48)
+                                        SetKeyword = Some (3,23--3,26) })],
+                     (3,4--3,62)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,5--3,62),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,0--3,62))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/SynTypeDefnWithMemberWithSetget.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--3,62),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--3,62))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SynTypeDefnWithStaticMemberWithGetset.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/SynTypeDefnWithStaticMemberWithGetset.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [GetSetMember
@@ -34,13 +33,8 @@ ImplFile
                                   Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,17--5,19)),
-                                        /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,17--5,19))],
-                                  None,
-                                  /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,13--5,19)),
-                               None,
+                                       (Const (Unit, (5,17--5,19)), (5,17--5,19))],
+                                  None, (5,13--5,19)), None,
                                Sequential
                                  (SuppressNeither, true,
                                   LongIdentSet
@@ -51,32 +45,17 @@ ImplFile
                                            [Const
                                               (String
                                                  ("ReadWrite2", Regular,
-                                                  /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,35--5,47)),
-                                               /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,35--5,47));
-                                            Const
-                                              (Int32 0,
-                                               /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,49--5,50))],
-                                           [/root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,47--5,48)],
-                                           /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,35--5,50)),
-                                        /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,34--5,35),
-                                        Some
-                                          /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,50--5,51),
-                                        /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,34--5,51)),
-                                     /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,22--5,51)),
-                                  Const
-                                    (Int32 4,
-                                     /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,53--5,54)),
-                                  /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,22--5,54)),
-                               /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,13--5,19),
-                               NoneAtInvisible,
+                                                  (5,35--5,47)), (5,35--5,47));
+                                            Const (Int32 0, (5,49--5,50))],
+                                           [(5,47--5,48)], (5,35--5,50)),
+                                        (5,34--5,35), Some (5,50--5,51),
+                                        (5,34--5,51)), (5,22--5,51)),
+                                  Const (Int32 4, (5,53--5,54)), (5,22--5,54)),
+                               (5,13--5,19), NoneAtInvisible,
                                { LeadingKeyword =
-                                  StaticMember
-                                    (/root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (3,4--3,10),
-                                     /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (3,11--3,17))
+                                  StaticMember ((3,4--3,10), (3,11--3,17))
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,20--5,21) })),
+                                 EqualsRange = Some (5,20--5,21) })),
                          Some
                            (SynBinding
                               (None, Normal, false, false, [],
@@ -99,9 +78,7 @@ ImplFile
                                   Pats
                                     [Named
                                        (SynIdent (x, None), false, None,
-                                        /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,18--4,19))],
-                                  None,
-                                  /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,13--4,19)),
+                                        (4,18--4,19))], None, (4,13--4,19)),
                                None,
                                LongIdentSet
                                  (SynLongIdent ([lastUsed], [], [None]),
@@ -111,52 +88,24 @@ ImplFile
                                         [Const
                                            (String
                                               ("ReadWrite2", Regular,
-                                               /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,35--4,47)),
-                                            /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,35--4,47));
-                                         Ident x],
-                                        [/root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,47--4,48)],
-                                        /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,35--4,50)),
-                                     /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,34--4,35),
-                                     Some
-                                       /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,50--4,51),
-                                     /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,34--4,51)),
-                                  /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,22--4,51)),
-                               /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,13--4,19),
+                                               (4,35--4,47)), (4,35--4,47));
+                                         Ident x], [(4,47--4,48)], (4,35--4,50)),
+                                     (4,34--4,35), Some (4,50--4,51),
+                                     (4,34--4,51)), (4,22--4,51)), (4,13--4,19),
                                NoneAtInvisible,
                                { LeadingKeyword =
-                                  StaticMember
-                                    (/root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (3,4--3,10),
-                                     /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (3,11--3,17))
+                                  StaticMember ((3,4--3,10), (3,11--3,17))
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,20--4,21) })),
-                         /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (3,4--5,54),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,8--4,12)
-                           GetKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,13--5,16)
-                           AndKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (5,8--5,11)
-                           SetKeyword =
-                            Some
-                              /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (4,13--4,16) })],
-                     /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (3,4--5,54)),
-                  [], None,
-                  /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (2,5--5,54),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (2,0--5,54))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/SynTypeDefnWithStaticMemberWithGetset.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                                 EqualsRange = Some (4,20--4,21) })),
+                         (3,4--5,54), { InlineKeyword = None
+                                        WithKeyword = (4,8--4,12)
+                                        GetKeyword = Some (5,13--5,16)
+                                        AndKeyword = Some (5,8--5,11)
+                                        SetKeyword = Some (4,13--4,16) })],
+                     (3,4--5,54)), [], None, (2,5--5,54),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--5,54))], PreXmlDocEmpty, [],
+          None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -13,19 +13,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                         None,
+                        (None, [], SimplePats ([], (2,8--2,10)), None,
                          PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                         { AsKeyword = None });
+                         (2,5--2,8), { AsKeyword = None });
                       GetSetMember
                         (None,
                          Some
@@ -47,66 +41,35 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([this; MyWriteOnlyProperty],
-                                     [/root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,15--4,16)],
+                                    ([this; MyWriteOnlyProperty], [(4,15--4,16)],
                                      [None; None]), Some set, None,
                                   Pats
                                     [Paren
                                        (Named
                                           (SynIdent (value, None), false, None,
-                                           /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,46--4,51)),
-                                        /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,45--4,52))],
-                                  None,
-                                  /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,41--4,52)),
-                               None,
+                                           (4,46--4,51)), (4,45--4,52))], None,
+                                  (4,41--4,52)), None,
                                LongIdentSet
                                  (SynLongIdent ([myInternalValue], [], [None]),
-                                  Ident value,
-                                  /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,55--4,79)),
-                               /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,41--4,52),
+                                  Ident value, (4,55--4,79)), (4,41--4,52),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,53--4,54) })),
-                         /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--4,79),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,36--4,40)
-                           GetKeyword = None
-                           AndKeyword = None
-                           SetKeyword =
-                            Some
-                              /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,41--4,44) })],
-                     /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (4,4--4,79)),
-                  [],
+                                 EqualsRange = Some (4,53--4,54) })),
+                         (4,4--4,79), { InlineKeyword = None
+                                        WithKeyword = (4,36--4,40)
+                                        GetKeyword = None
+                                        AndKeyword = None
+                                        SetKeyword = Some (4,41--4,44) })],
+                     (4,4--4,79)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                        None,
+                       (None, [], SimplePats ([], (2,8--2,10)), None,
                         PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                        { AsKeyword = None })),
-                  /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,5--4,79),
-                  { LeadingKeyword =
-                     Type
-                       /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--4,79))],
-          PreXmlDocEmpty, [], None,
-          /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,8), { AsKeyword = None })), (2,5--4,79),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--4,79))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Member/Write-onlyPropertyInSynMemberDefnMemberContainsTheRangeOfTheWithKeyword.fs (3,4--3,29)] },
-      set []))
+        CodeComments = [LineComment (3,4--3,29)] }, set []))

--- a/tests/service/data/SyntaxTree/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs.bsl
+++ b/tests/service/data/SyntaxTree/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs.bsl
@@ -11,15 +11,10 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (meh, None), false, None,
-                     /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (2,4--2,7)),
-                  None,
+                  Named (SynIdent (meh, None), false, None, (2,4--2,7)), None,
                   ObjExpr
                     (LongIdent (SynLongIdent ([Interface], [], [None])), None,
-                     Some
-                       /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (3,20--3,24),
-                     [],
+                     Some (3,20--3,24), [],
                      [Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -36,31 +31,17 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; Foo],
-                                  [/root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,21--4,22)],
-                                  [None; None]), None, None,
+                                 ([this; Foo], [(4,21--4,22)], [None; None]),
+                               None, None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,26--4,28)),
-                                     /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,26--4,28))],
-                               None,
-                               /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,17--4,28)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,31--4,33)),
-                            /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,17--4,28),
+                                    (Const (Unit, (4,26--4,28)), (4,26--4,28))],
+                               None, (4,17--4,28)), None,
+                            Const (Unit, (4,31--4,33)), (4,17--4,28),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Override
-                                 /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,8--4,16)
+                            { LeadingKeyword = Override (4,8--4,16)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,29--4,30) }),
-                         /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (4,8--4,33));
+                              EqualsRange = Some (4,29--4,30) }), (4,8--4,33));
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -77,36 +58,20 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; Bar],
-                                  [/root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,19--5,20)],
-                                  [None; None]), None, None,
+                                 ([this; Bar], [(5,19--5,20)], [None; None]),
+                               None, None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,24--5,26)),
-                                     /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,24--5,26))],
-                               None,
-                               /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,15--5,26)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,29--5,31)),
-                            /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,15--5,26),
+                                    (Const (Unit, (5,24--5,26)), (5,24--5,26))],
+                               None, (5,15--5,26)), None,
+                            Const (Unit, (5,29--5,31)), (5,15--5,26),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,8--5,14)
+                            { LeadingKeyword = Member (5,8--5,14)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,27--5,28) }),
-                         /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (5,8--5,31))],
+                              EqualsRange = Some (5,27--5,28) }), (5,8--5,31))],
                      [SynInterfaceImpl
                         (LongIdent (SynLongIdent ([SomethingElse], [], [None])),
-                         Some
-                           /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (6,30--6,34),
-                         [],
+                         Some (6,30--6,34), [],
                          [Member
                             (SynBinding
                                (None, Normal, false, false, [],
@@ -124,47 +89,22 @@ ImplFile
                                       SynArgInfo ([], false, None)), None),
                                 LongIdent
                                   (SynLongIdent
-                                     ([this; Blah],
-                                      [/root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,19--7,20)],
-                                      [None; None]), None, None,
+                                     ([this; Blah], [(7,19--7,20)], [None; None]),
+                                   None, None,
                                    Pats
                                      [Paren
-                                        (Const
-                                           (Unit,
-                                            /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,25--7,27)),
-                                         /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,25--7,27))],
-                                   None,
-                                   /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,15--7,27)),
-                                None,
-                                Const
-                                  (Unit,
-                                   /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,30--7,32)),
-                                /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,15--7,27),
+                                        (Const (Unit, (7,25--7,27)),
+                                         (7,25--7,27))], None, (7,15--7,27)),
+                                None, Const (Unit, (7,30--7,32)), (7,15--7,27),
                                 NoneAtInvisible,
-                                { LeadingKeyword =
-                                   Member
-                                     /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,8--7,14)
+                                { LeadingKeyword = Member (7,8--7,14)
                                   InlineKeyword = None
-                                  EqualsRange =
-                                   Some
-                                     /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,28--7,29) }),
-                             /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (7,8--7,32))],
-                         /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (6,6--7,34))],
-                     /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (3,6--3,19),
-                     /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (3,4--7,34)),
-                  /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (2,4--2,7),
-                  Yes
-                    /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (2,0--7,34),
-                  { LeadingKeyword =
-                     Let
-                       /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (2,0--2,3)
+                                  EqualsRange = Some (7,28--7,29) }),
+                             (7,8--7,32))], (6,6--7,34))], (3,6--3,19),
+                     (3,4--7,34)), (2,4--2,7), Yes (2,0--7,34),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (2,8--2,9) })],
-              /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (2,0--7,34))],
-          PreXmlDocEmpty, [], None,
-          /root/MemberFlag/SynExprObjMembersHaveCorrectKeywords.fs (2,0--8,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,8--2,9) })], (2,0--7,34))],
+          PreXmlDocEmpty, [], None, (2,0--8,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [AbstractSlot
@@ -21,11 +20,8 @@ ImplFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (3,4--3,20),
-                            { LeadingKeyword =
-                               Abstract
-                                 /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (3,4--3,12)
+                            None, None, (3,4--3,20),
+                            { LeadingKeyword = Abstract (3,4--3,12)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -34,8 +30,7 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (3,4--3,20),
+                           MemberKind = PropertyGet }, (3,4--3,20),
                          { GetSetKeywords = None });
                       AbstractSlot
                         (SynValSig
@@ -45,12 +40,9 @@ ImplFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (4,4--4,26),
+                            None, None, (4,4--4,26),
                             { LeadingKeyword =
-                               AbstractMember
-                                 (/root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (4,4--4,12),
-                                  /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (4,13--4,19))
+                               AbstractMember ((4,4--4,12), (4,13--4,19))
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -59,22 +51,11 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (4,4--4,26),
-                         { GetSetKeywords = None })],
-                     /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (3,4--4,26)),
-                  [], None,
-                  /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (2,5--4,26),
-                  { LeadingKeyword =
-                     Type
-                       /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (2,0--4,26))],
-          PreXmlDocEmpty, [], None,
-          /root/MemberFlag/SynMemberDefnAbstractSlotHasCorrectKeyword.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           MemberKind = PropertyGet }, (4,4--4,26),
+                         { GetSetKeywords = None })], (3,4--4,26)), [], None,
+                  (2,5--4,26), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,9--2,10)
+                                 WithKeyword = None })], (2,0--4,26))],
+          PreXmlDocEmpty, [], None, (2,0--5,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [AutoProperty
@@ -29,20 +28,12 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         Const
-                           (Int32 1,
-                            /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (3,32--3,33)),
-                         /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (3,4--3,33),
+                         None, Const (Int32 1, (3,32--3,33)), (3,4--3,33),
                          { LeadingKeyword =
                             StaticMemberVal
-                              (/root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (3,4--3,10),
-                               /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (3,11--3,17),
-                               /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (3,18--3,21))
+                              ((3,4--3,10), (3,11--3,17), (3,18--3,21))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (3,30--3,31)
+                           EqualsRange = Some (3,30--3,31)
                            GetSetKeywords = None });
                       AutoProperty
                         ([], false, X,
@@ -60,19 +51,11 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         Const
-                           (Int32 1,
-                            /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (4,25--4,26)),
-                         /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (4,4--4,26),
+                         None, Const (Int32 1, (4,25--4,26)), (4,4--4,26),
                          { LeadingKeyword =
-                            MemberVal
-                              (/root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (4,4--4,10),
-                               /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (4,11--4,14))
+                            MemberVal ((4,4--4,10), (4,11--4,14))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (4,23--4,24)
+                           EqualsRange = Some (4,23--4,24)
                            GetSetKeywords = None });
                       AutoProperty
                         ([], false, Y,
@@ -90,19 +73,11 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         Const
-                           (Int32 2,
-                            /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (5,27--5,28)),
-                         /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (5,4--5,28),
+                         None, Const (Int32 2, (5,27--5,28)), (5,4--5,28),
                          { LeadingKeyword =
-                            OverrideVal
-                              (/root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (5,4--5,12),
-                               /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (5,13--5,16))
+                            OverrideVal ((5,4--5,12), (5,13--5,16))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (5,25--5,26)
+                           EqualsRange = Some (5,25--5,26)
                            GetSetKeywords = None });
                       AutoProperty
                         ([], false, Z,
@@ -120,33 +95,15 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         Const
-                           (Int32 1,
-                            /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (6,26--6,27)),
-                         /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (6,4--6,27),
+                         None, Const (Int32 1, (6,26--6,27)), (6,4--6,27),
                          { LeadingKeyword =
-                            DefaultVal
-                              (/root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (6,4--6,11),
-                               /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (6,12--6,15))
+                            DefaultVal ((6,4--6,11), (6,12--6,15))
                            WithKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (6,24--6,25)
-                           GetSetKeywords = None })],
-                     /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (3,4--6,27)),
-                  [], None,
-                  /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (2,5--6,27),
-                  { LeadingKeyword =
-                     Type
-                       /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (2,0--6,27))],
-          PreXmlDocEmpty, [], None,
-          /root/MemberFlag/SynMemberDefnAutoPropertyHasCorrectKeyword.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           EqualsRange = Some (6,24--6,25)
+                           GetSetKeywords = None })], (3,4--6,27)), [], None,
+                  (2,5--6,27), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,9--2,10)
+                                 WithKeyword = None })], (2,0--6,27))],
+          PreXmlDocEmpty, [], None, (2,0--7,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs.bsl
@@ -10,8 +10,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -29,32 +28,18 @@ ImplFile
                                None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; B],
-                                  [/root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,22--3,23)],
-                                  [None; None]), None, None,
+                                 ([this; B], [(3,22--3,23)], [None; None]), None,
+                               None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,24--3,26)),
-                                     /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,24--3,26))],
-                               None,
-                               /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,18--3,26)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,29--3,31)),
-                            /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,18--3,26),
+                                    (Const (Unit, (3,24--3,26)), (3,24--3,26))],
+                               None, (3,18--3,26)), None,
+                            Const (Unit, (3,29--3,31)), (3,18--3,26),
                             NoneAtInvisible,
                             { LeadingKeyword =
-                               StaticMember
-                                 (/root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,4--3,10),
-                                  /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,11--3,17))
+                               StaticMember ((3,4--3,10), (3,11--3,17))
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,27--3,28) }),
-                         /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,4--3,31));
+                              EqualsRange = Some (3,27--3,28) }), (3,4--3,31));
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -71,31 +56,17 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; A],
-                                  [/root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,15--4,16)],
-                                  [None; None]), None, None,
+                                 ([this; A], [(4,15--4,16)], [None; None]), None,
+                               None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,17--4,19)),
-                                     /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,17--4,19))],
-                               None,
-                               /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,11--4,19)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,22--4,24)),
-                            /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,11--4,19),
+                                    (Const (Unit, (4,17--4,19)), (4,17--4,19))],
+                               None, (4,11--4,19)), None,
+                            Const (Unit, (4,22--4,24)), (4,11--4,19),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,4--4,10)
+                            { LeadingKeyword = Member (4,4--4,10)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,20--4,21) }),
-                         /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (4,4--4,24));
+                              EqualsRange = Some (4,20--4,21) }), (4,4--4,24));
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -112,31 +83,17 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; C],
-                                  [/root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,17--5,18)],
-                                  [None; None]), None, None,
+                                 ([this; C], [(5,17--5,18)], [None; None]), None,
+                               None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,19--5,21)),
-                                     /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,19--5,21))],
-                               None,
-                               /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,13--5,21)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,24--5,26)),
-                            /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,13--5,21),
+                                    (Const (Unit, (5,19--5,21)), (5,19--5,21))],
+                               None, (5,13--5,21)), None,
+                            Const (Unit, (5,24--5,26)), (5,13--5,21),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Override
-                                 /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,4--5,12)
+                            { LeadingKeyword = Override (5,4--5,12)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,22--5,23) }),
-                         /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (5,4--5,26));
+                              EqualsRange = Some (5,22--5,23) }), (5,4--5,26));
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -153,44 +110,21 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([this; D],
-                                  [/root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,16--6,17)],
-                                  [None; None]), None, None,
+                                 ([this; D], [(6,16--6,17)], [None; None]), None,
+                               None,
                                Pats
                                  [Paren
-                                    (Const
-                                       (Unit,
-                                        /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,18--6,20)),
-                                     /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,18--6,20))],
-                               None,
-                               /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,12--6,20)),
-                            None,
-                            Const
-                              (Unit,
-                               /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,23--6,25)),
-                            /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,12--6,20),
+                                    (Const (Unit, (6,18--6,20)), (6,18--6,20))],
+                               None, (6,12--6,20)), None,
+                            Const (Unit, (6,23--6,25)), (6,12--6,20),
                             NoneAtInvisible,
-                            { LeadingKeyword =
-                               Default
-                                 /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,4--6,11)
+                            { LeadingKeyword = Default (6,4--6,11)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,21--6,22) }),
-                         /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (6,4--6,25))],
-                     /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (3,4--6,25)),
-                  [], None,
-                  /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (2,5--6,25),
-                  { LeadingKeyword =
-                     Type
-                       /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (2,0--6,25))],
-          PreXmlDocEmpty, [], None,
-          /root/MemberFlag/SynMemberDefnMemberSynValDataHasCorrectKeyword.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
+                              EqualsRange = Some (6,21--6,22) }), (6,4--6,25))],
+                     (3,4--6,25)), [], None, (2,5--6,25),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--6,25))], PreXmlDocEmpty, [],
+          None, (2,0--7,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi.bsl
+++ b/tests/service/data/SyntaxTree/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Y],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -21,11 +20,8 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (5,4--5,20),
-                            { LeadingKeyword =
-                               Abstract
-                                 /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (5,4--5,12)
+                            None, None, (5,4--5,20),
+                            { LeadingKeyword = Abstract (5,4--5,12)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -34,8 +30,7 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (5,4--5,20),
+                           MemberKind = PropertyGet }, (5,4--5,20),
                          { GetSetKeywords = None });
                       Member
                         (SynValSig
@@ -45,12 +40,9 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (6,4--6,30),
+                            None, None, (6,4--6,30),
                             { LeadingKeyword =
-                               AbstractMember
-                                 (/root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (6,4--6,12),
-                                  /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (6,13--6,19))
+                               AbstractMember ((6,4--6,12), (6,13--6,19))
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -59,8 +51,7 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (6,4--6,30),
+                           MemberKind = PropertyGet }, (6,4--6,30),
                          { GetSetKeywords = None });
                       Member
                         (SynValSig
@@ -70,12 +61,9 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (7,4--7,28),
+                            None, None, (7,4--7,28),
                             { LeadingKeyword =
-                               StaticMember
-                                 (/root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (7,4--7,10),
-                                  /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (7,11--7,17))
+                               StaticMember ((7,4--7,10), (7,11--7,17))
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -84,8 +72,7 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (7,4--7,28),
+                           MemberKind = PropertyGet }, (7,4--7,28),
                          { GetSetKeywords = None });
                       Member
                         (SynValSig
@@ -95,11 +82,8 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((8,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (8,4--8,18),
-                            { LeadingKeyword =
-                               Member
-                                 /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (8,4--8,10)
+                            None, None, (8,4--8,18),
+                            { LeadingKeyword = Member (8,4--8,10)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -108,8 +92,7 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (8,4--8,18),
+                           MemberKind = PropertyGet }, (8,4--8,18),
                          { GetSetKeywords = None });
                       Member
                         (SynValSig
@@ -119,11 +102,8 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((9,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (9,4--9,20),
-                            { LeadingKeyword =
-                               Override
-                                 /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (9,4--9,12)
+                            None, None, (9,4--9,20),
+                            { LeadingKeyword = Override (9,4--9,12)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -132,8 +112,7 @@ SigFile
                            IsOverrideOrExplicitImpl = true
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (9,4--9,20),
+                           MemberKind = PropertyGet }, (9,4--9,20),
                          { GetSetKeywords = None });
                       Member
                         (SynValSig
@@ -143,11 +122,8 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((10,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (10,4--10,19),
-                            { LeadingKeyword =
-                               Default
-                                 /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (10,4--10,11)
+                            None, None, (10,4--10,19),
+                            { LeadingKeyword = Default (10,4--10,11)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -156,24 +132,12 @@ SigFile
                            IsOverrideOrExplicitImpl = true
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (10,4--10,19),
-                         { GetSetKeywords = None })],
-                     /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (5,4--10,19)),
-                  [],
-                  /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (4,5--10,19),
-                  { LeadingKeyword =
-                     Type
-                       /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (4,0--10,19))],
-          PreXmlDocEmpty, [], None,
-          /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (2,0--10,19),
-          { LeadingKeyword =
-             Namespace
-               /root/MemberFlag/SynMemberSigMemberHasCorrectKeywords.fsi (2,0--2,9) })],
+                           MemberKind = PropertyGet }, (10,4--10,19),
+                         { GetSetKeywords = None })], (5,4--10,19)), [],
+                  (4,5--10,19), { LeadingKeyword = Type (4,0--4,4)
+                                  EqualsRange = Some (4,7--4,8)
+                                  WithKeyword = None })], (4,0--10,19))],
+          PreXmlDocEmpty, [], None, (2,0--10,19),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs.bsl
@@ -14,27 +14,13 @@ ImplFile
                        (PostfixList
                           ([SynTyparDecl ([], SynTypar (a, None, false));
                             SynTyparDecl ([], SynTypar (b, None, false))], [],
-                           /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (5,8--5,16))),
-                     [], [Teq],
+                           (5,8--5,16))), [], [Teq],
                      PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     true, None,
-                     /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (5,5--5,8)),
-                  Simple
-                    (None
-                       /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (5,5--5,8),
-                     /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (5,5--5,8)),
-                  [], None,
-                  /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (4,0--5,8),
-                  { LeadingKeyword =
-                     Type
-                       /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (5,0--5,4)
+                     true, None, (5,5--5,8)),
+                  Simple (None (5,5--5,8), (5,5--5,8)), [], None, (4,0--5,8),
+                  { LeadingKeyword = Type (5,0--5,4)
                     EqualsRange = None
-                    WithKeyword = None })],
-              /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (4,0--5,8))],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (2,0--5,8),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespace/DeclaredNamespaceRangeShouldStartAtNamespaceKeyword.fs (2,0--2,9) })],
+                    WithKeyword = None })], (4,0--5,8))], PreXmlDocEmpty, [],
+          None, (2,0--5,8), { LeadingKeyword = Namespace (2,0--2,9) })],
       (true, false), { ConditionalDirectives = []
                        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespace/GlobalInOpenPathShouldContainTrivia.fs.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespace/GlobalInOpenPathShouldContainTrivia.fs.bsl
@@ -7,15 +7,9 @@ ImplFile
           [Open
              (ModuleOrNamespace
                 (SynLongIdent
-                   ([`global`; Node],
-                    [/root/ModuleOrNamespace/GlobalInOpenPathShouldContainTrivia.fs (4,11--4,12)],
-                    [Some (OriginalNotation "global"); None]),
-                 /root/ModuleOrNamespace/GlobalInOpenPathShouldContainTrivia.fs (4,5--4,16)),
-              /root/ModuleOrNamespace/GlobalInOpenPathShouldContainTrivia.fs (4,0--4,16))],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespace/GlobalInOpenPathShouldContainTrivia.fs (2,0--4,16),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespace/GlobalInOpenPathShouldContainTrivia.fs (2,0--2,9) })],
-      (true, false), { ConditionalDirectives = []
-                       CodeComments = [] }, set []))
+                   ([`global`; Node], [(4,11--4,12)],
+                    [Some (OriginalNotation "global"); None]), (4,5--4,16)),
+              (4,0--4,16))], PreXmlDocEmpty, [], None, (2,0--4,16),
+          { LeadingKeyword = Namespace (2,0--2,9) })], (true, false),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs.bsl
@@ -10,33 +10,16 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((6,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (6,5--6,6)),
+                     false, None, (6,5--6,6)),
                   Simple
                     (TypeAbbrev
                        (Ok, LongIdent (SynLongIdent ([int], [], [None])),
-                        /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (6,9--6,12)),
-                     /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (6,9--6,12)),
-                  [], None,
-                  /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (6,5--6,12),
-                  { LeadingKeyword =
-                     Type
-                       /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (6,0--6,4)
-                    EqualsRange =
-                     Some
-                       /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (6,7--6,8)
-                    WithKeyword = None })],
-              /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (6,0--6,12))],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (4,0--6,12),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (4,0--4,9) })],
+                        (6,9--6,12)), (6,9--6,12)), [], None, (6,5--6,12),
+                  { LeadingKeyword = Type (6,0--6,4)
+                    EqualsRange = Some (6,7--6,8)
+                    WithKeyword = None })], (6,0--6,12))], PreXmlDocEmpty, [],
+          None, (4,0--6,12), { LeadingKeyword = Namespace (4,0--4,9) })],
       (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (2,0--2,6);
-          LineComment
-            /root/ModuleOrNamespace/GlobalNamespaceShouldStartAtNamespaceKeyword.fs (3,0--3,6)] },
+        CodeComments = [LineComment (2,0--2,6); LineComment (3,0--3,6)] },
       set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs.bsl
@@ -11,53 +11,25 @@ ImplFile
                   PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (s, None), false, None,
-                     /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,4--5,5)),
+                  Named (SynIdent (s, None), false, None, (5,4--5,5)),
                   Some
                     (SynBindingReturnInfo
                        (LongIdent (SynLongIdent ([string], [], [None])),
-                        /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,8--5,14),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,6--5,7) })),
+                        (5,8--5,14), [], { ColonRange = Some (5,6--5,7) })),
                   Typed
-                    (Const
-                       (String
-                          ("s", Regular,
-                           /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,17--5,20)),
-                        /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,17--5,20)),
+                    (Const (String ("s", Regular, (5,17--5,20)), (5,17--5,20)),
                      LongIdent (SynLongIdent ([string], [], [None])),
-                     /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,17--5,20)),
-                  /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,4--5,5),
-                  Yes
-                    /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,0--5,20),
-                  { LeadingKeyword =
-                     Let
-                       /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,0--5,3)
+                     (5,17--5,20)), (5,4--5,5), Yes (5,0--5,20),
+                  { LeadingKeyword = Let (5,0--5,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,15--5,16) })],
-              /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (5,0--5,20))],
+                    EqualsRange = Some (5,15--5,16) })], (5,0--5,20))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-          [{ Attributes =
-              [{ TypeName = SynLongIdent ([Foo], [], [None])
-                 ArgExpr =
-                  Const
-                    (Unit,
-                     /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (2,4--2,7))
-                 Target = None
-                 AppliesToGetterAndSetter = false
-                 Range =
-                  /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (2,4--2,7) }]
-             Range =
-              /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (2,0--2,11) }],
-          None,
-          /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (2,0--5,20),
-          { LeadingKeyword =
-             Module
-               /root/ModuleOrNamespace/ModuleRangeShouldStartAtFirstAttribute.fs (3,0--3,6) })],
-      (true, false), { ConditionalDirectives = []
-                       CodeComments = [] }, set []))
+          [{ Attributes = [{ TypeName = SynLongIdent ([Foo], [], [None])
+                             ArgExpr = Const (Unit, (2,4--2,7))
+                             Target = None
+                             AppliesToGetterAndSetter = false
+                             Range = (2,4--2,7) }]
+             Range = (2,0--2,11) }], None, (2,0--5,20),
+          { LeadingKeyword = Module (3,0--3,6) })], (true, false),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs.bsl
@@ -7,47 +7,29 @@ ImplFile
           [Open
              (ModuleOrNamespace
                 (SynLongIdent
-                   ([FSharp; Compiler; Syntax],
-                    [/root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (7,11--7,12);
-                     /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (7,20--7,21)],
-                    [None; None; None]),
-                 /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (7,5--7,27)),
-              /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (7,0--7,27));
+                   ([FSharp; Compiler; Syntax], [(7,11--7,12); (7,20--7,21)],
+                    [None; None; None]), (7,5--7,27)), (7,0--7,27));
            Open
              (ModuleOrNamespace
                 (SynLongIdent
-                   ([FSharp; Compiler; Text],
-                    [/root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (8,11--8,12);
-                     /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (8,20--8,21)],
-                    [None; None; None]),
-                 /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (8,5--8,25)),
-              /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (8,0--8,25));
+                   ([FSharp; Compiler; Text], [(8,11--8,12); (8,20--8,21)],
+                    [None; None; None]), (8,5--8,25)), (8,0--8,25));
            Open
              (ModuleOrNamespace
                 (SynLongIdent
-                   ([FsAutoComplete; UntypedAstUtils],
-                    [/root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (9,19--9,20)],
-                    [None; None]),
-                 /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (9,5--9,35)),
-              /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (9,0--9,35));
+                   ([FsAutoComplete; UntypedAstUtils], [(9,19--9,20)],
+                    [None; None]), (9,5--9,35)), (9,0--9,35));
            Open
              (ModuleOrNamespace
                 (SynLongIdent
                    ([FSharp; Compiler; CodeAnalysis],
-                    [/root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (10,11--10,12);
-                     /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (10,20--10,21)],
-                    [None; None; None]),
-                 /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (10,5--10,33)),
-              /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (10,0--10,33));
+                    [(10,11--10,12); (10,20--10,21)], [None; None; None]),
+                 (10,5--10,33)), (10,0--10,33));
            NestedModule
              (SynComponentInfo
                 ([], None, [], [SynExprAppLocationsImpl],
                  PreXmlDoc ((12,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 Some
-                   (Internal
-                      /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (12,7--12,15)),
-                 /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (12,0--12,39)),
-              false,
+                 Some (Internal (12,7--12,15)), (12,0--12,39)), false,
               [Let
                  (false,
                   [SynBinding
@@ -56,36 +38,15 @@ ImplFile
                       SynValData
                         (None, SynValInfo ([], SynArgInfo ([], false, None)),
                          None),
-                      Named
-                        (SynIdent (a, None), false, None,
-                         /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (13,4--13,5)),
-                      None,
-                      Const
-                        (Int32 42,
-                         /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (13,8--13,10)),
-                      /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (13,4--13,5),
-                      Yes
-                        /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (13,0--13,10),
-                      { LeadingKeyword =
-                         Let
-                           /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (13,0--13,3)
-                        InlineKeyword = None
-                        EqualsRange =
-                         Some
-                           /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (13,6--13,7) })],
-                  /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (13,0--13,10))],
-              false,
-              /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (12,0--13,10),
-              { ModuleKeyword =
-                 Some
-                   /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (12,0--12,6)
-                EqualsRange =
-                 Some
-                   /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (12,40--12,41) })],
+                      Named (SynIdent (a, None), false, None, (13,4--13,5)),
+                      None, Const (Int32 42, (13,8--13,10)), (13,4--13,5),
+                      Yes (13,0--13,10), { LeadingKeyword = Let (13,0--13,3)
+                                           InlineKeyword = None
+                                           EqualsRange = Some (13,6--13,7) })],
+                  (13,0--13,10))], false, (12,0--13,10),
+              { ModuleKeyword = Some (12,0--12,6)
+                EqualsRange = Some (12,40--12,41) })],
           PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (2,0--13,10),
-          { LeadingKeyword =
-             Module
-               /root/ModuleOrNamespace/ModuleShouldContainModuleKeyword.fs (5,0--5,6) })],
-      (true, false), { ConditionalDirectives = []
-                       CodeComments = [] }, set []))
+          (2,0--13,10), { LeadingKeyword = Module (5,0--5,6) })], (true, false),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs.bsl
@@ -12,26 +12,12 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Teq],
                      PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (5,5--5,8)),
-                  ObjectModel
-                    (Class, [],
-                     /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (5,11--5,20)),
-                  [], None,
-                  /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (4,0--5,20),
-                  { LeadingKeyword =
-                     Type
-                       /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (5,0--5,4)
-                    EqualsRange =
-                     Some
-                       /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (5,9--5,10)
-                    WithKeyword = None })],
-              /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (4,0--5,20))],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (2,0--5,20),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (2,0--2,9) });
+                     false, None, (5,5--5,8)),
+                  ObjectModel (Class, [], (5,11--5,20)), [], None, (4,0--5,20),
+                  { LeadingKeyword = Type (5,0--5,4)
+                    EqualsRange = Some (5,9--5,10)
+                    WithKeyword = None })], (4,0--5,20))], PreXmlDocEmpty, [],
+          None, (2,0--5,20), { LeadingKeyword = Namespace (2,0--2,9) });
        SynModuleOrNamespace
          ([Foobar], false, DeclaredNamespace,
           [Let
@@ -41,28 +27,12 @@ ImplFile
                   PreXmlDoc ((9,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (x, None), false, None,
-                     /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (9,4--9,5)),
-                  None,
-                  Const
-                    (Int32 42,
-                     /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (9,8--9,10)),
-                  /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (9,4--9,5),
-                  Yes
-                    /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (9,0--9,10),
-                  { LeadingKeyword =
-                     Let
-                       /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (9,0--9,3)
+                  Named (SynIdent (x, None), false, None, (9,4--9,5)), None,
+                  Const (Int32 42, (9,8--9,10)), (9,4--9,5), Yes (9,0--9,10),
+                  { LeadingKeyword = Let (9,0--9,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (9,6--9,7) })],
-              /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (9,0--9,10))],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (7,0--9,10),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespace/MultipleDeclaredNamespacesShouldHaveARangeThatStartsAtTheNamespaceKeyword.fs (7,0--7,9) })],
-      (true, false), { ConditionalDirectives = []
-                       CodeComments = [] }, set []))
+                    EqualsRange = Some (9,6--9,7) })], (9,0--9,10))],
+          PreXmlDocEmpty, [], None, (7,0--9,10),
+          { LeadingKeyword = Namespace (7,0--7,9) })], (true, false),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs.bsl
@@ -8,9 +8,7 @@ ImplFile
              (SynComponentInfo
                 ([], None, [], [Bar],
                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (3,0--3,10)),
-              false,
+                 None, (3,0--3,10)), false,
               [Let
                  (false,
                   [SynBinding
@@ -19,36 +17,13 @@ ImplFile
                       SynValData
                         (None, SynValInfo ([], SynArgInfo ([], false, None)),
                          None),
-                      Named
-                        (SynIdent (a, None), false, None,
-                         /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (4,4--4,5)),
-                      None,
-                      Const
-                        (Int32 42,
-                         /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (4,8--4,10)),
-                      /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (4,4--4,5),
-                      Yes
-                        /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (4,0--4,10),
-                      { LeadingKeyword =
-                         Let
-                           /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (4,0--4,3)
+                      Named (SynIdent (a, None), false, None, (4,4--4,5)), None,
+                      Const (Int32 42, (4,8--4,10)), (4,4--4,5), Yes (4,0--4,10),
+                      { LeadingKeyword = Let (4,0--4,3)
                         InlineKeyword = None
-                        EqualsRange =
-                         Some
-                           /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (4,6--4,7) })],
-                  /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (4,0--4,10))],
-              false,
-              /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (3,0--4,10),
-              { ModuleKeyword =
-                 Some
-                   /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (3,0--3,6)
-                EqualsRange =
-                 Some
-                   /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (3,11--3,12) })],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (2,0--4,10),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespace/NamespaceShouldContainNamespaceKeyword.fs (2,0--2,9) })],
+                        EqualsRange = Some (4,6--4,7) })], (4,0--4,10))], false,
+              (3,0--4,10), { ModuleKeyword = Some (3,0--3,6)
+                             EqualsRange = Some (3,11--3,12) })], PreXmlDocEmpty,
+          [], None, (2,0--4,10), { LeadingKeyword = Namespace (2,0--2,9) })],
       (true, false), { ConditionalDirectives = []
                        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Bar],
                      PreXmlDoc ((6,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,5--6,8)),
+                     false, None, (6,5--6,8)),
                   Simple
                     (Union
                        (None,
@@ -22,44 +21,20 @@ SigFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((6,20), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,20--6,26),
-                                  { LeadingKeyword = None });
+                                  None, (6,20--6,26), { LeadingKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((6,29), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,29--6,32),
-                                  { LeadingKeyword = None })],
+                                  None, (6,29--6,32), { LeadingKeyword = None })],
                             PreXmlDoc ((6,11), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,13--6,32),
-                            { BarRange =
-                               Some
-                                 /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,11--6,12) })],
-                        /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,11--6,32)),
-                     /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,11--6,32)),
-                  [],
-                  /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,5--6,32),
-                  { LeadingKeyword =
-                     Type
-                       /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,0--6,4)
-                    EqualsRange =
-                     Some
-                       /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,9--6,10)
-                    WithKeyword = None })],
-              /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (6,0--6,32))],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (4,0--6,32),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (4,0--4,9) })],
+                            None, (6,13--6,32), { BarRange = Some (6,11--6,12) })],
+                        (6,11--6,32)), (6,11--6,32)), [], (6,5--6,32),
+                  { LeadingKeyword = Type (6,0--6,4)
+                    EqualsRange = Some (6,9--6,10)
+                    WithKeyword = None })], (6,0--6,32))], PreXmlDocEmpty, [],
+          None, (4,0--6,32), { LeadingKeyword = Namespace (4,0--4,9) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (2,0--2,6);
-          LineComment
-            /root/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi (3,0--3,6)] },
+        CodeComments = [LineComment (2,0--2,6); LineComment (3,0--3,6)] },
       set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi.bsl
@@ -10,32 +10,17 @@ SigFile
                  LongIdent (SynLongIdent ([string], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None,
-                 /root/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi (5,0--5,14),
-                 { LeadingKeyword =
-                    Val
-                      /root/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi (5,0--5,3)
-                   InlineKeyword = None
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi (5,0--5,14))],
+                 None, (5,0--5,14), { LeadingKeyword = Val (5,0--5,3)
+                                      InlineKeyword = None
+                                      WithKeyword = None
+                                      EqualsRange = None }), (5,0--5,14))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-          [{ Attributes =
-              [{ TypeName = SynLongIdent ([Foo], [], [None])
-                 ArgExpr =
-                  Const
-                    (Unit,
-                     /root/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi (2,4--2,7))
-                 Target = None
-                 AppliesToGetterAndSetter = false
-                 Range =
-                  /root/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi (2,4--2,7) }]
-             Range =
-              /root/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi (2,0--2,11) }],
-          None,
-          /root/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi (2,0--5,14),
-          { LeadingKeyword =
-             Module
-               /root/ModuleOrNamespaceSig/ModuleRangeShouldStartAtFirstAttribute.fsi (3,0--3,6) })],
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+          [{ Attributes = [{ TypeName = SynLongIdent ([Foo], [], [None])
+                             ArgExpr = Const (Unit, (2,4--2,7))
+                             Target = None
+                             AppliesToGetterAndSetter = false
+                             Range = (2,4--2,7) }]
+             Range = (2,0--2,11) }], None, (2,0--5,14),
+          { LeadingKeyword = Module (3,0--3,6) })], { ConditionalDirectives = []
+                                                      CodeComments = [] },
+      set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/ModuleShouldContainModuleKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/ModuleShouldContainModuleKeyword.fsi.bsl
@@ -10,19 +10,11 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None,
-                 /root/ModuleOrNamespaceSig/ModuleShouldContainModuleKeyword.fsi (4,0--4,10),
-                 { LeadingKeyword =
-                    Val
-                      /root/ModuleOrNamespaceSig/ModuleShouldContainModuleKeyword.fsi (4,0--4,3)
-                   InlineKeyword = None
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/ModuleOrNamespaceSig/ModuleShouldContainModuleKeyword.fsi (4,0--4,10))],
+                 None, (4,0--4,10), { LeadingKeyword = Val (4,0--4,3)
+                                      InlineKeyword = None
+                                      WithKeyword = None
+                                      EqualsRange = None }), (4,0--4,10))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/ModuleOrNamespaceSig/ModuleShouldContainModuleKeyword.fsi (2,0--4,10),
-          { LeadingKeyword =
-             Module
-               /root/ModuleOrNamespaceSig/ModuleShouldContainModuleKeyword.fsi (2,0--2,6) })],
+          (2,0--4,10), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi.bsl
@@ -8,35 +8,20 @@ SigFile
              (SynComponentInfo
                 ([], None, [], [Bar],
                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (3,0--3,10)),
-              false,
+                 None, (3,0--3,10)), false,
               [Val
                  (SynValSig
                     ([], SynIdent (a, None), SynValTyparDecls (None, true),
                      LongIdent (SynLongIdent ([int], [], [None])),
                      SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     None, None,
-                     /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (4,0--4,10),
-                     { LeadingKeyword =
-                        Val
-                          /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (4,0--4,3)
-                       InlineKeyword = None
-                       WithKeyword = None
-                       EqualsRange = None }),
-                  /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (4,0--4,10))],
-              /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (3,0--4,10),
-              { ModuleKeyword =
-                 Some
-                   /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (3,0--3,6)
-                EqualsRange =
-                 Some
-                   /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (3,11--3,12) })],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (2,0--4,10),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespaceSig/NamespaceShouldContainNamespaceKeyword.fsi (2,0--2,9) })],
+                     None, None, (4,0--4,10), { LeadingKeyword = Val (4,0--4,3)
+                                                InlineKeyword = None
+                                                WithKeyword = None
+                                                EqualsRange = None }),
+                  (4,0--4,10))], (3,0--4,10),
+              { ModuleKeyword = Some (3,0--3,6)
+                EqualsRange = Some (3,11--3,12) })], PreXmlDocEmpty, [], None,
+          (2,0--4,10), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi.bsl
@@ -10,8 +10,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Bar],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,5--4,8)),
+                     false, None, (4,5--4,8)),
                   Simple
                     (Union
                        (None,
@@ -23,39 +22,19 @@ SigFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((4,20), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,20--4,26),
-                                  { LeadingKeyword = None });
+                                  None, (4,20--4,26), { LeadingKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,29), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,29--4,32),
-                                  { LeadingKeyword = None })],
+                                  None, (4,29--4,32), { LeadingKeyword = None })],
                             PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,13--4,32),
-                            { BarRange =
-                               Some
-                                 /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,11--4,12) })],
-                        /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,11--4,32)),
-                     /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,11--4,32)),
-                  [],
-                  /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,5--4,32),
-                  { LeadingKeyword =
-                     Type
-                       /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,9--4,10)
-                    WithKeyword = None })],
-              /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (4,0--4,32))],
-          PreXmlDocEmpty, [], None,
-          /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (2,0--4,32),
-          { LeadingKeyword =
-             Namespace
-               /root/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi (2,0--2,9) })],
+                            None, (4,13--4,32), { BarRange = Some (4,11--4,12) })],
+                        (4,11--4,32)), (4,11--4,32)), [], (4,5--4,32),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,9--4,10)
+                    WithKeyword = None })], (4,0--4,32))], PreXmlDocEmpty, [],
+          None, (2,0--4,32), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs.bsl
+++ b/tests/service/data/SyntaxTree/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs.bsl
@@ -6,40 +6,18 @@ ImplFile
          ([TopLevel], false, NamedModule,
           [NestedModule
              (SynComponentInfo
-                ([{ Attributes =
-                     [{ TypeName = SynLongIdent ([Foo], [], [None])
-                        ArgExpr =
-                         Const
-                           (Unit,
-                            /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (4,2--4,5))
-                        Target = None
-                        AppliesToGetterAndSetter = false
-                        Range =
-                         /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (4,2--4,5) }]
-                    Range =
-                     /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (4,0--4,7) }],
-                 None, [], [Nested],
+                ([{ Attributes = [{ TypeName = SynLongIdent ([Foo], [], [None])
+                                    ArgExpr = Const (Unit, (4,2--4,5))
+                                    Target = None
+                                    AppliesToGetterAndSetter = false
+                                    Range = (4,2--4,5) }]
+                    Range = (4,0--4,7) }], None, [], [Nested],
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (5,0--5,13)),
-              false,
-              [Expr
-                 (Const
-                    (Unit,
-                     /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (6,4--6,6)),
-                  /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (6,4--6,6))],
-              false,
-              /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (4,0--6,6),
-              { ModuleKeyword =
-                 Some
-                   /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (5,0--5,6)
-                EqualsRange =
-                 Some
-                   /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (5,14--5,15) })],
+                 None, (5,0--5,13)), false,
+              [Expr (Const (Unit, (6,4--6,6)), (6,4--6,6))], false, (4,0--6,6),
+              { ModuleKeyword = Some (5,0--5,6)
+                EqualsRange = Some (5,14--5,15) })],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (2,0--6,6),
-          { LeadingKeyword =
-             Module
-               /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleDeclNestedModule.fs (2,0--2,6) })],
-      (true, false), { ConditionalDirectives = []
-                       CodeComments = [] }, set []))
+          (2,0--6,6), { LeadingKeyword = Module (2,0--2,6) })], (true, false),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi.bsl
+++ b/tests/service/data/SyntaxTree/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi.bsl
@@ -7,49 +7,27 @@ SigFile
          ([SomeNamespace], false, DeclaredNamespace,
           [NestedModule
              (SynComponentInfo
-                ([{ Attributes =
-                     [{ TypeName = SynLongIdent ([Foo], [], [None])
-                        ArgExpr =
-                         Const
-                           (Unit,
-                            /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (4,2--4,5))
-                        Target = None
-                        AppliesToGetterAndSetter = false
-                        Range =
-                         /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (4,2--4,5) }]
-                    Range =
-                     /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (4,0--4,7) }],
-                 None, [], [Nested],
+                ([{ Attributes = [{ TypeName = SynLongIdent ([Foo], [], [None])
+                                    ArgExpr = Const (Unit, (4,2--4,5))
+                                    Target = None
+                                    AppliesToGetterAndSetter = false
+                                    Range = (4,2--4,5) }]
+                    Range = (4,0--4,7) }], None, [], [Nested],
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (5,0--5,13)),
-              false,
+                 None, (5,0--5,13)), false,
               [Val
                  (SynValSig
                     ([], SynIdent (x, None), SynValTyparDecls (None, true),
                      LongIdent (SynLongIdent ([int], [], [None])),
                      SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                      PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                     None, None,
-                     /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (6,4--6,15),
-                     { LeadingKeyword =
-                        Val
-                          /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (6,4--6,7)
-                       InlineKeyword = None
-                       WithKeyword = None
-                       EqualsRange = None }),
-                  /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (6,4--6,15))],
-              /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (4,0--6,15),
-              { ModuleKeyword =
-                 Some
-                   /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (5,0--5,6)
-                EqualsRange =
-                 Some
-                   /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (5,14--5,15) })],
-          PreXmlDocEmpty, [], None,
-          /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (2,0--6,15),
-          { LeadingKeyword =
-             Namespace
-               /root/NestedModule/RangeOfAttributeShouldBeIncludedInSynModuleSigDeclNestedModule.fsi (2,0--2,9) })],
+                     None, None, (6,4--6,15), { LeadingKeyword = Val (6,4--6,7)
+                                                InlineKeyword = None
+                                                WithKeyword = None
+                                                EqualsRange = None }),
+                  (6,4--6,15))], (4,0--6,15),
+              { ModuleKeyword = Some (5,0--5,6)
+                EqualsRange = Some (5,14--5,15) })], PreXmlDocEmpty, [], None,
+          (2,0--6,15), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/NestedModule/RangeOfEqualSignShouldBePresent.fs.bsl
+++ b/tests/service/data/SyntaxTree/NestedModule/RangeOfEqualSignShouldBePresent.fs.bsl
@@ -8,24 +8,10 @@ ImplFile
              (SynComponentInfo
                 ([], None, [], [X],
                  PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/NestedModule/RangeOfEqualSignShouldBePresent.fs (2,0--2,8)),
-              false,
-              [Expr
-                 (Const
-                    (Unit,
-                     /root/NestedModule/RangeOfEqualSignShouldBePresent.fs (3,0--3,2)),
-                  /root/NestedModule/RangeOfEqualSignShouldBePresent.fs (3,0--3,2))],
-              false,
-              /root/NestedModule/RangeOfEqualSignShouldBePresent.fs (2,0--3,2),
-              { ModuleKeyword =
-                 Some
-                   /root/NestedModule/RangeOfEqualSignShouldBePresent.fs (2,0--2,6)
-                EqualsRange =
-                 Some
-                   /root/NestedModule/RangeOfEqualSignShouldBePresent.fs (2,9--2,10) })],
-          PreXmlDocEmpty, [], None,
-          /root/NestedModule/RangeOfEqualSignShouldBePresent.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                 None, (2,0--2,8)), false,
+              [Expr (Const (Unit, (3,0--3,2)), (3,0--3,2))], false, (2,0--3,2),
+              { ModuleKeyword = Some (2,0--2,6)
+                EqualsRange = Some (2,9--2,10) })], PreXmlDocEmpty, [], None,
+          (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi.bsl
+++ b/tests/service/data/SyntaxTree/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi.bsl
@@ -8,35 +8,20 @@ SigFile
              (SynComponentInfo
                 ([], None, [], [X],
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (4,0--4,8)),
-              false,
+                 None, (4,0--4,8)), false,
               [Val
                  (SynValSig
                     ([], SynIdent (bar, None), SynValTyparDecls (None, true),
                      LongIdent (SynLongIdent ([int], [], [None])),
                      SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                      PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     None, None,
-                     /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (5,0--5,13),
-                     { LeadingKeyword =
-                        Val
-                          /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (5,0--5,3)
-                       InlineKeyword = None
-                       WithKeyword = None
-                       EqualsRange = None }),
-                  /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (5,0--5,13))],
-              /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (4,0--5,13),
-              { ModuleKeyword =
-                 Some
-                   /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (4,0--4,6)
-                EqualsRange =
-                 Some
-                   /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (4,9--4,10) })],
-          PreXmlDocEmpty, [], None,
-          /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (2,0--5,13),
-          { LeadingKeyword =
-             Namespace
-               /root/NestedModule/RangeOfEqualSignShouldBePresentSignatureFile.fsi (2,0--2,9) })],
+                     None, None, (5,0--5,13), { LeadingKeyword = Val (5,0--5,3)
+                                                InlineKeyword = None
+                                                WithKeyword = None
+                                                EqualsRange = None }),
+                  (5,0--5,13))], (4,0--5,13), { ModuleKeyword = Some (4,0--4,6)
+                                                EqualsRange = Some (4,9--4,10) })],
+          PreXmlDocEmpty, [], None, (2,0--5,13),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi.bsl
+++ b/tests/service/data/SyntaxTree/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi.bsl
@@ -8,51 +8,33 @@ SigFile
          ([Microsoft; FSharp; Core], false, DeclaredNamespace,
           [Open
              (ModuleOrNamespace
-                (SynLongIdent ([System], [], [None]),
-                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (4,5--4,11)),
-              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (4,0--4,11));
+                (SynLongIdent ([System], [], [None]), (4,5--4,11)), (4,0--4,11));
            Open
              (ModuleOrNamespace
                 (SynLongIdent
-                   ([System; Collections; Generic],
-                    [/root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (5,11--5,12);
-                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (5,23--5,24)],
-                    [None; None; None]),
-                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (5,5--5,31)),
-              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (5,0--5,31));
+                   ([System; Collections; Generic], [(5,11--5,12); (5,23--5,24)],
+                    [None; None; None]), (5,5--5,31)), (5,0--5,31));
            Open
              (ModuleOrNamespace
                 (SynLongIdent
-                   ([Microsoft; FSharp; Core],
-                    [/root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (6,14--6,15);
-                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (6,21--6,22)],
-                    [None; None; None]),
-                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (6,5--6,26)),
-              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (6,0--6,26));
+                   ([Microsoft; FSharp; Core], [(6,14--6,15); (6,21--6,22)],
+                    [None; None; None]), (6,5--6,26)), (6,0--6,26));
            Open
              (ModuleOrNamespace
                 (SynLongIdent
                    ([Microsoft; FSharp; Collections],
-                    [/root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (7,14--7,15);
-                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (7,21--7,22)],
-                    [None; None; None]),
-                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (7,5--7,33)),
-              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (7,0--7,33));
+                    [(7,14--7,15); (7,21--7,22)], [None; None; None]),
+                 (7,5--7,33)), (7,0--7,33));
            Open
              (ModuleOrNamespace
                 (SynLongIdent
-                   ([System; Collections],
-                    [/root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (8,11--8,12)],
-                    [None; None]),
-                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (8,5--8,23)),
-              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (8,0--8,23));
+                   ([System; Collections], [(8,11--8,12)], [None; None]),
+                 (8,5--8,23)), (8,0--8,23));
            NestedModule
              (SynComponentInfo
                 ([], None, [], [Tuple],
                  PreXmlDoc ((11,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (11,0--11,12)),
-              false,
+                 None, (11,0--11,12)), false,
               [Types
                  ([SynTypeDefnSig
                      (SynComponentInfo
@@ -63,28 +45,25 @@ SigFile
                                 SynTyparDecl ([], SynTypar (T2, None, false));
                                 SynTyparDecl ([], SynTypar (T3, None, false));
                                 SynTyparDecl ([], SynTypar (T4, None, false))],
-                               [],
-                               /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (13,14--13,31))),
-                         [], [Tuple],
+                               [], (13,14--13,31))), [], [Tuple],
                          PreXmlDoc ((13,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         true, None,
-                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (13,9--13,14)),
+                         true, None, (13,9--13,14)),
                       ObjectModel
                         (Unspecified,
                          [Interface
                             (LongIdent
                                (SynLongIdent
                                   ([IStructuralEquatable], [], [None])),
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (14,8--14,38));
+                             (14,8--14,38));
                           Interface
                             (LongIdent
                                (SynLongIdent
                                   ([IStructuralComparable], [], [None])),
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (15,8--15,39));
+                             (15,8--15,39));
                           Interface
                             (LongIdent
                                (SynLongIdent ([IComparable], [], [None])),
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (16,8--16,29));
+                             (16,8--16,29));
                           Member
                             (SynValSig
                                ([], SynIdent (new, None),
@@ -95,53 +74,42 @@ SigFile
                                       [Type
                                          (Var
                                             (SynTypar (T1, None, false),
-                                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,14--17,17)));
-                                       Star
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,18--17,19);
+                                             (17,14--17,17)));
+                                       Star (17,18--17,19);
                                        Type
                                          (Var
                                             (SynTypar (T2, None, false),
-                                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,20--17,23)));
-                                       Star
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,24--17,25);
+                                             (17,20--17,23)));
+                                       Star (17,24--17,25);
                                        Type
                                          (Var
                                             (SynTypar (T3, None, false),
-                                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,26--17,29)));
-                                       Star
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,30--17,31);
+                                             (17,26--17,29)));
+                                       Star (17,30--17,31);
                                        Type
                                          (Var
                                             (SynTypar (T4, None, false),
-                                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,32--17,35)))],
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,14--17,35)),
+                                             (17,32--17,35)))], (17,14--17,35)),
                                    App
                                      (LongIdent
                                         (SynLongIdent ([Tuple], [], [None])),
-                                      Some
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,44--17,45),
+                                      Some (17,44--17,45),
                                       [Var
                                          (SynTypar (T1, None, false),
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,45--17,48));
+                                          (17,45--17,48));
                                        Var
                                          (SynTypar (T2, None, false),
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,49--17,52));
+                                          (17,49--17,52));
                                        Var
                                          (SynTypar (T3, None, false),
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,53--17,56));
+                                          (17,53--17,56));
                                        Var
                                          (SynTypar (T4, None, false),
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,57--17,60))],
-                                      [/root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,48--17,49);
-                                       /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,52--17,53);
-                                       /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,56--17,57)],
-                                      Some
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,60--17,61),
-                                      false,
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,39--17,61)),
-                                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,14--17,61),
-                                   { ArrowRange =
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,36--17,38) }),
+                                          (17,57--17,60))],
+                                      [(17,48--17,49); (17,52--17,53);
+                                       (17,56--17,57)], Some (17,60--17,61),
+                                      false, (17,39--17,61)), (17,14--17,61),
+                                   { ArrowRange = (17,36--17,38) }),
                                 SynValInfo
                                   ([[SynArgInfo ([], false, None);
                                      SynArgInfo ([], false, None);
@@ -149,11 +117,8 @@ SigFile
                                      SynArgInfo ([], false, None)]],
                                    SynArgInfo ([], false, None)), false, false,
                                 PreXmlDoc ((17,8), FSharp.Compiler.Xml.XmlDocCollector),
-                                None, None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,8--17,61),
-                                { LeadingKeyword =
-                                   New
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,8--17,11)
+                                None, None, (17,8--17,61),
+                                { LeadingKeyword = New (17,8--17,11)
                                   InlineKeyword = None
                                   WithKeyword = None
                                   EqualsRange = None }),
@@ -162,185 +127,117 @@ SigFile
                                IsOverrideOrExplicitImpl = false
                                IsFinal = false
                                GetterOrSetterIsCompilerGenerated = false
-                               MemberKind = Constructor },
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (17,8--17,61),
+                               MemberKind = Constructor }, (17,8--17,61),
                              { GetSetKeywords = None });
                           Member
                             (SynValSig
                                ([], SynIdent (Item1, None),
                                 SynValTyparDecls (None, true),
-                                Var
-                                  (SynTypar (T1, None, false),
-                                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (18,23--18,26)),
+                                Var (SynTypar (T1, None, false), (18,23--18,26)),
                                 SynValInfo ([], SynArgInfo ([], false, None)),
                                 false, false,
                                 PreXmlDoc ((18,8), FSharp.Compiler.Xml.XmlDocCollector),
-                                None, None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (18,8--18,35),
-                                { LeadingKeyword =
-                                   Member
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (18,8--18,14)
+                                None, None, (18,8--18,35),
+                                { LeadingKeyword = Member (18,8--18,14)
                                   InlineKeyword = None
-                                  WithKeyword =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (18,27--18,31)
+                                  WithKeyword = Some (18,27--18,31)
                                   EqualsRange = None }),
                              { IsInstance = true
                                IsDispatchSlot = false
                                IsOverrideOrExplicitImpl = false
                                IsFinal = false
                                GetterOrSetterIsCompilerGenerated = false
-                               MemberKind = PropertyGet },
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (18,8--18,35),
-                             { GetSetKeywords =
-                                Some
-                                  (Get
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (18,32--18,35)) });
+                               MemberKind = PropertyGet }, (18,8--18,35),
+                             { GetSetKeywords = Some (Get (18,32--18,35)) });
                           Member
                             (SynValSig
                                ([], SynIdent (Item2, None),
                                 SynValTyparDecls (None, true),
-                                Var
-                                  (SynTypar (T2, None, false),
-                                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (19,23--19,26)),
+                                Var (SynTypar (T2, None, false), (19,23--19,26)),
                                 SynValInfo ([], SynArgInfo ([], false, None)),
                                 false, false,
                                 PreXmlDoc ((19,8), FSharp.Compiler.Xml.XmlDocCollector),
-                                None, None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (19,8--19,35),
-                                { LeadingKeyword =
-                                   Member
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (19,8--19,14)
+                                None, None, (19,8--19,35),
+                                { LeadingKeyword = Member (19,8--19,14)
                                   InlineKeyword = None
-                                  WithKeyword =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (19,27--19,31)
+                                  WithKeyword = Some (19,27--19,31)
                                   EqualsRange = None }),
                              { IsInstance = true
                                IsDispatchSlot = false
                                IsOverrideOrExplicitImpl = false
                                IsFinal = false
                                GetterOrSetterIsCompilerGenerated = false
-                               MemberKind = PropertyGet },
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (19,8--19,35),
-                             { GetSetKeywords =
-                                Some
-                                  (Get
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (19,32--19,35)) });
+                               MemberKind = PropertyGet }, (19,8--19,35),
+                             { GetSetKeywords = Some (Get (19,32--19,35)) });
                           Member
                             (SynValSig
                                ([], SynIdent (Item3, None),
                                 SynValTyparDecls (None, true),
-                                Var
-                                  (SynTypar (T3, None, false),
-                                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (20,23--20,26)),
+                                Var (SynTypar (T3, None, false), (20,23--20,26)),
                                 SynValInfo ([], SynArgInfo ([], false, None)),
                                 false, false,
                                 PreXmlDoc ((20,8), FSharp.Compiler.Xml.XmlDocCollector),
-                                None, None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (20,8--20,35),
-                                { LeadingKeyword =
-                                   Member
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (20,8--20,14)
+                                None, None, (20,8--20,35),
+                                { LeadingKeyword = Member (20,8--20,14)
                                   InlineKeyword = None
-                                  WithKeyword =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (20,27--20,31)
+                                  WithKeyword = Some (20,27--20,31)
                                   EqualsRange = None }),
                              { IsInstance = true
                                IsDispatchSlot = false
                                IsOverrideOrExplicitImpl = false
                                IsFinal = false
                                GetterOrSetterIsCompilerGenerated = false
-                               MemberKind = PropertyGet },
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (20,8--20,35),
-                             { GetSetKeywords =
-                                Some
-                                  (Get
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (20,32--20,35)) });
+                               MemberKind = PropertyGet }, (20,8--20,35),
+                             { GetSetKeywords = Some (Get (20,32--20,35)) });
                           Member
                             (SynValSig
                                ([], SynIdent (Item4, None),
                                 SynValTyparDecls (None, true),
-                                Var
-                                  (SynTypar (T4, None, false),
-                                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (21,23--21,26)),
+                                Var (SynTypar (T4, None, false), (21,23--21,26)),
                                 SynValInfo ([], SynArgInfo ([], false, None)),
                                 false, false,
                                 PreXmlDoc ((21,8), FSharp.Compiler.Xml.XmlDocCollector),
-                                None, None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (21,8--21,35),
-                                { LeadingKeyword =
-                                   Member
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (21,8--21,14)
+                                None, None, (21,8--21,35),
+                                { LeadingKeyword = Member (21,8--21,14)
                                   InlineKeyword = None
-                                  WithKeyword =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (21,27--21,31)
+                                  WithKeyword = Some (21,27--21,31)
                                   EqualsRange = None }),
                              { IsInstance = true
                                IsDispatchSlot = false
                                IsOverrideOrExplicitImpl = false
                                IsFinal = false
                                GetterOrSetterIsCompilerGenerated = false
-                               MemberKind = PropertyGet },
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (21,8--21,35),
-                             { GetSetKeywords =
-                                Some
-                                  (Get
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (21,32--21,35)) })],
-                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (14,8--21,35)),
-                      [],
-                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (13,9--21,35),
-                      { LeadingKeyword =
-                         Type
-                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (13,4--13,8)
-                        EqualsRange =
-                         Some
-                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (13,32--13,33)
-                        WithKeyword = None })],
-                  /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (13,4--21,35))],
-              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (11,0--21,35),
-              { ModuleKeyword =
-                 Some
-                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (11,0--11,6)
-                EqualsRange =
-                 Some
-                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (11,13--11,14) });
+                               MemberKind = PropertyGet }, (21,8--21,35),
+                             { GetSetKeywords = Some (Get (21,32--21,35)) })],
+                         (14,8--21,35)), [], (13,9--21,35),
+                      { LeadingKeyword = Type (13,4--13,8)
+                        EqualsRange = Some (13,32--13,33)
+                        WithKeyword = None })], (13,4--21,35))], (11,0--21,35),
+              { ModuleKeyword = Some (11,0--11,6)
+                EqualsRange = Some (11,13--11,14) });
            NestedModule
              (SynComponentInfo
                 ([], None, [], [Choice],
                  PreXmlDoc ((24,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (24,0--24,13)),
-              false,
+                 None, (24,0--24,13)), false,
               [Types
                  ([SynTypeDefnSig
                      (SynComponentInfo
                         ([{ Attributes =
                              [{ TypeName =
                                  SynLongIdent ([StructuralEquality], [], [None])
-                                ArgExpr =
-                                 Const
-                                   (Unit,
-                                    /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (27,6--27,24))
+                                ArgExpr = Const (Unit, (27,6--27,24))
                                 Target = None
                                 AppliesToGetterAndSetter = false
-                                Range =
-                                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (27,6--27,24) };
+                                Range = (27,6--27,24) };
                               { TypeName =
                                  SynLongIdent
                                    ([StructuralComparison], [], [None])
-                                ArgExpr =
-                                 Const
-                                   (Unit,
-                                    /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (27,26--27,46))
+                                ArgExpr = Const (Unit, (27,26--27,46))
                                 Target = None
                                 AppliesToGetterAndSetter = false
-                                Range =
-                                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (27,26--27,46) }]
-                            Range =
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (27,4--27,48) };
+                                Range = (27,26--27,46) }]
+                            Range = (27,4--27,48) };
                           { Attributes =
                              [{ TypeName =
                                  SynLongIdent ([CompiledName], [], [None])
@@ -349,18 +246,13 @@ SigFile
                                    (Const
                                       (String
                                          ("FSharpChoice`6", Regular,
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (28,19--28,35)),
-                                       /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (28,19--28,35)),
-                                    /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (28,18--28,19),
-                                    Some
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (28,35--28,36),
-                                    /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (28,18--28,36))
+                                          (28,19--28,35)), (28,19--28,35)),
+                                    (28,18--28,19), Some (28,35--28,36),
+                                    (28,18--28,36))
                                 Target = None
                                 AppliesToGetterAndSetter = false
-                                Range =
-                                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (28,6--28,36) }]
-                            Range =
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (28,4--28,38) }],
+                                Range = (28,6--28,36) }]
+                            Range = (28,4--28,38) }],
                          Some
                            (PostfixList
                               ([SynTyparDecl ([], SynTypar (T1, None, false));
@@ -369,12 +261,9 @@ SigFile
                                 SynTyparDecl ([], SynTypar (T4, None, false));
                                 SynTyparDecl ([], SynTypar (T5, None, false));
                                 SynTyparDecl ([], SynTypar (T6, None, false))],
-                               [],
-                               /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (29,15--29,40))),
-                         [], [Choice],
+                               [], (29,15--29,40))), [], [Choice],
                          PreXmlDoc ((27,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         true, None,
-                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (29,9--29,15)),
+                         true, None, (29,9--29,15)),
                       Simple
                         (Union
                            (None,
@@ -385,18 +274,13 @@ SigFile
                                      ([], false, None,
                                       Var
                                         (SynTypar (T1, None, false),
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (31,22--31,25)),
-                                      false,
+                                         (31,22--31,25)), false,
                                       PreXmlDoc ((31,22), FSharp.Compiler.Xml.XmlDocCollector),
-                                      None,
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (31,22--31,25),
+                                      None, (31,22--31,25),
                                       { LeadingKeyword = None })],
                                 PreXmlDoc ((31,6), FSharp.Compiler.Xml.XmlDocCollector),
-                                None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (30,6--31,25),
-                                { BarRange =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (31,6--31,7) });
+                                None, (30,6--31,25),
+                                { BarRange = Some (31,6--31,7) });
                              SynUnionCase
                                ([], SynIdent (Choice2Of6, None),
                                 Fields
@@ -404,18 +288,13 @@ SigFile
                                      ([], false, None,
                                       Var
                                         (SynTypar (T2, None, false),
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (33,22--33,25)),
-                                      false,
+                                         (33,22--33,25)), false,
                                       PreXmlDoc ((33,22), FSharp.Compiler.Xml.XmlDocCollector),
-                                      None,
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (33,22--33,25),
+                                      None, (33,22--33,25),
                                       { LeadingKeyword = None })],
                                 PreXmlDoc ((33,6), FSharp.Compiler.Xml.XmlDocCollector),
-                                None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (32,6--33,25),
-                                { BarRange =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (33,6--33,7) });
+                                None, (32,6--33,25),
+                                { BarRange = Some (33,6--33,7) });
                              SynUnionCase
                                ([], SynIdent (Choice3Of6, None),
                                 Fields
@@ -423,18 +302,13 @@ SigFile
                                      ([], false, None,
                                       Var
                                         (SynTypar (T3, None, false),
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (35,22--35,25)),
-                                      false,
+                                         (35,22--35,25)), false,
                                       PreXmlDoc ((35,22), FSharp.Compiler.Xml.XmlDocCollector),
-                                      None,
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (35,22--35,25),
+                                      None, (35,22--35,25),
                                       { LeadingKeyword = None })],
                                 PreXmlDoc ((35,6), FSharp.Compiler.Xml.XmlDocCollector),
-                                None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (34,6--35,25),
-                                { BarRange =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (35,6--35,7) });
+                                None, (34,6--35,25),
+                                { BarRange = Some (35,6--35,7) });
                              SynUnionCase
                                ([], SynIdent (Choice4Of6, None),
                                 Fields
@@ -442,18 +316,13 @@ SigFile
                                      ([], false, None,
                                       Var
                                         (SynTypar (T4, None, false),
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (37,22--37,25)),
-                                      false,
+                                         (37,22--37,25)), false,
                                       PreXmlDoc ((37,22), FSharp.Compiler.Xml.XmlDocCollector),
-                                      None,
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (37,22--37,25),
+                                      None, (37,22--37,25),
                                       { LeadingKeyword = None })],
                                 PreXmlDoc ((37,6), FSharp.Compiler.Xml.XmlDocCollector),
-                                None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (36,6--37,25),
-                                { BarRange =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (37,6--37,7) });
+                                None, (36,6--37,25),
+                                { BarRange = Some (37,6--37,7) });
                              SynUnionCase
                                ([], SynIdent (Choice5Of6, None),
                                 Fields
@@ -461,18 +330,13 @@ SigFile
                                      ([], false, None,
                                       Var
                                         (SynTypar (T5, None, false),
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (39,22--39,25)),
-                                      false,
+                                         (39,22--39,25)), false,
                                       PreXmlDoc ((39,22), FSharp.Compiler.Xml.XmlDocCollector),
-                                      None,
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (39,22--39,25),
+                                      None, (39,22--39,25),
                                       { LeadingKeyword = None })],
                                 PreXmlDoc ((39,6), FSharp.Compiler.Xml.XmlDocCollector),
-                                None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (38,6--39,25),
-                                { BarRange =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (39,6--39,7) });
+                                None, (38,6--39,25),
+                                { BarRange = Some (39,6--39,7) });
                              SynUnionCase
                                ([], SynIdent (Choice6Of6, None),
                                 Fields
@@ -480,56 +344,30 @@ SigFile
                                      ([], false, None,
                                       Var
                                         (SynTypar (T6, None, false),
-                                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (41,22--41,25)),
-                                      false,
+                                         (41,22--41,25)), false,
                                       PreXmlDoc ((41,22), FSharp.Compiler.Xml.XmlDocCollector),
-                                      None,
-                                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (41,22--41,25),
+                                      None, (41,22--41,25),
                                       { LeadingKeyword = None })],
                                 PreXmlDoc ((41,6), FSharp.Compiler.Xml.XmlDocCollector),
-                                None,
-                                /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (40,6--41,25),
-                                { BarRange =
-                                   Some
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (41,6--41,7) })],
-                            /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (30,6--41,25)),
-                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (30,6--41,25)),
-                      [],
-                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (26,4--41,25),
-                      { LeadingKeyword =
-                         Type
-                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (29,4--29,8)
-                        EqualsRange =
-                         Some
-                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (29,41--29,42)
-                        WithKeyword = None })],
-                  /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (26,4--41,25))],
-              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (24,0--41,25),
-              { ModuleKeyword =
-                 Some
-                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (24,0--24,6)
-                EqualsRange =
-                 Some
-                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (24,14--24,15) });
+                                None, (40,6--41,25),
+                                { BarRange = Some (41,6--41,7) })],
+                            (30,6--41,25)), (30,6--41,25)), [], (26,4--41,25),
+                      { LeadingKeyword = Type (29,4--29,8)
+                        EqualsRange = Some (29,41--29,42)
+                        WithKeyword = None })], (26,4--41,25))], (24,0--41,25),
+              { ModuleKeyword = Some (24,0--24,6)
+                EqualsRange = Some (24,14--24,15) });
            NestedModule
              (SynComponentInfo
                 ([{ Attributes =
                      [{ TypeName = SynLongIdent ([AutoOpen], [], [None])
-                        ArgExpr =
-                         Const
-                           (Unit,
-                            /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (46,2--46,10))
+                        ArgExpr = Const (Unit, (46,2--46,10))
                         Target = None
                         AppliesToGetterAndSetter = false
-                        Range =
-                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (46,2--46,10) }]
-                    Range =
-                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (46,0--46,12) }],
-                 None, [], [Operators],
+                        Range = (46,2--46,10) }]
+                    Range = (46,0--46,12) }], None, [], [Operators],
                  PreXmlDoc ((46,0), FSharp.Compiler.Xml.XmlDocCollector), false,
-                 None,
-                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (47,0--47,16)),
-              false,
+                 None, (47,0--47,16)), false,
               [Types
                  ([SynTypeDefnSig
                      (SynComponentInfo
@@ -537,16 +375,10 @@ SigFile
                          Some
                            (PostfixList
                               ([SynTyparDecl ([], SynTypar (T, None, false))],
-                               [],
-                               /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (49,16--49,20))),
-                         [], [[,]],
+                               [], (49,16--49,20))), [], [[,]],
                          PreXmlDoc ((49,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         true, None,
-                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (49,9--49,16)),
-                      Simple
-                        (None
-                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (49,9--61,26),
-                         /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (49,9--61,26)),
+                         true, None, (49,9--49,16)),
+                      Simple (None (49,9--61,26), (49,9--61,26)),
                       [Member
                          (SynValSig
                             ([{ Attributes =
@@ -556,30 +388,21 @@ SigFile
                                      Paren
                                        (Const
                                           (String
-                                             ("Length1", Regular,
-                                              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,23--50,32)),
-                                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,23--50,32)),
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,22--50,23),
-                                        Some
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,32--50,33),
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,22--50,33))
+                                             ("Length1", Regular, (50,23--50,32)),
+                                           (50,23--50,32)), (50,22--50,23),
+                                        Some (50,32--50,33), (50,22--50,33))
                                     Target = None
                                     AppliesToGetterAndSetter = false
-                                    Range =
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,10--50,33) }]
-                                Range =
-                                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,8--50,35) }],
+                                    Range = (50,10--50,33) }]
+                                Range = (50,8--50,35) }],
                              SynIdent (Length1, None),
                              SynValTyparDecls (None, true),
                              LongIdent (SynLongIdent ([int], [], [None])),
                              SynValInfo ([], SynArgInfo ([], false, None)),
                              false, false,
                              PreXmlDoc ((50,8), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, None,
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,8--52,28),
-                             { LeadingKeyword =
-                                Member
-                                  /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (52,8--52,14)
+                             None, None, (50,8--52,28),
+                             { LeadingKeyword = Member (52,8--52,14)
                                InlineKeyword = None
                                WithKeyword = None
                                EqualsRange = None }),
@@ -588,8 +411,7 @@ SigFile
                             IsOverrideOrExplicitImpl = false
                             IsFinal = false
                             GetterOrSetterIsCompilerGenerated = false
-                            MemberKind = PropertyGet },
-                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (50,8--52,28),
+                            MemberKind = PropertyGet }, (50,8--52,28),
                           { GetSetKeywords = None });
                        Member
                          (SynValSig
@@ -600,30 +422,21 @@ SigFile
                                      Paren
                                        (Const
                                           (String
-                                             ("Length2", Regular,
-                                              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,23--53,32)),
-                                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,23--53,32)),
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,22--53,23),
-                                        Some
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,32--53,33),
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,22--53,33))
+                                             ("Length2", Regular, (53,23--53,32)),
+                                           (53,23--53,32)), (53,22--53,23),
+                                        Some (53,32--53,33), (53,22--53,33))
                                     Target = None
                                     AppliesToGetterAndSetter = false
-                                    Range =
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,10--53,33) }]
-                                Range =
-                                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,8--53,35) }],
+                                    Range = (53,10--53,33) }]
+                                Range = (53,8--53,35) }],
                              SynIdent (Length2, None),
                              SynValTyparDecls (None, true),
                              LongIdent (SynLongIdent ([int], [], [None])),
                              SynValInfo ([], SynArgInfo ([], false, None)),
                              false, false,
                              PreXmlDoc ((53,8), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, None,
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,8--55,28),
-                             { LeadingKeyword =
-                                Member
-                                  /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (55,8--55,14)
+                             None, None, (53,8--55,28),
+                             { LeadingKeyword = Member (55,8--55,14)
                                InlineKeyword = None
                                WithKeyword = None
                                EqualsRange = None }),
@@ -632,8 +445,7 @@ SigFile
                             IsOverrideOrExplicitImpl = false
                             IsFinal = false
                             GetterOrSetterIsCompilerGenerated = false
-                            MemberKind = PropertyGet },
-                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (53,8--55,28),
+                            MemberKind = PropertyGet }, (53,8--55,28),
                           { GetSetKeywords = None });
                        Member
                          (SynValSig
@@ -644,30 +456,20 @@ SigFile
                                      Paren
                                        (Const
                                           (String
-                                             ("Base1", Regular,
-                                              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,23--56,30)),
-                                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,23--56,30)),
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,22--56,23),
-                                        Some
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,30--56,31),
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,22--56,31))
+                                             ("Base1", Regular, (56,23--56,30)),
+                                           (56,23--56,30)), (56,22--56,23),
+                                        Some (56,30--56,31), (56,22--56,31))
                                     Target = None
                                     AppliesToGetterAndSetter = false
-                                    Range =
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,10--56,31) }]
-                                Range =
-                                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,8--56,33) }],
-                             SynIdent (Base1, None),
+                                    Range = (56,10--56,31) }]
+                                Range = (56,8--56,33) }], SynIdent (Base1, None),
                              SynValTyparDecls (None, true),
                              LongIdent (SynLongIdent ([int], [], [None])),
                              SynValInfo ([], SynArgInfo ([], false, None)),
                              false, false,
                              PreXmlDoc ((56,8), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, None,
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,8--58,26),
-                             { LeadingKeyword =
-                                Member
-                                  /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (58,8--58,14)
+                             None, None, (56,8--58,26),
+                             { LeadingKeyword = Member (58,8--58,14)
                                InlineKeyword = None
                                WithKeyword = None
                                EqualsRange = None }),
@@ -676,8 +478,7 @@ SigFile
                             IsOverrideOrExplicitImpl = false
                             IsFinal = false
                             GetterOrSetterIsCompilerGenerated = false
-                            MemberKind = PropertyGet },
-                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (56,8--58,26),
+                            MemberKind = PropertyGet }, (56,8--58,26),
                           { GetSetKeywords = None });
                        Member
                          (SynValSig
@@ -688,30 +489,20 @@ SigFile
                                      Paren
                                        (Const
                                           (String
-                                             ("Base2", Regular,
-                                              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,23--59,30)),
-                                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,23--59,30)),
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,22--59,23),
-                                        Some
-                                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,30--59,31),
-                                        /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,22--59,31))
+                                             ("Base2", Regular, (59,23--59,30)),
+                                           (59,23--59,30)), (59,22--59,23),
+                                        Some (59,30--59,31), (59,22--59,31))
                                     Target = None
                                     AppliesToGetterAndSetter = false
-                                    Range =
-                                     /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,10--59,31) }]
-                                Range =
-                                 /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,8--59,33) }],
-                             SynIdent (Base2, None),
+                                    Range = (59,10--59,31) }]
+                                Range = (59,8--59,33) }], SynIdent (Base2, None),
                              SynValTyparDecls (None, true),
                              LongIdent (SynLongIdent ([int], [], [None])),
                              SynValInfo ([], SynArgInfo ([], false, None)),
                              false, false,
                              PreXmlDoc ((59,8), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, None,
-                             /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,8--61,26),
-                             { LeadingKeyword =
-                                Member
-                                  /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (61,8--61,14)
+                             None, None, (59,8--61,26),
+                             { LeadingKeyword = Member (61,8--61,14)
                                InlineKeyword = None
                                WithKeyword = None
                                EqualsRange = None }),
@@ -720,38 +511,16 @@ SigFile
                             IsOverrideOrExplicitImpl = false
                             IsFinal = false
                             GetterOrSetterIsCompilerGenerated = false
-                            MemberKind = PropertyGet },
-                          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (59,8--61,26),
-                          { GetSetKeywords = None })],
-                      /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (49,9--61,26),
-                      { LeadingKeyword =
-                         Type
-                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (49,4--49,8)
+                            MemberKind = PropertyGet }, (59,8--61,26),
+                          { GetSetKeywords = None })], (49,9--61,26),
+                      { LeadingKeyword = Type (49,4--49,8)
                         EqualsRange = None
-                        WithKeyword =
-                         Some
-                           /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (49,21--49,25) })],
-                  /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (49,4--61,26))],
-              /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (45,0--61,26),
-              { ModuleKeyword =
-                 Some
-                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (47,0--47,6)
-                EqualsRange =
-                 Some
-                   /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (47,17--47,18) })],
-          PreXmlDocEmpty, [], None,
-          /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (2,0--61,26),
-          { LeadingKeyword =
-             Namespace
-               /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (2,0--2,9) })],
+                        WithKeyword = Some (49,21--49,25) })], (49,4--61,26))],
+              (45,0--61,26), { ModuleKeyword = Some (47,0--47,6)
+                               EqualsRange = Some (47,17--47,18) })],
+          PreXmlDocEmpty, [], None, (2,0--61,26),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments =
-         [LineComment
-            /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (51,8--51,82);
-          LineComment
-            /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (54,8--54,84);
-          LineComment
-            /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (57,8--57,88);
-          LineComment
-            /root/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi (60,8--60,89)] },
-      set []))
+         [LineComment (51,8--51,82); LineComment (54,8--54,84);
+          LineComment (57,8--57,88); LineComment (60,8--60,89)] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/ActivePatternAsFunction.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/ActivePatternAsFunction.fs.bsl
@@ -11,19 +11,9 @@ ImplFile
                    (false,
                     SynLongIdent
                       ([|Odd|Even|], [],
-                       [Some
-                          (HasParenthesis
-                             (/root/OperatorName/ActivePatternAsFunction.fs (2,0--2,1),
-                              /root/OperatorName/ActivePatternAsFunction.fs (2,11--2,12)))]),
-                    None,
-                    /root/OperatorName/ActivePatternAsFunction.fs (2,0--2,12)),
-                 Const
-                   (Int32 4,
-                    /root/OperatorName/ActivePatternAsFunction.fs (2,13--2,14)),
-                 /root/OperatorName/ActivePatternAsFunction.fs (2,0--2,14)),
-              /root/OperatorName/ActivePatternAsFunction.fs (2,0--2,14))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/ActivePatternAsFunction.fs (2,0--2,14),
+                       [Some (HasParenthesis ((2,0--2,1), (2,11--2,12)))]), None,
+                    (2,0--2,12)), Const (Int32 4, (2,13--2,14)), (2,0--2,14)),
+              (2,0--2,14))], PreXmlDocEmpty, [], None, (2,0--2,14),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/ActivePatternDefinition.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/ActivePatternDefinition.fs.bsl
@@ -17,22 +17,15 @@ ImplFile
                   LongIdent
                     (SynLongIdent
                        ([|Odd|Even|], [],
-                        [Some
-                           (HasParenthesis
-                              (/root/OperatorName/ActivePatternDefinition.fs (2,4--2,5),
-                               /root/OperatorName/ActivePatternDefinition.fs (2,15--2,16)))]),
+                        [Some (HasParenthesis ((2,4--2,5), (2,15--2,16)))]),
                      None, None,
                      Pats
                        [Paren
                           (Typed
                              (Named
-                                (SynIdent (a, None), false, None,
-                                 /root/OperatorName/ActivePatternDefinition.fs (2,18--2,19)),
+                                (SynIdent (a, None), false, None, (2,18--2,19)),
                               LongIdent (SynLongIdent ([int], [], [None])),
-                              /root/OperatorName/ActivePatternDefinition.fs (2,18--2,24)),
-                           /root/OperatorName/ActivePatternDefinition.fs (2,17--2,25))],
-                     None,
-                     /root/OperatorName/ActivePatternDefinition.fs (2,4--2,25)),
+                              (2,18--2,24)), (2,17--2,25))], None, (2,4--2,25)),
                   None,
                   IfThenElse
                     (App
@@ -44,7 +37,7 @@ ImplFile
                               SynLongIdent
                                 ([op_Equality], [],
                                  [Some (OriginalNotation "=")]), None,
-                              /root/OperatorName/ActivePatternDefinition.fs (2,37--2,38)),
+                              (2,37--2,38)),
                            App
                              (NonAtomic, false,
                               App
@@ -54,45 +47,19 @@ ImplFile
                                     SynLongIdent
                                       ([op_Modulus], [],
                                        [Some (OriginalNotation "%")]), None,
-                                    /root/OperatorName/ActivePatternDefinition.fs (2,33--2,34)),
-                                 Ident a,
-                                 /root/OperatorName/ActivePatternDefinition.fs (2,31--2,34)),
-                              Const
-                                (Int32 2,
-                                 /root/OperatorName/ActivePatternDefinition.fs (2,35--2,36)),
-                              /root/OperatorName/ActivePatternDefinition.fs (2,31--2,36)),
-                           /root/OperatorName/ActivePatternDefinition.fs (2,31--2,38)),
-                        Const
-                          (Int32 0,
-                           /root/OperatorName/ActivePatternDefinition.fs (2,39--2,40)),
-                        /root/OperatorName/ActivePatternDefinition.fs (2,31--2,40)),
-                     Ident Even, Some (Ident Odd),
-                     Yes
-                       /root/OperatorName/ActivePatternDefinition.fs (2,28--2,45),
-                     false,
-                     /root/OperatorName/ActivePatternDefinition.fs (2,28--2,59),
-                     { IfKeyword =
-                        /root/OperatorName/ActivePatternDefinition.fs (2,28--2,30)
+                                    (2,33--2,34)), Ident a, (2,31--2,34)),
+                              Const (Int32 2, (2,35--2,36)), (2,31--2,36)),
+                           (2,31--2,38)), Const (Int32 0, (2,39--2,40)),
+                        (2,31--2,40)), Ident Even, Some (Ident Odd),
+                     Yes (2,28--2,45), false, (2,28--2,59),
+                     { IfKeyword = (2,28--2,30)
                        IsElif = false
-                       ThenKeyword =
-                        /root/OperatorName/ActivePatternDefinition.fs (2,41--2,45)
-                       ElseKeyword =
-                        Some
-                          /root/OperatorName/ActivePatternDefinition.fs (2,51--2,55)
-                       IfToThenRange =
-                        /root/OperatorName/ActivePatternDefinition.fs (2,28--2,45) }),
-                  /root/OperatorName/ActivePatternDefinition.fs (2,4--2,25),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/OperatorName/ActivePatternDefinition.fs (2,0--2,3)
+                       ThenKeyword = (2,41--2,45)
+                       ElseKeyword = Some (2,51--2,55)
+                       IfToThenRange = (2,28--2,45) }), (2,4--2,25), NoneAtLet,
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/OperatorName/ActivePatternDefinition.fs (2,26--2,27) })],
-              /root/OperatorName/ActivePatternDefinition.fs (2,0--2,59))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/ActivePatternDefinition.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,26--2,27) })], (2,0--2,59))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/ActivePatternIdentifierInPrivateMember.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/ActivePatternIdentifierInPrivateMember.fs.bsl
@@ -9,19 +9,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [A],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],
@@ -38,62 +32,31 @@ ImplFile
                                   SynArgInfo ([], false, None)), None),
                             LongIdent
                               (SynLongIdent
-                                 ([_; |A'|],
-                                  [/root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (3,20--3,21)],
+                                 ([_; |A'|], [(3,20--3,21)],
                                   [None;
                                    Some
-                                     (HasParenthesis
-                                        (/root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (3,21--3,22),
-                                         /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (5,5--5,6)))]),
-                               None, None, Pats [],
-                               Some
-                                 (Private
-                                    /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (3,11--3,18)),
-                               /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (3,11--5,6)),
-                            None,
+                                     (HasParenthesis ((3,21--3,22), (5,5--5,6)))]),
+                               None, None, Pats [], Some (Private (3,11--3,18)),
+                               (3,11--5,6)), None,
                             LongIdent
                               (false,
                                SynLongIdent
                                  ([|Lazy|], [],
                                   [Some
-                                     (HasParenthesis
-                                        (/root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (5,9--5,10),
-                                         /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (7,5--7,6)))]),
-                               None,
-                               /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (5,9--7,6)),
-                            /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (3,11--5,6),
-                            NoneAtInvisible,
-                            { LeadingKeyword =
-                               Member
-                                 /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (3,4--3,10)
+                                     (HasParenthesis ((5,9--5,10), (7,5--7,6)))]),
+                               None, (5,9--7,6)), (3,11--5,6), NoneAtInvisible,
+                            { LeadingKeyword = Member (3,4--3,10)
                               InlineKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (5,7--5,8) }),
-                         /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (3,4--7,6))],
-                     /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (3,4--7,6)),
-                  [],
+                              EqualsRange = Some (5,7--5,8) }), (3,4--7,6))],
+                     (3,4--7,6)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,5--7,6),
-                  { LeadingKeyword =
-                     Type
-                       /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,0--7,6))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/ActivePatternIdentifierInPrivateMember.fs (2,0--8,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--7,6),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--7,6))], PreXmlDocEmpty, [],
+          None, (2,0--8,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/CustomOperatorDefinition.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/CustomOperatorDefinition.fs.bsl
@@ -20,20 +20,11 @@ ImplFile
                        ([op_Addition], [],
                         [Some
                            (OriginalNotationWithParen
-                              (/root/OperatorName/CustomOperatorDefinition.fs (2,4--2,5),
-                               "+",
-                               /root/OperatorName/CustomOperatorDefinition.fs (2,6--2,7)))]),
-                     None, None,
+                              ((2,4--2,5), "+", (2,6--2,7)))]), None, None,
                      Pats
-                       [Named
-                          (SynIdent (a, None), false, None,
-                           /root/OperatorName/CustomOperatorDefinition.fs (2,8--2,9));
-                        Named
-                          (SynIdent (b, None), false, None,
-                           /root/OperatorName/CustomOperatorDefinition.fs (2,10--2,11))],
-                     None,
-                     /root/OperatorName/CustomOperatorDefinition.fs (2,4--2,11)),
-                  None,
+                       [Named (SynIdent (a, None), false, None, (2,8--2,9));
+                        Named (SynIdent (b, None), false, None, (2,10--2,11))],
+                     None, (2,4--2,11)), None,
                   App
                     (NonAtomic, false,
                      App
@@ -42,24 +33,11 @@ ImplFile
                           (false,
                            SynLongIdent
                              ([op_Addition], [], [Some (OriginalNotation "+")]),
-                           None,
-                           /root/OperatorName/CustomOperatorDefinition.fs (2,16--2,17)),
-                        Ident a,
-                        /root/OperatorName/CustomOperatorDefinition.fs (2,14--2,17)),
-                     Ident b,
-                     /root/OperatorName/CustomOperatorDefinition.fs (2,14--2,19)),
-                  /root/OperatorName/CustomOperatorDefinition.fs (2,4--2,11),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/OperatorName/CustomOperatorDefinition.fs (2,0--2,3)
+                           None, (2,16--2,17)), Ident a, (2,14--2,17)), Ident b,
+                     (2,14--2,19)), (2,4--2,11), NoneAtLet,
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/OperatorName/CustomOperatorDefinition.fs (2,12--2,13) })],
-              /root/OperatorName/CustomOperatorDefinition.fs (2,0--2,19))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/CustomOperatorDefinition.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,12--2,13) })], (2,0--2,19))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/DetectDifferenceBetweenCompiledOperators.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/DetectDifferenceBetweenCompiledOperators.fs.bsl
@@ -15,27 +15,14 @@ ImplFile
                          ([op_Addition], [],
                           [Some
                              (OriginalNotationWithParen
-                                (/root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (2,0--2,1),
-                                 "+",
-                                 /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (2,2--2,3)))]),
-                       None,
-                       /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (2,0--2,3)),
-                    Ident a,
-                    /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (2,0--2,5)),
-                 Ident b,
-                 /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (2,0--2,7)),
-              /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (2,0--2,7));
+                                ((2,0--2,1), "+", (2,2--2,3)))]), None,
+                       (2,0--2,3)), Ident a, (2,0--2,5)), Ident b, (2,0--2,7)),
+              (2,0--2,7));
            Expr
              (App
                 (NonAtomic, false,
-                 App
-                   (NonAtomic, false, Ident op_Addition, Ident a,
-                    /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (3,0--3,13)),
-                 Ident b,
-                 /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (3,0--3,15)),
-              /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (3,0--3,15))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/DetectDifferenceBetweenCompiledOperators.fs (2,0--3,15),
-          { LeadingKeyword = None })], (true, false),
+                 App (NonAtomic, false, Ident op_Addition, Ident a, (3,0--3,13)),
+                 Ident b, (3,0--3,15)), (3,0--3,15))], PreXmlDocEmpty, [], None,
+          (2,0--3,15), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/InfixOperation.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/InfixOperation.fs.bsl
@@ -13,15 +13,9 @@ ImplFile
                       (false,
                        SynLongIdent
                          ([op_Addition], [], [Some (OriginalNotation "+")]),
-                       None, /root/OperatorName/InfixOperation.fs (2,2--2,3)),
-                    Const
-                      (Int32 1, /root/OperatorName/InfixOperation.fs (2,0--2,1)),
-                    /root/OperatorName/InfixOperation.fs (2,0--2,3)),
-                 Const
-                   (Int32 1, /root/OperatorName/InfixOperation.fs (2,4--2,5)),
-                 /root/OperatorName/InfixOperation.fs (2,0--2,5)),
-              /root/OperatorName/InfixOperation.fs (2,0--2,5))], PreXmlDocEmpty,
-          [], None, /root/OperatorName/InfixOperation.fs (2,0--2,5),
+                       None, (2,2--2,3)), Const (Int32 1, (2,0--2,1)),
+                    (2,0--2,3)), Const (Int32 1, (2,4--2,5)), (2,0--2,5)),
+              (2,0--2,5))], PreXmlDocEmpty, [], None, (2,0--2,5),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/NamedParameter.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/NamedParameter.fs.bsl
@@ -16,20 +16,9 @@ ImplFile
                             (false,
                              SynLongIdent
                                ([op_Equality], [], [Some (OriginalNotation "=")]),
-                             None,
-                             /root/OperatorName/NamedParameter.fs (2,3--2,4)),
-                          Ident x,
-                          /root/OperatorName/NamedParameter.fs (2,2--2,4)),
-                       Const
-                         (Int32 4,
-                          /root/OperatorName/NamedParameter.fs (2,4--2,5)),
-                       /root/OperatorName/NamedParameter.fs (2,2--2,5)),
-                    /root/OperatorName/NamedParameter.fs (2,1--2,2),
-                    Some /root/OperatorName/NamedParameter.fs (2,5--2,6),
-                    /root/OperatorName/NamedParameter.fs (2,1--2,6)),
-                 /root/OperatorName/NamedParameter.fs (2,0--2,6)),
-              /root/OperatorName/NamedParameter.fs (2,0--2,6))], PreXmlDocEmpty,
-          [], None, /root/OperatorName/NamedParameter.fs (2,0--2,6),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                             None, (2,3--2,4)), Ident x, (2,2--2,4)),
+                       Const (Int32 4, (2,4--2,5)), (2,2--2,5)), (2,1--2,2),
+                    Some (2,5--2,6), (2,1--2,6)), (2,0--2,6)), (2,0--2,6))],
+          PreXmlDocEmpty, [], None, (2,0--2,6), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/NameofOperator.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/NameofOperator.fs.bsl
@@ -13,13 +13,8 @@ ImplFile
                       ([op_Addition], [],
                        [Some
                           (OriginalNotationWithParen
-                             (/root/OperatorName/NameofOperator.fs (2,6--2,7),
-                              "+",
-                              /root/OperatorName/NameofOperator.fs (2,8--2,9)))]),
-                    None, /root/OperatorName/NameofOperator.fs (2,6--2,9)),
-                 /root/OperatorName/NameofOperator.fs (2,0--2,9)),
-              /root/OperatorName/NameofOperator.fs (2,0--2,9))], PreXmlDocEmpty,
-          [], None, /root/OperatorName/NameofOperator.fs (2,0--2,9),
+                             ((2,6--2,7), "+", (2,8--2,9)))]), None, (2,6--2,9)),
+                 (2,0--2,9)), (2,0--2,9))], PreXmlDocEmpty, [], None, (2,0--2,9),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/ObjectModelWithTwoMembers.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/ObjectModelWithTwoMembers.fs.bsl
@@ -9,19 +9,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/OperatorName/ObjectModelWithTwoMembers.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/OperatorName/ObjectModelWithTwoMembers.fs (2,6--2,8)),
-                         None,
+                        (None, [], SimplePats ([], (2,6--2,8)), None,
                          PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/OperatorName/ObjectModelWithTwoMembers.fs (2,5--2,6),
-                         { AsKeyword = None });
+                         (2,5--2,6), { AsKeyword = None });
                       LetBindings
                         ([SynBinding
                             (None, Normal, false, true, [],
@@ -32,23 +26,13 @@ ImplFile
                                 None),
                              Named
                                (SynIdent (allowInto, None), false, None,
-                                /root/OperatorName/ObjectModelWithTwoMembers.fs (3,16--3,25)),
-                             None,
-                             Const
-                               (Int32 0,
-                                /root/OperatorName/ObjectModelWithTwoMembers.fs (3,28--3,29)),
-                             /root/OperatorName/ObjectModelWithTwoMembers.fs (3,16--3,25),
-                             Yes
-                               /root/OperatorName/ObjectModelWithTwoMembers.fs (3,4--3,29),
-                             { LeadingKeyword =
-                                Let
-                                  /root/OperatorName/ObjectModelWithTwoMembers.fs (3,4--3,7)
+                                (3,16--3,25)), None,
+                             Const (Int32 0, (3,28--3,29)), (3,16--3,25),
+                             Yes (3,4--3,29),
+                             { LeadingKeyword = Let (3,4--3,7)
                                InlineKeyword = None
-                               EqualsRange =
-                                Some
-                                  /root/OperatorName/ObjectModelWithTwoMembers.fs (3,26--3,27) })],
-                         false, false,
-                         /root/OperatorName/ObjectModelWithTwoMembers.fs (3,4--3,29));
+                               EqualsRange = Some (3,26--3,27) })], false, false,
+                         (3,4--3,29));
                       GetSetMember
                         (Some
                            (SynBinding
@@ -68,27 +52,16 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([_; AllowIntoPattern],
-                                     [/root/OperatorName/ObjectModelWithTwoMembers.fs (4,12--4,13)],
+                                    ([_; AllowIntoPattern], [(4,12--4,13)],
                                      [None; None]), Some get, None,
                                   Pats
                                     [Paren
-                                       (Const
-                                          (Unit,
-                                           /root/OperatorName/ObjectModelWithTwoMembers.fs (4,38--4,40)),
-                                        /root/OperatorName/ObjectModelWithTwoMembers.fs (4,38--4,40))],
-                                  None,
-                                  /root/OperatorName/ObjectModelWithTwoMembers.fs (4,35--4,40)),
-                               None, Ident allowInto,
-                               /root/OperatorName/ObjectModelWithTwoMembers.fs (4,35--4,40),
-                               NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/OperatorName/ObjectModelWithTwoMembers.fs (4,4--4,10)
+                                       (Const (Unit, (4,38--4,40)), (4,38--4,40))],
+                                  None, (4,35--4,40)), None, Ident allowInto,
+                               (4,35--4,40), NoneAtInvisible,
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/OperatorName/ObjectModelWithTwoMembers.fs (4,41--4,42) })),
+                                 EqualsRange = Some (4,41--4,42) })),
                          Some
                            (SynBinding
                               (None, Normal, false, false, [],
@@ -108,65 +81,34 @@ ImplFile
                                      SynArgInfo ([], false, None)), None),
                                LongIdent
                                  (SynLongIdent
-                                    ([_; AllowIntoPattern],
-                                     [/root/OperatorName/ObjectModelWithTwoMembers.fs (4,12--4,13)],
+                                    ([_; AllowIntoPattern], [(4,12--4,13)],
                                      [None; None]), Some set, None,
                                   Pats
                                     [Named
                                        (SynIdent (v, None), false, None,
-                                        /root/OperatorName/ObjectModelWithTwoMembers.fs (4,61--4,62))],
-                                  None,
-                                  /root/OperatorName/ObjectModelWithTwoMembers.fs (4,57--4,62)),
+                                        (4,61--4,62))], None, (4,57--4,62)),
                                None,
                                LongIdentSet
                                  (SynLongIdent ([allowInto], [], [None]),
-                                  Ident v,
-                                  /root/OperatorName/ObjectModelWithTwoMembers.fs (4,65--4,79)),
-                               /root/OperatorName/ObjectModelWithTwoMembers.fs (4,57--4,62),
+                                  Ident v, (4,65--4,79)), (4,57--4,62),
                                NoneAtInvisible,
-                               { LeadingKeyword =
-                                  Member
-                                    /root/OperatorName/ObjectModelWithTwoMembers.fs (4,4--4,10)
+                               { LeadingKeyword = Member (4,4--4,10)
                                  InlineKeyword = None
-                                 EqualsRange =
-                                  Some
-                                    /root/OperatorName/ObjectModelWithTwoMembers.fs (4,63--4,64) })),
-                         /root/OperatorName/ObjectModelWithTwoMembers.fs (4,4--4,79),
-                         { InlineKeyword = None
-                           WithKeyword =
-                            /root/OperatorName/ObjectModelWithTwoMembers.fs (4,30--4,34)
-                           GetKeyword =
-                            Some
-                              /root/OperatorName/ObjectModelWithTwoMembers.fs (4,35--4,38)
-                           AndKeyword =
-                            Some
-                              /root/OperatorName/ObjectModelWithTwoMembers.fs (4,53--4,56)
-                           SetKeyword =
-                            Some
-                              /root/OperatorName/ObjectModelWithTwoMembers.fs (4,57--4,60) })],
-                     /root/OperatorName/ObjectModelWithTwoMembers.fs (3,4--4,79)),
-                  [],
+                                 EqualsRange = Some (4,63--4,64) })),
+                         (4,4--4,79), { InlineKeyword = None
+                                        WithKeyword = (4,30--4,34)
+                                        GetKeyword = Some (4,35--4,38)
+                                        AndKeyword = Some (4,53--4,56)
+                                        SetKeyword = Some (4,57--4,60) })],
+                     (3,4--4,79)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/OperatorName/ObjectModelWithTwoMembers.fs (2,6--2,8)),
-                        None,
+                       (None, [], SimplePats ([], (2,6--2,8)), None,
                         PreXmlDoc ((2,6), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/OperatorName/ObjectModelWithTwoMembers.fs (2,5--2,6),
-                        { AsKeyword = None })),
-                  /root/OperatorName/ObjectModelWithTwoMembers.fs (2,5--4,79),
-                  { LeadingKeyword =
-                     Type
-                       /root/OperatorName/ObjectModelWithTwoMembers.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/OperatorName/ObjectModelWithTwoMembers.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/OperatorName/ObjectModelWithTwoMembers.fs (2,0--4,79))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/ObjectModelWithTwoMembers.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,6), { AsKeyword = None })), (2,5--4,79),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--4,79))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/OperatorAsFunction.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/OperatorAsFunction.fs.bsl
@@ -15,20 +15,9 @@ ImplFile
                          ([op_Addition], [],
                           [Some
                              (OriginalNotationWithParen
-                                (/root/OperatorName/OperatorAsFunction.fs (2,0--2,1),
-                                 "+",
-                                 /root/OperatorName/OperatorAsFunction.fs (2,2--2,3)))]),
-                       None, /root/OperatorName/OperatorAsFunction.fs (2,0--2,3)),
-                    Const
-                      (Int32 3,
-                       /root/OperatorName/OperatorAsFunction.fs (2,4--2,5)),
-                    /root/OperatorName/OperatorAsFunction.fs (2,0--2,5)),
-                 Const
-                   (Int32 4, /root/OperatorName/OperatorAsFunction.fs (2,6--2,7)),
-                 /root/OperatorName/OperatorAsFunction.fs (2,0--2,7)),
-              /root/OperatorName/OperatorAsFunction.fs (2,0--2,7))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/OperatorAsFunction.fs (2,0--2,7),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                ((2,0--2,1), "+", (2,2--2,3)))]), None,
+                       (2,0--2,3)), Const (Int32 3, (2,4--2,5)), (2,0--2,5)),
+                 Const (Int32 4, (2,6--2,7)), (2,0--2,7)), (2,0--2,7))],
+          PreXmlDocEmpty, [], None, (2,0--2,7), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/OperatorInMemberDefinition.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/OperatorInMemberDefinition.fs.bsl
@@ -9,13 +9,8 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/OperatorName/OperatorInMemberDefinition.fs (2,5--2,6)),
-                  ObjectModel
-                    (Augmentation
-                       /root/OperatorName/OperatorInMemberDefinition.fs (2,7--2,11),
-                     [],
-                     /root/OperatorName/OperatorInMemberDefinition.fs (2,5--3,28)),
+                     false, None, (2,5--2,6)),
+                  ObjectModel (Augmentation (2,7--2,11), [], (2,5--3,28)),
                   [Member
                      (SynBinding
                         (None, Normal, false, false, [],
@@ -34,25 +29,18 @@ ImplFile
                                SynArgInfo ([], false, None)), None),
                          LongIdent
                            (SynLongIdent
-                              ([_; op_Addition],
-                               [/root/OperatorName/OperatorInMemberDefinition.fs (3,12--3,13)],
+                              ([_; op_Addition], [(3,12--3,13)],
                                [None;
                                 Some
                                   (OriginalNotationWithParen
-                                     (/root/OperatorName/OperatorInMemberDefinition.fs (3,13--3,14),
-                                      "+",
-                                      /root/OperatorName/OperatorInMemberDefinition.fs (3,15--3,16)))]),
-                            None, None,
+                                     ((3,13--3,14), "+", (3,15--3,16)))]), None,
+                            None,
                             Pats
                               [Named
-                                 (SynIdent (a, None), false, None,
-                                  /root/OperatorName/OperatorInMemberDefinition.fs (3,17--3,18));
+                                 (SynIdent (a, None), false, None, (3,17--3,18));
                                Named
-                                 (SynIdent (b, None), false, None,
-                                  /root/OperatorName/OperatorInMemberDefinition.fs (3,19--3,20))],
-                            None,
-                            /root/OperatorName/OperatorInMemberDefinition.fs (3,11--3,20)),
-                         None,
+                                 (SynIdent (b, None), false, None, (3,19--3,20))],
+                            None, (3,11--3,20)), None,
                          App
                            (NonAtomic, false,
                             App
@@ -62,31 +50,14 @@ ImplFile
                                   SynLongIdent
                                     ([op_Addition], [],
                                      [Some (OriginalNotation "+")]), None,
-                                  /root/OperatorName/OperatorInMemberDefinition.fs (3,25--3,26)),
-                               Ident a,
-                               /root/OperatorName/OperatorInMemberDefinition.fs (3,23--3,26)),
-                            Ident b,
-                            /root/OperatorName/OperatorInMemberDefinition.fs (3,23--3,28)),
-                         /root/OperatorName/OperatorInMemberDefinition.fs (3,11--3,20),
-                         NoneAtInvisible,
-                         { LeadingKeyword =
-                            Member
-                              /root/OperatorName/OperatorInMemberDefinition.fs (3,4--3,10)
+                                  (3,25--3,26)), Ident a, (3,23--3,26)), Ident b,
+                            (3,23--3,28)), (3,11--3,20), NoneAtInvisible,
+                         { LeadingKeyword = Member (3,4--3,10)
                            InlineKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/OperatorName/OperatorInMemberDefinition.fs (3,21--3,22) }),
-                      /root/OperatorName/OperatorInMemberDefinition.fs (3,4--3,28))],
-                  None,
-                  /root/OperatorName/OperatorInMemberDefinition.fs (2,5--3,28),
-                  { LeadingKeyword =
-                     Type
-                       /root/OperatorName/OperatorInMemberDefinition.fs (2,0--2,4)
-                    EqualsRange = None
-                    WithKeyword = None })],
-              /root/OperatorName/OperatorInMemberDefinition.fs (2,0--3,28))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/OperatorInMemberDefinition.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           EqualsRange = Some (3,21--3,22) }), (3,4--3,28))],
+                  None, (2,5--3,28), { LeadingKeyword = Type (2,0--2,4)
+                                       EqualsRange = None
+                                       WithKeyword = None })], (2,0--3,28))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/OperatorNameInSynValSig.fsi.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/OperatorNameInSynValSig.fsi.bsl
@@ -10,45 +10,31 @@ SigFile
                  SynIdent
                    (op_Amp,
                     Some
-                      (OriginalNotationWithParen
-                         (/root/OperatorName/OperatorNameInSynValSig.fsi (3,4--3,5),
-                          "&",
-                          /root/OperatorName/OperatorNameInSynValSig.fsi (3,6--3,7)))),
+                      (OriginalNotationWithParen ((3,4--3,5), "&", (3,6--3,7)))),
                  SynValTyparDecls (None, true),
                  Fun
                    (SignatureParameter
                       ([], false, Some e1,
                        LongIdent (SynLongIdent ([bool], [], [None])),
-                       /root/OperatorName/OperatorNameInSynValSig.fsi (3,9--3,17)),
+                       (3,9--3,17)),
                     Fun
                       (SignatureParameter
                          ([], false, Some e2,
                           LongIdent (SynLongIdent ([bool], [], [None])),
-                          /root/OperatorName/OperatorNameInSynValSig.fsi (3,21--3,29)),
+                          (3,21--3,29)),
                        LongIdent (SynLongIdent ([bool], [], [None])),
-                       /root/OperatorName/OperatorNameInSynValSig.fsi (3,21--3,37),
-                       { ArrowRange =
-                          /root/OperatorName/OperatorNameInSynValSig.fsi (3,30--3,32) }),
-                    /root/OperatorName/OperatorNameInSynValSig.fsi (3,9--3,37),
-                    { ArrowRange =
-                       /root/OperatorName/OperatorNameInSynValSig.fsi (3,18--3,20) }),
+                       (3,21--3,37), { ArrowRange = (3,30--3,32) }), (3,9--3,37),
+                    { ArrowRange = (3,18--3,20) }),
                  SynValInfo
                    ([[SynArgInfo ([], false, Some e1)];
                      [SynArgInfo ([], false, Some e2)]],
                     SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None,
-                 /root/OperatorName/OperatorNameInSynValSig.fsi (3,0--3,37),
-                 { LeadingKeyword =
-                    Val
-                      /root/OperatorName/OperatorNameInSynValSig.fsi (3,0--3,3)
-                   InlineKeyword = None
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/OperatorName/OperatorNameInSynValSig.fsi (3,0--3,37))],
+                 None, (3,0--3,37), { LeadingKeyword = Val (3,0--3,3)
+                                      InlineKeyword = None
+                                      WithKeyword = None
+                                      EqualsRange = None }), (3,0--3,37))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/OperatorName/OperatorNameInSynValSig.fsi (2,0--3,37),
-          { LeadingKeyword =
-             Module /root/OperatorName/OperatorNameInSynValSig.fsi (2,0--2,6) })],
+          (2,0--3,37), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/OperatorNameInValConstraint.fsi.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/OperatorNameInValConstraint.fsi.bsl
@@ -11,28 +11,18 @@ SigFile
                    (op_UnaryNegation,
                     Some
                       (OriginalNotationWithParen
-                         (/root/OperatorName/OperatorNameInValConstraint.fsi (12,15--12,16),
-                          "~-",
-                          /root/OperatorName/OperatorNameInValConstraint.fsi (12,18--12,19)))),
+                         ((12,15--12,16), "~-", (12,18--12,19)))),
                  SynValTyparDecls (None, true),
                  WithGlobalConstraints
                    (Fun
                       (SignatureParameter
                          ([], false, Some n,
-                          Var
-                            (SynTypar (T, HeadType, false),
-                             /root/OperatorName/OperatorNameInValConstraint.fsi (12,24--12,26)),
-                          /root/OperatorName/OperatorNameInValConstraint.fsi (12,21--12,26)),
-                       Var
-                         (SynTypar (T, HeadType, false),
-                          /root/OperatorName/OperatorNameInValConstraint.fsi (12,30--12,32)),
-                       /root/OperatorName/OperatorNameInValConstraint.fsi (12,21--12,32),
-                       { ArrowRange =
-                          /root/OperatorName/OperatorNameInValConstraint.fsi (12,27--12,29) }),
+                          Var (SynTypar (T, HeadType, false), (12,24--12,26)),
+                          (12,21--12,26)),
+                       Var (SynTypar (T, HeadType, false), (12,30--12,32)),
+                       (12,21--12,32), { ArrowRange = (12,27--12,29) }),
                     [WhereTyparSupportsMember
-                       (Var
-                          (SynTypar (T, HeadType, false),
-                           /root/OperatorName/OperatorNameInValConstraint.fsi (12,38--12,40)),
+                       (Var (SynTypar (T, HeadType, false), (12,38--12,40)),
                         Member
                           (SynValSig
                              ([],
@@ -40,30 +30,23 @@ SigFile
                                 (op_UnaryNegation,
                                  Some
                                    (OriginalNotationWithParen
-                                      (/root/OperatorName/OperatorNameInValConstraint.fsi (12,57--12,58),
-                                       "~-",
-                                       /root/OperatorName/OperatorNameInValConstraint.fsi (12,62--12,63)))),
+                                      ((12,57--12,58), "~-", (12,62--12,63)))),
                               SynValTyparDecls (None, true),
                               Fun
                                 (Var
                                    (SynTypar (T, HeadType, false),
-                                    /root/OperatorName/OperatorNameInValConstraint.fsi (12,65--12,67)),
+                                    (12,65--12,67)),
                                  Var
                                    (SynTypar (T, HeadType, false),
-                                    /root/OperatorName/OperatorNameInValConstraint.fsi (12,71--12,73)),
-                                 /root/OperatorName/OperatorNameInValConstraint.fsi (12,65--12,73),
-                                 { ArrowRange =
-                                    /root/OperatorName/OperatorNameInValConstraint.fsi (12,68--12,70) }),
+                                    (12,71--12,73)), (12,65--12,73),
+                                 { ArrowRange = (12,68--12,70) }),
                               SynValInfo
                                 ([[SynArgInfo ([], false, None)]],
                                  SynArgInfo ([], false, None)), false, false,
                               PreXmlDoc ((12,43), FSharp.Compiler.Xml.XmlDocCollector),
-                              None, None,
-                              /root/OperatorName/OperatorNameInValConstraint.fsi (12,43--12,73),
+                              None, None, (12,43--12,73),
                               { LeadingKeyword =
-                                 StaticMember
-                                   (/root/OperatorName/OperatorNameInValConstraint.fsi (12,43--12,49),
-                                    /root/OperatorName/OperatorNameInValConstraint.fsi (12,50--12,56))
+                                 StaticMember ((12,43--12,49), (12,50--12,56))
                                 InlineKeyword = None
                                 WithKeyword = None
                                 EqualsRange = None }),
@@ -72,46 +55,27 @@ SigFile
                              IsOverrideOrExplicitImpl = false
                              IsFinal = false
                              GetterOrSetterIsCompilerGenerated = false
-                             MemberKind = Member },
-                           /root/OperatorName/OperatorNameInValConstraint.fsi (12,43--12,73),
-                           { GetSetKeywords = None }),
-                        /root/OperatorName/OperatorNameInValConstraint.fsi (12,38--12,74));
+                             MemberKind = Member }, (12,43--12,73),
+                           { GetSetKeywords = None }), (12,38--12,74));
                      WhereTyparDefaultsToType
                        (SynTypar (T, HeadType, false),
                         LongIdent (SynLongIdent ([int], [], [None])),
-                        /root/OperatorName/OperatorNameInValConstraint.fsi (12,79--12,94))],
-                    /root/OperatorName/OperatorNameInValConstraint.fsi (12,21--12,94)),
+                        (12,79--12,94))], (12,21--12,94)),
                  SynValInfo
                    ([[SynArgInfo ([], false, Some n)]],
                     SynArgInfo ([], false, None)), true, false,
                  PreXmlDoc ((12,4), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None,
-                 /root/OperatorName/OperatorNameInValConstraint.fsi (4,4--12,94),
-                 { LeadingKeyword =
-                    Val
-                      /root/OperatorName/OperatorNameInValConstraint.fsi (12,4--12,7)
-                   InlineKeyword =
-                    Some
-                      /root/OperatorName/OperatorNameInValConstraint.fsi (12,8--12,14)
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/OperatorName/OperatorNameInValConstraint.fsi (4,4--12,94))],
+                 None, (4,4--12,94), { LeadingKeyword = Val (12,4--12,7)
+                                       InlineKeyword = Some (12,8--12,14)
+                                       WithKeyword = None
+                                       EqualsRange = None }), (4,4--12,94))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-          [{ Attributes =
-              [{ TypeName = SynLongIdent ([AutoOpen], [], [None])
-                 ArgExpr =
-                  Const
-                    (Unit,
-                     /root/OperatorName/OperatorNameInValConstraint.fsi (2,2--2,10))
-                 Target = None
-                 AppliesToGetterAndSetter = false
-                 Range =
-                  /root/OperatorName/OperatorNameInValConstraint.fsi (2,2--2,10) }]
-             Range =
-              /root/OperatorName/OperatorNameInValConstraint.fsi (2,0--2,12) }],
-          None, /root/OperatorName/OperatorNameInValConstraint.fsi (2,0--12,94),
-          { LeadingKeyword =
-             Module
-               /root/OperatorName/OperatorNameInValConstraint.fsi (3,4--3,10) })],
+          [{ Attributes = [{ TypeName = SynLongIdent ([AutoOpen], [], [None])
+                             ArgExpr = Const (Unit, (2,2--2,10))
+                             Target = None
+                             AppliesToGetterAndSetter = false
+                             Range = (2,2--2,10) }]
+             Range = (2,0--2,12) }], None, (2,0--12,94),
+          { LeadingKeyword = Module (3,4--3,10) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/OptionalExpression.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/OptionalExpression.fs.bsl
@@ -16,23 +16,12 @@ ImplFile
                             (false,
                              SynLongIdent
                                ([op_Equality], [], [Some (OriginalNotation "=")]),
-                             None,
-                             /root/OperatorName/OptionalExpression.fs (2,5--2,6)),
+                             None, (2,5--2,6)),
                           LongIdent
                             (true, SynLongIdent ([x], [], [None]), None,
-                             /root/OperatorName/OptionalExpression.fs (2,3--2,4)),
-                          /root/OperatorName/OptionalExpression.fs (2,3--2,6)),
-                       Const
-                         (Int32 7,
-                          /root/OperatorName/OptionalExpression.fs (2,7--2,8)),
-                       /root/OperatorName/OptionalExpression.fs (2,3--2,8)),
-                    /root/OperatorName/OptionalExpression.fs (2,1--2,2),
-                    Some /root/OperatorName/OptionalExpression.fs (2,8--2,9),
-                    /root/OperatorName/OptionalExpression.fs (2,1--2,9)),
-                 /root/OperatorName/OptionalExpression.fs (2,0--2,9)),
-              /root/OperatorName/OptionalExpression.fs (2,0--2,9))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/OptionalExpression.fs (2,0--2,9),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                             (2,3--2,4)), (2,3--2,6)),
+                       Const (Int32 7, (2,7--2,8)), (2,3--2,8)), (2,1--2,2),
+                    Some (2,8--2,9), (2,1--2,9)), (2,0--2,9)), (2,0--2,9))],
+          PreXmlDocEmpty, [], None, (2,0--2,9), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/PartialActivePatternAsFunction.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/PartialActivePatternAsFunction.fs.bsl
@@ -11,19 +11,9 @@ ImplFile
                    (false,
                     SynLongIdent
                       ([|Odd|_|], [],
-                       [Some
-                          (HasParenthesis
-                             (/root/OperatorName/PartialActivePatternAsFunction.fs (2,0--2,1),
-                              /root/OperatorName/PartialActivePatternAsFunction.fs (2,8--2,9)))]),
-                    None,
-                    /root/OperatorName/PartialActivePatternAsFunction.fs (2,0--2,9)),
-                 Const
-                   (Int32 4,
-                    /root/OperatorName/PartialActivePatternAsFunction.fs (2,10--2,11)),
-                 /root/OperatorName/PartialActivePatternAsFunction.fs (2,0--2,11)),
-              /root/OperatorName/PartialActivePatternAsFunction.fs (2,0--2,11))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/PartialActivePatternAsFunction.fs (2,0--2,11),
+                       [Some (HasParenthesis ((2,0--2,1), (2,8--2,9)))]), None,
+                    (2,0--2,9)), Const (Int32 4, (2,10--2,11)), (2,0--2,11)),
+              (2,0--2,11))], PreXmlDocEmpty, [], None, (2,0--2,11),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/PartialActivePatternDefinition.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/PartialActivePatternDefinition.fs.bsl
@@ -17,77 +17,37 @@ ImplFile
                   LongIdent
                     (SynLongIdent
                        ([|Int32Const|_|], [],
-                        [Some
-                           (HasParenthesis
-                              (/root/OperatorName/PartialActivePatternDefinition.fs (2,4--2,5),
-                               /root/OperatorName/PartialActivePatternDefinition.fs (2,19--2,20)))]),
+                        [Some (HasParenthesis ((2,4--2,5), (2,19--2,20)))]),
                      None, None,
                      Pats
                        [Paren
                           (Typed
                              (Named
-                                (SynIdent (a, None), false, None,
-                                 /root/OperatorName/PartialActivePatternDefinition.fs (2,22--2,23)),
+                                (SynIdent (a, None), false, None, (2,22--2,23)),
                               LongIdent (SynLongIdent ([SynConst], [], [None])),
-                              /root/OperatorName/PartialActivePatternDefinition.fs (2,22--2,33)),
-                           /root/OperatorName/PartialActivePatternDefinition.fs (2,21--2,34))],
-                     None,
-                     /root/OperatorName/PartialActivePatternDefinition.fs (2,4--2,34)),
+                              (2,22--2,33)), (2,21--2,34))], None, (2,4--2,34)),
                   None,
                   Match
-                    (Yes
-                       /root/OperatorName/PartialActivePatternDefinition.fs (2,37--2,49),
-                     Ident a,
+                    (Yes (2,37--2,49), Ident a,
                      [SynMatchClause
                         (LongIdent
                            (SynLongIdent
-                              ([SynConst; Int32],
-                               [/root/OperatorName/PartialActivePatternDefinition.fs (2,58--2,59)],
-                               [None; None]), None, None,
-                            Pats
-                              [Wild
-                                 /root/OperatorName/PartialActivePatternDefinition.fs (2,65--2,66)],
-                            None,
-                            /root/OperatorName/PartialActivePatternDefinition.fs (2,50--2,66)),
-                         None,
+                              ([SynConst; Int32], [(2,58--2,59)], [None; None]),
+                            None, None, Pats [Wild (2,65--2,66)], None,
+                            (2,50--2,66)), None,
                          App
-                           (NonAtomic, false, Ident Some, Ident a,
-                            /root/OperatorName/PartialActivePatternDefinition.fs (2,70--2,76)),
-                         /root/OperatorName/PartialActivePatternDefinition.fs (2,50--2,76),
-                         Yes,
-                         { ArrowRange =
-                            Some
-                              /root/OperatorName/PartialActivePatternDefinition.fs (2,67--2,69)
-                           BarRange = None });
+                           (NonAtomic, false, Ident Some, Ident a, (2,70--2,76)),
+                         (2,50--2,76), Yes, { ArrowRange = Some (2,67--2,69)
+                                              BarRange = None });
                       SynMatchClause
-                        (Wild
-                           /root/OperatorName/PartialActivePatternDefinition.fs (2,79--2,80),
-                         None, Ident None,
-                         /root/OperatorName/PartialActivePatternDefinition.fs (2,79--2,88),
-                         Yes,
-                         { ArrowRange =
-                            Some
-                              /root/OperatorName/PartialActivePatternDefinition.fs (2,81--2,83)
-                           BarRange =
-                            Some
-                              /root/OperatorName/PartialActivePatternDefinition.fs (2,77--2,78) })],
-                     /root/OperatorName/PartialActivePatternDefinition.fs (2,37--2,88),
-                     { MatchKeyword =
-                        /root/OperatorName/PartialActivePatternDefinition.fs (2,37--2,42)
-                       WithKeyword =
-                        /root/OperatorName/PartialActivePatternDefinition.fs (2,45--2,49) }),
-                  /root/OperatorName/PartialActivePatternDefinition.fs (2,4--2,34),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/OperatorName/PartialActivePatternDefinition.fs (2,0--2,3)
+                        (Wild (2,79--2,80), None, Ident None, (2,79--2,88), Yes,
+                         { ArrowRange = Some (2,81--2,83)
+                           BarRange = Some (2,77--2,78) })], (2,37--2,88),
+                     { MatchKeyword = (2,37--2,42)
+                       WithKeyword = (2,45--2,49) }), (2,4--2,34), NoneAtLet,
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/OperatorName/PartialActivePatternDefinition.fs (2,35--2,36) })],
-              /root/OperatorName/PartialActivePatternDefinition.fs (2,0--2,88))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/PartialActivePatternDefinition.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,35--2,36) })], (2,0--2,88))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs.bsl
@@ -15,33 +15,16 @@ ImplFile
                   Named
                     (SynIdent
                        (|Boolean|_|,
-                        Some
-                          (HasParenthesis
-                             (/root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,4--2,5),
-                              /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,16--2,17)))),
-                     false, None,
-                     /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,5--2,16)),
-                  None,
+                        Some (HasParenthesis ((2,4--2,5), (2,16--2,17)))), false,
+                     None, (2,5--2,16)), None,
                   LongIdent
                     (false,
                      SynLongIdent
-                       ([Boolean; parse],
-                        [/root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,27--2,28)],
-                        [None; None]), None,
-                     /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,20--2,33)),
-                  /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,4--2,17),
-                  Yes
-                    /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,0--2,33),
-                  { LeadingKeyword =
-                     Let
-                       /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,0--2,3)
+                       ([Boolean; parse], [(2,27--2,28)], [None; None]), None,
+                     (2,20--2,33)), (2,4--2,17), Yes (2,0--2,33),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,18--2,19) })],
-              /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,0--2,33))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/PartialActivePatternDefinitionWithoutParameters.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,18--2,19) })], (2,0--2,33))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/PrefixOperation.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/PrefixOperation.fs.bsl
@@ -11,12 +11,8 @@ ImplFile
                    (false,
                     SynLongIdent
                       ([op_UnaryPlus], [], [Some (OriginalNotation "+")]), None,
-                    /root/OperatorName/PrefixOperation.fs (2,0--2,1)),
-                 Const
-                   (Int32 -86, /root/OperatorName/PrefixOperation.fs (2,2--2,5)),
-                 /root/OperatorName/PrefixOperation.fs (2,0--2,5)),
-              /root/OperatorName/PrefixOperation.fs (2,0--2,5))], PreXmlDocEmpty,
-          [], None, /root/OperatorName/PrefixOperation.fs (2,0--2,5),
+                    (2,0--2,1)), Const (Int32 -86, (2,2--2,5)), (2,0--2,5)),
+              (2,0--2,5))], PreXmlDocEmpty, [], None, (2,0--2,5),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/PrefixOperationWithTwoCharacters.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/PrefixOperationWithTwoCharacters.fs.bsl
@@ -11,13 +11,7 @@ ImplFile
                    (false,
                     SynLongIdent
                       ([op_SpliceUntyped], [], [Some (OriginalNotation "%%")]),
-                    None,
-                    /root/OperatorName/PrefixOperationWithTwoCharacters.fs (2,0--2,2)),
-                 Ident arg,
-                 /root/OperatorName/PrefixOperationWithTwoCharacters.fs (2,0--2,5)),
-              /root/OperatorName/PrefixOperationWithTwoCharacters.fs (2,0--2,5))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/PrefixOperationWithTwoCharacters.fs (2,0--2,5),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    None, (2,0--2,2)), Ident arg, (2,0--2,5)), (2,0--2,5))],
+          PreXmlDocEmpty, [], None, (2,0--2,5), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/OperatorName/QualifiedOperatorExpression.fs.bsl
+++ b/tests/service/data/SyntaxTree/OperatorName/QualifiedOperatorExpression.fs.bsl
@@ -21,46 +21,25 @@ ImplFile
                        [Paren
                           (Typed
                              (Named
-                                (SynIdent (x, None), false, None,
-                                 /root/OperatorName/QualifiedOperatorExpression.fs (2,13--2,14)),
+                                (SynIdent (x, None), false, None, (2,13--2,14)),
                               LongIdent (SynLongIdent ([byte], [], [None])),
-                              /root/OperatorName/QualifiedOperatorExpression.fs (2,13--2,19)),
-                           /root/OperatorName/QualifiedOperatorExpression.fs (2,12--2,20));
-                        Named
-                          (SynIdent (n, None), false, None,
-                           /root/OperatorName/QualifiedOperatorExpression.fs (2,21--2,22))],
-                     None,
-                     /root/OperatorName/QualifiedOperatorExpression.fs (2,4--2,22)),
-                  None,
+                              (2,13--2,19)), (2,12--2,20));
+                        Named (SynIdent (n, None), false, None, (2,21--2,22))],
+                     None, (2,4--2,22)), None,
                   App
                     (NonAtomic, false,
                      LongIdent
                        (false,
                         SynLongIdent
-                          ([Checked; op_Multiply],
-                           [/root/OperatorName/QualifiedOperatorExpression.fs (2,32--2,33)],
+                          ([Checked; op_Multiply], [(2,32--2,33)],
                            [None;
                             Some
                               (OriginalNotationWithParen
-                                 (/root/OperatorName/QualifiedOperatorExpression.fs (2,33--2,34),
-                                  "*",
-                                  /root/OperatorName/QualifiedOperatorExpression.fs (2,37--2,38)))]),
-                        None,
-                        /root/OperatorName/QualifiedOperatorExpression.fs (2,25--2,38)),
-                     Ident x,
-                     /root/OperatorName/QualifiedOperatorExpression.fs (2,25--2,40)),
-                  /root/OperatorName/QualifiedOperatorExpression.fs (2,4--2,22),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/OperatorName/QualifiedOperatorExpression.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/OperatorName/QualifiedOperatorExpression.fs (2,23--2,24) })],
-              /root/OperatorName/QualifiedOperatorExpression.fs (2,0--2,40))],
-          PreXmlDocEmpty, [], None,
-          /root/OperatorName/QualifiedOperatorExpression.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                 ((2,33--2,34), "*", (2,37--2,38)))]), None,
+                        (2,25--2,38)), Ident x, (2,25--2,40)), (2,4--2,22),
+                  NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                               InlineKeyword = None
+                               EqualsRange = Some (2,23--2,24) })], (2,0--2,40))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ParsedHashDirective/RegularStringAsParsedHashDirectiveArgument.fs.bsl
+++ b/tests/service/data/SyntaxTree/ParsedHashDirective/RegularStringAsParsedHashDirectiveArgument.fs.bsl
@@ -5,13 +5,7 @@ ImplFile
       [],
       [SynModuleOrNamespace
          ([RegularStringAsParsedHashDirectiveArgument], false, AnonModule,
-          [HashDirective
-             (ParsedHashDirective
-                ("I", [],
-                 /root/ParsedHashDirective/RegularStringAsParsedHashDirectiveArgument.fs (2,0--2,2)),
-              /root/ParsedHashDirective/RegularStringAsParsedHashDirectiveArgument.fs (2,0--2,4))],
-          PreXmlDocEmpty, [], None,
-          /root/ParsedHashDirective/RegularStringAsParsedHashDirectiveArgument.fs (2,0--2,4),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+          [HashDirective (ParsedHashDirective ("I", [], (2,0--2,2)), (2,0--2,4))],
+          PreXmlDocEmpty, [], None, (2,0--2,4), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ParsedHashDirective/SourceIdentifierAsParsedHashDirectiveArgument.fs.bsl
+++ b/tests/service/data/SyntaxTree/ParsedHashDirective/SourceIdentifierAsParsedHashDirectiveArgument.fs.bsl
@@ -10,11 +10,7 @@ ImplFile
                 ("I",
                  [SourceIdentifier
                     ("__SOURCE_DIRECTORY__", "/root/ParsedHashDirective",
-                     /root/ParsedHashDirective/SourceIdentifierAsParsedHashDirectiveArgument.fs (0,0--0,0))],
-                 /root/ParsedHashDirective/SourceIdentifierAsParsedHashDirectiveArgument.fs (0,0--0,0)),
-              /root/ParsedHashDirective/SourceIdentifierAsParsedHashDirectiveArgument.fs (2,0--2,23))],
-          PreXmlDocEmpty, [], None,
-          /root/ParsedHashDirective/SourceIdentifierAsParsedHashDirectiveArgument.fs (2,0--2,23),
-          { LeadingKeyword = None })], (true, false),
+                     (0,0--0,0))], (0,0--0,0)), (2,0--2,23))], PreXmlDocEmpty,
+          [], None, (2,0--2,23), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ParsedHashDirective/TripleQuoteStringAsParsedHashDirectiveArgument.fs.bsl
+++ b/tests/service/data/SyntaxTree/ParsedHashDirective/TripleQuoteStringAsParsedHashDirectiveArgument.fs.bsl
@@ -6,12 +6,7 @@ ImplFile
       [SynModuleOrNamespace
          ([TripleQuoteStringAsParsedHashDirectiveArgument], false, AnonModule,
           [HashDirective
-             (ParsedHashDirective
-                ("nowarn", [],
-                 /root/ParsedHashDirective/TripleQuoteStringAsParsedHashDirectiveArgument.fs (2,0--2,7)),
-              /root/ParsedHashDirective/TripleQuoteStringAsParsedHashDirectiveArgument.fs (2,0--2,9))],
-          PreXmlDocEmpty, [], None,
-          /root/ParsedHashDirective/TripleQuoteStringAsParsedHashDirectiveArgument.fs (2,0--2,9),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+             (ParsedHashDirective ("nowarn", [], (2,0--2,7)), (2,0--2,9))],
+          PreXmlDocEmpty, [], None, (2,0--2,9), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ParsedHashDirective/VerbatimStringAsParsedHashDirectiveArgument.fs.bsl
+++ b/tests/service/data/SyntaxTree/ParsedHashDirective/VerbatimStringAsParsedHashDirectiveArgument.fs.bsl
@@ -5,13 +5,7 @@ ImplFile
       [],
       [SynModuleOrNamespace
          ([VerbatimStringAsParsedHashDirectiveArgument], false, AnonModule,
-          [HashDirective
-             (ParsedHashDirective
-                ("I", [],
-                 /root/ParsedHashDirective/VerbatimStringAsParsedHashDirectiveArgument.fs (2,0--2,2)),
-              /root/ParsedHashDirective/VerbatimStringAsParsedHashDirectiveArgument.fs (2,0--2,4))],
-          PreXmlDocEmpty, [], None,
-          /root/ParsedHashDirective/VerbatimStringAsParsedHashDirectiveArgument.fs (2,0--2,4),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+          [HashDirective (ParsedHashDirective ("I", [], (2,0--2,2)), (2,0--2,4))],
+          PreXmlDocEmpty, [], None, (2,0--2,4), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Pattern/InHeadPattern.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/InHeadPattern.fs.bsl
@@ -12,37 +12,20 @@ ImplFile
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
                   ListCons
-                    (Const (Int32 1, /root/Pattern/InHeadPattern.fs (2,4--2,5)),
-                     Wild /root/Pattern/InHeadPattern.fs (2,9--2,10),
-                     /root/Pattern/InHeadPattern.fs (2,4--2,10),
-                     { ColonColonRange =
-                        /root/Pattern/InHeadPattern.fs (2,6--2,8) }), None,
+                    (Const (Int32 1, (2,4--2,5)), Wild (2,9--2,10), (2,4--2,10),
+                     { ColonColonRange = (2,6--2,8) }), None,
                   ArrayOrListComputed
                     (false,
                      Sequential
-                       (SuppressNeither, true,
-                        Const
-                          (Int32 4, /root/Pattern/InHeadPattern.fs (2,15--2,16)),
+                       (SuppressNeither, true, Const (Int32 4, (2,15--2,16)),
                         Sequential
-                          (SuppressNeither, true,
-                           Const
-                             (Int32 5,
-                              /root/Pattern/InHeadPattern.fs (2,18--2,19)),
-                           Const
-                             (Int32 6,
-                              /root/Pattern/InHeadPattern.fs (2,21--2,22)),
-                           /root/Pattern/InHeadPattern.fs (2,18--2,22)),
-                        /root/Pattern/InHeadPattern.fs (2,15--2,22)),
-                     /root/Pattern/InHeadPattern.fs (2,13--2,24)),
-                  /root/Pattern/InHeadPattern.fs (2,4--2,10),
-                  Yes /root/Pattern/InHeadPattern.fs (2,0--2,24),
-                  { LeadingKeyword =
-                     Let /root/Pattern/InHeadPattern.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some /root/Pattern/InHeadPattern.fs (2,11--2,12) })],
-              /root/Pattern/InHeadPattern.fs (2,0--2,24))], PreXmlDocEmpty, [],
-          None, /root/Pattern/InHeadPattern.fs (2,0--3,0),
+                          (SuppressNeither, true, Const (Int32 5, (2,18--2,19)),
+                           Const (Int32 6, (2,21--2,22)), (2,18--2,22)),
+                        (2,15--2,22)), (2,13--2,24)), (2,4--2,10),
+                  Yes (2,0--2,24), { LeadingKeyword = Let (2,0--2,3)
+                                     InlineKeyword = None
+                                     EqualsRange = Some (2,11--2,12) })],
+              (2,0--2,24))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Pattern/OperatorInMatchPattern.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/OperatorInMatchPattern.fs.bsl
@@ -6,41 +6,23 @@ ImplFile
          ([OperatorInMatchPattern], false, AnonModule,
           [Expr
              (Match
-                (Yes /root/Pattern/OperatorInMatchPattern.fs (2,0--2,12),
-                 Ident x,
+                (Yes (2,0--2,12), Ident x,
                  [SynMatchClause
                     (ListCons
                        (Paren
                           (Named
-                             (SynIdent (head, None), false, None,
-                              /root/Pattern/OperatorInMatchPattern.fs (3,3--3,7)),
-                           /root/Pattern/OperatorInMatchPattern.fs (3,2--3,8)),
+                             (SynIdent (head, None), false, None, (3,3--3,7)),
+                           (3,2--3,8)),
                         Paren
                           (Named
-                             (SynIdent (tail, None), false, None,
-                              /root/Pattern/OperatorInMatchPattern.fs (3,13--3,17)),
-                           /root/Pattern/OperatorInMatchPattern.fs (3,12--3,18)),
-                        /root/Pattern/OperatorInMatchPattern.fs (3,2--3,18),
-                        { ColonColonRange =
-                           /root/Pattern/OperatorInMatchPattern.fs (3,9--3,11) }),
-                     None,
-                     Const
-                       (Unit,
-                        /root/Pattern/OperatorInMatchPattern.fs (3,22--3,24)),
-                     /root/Pattern/OperatorInMatchPattern.fs (3,2--3,24), Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Pattern/OperatorInMatchPattern.fs (3,19--3,21)
-                       BarRange =
-                        Some /root/Pattern/OperatorInMatchPattern.fs (3,0--3,1) })],
-                 /root/Pattern/OperatorInMatchPattern.fs (2,0--3,24),
-                 { MatchKeyword =
-                    /root/Pattern/OperatorInMatchPattern.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/Pattern/OperatorInMatchPattern.fs (2,8--2,12) }),
-              /root/Pattern/OperatorInMatchPattern.fs (2,0--3,24))],
-          PreXmlDocEmpty, [], None,
-          /root/Pattern/OperatorInMatchPattern.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                             (SynIdent (tail, None), false, None, (3,13--3,17)),
+                           (3,12--3,18)), (3,2--3,18),
+                        { ColonColonRange = (3,9--3,11) }), None,
+                     Const (Unit, (3,22--3,24)), (3,2--3,24), Yes,
+                     { ArrowRange = Some (3,19--3,21)
+                       BarRange = Some (3,0--3,1) })], (2,0--3,24),
+                 { MatchKeyword = (2,0--2,5)
+                   WithKeyword = (2,8--2,12) }), (2,0--3,24))], PreXmlDocEmpty,
+          [], None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Pattern/OperatorInSynPatLongIdent.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/OperatorInSynPatLongIdent.fs.bsl
@@ -13,46 +13,22 @@ ImplFile
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
                   Paren
                     (ListCons
-                       (Named
-                          (SynIdent (head, None), false, None,
-                           /root/Pattern/OperatorInSynPatLongIdent.fs (2,5--2,9)),
-                        Named
-                          (SynIdent (tail, None), false, None,
-                           /root/Pattern/OperatorInSynPatLongIdent.fs (2,11--2,15)),
-                        /root/Pattern/OperatorInSynPatLongIdent.fs (2,5--2,15),
-                        { ColonColonRange =
-                           /root/Pattern/OperatorInSynPatLongIdent.fs (2,9--2,11) }),
-                     /root/Pattern/OperatorInSynPatLongIdent.fs (2,4--2,16)),
-                  None,
+                       (Named (SynIdent (head, None), false, None, (2,5--2,9)),
+                        Named (SynIdent (tail, None), false, None, (2,11--2,15)),
+                        (2,5--2,15), { ColonColonRange = (2,9--2,11) }),
+                     (2,4--2,16)), None,
                   ArrayOrListComputed
                     (false,
                      Sequential
-                       (SuppressNeither, true,
-                        Const
-                          (Int32 1,
-                           /root/Pattern/OperatorInSynPatLongIdent.fs (2,22--2,23)),
+                       (SuppressNeither, true, Const (Int32 1, (2,22--2,23)),
                         Sequential
-                          (SuppressNeither, true,
-                           Const
-                             (Int32 2,
-                              /root/Pattern/OperatorInSynPatLongIdent.fs (2,24--2,25)),
-                           Const
-                             (Int32 4,
-                              /root/Pattern/OperatorInSynPatLongIdent.fs (2,26--2,27)),
-                           /root/Pattern/OperatorInSynPatLongIdent.fs (2,24--2,27)),
-                        /root/Pattern/OperatorInSynPatLongIdent.fs (2,22--2,27)),
-                     /root/Pattern/OperatorInSynPatLongIdent.fs (2,20--2,28)),
-                  /root/Pattern/OperatorInSynPatLongIdent.fs (2,4--2,16),
-                  Yes /root/Pattern/OperatorInSynPatLongIdent.fs (2,0--2,28),
-                  { LeadingKeyword =
-                     Let /root/Pattern/OperatorInSynPatLongIdent.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Pattern/OperatorInSynPatLongIdent.fs (2,17--2,18) })],
-              /root/Pattern/OperatorInSynPatLongIdent.fs (2,0--2,28))],
-          PreXmlDocEmpty, [], None,
-          /root/Pattern/OperatorInSynPatLongIdent.fs (2,0--3,0),
+                          (SuppressNeither, true, Const (Int32 2, (2,24--2,25)),
+                           Const (Int32 4, (2,26--2,27)), (2,24--2,27)),
+                        (2,22--2,27)), (2,20--2,28)), (2,4--2,16),
+                  Yes (2,0--2,28), { LeadingKeyword = Let (2,0--2,3)
+                                     InlineKeyword = None
+                                     EqualsRange = Some (2,17--2,18) })],
+              (2,0--2,28))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs.bsl
@@ -6,65 +6,30 @@ ImplFile
          ([ParenthesesOfSynArgPatsNamePatPairs], false, AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (2,0--2,15),
-                 Ident data,
+                (Yes (2,0--2,15), Ident data,
                  [SynMatchClause
                     (LongIdent
                        (SynLongIdent ([OnePartData], [], [None]), None, None,
                         NamePatPairs
-                          ([(part1,
-                             /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (4,10--4,11),
+                          ([(part1, (4,10--4,11),
                              Named
-                               (SynIdent (p1, None), false, None,
-                                /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (4,12--4,14)))],
-                           /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (4,4--5,13),
-                           { ParenRange =
-                              /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (3,13--5,13) }),
-                        None,
-                        /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (3,2--5,13)),
-                     None, Ident p1,
-                     /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (3,2--5,19),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (5,14--5,16)
-                       BarRange =
-                        Some
-                          /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (3,0--3,1) });
+                               (SynIdent (p1, None), false, None, (4,12--4,14)))],
+                           (4,4--5,13), { ParenRange = (3,13--5,13) }), None,
+                        (3,2--5,13)), None, Ident p1, (3,2--5,19), Yes,
+                     { ArrowRange = Some (5,14--5,16)
+                       BarRange = Some (3,0--3,1) });
                   SynMatchClause
-                    (Wild
-                       /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (6,2--6,3),
-                     None,
+                    (Wild (6,2--6,3), None,
                      App
                        (NonAtomic, false, Ident failwith,
                         Const
-                          (String
-                             ("todo", Regular,
-                              /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (6,16--6,22)),
-                           /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (6,16--6,22)),
-                        /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (6,7--6,22)),
-                     /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (6,2--6,22),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (6,4--6,6)
-                       BarRange =
-                        Some
-                          /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (6,0--6,1) })],
-                 /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (2,0--6,22),
-                 { MatchKeyword =
-                    /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (2,11--2,15) }),
-              /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (2,0--6,22))],
-          PreXmlDocEmpty, [], None,
-          /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (2,0--7,0),
-          { LeadingKeyword = None })], (true, false),
+                          (String ("todo", Regular, (6,16--6,22)), (6,16--6,22)),
+                        (6,7--6,22)), (6,2--6,22), Yes,
+                     { ArrowRange = Some (6,4--6,6)
+                       BarRange = Some (6,0--6,1) })], (2,0--6,22),
+                 { MatchKeyword = (2,0--2,5)
+                   WithKeyword = (2,11--2,15) }), (2,0--6,22))], PreXmlDocEmpty,
+          [], None, (2,0--7,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (3,15--3,21);
-          BlockComment
-            /root/Pattern/ParenthesesOfSynArgPatsNamePatPairs.fs (5,2--5,11)] },
+        CodeComments = [LineComment (3,15--3,21); BlockComment (5,2--5,11)] },
       set []))

--- a/tests/service/data/SyntaxTree/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -9,40 +9,20 @@ ImplFile
           AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (2,0--2,12),
-                 Ident x,
+                (Yes (2,0--2,12), Ident x,
                  [SynMatchClause
                     (LongIdent
                        (SynLongIdent ([X], [], [None]), None, None,
                         NamePatPairs
-                          ([(Y,
-                             /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (3,7--3,8),
+                          ([(Y, (3,7--3,8),
                              Named
-                               (SynIdent (y, None), false, None,
-                                /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (3,9--3,10)))],
-                           /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (3,4--3,11),
-                           { ParenRange =
-                              /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (3,3--3,11) }),
-                        None,
-                        /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (3,2--3,11)),
-                     None, Ident y,
-                     /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (3,2--3,16),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (3,12--3,14)
-                       BarRange =
-                        Some
-                          /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (3,0--3,1) })],
-                 /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (2,0--3,16),
-                 { MatchKeyword =
-                    /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (2,8--2,12) }),
-              /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (2,0--3,16))],
-          PreXmlDocEmpty, [], None,
-          /root/Pattern/SynArgPatsNamePatPairsContainsTheRangeOfTheEqualsSign.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                               (SynIdent (y, None), false, None, (3,9--3,10)))],
+                           (3,4--3,11), { ParenRange = (3,3--3,11) }), None,
+                        (3,2--3,11)), None, Ident y, (3,2--3,16), Yes,
+                     { ArrowRange = Some (3,12--3,14)
+                       BarRange = Some (3,0--3,1) })], (2,0--3,16),
+                 { MatchKeyword = (2,0--2,5)
+                   WithKeyword = (2,8--2,12) }), (2,0--3,16))], PreXmlDocEmpty,
+          [], None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Pattern/SynPatOrContainsTheRangeOfTheBar.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/SynPatOrContainsTheRangeOfTheBar.fs.bsl
@@ -6,57 +6,25 @@ ImplFile
          ([SynPatOrContainsTheRangeOfTheBar], false, AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (2,0--2,12),
-                 Ident x,
+                (Yes (2,0--2,12), Ident x,
                  [SynMatchClause
                     (Or
                        (LongIdent
                           (SynLongIdent ([A], [], [None]), None, None, Pats [],
-                           None,
-                           /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (3,2--3,3)),
+                           None, (3,2--3,3)),
                         LongIdent
                           (SynLongIdent ([B], [], [None]), None, None, Pats [],
-                           None,
-                           /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (4,2--4,3)),
-                        /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (3,2--4,3),
-                        { BarRange =
-                           /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (4,0--4,1) }),
-                     None,
-                     Const
-                       (Unit,
-                        /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (4,7--4,9)),
-                     /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (3,2--4,9),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (4,4--4,6)
-                       BarRange =
-                        Some
-                          /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (3,0--3,1) });
+                           None, (4,2--4,3)), (3,2--4,3),
+                        { BarRange = (4,0--4,1) }), None,
+                     Const (Unit, (4,7--4,9)), (3,2--4,9), Yes,
+                     { ArrowRange = Some (4,4--4,6)
+                       BarRange = Some (3,0--3,1) });
                   SynMatchClause
-                    (Wild
-                       /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (5,2--5,3),
-                     None,
-                     Const
-                       (Unit,
-                        /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (5,7--5,9)),
-                     /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (5,2--5,9),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (5,4--5,6)
-                       BarRange =
-                        Some
-                          /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (5,0--5,1) })],
-                 /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (2,0--5,9),
-                 { MatchKeyword =
-                    /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (2,8--2,12) }),
-              /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (2,0--5,9))],
-          PreXmlDocEmpty, [], None,
-          /root/Pattern/SynPatOrContainsTheRangeOfTheBar.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                    (Wild (5,2--5,3), None, Const (Unit, (5,7--5,9)), (5,2--5,9),
+                     Yes, { ArrowRange = Some (5,4--5,6)
+                            BarRange = Some (5,0--5,1) })], (2,0--5,9),
+                 { MatchKeyword = (2,0--2,5)
+                   WithKeyword = (2,8--2,12) }), (2,0--5,9))], PreXmlDocEmpty,
+          [], None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -6,52 +6,21 @@ ImplFile
          ([SynPatRecordContainsTheRangeOfTheEqualsSign], false, AnonModule,
           [Expr
              (Match
-                (Yes
-                   /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (2,0--2,12),
-                 Ident x,
+                (Yes (2,0--2,12), Ident x,
                  [SynMatchClause
                     (Record
-                       ([(([], Foo),
-                          /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (3,8--3,9),
+                       ([(([], Foo), (3,8--3,9),
                           Named
-                            (SynIdent (bar, None), false, None,
-                             /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (3,10--3,13)))],
-                        /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (3,2--3,15)),
-                     None,
-                     Const
-                       (Unit,
-                        /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (3,19--3,21)),
-                     /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (3,2--3,21),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (3,16--3,18)
-                       BarRange =
-                        Some
-                          /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (3,0--3,1) });
+                            (SynIdent (bar, None), false, None, (3,10--3,13)))],
+                        (3,2--3,15)), None, Const (Unit, (3,19--3,21)),
+                     (3,2--3,21), Yes, { ArrowRange = Some (3,16--3,18)
+                                         BarRange = Some (3,0--3,1) });
                   SynMatchClause
-                    (Wild
-                       /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (4,2--4,3),
-                     None,
-                     Const
-                       (Unit,
-                        /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (4,7--4,9)),
-                     /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (4,2--4,9),
-                     Yes,
-                     { ArrowRange =
-                        Some
-                          /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (4,4--4,6)
-                       BarRange =
-                        Some
-                          /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (4,0--4,1) })],
-                 /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (2,0--4,9),
-                 { MatchKeyword =
-                    /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (2,0--2,5)
-                   WithKeyword =
-                    /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (2,8--2,12) }),
-              /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (2,0--4,9))],
-          PreXmlDocEmpty, [], None,
-          /root/Pattern/SynPatRecordContainsTheRangeOfTheEqualsSign.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                    (Wild (4,2--4,3), None, Const (Unit, (4,7--4,9)), (4,2--4,9),
+                     Yes, { ArrowRange = Some (4,4--4,6)
+                            BarRange = Some (4,0--4,1) })], (2,0--4,9),
+                 { MatchKeyword = (2,0--2,5)
+                   WithKeyword = (2,8--2,12) }), (2,0--4,9))], PreXmlDocEmpty,
+          [], None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -21,43 +20,22 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            Some
-                              (Const
-                                 (Int32 10,
-                                  /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (5,21--5,23))),
-                            /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (5,4--5,23),
-                            { LeadingKeyword =
-                               Member
-                                 /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (5,4--5,10)
-                              InlineKeyword = None
-                              WithKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (5,19--5,20) }),
+                            None, Some (Const (Int32 10, (5,21--5,23))),
+                            (5,4--5,23), { LeadingKeyword = Member (5,4--5,10)
+                                           InlineKeyword = None
+                                           WithKeyword = None
+                                           EqualsRange = Some (5,19--5,20) }),
                          { IsInstance = true
                            IsDispatchSlot = false
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (5,4--5,23),
-                         { GetSetKeywords = None })],
-                     /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (5,4--5,23)),
-                  [],
-                  /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (4,5--5,23),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (4,0--5,23))],
+                           MemberKind = PropertyGet }, (5,4--5,23),
+                         { GetSetKeywords = None })], (5,4--5,23)), [],
+                  (4,5--5,23), { LeadingKeyword = Type (4,0--4,4)
+                                 EqualsRange = Some (4,7--4,8)
+                                 WithKeyword = None })], (4,0--5,23))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (2,0--5,23),
-          { LeadingKeyword =
-             Module
-               /root/SignatureType/EqualsTokenIsPresentInSynValSigMember.fsi (2,0--2,6) })],
+          (2,0--5,23), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi.bsl
@@ -10,24 +10,12 @@ SigFile
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 Some
-                   (Const
-                      (Int32 9,
-                       /root/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi (4,14--4,15))),
-                 /root/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi (4,0--4,15),
-                 { LeadingKeyword =
-                    Val
-                      /root/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi (4,0--4,3)
+                 Some (Const (Int32 9, (4,14--4,15))), (4,0--4,15),
+                 { LeadingKeyword = Val (4,0--4,3)
                    InlineKeyword = None
                    WithKeyword = None
-                   EqualsRange =
-                    Some
-                      /root/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi (4,12--4,13) }),
-              /root/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi (4,0--4,15))],
+                   EqualsRange = Some (4,12--4,13) }), (4,0--4,15))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi (2,0--4,15),
-          { LeadingKeyword =
-             Module
-               /root/SignatureType/EqualsTokenIsPresentInSynValSigValue.fsi (2,0--2,6) })],
+          (2,0--4,15), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/LeadingKeywordInRecursiveTypes.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/LeadingKeywordInRecursiveTypes.fsi.bsl
@@ -9,44 +9,26 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [A],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   Simple
                     (TypeAbbrev
                        (Ok, LongIdent (SynLongIdent ([obj], [], [None])),
-                        /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (2,9--2,12)),
-                     /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (2,9--2,12)),
-                  [],
-                  /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (2,5--2,12),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (2,7--2,8)
+                        (2,9--2,12)), (2,9--2,12)), [], (2,5--2,12),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
                     WithKeyword = None });
                SynTypeDefnSig
                  (SynComponentInfo
                     ([], None, [], [B],
                      PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (3,4--3,5)),
+                     false, None, (3,4--3,5)),
                   Simple
                     (TypeAbbrev
                        (Ok, LongIdent (SynLongIdent ([int], [], [None])),
-                        /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (3,8--3,11)),
-                     /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (3,8--3,11)),
-                  [],
-                  /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (3,4--3,11),
-                  { LeadingKeyword =
-                     And
-                       /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (3,0--3,3)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (3,6--3,7)
-                    WithKeyword = None })],
-              /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (2,0--3,11))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/LeadingKeywordInRecursiveTypes.fsi (2,0--4,0),
-          { LeadingKeyword = None })], { ConditionalDirectives = []
-                                         CodeComments = [] }, set []))
+                        (3,8--3,11)), (3,8--3,11)), [], (3,4--3,11),
+                  { LeadingKeyword = And (3,0--3,3)
+                    EqualsRange = Some (3,6--3,7)
+                    WithKeyword = None })], (2,0--3,11))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi.bsl
@@ -11,8 +11,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (4,5--4,8)),
+                     false, None, (4,5--4,8)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -23,44 +22,24 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (5,4--5,42),
+                            None, None, (5,4--5,42),
                             { LeadingKeyword =
-                               AbstractMember
-                                 (/root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (5,4--5,12),
-                                  /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (5,13--5,19))
+                               AbstractMember ((5,4--5,12), (5,13--5,19))
                               InlineKeyword = None
-                              WithKeyword =
-                               Some
-                                 /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (5,30--5,34)
+                              WithKeyword = Some (5,30--5,34)
                               EqualsRange = None }),
                          { IsInstance = true
                            IsDispatchSlot = true
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGetSet },
-                         /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (5,4--5,42),
+                           MemberKind = PropertyGetSet }, (5,4--5,42),
                          { GetSetKeywords =
-                            Some
-                              (GetSet
-                                 (/root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (5,35--5,38),
-                                  /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (5,39--5,42))) })],
-                     /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (5,4--5,42)),
-                  [],
-                  /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (4,5--5,42),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (4,9--4,10)
-                    WithKeyword = None })],
-              /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (4,0--5,42))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (2,0--5,42),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/MemberSigOfSynMemberSigMemberShouldContainsTheRangeOfTheWithKeyword.fsi (2,0--2,9) })],
+                            Some (GetSet ((5,35--5,38), (5,39--5,42))) })],
+                     (5,4--5,42)), [], (4,5--5,42),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,9--4,10)
+                    WithKeyword = None })], (4,0--5,42))], PreXmlDocEmpty, [],
+          None, (2,0--5,42), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [A],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [NestedType
@@ -18,34 +17,16 @@ SigFile
                            (SynComponentInfo
                               ([], None, [], [B],
                                PreXmlDoc ((3,16), FSharp.Compiler.Xml.XmlDocCollector),
-                               false, None,
-                               /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (3,16--3,17)),
-                            ObjectModel
-                              (Class, [],
-                               /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (4,20--5,23)),
-                            [],
-                            /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (3,16--5,23),
+                               false, None, (3,16--3,17)),
+                            ObjectModel (Class, [], (4,20--5,23)), [],
+                            (3,16--5,23),
                             { LeadingKeyword =
-                               StaticType
-                                 (/root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (3,4--3,10),
-                                  /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (3,11--3,15))
-                              EqualsRange =
-                               Some
-                                 /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (3,18--3,19)
-                              WithKeyword = None }),
-                         /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (3,4--6,0))],
-                     /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (3,4--6,0)),
-                  [],
-                  /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (2,5--6,0),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (2,7--2,8)
-                    WithKeyword = None })],
-              /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (2,0--6,0))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/NestedTypeHasStaticTypeAsLeadingKeyword.fsi (2,0--6,0),
-          { LeadingKeyword = None })], { ConditionalDirectives = []
-                                         CodeComments = [] }, set []))
+                               StaticType ((3,4--3,10), (3,11--3,15))
+                              EqualsRange = Some (3,18--3,19)
+                              WithKeyword = None }), (3,4--6,0))], (3,4--6,0)),
+                  [], (2,5--6,0), { LeadingKeyword = Type (2,0--2,4)
+                                    EqualsRange = Some (2,7--2,8)
+                                    WithKeyword = None })], (2,0--6,0))],
+          PreXmlDocEmpty, [], None, (2,0--6,0), { LeadingKeyword = None })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi.bsl
@@ -9,25 +9,16 @@ SigFile
                 (SynExceptionDefnRepr
                    ([{ Attributes =
                         [{ TypeName = SynLongIdent ([NoEquality], [], [None])
-                           ArgExpr =
-                            Const
-                              (Unit,
-                               /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (5,2--5,12))
+                           ArgExpr = Const (Unit, (5,2--5,12))
                            Target = None
                            AppliesToGetterAndSetter = false
-                           Range =
-                            /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (5,2--5,12) };
+                           Range = (5,2--5,12) };
                          { TypeName = SynLongIdent ([NoComparison], [], [None])
-                           ArgExpr =
-                            Const
-                              (Unit,
-                               /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (5,14--5,26))
+                           ArgExpr = Const (Unit, (5,14--5,26))
                            Target = None
                            AppliesToGetterAndSetter = false
-                           Range =
-                            /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (5,14--5,26) }]
-                       Range =
-                        /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (5,0--5,28) }],
+                           Range = (5,14--5,26) }]
+                       Range = (5,0--5,28) }],
                     SynUnionCase
                       ([], SynIdent (SyntaxError, None),
                        Fields
@@ -35,34 +26,18 @@ SigFile
                             ([], false, None,
                              LongIdent (SynLongIdent ([obj], [], [None])), false,
                              PreXmlDoc ((6,25), FSharp.Compiler.Xml.XmlDocCollector),
-                             None,
-                             /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (6,25--6,28),
-                             { LeadingKeyword = None });
+                             None, (6,25--6,28), { LeadingKeyword = None });
                           SynField
                             ([], false, Some range,
                              LongIdent (SynLongIdent ([range], [], [None])),
                              false,
                              PreXmlDoc ((6,31), FSharp.Compiler.Xml.XmlDocCollector),
-                             None,
-                             /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (6,31--6,43),
-                             { LeadingKeyword = None })], PreXmlDocEmpty, None,
-                       /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (6,10--6,43),
-                       { BarRange = None }), None,
-                    PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                    /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (5,0--6,43)),
-                 None, [],
-                 /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (5,0--6,43)),
-              /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (5,0--6,43))],
+                             None, (6,31--6,43), { LeadingKeyword = None })],
+                       PreXmlDocEmpty, None, (6,10--6,43), { BarRange = None }),
+                    None, PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
+                    None, (5,0--6,43)), None, [], (5,0--6,43)), (5,0--6,43))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [],
-          Some
-            (Internal
-               /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (2,7--2,15)),
-          /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (2,0--6,43),
-          { LeadingKeyword =
-             Module
-               /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (2,0--2,6) })],
+          Some (Internal (2,7--2,15)), (2,0--6,43),
+          { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi (4,0--4,90)] },
-      set []))
+        CodeComments = [LineComment (4,0--4,90)] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi.bsl
@@ -10,37 +10,17 @@ SigFile
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName = SynLongIdent ([Foo1], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (4,2--4,6))
+                            ArgExpr = Const (Unit, (4,2--4,6))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (4,2--4,6) }]
-                        Range =
-                         /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (4,0--4,8) }],
-                     None, [], [MyType],
+                            Range = (4,2--4,6) }]
+                        Range = (4,0--4,8) }], None, [], [MyType],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (5,5--5,11)),
-                  ObjectModel
-                    (Class, [],
-                     /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (6,4--7,7)),
-                  [],
-                  /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (4,0--7,7),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (5,0--5,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (5,12--5,13)
-                    WithKeyword = None })],
-              /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (4,0--7,7))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (2,0--7,7),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynTypeDefnSig.fsi (2,0--2,9) })],
+                     false, None, (5,5--5,11)),
+                  ObjectModel (Class, [], (6,4--7,7)), [], (4,0--7,7),
+                  { LeadingKeyword = Type (5,0--5,4)
+                    EqualsRange = Some (5,12--5,13)
+                    WithKeyword = None })], (4,0--7,7))], PreXmlDocEmpty, [],
+          None, (2,0--7,7), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi.bsl
@@ -10,34 +10,25 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [FooType],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (4,5--4,12)),
+                     false, None, (4,5--4,12)),
                   ObjectModel
                     (Unspecified,
                      [Member
                         (SynValSig
                            ([{ Attributes =
                                 [{ TypeName = SynLongIdent ([Foo2], [], [None])
-                                   ArgExpr =
-                                    Const
-                                      (Unit,
-                                       /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (5,6--5,10))
+                                   ArgExpr = Const (Unit, (5,6--5,10))
                                    Target = None
                                    AppliesToGetterAndSetter = false
-                                   Range =
-                                    /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (5,6--5,10) }]
-                               Range =
-                                /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (5,4--5,12) }],
-                            SynIdent (x, None), SynValTyparDecls (None, true),
+                                   Range = (5,6--5,10) }]
+                               Range = (5,4--5,12) }], SynIdent (x, None),
+                            SynValTyparDecls (None, true),
                             LongIdent (SynLongIdent ([int], [], [None])),
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (5,4--6,20),
-                            { LeadingKeyword =
-                               Abstract
-                                 /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (6,4--6,12)
+                            None, None, (5,4--6,20),
+                            { LeadingKeyword = Abstract (6,4--6,12)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -46,27 +37,12 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (5,4--6,20),
-                         { GetSetKeywords = None })],
-                     /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (5,4--6,20)),
-                  [],
-                  /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (4,5--6,20),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (4,13--4,14)
-                    WithKeyword = None })],
-              /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (4,0--6,20))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (2,0--6,20),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (2,0--2,9) })],
+                           MemberKind = PropertyGet }, (5,4--6,20),
+                         { GetSetKeywords = None })], (5,4--6,20)), [],
+                  (4,5--6,20), { LeadingKeyword = Type (4,0--4,4)
+                                 EqualsRange = Some (4,13--4,14)
+                                 WithKeyword = None })], (4,0--6,20))],
+          PreXmlDocEmpty, [], None, (2,0--6,20),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/SignatureType/RangeOfAttributeShouldBeIncludedInSynValSpfnAndMember.fsi (5,13--5,23)] },
-      set []))
+        CodeComments = [LineComment (5,13--5,23)] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi.bsl
@@ -10,63 +10,39 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (4,5--4,8)),
+                     false, None, (4,5--4,8)),
                   Simple
                     (Union
                        (None,
                         [SynUnionCase
                            ([], SynIdent (Bar, None), Fields [],
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (5,6--5,9),
-                            { BarRange =
-                               Some
-                                 /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (5,4--5,5) })],
-                        /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (5,4--5,9)),
-                     /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (5,4--5,9)),
-                  [],
-                  /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (4,5--5,9),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (4,9--4,10)
+                            None, (5,6--5,9), { BarRange = Some (5,4--5,5) })],
+                        (5,4--5,9)), (5,4--5,9)), [], (4,5--5,9),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,9--4,10)
                     WithKeyword = None });
                SynTypeDefnSig
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName =
                              SynLongIdent ([CustomEquality], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (7,6--7,20))
+                            ArgExpr = Const (Unit, (7,6--7,20))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (7,6--7,20) }]
-                        Range =
-                         /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (7,4--7,22) }],
-                     None, [], [Bang],
+                            Range = (7,6--7,20) }]
+                        Range = (7,4--7,22) }], None, [], [Bang],
                      PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (7,23--7,27)),
+                     false, None, (7,23--7,27)),
                   Simple
                     (Record
-                       (Some
-                          (Internal
-                             /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (8,4--8,12)),
+                       (Some (Internal (8,4--8,12)),
                         [SynField
                            ([], false, Some LongNameBarBarBarBarBarBarBar,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((10,12), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (10,12--10,46),
-                            { LeadingKeyword = None })],
-                        /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (8,4--11,9)),
-                     /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (8,4--11,9)),
+                            None, (10,12--10,46), { LeadingKeyword = None })],
+                        (8,4--11,9)), (8,4--11,9)),
                   [Member
                      (SynValSig
                         ([], SynIdent (GetHashCode, None),
@@ -74,18 +50,13 @@ SigFile
                          Fun
                            (LongIdent (SynLongIdent ([unit], [], [None])),
                             LongIdent (SynLongIdent ([int], [], [None])),
-                            /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (12,31--12,42),
-                            { ArrowRange =
-                               /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (12,36--12,38) }),
+                            (12,31--12,42), { ArrowRange = (12,36--12,38) }),
                          SynValInfo
                            ([[SynArgInfo ([], false, None)]],
                             SynArgInfo ([], false, None)), false, false,
                          PreXmlDoc ((12,8), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, None,
-                         /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (12,8--12,42),
-                         { LeadingKeyword =
-                            Override
-                              /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (12,8--12,16)
+                         None, None, (12,8--12,42),
+                         { LeadingKeyword = Override (12,8--12,16)
                            InlineKeyword = None
                            WithKeyword = None
                            EqualsRange = None }),
@@ -94,22 +65,11 @@ SigFile
                         IsOverrideOrExplicitImpl = true
                         IsFinal = false
                         GetterOrSetterIsCompilerGenerated = false
-                        MemberKind = Member },
-                      /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (12,8--12,42),
-                      { GetSetKeywords = None })],
-                  /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (7,4--12,42),
-                  { LeadingKeyword =
-                     And
-                       /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (7,0--7,3)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (7,28--7,29)
-                    WithKeyword = None })],
-              /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (4,0--12,42))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (2,0--12,42),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi (2,0--2,9) })],
+                        MemberKind = Member }, (12,8--12,42),
+                      { GetSetKeywords = None })], (7,4--12,42),
+                  { LeadingKeyword = And (7,0--7,3)
+                    EqualsRange = Some (7,28--7,29)
+                    WithKeyword = None })], (4,0--12,42))], PreXmlDocEmpty, [],
+          None, (2,0--12,42), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi.bsl
@@ -15,41 +15,29 @@ SigFile
                             ([], false, None,
                              LongIdent (SynLongIdent ([obj], [], [None])), false,
                              PreXmlDoc ((4,25), FSharp.Compiler.Xml.XmlDocCollector),
-                             None,
-                             /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (4,25--4,28),
-                             { LeadingKeyword = None });
+                             None, (4,25--4,28), { LeadingKeyword = None });
                           SynField
                             ([], false, Some range,
                              LongIdent (SynLongIdent ([range], [], [None])),
                              false,
                              PreXmlDoc ((4,31), FSharp.Compiler.Xml.XmlDocCollector),
-                             None,
-                             /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (4,31--4,43),
-                             { LeadingKeyword = None })], PreXmlDocEmpty, None,
-                       /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (4,10--4,43),
-                       { BarRange = None }), None,
-                    PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                    /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (4,0--4,43)),
-                 Some
-                   /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (4,44--4,48),
+                             None, (4,31--4,43), { LeadingKeyword = None })],
+                       PreXmlDocEmpty, None, (4,10--4,43), { BarRange = None }),
+                    None, PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
+                    None, (4,0--4,43)), Some (4,44--4,48),
                  [Member
                     (SynValSig
                        ([], SynIdent (Meh, None), SynValTyparDecls (None, true),
                         Fun
                           (LongIdent (SynLongIdent ([string], [], [None])),
                            LongIdent (SynLongIdent ([int], [], [None])),
-                           /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (5,17--5,30),
-                           { ArrowRange =
-                              /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (5,24--5,26) }),
+                           (5,17--5,30), { ArrowRange = (5,24--5,26) }),
                         SynValInfo
                           ([[SynArgInfo ([], false, None)]],
                            SynArgInfo ([], false, None)), false, false,
                         PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                        None, None,
-                        /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (5,4--5,30),
-                        { LeadingKeyword =
-                           Member
-                             /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (5,4--5,10)
+                        None, None, (5,4--5,30),
+                        { LeadingKeyword = Member (5,4--5,10)
                           InlineKeyword = None
                           WithKeyword = None
                           EqualsRange = None }),
@@ -58,23 +46,13 @@ SigFile
                        IsOverrideOrExplicitImpl = false
                        IsFinal = false
                        GetterOrSetterIsCompilerGenerated = false
-                       MemberKind = Member },
-                     /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (5,4--5,30),
-                     { GetSetKeywords = None })],
-                 /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (4,0--5,30)),
-              /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (4,0--5,30));
+                       MemberKind = Member }, (5,4--5,30),
+                     { GetSetKeywords = None })], (4,0--5,30)), (4,0--5,30));
            Open
-             (ModuleOrNamespace
-                (SynLongIdent ([Foo], [], [None]),
-                 /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (7,5--7,8)),
-              /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (7,0--7,8))],
+             (ModuleOrNamespace (SynLongIdent ([Foo], [], [None]), (7,5--7,8)),
+              (7,0--7,8))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [],
-          Some
-            (Internal
-               /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (2,7--2,15)),
-          /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (2,0--7,8),
-          { LeadingKeyword =
-             Module
-               /root/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi (2,0--2,6) })],
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+          Some (Internal (2,7--2,15)), (2,0--7,8),
+          { LeadingKeyword = Module (2,0--2,6) })], { ConditionalDirectives = []
+                                                      CodeComments = [] },
+      set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi.bsl
@@ -10,16 +10,13 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [MyFunction],
                      PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (3,5--3,15)),
+                     false, None, (3,5--3,15)),
                   ObjectModel
                     (Delegate
                        (Fun
                           (LongIdent (SynLongIdent ([int], [], [None])),
                            LongIdent (SynLongIdent ([string], [], [None])),
-                           /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (4,16--4,29),
-                           { ArrowRange =
-                              /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (4,20--4,22) }),
+                           (4,16--4,29), { ArrowRange = (4,20--4,22) }),
                         SynValInfo
                           ([[SynArgInfo ([], false, None)]],
                            SynArgInfo ([], false, None))),
@@ -30,14 +27,11 @@ SigFile
                             Fun
                               (LongIdent (SynLongIdent ([int], [], [None])),
                                LongIdent (SynLongIdent ([string], [], [None])),
-                               /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (4,16--4,29),
-                               { ArrowRange =
-                                  /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (4,20--4,22) }),
+                               (4,16--4,29), { ArrowRange = (4,20--4,22) }),
                             SynValInfo
                               ([[SynArgInfo ([], false, None)]],
                                SynArgInfo ([], false, None)), false, false,
-                            PreXmlDocEmpty, None, None,
-                            /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (4,4--4,29),
+                            PreXmlDocEmpty, None, None, (4,4--4,29),
                             { LeadingKeyword = Synthetic
                               InlineKeyword = None
                               WithKeyword = None
@@ -47,24 +41,12 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (4,4--4,29),
-                         { GetSetKeywords = None })],
-                     /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (4,4--4,29)),
-                  [],
-                  /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (3,5--4,29),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (3,0--3,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (3,16--3,17)
-                    WithKeyword = None })],
-              /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (3,0--4,29))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (2,0--4,29),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/RangeOfSynTypeDefnSigDelegateOfShouldStartFromName.fsi (2,0--2,9) })],
+                           MemberKind = Member }, (4,4--4,29),
+                         { GetSetKeywords = None })], (4,4--4,29)), [],
+                  (3,5--4,29), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,16--3,17)
+                                 WithKeyword = None })], (3,0--4,29))],
+          PreXmlDocEmpty, [], None, (2,0--4,29),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi.bsl
@@ -10,11 +10,8 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [MyRecord],
                      PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (3,5--3,13)),
-                  ObjectModel
-                    (Class, [],
-                     /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (4,4--5,7)),
+                     false, None, (3,5--3,13)),
+                  ObjectModel (Class, [], (4,4--5,7)),
                   [Member
                      (SynValSig
                         ([], SynIdent (Score, None),
@@ -22,18 +19,13 @@ SigFile
                          Fun
                            (LongIdent (SynLongIdent ([unit], [], [None])),
                             LongIdent (SynLongIdent ([int], [], [None])),
-                            /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (6,19--6,30),
-                            { ArrowRange =
-                               /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (6,24--6,26) }),
+                            (6,19--6,30), { ArrowRange = (6,24--6,26) }),
                          SynValInfo
                            ([[SynArgInfo ([], false, None)]],
                             SynArgInfo ([], false, None)), false, false,
                          PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, None,
-                         /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (6,4--6,30),
-                         { LeadingKeyword =
-                            Member
-                              /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (6,4--6,10)
+                         None, None, (6,4--6,30),
+                         { LeadingKeyword = Member (6,4--6,10)
                            InlineKeyword = None
                            WithKeyword = None
                            EqualsRange = None }),
@@ -42,22 +34,11 @@ SigFile
                         IsOverrideOrExplicitImpl = false
                         IsFinal = false
                         GetterOrSetterIsCompilerGenerated = false
-                        MemberKind = Member },
-                      /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (6,4--6,30),
-                      { GetSetKeywords = None })],
-                  /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (3,5--6,30),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (3,0--3,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (3,14--3,15)
-                    WithKeyword = None })],
-              /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (3,0--6,30))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (2,0--6,30),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/RangeOfSynTypeDefnSigObjectModelShouldEndAtLastMember.fsi (2,0--2,9) })],
+                        MemberKind = Member }, (6,4--6,30),
+                      { GetSetKeywords = None })], (3,5--6,30),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,14--3,15)
+                    WithKeyword = None })], (3,0--6,30))], PreXmlDocEmpty, [],
+          None, (2,0--6,30), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi.bsl
@@ -10,8 +10,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [MyRecord],
                      PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (3,5--3,13)),
+                     false, None, (3,5--3,13)),
                   Simple
                     (Record
                        (None,
@@ -19,11 +18,8 @@ SigFile
                            ([], false, Some Level,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (4,6--4,16),
-                            { LeadingKeyword = None })],
-                        /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (4,4--4,18)),
-                     /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (4,4--4,18)),
+                            None, (4,6--4,16), { LeadingKeyword = None })],
+                        (4,4--4,18)), (4,4--4,18)),
                   [Member
                      (SynValSig
                         ([], SynIdent (Score, None),
@@ -31,18 +27,13 @@ SigFile
                          Fun
                            (LongIdent (SynLongIdent ([unit], [], [None])),
                             LongIdent (SynLongIdent ([int], [], [None])),
-                            /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (5,19--5,30),
-                            { ArrowRange =
-                               /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (5,24--5,26) }),
+                            (5,19--5,30), { ArrowRange = (5,24--5,26) }),
                          SynValInfo
                            ([[SynArgInfo ([], false, None)]],
                             SynArgInfo ([], false, None)), false, false,
                          PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, None,
-                         /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (5,4--5,30),
-                         { LeadingKeyword =
-                            Member
-                              /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (5,4--5,10)
+                         None, None, (5,4--5,30),
+                         { LeadingKeyword = Member (5,4--5,10)
                            InlineKeyword = None
                            WithKeyword = None
                            EqualsRange = None }),
@@ -51,22 +42,11 @@ SigFile
                         IsOverrideOrExplicitImpl = false
                         IsFinal = false
                         GetterOrSetterIsCompilerGenerated = false
-                        MemberKind = Member },
-                      /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (5,4--5,30),
-                      { GetSetKeywords = None })],
-                  /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (3,5--5,30),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (3,0--3,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (3,14--3,15)
-                    WithKeyword = None })],
-              /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (3,0--5,30))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (2,0--5,30),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi (2,0--2,9) })],
+                        MemberKind = Member }, (5,4--5,30),
+                      { GetSetKeywords = None })], (3,5--5,30),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,14--3,15)
+                    WithKeyword = None })], (3,0--5,30))], PreXmlDocEmpty, [],
+          None, (2,0--5,30), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi.bsl
@@ -9,55 +9,31 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [SomeCollection],
                      PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (3,5--3,19)),
-                  Simple
-                    (None
-                       /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (3,5--5,37),
-                     /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (3,5--5,37)),
+                     false, None, (3,5--3,19)),
+                  Simple (None (3,5--5,37), (3,5--5,37)),
                   [ValField
                      (SynField
                         ([], false, Some LastIndex,
                          LongIdent (SynLongIdent ([int], [], [None])), false,
                          PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (4,4--4,23),
-                         { LeadingKeyword =
-                            Some
-                              (Val
-                                 /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (4,4--4,7)) }),
-                      /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (4,4--4,23));
+                         None, (4,4--4,23),
+                         { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                      (4,4--4,23));
                    ValField
                      (SynField
                         ([], false, Some SomeThingElse,
                          Fun
                            (LongIdent (SynLongIdent ([int], [], [None])),
                             LongIdent (SynLongIdent ([string], [], [None])),
-                            /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (5,24--5,37),
-                            { ArrowRange =
-                               /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (5,28--5,30) }),
-                         false,
+                            (5,24--5,37), { ArrowRange = (5,28--5,30) }), false,
                          PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None,
-                         /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (5,4--5,37),
-                         { LeadingKeyword =
-                            Some
-                              (Val
-                                 /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (5,4--5,7)) }),
-                      /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (5,4--5,37))],
-                  /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (3,5--5,37),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (3,0--3,4)
+                         None, (5,4--5,37),
+                         { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                      (5,4--5,37))], (3,5--5,37),
+                  { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = None
-                    WithKeyword =
-                     Some
-                       /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (3,20--3,24) })],
-              /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (3,0--5,37))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (2,0--5,37),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi (2,0--2,9) })],
+                    WithKeyword = Some (3,20--3,24) })], (3,0--5,37))],
+          PreXmlDocEmpty, [], None, (2,0--5,37),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi.bsl
@@ -9,28 +9,11 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Meh],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (4,5--4,8)),
-                  ObjectModel
-                    (Class, [],
-                     /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (5,8--6,11)),
-                  [],
-                  /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (4,5--6,11),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (4,9--4,10)
-                    WithKeyword = None })],
-              /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (4,0--6,11))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (2,0--6,11),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (2,0--2,9) })],
+                     false, None, (4,5--4,8)),
+                  ObjectModel (Class, [], (5,8--6,11)), [], (4,5--6,11),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,9--4,10)
+                    WithKeyword = None })], (4,0--6,11))], PreXmlDocEmpty, [],
+          None, (2,0--6,11), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/SignatureType/RangeOfTypeShouldEndAtEndKeyword.fsi (9,0--9,6)] },
-      set []))
+        CodeComments = [LineComment (9,0--9,6)] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi.bsl
@@ -11,30 +11,22 @@ SigFile
                    ([],
                     SynUnionCase
                       ([], SynIdent (Foo, None), Fields [], PreXmlDocEmpty, None,
-                       /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,10--4,13),
-                       { BarRange = None }), None,
+                       (4,10--4,13), { BarRange = None }), None,
                     PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                    /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,0--4,13)),
-                 Some
-                   /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,14--4,18),
+                    (4,0--4,13)), Some (4,14--4,18),
                  [Member
                     (SynValSig
                        ([], SynIdent (Meh, None), SynValTyparDecls (None, true),
                         Fun
                           (LongIdent (SynLongIdent ([unit], [], [None])),
                            LongIdent (SynLongIdent ([unit], [], [None])),
-                           /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,13--5,25),
-                           { ArrowRange =
-                              /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,18--5,20) }),
+                           (5,13--5,25), { ArrowRange = (5,18--5,20) }),
                         SynValInfo
                           ([[SynArgInfo ([], false, None)]],
                            SynArgInfo ([], false, None)), false, false,
                         PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
-                        None, None,
-                        /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,0--5,25),
-                        { LeadingKeyword =
-                           Member
-                             /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,0--5,6)
+                        None, None, (5,0--5,25),
+                        { LeadingKeyword = Member (5,0--5,6)
                           InlineKeyword = None
                           WithKeyword = None
                           EqualsRange = None }),
@@ -43,15 +35,9 @@ SigFile
                        IsOverrideOrExplicitImpl = false
                        IsFinal = false
                        GetterOrSetterIsCompilerGenerated = false
-                       MemberKind = Member },
-                     /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,0--5,25),
-                     { GetSetKeywords = None })],
-                 /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,0--5,25)),
-              /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,0--5,25))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (2,0--5,25),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/SynExceptionSigShouldContainsTheRangeOfTheWithKeyword.fsi (2,0--2,9) })],
+                       MemberKind = Member }, (5,0--5,25),
+                     { GetSetKeywords = None })], (4,0--5,25)), (4,0--5,25))],
+          PreXmlDocEmpty, [], None, (2,0--5,25),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi.bsl
@@ -10,30 +10,21 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,5--4,8)),
-                  Simple
-                    (None
-                       /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,5--5,25),
-                     /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,5--5,25)),
+                     false, None, (4,5--4,8)),
+                  Simple (None (4,5--5,25), (4,5--5,25)),
                   [Member
                      (SynValSig
                         ([], SynIdent (Meh, None), SynValTyparDecls (None, true),
                          Fun
                            (LongIdent (SynLongIdent ([unit], [], [None])),
                             LongIdent (SynLongIdent ([unit], [], [None])),
-                            /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,13--5,25),
-                            { ArrowRange =
-                               /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,18--5,20) }),
+                            (5,13--5,25), { ArrowRange = (5,18--5,20) }),
                          SynValInfo
                            ([[SynArgInfo ([], false, None)]],
                             SynArgInfo ([], false, None)), false, false,
                          PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, None,
-                         /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,0--5,25),
-                         { LeadingKeyword =
-                            Member
-                              /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,0--5,6)
+                         None, None, (5,0--5,25),
+                         { LeadingKeyword = Member (5,0--5,6)
                            InlineKeyword = None
                            WithKeyword = None
                            EqualsRange = None }),
@@ -42,22 +33,12 @@ SigFile
                         IsOverrideOrExplicitImpl = false
                         IsFinal = false
                         GetterOrSetterIsCompilerGenerated = false
-                        MemberKind = Member },
-                      /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (5,0--5,25),
-                      { GetSetKeywords = None })],
-                  /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,5--5,25),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,0--4,4)
+                        MemberKind = Member }, (5,0--5,25),
+                      { GetSetKeywords = None })], (4,5--5,25),
+                  { LeadingKeyword = Type (4,0--4,4)
                     EqualsRange = None
-                    WithKeyword =
-                     Some
-                       /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,9--4,13) })],
-              /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (4,0--5,25))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (2,0--5,25),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi (2,0--2,9) })],
+                    WithKeyword = Some (4,9--4,13) })], (4,0--5,25))],
+          PreXmlDocEmpty, [], None, (2,0--5,25),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi.bsl
@@ -10,50 +10,25 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Bear],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (4,5--4,9)),
+                     false, None, (4,5--4,9)),
                   Simple
                     (Enum
                        ([SynEnumCase
                            ([], SynIdent (BlackBear, None),
-                            Const
-                              (Int32 1,
-                               /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (5,18--5,19)),
+                            Const (Int32 1, (5,18--5,19)),
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (5,6--5,19),
-                            { BarRange =
-                               Some
-                                 /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (5,4--5,5)
-                              EqualsRange =
-                               /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (5,16--5,17) });
+                            (5,6--5,19), { BarRange = Some (5,4--5,5)
+                                           EqualsRange = (5,16--5,17) });
                          SynEnumCase
                            ([], SynIdent (PolarBear, None),
-                            Const
-                              (Int32 2,
-                               /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (6,18--6,19)),
+                            Const (Int32 2, (6,18--6,19)),
                             PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (6,6--6,19),
-                            { BarRange =
-                               Some
-                                 /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (6,4--6,5)
-                              EqualsRange =
-                               /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (6,16--6,17) })],
-                        /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (5,4--6,19)),
-                     /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (5,4--6,19)),
-                  [],
-                  /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (4,5--6,19),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (4,10--4,11)
-                    WithKeyword = None })],
-              /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (4,0--6,19))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (2,0--6,19),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/SynTypeDefnSigWithEnumContainsTheRangeOfTheEqualsSign.fsi (2,0--2,9) })],
+                            (6,6--6,19), { BarRange = Some (6,4--6,5)
+                                           EqualsRange = (6,16--6,17) })],
+                        (5,4--6,19)), (5,4--6,19)), [], (4,5--6,19),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,10--4,11)
+                    WithKeyword = None })], (4,0--6,19))], PreXmlDocEmpty, [],
+          None, (2,0--6,19), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi.bsl
@@ -11,25 +11,11 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Foobar],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi (4,5--4,11)),
-                  ObjectModel
-                    (Class, [],
-                     /root/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi (5,4--6,7)),
-                  [],
-                  /root/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi (4,5--6,7),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi (4,12--4,13)
-                    WithKeyword = None })],
-              /root/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi (4,0--6,7))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi (2,0--6,7),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/SynTypeDefnSigWithObjectModelClassContainsTheRangeOfTheEqualsSign.fsi (2,0--2,9) })],
+                     false, None, (4,5--4,11)),
+                  ObjectModel (Class, [], (5,4--6,7)), [], (4,5--6,7),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,12--4,13)
+                    WithKeyword = None })], (4,0--6,7))], PreXmlDocEmpty, [],
+          None, (2,0--6,7), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi.bsl
@@ -11,16 +11,13 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Delegate
                        (Fun
                           (LongIdent (SynLongIdent ([string], [], [None])),
                            LongIdent (SynLongIdent ([string], [], [None])),
-                           /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,21--4,37),
-                           { ArrowRange =
-                              /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,28--4,30) }),
+                           (4,21--4,37), { ArrowRange = (4,28--4,30) }),
                         SynValInfo
                           ([[SynArgInfo ([], false, None)]],
                            SynArgInfo ([], false, None))),
@@ -31,14 +28,11 @@ SigFile
                             Fun
                               (LongIdent (SynLongIdent ([string], [], [None])),
                                LongIdent (SynLongIdent ([string], [], [None])),
-                               /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,21--4,37),
-                               { ArrowRange =
-                                  /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,28--4,30) }),
+                               (4,21--4,37), { ArrowRange = (4,28--4,30) }),
                             SynValInfo
                               ([[SynArgInfo ([], false, None)]],
                                SynArgInfo ([], false, None)), false, false,
-                            PreXmlDocEmpty, None, None,
-                            /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,9--4,37),
+                            PreXmlDocEmpty, None, None, (4,9--4,37),
                             { LeadingKeyword = Synthetic
                               InlineKeyword = None
                               WithKeyword = None
@@ -48,24 +42,12 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,9--4,37),
-                         { GetSetKeywords = None })],
-                     /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,9--4,37)),
-                  [],
-                  /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,5--4,37),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (4,0--4,37))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (2,0--4,37),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/SynTypeDefnSigWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fsi (2,0--2,9) })],
+                           MemberKind = Member }, (4,9--4,37),
+                         { GetSetKeywords = None })], (4,9--4,37)), [],
+                  (4,5--4,37), { LeadingKeyword = Type (4,0--4,4)
+                                 EqualsRange = Some (4,7--4,8)
+                                 WithKeyword = None })], (4,0--4,37))],
+          PreXmlDocEmpty, [], None, (2,0--4,37),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi.bsl
@@ -10,8 +10,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [Shape],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (4,5--4,10)),
+                     false, None, (4,5--4,10)),
                   Simple
                     (Union
                        (None,
@@ -23,15 +22,9 @@ SigFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((5,12), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (5,12--5,15),
-                                  { LeadingKeyword = None })],
+                                  None, (5,12--5,15), { LeadingKeyword = None })],
                             PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (5,2--5,15),
-                            { BarRange =
-                               Some
-                                 /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (5,0--5,1) });
+                            None, (5,2--5,15), { BarRange = Some (5,0--5,1) });
                          SynUnionCase
                            ([], SynIdent (Rectangle, None),
                             Fields
@@ -40,39 +33,19 @@ SigFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((6,15), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (6,15--6,18),
-                                  { LeadingKeyword = None });
+                                  None, (6,15--6,18), { LeadingKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((6,21), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (6,21--6,24),
-                                  { LeadingKeyword = None })],
+                                  None, (6,21--6,24), { LeadingKeyword = None })],
                             PreXmlDoc ((6,0), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (6,2--6,24),
-                            { BarRange =
-                               Some
-                                 /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (6,0--6,1) })],
-                        /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (5,0--6,24)),
-                     /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (5,0--6,24)),
-                  [],
-                  /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (4,5--6,24),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (4,11--4,12)
-                    WithKeyword = None })],
-              /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (4,0--6,24))],
-          PreXmlDocEmpty, [], None,
-          /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (2,0--6,24),
-          { LeadingKeyword =
-             Namespace
-               /root/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi (2,0--2,9) })],
+                            None, (6,2--6,24), { BarRange = Some (6,0--6,1) })],
+                        (5,0--6,24)), (5,0--6,24)), [], (4,5--6,24),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,11--4,12)
+                    WithKeyword = None })], (4,0--6,24))], PreXmlDocEmpty, [],
+          None, (2,0--6,24), { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/SynValSigContainsParameterNames.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/SynValSigContainsParameterNames.fsi.bsl
@@ -19,11 +19,8 @@ SigFile
                                  None,
                                  [LongIdent
                                     (SynLongIdent ([SynMemberFlags], [], [None]))],
-                                 [], None, true,
-                                 /root/SignatureType/SynValSigContainsParameterNames.fsi (4,20--4,41)),
-                              /root/SignatureType/SynValSigContainsParameterNames.fsi (4,4--4,41)));
-                        Star
-                          /root/SignatureType/SynValSigContainsParameterNames.fsi (4,42--4,43);
+                                 [], None, true, (4,20--4,41)), (4,4--4,41)));
+                        Star (4,42--4,43);
                         Type
                           (SignatureParameter
                              ([], false, Some pat,
@@ -32,39 +29,28 @@ SigFile
                                  None,
                                  [LongIdent
                                     (SynLongIdent ([SynPat], [], [None]))], [],
-                                 None, true,
-                                 /root/SignatureType/SynValSigContainsParameterNames.fsi (4,49--4,62)),
-                              /root/SignatureType/SynValSigContainsParameterNames.fsi (4,44--4,62)));
-                        Star
-                          /root/SignatureType/SynValSigContainsParameterNames.fsi (4,63--4,64);
+                                 None, true, (4,49--4,62)), (4,44--4,62)));
+                        Star (4,63--4,64);
                         Type
                           (App
                              (LongIdent (SynLongIdent ([option], [], [None])),
                               None,
                               [LongIdent
                                  (SynLongIdent ([SynReturnInfo], [], [None]))],
-                              [], None, true,
-                              /root/SignatureType/SynValSigContainsParameterNames.fsi (4,65--4,85)));
-                        Star
-                          /root/SignatureType/SynValSigContainsParameterNames.fsi (4,86--4,87);
+                              [], None, true, (4,65--4,85))); Star (4,86--4,87);
                         Type
                           (SignatureParameter
                              ([], false, Some origRhsExpr,
                               LongIdent (SynLongIdent ([SynExpr], [], [None])),
-                              /root/SignatureType/SynValSigContainsParameterNames.fsi (4,88--4,108)))],
-                       /root/SignatureType/SynValSigContainsParameterNames.fsi (4,4--4,108)),
+                              (4,88--4,108)))], (4,4--4,108)),
                     Fun
                       (SignatureParameter
                          ([], false, Some x,
                           LongIdent (SynLongIdent ([string], [], [None])),
-                          /root/SignatureType/SynValSigContainsParameterNames.fsi (5,8--5,17)),
+                          (5,8--5,17)),
                        LongIdent (SynLongIdent ([SynValData2], [], [None])),
-                       /root/SignatureType/SynValSigContainsParameterNames.fsi (5,8--6,23),
-                       { ArrowRange =
-                          /root/SignatureType/SynValSigContainsParameterNames.fsi (5,18--5,20) }),
-                    /root/SignatureType/SynValSigContainsParameterNames.fsi (4,4--6,23),
-                    { ArrowRange =
-                       /root/SignatureType/SynValSigContainsParameterNames.fsi (4,109--4,111) }),
+                       (5,8--6,23), { ArrowRange = (5,18--5,20) }), (4,4--6,23),
+                    { ArrowRange = (4,109--4,111) }),
                  SynValInfo
                    ([[SynArgInfo ([], false, Some memberFlagsOpt);
                       SynArgInfo ([], false, Some pat);
@@ -73,19 +59,11 @@ SigFile
                      [SynArgInfo ([], false, Some x)]],
                     SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None,
-                 /root/SignatureType/SynValSigContainsParameterNames.fsi (3,0--6,23),
-                 { LeadingKeyword =
-                    Val
-                      /root/SignatureType/SynValSigContainsParameterNames.fsi (3,0--3,3)
-                   InlineKeyword = None
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/SignatureType/SynValSigContainsParameterNames.fsi (3,0--6,23))],
+                 None, (3,0--6,23), { LeadingKeyword = Val (3,0--3,3)
+                                      InlineKeyword = None
+                                      WithKeyword = None
+                                      EqualsRange = None }), (3,0--6,23))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/SignatureType/SynValSigContainsParameterNames.fsi (2,0--6,23),
-          { LeadingKeyword =
-             Module
-               /root/SignatureType/SynValSigContainsParameterNames.fsi (2,0--2,6) })],
+          (2,0--6,23), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -21,91 +20,55 @@ SigFile
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            Some
-                              (Const
-                                 (Int32 10,
-                                  /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (5,21--5,23))),
-                            /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (5,4--5,23),
-                            { LeadingKeyword =
-                               Member
-                                 /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (5,4--5,10)
-                              InlineKeyword = None
-                              WithKeyword = None
-                              EqualsRange =
-                               Some
-                                 /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (5,19--5,20) }),
+                            None, Some (Const (Int32 10, (5,21--5,23))),
+                            (5,4--5,23), { LeadingKeyword = Member (5,4--5,10)
+                                           InlineKeyword = None
+                                           WithKeyword = None
+                                           EqualsRange = Some (5,19--5,20) }),
                          { IsInstance = true
                            IsDispatchSlot = false
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = PropertyGet },
-                         /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (5,4--5,23),
-                         { GetSetKeywords = None })],
-                     /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (5,4--5,23)),
-                  [],
-                  /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (4,5--5,23),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (4,7--4,8)
-                    WithKeyword = None })],
-              /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (4,0--5,23));
+                           MemberKind = PropertyGet }, (5,4--5,23),
+                         { GetSetKeywords = None })], (5,4--5,23)), [],
+                  (4,5--5,23), { LeadingKeyword = Type (4,0--4,4)
+                                 EqualsRange = Some (4,7--4,8)
+                                 WithKeyword = None })], (4,0--5,23));
            Types
              ([SynTypeDefnSig
                  (SynComponentInfo
                     ([], None, [], [Y],
                      PreXmlDoc ((11,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (11,5--11,6)),
+                     false, None, (11,5--11,6)),
                   Simple
                     (TypeAbbrev
                        (Ok, LongIdent (SynLongIdent ([int], [], [None])),
-                        /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (11,9--11,12)),
-                     /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (11,9--11,12)),
-                  [],
-                  /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (7,0--11,12),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (11,0--11,4)
-                    EqualsRange =
-                     Some
-                       /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (11,7--11,8)
-                    WithKeyword = None })],
-              /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (7,0--11,12));
+                        (11,9--11,12)), (11,9--11,12)), [], (7,0--11,12),
+                  { LeadingKeyword = Type (11,0--11,4)
+                    EqualsRange = Some (11,7--11,8)
+                    WithKeyword = None })], (7,0--11,12));
            Types
              ([SynTypeDefnSig
                  (SynComponentInfo
                     ([], None, [], [Z],
                      PreXmlDoc ((14,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (14,5--14,6)),
-                  Simple
-                    (None
-                       /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (14,5--15,32),
-                     /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (14,5--15,32)),
+                     false, None, (14,5--14,6)),
+                  Simple (None (14,5--15,32), (14,5--15,32)),
                   [Member
                      (SynValSig
                         ([], SynIdent (P, None), SynValTyparDecls (None, true),
                          Fun
                            (LongIdent (SynLongIdent ([int], [], [None])),
                             LongIdent (SynLongIdent ([int], [], [None])),
-                            /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (15,22--15,32),
-                            { ArrowRange =
-                               /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (15,26--15,28) }),
+                            (15,22--15,32), { ArrowRange = (15,26--15,28) }),
                          SynValInfo
                            ([[SynArgInfo ([], false, None)]],
                             SynArgInfo ([], false, None)), false, false,
                          PreXmlDoc ((15,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, None,
-                         /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (15,4--15,32),
+                         None, None, (15,4--15,32),
                          { LeadingKeyword =
-                            StaticMember
-                              (/root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (15,4--15,10),
-                               /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (15,11--15,17))
+                            StaticMember ((15,4--15,10), (15,11--15,17))
                            InlineKeyword = None
                            WithKeyword = None
                            EqualsRange = None }),
@@ -114,29 +77,14 @@ SigFile
                         IsOverrideOrExplicitImpl = false
                         IsFinal = false
                         GetterOrSetterIsCompilerGenerated = false
-                        MemberKind = Member },
-                      /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (15,4--15,32),
-                      { GetSetKeywords = None })],
-                  /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (14,5--15,32),
-                  { LeadingKeyword =
-                     Type
-                       /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (14,0--14,4)
+                        MemberKind = Member }, (15,4--15,32),
+                      { GetSetKeywords = None })], (14,5--15,32),
+                  { LeadingKeyword = Type (14,0--14,4)
                     EqualsRange = None
-                    WithKeyword =
-                     Some
-                       /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (14,7--14,11) })],
-              /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (14,0--15,32))],
+                    WithKeyword = Some (14,7--14,11) })], (14,0--15,32))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (2,0--15,32),
-          { LeadingKeyword =
-             Module
-               /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (2,0--2,6) })],
+          (2,0--15,32), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives =
-         [If
-            (Ident "CHECK_LINE0_TYPES",
-             /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (8,0--8,21));
-          Else
-            /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (10,0--10,5);
-          EndIf
-            /root/SignatureType/TriviaIsPresentInSynTypeDefnSig.fsi (12,0--12,6)]
+         [If (Ident "CHECK_LINE0_TYPES", (8,0--8,21)); Else (10,0--10,5);
+          EndIf (12,0--12,6)]
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/ValKeywordIsPresentInSynValSig.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/ValKeywordIsPresentInSynValSig.fsi.bsl
@@ -6,38 +6,21 @@ SigFile
          ([Meh], false, NamedModule,
           [Val
              (SynValSig
-                ([{ Attributes =
-                     [{ TypeName = SynLongIdent ([Foo], [], [None])
-                        ArgExpr =
-                         Const
-                           (Unit,
-                            /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (4,2--4,5))
-                        Target = None
-                        AppliesToGetterAndSetter = false
-                        Range =
-                         /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (4,2--4,5) }]
-                    Range =
-                     /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (4,0--4,7) }],
-                 SynIdent (a, None), SynValTyparDecls (None, true),
+                ([{ Attributes = [{ TypeName = SynLongIdent ([Foo], [], [None])
+                                    ArgExpr = Const (Unit, (4,2--4,5))
+                                    Target = None
+                                    AppliesToGetterAndSetter = false
+                                    Range = (4,2--4,5) }]
+                    Range = (4,0--4,7) }], SynIdent (a, None),
+                 SynValTyparDecls (None, true),
                  LongIdent (SynLongIdent ([int], [], [None])),
                  SynValInfo ([], SynArgInfo ([], false, None)), false, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None,
-                 /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (4,0--6,11),
-                 { LeadingKeyword =
-                    Val
-                      /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (6,0--6,3)
-                   InlineKeyword = None
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (4,0--6,11))],
+                 None, (4,0--6,11), { LeadingKeyword = Val (6,0--6,3)
+                                      InlineKeyword = None
+                                      WithKeyword = None
+                                      EqualsRange = None }), (4,0--6,11))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (2,0--6,11),
-          { LeadingKeyword =
-             Module
-               /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (2,0--2,6) })],
+          (2,0--6,11), { LeadingKeyword = Module (2,0--2,6) })],
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/SignatureType/ValKeywordIsPresentInSynValSig.fsi (5,0--5,6)] },
-      set []))
+        CodeComments = [LineComment (5,0--5,6)] }, set []))

--- a/tests/service/data/SyntaxTree/SourceIdentifier/_LINE_.fs.bsl
+++ b/tests/service/data/SyntaxTree/SourceIdentifier/_LINE_.fs.bsl
@@ -5,12 +5,8 @@ ImplFile
       [SynModuleOrNamespace
          ([_LINE_], false, AnonModule,
           [Expr
-             (Const
-                (SourceIdentifier
-                   ("__LINE__", "2", /root/SourceIdentifier/_LINE_.fs (2,0--2,8)),
-                 /root/SourceIdentifier/_LINE_.fs (2,0--2,8)),
-              /root/SourceIdentifier/_LINE_.fs (2,0--2,8))], PreXmlDocEmpty, [],
-          None, /root/SourceIdentifier/_LINE_.fs (2,0--2,8),
+             (Const (SourceIdentifier ("__LINE__", "2", (2,0--2,8)), (2,0--2,8)),
+              (2,0--2,8))], PreXmlDocEmpty, [], None, (2,0--2,8),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SourceIdentifier/_SOURCEDIRECTORY_.fs.bsl
+++ b/tests/service/data/SyntaxTree/SourceIdentifier/_SOURCEDIRECTORY_.fs.bsl
@@ -7,12 +7,8 @@ ImplFile
           [Expr
              (Const
                 (SourceIdentifier
-                   ("__SOURCE_DIRECTORY__", "/root/SourceIdentifier",
-                    /root/SourceIdentifier/_SOURCEDIRECTORY_.fs (0,0--0,0)),
-                 /root/SourceIdentifier/_SOURCEDIRECTORY_.fs (0,0--0,0)),
-              /root/SourceIdentifier/_SOURCEDIRECTORY_.fs (0,0--0,0))],
-          PreXmlDocEmpty, [], None,
-          /root/SourceIdentifier/_SOURCEDIRECTORY_.fs (2,0--2,20),
-          { LeadingKeyword = None })], (true, false),
+                   ("__SOURCE_DIRECTORY__", "/root/SourceIdentifier", (0,0--0,0)),
+                 (0,0--0,0)), (0,0--0,0))], PreXmlDocEmpty, [], None,
+          (2,0--2,20), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SourceIdentifier/_SOURCEFILE_.fs.bsl
+++ b/tests/service/data/SyntaxTree/SourceIdentifier/_SOURCEFILE_.fs.bsl
@@ -7,12 +7,8 @@ ImplFile
           [Expr
              (Const
                 (SourceIdentifier
-                   ("__SOURCE_FILE__", "_SOURCEFILE_.fs",
-                    /root/SourceIdentifier/_SOURCEFILE_.fs (2,0--2,15)),
-                 /root/SourceIdentifier/_SOURCEFILE_.fs (2,0--2,15)),
-              /root/SourceIdentifier/_SOURCEFILE_.fs (2,0--2,15))],
-          PreXmlDocEmpty, [], None,
-          /root/SourceIdentifier/_SOURCEFILE_.fs (2,0--2,15),
-          { LeadingKeyword = None })], (true, false),
+                   ("__SOURCE_FILE__", "_SOURCEFILE_.fs", (2,0--2,15)),
+                 (2,0--2,15)), (2,0--2,15))], PreXmlDocEmpty, [], None,
+          (2,0--2,15), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/String/SynConstBytesWithSynByteStringKindRegular.fs.bsl
+++ b/tests/service/data/SyntaxTree/String/SynConstBytesWithSynByteStringKindRegular.fs.bsl
@@ -11,28 +11,13 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (bytes, None), false, None,
-                     /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,4--2,9)),
-                  None,
+                  Named (SynIdent (bytes, None), false, None, (2,4--2,9)), None,
                   Const
-                    (Bytes
-                       ([|121uy; 111uy|], Regular,
-                        /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,12--2,17)),
-                     /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,12--2,17)),
-                  /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,4--2,9),
-                  Yes
-                    /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,0--2,17),
-                  { LeadingKeyword =
-                     Let
-                       /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,0--2,3)
+                    (Bytes ([|121uy; 111uy|], Regular, (2,12--2,17)),
+                     (2,12--2,17)), (2,4--2,9), Yes (2,0--2,17),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,10--2,11) })],
-              /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,0--2,17))],
-          PreXmlDocEmpty, [], None,
-          /root/String/SynConstBytesWithSynByteStringKindRegular.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,10--2,11) })], (2,0--2,17))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/String/SynConstBytesWithSynByteStringKindVerbatim.fs.bsl
+++ b/tests/service/data/SyntaxTree/String/SynConstBytesWithSynByteStringKindVerbatim.fs.bsl
@@ -11,28 +11,13 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (bytes, None), false, None,
-                     /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,4--2,9)),
-                  None,
+                  Named (SynIdent (bytes, None), false, None, (2,4--2,9)), None,
                   Const
-                    (Bytes
-                       ([|121uy; 111uy|], Verbatim,
-                        /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,12--2,18)),
-                     /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,12--2,18)),
-                  /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,4--2,9),
-                  Yes
-                    /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,0--2,18),
-                  { LeadingKeyword =
-                     Let
-                       /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,0--2,3)
+                    (Bytes ([|121uy; 111uy|], Verbatim, (2,12--2,18)),
+                     (2,12--2,18)), (2,4--2,9), Yes (2,0--2,18),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,10--2,11) })],
-              /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,0--2,18))],
-          PreXmlDocEmpty, [], None,
-          /root/String/SynConstBytesWithSynByteStringKindVerbatim.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,10--2,11) })], (2,0--2,18))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/String/SynConstStringWithSynStringKindRegular.fs.bsl
+++ b/tests/service/data/SyntaxTree/String/SynConstStringWithSynStringKindRegular.fs.bsl
@@ -11,28 +11,12 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (s, None), false, None,
-                     /root/String/SynConstStringWithSynStringKindRegular.fs (2,4--2,5)),
-                  None,
-                  Const
-                    (String
-                       ("yo", Regular,
-                        /root/String/SynConstStringWithSynStringKindRegular.fs (2,8--2,12)),
-                     /root/String/SynConstStringWithSynStringKindRegular.fs (2,8--2,12)),
-                  /root/String/SynConstStringWithSynStringKindRegular.fs (2,4--2,5),
-                  Yes
-                    /root/String/SynConstStringWithSynStringKindRegular.fs (2,0--2,12),
-                  { LeadingKeyword =
-                     Let
-                       /root/String/SynConstStringWithSynStringKindRegular.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/String/SynConstStringWithSynStringKindRegular.fs (2,6--2,7) })],
-              /root/String/SynConstStringWithSynStringKindRegular.fs (2,0--2,12))],
-          PreXmlDocEmpty, [], None,
-          /root/String/SynConstStringWithSynStringKindRegular.fs (2,0--3,0),
+                  Named (SynIdent (s, None), false, None, (2,4--2,5)), None,
+                  Const (String ("yo", Regular, (2,8--2,12)), (2,8--2,12)),
+                  (2,4--2,5), Yes (2,0--2,12), { LeadingKeyword = Let (2,0--2,3)
+                                                 InlineKeyword = None
+                                                 EqualsRange = Some (2,6--2,7) })],
+              (2,0--2,12))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/String/SynConstStringWithSynStringKindTripleQuote.fs.bsl
+++ b/tests/service/data/SyntaxTree/String/SynConstStringWithSynStringKindTripleQuote.fs.bsl
@@ -11,26 +11,12 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (s, None), false, None,
-                     /root/String/SynConstStringWithSynStringKindTripleQuote.fs (2,4--2,5)),
-                  None,
-                  ArbitraryAfterError
-                    ("localBinding1",
-                     /root/String/SynConstStringWithSynStringKindTripleQuote.fs (2,7--2,7)),
-                  /root/String/SynConstStringWithSynStringKindTripleQuote.fs (2,4--2,5),
-                  Yes
-                    /root/String/SynConstStringWithSynStringKindTripleQuote.fs (2,4--2,7),
-                  { LeadingKeyword =
-                     Let
-                       /root/String/SynConstStringWithSynStringKindTripleQuote.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/String/SynConstStringWithSynStringKindTripleQuote.fs (2,6--2,7) })],
-              /root/String/SynConstStringWithSynStringKindTripleQuote.fs (2,0--2,7))],
-          PreXmlDocEmpty, [], None,
-          /root/String/SynConstStringWithSynStringKindTripleQuote.fs (2,0--3,0),
+                  Named (SynIdent (s, None), false, None, (2,4--2,5)), None,
+                  ArbitraryAfterError ("localBinding1", (2,7--2,7)), (2,4--2,5),
+                  Yes (2,4--2,7), { LeadingKeyword = Let (2,0--2,3)
+                                    InlineKeyword = None
+                                    EqualsRange = Some (2,6--2,7) })],
+              (2,0--2,7))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/String/SynConstStringWithSynStringKindVerbatim.fs.bsl
+++ b/tests/service/data/SyntaxTree/String/SynConstStringWithSynStringKindVerbatim.fs.bsl
@@ -11,28 +11,12 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (s, None), false, None,
-                     /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,4--2,5)),
-                  None,
-                  Const
-                    (String
-                       ("yo", Verbatim,
-                        /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,8--2,13)),
-                     /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,8--2,13)),
-                  /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,4--2,5),
-                  Yes
-                    /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,0--2,13),
-                  { LeadingKeyword =
-                     Let
-                       /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,6--2,7) })],
-              /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,0--2,13))],
-          PreXmlDocEmpty, [], None,
-          /root/String/SynConstStringWithSynStringKindVerbatim.fs (2,0--3,0),
+                  Named (SynIdent (s, None), false, None, (2,4--2,5)), None,
+                  Const (String ("yo", Verbatim, (2,8--2,13)), (2,8--2,13)),
+                  (2,4--2,5), Yes (2,0--2,13), { LeadingKeyword = Let (2,0--2,3)
+                                                 InlineKeyword = None
+                                                 EqualsRange = Some (2,6--2,7) })],
+              (2,0--2,13))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/String/SynExprInterpolatedStringWithSynStringKindRegular.fs.bsl
+++ b/tests/service/data/SyntaxTree/String/SynExprInterpolatedStringWithSynStringKindRegular.fs.bsl
@@ -12,37 +12,15 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (s, None), false, None,
-                     /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,4--2,5)),
-                  None,
+                  Named (SynIdent (s, None), false, None, (2,4--2,5)), None,
                   InterpolatedString
-                    ([String
-                        ("yo ",
-                         /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,8--2,14));
-                      FillExpr
-                        (Const
-                           (Int32 42,
-                            /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,14--2,16)),
-                         None);
-                      String
-                        ("",
-                         /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,16--2,18))],
-                     Regular,
-                     /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,8--2,18)),
-                  /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,4--2,5),
-                  Yes
-                    /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,0--2,18),
-                  { LeadingKeyword =
-                     Let
-                       /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,6--2,7) })],
-              /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,0--2,18))],
-          PreXmlDocEmpty, [], None,
-          /root/String/SynExprInterpolatedStringWithSynStringKindRegular.fs (2,0--3,0),
+                    ([String ("yo ", (2,8--2,14));
+                      FillExpr (Const (Int32 42, (2,14--2,16)), None);
+                      String ("", (2,16--2,18))], Regular, (2,8--2,18)),
+                  (2,4--2,5), Yes (2,0--2,18), { LeadingKeyword = Let (2,0--2,3)
+                                                 InlineKeyword = None
+                                                 EqualsRange = Some (2,6--2,7) })],
+              (2,0--2,18))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs.bsl
+++ b/tests/service/data/SyntaxTree/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs.bsl
@@ -14,26 +14,12 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (s, None), false, None,
-                     /root/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs (2,4--2,5)),
-                  None,
-                  ArbitraryAfterError
-                    ("localBinding1",
-                     /root/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs (2,7--2,7)),
-                  /root/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs (2,4--2,5),
-                  Yes
-                    /root/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs (2,4--2,7),
-                  { LeadingKeyword =
-                     Let
-                       /root/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs (2,0--2,3)
-                    InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs (2,6--2,7) })],
-              /root/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs (2,0--2,7))],
-          PreXmlDocEmpty, [], None,
-          /root/String/SynExprInterpolatedStringWithSynStringKindTripleQuote.fs (2,0--3,0),
+                  Named (SynIdent (s, None), false, None, (2,4--2,5)), None,
+                  ArbitraryAfterError ("localBinding1", (2,7--2,7)), (2,4--2,5),
+                  Yes (2,4--2,7), { LeadingKeyword = Let (2,0--2,3)
+                                    InlineKeyword = None
+                                    EqualsRange = Some (2,6--2,7) })],
+              (2,0--2,7))], PreXmlDocEmpty, [], None, (2,0--3,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs.bsl
+++ b/tests/service/data/SyntaxTree/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs.bsl
@@ -14,37 +14,16 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Named
-                    (SynIdent (s, None), false, None,
-                     /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,4--2,5)),
-                  None,
+                  Named (SynIdent (s, None), false, None, (2,4--2,5)), None,
                   InterpolatedString
-                    ([String
-                        ("Migrate notes of file "",
-                         /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,8--2,36));
+                    ([String ("Migrate notes of file "", (2,8--2,36));
                       FillExpr (Ident oldId, None);
-                      String
-                        ("" to new file "",
-                         /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,41--2,60));
-                      FillExpr (Ident newId, None);
-                      String
-                        ("".",
-                         /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,65--2,70))],
-                     Verbatim,
-                     /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,8--2,70)),
-                  /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,4--2,5),
-                  Yes
-                    /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,0--2,70),
-                  { LeadingKeyword =
-                     Let
-                       /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,0--2,3)
+                      String ("" to new file "", (2,41--2,60));
+                      FillExpr (Ident newId, None); String ("".", (2,65--2,70))],
+                     Verbatim, (2,8--2,70)), (2,4--2,5), Yes (2,0--2,70),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,6--2,7) })],
-              /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,0--2,70))],
-          PreXmlDocEmpty, [], None,
-          /root/String/SynExprInterpolatedStringWithSynStringKindVerbatim.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,6--2,7) })], (2,0--2,70))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynIdent/IncompleteLongIdent.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynIdent/IncompleteLongIdent.fs.bsl
@@ -6,15 +6,9 @@ ImplFile
          ([Module], false, NamedModule,
           [Expr
              (LongIdent
-                (false,
-                 SynLongIdent
-                   ([A], [/root/SynIdent/IncompleteLongIdent.fs (4,1--4,2)],
-                    [None]), None,
-                 /root/SynIdent/IncompleteLongIdent.fs (4,0--4,2)),
-              /root/SynIdent/IncompleteLongIdent.fs (4,0--4,2))],
+                (false, SynLongIdent ([A], [(4,1--4,2)], [None]), None,
+                 (4,0--4,2)), (4,0--4,2))],
           PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          /root/SynIdent/IncompleteLongIdent.fs (2,0--4,2),
-          { LeadingKeyword =
-             Module /root/SynIdent/IncompleteLongIdent.fs (2,0--2,6) })],
-      (true, false), { ConditionalDirectives = []
-                       CodeComments = [] }, set []))
+          (2,0--4,2), { LeadingKeyword = Module (2,0--2,6) })], (true, false),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs.bsl
@@ -19,43 +19,27 @@ ImplFile
                        ([op_BangBang], [],
                         [Some
                            (OriginalNotationWithParen
-                              (/root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,11--2,12),
-                               "!!",
-                               /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,14--2,15)))]),
-                     None, None,
+                              ((2,11--2,12), "!!", (2,14--2,15)))]), None, None,
                      Pats
                        [Paren
                           (Typed
                              (Named
-                                (SynIdent (x, None), false, None,
-                                 /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,17--2,18)),
+                                (SynIdent (x, None), false, None, (2,17--2,18)),
                               Tuple
                                 (false,
                                  [Type
                                     (Var
                                        (SynTypar (a, HeadType, false),
-                                        /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,20--2,22)));
-                                  Star
-                                    /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,23--2,24);
+                                        (2,20--2,22))); Star (2,23--2,24);
                                   Type
                                     (Var
                                        (SynTypar (b, HeadType, false),
-                                        /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,25--2,27)))],
-                                 /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,20--2,27)),
-                              /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,17--2,27)),
-                           /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,16--2,28))],
-                     None,
-                     /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,11--2,28)),
+                                        (2,25--2,27)))], (2,20--2,27)),
+                              (2,17--2,27)), (2,16--2,28))], None, (2,11--2,28)),
                   Some
                     (SynBindingReturnInfo
-                       (Var
-                          (SynTypar (c, HeadType, false),
-                           /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,31--2,33)),
-                        /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,31--2,33),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,29--2,30) })),
+                       (Var (SynTypar (c, HeadType, false), (2,31--2,33)),
+                        (2,31--2,33), [], { ColonRange = Some (2,29--2,30) })),
                   Typed
                     (Paren
                        (TraitCall
@@ -64,20 +48,15 @@ ImplFile
                                 (Or
                                    (Var
                                       (SynTypar (a, HeadType, false),
-                                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,38--2,40)),
+                                       (2,38--2,40)),
                                     Var
                                       (SynTypar (b, HeadType, false),
-                                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,44--2,46)),
-                                    /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,38--2,46),
-                                    { OrKeyword =
-                                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,41--2,43) }),
+                                       (2,44--2,46)), (2,38--2,46),
+                                    { OrKeyword = (2,41--2,43) }),
                                  Var
-                                   (SynTypar (c, HeadType, false),
-                                    /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,50--2,52)),
-                                 /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,38--2,52),
-                                 { OrKeyword =
-                                    /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,47--2,49) }),
-                              /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,37--2,53)),
+                                   (SynTypar (c, HeadType, false), (2,50--2,52)),
+                                 (2,38--2,52), { OrKeyword = (2,47--2,49) }),
+                              (2,37--2,53)),
                            Member
                              (SynValSig
                                 ([], SynIdent (op_Implicit, None),
@@ -88,31 +67,23 @@ ImplFile
                                        [Type
                                           (Var
                                              (SynTypar (a, HeadType, false),
-                                              /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,83--2,85)));
-                                        Star
-                                          /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,86--2,87);
+                                              (2,83--2,85))); Star (2,86--2,87);
                                         Type
                                           (Var
                                              (SynTypar (b, HeadType, false),
-                                              /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,88--2,90)))],
-                                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,83--2,90)),
+                                              (2,88--2,90)))], (2,83--2,90)),
                                     Var
                                       (SynTypar (c, HeadType, false),
-                                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,94--2,96)),
-                                    /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,83--2,96),
-                                    { ArrowRange =
-                                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,91--2,93) }),
+                                       (2,94--2,96)), (2,83--2,96),
+                                    { ArrowRange = (2,91--2,93) }),
                                  SynValInfo
                                    ([[SynArgInfo ([], false, None);
                                       SynArgInfo ([], false, None)]],
                                     SynArgInfo ([], false, None)), false, false,
                                  PreXmlDoc ((2,56), FSharp.Compiler.Xml.XmlDocCollector),
-                                 None, None,
-                                 /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,56--2,96),
+                                 None, None, (2,56--2,96),
                                  { LeadingKeyword =
-                                    StaticMember
-                                      (/root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,56--2,62),
-                                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,63--2,69))
+                                    StaticMember ((2,56--2,62), (2,63--2,69))
                                    InlineKeyword = None
                                    WithKeyword = None
                                    EqualsRange = None }),
@@ -121,32 +92,14 @@ ImplFile
                                 IsOverrideOrExplicitImpl = false
                                 IsFinal = false
                                 GetterOrSetterIsCompilerGenerated = false
-                                MemberKind = Member },
-                              /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,56--2,96),
-                              { GetSetKeywords = None }), Ident x,
-                           /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,36--2,100)),
-                        /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,36--2,37),
-                        Some
-                          /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,99--2,100),
-                        /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,36--2,100)),
-                     Var
-                       (SynTypar (c, HeadType, false),
-                        /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,31--2,33)),
-                     /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,36--2,100)),
-                  /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,11--2,28),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,0--2,3)
-                    InlineKeyword =
-                     Some
-                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,4--2,10)
-                    EqualsRange =
-                     Some
-                       /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,34--2,35) })],
-              /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,0--2,100))],
-          PreXmlDocEmpty, [], None,
-          /root/SynType/NestedSynTypeOrInsideSynExprTraitCall.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                MemberKind = Member }, (2,56--2,96),
+                              { GetSetKeywords = None }), Ident x, (2,36--2,100)),
+                        (2,36--2,37), Some (2,99--2,100), (2,36--2,100)),
+                     Var (SynTypar (c, HeadType, false), (2,31--2,33)),
+                     (2,36--2,100)), (2,11--2,28), NoneAtLet,
+                  { LeadingKeyword = Let (2,0--2,3)
+                    InlineKeyword = Some (2,4--2,10)
+                    EqualsRange = Some (2,34--2,35) })], (2,0--2,100))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/SingleSynTypeInsideSynExprTraitCall.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/SingleSynTypeInsideSynExprTraitCall.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -43,7 +42,7 @@ ImplFile
                                            [WhereTyparSupportsMember
                                               (Var
                                                  (SynTypar (b, HeadType, false),
-                                                  /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,50--3,52)),
+                                                  (3,50--3,52)),
                                                Member
                                                  (SynValSig
                                                     ([],
@@ -58,23 +57,22 @@ ImplFile
                                                                  (SynTypar
                                                                     (a, HeadType,
                                                                      false),
-                                                                  /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,78--3,80)));
-                                                            Star
-                                                              /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,81--3,82);
+                                                                  (3,78--3,80)));
+                                                            Star (3,81--3,82);
                                                             Type
                                                               (Var
                                                                  (SynTypar
                                                                     (b, HeadType,
                                                                      false),
-                                                                  /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,83--3,85)))],
-                                                           /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,78--3,85)),
+                                                                  (3,83--3,85)))],
+                                                           (3,78--3,85)),
                                                         Var
                                                           (SynTypar
                                                              (c, HeadType, false),
-                                                           /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,89--3,91)),
-                                                        /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,78--3,91),
+                                                           (3,89--3,91)),
+                                                        (3,78--3,91),
                                                         { ArrowRange =
-                                                           /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,86--3,88) }),
+                                                           (3,86--3,88) }),
                                                      SynValInfo
                                                        ([[SynArgInfo
                                                             ([], false, None);
@@ -84,12 +82,11 @@ ImplFile
                                                           ([], false, None)),
                                                      false, false,
                                                      PreXmlDoc ((3,55), FSharp.Compiler.Xml.XmlDocCollector),
-                                                     None, None,
-                                                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,55--3,91),
+                                                     None, None, (3,55--3,91),
                                                      { LeadingKeyword =
                                                         StaticMember
-                                                          (/root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,55--3,61),
-                                                           /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,62--3,68))
+                                                          ((3,55--3,61),
+                                                           (3,62--3,68))
                                                        InlineKeyword = None
                                                        WithKeyword = None
                                                        EqualsRange = None }),
@@ -101,10 +98,9 @@ ImplFile
                                                     GetterOrSetterIsCompilerGenerated =
                                                      false
                                                     MemberKind = Member },
-                                                  /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,55--3,91),
+                                                  (3,55--3,91),
                                                   { GetSetKeywords = None }),
-                                               /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,50--3,92))],
-                                           /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,32--3,93))),
+                                               (3,50--3,92))], (3,32--3,93))),
                                      false)),
                                Pats
                                  [Paren
@@ -113,29 +109,23 @@ ImplFile
                                         [Typed
                                            (Named
                                               (SynIdent (a, None), false, None,
-                                               /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,94--3,95)),
+                                               (3,94--3,95)),
                                             Var
                                               (SynTypar (a, HeadType, false),
-                                               /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,97--3,99)),
-                                            /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,94--3,99));
+                                               (3,97--3,99)), (3,94--3,99));
                                          Typed
                                            (Named
                                               (SynIdent (f, None), false, None,
-                                               /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,101--3,102)),
+                                               (3,101--3,102)),
                                             Var
                                               (SynTypar (b, HeadType, false),
-                                               /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,104--3,106)),
-                                            /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,101--3,106))],
-                                        /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,94--3,106)),
-                                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,93--3,107))],
-                               None,
-                               /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,25--3,107)),
-                            None,
+                                               (3,104--3,106)), (3,101--3,106))],
+                                        (3,94--3,106)), (3,93--3,107))], None,
+                               (3,25--3,107)), None,
                             Paren
                               (TraitCall
                                  (Var
-                                    (SynTypar (b, HeadType, false),
-                                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,9--4,11)),
+                                    (SynTypar (b, HeadType, false), (4,9--4,11)),
                                   Member
                                     (SynValSig
                                        ([], SynIdent (replace, None),
@@ -147,33 +137,28 @@ ImplFile
                                                  (Var
                                                     (SynTypar
                                                        (a, HeadType, false),
-                                                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,38--4,40)));
-                                               Star
-                                                 /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,41--4,42);
+                                                     (4,38--4,40)));
+                                               Star (4,41--4,42);
                                                Type
                                                  (Var
                                                     (SynTypar
                                                        (b, HeadType, false),
-                                                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,43--4,45)))],
-                                              /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,38--4,45)),
+                                                     (4,43--4,45)))],
+                                              (4,38--4,45)),
                                            Var
                                              (SynTypar (c, HeadType, false),
-                                              /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,49--4,51)),
-                                           /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,38--4,51),
-                                           { ArrowRange =
-                                              /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,46--4,48) }),
+                                              (4,49--4,51)), (4,38--4,51),
+                                           { ArrowRange = (4,46--4,48) }),
                                         SynValInfo
                                           ([[SynArgInfo ([], false, None);
                                              SynArgInfo ([], false, None)]],
                                            SynArgInfo ([], false, None)), false,
                                         false,
                                         PreXmlDoc ((4,15), FSharp.Compiler.Xml.XmlDocCollector),
-                                        None, None,
-                                        /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,15--4,51),
+                                        None, None, (4,15--4,51),
                                         { LeadingKeyword =
                                            StaticMember
-                                             (/root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,15--4,21),
-                                              /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,22--4,28))
+                                             ((4,15--4,21), (4,22--4,28))
                                           InlineKeyword = None
                                           WithKeyword = None
                                           EqualsRange = None }),
@@ -182,49 +167,24 @@ ImplFile
                                        IsOverrideOrExplicitImpl = false
                                        IsFinal = false
                                        GetterOrSetterIsCompilerGenerated = false
-                                       MemberKind = Member },
-                                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,15--4,51),
+                                       MemberKind = Member }, (4,15--4,51),
                                      { GetSetKeywords = None }),
                                   Paren
                                     (Tuple
                                        (false, [Ident a; Ident f],
-                                        [/root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,55--4,56)],
-                                        /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,54--4,58)),
-                                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,53--4,54),
-                                     Some
-                                       /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,58--4,59),
-                                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,53--4,59)),
-                                  /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,8--4,60)),
-                               /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,8--4,9),
-                               Some
-                                 /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,59--4,60),
-                               /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (4,8--4,60)),
-                            /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,25--3,107),
+                                        [(4,55--4,56)], (4,54--4,58)),
+                                     (4,53--4,54), Some (4,58--4,59),
+                                     (4,53--4,59)), (4,8--4,60)), (4,8--4,9),
+                               Some (4,59--4,60), (4,8--4,60)), (3,25--3,107),
                             NoneAtInvisible,
                             { LeadingKeyword =
-                               StaticMember
-                                 (/root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,4--3,10),
-                                  /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,11--3,17))
-                              InlineKeyword =
-                               Some
-                                 /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,18--3,24)
-                              EqualsRange =
-                               Some
-                                 /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,108--3,109) }),
-                         /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,4--4,60))],
-                     /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (3,4--4,60)),
-                  [], None,
-                  /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (2,5--4,60),
-                  { LeadingKeyword =
-                     Type
-                       /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (2,0--4,60))],
-          PreXmlDocEmpty, [], None,
-          /root/SynType/SingleSynTypeInsideSynExprTraitCall.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                               StaticMember ((3,4--3,10), (3,11--3,17))
+                              InlineKeyword = Some (3,18--3,24)
+                              EqualsRange = Some (3,108--3,109) }), (3,4--4,60))],
+                     (3,4--4,60)), [], None, (2,5--4,60),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--4,60))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/SynTypeOrInsideSynExprTraitCall.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/SynTypeOrInsideSynExprTraitCall.fs.bsl
@@ -19,48 +19,29 @@ ImplFile
                        ([op_BangBang], [],
                         [Some
                            (OriginalNotationWithParen
-                              (/root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,11--2,12),
-                               "!!",
-                               /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,14--2,15)))]),
-                     None, None,
+                              ((2,11--2,12), "!!", (2,14--2,15)))]), None, None,
                      Pats
                        [Paren
                           (Typed
                              (Named
-                                (SynIdent (x, None), false, None,
-                                 /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,17--2,18)),
-                              Var
-                                (SynTypar (a, HeadType, false),
-                                 /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,20--2,22)),
-                              /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,17--2,22)),
-                           /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,16--2,23))],
-                     None,
-                     /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,11--2,23)),
+                                (SynIdent (x, None), false, None, (2,17--2,18)),
+                              Var (SynTypar (a, HeadType, false), (2,20--2,22)),
+                              (2,17--2,22)), (2,16--2,23))], None, (2,11--2,23)),
                   Some
                     (SynBindingReturnInfo
-                       (Var
-                          (SynTypar (b, HeadType, false),
-                           /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,26--2,28)),
-                        /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,26--2,28),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,24--2,25) })),
+                       (Var (SynTypar (b, HeadType, false), (2,26--2,28)),
+                        (2,26--2,28), [], { ColonRange = Some (2,24--2,25) })),
                   Typed
                     (Paren
                        (TraitCall
                           (Paren
                              (Or
                                 (Var
-                                   (SynTypar (a, HeadType, false),
-                                    /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,33--2,35)),
+                                   (SynTypar (a, HeadType, false), (2,33--2,35)),
                                  Var
-                                   (SynTypar (b, HeadType, false),
-                                    /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,39--2,41)),
-                                 /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,33--2,41),
-                                 { OrKeyword =
-                                    /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,36--2,38) }),
-                              /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,32--2,42)),
+                                   (SynTypar (b, HeadType, false), (2,39--2,41)),
+                                 (2,33--2,41), { OrKeyword = (2,36--2,38) }),
+                              (2,32--2,42)),
                            Member
                              (SynValSig
                                 ([], SynIdent (op_Implicit, None),
@@ -68,23 +49,18 @@ ImplFile
                                  Fun
                                    (Var
                                       (SynTypar (a, HeadType, false),
-                                       /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,72--2,74)),
+                                       (2,72--2,74)),
                                     Var
                                       (SynTypar (b, HeadType, false),
-                                       /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,78--2,80)),
-                                    /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,72--2,80),
-                                    { ArrowRange =
-                                       /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,75--2,77) }),
+                                       (2,78--2,80)), (2,72--2,80),
+                                    { ArrowRange = (2,75--2,77) }),
                                  SynValInfo
                                    ([[SynArgInfo ([], false, None)]],
                                     SynArgInfo ([], false, None)), false, false,
                                  PreXmlDoc ((2,45), FSharp.Compiler.Xml.XmlDocCollector),
-                                 None, None,
-                                 /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,45--2,80),
+                                 None, None, (2,45--2,80),
                                  { LeadingKeyword =
-                                    StaticMember
-                                      (/root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,45--2,51),
-                                       /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,52--2,58))
+                                    StaticMember ((2,45--2,51), (2,52--2,58))
                                    InlineKeyword = None
                                    WithKeyword = None
                                    EqualsRange = None }),
@@ -93,32 +69,14 @@ ImplFile
                                 IsOverrideOrExplicitImpl = false
                                 IsFinal = false
                                 GetterOrSetterIsCompilerGenerated = false
-                                MemberKind = Member },
-                              /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,45--2,80),
-                              { GetSetKeywords = None }), Ident x,
-                           /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,31--2,84)),
-                        /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,31--2,32),
-                        Some
-                          /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,83--2,84),
-                        /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,31--2,84)),
-                     Var
-                       (SynTypar (b, HeadType, false),
-                        /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,26--2,28)),
-                     /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,31--2,84)),
-                  /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,11--2,23),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,0--2,3)
-                    InlineKeyword =
-                     Some
-                       /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,4--2,10)
-                    EqualsRange =
-                     Some
-                       /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,29--2,30) })],
-              /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,0--2,84))],
-          PreXmlDocEmpty, [], None,
-          /root/SynType/SynTypeOrInsideSynExprTraitCall.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                MemberKind = Member }, (2,45--2,80),
+                              { GetSetKeywords = None }), Ident x, (2,31--2,84)),
+                        (2,31--2,32), Some (2,83--2,84), (2,31--2,84)),
+                     Var (SynTypar (b, HeadType, false), (2,26--2,28)),
+                     (2,31--2,84)), (2,11--2,23), NoneAtLet,
+                  { LeadingKeyword = Let (2,0--2,3)
+                    InlineKeyword = Some (2,4--2,10)
+                    EqualsRange = Some (2,29--2,30) })], (2,0--2,84))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs.bsl
@@ -27,14 +27,12 @@ ImplFile
                                        (Or
                                           (Var
                                              (SynTypar (T1, None, false),
-                                              /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,41--2,44)),
+                                              (2,41--2,44)),
                                            Var
                                              (SynTypar (T2, None, false),
-                                              /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,48--2,51)),
-                                           /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,41--2,51),
-                                           { OrKeyword =
-                                              /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,45--2,47) }),
-                                        /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,40--2,52)),
+                                              (2,48--2,51)), (2,41--2,51),
+                                           { OrKeyword = (2,45--2,47) }),
+                                        (2,40--2,52)),
                                      Member
                                        (SynValSig
                                           ([], SynIdent (StaticMethod, None),
@@ -46,20 +44,17 @@ ImplFile
                                               LongIdent
                                                 (SynLongIdent
                                                    ([int], [], [None])),
-                                              /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,84--2,94),
-                                              { ArrowRange =
-                                                 /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,88--2,90) }),
+                                              (2,84--2,94),
+                                              { ArrowRange = (2,88--2,90) }),
                                            SynValInfo
                                              ([[SynArgInfo ([], false, None)]],
                                               SynArgInfo ([], false, None)),
                                            false, false,
                                            PreXmlDoc ((2,56), FSharp.Compiler.Xml.XmlDocCollector),
-                                           None, None,
-                                           /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,56--2,94),
+                                           None, None, (2,56--2,94),
                                            { LeadingKeyword =
                                               StaticMember
-                                                (/root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,56--2,62),
-                                                 /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,63--2,69))
+                                                ((2,56--2,62), (2,63--2,69))
                                              InlineKeyword = None
                                              WithKeyword = None
                                              EqualsRange = None }),
@@ -69,48 +64,22 @@ ImplFile
                                           IsFinal = false
                                           GetterOrSetterIsCompilerGenerated =
                                            false
-                                          MemberKind = Member },
-                                        /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,56--2,94),
-                                        { GetSetKeywords = None }),
-                                     /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,40--2,95))],
-                                 /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,25--2,97))),
-                           false)),
-                     Pats
-                       [Paren
-                          (Const
-                             (Unit,
-                              /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,97--2,99)),
-                           /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,97--2,99))],
-                     None,
-                     /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,11--2,99)),
+                                          MemberKind = Member }, (2,56--2,94),
+                                        { GetSetKeywords = None }), (2,40--2,95))],
+                                 (2,25--2,97))), false)),
+                     Pats [Paren (Const (Unit, (2,97--2,99)), (2,97--2,99))],
+                     None, (2,11--2,99)),
                   Some
                     (SynBindingReturnInfo
                        (LongIdent (SynLongIdent ([int], [], [None])),
-                        /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,102--2,105),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,100--2,101) })),
+                        (2,102--2,105), [], { ColonRange = Some (2,100--2,101) })),
                   Typed
-                    (Const
-                       (Unit,
-                        /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (3,4--3,6)),
-                     LongIdent (SynLongIdent ([int], [], [None])),
-                     /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (3,4--3,6)),
-                  /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,11--2,99),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,0--2,3)
-                    InlineKeyword =
-                     Some
-                       /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,4--2,10)
-                    EqualsRange =
-                     Some
-                       /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,106--2,107) })],
-              /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,0--3,6))],
-          PreXmlDocEmpty, [], None,
-          /root/SynType/SynTypeOrInsideSynTypeConstraintWhereTyparSupportsMember.fs (2,0--4,0),
+                    (Const (Unit, (3,4--3,6)),
+                     LongIdent (SynLongIdent ([int], [], [None])), (3,4--3,6)),
+                  (2,11--2,99), NoneAtLet, { LeadingKeyword = Let (2,0--2,3)
+                                             InlineKeyword = Some (2,4--2,10)
+                                             EqualsRange = Some (2,106--2,107) })],
+              (2,0--3,6))], PreXmlDocEmpty, [], None, (2,0--4,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs.bsl
@@ -20,28 +20,18 @@ ImplFile
                        [Paren
                           (Typed
                              (Named
-                                (SynIdent (x, None), false, None,
-                                 /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,14--2,15)),
-                              Var
-                                (SynTypar (T, None, false),
-                                 /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,17--2,19)),
-                              /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,14--2,19)),
-                           /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,13--2,20))],
-                     None,
-                     /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,11--2,20)),
+                                (SynIdent (x, None), false, None, (2,14--2,15)),
+                              Var (SynTypar (T, None, false), (2,17--2,19)),
+                              (2,14--2,19)), (2,13--2,20))], None, (2,11--2,20)),
                   None,
                   Paren
                     (TraitCall
                        (Paren
                           (Or
-                             (Var
-                                (SynTypar (T, HeadType, false),
-                                 /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,25--2,27)),
+                             (Var (SynTypar (T, HeadType, false), (2,25--2,27)),
                               LongIdent (SynLongIdent ([int], [], [None])),
-                              /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,25--2,34),
-                              { OrKeyword =
-                                 /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,28--2,30) }),
-                           /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,24--2,35)),
+                              (2,25--2,34), { OrKeyword = (2,28--2,30) }),
+                           (2,24--2,35)),
                         Member
                           (SynValSig
                              ([], SynIdent (A, None),
@@ -50,12 +40,9 @@ ImplFile
                               SynValInfo ([], SynArgInfo ([], false, None)),
                               false, false,
                               PreXmlDoc ((2,39), FSharp.Compiler.Xml.XmlDocCollector),
-                              None, None,
-                              /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,39--2,59),
+                              None, None, (2,39--2,59),
                               { LeadingKeyword =
-                                 StaticMember
-                                   (/root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,39--2,45),
-                                    /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,46--2,52))
+                                 StaticMember ((2,39--2,45), (2,46--2,52))
                                 InlineKeyword = None
                                 WithKeyword = None
                                 EqualsRange = None }),
@@ -64,31 +51,13 @@ ImplFile
                              IsOverrideOrExplicitImpl = false
                              IsFinal = false
                              GetterOrSetterIsCompilerGenerated = false
-                             MemberKind = PropertyGet },
-                           /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,39--2,59),
+                             MemberKind = PropertyGet }, (2,39--2,59),
                            { GetSetKeywords = None }),
-                        Const
-                          (Unit,
-                           /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,61--2,63)),
-                        /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,23--2,64)),
-                     /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,23--2,24),
-                     Some
-                       /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,63--2,64),
-                     /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,23--2,64)),
-                  /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,11--2,20),
-                  NoneAtLet,
-                  { LeadingKeyword =
-                     Let
-                       /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,0--2,3)
-                    InlineKeyword =
-                     Some
-                       /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,4--2,10)
-                    EqualsRange =
-                     Some
-                       /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,21--2,22) })],
-              /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,0--2,64))],
-          PreXmlDocEmpty, [], None,
-          /root/SynType/SynTypeOrWithAppTypeOnTheRightHandSide.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                        Const (Unit, (2,61--2,63)), (2,23--2,64)), (2,23--2,24),
+                     Some (2,63--2,64), (2,23--2,64)), (2,11--2,20), NoneAtLet,
+                  { LeadingKeyword = Let (2,0--2,3)
+                    InlineKeyword = Some (2,4--2,10)
+                    EqualsRange = Some (2,21--2,22) })], (2,0--2,64))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi.bsl
@@ -10,8 +10,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [T],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -28,21 +27,14 @@ SigFile
                                                  SynLongIdent
                                                    ([SomeAttribute], [], [None])
                                                 ArgExpr =
-                                                 Const
-                                                   (Unit,
-                                                    /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,16--3,29))
+                                                 Const (Unit, (3,16--3,29))
                                                 Target = None
                                                 AppliesToGetterAndSetter = false
-                                                Range =
-                                                 /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,16--3,29) }]
-                                            Range =
-                                             /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,14--3,31) }],
-                                         false, None,
+                                                Range = (3,16--3,29) }]
+                                            Range = (3,14--3,31) }], false, None,
                                          LongIdent
                                            (SynLongIdent ([a], [], [None])),
-                                         /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,14--3,33)));
-                                   Star
-                                     /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,34--3,35);
+                                         (3,14--3,33))); Star (3,34--3,35);
                                    Type
                                      (SignatureParameter
                                         ([{ Attributes =
@@ -50,64 +42,41 @@ SigFile
                                                  SynLongIdent
                                                    ([OtherAttribute], [], [None])
                                                 ArgExpr =
-                                                 Const
-                                                   (Unit,
-                                                    /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,38--3,52))
+                                                 Const (Unit, (3,38--3,52))
                                                 Target = None
                                                 AppliesToGetterAndSetter = false
-                                                Range =
-                                                 /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,38--3,52) }]
-                                            Range =
-                                             /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,36--3,54) }],
-                                         false, None,
+                                                Range = (3,38--3,52) }]
+                                            Range = (3,36--3,54) }], false, None,
                                          LongIdent
                                            (SynLongIdent ([b], [], [None])),
-                                         /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,36--3,56)))],
-                                  /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,14--3,56)),
+                                         (3,36--3,56)))], (3,14--3,56)),
                                LongIdent (SynLongIdent ([int], [], [None])),
-                               /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,14--3,63),
-                               { ArrowRange =
-                                  /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,57--3,59) }),
+                               (3,14--3,63), { ArrowRange = (3,57--3,59) }),
                             SynValInfo
                               ([[SynArgInfo
                                    ([{ Attributes =
                                         [{ TypeName =
                                             SynLongIdent
                                               ([SomeAttribute], [], [None])
-                                           ArgExpr =
-                                            Const
-                                              (Unit,
-                                               /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,16--3,29))
+                                           ArgExpr = Const (Unit, (3,16--3,29))
                                            Target = None
                                            AppliesToGetterAndSetter = false
-                                           Range =
-                                            /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,16--3,29) }]
-                                       Range =
-                                        /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,14--3,31) }],
-                                    false, None);
+                                           Range = (3,16--3,29) }]
+                                       Range = (3,14--3,31) }], false, None);
                                  SynArgInfo
                                    ([{ Attributes =
                                         [{ TypeName =
                                             SynLongIdent
                                               ([OtherAttribute], [], [None])
-                                           ArgExpr =
-                                            Const
-                                              (Unit,
-                                               /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,38--3,52))
+                                           ArgExpr = Const (Unit, (3,38--3,52))
                                            Target = None
                                            AppliesToGetterAndSetter = false
-                                           Range =
-                                            /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,38--3,52) }]
-                                       Range =
-                                        /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,36--3,54) }],
-                                    false, None)]], SynArgInfo ([], false, None)),
-                            false, false,
+                                           Range = (3,38--3,52) }]
+                                       Range = (3,36--3,54) }], false, None)]],
+                               SynArgInfo ([], false, None)), false, false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,4--3,63),
-                            { LeadingKeyword =
-                               Member
-                                 /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,4--3,10)
+                            None, None, (3,4--3,63),
+                            { LeadingKeyword = Member (3,4--3,10)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -116,21 +85,11 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,4--3,63),
-                         { GetSetKeywords = None })],
-                     /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (3,4--3,63)),
-                  [],
-                  /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (2,5--3,63),
-                  { LeadingKeyword =
-                     Type
-                       /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (2,7--2,8)
-                    WithKeyword = None })],
-              /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (2,0--3,63))],
-          PreXmlDocEmpty, [], None,
-          /root/SynType/SynTypeTupleDoesIncludeLeadingParameterAttributes.fsi (2,0--4,0),
-          { LeadingKeyword = None })], { ConditionalDirectives = []
-                                         CodeComments = [] }, set []))
+                           MemberKind = Member }, (3,4--3,63),
+                         { GetSetKeywords = None })], (3,4--3,63)), [],
+                  (2,5--3,63), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,63))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi.bsl
@@ -9,8 +9,7 @@ SigFile
                  (SynComponentInfo
                     ([], None, [], [T],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [Member
@@ -25,30 +24,22 @@ SigFile
                                         ([], false, Some p1,
                                          LongIdent
                                            (SynLongIdent ([a], [], [None])),
-                                         /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,14--3,19)));
-                                   Star
-                                     /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,20--3,21);
+                                         (3,14--3,19))); Star (3,20--3,21);
                                    Type
                                      (SignatureParameter
                                         ([], false, Some p2,
                                          LongIdent
                                            (SynLongIdent ([b], [], [None])),
-                                         /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,22--3,27)))],
-                                  /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,14--3,27)),
+                                         (3,22--3,27)))], (3,14--3,27)),
                                LongIdent (SynLongIdent ([int], [], [None])),
-                               /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,14--3,34),
-                               { ArrowRange =
-                                  /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,28--3,30) }),
+                               (3,14--3,34), { ArrowRange = (3,28--3,30) }),
                             SynValInfo
                               ([[SynArgInfo ([], false, Some p1);
                                  SynArgInfo ([], false, Some p2)]],
                                SynArgInfo ([], false, None)), false, false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,4--3,34),
-                            { LeadingKeyword =
-                               Member
-                                 /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,4--3,10)
+                            None, None, (3,4--3,34),
+                            { LeadingKeyword = Member (3,4--3,10)
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -57,21 +48,11 @@ SigFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,4--3,34),
-                         { GetSetKeywords = None })],
-                     /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (3,4--3,34)),
-                  [],
-                  /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (2,5--3,34),
-                  { LeadingKeyword =
-                     Type
-                       /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (2,7--2,8)
-                    WithKeyword = None })],
-              /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (2,0--3,34))],
-          PreXmlDocEmpty, [], None,
-          /root/SynType/SynTypeTupleDoesIncludeLeadingParameterName.fsi (2,0--4,0),
-          { LeadingKeyword = None })], { ConditionalDirectives = []
-                                         CodeComments = [] }, set []))
+                           MemberKind = Member }, (3,4--3,34),
+                         { GetSetKeywords = None })], (3,4--3,34)), [],
+                  (2,5--3,34), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,34))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/AttributesInOptionalNamedMemberParameter.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/AttributesInOptionalNamedMemberParameter.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/AttributesInOptionalNamedMemberParameter.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [AbstractSlot
@@ -22,67 +21,42 @@ ImplFile
                                  ([{ Attributes =
                                       [{ TypeName =
                                           SynLongIdent ([Foo], [], [None])
-                                         ArgExpr =
-                                          Const
-                                            (Unit,
-                                             /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,25--3,28))
+                                         ArgExpr = Const (Unit, (3,25--3,28))
                                          Target = None
                                          AppliesToGetterAndSetter = false
-                                         Range =
-                                          /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,25--3,28) };
+                                         Range = (3,25--3,28) };
                                        { TypeName =
                                           SynLongIdent ([Bar], [], [None])
-                                         ArgExpr =
-                                          Const
-                                            (Unit,
-                                             /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,30--3,33))
+                                         ArgExpr = Const (Unit, (3,30--3,33))
                                          Target = None
                                          AppliesToGetterAndSetter = false
-                                         Range =
-                                          /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,30--3,33) }]
-                                     Range =
-                                      /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,23--3,35) }],
-                                  true, Some a,
+                                         Range = (3,30--3,33) }]
+                                     Range = (3,23--3,35) }], true, Some a,
                                   LongIdent (SynLongIdent ([A], [], [None])),
-                                  /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,23--3,41)),
+                                  (3,23--3,41)),
                                LongIdent (SynLongIdent ([B], [], [None])),
-                               /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,23--3,46),
-                               { ArrowRange =
-                                  /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,42--3,44) }),
+                               (3,23--3,46), { ArrowRange = (3,42--3,44) }),
                             SynValInfo
                               ([[SynArgInfo
                                    ([{ Attributes =
                                         [{ TypeName =
                                             SynLongIdent ([Foo], [], [None])
-                                           ArgExpr =
-                                            Const
-                                              (Unit,
-                                               /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,25--3,28))
+                                           ArgExpr = Const (Unit, (3,25--3,28))
                                            Target = None
                                            AppliesToGetterAndSetter = false
-                                           Range =
-                                            /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,25--3,28) };
+                                           Range = (3,25--3,28) };
                                          { TypeName =
                                             SynLongIdent ([Bar], [], [None])
-                                           ArgExpr =
-                                            Const
-                                              (Unit,
-                                               /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,30--3,33))
+                                           ArgExpr = Const (Unit, (3,30--3,33))
                                            Target = None
                                            AppliesToGetterAndSetter = false
-                                           Range =
-                                            /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,30--3,33) }]
-                                       Range =
-                                        /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,23--3,35) }],
-                                    true, Some a)]],
+                                           Range = (3,30--3,33) }]
+                                       Range = (3,23--3,35) }], true, Some a)]],
                                SynArgInfo ([], false, None)), false, false,
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, None,
-                            /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,4--3,46),
+                            None, None, (3,4--3,46),
                             { LeadingKeyword =
-                               AbstractMember
-                                 (/root/Type/AttributesInOptionalNamedMemberParameter.fs (3,4--3,12),
-                                  /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,13--3,19))
+                               AbstractMember ((3,4--3,12), (3,13--3,19))
                               InlineKeyword = None
                               WithKeyword = None
                               EqualsRange = None }),
@@ -91,22 +65,11 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,4--3,46),
-                         { GetSetKeywords = None })],
-                     /root/Type/AttributesInOptionalNamedMemberParameter.fs (3,4--3,46)),
-                  [], None,
-                  /root/Type/AttributesInOptionalNamedMemberParameter.fs (2,5--3,46),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/AttributesInOptionalNamedMemberParameter.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/AttributesInOptionalNamedMemberParameter.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/Type/AttributesInOptionalNamedMemberParameter.fs (2,0--3,46))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/AttributesInOptionalNamedMemberParameter.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           MemberKind = Member }, (3,4--3,46),
+                         { GetSetKeywords = None })], (3,4--3,46)), [], None,
+                  (2,5--3,46), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--3,46))],
+          PreXmlDocEmpty, [], None, (2,0--4,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs.bsl
@@ -9,48 +9,25 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Enum
                        ([SynEnumCase
                            ([], SynIdent (One, None),
-                            Const
-                              (Int32 1,
-                               /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (3,13--3,23)),
+                            Const (Int32 1, (3,13--3,23)),
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (3,6--3,23),
-                            { BarRange =
-                               Some
-                                 /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (3,4--3,5)
-                              EqualsRange =
-                               /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (3,10--3,11) });
+                            (3,6--3,23), { BarRange = Some (3,4--3,5)
+                                           EqualsRange = (3,10--3,11) });
                          SynEnumCase
                            ([], SynIdent (Two, None),
-                            Const
-                              (Int32 2,
-                               /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (4,12--4,13)),
+                            Const (Int32 2, (4,12--4,13)),
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (4,6--4,13),
-                            { BarRange =
-                               Some
-                                 /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (4,4--4,5)
-                              EqualsRange =
-                               /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (4,10--4,11) })],
-                        /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (3,4--4,13)),
-                     /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (3,4--4,13)),
-                  [], None,
-                  /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (2,5--4,13),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (2,0--4,13))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/MultipleSynEnumCaseContainsRangeOfConstant.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                            (4,6--4,13), { BarRange = Some (4,4--4,5)
+                                           EqualsRange = (4,10--4,11) })],
+                        (3,4--4,13)), (3,4--4,13)), [], None, (2,5--4,13),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--4,13))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/NamedParametersInDelegateType.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/NamedParametersInDelegateType.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/NamedParametersInDelegateType.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Delegate
                        (Fun
@@ -20,27 +19,20 @@ ImplFile
                                  (SignatureParameter
                                     ([], false, Some a,
                                      LongIdent (SynLongIdent ([A], [], [None])),
-                                     /root/Type/NamedParametersInDelegateType.fs (2,23--2,27)));
-                               Star
-                                 /root/Type/NamedParametersInDelegateType.fs (2,28--2,29);
+                                     (2,23--2,27))); Star (2,28--2,29);
                                Type
                                  (SignatureParameter
                                     ([], false, Some b,
                                      LongIdent (SynLongIdent ([B], [], [None])),
-                                     /root/Type/NamedParametersInDelegateType.fs (2,30--2,34)))],
-                              /root/Type/NamedParametersInDelegateType.fs (2,23--2,34)),
+                                     (2,30--2,34)))], (2,23--2,34)),
                            Fun
                              (SignatureParameter
                                 ([], false, Some c,
                                  LongIdent (SynLongIdent ([C], [], [None])),
-                                 /root/Type/NamedParametersInDelegateType.fs (2,38--2,41)),
+                                 (2,38--2,41)),
                               LongIdent (SynLongIdent ([D], [], [None])),
-                              /root/Type/NamedParametersInDelegateType.fs (2,38--2,46),
-                              { ArrowRange =
-                                 /root/Type/NamedParametersInDelegateType.fs (2,42--2,44) }),
-                           /root/Type/NamedParametersInDelegateType.fs (2,23--2,46),
-                           { ArrowRange =
-                              /root/Type/NamedParametersInDelegateType.fs (2,35--2,37) }),
+                              (2,38--2,46), { ArrowRange = (2,42--2,44) }),
+                           (2,23--2,46), { ArrowRange = (2,35--2,37) }),
                         SynValInfo
                           ([[SynArgInfo ([], false, Some a);
                              SynArgInfo ([], false, Some b)];
@@ -58,35 +50,27 @@ ImplFile
                                         ([], false, Some a,
                                          LongIdent
                                            (SynLongIdent ([A], [], [None])),
-                                         /root/Type/NamedParametersInDelegateType.fs (2,23--2,27)));
-                                   Star
-                                     /root/Type/NamedParametersInDelegateType.fs (2,28--2,29);
+                                         (2,23--2,27))); Star (2,28--2,29);
                                    Type
                                      (SignatureParameter
                                         ([], false, Some b,
                                          LongIdent
                                            (SynLongIdent ([B], [], [None])),
-                                         /root/Type/NamedParametersInDelegateType.fs (2,30--2,34)))],
-                                  /root/Type/NamedParametersInDelegateType.fs (2,23--2,34)),
+                                         (2,30--2,34)))], (2,23--2,34)),
                                Fun
                                  (SignatureParameter
                                     ([], false, Some c,
                                      LongIdent (SynLongIdent ([C], [], [None])),
-                                     /root/Type/NamedParametersInDelegateType.fs (2,38--2,41)),
+                                     (2,38--2,41)),
                                   LongIdent (SynLongIdent ([D], [], [None])),
-                                  /root/Type/NamedParametersInDelegateType.fs (2,38--2,46),
-                                  { ArrowRange =
-                                     /root/Type/NamedParametersInDelegateType.fs (2,42--2,44) }),
-                               /root/Type/NamedParametersInDelegateType.fs (2,23--2,46),
-                               { ArrowRange =
-                                  /root/Type/NamedParametersInDelegateType.fs (2,35--2,37) }),
+                                  (2,38--2,46), { ArrowRange = (2,42--2,44) }),
+                               (2,23--2,46), { ArrowRange = (2,35--2,37) }),
                             SynValInfo
                               ([[SynArgInfo ([], false, Some a);
                                  SynArgInfo ([], false, Some b)];
                                 [SynArgInfo ([], false, Some c)]],
                                SynArgInfo ([], false, None)), false, false,
-                            PreXmlDocEmpty, None, None,
-                            /root/Type/NamedParametersInDelegateType.fs (2,11--2,46),
+                            PreXmlDocEmpty, None, None, (2,11--2,46),
                             { LeadingKeyword = Synthetic
                               InlineKeyword = None
                               WithKeyword = None
@@ -96,21 +80,11 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/Type/NamedParametersInDelegateType.fs (2,11--2,46),
-                         { GetSetKeywords = None })],
-                     /root/Type/NamedParametersInDelegateType.fs (2,11--2,46)),
-                  [], None,
-                  /root/Type/NamedParametersInDelegateType.fs (2,5--2,46),
-                  { LeadingKeyword =
-                     Type /root/Type/NamedParametersInDelegateType.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/NamedParametersInDelegateType.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Type/NamedParametersInDelegateType.fs (2,0--2,46))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/NamedParametersInDelegateType.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           MemberKind = Member }, (2,11--2,46),
+                         { GetSetKeywords = None })], (2,11--2,46)), [], None,
+                  (2,5--2,46), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,9--2,10)
+                                 WithKeyword = None })], (2,0--2,46))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [A],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Unspecified,
                      [NestedType
@@ -18,35 +17,17 @@ ImplFile
                            (SynComponentInfo
                               ([], None, [], [B],
                                PreXmlDoc ((3,16), FSharp.Compiler.Xml.XmlDocCollector),
-                               false, None,
-                               /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (3,16--3,17)),
-                            ObjectModel
-                              (Class, [],
-                               /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (4,20--5,23)),
-                            [], None,
-                            /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (3,16--5,23),
+                               false, None, (3,16--3,17)),
+                            ObjectModel (Class, [], (4,20--5,23)), [], None,
+                            (3,16--5,23),
                             { LeadingKeyword =
-                               StaticType
-                                 (/root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (3,4--3,10),
-                                  /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (3,11--3,15))
-                              EqualsRange =
-                               Some
-                                 /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (3,18--3,19)
-                              WithKeyword = None }), None,
-                         /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (3,4--6,0))],
-                     /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (3,4--6,0)),
-                  [], None,
-                  /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (2,5--6,0),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (2,0--6,0))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/NestedTypeHasStaticTypeAsLeadingKeyword.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                               StaticType ((3,4--3,10), (3,11--3,15))
+                              EqualsRange = Some (3,18--3,19)
+                              WithKeyword = None }), None, (3,4--6,0))],
+                     (3,4--6,0)), [], None, (2,5--6,0),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--6,0))], PreXmlDocEmpty, [],
+          None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs.bsl
@@ -9,35 +9,17 @@ ImplFile
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName = SynLongIdent ([Foo], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (2,2--2,5))
+                            ArgExpr = Const (Unit, (2,2--2,5))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (2,2--2,5) }]
-                        Range =
-                         /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (2,0--2,7) }],
-                     None, [], [Bar],
+                            Range = (2,2--2,5) }]
+                        Range = (2,0--2,7) }], None, [], [Bar],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (3,5--3,8)),
-                  ObjectModel
-                    (Class, [],
-                     /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (4,4--5,7)),
-                  [], None,
-                  /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (2,0--5,7),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (3,0--3,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (3,9--3,10)
-                    WithKeyword = None })],
-              /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (2,0--5,7))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/RangeOfAttributeShouldBeIncludedInSynTypeDefn.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                     false, None, (3,5--3,8)),
+                  ObjectModel (Class, [], (4,4--5,7)), [], None, (2,0--5,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,9--3,10)
+                    WithKeyword = None })], (2,0--5,7))], PreXmlDocEmpty, [],
+          None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs.bsl
@@ -10,34 +10,23 @@ ImplFile
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName = SynLongIdent ([NoEquality], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (2,2--2,12))
+                            ArgExpr = Const (Unit, (2,2--2,12))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (2,2--2,12) };
+                            Range = (2,2--2,12) };
                           { TypeName = SynLongIdent ([NoComparison], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (2,15--2,27))
+                            ArgExpr = Const (Unit, (2,15--2,27))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (2,15--2,27) }]
-                        Range =
-                         /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (2,0--2,29) }],
+                            Range = (2,15--2,27) }]
+                        Range = (2,0--2,29) }],
                      Some
                        (PostfixList
                           ([SynTyparDecl ([], SynTypar (context, None, false));
                             SynTyparDecl ([], SynTypar (a, None, false))], [],
-                           /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (3,8--3,22))),
-                     [], [Foo],
+                           (3,8--3,22))), [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     true, None,
-                     /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (3,5--3,8)),
+                     true, None, (3,5--3,8)),
                   Simple
                     (Union
                        (None,
@@ -49,122 +38,67 @@ ImplFile
                                   App
                                     (LongIdent
                                        (SynLongIdent ([ApplyCrate], [], [None])),
-                                     Some
-                                       /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,25--4,26),
+                                     Some (4,25--4,26),
                                      [Var
                                         (SynTypar (context, None, false),
-                                         /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,26--4,34));
+                                         (4,26--4,34));
                                       Var
-                                        (SynTypar (a, None, false),
-                                         /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,36--4,38))],
-                                     [/root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,34--4,35)],
-                                     Some
-                                       /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,38--4,39),
-                                     false,
-                                     /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,15--4,39)),
-                                  false,
+                                        (SynTypar (a, None, false), (4,36--4,38))],
+                                     [(4,34--4,35)], Some (4,38--4,39), false,
+                                     (4,15--4,39)), false,
                                   PreXmlDoc ((4,15), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,15--4,39),
-                                  { LeadingKeyword = None })],
+                                  None, (4,15--4,39), { LeadingKeyword = None })],
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,6--4,39),
-                            { BarRange =
-                               Some
-                                 /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,4--4,5) })],
-                        /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,4--4,39)),
-                     /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (4,4--4,39)),
-                  [], None,
-                  /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (2,0--4,39),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (3,0--3,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (3,23--3,24)
+                            None, (4,6--4,39), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,39)), (4,4--4,39)), [], None, (2,0--4,39),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,23--3,24)
                     WithKeyword = None });
                SynTypeDefn
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName =
                              SynLongIdent ([CustomEquality], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,6--6,20))
+                            ArgExpr = Const (Unit, (6,6--6,20))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,6--6,20) };
+                            Range = (6,6--6,20) };
                           { TypeName = SynLongIdent ([NoComparison], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,23--6,35))
+                            ArgExpr = Const (Unit, (6,23--6,35))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,23--6,35) }]
-                        Range =
-                         /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,4--6,37) }],
+                            Range = (6,23--6,35) }]
+                        Range = (6,4--6,37) }],
                      Some
                        (PostfixList
                           ([SynTyparDecl ([], SynTypar (context, None, false));
                             SynTyparDecl ([], SynTypar (a, None, false))], [],
-                           /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,41--6,55))),
-                     [], [Bar],
+                           (6,41--6,55))), [], [Bar],
                      PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
-                     true, None,
-                     /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,38--6,41)),
+                     true, None, (6,38--6,41)),
                   Simple
                     (Record
-                       (Some
-                          (Internal
-                             /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (7,4--7,12)),
+                       (Some (Internal (7,4--7,12)),
                         [SynField
                            ([], false, Some Hash,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((8,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (8,8--8,18),
-                            { LeadingKeyword = None });
+                            None, (8,8--8,18), { LeadingKeyword = None });
                          SynField
                            ([], false, Some Foo,
                             App
                               (LongIdent (SynLongIdent ([Foo], [], [None])),
-                               Some
-                                 /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (9,17--9,18),
-                               [Var
-                                  (SynTypar (a, None, false),
-                                   /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (9,18--9,20));
-                                Var
-                                  (SynTypar (b, None, false),
-                                   /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (9,22--9,24))],
-                               [/root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (9,20--9,21)],
-                               Some
-                                 /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (9,24--9,25),
-                               false,
-                               /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (9,14--9,25)),
-                            false,
+                               Some (9,17--9,18),
+                               [Var (SynTypar (a, None, false), (9,18--9,20));
+                                Var (SynTypar (b, None, false), (9,22--9,24))],
+                               [(9,20--9,21)], Some (9,24--9,25), false,
+                               (9,14--9,25)), false,
                             PreXmlDoc ((9,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (9,8--9,25),
-                            { LeadingKeyword = None })],
-                        /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (7,4--10,5)),
-                     /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (7,4--10,5)),
-                  [], None,
-                  /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,4--10,5),
-                  { LeadingKeyword =
-                     And
-                       /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,0--6,3)
-                    EqualsRange =
-                     Some
-                       /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (6,56--6,57)
-                    WithKeyword = None })],
-              /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (2,0--10,5))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs (2,0--11,0),
-          { LeadingKeyword = None })], (true, false),
+                            None, (9,8--9,25), { LeadingKeyword = None })],
+                        (7,4--10,5)), (7,4--10,5)), [], None, (6,4--10,5),
+                  { LeadingKeyword = And (6,0--6,3)
+                    EqualsRange = Some (6,56--6,57)
+                    WithKeyword = None })], (2,0--10,5))], PreXmlDocEmpty, [],
+          None, (2,0--11,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SingleSynEnumCaseContainsRangeOfConstant.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SingleSynEnumCaseContainsRangeOfConstant.fs.bsl
@@ -9,34 +9,19 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Enum
                        ([SynEnumCase
                            ([], SynIdent (One, None),
-                            Const
-                              (Int32 1,
-                               /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,17--2,27)),
+                            Const (Int32 1, (2,17--2,27)),
                             PreXmlDoc ((2,11), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,11--2,27),
-                            { BarRange = None
-                              EqualsRange =
-                               /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,15--2,16) })],
-                        /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,11--2,27)),
-                     /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,11--2,27)),
-                  [], None,
-                  /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,5--2,27),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,0--2,27))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SingleSynEnumCaseContainsRangeOfConstant.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
+                            (2,11--2,27), { BarRange = None
+                                            EqualsRange = (2,15--2,16) })],
+                        (2,11--2,27)), (2,11--2,27)), [], None, (2,5--2,27),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--2,27))], PreXmlDocEmpty, [],
+          None, (2,0--3,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -12,23 +12,16 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   ObjectModel
                     (Unspecified,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                         None,
+                        (None, [], SimplePats ([], (2,8--2,10)), None,
                          PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                         { AsKeyword = None });
+                         (2,5--2,8), { AsKeyword = None });
                       Interface
                         (LongIdent (SynLongIdent ([Bar], [], [None])),
-                         Some
-                           /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (3,18--3,22),
+                         Some (3,18--3,22),
                          Some
                            [Member
                               (SynBinding
@@ -51,54 +44,25 @@ ImplFile
                                      None,
                                      Pats
                                        [Paren
-                                          (Const
-                                             (Unit,
-                                              /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (4,19--4,21)),
-                                           /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (4,19--4,21))],
-                                     None,
-                                     /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (4,15--4,21)),
-                                  None,
-                                  Const
-                                    (Unit,
-                                     /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (4,24--4,26)),
-                                  /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (4,15--4,21),
+                                          (Const (Unit, (4,19--4,21)),
+                                           (4,19--4,21))], None, (4,15--4,21)),
+                                  None, Const (Unit, (4,24--4,26)), (4,15--4,21),
                                   NoneAtInvisible,
-                                  { LeadingKeyword =
-                                     Member
-                                       /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (4,8--4,14)
+                                  { LeadingKeyword = Member (4,8--4,14)
                                     InlineKeyword = None
-                                    EqualsRange =
-                                     Some
-                                       /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (4,22--4,23) }),
-                               /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (4,8--4,26))],
-                         /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (3,4--4,26));
+                                    EqualsRange = Some (4,22--4,23) }),
+                               (4,8--4,26))], (3,4--4,26));
                       Interface
                         (LongIdent (SynLongIdent ([Other], [], [None])), None,
-                         None,
-                         /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (5,4--5,19))],
-                     /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (3,4--5,19)),
-                  [],
+                         None, (5,4--5,19))], (3,4--5,19)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,8--2,10)),
-                        None,
+                       (None, [], SimplePats ([], (2,8--2,10)), None,
                         PreXmlDoc ((2,8), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,5--2,8),
-                        { AsKeyword = None })),
-                  /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,5--5,19),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,0--5,19))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynMemberDefnInterfaceContainsTheRangeOfTheWithKeyword.fs (2,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,8), { AsKeyword = None })), (2,5--5,19),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--5,19))], PreXmlDocEmpty, [],
+          None, (2,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs.bsl
@@ -12,40 +12,20 @@ ImplFile
                  (SynComponentInfo
                     ([{ Attributes =
                          [{ TypeName = SynLongIdent ([MyAttribute], [], [None])
-                            ArgExpr =
-                             Const
-                               (Unit,
-                                /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (2,2--2,13))
+                            ArgExpr = Const (Unit, (2,2--2,13))
                             Target = None
                             AppliesToGetterAndSetter = false
-                            Range =
-                             /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (2,2--2,13) }]
-                        Range =
-                         /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (2,0--2,15) }],
-                     None, [], [A],
+                            Range = (2,2--2,13) }]
+                        Range = (2,0--2,15) }], None, [], [A],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   Simple
                     (TypeAbbrev
                        (Ok, LongIdent (SynLongIdent ([B], [], [None])),
-                        /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (4,9--4,10)),
-                     /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (4,9--4,10)),
-                  [], None,
-                  /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (2,0--4,10),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (4,7--4,8)
-                    WithKeyword = None })],
-              /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (2,0--4,10))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                        (4,9--4,10)), (4,9--4,10)), [], None, (2,0--4,10),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,7--4,8)
+                    WithKeyword = None })], (2,0--4,10))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Type/SynTypeDefnWithAttributeContainsTheRangeOfTheTypeKeyword.fs (3,0--3,8)] },
-      set []))
+        CodeComments = [LineComment (3,0--3,8)] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -12,13 +12,8 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Int32],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (2,5--2,10)),
-                  ObjectModel
-                    (Augmentation
-                       /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (2,11--2,15),
-                     [],
-                     /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (2,5--3,21)),
+                     false, None, (2,5--2,10)),
+                  ObjectModel (Augmentation (2,11--2,15), [], (2,5--3,21)),
                   [Member
                      (SynBinding
                         (None, Normal, false, false, [],
@@ -35,34 +30,16 @@ ImplFile
                                SynArgInfo ([], false, None)), None),
                          LongIdent
                            (SynLongIdent
-                              ([_; Zero],
-                               [/root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (3,12--3,13)],
-                               [None; None]), None, None, Pats [], None,
-                            /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (3,11--3,17)),
-                         None,
-                         Const
-                           (Int32 0,
-                            /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (3,20--3,21)),
-                         /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (3,11--3,17),
-                         NoneAtInvisible,
-                         { LeadingKeyword =
-                            Member
-                              /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (3,4--3,10)
-                           InlineKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (3,18--3,19) }),
-                      /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (3,4--3,21))],
-                  None,
-                  /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (2,5--3,21),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (2,0--2,4)
+                              ([_; Zero], [(3,12--3,13)], [None; None]), None,
+                            None, Pats [], None, (3,11--3,17)), None,
+                         Const (Int32 0, (3,20--3,21)), (3,11--3,17),
+                         NoneAtInvisible, { LeadingKeyword = Member (3,4--3,10)
+                                            InlineKeyword = None
+                                            EqualsRange = Some (3,18--3,19) }),
+                      (3,4--3,21))], None, (2,5--3,21),
+                  { LeadingKeyword = Type (2,0--2,4)
                     EqualsRange = None
-                    WithKeyword = None })],
-              /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (2,0--3,21))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeDefnWithAugmentationContainsTheRangeOfTheWithKeyword.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                    WithKeyword = None })], (2,0--3,21))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -11,48 +11,25 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Bear],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (2,5--2,9)),
+                     false, None, (2,5--2,9)),
                   Simple
                     (Enum
                        ([SynEnumCase
                            ([], SynIdent (BlackBear, None),
-                            Const
-                              (Int32 1,
-                               /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (3,18--3,19)),
+                            Const (Int32 1, (3,18--3,19)),
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (3,6--3,19),
-                            { BarRange =
-                               Some
-                                 /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (3,4--3,5)
-                              EqualsRange =
-                               /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (3,16--3,17) });
+                            (3,6--3,19), { BarRange = Some (3,4--3,5)
+                                           EqualsRange = (3,16--3,17) });
                          SynEnumCase
                            ([], SynIdent (PolarBear, None),
-                            Const
-                              (Int32 2,
-                               /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (4,18--4,19)),
+                            Const (Int32 2, (4,18--4,19)),
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (4,6--4,19),
-                            { BarRange =
-                               Some
-                                 /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (4,4--4,5)
-                              EqualsRange =
-                               /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (4,16--4,17) })],
-                        /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (3,4--4,19)),
-                     /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (3,4--4,19)),
-                  [], None,
-                  /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (2,5--4,19),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (2,10--2,11)
-                    WithKeyword = None })],
-              /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (2,0--4,19))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeDefnWithEnumContainsTheRangeOfTheEqualsSign.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                            (4,6--4,19), { BarRange = Some (4,4--4,5)
+                                           EqualsRange = (4,16--4,17) })],
+                        (3,4--4,19)), (3,4--4,19)), [], None, (2,5--4,19),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,10--2,11)
+                    WithKeyword = None })], (2,0--4,19))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -12,42 +12,21 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foobar],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,5--2,11)),
+                     false, None, (2,5--2,11)),
                   ObjectModel
                     (Class,
                      [ImplicitCtor
-                        (None, [],
-                         SimplePats
-                           ([],
-                            /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,12--2,14)),
-                         None,
+                        (None, [], SimplePats ([], (2,12--2,14)), None,
                          PreXmlDoc ((2,12), FSharp.Compiler.Xml.XmlDocCollector),
-                         /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,5--2,11),
-                         { AsKeyword = None })],
-                     /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (3,4--4,7)),
-                  [],
+                         (2,5--2,11), { AsKeyword = None })], (3,4--4,7)), [],
                   Some
                     (ImplicitCtor
-                       (None, [],
-                        SimplePats
-                          ([],
-                           /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,12--2,14)),
-                        None,
+                       (None, [], SimplePats ([], (2,12--2,14)), None,
                         PreXmlDoc ((2,12), FSharp.Compiler.Xml.XmlDocCollector),
-                        /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,5--2,11),
-                        { AsKeyword = None })),
-                  /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,5--4,7),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,15--2,16)
-                    WithKeyword = None })],
-              /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,0--4,7))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeDefnWithObjectModelClassContainsTheRangeOfTheEqualsSign.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                        (2,5--2,11), { AsKeyword = None })), (2,5--4,7),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,15--2,16)
+                    WithKeyword = None })], (2,0--4,7))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -13,16 +13,13 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   ObjectModel
                     (Delegate
                        (Fun
                           (LongIdent (SynLongIdent ([string], [], [None])),
                            LongIdent (SynLongIdent ([string], [], [None])),
-                           /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,21--2,37),
-                           { ArrowRange =
-                              /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,28--2,30) }),
+                           (2,21--2,37), { ArrowRange = (2,28--2,30) }),
                         SynValInfo
                           ([[SynArgInfo ([], false, None)]],
                            SynArgInfo ([], false, None))),
@@ -33,14 +30,11 @@ ImplFile
                             Fun
                               (LongIdent (SynLongIdent ([string], [], [None])),
                                LongIdent (SynLongIdent ([string], [], [None])),
-                               /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,21--2,37),
-                               { ArrowRange =
-                                  /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,28--2,30) }),
+                               (2,21--2,37), { ArrowRange = (2,28--2,30) }),
                             SynValInfo
                               ([[SynArgInfo ([], false, None)]],
                                SynArgInfo ([], false, None)), false, false,
-                            PreXmlDocEmpty, None, None,
-                            /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,9--2,37),
+                            PreXmlDocEmpty, None, None, (2,9--2,37),
                             { LeadingKeyword = Synthetic
                               InlineKeyword = None
                               WithKeyword = None
@@ -50,22 +44,11 @@ ImplFile
                            IsOverrideOrExplicitImpl = false
                            IsFinal = false
                            GetterOrSetterIsCompilerGenerated = false
-                           MemberKind = Member },
-                         /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,9--2,37),
-                         { GetSetKeywords = None })],
-                     /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,9--2,37)),
-                  [], None,
-                  /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,5--2,37),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,0--2,37))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeDefnWithObjectModelDelegateContainsTheRangeOfTheEqualsSign.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           MemberKind = Member }, (2,9--2,37),
+                         { GetSetKeywords = None })], (2,9--2,37)), [], None,
+                  (2,5--2,37), { LeadingKeyword = Type (2,0--2,4)
+                                 EqualsRange = Some (2,7--2,8)
+                                 WithKeyword = None })], (2,0--2,37))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -12,8 +12,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Record
                        (None,
@@ -21,11 +20,8 @@ ImplFile
                            ([], false, Some Bar,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (3,6--3,15),
-                            { LeadingKeyword = None })],
-                        /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (3,4--3,17)),
-                     /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (3,4--3,17)),
+                            None, (3,6--3,15), { LeadingKeyword = None })],
+                        (3,4--3,17)), (3,4--3,17)),
                   [Member
                      (SynBinding
                         (None, Normal, false, false, [],
@@ -43,22 +39,18 @@ ImplFile
                                SynArgInfo ([], false, None)), None),
                          LongIdent
                            (SynLongIdent
-                              ([this; Meh],
-                               [/root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,19--5,20)],
-                               [None; None]), None, None,
+                              ([this; Meh], [(5,19--5,20)], [None; None]), None,
+                            None,
                             Pats
                               [Paren
                                  (Typed
                                     (Named
                                        (SynIdent (v, None), false, None,
-                                        /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,25--5,26)),
+                                        (5,25--5,26)),
                                      LongIdent
                                        (SynLongIdent ([int], [], [None])),
-                                     /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,25--5,30)),
-                                  /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,24--5,31))],
-                            None,
-                            /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,15--5,31)),
-                         None,
+                                     (5,25--5,30)), (5,24--5,31))], None,
+                            (5,15--5,31)), None,
                          App
                            (NonAtomic, false,
                             App
@@ -68,41 +60,20 @@ ImplFile
                                   SynLongIdent
                                     ([op_Addition], [],
                                      [Some (OriginalNotation "+")]), None,
-                                  /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,43--5,44)),
+                                  (5,43--5,44)),
                                LongIdent
                                  (false,
                                   SynLongIdent
-                                    ([this; Bar],
-                                     [/root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,38--5,39)],
-                                     [None; None]), None,
-                                  /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,34--5,42)),
-                               /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,34--5,44)),
-                            Ident v,
-                            /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,34--5,46)),
-                         /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,15--5,31),
-                         NoneAtInvisible,
-                         { LeadingKeyword =
-                            Member
-                              /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,8--5,14)
+                                    ([this; Bar], [(5,38--5,39)], [None; None]),
+                                  None, (5,34--5,42)), (5,34--5,44)), Ident v,
+                            (5,34--5,46)), (5,15--5,31), NoneAtInvisible,
+                         { LeadingKeyword = Member (5,8--5,14)
                            InlineKeyword = None
-                           EqualsRange =
-                            Some
-                              /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,32--5,33) }),
-                      /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (5,8--5,46))],
-                  None,
-                  /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (2,5--5,46),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (2,9--2,10)
-                    WithKeyword =
-                     Some
-                       /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (4,4--4,8) })],
-              /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (2,0--5,46))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs (2,0--6,0),
+                           EqualsRange = Some (5,32--5,33) }), (5,8--5,46))],
+                  None, (2,5--5,46), { LeadingKeyword = Type (2,0--2,4)
+                                       EqualsRange = Some (2,9--2,10)
+                                       WithKeyword = Some (4,4--4,8) })],
+              (2,0--5,46))], PreXmlDocEmpty, [], None, (2,0--6,0),
           { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -11,8 +11,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Shape],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (2,5--2,10)),
+                     false, None, (2,5--2,10)),
                   Simple
                     (Union
                        (None,
@@ -24,15 +23,9 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((3,16), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (3,16--3,19),
-                                  { LeadingKeyword = None })],
+                                  None, (3,16--3,19), { LeadingKeyword = None })],
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (3,6--3,19),
-                            { BarRange =
-                               Some
-                                 /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (3,4--3,5) });
+                            None, (3,6--3,19), { BarRange = Some (3,4--3,5) });
                          SynUnionCase
                            ([], SynIdent (Rectangle, None),
                             Fields
@@ -41,37 +34,19 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,19), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (4,19--4,22),
-                                  { LeadingKeyword = None });
+                                  None, (4,19--4,22), { LeadingKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,25), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (4,25--4,28),
-                                  { LeadingKeyword = None })],
+                                  None, (4,25--4,28), { LeadingKeyword = None })],
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (4,6--4,28),
-                            { BarRange =
-                               Some
-                                 /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (4,4--4,5) })],
-                        /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (3,4--4,28)),
-                     /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (3,4--4,28)),
-                  [], None,
-                  /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (2,5--4,28),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (2,11--2,12)
-                    WithKeyword = None })],
-              /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (2,0--4,28))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                            None, (4,6--4,28), { BarRange = Some (4,4--4,5) })],
+                        (3,4--4,28)), (3,4--4,28)), [], None, (2,5--4,28),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,11--2,12)
+                    WithKeyword = None })], (2,0--4,28))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs.bsl
@@ -12,48 +12,26 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [A],
                      PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (4,5--4,6)),
+                     false, None, (4,5--4,6)),
                   Simple
                     (TypeAbbrev
                        (Ok, LongIdent (SynLongIdent ([B], [], [None])),
-                        /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (4,9--4,10)),
-                     /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (4,9--4,10)),
-                  [], None,
-                  /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (2,0--4,10),
-                  { LeadingKeyword =
-                     Type
-                       /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (4,0--4,4)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (4,7--4,8)
+                        (4,9--4,10)), (4,9--4,10)), [], None, (2,0--4,10),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,7--4,8)
                     WithKeyword = None });
                SynTypeDefn
                  (SynComponentInfo
                     ([], None, [], [C],
                      PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (5,4--5,5)),
+                     false, None, (5,4--5,5)),
                   Simple
                     (TypeAbbrev
                        (Ok, LongIdent (SynLongIdent ([D], [], [None])),
-                        /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (5,8--5,9)),
-                     /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (5,8--5,9)),
-                  [], None,
-                  /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (5,4--5,9),
-                  { LeadingKeyword =
-                     And
-                       /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (5,0--5,3)
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (5,6--5,7)
-                    WithKeyword = None })],
-              /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (2,0--5,9))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (4,0--6,0),
-          { LeadingKeyword = None })], (true, false),
+                        (5,8--5,9)), (5,8--5,9)), [], None, (5,4--5,9),
+                  { LeadingKeyword = And (5,0--5,3)
+                    EqualsRange = Some (5,6--5,7)
+                    WithKeyword = None })], (2,0--5,9))], PreXmlDocEmpty, [],
+          None, (4,0--6,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment
-            /root/Type/SynTypeDefnWithXmlDocContainsTheRangeOfTheTypeKeyword.fs (3,0--3,8)] },
-      set []))
+        CodeComments = [LineComment (3,0--3,8)] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeFunHasRangeOfArrow.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeFunHasRangeOfArrow.fs.bsl
@@ -9,30 +9,18 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/Type/SynTypeFunHasRangeOfArrow.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   Simple
                     (TypeAbbrev
                        (Ok,
                         Fun
                           (LongIdent (SynLongIdent ([string], [], [None])),
                            LongIdent (SynLongIdent ([int], [], [None])),
-                           /root/Type/SynTypeFunHasRangeOfArrow.fs (2,9--3,20),
-                           { ArrowRange =
-                              /root/Type/SynTypeFunHasRangeOfArrow.fs (2,16--2,18) }),
-                        /root/Type/SynTypeFunHasRangeOfArrow.fs (2,9--3,20)),
-                     /root/Type/SynTypeFunHasRangeOfArrow.fs (2,9--3,20)), [],
-                  None, /root/Type/SynTypeFunHasRangeOfArrow.fs (2,5--3,20),
-                  { LeadingKeyword =
-                     Type /root/Type/SynTypeFunHasRangeOfArrow.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/Type/SynTypeFunHasRangeOfArrow.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/Type/SynTypeFunHasRangeOfArrow.fs (2,0--3,20))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeFunHasRangeOfArrow.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                           (2,9--3,20), { ArrowRange = (2,16--2,18) }),
+                        (2,9--3,20)), (2,9--3,20)), [], None, (2,5--3,20),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,20))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
-        CodeComments =
-         [LineComment /root/Type/SynTypeFunHasRangeOfArrow.fs (2,19--2,59)] },
-      set []))
+        CodeComments = [LineComment (2,19--2,59)] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeTupleWithStruct.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeTupleWithStruct.fs.bsl
@@ -11,38 +11,27 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Wild /root/Type/SynTypeTupleWithStruct.fs (2,4--2,5),
+                  Wild (2,4--2,5),
                   Some
                     (SynBindingReturnInfo
                        (Tuple
                           (true,
                            [Type (LongIdent (SynLongIdent ([int], [], [None])));
-                            Star
-                              /root/Type/SynTypeTupleWithStruct.fs (2,19--2,20);
+                            Star (2,19--2,20);
                             Type (LongIdent (SynLongIdent ([int], [], [None])))],
-                           /root/Type/SynTypeTupleWithStruct.fs (2,7--2,25)),
-                        /root/Type/SynTypeTupleWithStruct.fs (2,7--2,25), [],
-                        { ColonRange =
-                           Some /root/Type/SynTypeTupleWithStruct.fs (2,5--2,6) })),
+                           (2,7--2,25)), (2,7--2,25), [],
+                        { ColonRange = Some (2,5--2,6) })),
                   Typed
-                    (Const
-                       (Unit, /root/Type/SynTypeTupleWithStruct.fs (2,28--2,30)),
+                    (Const (Unit, (2,28--2,30)),
                      Tuple
                        (true,
                         [Type (LongIdent (SynLongIdent ([int], [], [None])));
-                         Star /root/Type/SynTypeTupleWithStruct.fs (2,19--2,20);
+                         Star (2,19--2,20);
                          Type (LongIdent (SynLongIdent ([int], [], [None])))],
-                        /root/Type/SynTypeTupleWithStruct.fs (2,7--2,25)),
-                     /root/Type/SynTypeTupleWithStruct.fs (2,28--2,30)),
-                  /root/Type/SynTypeTupleWithStruct.fs (2,4--2,5),
-                  Yes /root/Type/SynTypeTupleWithStruct.fs (2,0--2,30),
-                  { LeadingKeyword =
-                     Let /root/Type/SynTypeTupleWithStruct.fs (2,0--2,3)
+                        (2,7--2,25)), (2,28--2,30)), (2,4--2,5), Yes (2,0--2,30),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some /root/Type/SynTypeTupleWithStruct.fs (2,26--2,27) })],
-              /root/Type/SynTypeTupleWithStruct.fs (2,0--2,30))], PreXmlDocEmpty,
-          [], None, /root/Type/SynTypeTupleWithStruct.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,26--2,27) })], (2,0--2,30))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/SynTypeTupleWithStructRecovery.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeTupleWithStructRecovery.fs.bsl
@@ -11,44 +11,27 @@ ImplFile
                   PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
                   SynValData
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
-                  Wild /root/Type/SynTypeTupleWithStructRecovery.fs (2,4--2,5),
+                  Wild (2,4--2,5),
                   Some
                     (SynBindingReturnInfo
                        (Tuple
                           (true,
                            [Type (LongIdent (SynLongIdent ([int], [], [None])));
-                            Star
-                              /root/Type/SynTypeTupleWithStructRecovery.fs (2,19--2,20);
+                            Star (2,19--2,20);
                             Type (LongIdent (SynLongIdent ([int], [], [None])))],
-                           /root/Type/SynTypeTupleWithStructRecovery.fs (2,7--2,24)),
-                        /root/Type/SynTypeTupleWithStructRecovery.fs (2,7--2,26),
-                        [],
-                        { ColonRange =
-                           Some
-                             /root/Type/SynTypeTupleWithStructRecovery.fs (2,5--2,6) })),
+                           (2,7--2,24)), (2,7--2,26), [],
+                        { ColonRange = Some (2,5--2,6) })),
                   Typed
-                    (Const
-                       (Unit,
-                        /root/Type/SynTypeTupleWithStructRecovery.fs (2,27--2,29)),
+                    (Const (Unit, (2,27--2,29)),
                      Tuple
                        (true,
                         [Type (LongIdent (SynLongIdent ([int], [], [None])));
-                         Star
-                           /root/Type/SynTypeTupleWithStructRecovery.fs (2,19--2,20);
+                         Star (2,19--2,20);
                          Type (LongIdent (SynLongIdent ([int], [], [None])))],
-                        /root/Type/SynTypeTupleWithStructRecovery.fs (2,7--2,24)),
-                     /root/Type/SynTypeTupleWithStructRecovery.fs (2,27--2,29)),
-                  /root/Type/SynTypeTupleWithStructRecovery.fs (2,4--2,5),
-                  Yes /root/Type/SynTypeTupleWithStructRecovery.fs (2,0--2,29),
-                  { LeadingKeyword =
-                     Let /root/Type/SynTypeTupleWithStructRecovery.fs (2,0--2,3)
+                        (2,7--2,24)), (2,27--2,29)), (2,4--2,5), Yes (2,0--2,29),
+                  { LeadingKeyword = Let (2,0--2,3)
                     InlineKeyword = None
-                    EqualsRange =
-                     Some
-                       /root/Type/SynTypeTupleWithStructRecovery.fs (2,25--2,26) })],
-              /root/Type/SynTypeTupleWithStructRecovery.fs (2,0--2,29))],
-          PreXmlDocEmpty, [], None,
-          /root/Type/SynTypeTupleWithStructRecovery.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                    EqualsRange = Some (2,25--2,26) })], (2,0--2,29))],
+          PreXmlDocEmpty, [], None, (2,0--3,0), { LeadingKeyword = None })],
+      (true, false), { ConditionalDirectives = []
+                       CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/UnionCase/MultipleSynUnionCasesHaveBarRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/MultipleSynUnionCasesHaveBarRange.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Union
                        (None,
@@ -22,15 +21,9 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((3,13), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (3,13--3,19),
-                                  { LeadingKeyword = None })],
+                                  None, (3,13--3,19), { LeadingKeyword = None })],
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (3,6--3,19),
-                            { BarRange =
-                               Some
-                                 /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (3,4--3,5) });
+                            None, (3,6--3,19), { BarRange = Some (3,4--3,5) });
                          SynUnionCase
                            ([], SynIdent (Bear, None),
                             Fields
@@ -39,29 +32,13 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,14), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (4,14--4,17),
-                                  { LeadingKeyword = None })],
+                                  None, (4,14--4,17), { LeadingKeyword = None })],
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (4,6--4,17),
-                            { BarRange =
-                               Some
-                                 /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (4,4--4,5) })],
-                        /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (3,4--4,17)),
-                     /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (3,4--4,17)),
-                  [], None,
-                  /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (2,5--4,17),
-                  { LeadingKeyword =
-                     Type
-                       /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (2,0--4,17))],
-          PreXmlDocEmpty, [], None,
-          /root/UnionCase/MultipleSynUnionCasesHaveBarRange.fs (2,0--5,0),
-          { LeadingKeyword = None })], (true, false),
+                            None, (4,6--4,17), { BarRange = Some (4,4--4,5) })],
+                        (3,4--4,17)), (3,4--4,17)), [], None, (2,5--4,17),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--4,17))], PreXmlDocEmpty, [],
+          None, (2,0--5,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/UnionCase/PrivateKeywordHasRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/PrivateKeywordHasRange.fs.bsl
@@ -9,13 +9,10 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Currency],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/UnionCase/PrivateKeywordHasRange.fs (2,5--2,13)),
+                     false, None, (2,5--2,13)),
                   Simple
                     (Union
-                       (Some
-                          (Private
-                             /root/UnionCase/PrivateKeywordHasRange.fs (7,4--7,11)),
+                       (Some (Private (7,4--7,11)),
                         [SynUnionCase
                            ([], SynIdent (Code, None),
                             Fields
@@ -24,33 +21,15 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((9,14), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/UnionCase/PrivateKeywordHasRange.fs (9,14--9,20),
-                                  { LeadingKeyword = None })],
+                                  None, (9,14--9,20), { LeadingKeyword = None })],
                             PreXmlDoc ((9,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/UnionCase/PrivateKeywordHasRange.fs (9,6--9,20),
-                            { BarRange =
-                               Some
-                                 /root/UnionCase/PrivateKeywordHasRange.fs (9,4--9,5) })],
-                        /root/UnionCase/PrivateKeywordHasRange.fs (7,4--9,20)),
-                     /root/UnionCase/PrivateKeywordHasRange.fs (7,4--9,20)), [],
-                  None, /root/UnionCase/PrivateKeywordHasRange.fs (2,5--9,20),
-                  { LeadingKeyword =
-                     Type /root/UnionCase/PrivateKeywordHasRange.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/UnionCase/PrivateKeywordHasRange.fs (2,14--2,15)
-                    WithKeyword = None })],
-              /root/UnionCase/PrivateKeywordHasRange.fs (2,0--9,20))],
-          PreXmlDocEmpty, [], None,
-          /root/UnionCase/PrivateKeywordHasRange.fs (2,0--10,0),
-          { LeadingKeyword = None })], (true, false),
+                            None, (9,6--9,20), { BarRange = Some (9,4--9,5) })],
+                        (7,4--9,20)), (7,4--9,20)), [], None, (2,5--9,20),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,14--2,15)
+                    WithKeyword = None })], (2,0--9,20))], PreXmlDocEmpty, [],
+          None, (2,0--10,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives =
-         [If
-            (Not (Ident "FABLE_COMPILER"),
-             /root/UnionCase/PrivateKeywordHasRange.fs (6,0--6,19));
-          EndIf /root/UnionCase/PrivateKeywordHasRange.fs (8,0--8,6)]
-        CodeComments =
-         [LineComment /root/UnionCase/PrivateKeywordHasRange.fs (3,4--3,67);
-          LineComment /root/UnionCase/PrivateKeywordHasRange.fs (4,4--4,56)] },
+         [If (Not (Ident "FABLE_COMPILER"), (6,0--6,19)); EndIf (8,0--8,6)]
+        CodeComments = [LineComment (3,4--3,67); LineComment (4,4--4,56)] },
       set []))

--- a/tests/service/data/SyntaxTree/UnionCase/SingleSynUnionCaseHasBarRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/SingleSynUnionCaseHasBarRange.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Union
                        (None,
@@ -22,29 +21,13 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((2,20), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,20--2,26),
-                                  { LeadingKeyword = None })],
+                                  None, (2,20--2,26), { LeadingKeyword = None })],
                             PreXmlDoc ((2,11), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,13--2,26),
-                            { BarRange =
-                               Some
-                                 /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,11--2,12) })],
-                        /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,11--2,26)),
-                     /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,11--2,26)),
-                  [], None,
-                  /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,5--2,26),
-                  { LeadingKeyword =
-                     Type
-                       /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,0--2,26))],
-          PreXmlDocEmpty, [], None,
-          /root/UnionCase/SingleSynUnionCaseHasBarRange.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
+                            None, (2,13--2,26), { BarRange = Some (2,11--2,12) })],
+                        (2,11--2,26)), (2,11--2,26)), [], None, (2,5--2,26),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--2,26))], PreXmlDocEmpty, [],
+          None, (2,0--3,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/UnionCase/SingleSynUnionCaseWithoutBar.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/SingleSynUnionCaseWithoutBar.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Union
                        (None,
@@ -22,27 +21,13 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((2,18), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,18--2,24),
-                                  { LeadingKeyword = None })],
+                                  None, (2,18--2,24), { LeadingKeyword = None })],
                             PreXmlDoc ((2,11), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,11--2,24),
-                            { BarRange = None })],
-                        /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,11--2,24)),
-                     /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,11--2,24)),
-                  [], None,
-                  /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,5--2,24),
-                  { LeadingKeyword =
-                     Type
-                       /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,0--2,24))],
-          PreXmlDocEmpty, [], None,
-          /root/UnionCase/SingleSynUnionCaseWithoutBar.fs (2,0--3,0),
-          { LeadingKeyword = None })], (true, false),
+                            None, (2,11--2,24), { BarRange = None })],
+                        (2,11--2,24)), (2,11--2,24)), [], None, (2,5--2,24),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--2,24))], PreXmlDocEmpty, [],
+          None, (2,0--3,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/UnionCase/SynUnionCaseKindFullType.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/SynUnionCaseKindFullType.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [X],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/UnionCase/SynUnionCaseKindFullType.fs (2,5--2,6)),
+                     false, None, (2,5--2,6)),
                   Simple
                     (Union
                        (None,
@@ -22,34 +21,20 @@ ImplFile
                                   [Type
                                      (LongIdent
                                         (SynLongIdent ([int], [], [None])));
-                                   Star
-                                     /root/UnionCase/SynUnionCaseKindFullType.fs (3,13--3,14);
+                                   Star (3,13--3,14);
                                    Type
                                      (SignatureParameter
                                         ([], false, Some z,
                                          LongIdent
                                            (SynLongIdent ([int], [], [None])),
-                                         /root/UnionCase/SynUnionCaseKindFullType.fs (3,15--3,20)))],
-                                  /root/UnionCase/SynUnionCaseKindFullType.fs (3,9--3,20)),
+                                         (3,15--3,20)))], (3,9--3,20)),
                                SynValInfo ([], SynArgInfo ([], false, None))),
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/UnionCase/SynUnionCaseKindFullType.fs (3,6--3,20),
-                            { BarRange =
-                               Some
-                                 /root/UnionCase/SynUnionCaseKindFullType.fs (3,4--3,5) })],
-                        /root/UnionCase/SynUnionCaseKindFullType.fs (3,4--3,20)),
-                     /root/UnionCase/SynUnionCaseKindFullType.fs (3,4--3,20)),
-                  [], None,
-                  /root/UnionCase/SynUnionCaseKindFullType.fs (2,5--3,20),
-                  { LeadingKeyword =
-                     Type /root/UnionCase/SynUnionCaseKindFullType.fs (2,0--2,4)
-                    EqualsRange =
-                     Some /root/UnionCase/SynUnionCaseKindFullType.fs (2,7--2,8)
-                    WithKeyword = None })],
-              /root/UnionCase/SynUnionCaseKindFullType.fs (2,0--3,20))],
-          PreXmlDocEmpty, [], None,
-          /root/UnionCase/SynUnionCaseKindFullType.fs (2,0--4,0),
-          { LeadingKeyword = None })], (true, false),
+                            None, (3,6--3,20), { BarRange = Some (3,4--3,5) })],
+                        (3,4--3,20)), (3,4--3,20)), [], None, (2,5--3,20),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,7--2,8)
+                    WithKeyword = None })], (2,0--3,20))], PreXmlDocEmpty, [],
+          None, (2,0--4,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/UnionCase/UnionCaseFieldsCanHaveComments.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/UnionCaseFieldsCanHaveComments.fs.bsl
@@ -9,8 +9,7 @@ ImplFile
                  (SynComponentInfo
                     ([], None, [], [Foo],
                      PreXmlDoc ((2,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None,
-                     /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (2,5--2,8)),
+                     false, None, (2,5--2,8)),
                   Simple
                     (Union
                        (None,
@@ -22,37 +21,19 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((6,2), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (5,2--6,15),
-                                  { LeadingKeyword = None });
+                                  None, (5,2--6,15), { LeadingKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([bool], [], [None])),
                                   false,
                                   PreXmlDoc ((8,2), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None,
-                                  /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (7,2--8,6),
-                                  { LeadingKeyword = None })],
+                                  None, (7,2--8,6), { LeadingKeyword = None })],
                             PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                            None,
-                            /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (3,0--8,6),
-                            { BarRange =
-                               Some
-                                 /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (4,0--4,1) })],
-                        /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (3,0--8,6)),
-                     /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (3,0--8,6)),
-                  [], None,
-                  /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (2,5--8,6),
-                  { LeadingKeyword =
-                     Type
-                       /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (2,0--2,4)
-                    EqualsRange =
-                     Some
-                       /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (2,9--2,10)
-                    WithKeyword = None })],
-              /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (2,0--8,6))],
-          PreXmlDocEmpty, [], None,
-          /root/UnionCase/UnionCaseFieldsCanHaveComments.fs (2,0--9,0),
-          { LeadingKeyword = None })], (true, false),
+                            None, (3,0--8,6), { BarRange = Some (4,0--4,1) })],
+                        (3,0--8,6)), (3,0--8,6)), [], None, (2,5--8,6),
+                  { LeadingKeyword = Type (2,0--2,4)
+                    EqualsRange = Some (2,9--2,10)
+                    WithKeyword = None })], (2,0--8,6))], PreXmlDocEmpty, [],
+          None, (2,0--9,0), { LeadingKeyword = None })], (true, false),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Val/InlineKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Val/InlineKeyword.fsi.bsl
@@ -8,20 +8,17 @@ SigFile
                 ([], SynIdent (meh, None), SynValTyparDecls (None, true),
                  Fun
                    (LongIdent (SynLongIdent ([int], [], [None])),
-                    LongIdent (SynLongIdent ([int], [], [None])),
-                    /root/Val/InlineKeyword.fsi (4,16--4,26),
-                    { ArrowRange = /root/Val/InlineKeyword.fsi (4,20--4,22) }),
+                    LongIdent (SynLongIdent ([int], [], [None])), (4,16--4,26),
+                    { ArrowRange = (4,20--4,22) }),
                  SynValInfo
                    ([[SynArgInfo ([], false, None)]],
                     SynArgInfo ([], false, None)), true, false,
                  PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector), None,
-                 None, /root/Val/InlineKeyword.fsi (4,0--4,26),
-                 { LeadingKeyword = Val /root/Val/InlineKeyword.fsi (4,0--4,3)
-                   InlineKeyword = Some /root/Val/InlineKeyword.fsi (4,4--4,10)
-                   WithKeyword = None
-                   EqualsRange = None }),
-              /root/Val/InlineKeyword.fsi (4,0--4,26))], PreXmlDocEmpty, [],
-          None, /root/Val/InlineKeyword.fsi (2,0--4,26),
-          { LeadingKeyword = Namespace /root/Val/InlineKeyword.fsi (2,0--2,9) })],
+                 None, (4,0--4,26), { LeadingKeyword = Val (4,0--4,3)
+                                      InlineKeyword = Some (4,4--4,10)
+                                      WithKeyword = None
+                                      EqualsRange = None }), (4,0--4,26))],
+          PreXmlDocEmpty, [], None, (2,0--4,26),
+          { LeadingKeyword = Namespace (2,0--2,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))


### PR DESCRIPTION
After looking at new parser tests in #13089, I thought the file names in the AST dump only add noise and don't help with anything. Are there any cases where it's really helpful to always have them in `Range.ToString()`?

This PR removes file names from `Range.ToString()` (while it's still available in its `DebuggerDisplay`) as an experiment. The syntax tree dumps are much easier to look at now.