### PR TITLE
Visual Studio - enable container search in "go to all"

### DIFF
--- a/src/Compiler/Service/ServiceNavigation.fsi
+++ b/src/Compiler/Service/ServiceNavigation.fsi
@@ -98,15 +98,17 @@ type NavigableContainerType =
     | Type
     | Exception
 
+[<Sealed>]
 type NavigableContainer =
-    {
-        /// The kind of container.
-        Type: NavigableContainerType
+    /// The kind of container.
+    member Type: NavigableContainerType
 
-        /// If Type = File, this is the name of the file
-        /// In other cases it is the logical name of the entity.
-        LogicalName: string
-    }
+    /// The fully qualified name of the container.
+    /// For files it returns empty string.
+    member FullName: string
+
+    /// The name of the container or file
+    member Name: string
 
 type NavigableItem =
     { LogicalName: string

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -60,6 +60,9 @@ type Document with
     member this.IsFSharpScript =
         isScriptFile this.FilePath
 
+    member this.IsFSharpSignatureFile =
+        isSignatureFile this.FilePath
+
 module private SourceText =
 
     open System.Runtime.CompilerServices

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
@@ -174,7 +174,7 @@ type internal FSharpNavigateToSearchService [<ImportingConstructor>]
                 }
 
             let! items = getNavigableItems document
-            let! processed = items |> Seq.map (fun item -> processItem item) |> Async.Parallel
+            let! processed = items |> Seq.map processItem |> Async.Parallel
             return processed |> Array.choose id
         }
 

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
@@ -5,117 +5,45 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 open System
 open System.IO
 open System.Composition
-open System.Collections.Generic
 open System.Collections.Immutable
+open System.Collections.Concurrent
 open System.Threading.Tasks
-open System.Runtime.Caching
 open System.Globalization
 
 open Microsoft.CodeAnalysis
-open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.NavigateTo
 open Microsoft.VisualStudio.Text.PatternMatching
 
 open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Syntax
+open Microsoft.VisualStudio.LanguageServices
 
-type internal NavigableItem(document: Document, sourceSpan: TextSpan, glyph: Glyph, logicalName: string, kind: string, additionalInfo: string) =
-    inherit FSharpNavigableItem(glyph, ImmutableArray.Create (TaggedText(TextTags.Text, logicalName)), document, sourceSpan)
+[<Export(typeof<IFSharpNavigateToSearchService>)>]
+type internal FSharpNavigateToSearchService 
+    [<ImportingConstructor>] 
+    (
+        patternMatcherFactory: IPatternMatcherFactory,
+        workspace: VisualStudioWorkspace
+    ) =
 
-    // This use of compiler logical names is leaking out into the IDE. We should only report display names here.
-    member _.LogicalName = logicalName
-    member _.Kind = kind
-    member _.AdditionalInfo = additionalInfo
+    let cache = ConcurrentDictionary<DocumentId, VersionStamp * NavigableItem array>()
 
-type internal NavigateToSearchResult(item: NavigableItem, matchKind: FSharpNavigateToMatchKind) =
-    inherit FSharpNavigateToSearchResult(item.AdditionalInfo, item.Kind, matchKind, item.LogicalName, item)
+    do workspace.WorkspaceChanged.Add <| fun e -> if e.NewSolution.Id <> e.OldSolution.Id then cache.Clear()
 
-module private Index =
-    [<System.Diagnostics.DebuggerDisplay("{DebugString()}")>]
-    type private IndexEntry(str: string, offset: int, item: NavigableItem) =
-        member _.String = str
-        member _.Offset = offset
-        member _.Length = str.Length - offset
-        member _.Item = item
-        member x.StartsWith (s: string) = 
-            if s.Length > x.Length then false
-            else CultureInfo.CurrentCulture.CompareInfo.IndexOf(str, s, offset, s.Length, CompareOptions.IgnoreCase) = offset
+    let getNavigableItems (document: Document) = async {
+        let! currentVersion = document.GetTextVersionAsync() |> Async.AwaitTask
+        match cache.TryGetValue document.Id with
+        | true, (version, items) when version = currentVersion ->
+            return items
+        | _ ->  
+            let! parseResults = document.GetFSharpParseResultsAsync(nameof(FSharpNavigateToSearchService))
+            let items = parseResults.ParseTree |> NavigateTo.GetNavigableItems
+            cache[document.Id] <- currentVersion, items
+            return items
+    }
 
-    let private indexEntryComparer =
-        { new IComparer<IndexEntry> with
-            member _.Compare(a, b) = 
-                let res = CultureInfo.CurrentCulture.CompareInfo.Compare(a.String, a.Offset, b.String, b.Offset, CompareOptions.IgnoreCase)
-                if res = 0 then a.Offset.CompareTo(b.Offset) else res }
-
-    type IIndexedNavigableItems =
-        abstract Find: searchValue: string -> FSharpNavigateToSearchResult []
-        abstract AllItems: NavigableItem []
-
-    let private navigateToSearchResultComparer =
-        { new IEqualityComparer<FSharpNavigateToSearchResult> with 
-            member _.Equals(x: FSharpNavigateToSearchResult, y: FSharpNavigateToSearchResult) =
-                match x, y with
-                | null, _ | _, null -> false
-                | _ -> x.NavigableItem.Document.Id = y.NavigableItem.Document.Id &&
-                       x.NavigableItem.SourceSpan = y.NavigableItem.SourceSpan
-            
-            member _.GetHashCode(x: FSharpNavigateToSearchResult) =
-                if isNull x then 0
-                else 23 * (17 * 23 + x.NavigableItem.Document.Id.GetHashCode()) + x.NavigableItem.SourceSpan.GetHashCode() }
-
-    let build (items: NavigableItem []) =
-        let entries = ResizeArray()
-
-        for item in items do
-            let name = 
-                // This conversion back from logical names to display names should never be needed, because
-                // the FCS API should only report display names in the first place.
-                if PrettyNaming.IsLogicalOpName item.LogicalName then 
-                    PrettyNaming.ConvertValLogicalNameToDisplayNameCore item.LogicalName
-                else 
-                    item.LogicalName
-            for i = 0 to name.Length - 1 do
-                entries.Add(IndexEntry(name, i, item))
-
-        entries.Sort(indexEntryComparer)
-        { new IIndexedNavigableItems with
-              member _.Find (searchValue) =
-                  let result = HashSet(navigateToSearchResultComparer)
-                  if entries.Count > 0 then 
-                     let entryToFind = IndexEntry(searchValue, 0, Unchecked.defaultof<_>)
-                     
-                     let initial = 
-                         let p = entries.BinarySearch(entryToFind, indexEntryComparer)
-                         if p < 0 then ~~~p else p
-                     
-                     let handle index =
-                         let entry = entries.[index]
-                         let matchKind = 
-                             if entry.Offset = 0 then
-                                 if entry.Length = searchValue.Length then FSharpNavigateToMatchKind.Exact
-                                 else FSharpNavigateToMatchKind.Prefix
-                             else FSharpNavigateToMatchKind.Substring
-                         let item = entry.Item
-                         result.Add (NavigateToSearchResult(item, matchKind) :> FSharpNavigateToSearchResult) |> ignore
-                    
-                     // in case if there are multiple matching items binary search might return not the first one.
-                     // in this case we'll walk backwards searching for the applicable answers
-                     let mutable pos = initial
-                     while pos >= 0 && pos < entries.Count && entries.[pos].StartsWith searchValue do
-                         handle pos
-                         pos <- pos - 1
-                    
-                     // value of 'initial' position was already handled on the previous step so here we'll bump it
-                     let mutable pos = initial + 1
-                     while pos < entries.Count && entries.[pos].StartsWith searchValue do
-                         handle pos
-                         pos <- pos + 1
-                  Seq.toArray result 
-              member _.AllItems = items }
-
-[<AutoOpen>]
-module private Utils =
+    let kindsProvided = ImmutableHashSet.Create(FSharpNavigateToItemKind.Module, FSharpNavigateToItemKind.Class, FSharpNavigateToItemKind.Field, FSharpNavigateToItemKind.Property, FSharpNavigateToItemKind.Method, FSharpNavigateToItemKind.Enum, FSharpNavigateToItemKind.EnumItem) :> IImmutableSet<string>
 
     let navigateToItemKindToRoslynKind = function
         | NavigableItemKind.Module -> FSharpNavigateToItemKind.Module
@@ -144,86 +72,20 @@ module private Utils =
         | NavigableItemKind.UnionCase -> Glyph.EnumPublic
 
     let containerToString (container: NavigableContainer) (document: Document) =
-        let project = document.Project
         let typeAsString =
             match container.Type with
-            | NavigableContainerType.File -> "project "
-            | NavigableContainerType.Namespace -> "namespace "
-            | NavigableContainerType.Module -> "module "
-            | NavigableContainerType.Exception -> "exception "
-            | NavigableContainerType.Type -> "type "
+            | NavigableContainerType.File -> "project"
+            | NavigableContainerType.Namespace -> "namespace"
+            | NavigableContainerType.Module -> "module"
+            | NavigableContainerType.Exception -> "exception"
+            | NavigableContainerType.Type -> "type"
         let name =
             match container.Type with
             | NavigableContainerType.File ->
-                (Path.GetFileNameWithoutExtension project.Name) + ", " + (Path.GetFileName container.LogicalName)
+                $"{Path.GetFileNameWithoutExtension document.Project.Name}, {Path.GetFileName container.LogicalName}"
             | _ -> container.LogicalName
 
-        let combined = typeAsString + name
-
-        if isSignatureFile document.FilePath then
-            "signature for: " + combined
-        else
-            combined
-
-    type PerDocumentSavedData = { Hash: int; Items: Index.IIndexedNavigableItems }
-
-[<Export(typeof<IFSharpNavigateToSearchService>)>]
-type internal FSharpNavigateToSearchService 
-    [<ImportingConstructor>] 
-    (
-        patternMatcherFactory: IPatternMatcherFactory
-    ) =
-
-    let kindsProvided = ImmutableHashSet.Create(FSharpNavigateToItemKind.Module, FSharpNavigateToItemKind.Class, FSharpNavigateToItemKind.Field, FSharpNavigateToItemKind.Property, FSharpNavigateToItemKind.Method, FSharpNavigateToItemKind.Enum, FSharpNavigateToItemKind.EnumItem) :> IImmutableSet<string>
-
-    // Save the backing navigation data in a memory cache held in a sliding window
-    let itemsByDocumentId = new MemoryCache("FSharp.Editor.FSharpNavigateToSearchService")
-
-    let GetNavigableItems(document: Document, kinds: IImmutableSet<string>) =
-        async {
-            let! cancellationToken = Async.CancellationToken
-            let! parseResults = document.GetFSharpParseResultsAsync(nameof(FSharpNavigateToSearchService))
-            let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-            let navItems parsedInput =
-                NavigateTo.GetNavigableItems parsedInput
-                |> Array.filter (fun i -> kinds.Contains(navigateToItemKindToRoslynKind i.Kind))
-
-            let items = parseResults.ParseTree |> navItems
-            let navigableItems =
-                [|
-                    for item in items do
-                        match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, item.Range) with 
-                        | None -> ()
-                        | Some sourceSpan ->
-                            let glyph = navigateToItemKindToGlyph item.Kind
-                            let kind = navigateToItemKindToRoslynKind item.Kind
-                            let additionalInfo = containerToString item.Container document
-                            let _name =
-                                if isSignatureFile document.FilePath then
-                                    item.LogicalName + " (signature)"
-                                else
-                                    item.LogicalName
-                            yield NavigableItem(document, sourceSpan, glyph, item.LogicalName, kind, additionalInfo)
-                |]
-            return navigableItems
-        }
-
-    let getCachedIndexedNavigableItems(document: Document, kinds: IImmutableSet<string>) =
-        async {
-            let! cancellationToken = Async.CancellationToken
-            let! textVersion = document.GetTextVersionAsync(cancellationToken)  |> Async.AwaitTask
-            let textVersionHash = hash textVersion
-            let key = document.Id.ToString()
-            match itemsByDocumentId.Get(key) with
-            | :? PerDocumentSavedData as data when data.Hash = textVersionHash -> return data.Items
-            | _ -> 
-                let! items = GetNavigableItems(document, kinds)
-                let indexedItems = Index.build items
-                let data = { Hash= textVersionHash; Items = indexedItems }
-                let cacheItem = CacheItem(key, data)
-                let policy = CacheItemPolicy(SlidingExpiration=DefaultTuning.PerDocumentSavedDataSlidingWindow)
-                itemsByDocumentId.Set(cacheItem, policy)
-                return indexedItems }
+        if document.IsFSharpSignatureFile then $"signature for: {typeAsString} {name}" else $"{typeAsString} {name}"
 
     let patternMatchKindToNavigateToMatchKind = function
         | PatternMatchKind.Exact -> FSharpNavigateToMatchKind.Exact
@@ -235,52 +97,70 @@ type internal FSharpNavigateToSearchService
         | PatternMatchKind.CamelCaseSubstring -> FSharpNavigateToMatchKind.CamelCaseSubstring
         | PatternMatchKind.CamelCaseNonContiguousSubstring -> FSharpNavigateToMatchKind.CamelCaseNonContiguousSubstring
         | PatternMatchKind.Fuzzy -> FSharpNavigateToMatchKind.Fuzzy
-        | _ -> FSharpNavigateToMatchKind.Fuzzy
+        | _ -> FSharpNavigateToMatchKind.None
+
+    let createMatcherFor searchPattern =
+        let patternMatcher =
+            lazy patternMatcherFactory.CreatePatternMatcher(searchPattern, PatternMatcherCreationOptions(
+                cultureInfo = CultureInfo.CurrentUICulture,
+                flags = (PatternMatcherCreationFlags.AllowFuzzyMatching ||| PatternMatcherCreationFlags.AllowSimpleSubstringMatching)
+            ))
+        // PatternMatcher will not match operators and some backtick escaped identifiers.
+        // To handle them, do a simple substring match first.
+        fun (name: string) ->
+            match name.IndexOf(searchPattern, StringComparison.CurrentCultureIgnoreCase) with
+            | i when i > 0 ->
+                PatternMatch(PatternMatchKind.Substring, false, true) |> Some
+            | 0 when name.Length = searchPattern.Length ->
+                PatternMatch(PatternMatchKind.Exact, false, true) |> Some
+            | 0 ->
+                PatternMatch(PatternMatchKind.Prefix, false, true) |> Some
+            | _ ->
+                patternMatcher.Value.TryMatch name |> Option.ofNullable
+
+    let processDocument (document: Document) (tryMatch: string -> PatternMatch option) (kinds: IImmutableSet<string>) =
+        async {
+            let! sourceText = document.GetTextAsync Async.DefaultCancellationToken |> Async.AwaitTask
+
+            let processItem item = asyncMaybe {
+                do! Option.guard (kinds.Contains(navigateToItemKindToRoslynKind item.Kind))
+                let name = 
+                    // This conversion back from logical names to display names should never be needed, because
+                    // the FCS API should only report display names in the first place.
+                    if PrettyNaming.IsLogicalOpName item.LogicalName then 
+                        PrettyNaming.ConvertValLogicalNameToDisplayNameCore item.LogicalName
+                    else 
+                        item.LogicalName
+                let! m = tryMatch name
+                let! sourceSpan = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, item.Range)
+                let glyph = navigateToItemKindToGlyph item.Kind
+                let kind = navigateToItemKindToRoslynKind item.Kind
+                let additionalInfo = containerToString item.Container document
+                return FSharpNavigateToSearchResult(additionalInfo, kind, patternMatchKindToNavigateToMatchKind m.Kind, name, 
+                    FSharpNavigableItem(glyph, ImmutableArray.Create (TaggedText(TextTags.Text, name)), document, sourceSpan))
+            }
+
+            let! items = getNavigableItems document 
+            let! processed = items |> Seq.map (fun item -> processItem item) |> Async.Parallel
+            return processed |> Array.choose id
+        }
 
     interface IFSharpNavigateToSearchService with
         member _.SearchProjectAsync(project, _priorityDocuments, searchPattern, kinds, cancellationToken) : Task<ImmutableArray<FSharpNavigateToSearchResult>> =
-            asyncMaybe {
-                let! items =
-                    project.Documents
-                    |> Seq.map (fun document -> getCachedIndexedNavigableItems(document, kinds))
+            async {
+                if not project.IsFSharp then raise (ArgumentException("Project is not a F# project", nameof project))
+                let tryMatch = createMatcherFor searchPattern
+                let! results =
+                    seq { for document in project.Documents -> processDocument document tryMatch kinds }
                     |> Async.Parallel
-                    |> liftAsync
-                
-                let items =
-                    if searchPattern.Length = 1 then
-                        items 
-                        |> Array.map (fun items -> items.Find(searchPattern))
-                        |> Array.concat
-                        |> Array.filter (fun x -> x.Name.Length = 1 && String.Equals(x.Name, searchPattern, StringComparison.InvariantCultureIgnoreCase))
-                    else
-                        [| yield! items |> Array.map (fun items -> items.Find(searchPattern)) |> Array.concat
-                           let patternMatcherOptions = PatternMatcherCreationOptions(
-                               cultureInfo = CultureInfo.CurrentUICulture,
-                               flags = PatternMatcherCreationFlags.AllowFuzzyMatching
-                           )
-                           let patternMatcher = patternMatcherFactory.CreatePatternMatcher(searchPattern, patternMatcherOptions)
-                           yield! items
-                                  |> Array.collect (fun item -> item.AllItems)
-                                  |> Array.Parallel.choose (fun x -> 
-                                      patternMatcher.TryMatch(x.LogicalName)
-                                      |> Option.ofNullable
-                                      |> Option.map (fun pm ->
-                                          NavigateToSearchResult(x, patternMatchKindToNavigateToMatchKind pm.Kind) :> FSharpNavigateToSearchResult)) |]
+                return results |> Array.concat |> Array.toImmutableArray
+            } |> RoslynHelpers.StartAsyncAsTask cancellationToken
 
-                return items |> Array.distinctBy (fun x -> x.NavigableItem.Document.Id, x.NavigableItem.SourceSpan)
-            } 
-            |> Async.map (Option.defaultValue [||])
-            |> Async.map Seq.toImmutableArray
-            |> RoslynHelpers.StartAsyncAsTask(cancellationToken)
-
-        member _.SearchDocumentAsync(document, searchPattern, kinds, cancellationToken) : Task<ImmutableArray<FSharpNavigateToSearchResult>> =
-            asyncMaybe {
-                let! items = getCachedIndexedNavigableItems(document, kinds) |> liftAsync
-                return items.Find(searchPattern)
-            }
-            |> Async.map (Option.defaultValue [||])
-            |> Async.map Seq.toImmutableArray
-            |> RoslynHelpers.StartAsyncAsTask(cancellationToken)
+        member _.SearchDocumentAsync(document: Document, searchPattern, kinds, cancellationToken) : Task<ImmutableArray<FSharpNavigateToSearchResult>> =
+            async { 
+                let! result = processDocument document (createMatcherFor searchPattern) kinds
+                return result |> Array.toImmutableArray
+            } |> RoslynHelpers.StartAsyncAsTask cancellationToken
 
         member _.KindsProvided = kindsProvided
 

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
@@ -13,15 +13,14 @@ open System.Globalization
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.NavigateTo
+open Microsoft.VisualStudio.LanguageServices
 open Microsoft.VisualStudio.Text.PatternMatching
 
 open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Syntax
-open Microsoft.VisualStudio.LanguageServices
 
 [<Export(typeof<IFSharpNavigateToSearchService>)>]
-type internal FSharpNavigateToSearchService 
-    [<ImportingConstructor>] 
+type internal FSharpNavigateToSearchService [<ImportingConstructor>]
     (
         patternMatcherFactory: IPatternMatcherFactory,
         workspace: VisualStudioWorkspace
@@ -29,23 +28,38 @@ type internal FSharpNavigateToSearchService
 
     let cache = ConcurrentDictionary<DocumentId, VersionStamp * NavigableItem array>()
 
-    do workspace.WorkspaceChanged.Add <| fun e -> if e.NewSolution.Id <> e.OldSolution.Id then cache.Clear()
+    do
+        workspace.WorkspaceChanged.Add
+        <| fun e ->
+            if e.NewSolution.Id <> e.OldSolution.Id then
+                cache.Clear()
 
-    let getNavigableItems (document: Document) = async {
-        let! currentVersion = document.GetTextVersionAsync() |> Async.AwaitTask
-        match cache.TryGetValue document.Id with
-        | true, (version, items) when version = currentVersion ->
-            return items
-        | _ ->  
-            let! parseResults = document.GetFSharpParseResultsAsync(nameof(FSharpNavigateToSearchService))
-            let items = parseResults.ParseTree |> NavigateTo.GetNavigableItems
-            cache[document.Id] <- currentVersion, items
-            return items
-    }
+    let getNavigableItems (document: Document) =
+        async {
+            let! currentVersion = document.GetTextVersionAsync() |> Async.AwaitTask
 
-    let kindsProvided = ImmutableHashSet.Create(FSharpNavigateToItemKind.Module, FSharpNavigateToItemKind.Class, FSharpNavigateToItemKind.Field, FSharpNavigateToItemKind.Property, FSharpNavigateToItemKind.Method, FSharpNavigateToItemKind.Enum, FSharpNavigateToItemKind.EnumItem) :> IImmutableSet<string>
+            match cache.TryGetValue document.Id with
+            | true, (version, items) when version = currentVersion -> return items
+            | _ ->
+                let! parseResults = document.GetFSharpParseResultsAsync(nameof (FSharpNavigateToSearchService))
+                let items = parseResults.ParseTree |> NavigateTo.GetNavigableItems
+                cache[document.Id] <- currentVersion, items
+                return items
+        }
 
-    let navigateToItemKindToRoslynKind = function
+    let kindsProvided =
+        ImmutableHashSet.Create(
+            FSharpNavigateToItemKind.Module,
+            FSharpNavigateToItemKind.Class,
+            FSharpNavigateToItemKind.Field,
+            FSharpNavigateToItemKind.Property,
+            FSharpNavigateToItemKind.Method,
+            FSharpNavigateToItemKind.Enum,
+            FSharpNavigateToItemKind.EnumItem
+        )
+
+    let navigateToItemKindToRoslynKind =
+        function
         | NavigableItemKind.Module -> FSharpNavigateToItemKind.Module
         | NavigableItemKind.ModuleAbbreviation -> FSharpNavigateToItemKind.Module
         | NavigableItemKind.Exception -> FSharpNavigateToItemKind.Class
@@ -58,7 +72,8 @@ type internal FSharpNavigateToSearchService
         | NavigableItemKind.EnumCase -> FSharpNavigateToItemKind.EnumItem
         | NavigableItemKind.UnionCase -> FSharpNavigateToItemKind.EnumItem
 
-    let navigateToItemKindToGlyph = function
+    let navigateToItemKindToGlyph =
+        function
         | NavigableItemKind.Module -> Glyph.ModulePublic
         | NavigableItemKind.ModuleAbbreviation -> Glyph.ModulePublic
         | NavigableItemKind.Exception -> Glyph.ClassPublic
@@ -79,15 +94,20 @@ type internal FSharpNavigateToSearchService
             | NavigableContainerType.Module -> "module"
             | NavigableContainerType.Exception -> "exception"
             | NavigableContainerType.Type -> "type"
+
         let name =
             match container.Type with
             | NavigableContainerType.File ->
                 $"{Path.GetFileNameWithoutExtension document.Project.Name}, {Path.GetFileName container.LogicalName}"
             | _ -> container.LogicalName
 
-        if document.IsFSharpSignatureFile then $"signature for: {typeAsString} {name}" else $"{typeAsString} {name}"
+        if document.IsFSharpSignatureFile then
+            $"signature for: {typeAsString} {name}"
+        else
+            $"{typeAsString} {name}"
 
-    let patternMatchKindToNavigateToMatchKind = function
+    let patternMatchKindToNavigateToMatchKind =
+        function
         | PatternMatchKind.Exact -> FSharpNavigateToMatchKind.Exact
         | PatternMatchKind.Prefix -> FSharpNavigateToMatchKind.Prefix
         | PatternMatchKind.Substring -> FSharpNavigateToMatchKind.Substring
@@ -101,66 +121,94 @@ type internal FSharpNavigateToSearchService
 
     let createMatcherFor searchPattern =
         let patternMatcher =
-            lazy patternMatcherFactory.CreatePatternMatcher(searchPattern, PatternMatcherCreationOptions(
-                cultureInfo = CultureInfo.CurrentUICulture,
-                flags = (PatternMatcherCreationFlags.AllowFuzzyMatching ||| PatternMatcherCreationFlags.AllowSimpleSubstringMatching)
-            ))
+            lazy
+                patternMatcherFactory.CreatePatternMatcher(
+                    searchPattern,
+                    PatternMatcherCreationOptions(
+                        cultureInfo = CultureInfo.CurrentUICulture,
+                        flags =
+                            (PatternMatcherCreationFlags.AllowFuzzyMatching
+                             ||| PatternMatcherCreationFlags.AllowSimpleSubstringMatching)
+                    )
+                )
         // PatternMatcher will not match operators and some backtick escaped identifiers.
         // To handle them, do a simple substring match first.
         fun (name: string) ->
             match name.IndexOf(searchPattern, StringComparison.CurrentCultureIgnoreCase) with
-            | i when i > 0 ->
-                PatternMatch(PatternMatchKind.Substring, false, true) |> Some
-            | 0 when name.Length = searchPattern.Length ->
-                PatternMatch(PatternMatchKind.Exact, false, true) |> Some
-            | 0 ->
-                PatternMatch(PatternMatchKind.Prefix, false, true) |> Some
-            | _ ->
-                patternMatcher.Value.TryMatch name |> Option.ofNullable
+            | i when i > 0 -> PatternMatch(PatternMatchKind.Substring, false, true) |> Some
+            | 0 when name.Length = searchPattern.Length -> PatternMatch(PatternMatchKind.Exact, false, true) |> Some
+            | 0 -> PatternMatch(PatternMatchKind.Prefix, false, true) |> Some
+            | _ -> patternMatcher.Value.TryMatch name |> Option.ofNullable
 
     let processDocument (document: Document) (tryMatch: string -> PatternMatch option) (kinds: IImmutableSet<string>) =
         async {
             let! sourceText = document.GetTextAsync Async.DefaultCancellationToken |> Async.AwaitTask
 
-            let processItem item = asyncMaybe {
-                do! Option.guard (kinds.Contains(navigateToItemKindToRoslynKind item.Kind))
-                let name = 
-                    // This conversion back from logical names to display names should never be needed, because
-                    // the FCS API should only report display names in the first place.
-                    if PrettyNaming.IsLogicalOpName item.LogicalName then 
-                        PrettyNaming.ConvertValLogicalNameToDisplayNameCore item.LogicalName
-                    else 
-                        item.LogicalName
-                let! m = tryMatch name
-                let! sourceSpan = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, item.Range)
-                let glyph = navigateToItemKindToGlyph item.Kind
-                let kind = navigateToItemKindToRoslynKind item.Kind
-                let additionalInfo = containerToString item.Container document
-                return FSharpNavigateToSearchResult(additionalInfo, kind, patternMatchKindToNavigateToMatchKind m.Kind, name, 
-                    FSharpNavigableItem(glyph, ImmutableArray.Create (TaggedText(TextTags.Text, name)), document, sourceSpan))
-            }
+            let processItem item =
+                asyncMaybe {
+                    do! Option.guard (kinds.Contains(navigateToItemKindToRoslynKind item.Kind))
 
-            let! items = getNavigableItems document 
+                    let name =
+                        // This conversion back from logical names to display names should never be needed, because
+                        // the FCS API should only report display names in the first place.
+                        if PrettyNaming.IsLogicalOpName item.LogicalName then
+                            PrettyNaming.ConvertValLogicalNameToDisplayNameCore item.LogicalName
+                        else
+                            item.LogicalName
+
+                    let! m = tryMatch name
+                    let! sourceSpan = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, item.Range)
+                    let glyph = navigateToItemKindToGlyph item.Kind
+                    let kind = navigateToItemKindToRoslynKind item.Kind
+                    let additionalInfo = containerToString item.Container document
+
+                    return
+                        FSharpNavigateToSearchResult(
+                            additionalInfo,
+                            kind,
+                            patternMatchKindToNavigateToMatchKind m.Kind,
+                            name,
+                            FSharpNavigableItem(glyph, ImmutableArray.Create(TaggedText(TextTags.Text, name)), document, sourceSpan)
+                        )
+                }
+
+            let! items = getNavigableItems document
             let! processed = items |> Seq.map (fun item -> processItem item) |> Async.Parallel
             return processed |> Array.choose id
         }
 
     interface IFSharpNavigateToSearchService with
-        member _.SearchProjectAsync(project, _priorityDocuments, searchPattern, kinds, cancellationToken) : Task<ImmutableArray<FSharpNavigateToSearchResult>> =
+        member _.SearchProjectAsync
+            (
+                project,
+                _priorityDocuments,
+                searchPattern,
+                kinds,
+                cancellationToken
+            ) : Task<ImmutableArray<FSharpNavigateToSearchResult>> =
             async {
-                if not project.IsFSharp then raise (ArgumentException("Project is not a F# project", nameof project))
                 let tryMatch = createMatcherFor searchPattern
+
                 let! results =
                     seq { for document in project.Documents -> processDocument document tryMatch kinds }
                     |> Async.Parallel
-                return results |> Array.concat |> Array.toImmutableArray
-            } |> RoslynHelpers.StartAsyncAsTask cancellationToken
 
-        member _.SearchDocumentAsync(document: Document, searchPattern, kinds, cancellationToken) : Task<ImmutableArray<FSharpNavigateToSearchResult>> =
-            async { 
+                return results |> Array.concat |> Array.toImmutableArray
+            }
+            |> RoslynHelpers.StartAsyncAsTask cancellationToken
+
+        member _.SearchDocumentAsync
+            (
+                document: Document,
+                searchPattern,
+                kinds,
+                cancellationToken
+            ) : Task<ImmutableArray<FSharpNavigateToSearchResult>> =
+            async {
                 let! result = processDocument document (createMatcherFor searchPattern) kinds
                 return result |> Array.toImmutableArray
-            } |> RoslynHelpers.StartAsyncAsTask cancellationToken
+            }
+            |> RoslynHelpers.StartAsyncAsTask cancellationToken
 
         member _.KindsProvided = kindsProvided
 

--- a/vsintegration/tests/FSharp.Editor.Tests/NavigateToSearchServiceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/NavigateToSearchServiceTests.fs
@@ -58,7 +58,7 @@ module HeyHo =
     let ``capitalized camel case`` () =
         assertResultsContain "CLN" "CamelCaseLongName"
 
-    [<Fact(Skip = "Old pattern matcher matches only capital letters to camel case.")>]
+    [<Fact>]
     let ``lower camel case`` () =
         assertResultsContain "cln" "CamelCaseLongName"
 
@@ -69,5 +69,5 @@ module HeyHo =
     let ``backticked identifier`` () =
         assertResultsContain "a few words" "a few words"
 
-    [<Fact(Skip = "Operators show logical name instead of display name.")>]
+    [<Fact>]
     let ``operator`` () = assertResultsContain "+>" "+>"

--- a/vsintegration/tests/FSharp.Editor.Tests/NavigateToSearchServiceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/NavigateToSearchServiceTests.fs
@@ -25,6 +25,11 @@ module HeyHo =
     let two'' = 2
 
     type CamelCaseLongName = class end
+
+    module Alpha =
+        module Beta =
+            type Gamma() =
+                member val Delta = 3
 """
 
     let sourceText = SourceText.From(fileContents)
@@ -71,3 +76,6 @@ module HeyHo =
 
     [<Fact>]
     let ``operator`` () = assertResultsContain "+>" "+>"
+
+    [<Fact>]
+    let ``nested containers`` () = assertResultsContain "hh.a.b.g.d" "Delta"


### PR DESCRIPTION
Built in pattern matcher allows for path based searches:
![image](https://user-images.githubusercontent.com/1760221/222714616-af8e34f4-75bc-4b47-8058-54cfe25ec5d2.png)
If we provide fully qualified names it will do a match over the path parts, e.g. in VisualFSharp.sln:
"a.par.ch" will return `Array.Parallel.choose`,
"fs.c.li.mf" will return `List.mapFold`,
"async.sc" will return `Async.StartChild` etc.

Might be useful, it always worked for C#, so it is something a user might expect to work.

This modifies `NavigableContainer` in FCS. I think and hope only Visual Studio ever used this?
