### PR TITLE
Remove unused values from compilation to avoid FS1182

### DIFF
--- a/src/Compiler/Driver/StaticLinking.fs
+++ b/src/Compiler/Driver/StaticLinking.fs
@@ -98,7 +98,9 @@ type TypeForwarding(tcImports: TcImports) =
 
     member _.TypeForwardILTypeRef tref = typeForwardILTypeRef tref
 
+#if !NO_TYPEPROVIDERS
 let debugStaticLinking = isEnvVarSet "FSHARP_DEBUG_STATIC_LINKING"
+#endif
 
 let StaticLinkILModules
     (
@@ -419,6 +421,7 @@ let FindDependentILModulesForStaticLinking (ctok, tcConfig: TcConfig, tcImports:
                     (n.ccu, n.data)
         ]
 
+#if !NO_TYPEPROVIDERS
 // Add all provider-generated assemblies into the static linking set
 let FindProviderGeneratedILModules (ctok, tcImports: TcImports, providerGeneratedAssemblies: (ImportedBinary * _) list) =
     [
@@ -442,6 +445,7 @@ let FindProviderGeneratedILModules (ctok, tcImports: TcImports, providerGenerate
                 (ccu, dllInfo.ILScopeRef, modul), (ilAssemRef.Name, provAssemStaticLinkInfo)
             | None -> ()
     ]
+#endif
 
 /// Split the list into left, middle and right parts at the first element satisfying 'p'. If no element matches return
 /// 'None' for the middle part.

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -29,7 +29,9 @@ open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps
 open FSharp.Compiler.TcGlobals
 
+#if !NO_TYPEPROVIDERS
 let verbose = false
+#endif
 
 let ffailwith fileName str =
     let msg = FSComp.SR.pickleErrorReadingWritingMetadata(fileName, str)


### PR DESCRIPTION
These changes fix build errors when attempting to source-build fsharp with the bootstrap flow, using the latest 8.0 preview 1 SDK as the target SDK to build the project. This results in FS1182 warnings for several cases of unused values, which are then treated as errors.

These changes address the issue by compiling out the values for the condition that they're not referenced.

