### PR TITLE
Autogenerate namespace+module for Custom signature files in ProjectGe…

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/CommonWorkflows.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/CommonWorkflows.fs
@@ -7,7 +7,6 @@ open System.Diagnostics
 open Xunit
 
 open FSharp.Test.ProjectGeneration
-open FSharp.Test.ProjectGeneration.Internal
 open FSharp.Compiler.Text
 open FSharp.Compiler.CodeAnalysis
 

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
@@ -201,12 +201,11 @@ let foo x = 5""" })
 [<Fact>]
 let ``We find values of a type that has been aliased`` () =
 
-    let project = SyntheticProject.Create("TypeAliasTest",
+    let project = SyntheticProject.Create(
         { sourceFile "First" [] with
             ExtraSource = "type MyInt = int32\n" +
                           "let myNum = 7"
-            SignatureFile = Custom ("module TypeAliasTest.ModuleFirst\n" +
-                                    "type MyInt = int32\n" +
+            SignatureFile = Custom ("type MyInt = int32\n" +
                                     "val myNum: MyInt") },
         { sourceFile "Second" [] with
             ExtraSource = "let goo x = ModuleFirst.myNum + x"})
@@ -252,7 +251,7 @@ let x = MyType()
 """
     SyntheticProject.Create(
         { sourceFile "Program" [] with
-            SignatureFile = Custom "module Moo"
+            SignatureFile = Custom ""
             Source = source } ).Workflow {
 
         placeCursor "Program" "MyType"
@@ -281,7 +280,7 @@ let x = MyType()
 """
     let project = SyntheticProject.Create(
         { sourceFile "Program" [] with
-            SignatureFile = Custom "module Moo"
+            SignatureFile = Custom ""
             Source = source } )
 
     ProjectWorkflowBuilder(project, useGetSource = true, useChangeNotifications = true) {

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SymbolUse.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SymbolUse.fs
@@ -33,14 +33,12 @@ module IsPrivateToFile =
 
     [<Fact>]
     let ``Function definition not in signature file`` () =
-        let projectName = "IsPrivateToFileTest1"
         let signature = $"""
-module {projectName}.ModuleFirst
 type TFirstV_1<'a> = | TFirst of 'a
 val f: x: 'a -> TFirstV_1<'a>
 // no f2 here
 """
-        let project = SyntheticProject.Create(projectName,
+        let project = SyntheticProject.Create(
             { sourceFile "First" [] with SignatureFile = Custom signature },
             sourceFile "Second" ["First"])
 


### PR DESCRIPTION
…neration


This makes it easier to use custom signature files in tests. Before you had to explicitly name the project (because otherwise name is auto-generated) and manually add the namespace. With this you can just write the content.