### PR TITLE
Revert "Unskip some tests"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -323,9 +323,6 @@ stages:
 
         # Windows With Compressed Metadata
         - job: WindowsCompressedMetadata
-          variables:
-          - name: XUNIT_LOGS
-            value: $(Build.SourcesDirectory)\artifacts\TestResults\$(_configuration)
           pool:
             # The PR build definition sets this variable:
             #   WindowsMachineQueueName=Windows.vs2022.amd64.open

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/BuildProjectTests.cs
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/BuildProjectTests.cs
@@ -11,7 +11,7 @@ namespace FSharp.Editor.IntegrationTests;
 
 public class BuildProjectTests : AbstractIntegrationTest
 {
-    [IdeFact]
+    [IdeFact(Skip = "Flaky")]
     public async Task SuccessfulBuild()
     {
         var template = WellKnownProjectTemplates.FSharpNetCoreClassLibrary;
@@ -31,7 +31,7 @@ let answer = 42
         Assert.Contains(expectedBuildSummary, actualBuildSummary);
     }
 
-    [IdeFact]
+    [IdeFact(Skip = "Flaky")]
     public async Task FailedBuild()
     {
         var template = WellKnownProjectTemplates.FSharpNetCoreClassLibrary;


### PR DESCRIPTION
Reverts dotnet/fsharp#14917

Still flaky - https://dev.azure.com/dnceng-public/public/_build/results?buildId=210952&view=logs&jobId=882ba401-d5d6-57d5-a958-980a439dbeb8&j=882ba401-d5d6-57d5-a958-980a439dbeb8&t=acba9bf3-f83d-5137-6b7f-407d581179ea

We need to make them
- Optional (do not fail the merge, be a warning).
- Do not run them in signed CI (not sure if it's already the case)