### PR TITLE
Use a more accurate range for no matching overload 

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -9780,7 +9780,12 @@ and TcMethodApplication
             CanonicalizePartialInferenceProblem cenv.css denv mItem
                  (unnamedCurriedCallerArgs |> List.collectSquared (fun callerArg -> freeInTypeLeftToRight g false callerArg.CallerArgumentType))
 
-        let result, errors = ResolveOverloadingForCall denv cenv.css mItem methodName callerArgs ad postArgumentTypeCheckingCalledMethGroup true returnTy
+        let m =
+            match returnTy with
+            | MustConvertTo _ when g.langVersion.SupportsFeature LanguageFeature.AdditionalTypeDirectedConversions -> mMethExpr
+            | _ -> mItem
+
+        let result, errors = ResolveOverloadingForCall denv cenv.css m methodName callerArgs ad postArgumentTypeCheckingCalledMethGroup true returnTy
 
         match afterResolution, result with
         | AfterResolution.DoNothing, _ -> ()

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -9780,7 +9780,7 @@ and TcMethodApplication
             CanonicalizePartialInferenceProblem cenv.css denv mItem
                  (unnamedCurriedCallerArgs |> List.collectSquared (fun callerArg -> freeInTypeLeftToRight g false callerArg.CallerArgumentType))
 
-        let result, errors = ResolveOverloadingForCall denv cenv.css mMethExpr methodName callerArgs ad postArgumentTypeCheckingCalledMethGroup true returnTy
+        let result, errors = ResolveOverloadingForCall denv cenv.css mItem methodName callerArgs ad postArgumentTypeCheckingCalledMethGroup true returnTy
 
         match afterResolution, result with
         | AfterResolution.DoNothing, _ -> ()

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -9780,12 +9780,7 @@ and TcMethodApplication
             CanonicalizePartialInferenceProblem cenv.css denv mItem
                  (unnamedCurriedCallerArgs |> List.collectSquared (fun callerArg -> freeInTypeLeftToRight g false callerArg.CallerArgumentType))
 
-        let m =
-            match returnTy with
-            | MustConvertTo _ when g.langVersion.SupportsFeature LanguageFeature.AdditionalTypeDirectedConversions -> mMethExpr
-            | _ -> mItem
-
-        let result, errors = ResolveOverloadingForCall denv cenv.css m methodName callerArgs ad postArgumentTypeCheckingCalledMethGroup true returnTy
+        let result, errors = ResolveOverloadingForCall denv cenv.css mItem methodName callerArgs ad postArgumentTypeCheckingCalledMethGroup true returnTy
 
         match afterResolution, result with
         | AfterResolution.DoNothing, _ -> ()

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -3907,7 +3907,11 @@ let private ResolveExprDotLongIdent (ncenv: NameResolver) m ad nenv ty (id: Iden
     | _ ->
         ForceRaise adhocDotSearchAccessible
 
-let ComputeItemRange wholem (lid: Ident list) rest =
+let ComputeItemRange (item: Item) wholem (lid: Ident list) rest =
+    match item, lid with
+    | Item.MethodGroup _, [ methodIdent ] -> methodIdent.idRange
+    | _ ->
+
     match rest with
     | [] -> wholem
     | _ ->
@@ -3955,7 +3959,7 @@ let ResolveLongIdentAsExprAndComputeRange (sink: TcResultsSink) (ncenv: NameReso
     match ResolveExprLongIdent sink ncenv wholem ad nenv typeNameResInfo lid with 
     | Exception e -> Exception e 
     | Result (tinstEnclosing, item1, rest) ->
-    let itemRange = ComputeItemRange wholem lid rest
+    let itemRange = ComputeItemRange item1 wholem lid rest
 
     let item = FilterMethodGroups ncenv itemRange item1 true
 
@@ -4019,7 +4023,7 @@ let ResolveExprDotLongIdentAndComputeRange (sink: TcResultsSink) (ncenv: NameRes
             | id :: rest ->
                 ResolveExprDotLongIdent ncenv wholem ad nenv ty id rest typeNameResInfo findFlag
             | _ -> error(InternalError("ResolveExprDotLongIdentAndComputeRange", wholem))
-        let itemRange = ComputeItemRange wholem lid rest
+        let itemRange = ComputeItemRange item wholem lid rest
         resInfo, item, rest, itemRange
 
     // "true" resolution

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/AccessibilityAnnotations/Basic/Basic.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/AccessibilityAnnotations/Basic/Basic.fs
@@ -129,7 +129,7 @@ module AccessibilityAnnotations_Basic =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 629, Line 11, Col 24, Line 11, Col 41, "Method 'MemberwiseClone' is not accessible from this code location")
+            (Error 629, Line 11, Col 26, Line 11, Col 41, "Method 'MemberwiseClone' is not accessible from this code location")
         ]
 
     //SOURCE=E_MoreAccessibleBaseClass01.fs                                           # E_MoreAccessibleBaseClass01.fs

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -114,7 +114,7 @@ module CustomAttributes_AttributeUsage =
         |> withDiagnostics [
             (Error 685, Line 14, Col 3, Line 14, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
             (Error 685, Line 26, Col 3, Line 26, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
-            (Error 685, Line 28, Col 1, Line 28, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
+            (Error 685, Line 28, Col 3, Line 28, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
         ]
 
     // SOURCE=E_RequiresExplicitTypeArguments02.fs SCFLAGS="--test:ErrorRanges"	# E_RequiresExplicitTypeArguments02.fs

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -112,8 +112,8 @@ module CustomAttributes_AttributeUsage =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 685, Line 14, Col 1, Line 14, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
-            (Error 685, Line 26, Col 1, Line 26, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
+            (Error 685, Line 14, Col 3, Line 14, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
+            (Error 685, Line 26, Col 3, Line 26, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
             (Error 685, Line 28, Col 1, Line 28, Col 6, "The generic function 'Foo' must be given explicit type argument(s)")
         ]
 
@@ -124,7 +124,7 @@ module CustomAttributes_AttributeUsage =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 685, Line 20, Col 5, Line 20, Col 10, "The generic function 'Foo' must be given explicit type argument(s)")
+            (Error 685, Line 20, Col 7, Line 20, Col 10, "The generic function 'Foo' must be given explicit type argument(s)")
         ]
 
     // SOURCE=E_WithBitwiseOr01.fsx  SCFLAGS="--test:ErrorRanges -a"	# E_WithBitwiseOr01.fsx

--- a/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/neg_invalid_constructor.fs.err.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/neg_invalid_constructor.fs.err.bsl
@@ -1,4 +1,4 @@
-neg_invalid_constructor.fs (3,29)-(3,56) typecheck error A unique overload for method 'ImmutableStack`1' could not be determined based on type information prior to this program point. A type annotation may be needed.
+neg_invalid_constructor.fs (3,29)-(3,43) typecheck error A unique overload for method 'ImmutableStack`1' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a list
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
@@ -748,4 +748,7 @@ let x = X.M1(Y())
         |> withOptions ["--warnon:3388";"--warnon:3389";"--warnon:3395";"--warnaserror+"]
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic ((Error 3395, Line 6, Col 14, Line 6, Col 17, "This expression uses the implicit conversion 'static member Y.op_Implicit: y: Y -> X' to convert type 'Y' to type 'X'."))
+        |> withDiagnostics [
+            (Error 3395, Line 6, Col 14, Line 6, Col 17, "This expression uses the implicit conversion 'static member Y.op_Implicit: y: Y -> X' to convert type 'Y' to type 'X'.")
+            (Error 3395, Line 6, Col 14, Line 6, Col 15, "This expression uses the implicit conversion 'static member Y.op_Implicit: y: Y -> X' to convert type 'Y' to type 'X'.")
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/Interop/RequiredAndInitOnlyProperties.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Interop/RequiredAndInitOnlyProperties.fs
@@ -209,7 +209,7 @@ let main _ =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            Error 810, Line 9, Col 5, Line 9, Col 21, "Cannot call 'set_GetInit' - a setter for init-only property, please use object initialization instead. See https://aka.ms/fsharp-assigning-values-to-properties-at-initialization"
+            Error 810, Line 9, Col 10, Line 9, Col 21, "Cannot call 'set_GetInit' - a setter for init-only property, please use object initialization instead. See https://aka.ms/fsharp-assigning-values-to-properties-at-initialization"
         ]
 
     [<FactForNETCOREAPP>]

--- a/tests/FSharp.Compiler.ComponentTests/Language/ObsoleteAttributeCheckingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ObsoleteAttributeCheckingTests.fs
@@ -68,7 +68,7 @@ c.Update()
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 101, Line 9, Col 1, Line 9, Col 9, "This construct is deprecated. Use B instead")
+            (Error 101, Line 9, Col 3, Line 9, Col 9, "This construct is deprecated. Use B instead")
         ]
 
     [<Fact>]
@@ -88,7 +88,7 @@ c.Update()
         |> shouldFail
         |> withDiagnostics [
             (Error 101, Line 8, Col 9, Line 8, Col 10, "This construct is deprecated. Use B instead");
-            (Error 101, Line 9, Col 1, Line 9, Col 9, "This construct is deprecated. Use B instead")
+            (Error 101, Line 9, Col 3, Line 9, Col 9, "This construct is deprecated. Use B instead")
         ]
 
     [<Fact>]
@@ -109,7 +109,7 @@ c.Update()
         |> shouldFail
         |> withDiagnostics [
             (Error 101, Line 9, Col 9, Line 9, Col 10, "This construct is deprecated. Use B instead");
-            (Error 101, Line 10, Col 1, Line 10, Col 9, "This construct is deprecated. Use B instead")
+            (Error 101, Line 10, Col 3, Line 10, Col 9, "This construct is deprecated. Use B instead")
         ]
 
     [<Fact>]
@@ -148,7 +148,7 @@ c.Update()
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 101, Line 10, Col 1, Line 10, Col 9, "This construct is deprecated. Use B instead")
+            (Error 101, Line 10, Col 3, Line 10, Col 9, "This construct is deprecated. Use B instead")
         ]
 
     [<Fact>]
@@ -593,7 +593,7 @@ b.text("Hello 2") |> ignore
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 101, Line 16, Col 1, Line 16, Col 7, "This construct is deprecated. Use B instead")
+            (Error 101, Line 16, Col 3, Line 16, Col 7, "This construct is deprecated. Use B instead")
         ]
     
     [<Fact>]

--- a/tests/fsharp/core/auto-widen/5.0/test.bsl
+++ b/tests/fsharp/core/auto-widen/5.0/test.bsl
@@ -9,7 +9,7 @@ test.fsx(14,20,14,41): typecheck error FS0001: This expression was expected to h
 but here has type
     'int'    
 
-test.fsx(17,20,17,44): typecheck error FS0001: This expression was expected to have type
+test.fsx(17,20,17,38): typecheck error FS0001: This expression was expected to have type
     'obj'    
 but here has type
     'int'    
@@ -149,7 +149,7 @@ test.fsx(69,26,69,29): typecheck error FS0001: This expression was expected to h
 but here has type
     'int'    
 
-test.fsx(93,13,93,20): typecheck error FS0041: No overloads match for method 'M1'.
+test.fsx(93,13,93,17): typecheck error FS0041: No overloads match for method 'M1'.
 
 Known type of argument: int
 
@@ -157,7 +157,7 @@ Available overloads:
  - static member C.M1: x: int64 -> unit // Argument 'x' doesn't match
  - static member C.M1: x: string -> 'a0 // Argument 'x' doesn't match
 
-test.fsx(99,13,99,22): typecheck error FS0041: No overloads match for method 'M1'.
+test.fsx(99,13,99,17): typecheck error FS0041: No overloads match for method 'M1'.
 
 Known type of argument: x: int
 
@@ -170,7 +170,7 @@ test.fsx(116,20,116,21): typecheck error FS0001: This expression was expected to
 but here has type
     'int'    
 
-test.fsx(121,14,121,21): typecheck error FS0041: No overloads match for method 'M1'.
+test.fsx(121,14,121,18): typecheck error FS0041: No overloads match for method 'M1'.
 
 Known type of argument: int
 
@@ -188,7 +188,7 @@ test.fsx(122,22,122,23): typecheck error FS0001: This expression was expected to
 but here has type
     'int'    
 
-test.fsx(127,14,127,21): typecheck error FS0041: No overloads match for method 'M1'.
+test.fsx(127,14,127,18): typecheck error FS0041: No overloads match for method 'M1'.
 
 Known type of argument: int
 

--- a/tests/fsharp/typecheck/constructors/neg_invalid_constructor.bsl
+++ b/tests/fsharp/typecheck/constructors/neg_invalid_constructor.bsl
@@ -1,4 +1,4 @@
-typecheck/constructors/neg_invalid_constructor.fs (3,29)-(3,56) typecheck error A unique overload for method 'ImmutableStack`1' could not be determined based on type information prior to this program point. A type annotation may be needed.
+typecheck/constructors/neg_invalid_constructor.fs (3,29)-(3,43) typecheck error A unique overload for method 'ImmutableStack`1' could not be determined based on type information prior to this program point. A type annotation may be needed.
 
 Known type of argument: 'a list
 


### PR DESCRIPTION
Supersedes https://github.com/dotnet/fsharp/pull/14844 

Attempts to Fix https://github.com/dotnet/fsharp/issues/14284 as part of the [Amplifying F#](https://amplifying-fsharp.github.io/sessions/2023/03/03/)  initiative. [Live session](https://www.youtube.com/watch?v=rL5RrJUiBvE&t=926s)