### PR TITLE
VisualStudio :: Task List for F#

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -18,7 +18,7 @@
     <InternalsVisibleTo Include="VisualFSharp.Salsa" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup>    
     <EmbeddedResource Include="FSharp.Editor.resx">
       <GenerateSource>true</GenerateSource>
       <GeneratedModuleName>Microsoft.VisualStudio.FSharp.Editor.SR</GeneratedModuleName>
@@ -73,6 +73,7 @@
     <Compile Include="Diagnostics\UnusedDeclarationsAnalyzer.fs" />
     <Compile Include="Diagnostics\UnusedOpensDiagnosticAnalyzer.fs" />
     <Compile Include="DocComments\XMLDocumentation.fs" />
+	<Compile Include="TaskList\TaskListService.fs" />
     <Compile Include="Completion\CompletionUtils.fs" />
     <Compile Include="Completion\CompletionProvider.fs" />
     <Compile Include="Completion\PathCompletionUtilities.fs" />

--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -39,6 +39,7 @@ type internal LexerSymbolKind =
     | String = 6
     | Other = 7
     | Keyword = 8
+    | Comment = 9
 
 type internal LexerSymbol =
     { Kind: LexerSymbolKind
@@ -358,6 +359,8 @@ module internal Tokenizer =
         member token.IsOperator = (token.ColorClass = FSharpTokenColorKind.Operator)
         member token.IsPunctuation = (token.ColorClass = FSharpTokenColorKind.Punctuation)
         member token.IsString = (token.ColorClass = FSharpTokenColorKind.String)
+        member token.IsComment = (token.ColorClass = FSharpTokenColorKind.Comment)
+        member token.IsKeyWord = (token.ColorClass = FSharpTokenColorKind.Keyword)
     
     /// This is the information we save for each token in a line for each active document.
     /// It is a memory-critical data structure - do not make larger. This used to be ~100 bytes class, is now 8-byte struct
@@ -389,7 +392,8 @@ module internal Tokenizer =
                 elif token.IsIdentifier then LexerSymbolKind.Ident 
                 elif token.IsPunctuation then LexerSymbolKind.Punctuation
                 elif token.IsString then LexerSymbolKind.String
-                elif token.ColorClass = FSharpTokenColorKind.Keyword then LexerSymbolKind.Keyword
+                elif token.IsKeyWord then LexerSymbolKind.Keyword
+                elif token.IsComment then LexerSymbolKind.Comment
                 else LexerSymbolKind.Other
             Debug.Assert(uint32 token.Tag < 0xFFFFu)
             Debug.Assert(uint32 kind < 0xFFu)

--- a/vsintegration/src/FSharp.Editor/TaskList/TaskListService.fs
+++ b/vsintegration/src/FSharp.Editor/TaskList/TaskListService.fs
@@ -1,0 +1,44 @@
+﻿
+// Microsoft.CodeAnalysis.ExternalAccess.FSharp.TaskList.FSharpTaskListService
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.ComponentModel.Composition
+open Microsoft.CodeAnalysis.Text
+open FSharp.Compiler.CodeAnalysis
+open System.Runtime.InteropServices
+open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
+open Microsoft.CodeAnalysis.ExternalAccess.FSharp.TaskList
+open FSharp.Compiler
+open System.Collections.Immutable
+
+[<Export(typeof<IFSharpTaskListService>)>]
+type internal FSharpTaskListService 
+    [<ImportingConstructor>]
+    (
+    ) =
+
+    interface IFSharpTaskListService with
+        member _.GetTaskListItemsAsync(doc,desc,cancellationToken) = 
+            asyncMaybe{
+                let foundTaskItems = ImmutableArray.CreateBuilder()
+                let! sourceText = doc.GetTextAsync(cancellationToken)
+                let! _, _, parsingOptions, _ = doc.GetFSharpCompilationOptionsAsync(nameof(FSharpTaskListService)) |> liftAsync
+                let defines = CompilerEnvironment.GetConditionalDefinesForEditing parsingOptions
+                for line in sourceText.Lines do
+                    let lineFirstPos = line.Start
+                    let tokens = Tokenizer.tokenizeLine(doc.Id, sourceText, line.Span.Start, doc.FilePath, defines)
+                    let commentTokens = tokens |> Array.filter(fun t -> t.Kind = LexerSymbolKind.Comment)
+                    for ct in commentTokens do
+                        let text = line.ToString()
+                        for d in desc do 
+                            let idx = text.IndexOf(value = text,startIndex = ct.LeftColumn, count = (ct.RightColumn - ct.LeftColumn), comparisonType = StringComparison.OrdinalIgnoreCase)                    
+                            if idx > -1 && not(Char.IsLetter(text[idx+d.Text.Length])) then 
+                                let taskLength = ct.RightColumn-idx                                
+                                foundTaskItems.Add(new FSharpTaskListItem(d, text.Substring(idx,taskLength), doc, new TextSpan(line.Span.Start+idx, taskLength)))
+                       
+                foundTaskItems.ToImmutable()
+            } 
+            |> Async.map Option.toNullable
+            |> RoslynHelpers.StartAsyncAsTask cancellationToken

--- a/vsintegration/src/FSharp.Editor/TaskList/TaskListService.fs
+++ b/vsintegration/src/FSharp.Editor/TaskList/TaskListService.fs
@@ -56,7 +56,7 @@ type internal FSharpTaskListService
                                 let taskLength = 1+ct.Right-idx                
                                 // A descriptor followed by another letter is not a todocomment, like todoabc. But TODO, TODO2 or TODO: should be.
                                 if (idx+taskLength) >= lineTxt.Length || not (Char.IsLetter(lineTxt.[idx+taskLength])) then
-                                    foundTaskItems.Add(new FSharpTaskListItem(d, lineTxt.Substring(idx,taskLength), doc, new TextSpan(line.Span.Start+idx, taskLength)))
+                                    foundTaskItems.Add(new FSharpTaskListItem(d, lineTxt.Substring(idx,taskLength).TrimEnd([|'*';')'|]), doc, new TextSpan(line.Span.Start+idx, taskLength)))
                                 else Debug.WriteLine($"Failed terminating criteria: idx= {idx}, len = {taskLength}, %A{ct}")
                        
                 return foundTaskItems.ToImmutable()


### PR DESCRIPTION
Task List is an old VS feature:
![image](https://user-images.githubusercontent.com/46543583/226577252-2d01dd2f-c697-4d80-a82a-5cc0c229e9d7.png)

VS has predefined terms to be spotted within comments and converted into tasks:
![image](https://user-images.githubusercontent.com/46543583/226577484-20522396-c430-468e-abd5-92bcfe3f2b3e.png)


Corner case: If the term is followed by another letter (e.g. user configured HACK and text contains "hackathon"), it is not considered to be a task. C# has the same logic.

This is the results in various situations:
regular `//` , inline `(**)`, multiline `(*...*)`, doc `///` comments.
This feature respects current `DEFINE` criteria and unreachable code is skipped.


![image](https://user-images.githubusercontent.com/46543583/226582332-7dd23ce8-f22f-4962-bc06-984b01949b97.png)
