### PR TITLE
Preview features telemetry

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -105,8 +105,6 @@ type internal FSharpWorkspaceServiceFactory
                 | _ ->
                     let checker =
                         lazy
-                            TelemetryReporter.reportEvent "languageservicestarted" []
-
                             let editorOptions =
                                 let editorOptions = workspace.Services.GetService<EditorOptions>()
 
@@ -128,6 +126,18 @@ type internal FSharpWorkspaceServiceFactory
                             let useSyntaxTreeCache =
                                 getOption (fun options -> options.LanguageServicePerformance.UseSyntaxTreeCache) LanguageServicePerformanceOptions.Default.UseSyntaxTreeCache
 
+                            let enableInMemoryCrossProjectReferences =
+                                getOption (fun options -> options.LanguageServicePerformance.EnableInMemoryCrossProjectReferences) false
+
+                            let enableFastFindReferences =
+                                getOption (fun options -> options.LanguageServicePerformance.EnableFastFindReferences) false
+
+                            let isInlineParameterNameHintsEnabled =
+                                getOption (fun options -> options.Advanced.IsInlineParameterNameHintsEnabled) false
+
+                            let isInlineTypeHintsEnabled =
+                                getOption (fun options -> options.Advanced.IsInlineTypeHintsEnabled) false
+
                             let checker =
                                 FSharpChecker.Create(
                                     projectCacheSize = 5000, // We do not care how big the cache is. VS will actually tell FCS to clear caches, so this is fine.
@@ -141,6 +151,16 @@ type internal FSharpWorkspaceServiceFactory
                                     captureIdentifiersWhenParsing = true,
                                     documentSource = (if enableLiveBuffers then DocumentSource.Custom getSource else DocumentSource.FileSystem),
                                     useSyntaxTreeCache = useSyntaxTreeCache)
+
+                            TelemetryReporter.reportEvent "languageservicestarted" [
+                                nameof enableLiveBuffers, enableLiveBuffers
+                                nameof useSyntaxTreeCache, useSyntaxTreeCache
+                                nameof enableParallelReferenceResolution, enableParallelReferenceResolution
+                                nameof enableInMemoryCrossProjectReferences, enableInMemoryCrossProjectReferences
+                                nameof enableFastFindReferences, enableFastFindReferences
+                                nameof isInlineParameterNameHintsEnabled, isInlineParameterNameHintsEnabled
+                                nameof isInlineTypeHintsEnabled, isInlineTypeHintsEnabled
+                            ]
 
                             if enableLiveBuffers then
                                 workspace.WorkspaceChanged.Add(fun args ->

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -14,7 +14,8 @@ open Microsoft.CodeAnalysis.Text
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text
-open Microsoft.VisualStudio.FSharp.Editor.Symbols 
+open Microsoft.VisualStudio.FSharp.Editor.Symbols
+open Microsoft.VisualStudio.FSharp.Editor.Telemetry
 
 module internal SymbolHelpers =
     /// Used for local code fixes in a document, e.g. to rename local parameters
@@ -37,10 +38,19 @@ module internal SymbolHelpers =
         }
 
     let getSymbolUsesInProjects (symbol: FSharpSymbol, projects: Project list, onFound: Document -> TextSpan -> range -> Async<unit>, ct: CancellationToken) =
-        projects
-        |> Seq.map (fun project ->
-            Task.Run(fun () -> project.FindFSharpReferencesAsync(symbol, onFound, "getSymbolUsesInProjects", ct)))
-        |> Task.WhenAll
+        match projects with
+        | [] -> Task.CompletedTask
+        | firstProject::_ ->
+            let isFastFindReferencesEnabled = firstProject.IsFastFindReferencesEnabled
+            let props = [ nameof isFastFindReferencesEnabled, isFastFindReferencesEnabled :> obj ]
+            backgroundTask {
+                TelemetryReporter.reportEvent "getSymbolUsesInProjectsStarted" props
+                do! projects
+                    |> Seq.map (fun project ->
+                        Task.Run(fun () -> project.FindFSharpReferencesAsync(symbol, onFound, "getSymbolUsesInProjects", ct)))
+                    |> Task.WhenAll
+                TelemetryReporter.reportEvent "getSymbolUsesInProjectsFinished" props
+            }
 
     let getSymbolUsesInSolution (symbol: FSharpSymbol, declLoc: SymbolDeclarationLocation, checkFileResults: FSharpCheckFileResults, solution: Solution, ct: CancellationToken) =
         async {


### PR DESCRIPTION
closes #14872 

Adds some more telemetry. 

- On startup we add info about which preview features are enabled
- We send an event when `getSymbolUsesInProjects` is started and finished (unless cancelled), which could be either a _rename_ or _find all references_, and whether _Fast find references & rename_ is on.