### PR TITLE
Fix finding references to aliased types part 2

### DIFF
--- a/src/Compiler/Service/ItemKey.fs
+++ b/src/Compiler/Service/ItemKey.fs
@@ -234,9 +234,9 @@ and [<Sealed>] ItemKeyStoreBuilder() =
         | TType_forall (_, ty) -> writeType false ty
 
         | TType_app (tcref, _, _) ->
-            match tcref.TypeAbbrev with
-            | Some ty -> writeType isStandalone ty
-            | None -> writeEntityRef tcref
+            match isStandalone, tcref.TypeAbbrev with
+            | false, Some ty -> writeType false ty
+            | _ -> writeEntityRef tcref
 
         | TType_tuple (_, tinst) ->
             writeString ItemKeyTags.typeTuple

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
@@ -3,6 +3,7 @@
 open Xunit
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Test.ProjectGeneration
+open FSharp.Test.ProjectGeneration.Helpers
 
 type Occurence = Definition | InType | Use
 
@@ -198,7 +199,7 @@ let foo x = 5""" })
         }
 
 [<Fact>]
-let ``We find a type that has been aliased`` () =
+let ``We find values of a type that has been aliased`` () =
 
     let project = SyntheticProject.Create("TypeAliasTest",
         { sourceFile "First" [] with
@@ -218,3 +219,24 @@ let ``We find a type that has been aliased`` () =
             "FileSecond.fs", 6, 12, 29
         ])
     }
+
+[<Fact>]
+let ``We don't find type aliases for a type`` () =
+
+    let source = """
+type MyType =
+    member _.foo = "boo"
+    member x.this : mytype = x
+and mytype = MyType
+"""
+
+    let fileName, options, checker = singleFileChecker source
+
+    let symbolUse = getSymbolUse fileName source "MyType" options checker |> Async.RunSynchronously
+
+    checker.FindBackgroundReferencesInFile(fileName, options, symbolUse.Symbol, fastCheck = true)
+    |> Async.RunSynchronously
+    |> expectToFind [
+        fileName, 2, 5, 11
+        fileName, 5, 13, 19
+    ]


### PR DESCRIPTION
I found a regression caused by https://github.com/dotnet/fsharp/pull/14795

It went too far and would match type abbreviations even when referred to directly. This can be a problem especially when you try to rename such type. 

This PR also adds a lighter way to test `FSharpChecker` with only a single file. 