### PR TITLE
Trim away netframework targets in source-build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <GitHubRepositoryName>fsharp</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+    <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
﻿### Summary of the changes

This is part of the source-build work to enable trimming of net4* targets. Parent repos (`installer` and `sdk`) have been updated, so the next step is to update dependencies, like `fsharp`.

Here's how this is consumed: https://github.com/dotnet/arcade/pull/12785

Top-level tracking issue: https://github.com/dotnet/source-build/issues/3014

This essentially just avoids building net4* TFMs when building Linux source build.

Fixes: https://github.com/dotnet/fsharp/issues/13829