### PR TITLE
Add `GraphNode.FromResult`

### DIFF
--- a/src/Compiler/Facilities/BuildGraph.fsi
+++ b/src/Compiler/Facilities/BuildGraph.fsi
@@ -102,6 +102,9 @@ type internal GraphNode<'T> =
     /// By default, 'retryCompute' is 'true'.
     new: computation: NodeCode<'T> -> GraphNode<'T>
 
+    /// Creates a GraphNode with given result already cached.
+    static member FromResult: 'T -> GraphNode<'T>
+
     /// Return NodeCode which, when executed, will get the value of the computation if already computed, or
     /// await an existing in-progress computation for the node if one exists, or else will synchronously
     /// start the computation on the current thread.

--- a/src/Compiler/Service/IncrementalBuild.fs
+++ b/src/Compiler/Service/IncrementalBuild.fs
@@ -275,7 +275,7 @@ type TcInfoNode =
     static member FromState(state: TcInfoState) =
         let tcInfo = state.TcInfo
         let tcInfoExtras = state.TcInfoExtras
-        TcInfoNode(GraphNode(node.Return tcInfo), GraphNode(node.Return (tcInfo, defaultArg tcInfoExtras emptyTcInfoExtras)))
+        TcInfoNode(GraphNode.FromResult tcInfo, GraphNode.FromResult (tcInfo, defaultArg tcInfoExtras emptyTcInfoExtras))
 
 /// Bound model of an underlying syntax and typed tree.
 [<Sealed>]
@@ -1098,7 +1098,7 @@ module IncrementalBuilderStateHelpers =
             | ValueSome(boundModel) when initialState.enablePartialTypeChecking && boundModel.BackingSignature.IsSome ->
                 let newBoundModel = boundModel.ClearTcInfoExtras()
                 { state with
-                    boundModels = state.boundModels.SetItem(slot, GraphNode(node.Return newBoundModel))
+                    boundModels = state.boundModels.SetItem(slot, GraphNode.FromResult newBoundModel)
                     stampedFileNames = state.stampedFileNames.SetItem(slot, stamp)
                 }
             | _ ->
@@ -1165,7 +1165,7 @@ type IncrementalBuilderState with
         let referencedAssemblies = initialState.referencedAssemblies
 
         let cache = TimeStampCache(defaultTimeStamp)
-        let initialBoundModel = GraphNode(node.Return initialBoundModel)
+        let initialBoundModel = GraphNode.FromResult initialBoundModel
         let boundModels = ImmutableArrayBuilder.create fileNames.Length
 
         for slot = 0 to fileNames.Length - 1 do

--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -410,7 +410,7 @@ type BackgroundCompiler
     let createBuilderNode (options, userOpName, ct: CancellationToken) =
         lock gate (fun () ->
             if ct.IsCancellationRequested then
-                GraphNode(node.Return(None, [||]))
+                GraphNode.FromResult (None, [||])
             else
                 let getBuilderNode = GraphNode(CreateOneIncrementalBuilder(options, userOpName))
                 incrementalBuildersCache.Set(AnyCallerThread, options, getBuilderNode)

--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -410,7 +410,7 @@ type BackgroundCompiler
     let createBuilderNode (options, userOpName, ct: CancellationToken) =
         lock gate (fun () ->
             if ct.IsCancellationRequested then
-                GraphNode.FromResult (None, [||])
+                GraphNode.FromResult(None, [||])
             else
                 let getBuilderNode = GraphNode(CreateOneIncrementalBuilder(options, userOpName))
                 incrementalBuildersCache.Set(AnyCallerThread, options, getBuilderNode)

--- a/tests/FSharp.Compiler.UnitTests/BuildGraphTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/BuildGraphTests.fs
@@ -272,3 +272,10 @@ module BuildGraphTests =
         tasks
         |> Seq.iter (fun x -> 
             try x.Wait(1000) |> ignore with | :? TimeoutException -> reraise() | _ -> ())
+
+    [<Fact>]
+    let ``GraphNode created from an already computed result will return it in tryPeekValue`` () =
+        let graphNode = GraphNode.FromResult 1
+
+        Assert.shouldBeTrue graphNode.HasValue
+        Assert.shouldBe (ValueSome 1) (graphNode.TryPeekValue())


### PR DESCRIPTION
This should avoid some unneeded work and allocations when we create a `GraphNode` with an already computed result.