### PR TITLE
Fix NavigateToSearchService tests and make FSharp.Editor.Tests faster

### DIFF
--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="$(MicrosoftCodeAnalysisEditorFeaturesTextVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="$(MicrosoftCodeAnalysisExternalAccessFSharpVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
   </ItemGroup>
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
@@ -63,19 +63,16 @@ module MefHelpers =
                 )
 
             let parts = partDiscovery.CreatePartsAsync(asms).Result
-            ComposableCatalog
-                .Create(resolver)
-                .AddParts(parts)
-                .WithCompositionService()
+            ComposableCatalog.Create(resolver).AddParts(parts).WithCompositionService()
 
-        let configuration =
-            CompositionConfiguration.Create(catalog)
+        let configuration = CompositionConfiguration.Create(catalog)
 
         RuntimeComposition
             .CreateRuntimeComposition(configuration)
             .CreateExportProviderFactory()
 
-    let createExportProvider () = exportProviderFactory.CreateExportProvider()
+    let createExportProvider () =
+        exportProviderFactory.CreateExportProvider()
 
 type TestWorkspaceServiceMetadata(serviceType: string, layer: string) =
 


### PR DESCRIPTION
We need one more assembly in FSharp.Editor.Tests MEF imports because of #14746.
Reusing ExportProviderFactory should somewhat speed up FSharp.Editor.Tests.

