### PR TITLE
Enable more caching of parse results in FCS

### DIFF
--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -39,8 +39,8 @@ open FSharp.Compiler.BuildGraph
 [<AutoOpen>]
 module EnvMisc =
     let braceMatchCacheSize = GetEnvInteger "FCS_BraceMatchCacheSize" 5
-    let parseFileCacheSize = GetEnvInteger "FCS_ParseFileCacheSize" 2
-    let checkFileInProjectCacheSize = GetEnvInteger "FCS_CheckFileInProjectCacheSize" 10
+    let parseFileCacheSize = GetEnvInteger "FCS_ParseFileCacheSize" 100
+    let checkFileInProjectCacheSize = GetEnvInteger "FCS_CheckFileInProjectCacheSize" 100
 
     let projectCacheSizeDefault = GetEnvInteger "FCS_ProjectCacheSizeDefault" 3
     let frameworkTcImportsCacheStrongSize = GetEnvInteger "FCS_frameworkTcImportsCacheStrongSizeDefault" 8

--- a/src/Compiler/Service/service.fsi
+++ b/src/Compiler/Service/service.fsi
@@ -91,9 +91,15 @@ type public FSharpChecker =
     /// <param name="sourceText">The source to be parsed.</param>
     /// <param name="options">Parsing options for the project or script.</param>
     /// <param name="cache">Store the parse in a size-limited cache assocaited with the FSharpChecker. Default: true</param>
+    /// <param name="fileVersion">An integer that can be used to indicate the version of the file.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member ParseFile:
-        fileName: string * sourceText: ISourceText * options: FSharpParsingOptions * ?cache: bool * ?userOpName: string ->
+        fileName: string *
+        sourceText: ISourceText *
+        options: FSharpParsingOptions *
+        ?cache: bool *
+        ?fileVersion: int *
+        ?userOpName: string ->
             Async<FSharpParseFileResults>
 
     /// <summary>
@@ -104,10 +110,16 @@ type public FSharpChecker =
     /// <param name="source">The source to be parsed.</param>
     /// <param name="options">Parsing options for the project or script.</param>
     /// <param name="cache">Store the parse in a size-limited cache assocaited with the FSharpChecker. Default: true</param>
+    /// <param name="fileVersion">An integer that can be used to indicate the version of the file. This will be returned by TryGetRecentCheckResultsForFile when looking up the file.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     [<Obsolete("Please call checker.ParseFile instead.  To do this, you must also pass FSharpParsingOptions instead of FSharpProjectOptions. If necessary generate FSharpParsingOptions from FSharpProjectOptions by calling checker.GetParsingOptionsFromProjectOptions(options)")>]
     member ParseFileInProject:
-        fileName: string * source: string * options: FSharpProjectOptions * ?cache: bool * ?userOpName: string ->
+        fileName: string *
+        source: string *
+        options: FSharpProjectOptions *
+        ?cache: bool *
+        ?fileVersion: int *
+        ?userOpName: string ->
             Async<FSharpParseFileResults>
 
     /// <summary>
@@ -122,18 +134,17 @@ type public FSharpChecker =
     /// </summary>
     ///
     /// <param name="parseResults">The results of ParseFile for this file.</param>
-    /// <param name="fileName">The name of the file in the project whose source is being checked.</param>
-    /// <param name="fileVersion">An integer that can be used to indicate the version of the file. This will be returned by TryGetRecentCheckResultsForFile when looking up the file.</param>
-    /// <param name="source">The full source for the file.</param>
+    /// <param name="fileName">The name of the file in the project whose source is being checked.</param>    /// <param name="source">The full source for the file.</param>
     /// <param name="options">The options for the project or script.</param>
+    /// <param name="fileVersion">An integer that can be used to indicate the version of the file. This will be returned by TryGetRecentCheckResultsForFile when looking up the file.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     [<Obsolete("This member should no longer be used, please use 'CheckFileInProject'")>]
     member CheckFileInProjectAllowingStaleCachedResults:
         parseResults: FSharpParseFileResults *
         fileName: string *
-        fileVersion: int *
         source: string *
         options: FSharpProjectOptions *
+        ?fileVersion: int *
         ?userOpName: string ->
             Async<FSharpCheckFileAnswer option>
 
@@ -351,11 +362,11 @@ type public FSharpChecker =
     ///
     /// <param name="fileName">The file name for the file.</param>
     /// <param name="options">The options for the project or script, used to determine active --define conditionals and other options relevant to parsing.</param>
-    /// <param name="sourceText">Optionally, specify source that must match the previous parse precisely.</param>
+    /// <param name="fileVersion">Optionally, specify integer indicating current version of the file.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member TryGetRecentCheckResultsForFile:
-        fileName: string * options: FSharpProjectOptions * ?sourceText: ISourceText * ?userOpName: string ->
-            (FSharpParseFileResults * FSharpCheckFileResults (* hash *) * int64) option
+        fileName: string * options: FSharpProjectOptions * ?fileVersion: int * ?userOpName: string ->
+            (FSharpParseFileResults * FSharpCheckFileResults (* hash *) * int) option
 
     /// This function is called when the entire environment is known to have changed for reasons not encoded in the ProjectOptions of any project/compilation.
     member InvalidateAll: unit -> unit

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -21,7 +21,7 @@ module private CheckerExtensions =
                 let! sourceText = document.GetTextAsync(ct) |> Async.AwaitTask
                 let! version = document.GetTextVersionAsync ct |> Async.AwaitTask
                 let textVersionHash = version.GetHashCode()
-                return! checker.ParseFile(document.FilePath, sourceText.ToFSharpSourceText(), parsingOptions, cache=true, fileVersion=textVersionHash, userOpName=userOpName)
+                return! checker.ParseFile(document.FilePath, sourceText.ToFSharpSourceText(), parsingOptions, fileVersion=textVersionHash, userOpName=userOpName)
             }
 
         /// Parse and check the source text from the Roslyn document with possible stale results.

--- a/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
+++ b/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
@@ -202,7 +202,7 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
                             | FSharpCheckFileAnswer.Succeeded results -> Some results, false
 
                         sr.Value <- None
-                        parseResults,typedResults,true,aborted,int64 req.Timestamp
+                        parseResults,typedResults,true,aborted, req.Timestamp
                 
                 // Now that we have the parseResults, we can SetDependencyFiles().
                 // 


### PR DESCRIPTION
This is a quick draft to try to enable more caching, see #14848 
It works in Visual Studio for now.
