### PR TITLE
Fix range for ModuleAbbrev

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -643,14 +643,17 @@ moduleSpfn:
 
   | opt_attributes opt_access moduleIntro colonOrEquals namedModuleAbbrevBlock 
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let _mModule, isRec, path, vis, attribs2 = $3
+        let mModule, isRec, path, vis, attribs2 = $3
         if isRec then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsInvalidUseOfRec())
         if not (isSingleton path) then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsModuleAbbreviationMustBeSimpleName())
         if not (isNil $1) then raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsIgnoreAttributesOnModuleAbbreviation())
         if not (isNil attribs2) then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsIgnoreAttributesOnModuleAbbreviation())
         match vis with
         | Some vis -> raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsIgnoreVisibilityOnModuleAbbreviationAlwaysPrivate(vis.ToString()))
-        | _ -> SynModuleSigDecl.ModuleAbbrev(List.head path, $5, rhs2 parseState 1 5) } 
+        | _ ->
+            let lid: SynLongIdent = $5
+            let m = unionRanges mModule lid.Range
+            SynModuleSigDecl.ModuleAbbrev(List.head path, lid.LongIdent, m) } 
 
   | opt_attributes opt_access moduleIntro colonOrEquals moduleSpecBlock
       { let mModule, isRec, path, vis, attribs2 = $3
@@ -1327,10 +1330,10 @@ openDecl:
 /* We don't use it in signature files */
 namedModuleAbbrevBlock:
   | OBLOCKBEGIN path oblockend 
-     { $2.LongIdent }
+     { $2 }
 
   | path 
-     { $1.LongIdent  }
+     { $1  }
        
 
 /* The right-hand-side of a module definition */ 

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/ModuleAbbreviation.fsi
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/ModuleAbbreviation.fsi
@@ -1,0 +1,12 @@
+module Foo
+
+open System
+open System.Text
+
+module A = B
+
+module Bar =
+    type a =
+        | Ex
+        | Why
+        | Zed

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/ModuleAbbreviation.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/ModuleAbbreviation.fsi.bsl
@@ -1,0 +1,52 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/ModuleOrNamespaceSig/ModuleAbbreviation.fsi",
+      QualifiedNameOfFile Foo, [], [],
+      [SynModuleOrNamespaceSig
+         ([Foo], false, NamedModule,
+          [Open
+             (ModuleOrNamespace
+                (SynLongIdent ([System], [], [None]), (3,5--3,11)), (3,0--3,11));
+           Open
+             (ModuleOrNamespace
+                (SynLongIdent ([System; Text], [(4,11--4,12)], [None; None]),
+                 (4,5--4,16)), (4,0--4,16)); ModuleAbbrev (A, [B], (6,0--6,12));
+           NestedModule
+             (SynComponentInfo
+                ([], None, [], [Bar],
+                 PreXmlDoc ((8,0), FSharp.Compiler.Xml.XmlDocCollector), false,
+                 None, (8,0--8,10)), false,
+              [Types
+                 ([SynTypeDefnSig
+                     (SynComponentInfo
+                        ([], None, [], [a],
+                         PreXmlDoc ((9,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         false, None, (9,9--9,10)),
+                      Simple
+                        (Union
+                           (None,
+                            [SynUnionCase
+                               ([], SynIdent (Ex, None), Fields [],
+                                PreXmlDoc ((10,8), FSharp.Compiler.Xml.XmlDocCollector),
+                                None, (10,10--10,12),
+                                { BarRange = Some (10,8--10,9) });
+                             SynUnionCase
+                               ([], SynIdent (Why, None), Fields [],
+                                PreXmlDoc ((11,8), FSharp.Compiler.Xml.XmlDocCollector),
+                                None, (11,10--11,13),
+                                { BarRange = Some (11,8--11,9) });
+                             SynUnionCase
+                               ([], SynIdent (Zed, None), Fields [],
+                                PreXmlDoc ((12,8), FSharp.Compiler.Xml.XmlDocCollector),
+                                None, (12,10--12,13),
+                                { BarRange = Some (12,8--12,9) })],
+                            (10,8--12,13)), (10,8--12,13)), [], (9,9--12,13),
+                      { LeadingKeyword = Type (9,4--9,8)
+                        EqualsRange = Some (9,11--9,12)
+                        WithKeyword = None })], (9,4--12,13))], (8,0--12,13),
+              { ModuleKeyword = Some (8,0--8,6)
+                EqualsRange = Some (8,11--8,12) })],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--12,13), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))


### PR DESCRIPTION
Fix range for ModuleAbbrev by unionRanging with the SynLongIdent.Range of the namedModuleAbbrevBlock

Joint work with @nojaf 
Fixes #14912 