### PR TITLE
First take on the F# telemetry

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -28,6 +28,7 @@
     </EmbeddedText>
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\src\LegacyMSBuildResolver\LegacyMSBuildReferenceResolver.fsi" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\src\LegacyMSBuildResolver\LegacyMSBuildReferenceResolver.fs" />
+    <Compile Include="Telemetry\TelemetryReporter.fs" />
     <Compile Include="Common\AssemblyInfo.fs" />
     <Compile Include="Common\Logger.fsi" />
     <Compile Include="Common\Logger.fs" />

--- a/vsintegration/src/FSharp.Editor/Hints/Hints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/Hints.fs
@@ -16,3 +16,7 @@ module Hints =
         Range: range
         Parts: TaggedText list
     }
+
+    let serialize = function
+        | TypeHint -> "type"
+        | ParameterNameHint -> "parameterName"

--- a/vsintegration/src/FSharp.Editor/Hints/Hints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/Hints.fs
@@ -17,6 +17,7 @@ module Hints =
         Parts: TaggedText list
     }
 
-    let serialize = function
+    let serialize kind =
+        match kind with
         | TypeHint -> "type"
         | ParameterNameHint -> "parameterName"

--- a/vsintegration/src/FSharp.Editor/Hints/RoslynAdapter.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/RoslynAdapter.fs
@@ -6,6 +6,7 @@ open System.Collections.Immutable
 open System.ComponentModel.Composition
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.InlineHints
 open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.FSharp.Editor.Telemetry
 
 // So the Roslyn interface is called IFSharpInlineHintsService
 // but our implementation is called just HintsService.
@@ -27,6 +28,9 @@ type internal RoslynAdapter
                 if hintKinds.IsEmpty then
                     return ImmutableArray.Empty
                 else
+                    let hintKindsSerialized = hintKinds |> Set.map Hints.serialize |> String.concat ","
+                    TelemetryReporter.reportEvent "hints" [("hints.kinds", hintKindsSerialized)]
+
                     let! sourceText = document.GetTextAsync cancellationToken |> Async.AwaitTask
                     let! nativeHints =
                         HintService.getHintsForDocument 

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -94,7 +94,6 @@ type internal FSharpWorkspaceServiceFactory
                     None
 
             let getSource filename =
-                TelemetryReporter.reportEvent "livebuffers" []
                 workspace.CurrentSolution.TryGetDocumentFromPath(filename)
                 |> Option.map(fun document ->
                     let text = document.GetTextAsync().Result
@@ -106,6 +105,8 @@ type internal FSharpWorkspaceServiceFactory
                 | _ ->
                     let checker =
                         lazy
+                            TelemetryReporter.reportEvent "languageservicestarted" []
+
                             let editorOptions =
                                 let editorOptions = workspace.Services.GetService<EditorOptions>()
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -27,6 +27,7 @@ open Microsoft.CodeAnalysis.ExternalAccess.FSharp
 open Microsoft.CodeAnalysis.Host
 open Microsoft.CodeAnalysis.Host.Mef
 open Microsoft.VisualStudio.FSharp.Editor.WorkspaceExtensions
+open Microsoft.VisualStudio.FSharp.Editor.Telemetry
 open System.Threading.Tasks
 
 #nowarn "9" // NativePtr.toNativeInt
@@ -93,6 +94,7 @@ type internal FSharpWorkspaceServiceFactory
                     None
 
             let getSource filename =
+                TelemetryReporter.reportEvent "livebuffers" []
                 workspace.CurrentSolution.TryGetDocumentFromPath(filename)
                 |> Option.map(fun document ->
                     let text = document.GetTextAsync().Result

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -6,6 +6,7 @@ open System.Runtime.CompilerServices
 open System.Threading
 open System.Threading.Tasks
 open Microsoft.CodeAnalysis
+open Microsoft.VisualStudio.FSharp.Editor.Telemetry
 open FSharp.Compiler
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
@@ -226,6 +227,7 @@ type Project with
         let documents = this.Documents |> Seq.filter (fun document -> not (canSkipDocuments.Contains document.FilePath))
 
         if this.IsFastFindReferencesEnabled then
+            TelemetryReporter.reportEvent "fastfindreferences" []
             do! documents
                 |> Seq.map (fun doc ->
                     Task.Run(fun () ->

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -6,7 +6,6 @@ open System.Runtime.CompilerServices
 open System.Threading
 open System.Threading.Tasks
 open Microsoft.CodeAnalysis
-open Microsoft.VisualStudio.FSharp.Editor.Telemetry
 open FSharp.Compiler
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
@@ -227,7 +226,6 @@ type Project with
         let documents = this.Documents |> Seq.filter (fun document -> not (canSkipDocuments.Contains document.FilePath))
 
         if this.IsFastFindReferencesEnabled then
-            TelemetryReporter.reportEvent "fastfindreferences" []
             do! documents
                 |> Seq.map (fun doc ->
                     Task.Run(fun () ->

--- a/vsintegration/src/FSharp.Editor/Telemetry/TelemetryReporter.fs
+++ b/vsintegration/src/FSharp.Editor/Telemetry/TelemetryReporter.fs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor.Telemetry
+
+open Microsoft.VisualStudio.Telemetry
+
+module TelemetryReporter =
+
+    let eventPrefix = "dotnet/fsharp/"
+    let propPrefix = "dotnet.fsharp."
+
+    let getFullEventName name = eventPrefix + name
+    let getFullPropName name = propPrefix + name
+
+    let createEvent name (props: (string * obj) list) = 
+        let event = TelemetryEvent (getFullEventName name)
+
+        props
+        |> List.map (fun (k, v) -> getFullPropName k, v)
+        |> List.iter event.Properties.Add
+
+        event
+
+    let reportEvent name props =
+        let session = TelemetryService.DefaultSession
+        let event = createEvent name props
+        session.PostEvent event
+


### PR DESCRIPTION
This is the first shot on the F#-specific telemetry in the VS. 

One of the things we are interested in is the usage of our preview/experimental features: #14872
So here we achieve that by sending respective events. Here is how things look like in the VS monitor:
![image](https://user-images.githubusercontent.com/5451366/224821483-20d2d9bc-ee6b-41c6-bc89-c4c37c073d6a.png)

This is inspired by Razor's [TelemetryReporter](https://github.com/dotnet/razor/blob/main/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Telemetry/TelemetryReporter.cs).

As of now, there is no proper thought behind the structure of events or any event design for that matter - we are just getting our hands dirty here.


