### PR TITLE
Fix AST features offered by fantomas-tools in docs (#14838

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ Welcome to [the F# compiler and tools repository](https://github.com/dotnet/fsha
 
 * [sharplab.io](https://sharplab.io/) can be used to decompile code.
 
-* [fantomas-tools](https://fsprojects.github.io/fantomas-tools/#/ast) can be used to view the Untyped & Typed Abstract Syntax Tree.
+* [fantomas-tools](https://fsprojects.github.io/fantomas-tools/#/ast) can be used to view the Untyped Abstract Syntax Tree.
 
 ## Attribution
 


### PR DESCRIPTION
The feature to view the typed AST was removed from the fantomas-tools some time ago.