### PR TITLE
Name resolution: report interface, record, and union types; report type arguments

### DIFF
--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -2483,11 +2483,7 @@ let private ResolveObjectConstructorPrim (ncenv: NameResolver) edenv resInfo m a
                     [DefaultStructCtor(g, ty)]
                 else []
             if (isNil defaultStructCtorInfo && isNil ctorInfos) || (not (isAppTy g ty) && not (isAnyTupleTy g ty)) then
-                let nm = NicePrint.minimalStringOfType edenv ty
-                if isRecdTy g ty || isUnionTy g ty then
-                    success (resInfo, Item.Types(nm, [ty]))
-                else
-                    raze (Error(FSComp.SR.nrNoConstructorsAvailableForType(nm), m))
+                raze (Error(FSComp.SR.nrNoConstructorsAvailableForType(NicePrint.minimalStringOfType edenv ty), m))
             else
                 let ctorInfos = ctorInfos |> List.filter (IsMethInfoAccessible amap m ad)
                 let metadataTy = convertToTypeWithMetadataIfPossible g ty

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -2484,10 +2484,10 @@ let private ResolveObjectConstructorPrim (ncenv: NameResolver) edenv resInfo m a
                 else []
             if (isNil defaultStructCtorInfo && isNil ctorInfos) || (not (isAppTy g ty) && not (isAnyTupleTy g ty)) then
                 let nm = NicePrint.minimalStringOfType edenv ty
-                if not (isRecdTy g ty || isUnionTy g ty) then
-                    errorR (Error(FSComp.SR.nrNoConstructorsAvailableForType(nm), m))
-
-                success (resInfo, Item.Types(nm, [ty]))
+                if isRecdTy g ty || isUnionTy g ty then
+                    success (resInfo, Item.Types(nm, [ty]))
+                else
+                    raze (Error(FSComp.SR.nrNoConstructorsAvailableForType(nm), m))
             else
                 let ctorInfos = ctorInfos |> List.filter (IsMethInfoAccessible amap m ad)
                 let metadataTy = convertToTypeWithMetadataIfPossible g ty


### PR DESCRIPTION
Adds type checker recovery for cases where an interface, record, or union type is used in an expression.
Also adds reporting of the inferred type arguments, makes them accessible in reported `FSharpSymbolUse.GenericArguments`.

```fsharp
IDisposable 
IList<int>
ITop<int>.INested1<double>
ITop<int>.INested2
```

Before:
<img width="247" alt="Screenshot 2023-02-20 at 22 39 15" src="https://user-images.githubusercontent.com/3923587/220202099-83e89974-02ce-4a36-b1bc-39e0a970278e.png">

After
<img width="367" alt="Screenshot 2023-02-20 at 22 33 04" src="https://user-images.githubusercontent.com/3923587/220201975-11b1359f-6f0e-4130-b547-9b38854c3a1d.png">


```fsharp
type R1 =
    { F: int }
    static member P = 1
   
type R2<'T> =
    { F: 'T }

R1
R2<int>
```

<img width="387" alt="Screenshot 2023-02-20 at 22 34 07" src="https://user-images.githubusercontent.com/3923587/220201998-65e9854c-aa51-493d-8112-e2042e532ffd.png">


```fsharp
type U1 = | A
type U2<'T> = | A

U1
U2<int>
```

<img width="445" alt="Screenshot 2023-02-20 at 22 34 15" src="https://user-images.githubusercontent.com/3923587/220202011-e04995ce-0451-4b5b-9773-d85f4ceed788.png">
