### PR TITLE
Write compilation references and compilation options to PDBs

### DIFF
--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -3006,6 +3006,9 @@ type ILModuleDef =
         NativeResources: ILNativeResource list
         CustomAttrsStored: ILAttributesStored
         MetadataIndex: int32
+        TimeDateStamp: int32
+        ImageSize: int32
+        Mvid: Guid
     }
 
     member x.ManifestOfAssembly =
@@ -4194,6 +4197,9 @@ let mkILSimpleModule
     flags
     exportedTypes
     metadataVersion
+    timeDateStamp
+    imageSize
+    mvid
     =
     let manifest =
         {
@@ -4239,6 +4245,9 @@ let mkILSimpleModule
         MetadataVersion = metadataVersion
         Resources = mkILResources []
         MetadataIndex = NoMetadataIdx
+        TimeDateStamp = timeDateStamp
+        ImageSize = imageSize
+        Mvid = mvid
     }
 
 //-----------------------------------------------------------------------

--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -3008,7 +3008,7 @@ type ILModuleDef =
         MetadataIndex: int32
         TimeDateStamp: int32
         ImageSize: int32
-        Mvid: Guid
+        Mvid: System.Guid
     }
 
     member x.ManifestOfAssembly =

--- a/src/Compiler/AbstractIL/il.fsi
+++ b/src/Compiler/AbstractIL/il.fsi
@@ -1751,6 +1751,11 @@ type ILModuleDef =
         NativeResources: ILNativeResource list
         CustomAttrsStored: ILAttributesStored
         MetadataIndex: int32
+        /// The low 32 bits of the number of seconds since 00:00 January 1, 1970, that indicates when the file was created.
+        TimeDateStamp: int32
+        /// The size of the module in memory (from the PE32 optional header)
+        ImageSize: int32
+        Mvid: System.Guid
     }
 
     member ManifestOfAssembly: ILAssemblyManifest
@@ -2216,6 +2221,9 @@ val mkILSimpleModule:
     int ->
     ILExportedTypesAndForwarders ->
     string ->
+    timeDateStamp: int ->
+    imageSize: int ->
+    mvid: System.Guid ->
         ILModuleDef
 
 /// Generate references to existing type definitions, method definitions

--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -263,10 +263,6 @@ let seekReadBytes (mdv: BinaryView) addr len = mdv.ReadBytes(addr, len)
 let seekReadInt32 (mdv: BinaryView) addr = mdv.ReadInt32 addr
 let seekReadUInt16 (mdv: BinaryView) addr = mdv.ReadUInt16 addr
 
-let seekReadUtf8String (mdv: BinaryView) addr len = 
-    let b = mdv.ReadBytes(addr, len)
-    System.Text.Encoding.UTF8.GetString(b)
-
 let seekReadByteAsInt32 mdv addr = int32 (seekReadByte mdv addr)
 
 let seekReadInt64 mdv addr =

--- a/src/Compiler/AbstractIL/ilwrite.fs
+++ b/src/Compiler/AbstractIL/ilwrite.fs
@@ -3799,7 +3799,9 @@ type options =
      dumpDebugInfo: bool
      referenceAssemblyOnly: bool
      referenceAssemblyAttribOpt: ILAttribute option
-     pathMap: PathMap }
+     pathMap: PathMap
+     compilationReferences: PdbMetadataReferenceInfo list
+     compilationOptions: (string * string) list }
 
 let writeBinaryAux (stream: Stream, options: options, modul, normalizeAssemblyRefs) =
 
@@ -3962,7 +3964,7 @@ let writeBinaryAux (stream: Stream, options: options, modul, normalizeAssemblyRe
             match options.pdbfile, options.portablePDB with
             | Some _, true ->
                 let pdbInfo =
-                    generatePortablePdb options.embedAllSource options.embedSourceList options.sourceLink options.checksumAlgorithm pdbData options.pathMap
+                    generatePortablePdb options.embedAllSource options.embedSourceList options.sourceLink options.checksumAlgorithm pdbData options.pathMap options.compilationReferences options.compilationOptions
 
                 if options.embeddedPDB then
                     let (uncompressedLength, contentId, stream, algorithmName, checkSum) = pdbInfo

--- a/src/Compiler/AbstractIL/ilwrite.fsi
+++ b/src/Compiler/AbstractIL/ilwrite.fsi
@@ -25,7 +25,9 @@ type options =
       dumpDebugInfo: bool
       referenceAssemblyOnly: bool
       referenceAssemblyAttribOpt: ILAttribute option
-      pathMap: PathMap }
+      pathMap: PathMap
+      compilationReferences: PdbMetadataReferenceInfo list
+      compilationOptions: (string * string) list }
 
 /// Write a binary to the file system.
 val WriteILBinaryFile: options: options * inputModule: ILModuleDef * (ILAssemblyRef -> ILAssemblyRef) -> unit

--- a/src/Compiler/AbstractIL/ilwritepdb.fsi
+++ b/src/Compiler/AbstractIL/ilwritepdb.fsi
@@ -67,6 +67,17 @@ type PdbMethodData =
       DebugRange: (PdbSourceLoc * PdbSourceLoc) option
       DebugPoints: PdbDebugPoint[] }
 
+/// maps to the layout of the `MetadataReferenceInfo` from the PortablePdb spec
+type PdbMetadataReferenceInfo =
+    {
+        FileName: string
+        Aliases: string[]
+        Flags: byte
+        TimeStamp: uint32
+        FileSize: uint32
+        MVID: System.Guid
+    }
+
 [<NoEquality; NoComparison>]
 type PdbData =
     {
@@ -109,6 +120,8 @@ val generatePortablePdb:
     checksumAlgorithm: HashAlgorithm ->
     info: PdbData ->
     pathMap: PathMap ->
+    references: PdbMetadataReferenceInfo list ->
+    options: (string * string) list ->
         int64 * BlobContentId * MemoryStream * string * byte[]
 
 val compressPortablePdbStream: stream: MemoryStream -> MemoryStream

--- a/src/Compiler/Driver/CompilerConfig.fs
+++ b/src/Compiler/Driver/CompilerConfig.fs
@@ -606,6 +606,8 @@ type TcConfigBuilder =
         mutable typeCheckingConfig: TypeCheckingConfig
 
         mutable dumpSignatureData: bool
+        
+        mutable sourceFiles: string []
     }
 
     // Directories to start probing in
@@ -806,6 +808,7 @@ type TcConfigBuilder =
                     DumpGraph = false
                 }
             dumpSignatureData = false
+            sourceFiles = Array.empty
         }
 
     member tcConfigB.FxResolver =
@@ -1347,6 +1350,7 @@ type TcConfig private (data: TcConfigBuilder, validate: bool) =
     member _.captureIdentifiersWhenParsing = data.captureIdentifiersWhenParsing
     member _.typeCheckingConfig = data.typeCheckingConfig
     member _.dumpSignatureData = data.dumpSignatureData
+    member _.sourceFiles = data.sourceFiles
 
     static member Create(builder, validate) =
         use _ = UseBuildPhase BuildPhase.Parameter

--- a/src/Compiler/Driver/CompilerConfig.fsi
+++ b/src/Compiler/Driver/CompilerConfig.fsi
@@ -515,6 +515,8 @@ type TcConfigBuilder =
         mutable typeCheckingConfig: TypeCheckingConfig
 
         mutable dumpSignatureData: bool
+
+        mutable sourceFiles: string []
     }
 
     static member CreateNew:
@@ -887,6 +889,8 @@ type TcConfig =
     member typeCheckingConfig: TypeCheckingConfig
 
     member dumpSignatureData: bool
+    
+    member sourceFiles: string []
 
 /// Represents a computation to return a TcConfig. Normally this is just a constant immutable TcConfig,
 /// but for F# Interactive it may be based on an underlying mutable TcConfigBuilder.

--- a/src/Compiler/Driver/CreateILModule.fs
+++ b/src/Compiler/Driver/CreateILModule.fs
@@ -346,6 +346,11 @@ module MainModuleBuilder =
                 flags
                 (mkILExportedTypes exportedTypesList)
                 metadataVersion
+                //TODO: validate these next two numbers
+                0
+                0
+                Guid.Empty
+
 
         let disableJitOptimizations = not tcConfig.optSettings.JitOptimizationsEnabled
 

--- a/src/Compiler/Driver/fsc.fs
+++ b/src/Compiler/Driver/fsc.fs
@@ -1095,6 +1095,7 @@ let private createCompilationOptions (config: TcConfig) (imports: TcImports) (ct
         "compiler-target", config.target.ToString()
         // TODO: optimization options?
         match config.platform with | Some platform -> "platform", platform.ToString() | None -> ()
+        "version", "2" // TODO: determinism validation in NuGet Package Explorer is C#-specific: https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/ae4f65fa7e1f000dc5843d6ecc9200147dbf3bfc/Core/AssemblyMetadata/AssemblyDebugData.cs#L14
     ]
 
 /// Sixth phase of compilation.

--- a/src/Compiler/Driver/fsc.fs
+++ b/src/Compiler/Driver/fsc.fs
@@ -1055,7 +1055,7 @@ let private createCompilationReferences (imports: TcImports): ILPdbWriter.PdbMet
                     let isAssembly = 0b1uy
                     let embedInteropTypes = false //TODO: read this flag from moduleDef/properties?
                     {
-                        FileName = dll.FileName
+                        FileName = Path.GetFileName dll.FileName
                         Aliases = [| |] //TODO: does F# support `extern alias`?
                         Flags =  isAssembly ||| (if embedInteropTypes then 0b10uy else 0b0uy) 
                         TimeStamp = uint32 moduleDef.TimeDateStamp

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -1419,6 +1419,11 @@ type internal FsiDynamicCompiler(
         if progress then fprintfn fsiConsoleOutput.Out "Creating main module..."
         let mainModule =
             mkILSimpleModule dynamicCcuName (GetGeneratedILModuleName tcConfigB.target dynamicCcuName) (tcConfigB.target = CompilerTarget.Dll) tcConfigB.subsystemVersion tcConfigB.useHighEntropyVA (mkILTypeDefs codegenResults.ilTypeDefs) None None 0x0 (mkILExportedTypes []) ""
+                //TODO: validate these two values
+                0
+                0
+                Guid.Empty
+
         { mainModule
           with Manifest =
                 (let man = mainModule.ManifestOfAssembly
@@ -1470,6 +1475,9 @@ type internal FsiDynamicCompiler(
             referenceAssemblyOnly = false
             referenceAssemblyAttribOpt = None
             pathMap = tcConfig.pathMap
+            // TODO: should FSI flow through compilation references/option metadata?
+            compilationReferences = []
+            compilationOptions = []
         }
 
         let assemblyBytes, pdbBytes = WriteILBinaryInMemory (opts, ilxMainModule, id)


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/12002

This writes the Compilation Metadata References and Compilation Options tables to the CustomDebugInformation area of the PDB. There are a number of TODOs, and I'm not 100% sure I'm getting the actual information we will want to get a real end-to-end setup.

With these changes, we look like other .NET assemblies!

![image](https://user-images.githubusercontent.com/573979/227829708-98598210-4f85-496e-8f2e-2df2bf66365b.png)

What this should do immediately is allow VS-based tooling to synthesize MetadataReferences from this cached data, so that go-to-def for sourcelinked files has a matching set of assembly references to do typechecking against (and therefore light up IDE tooling). 

There are a number of TODOs that I'd like to get some feedback on. I'm fairly sure I'm reading required data correctly, but I want to make sure the sources I'm pulling it from are correct.
Also I'm certain I'm missing a number of compiler options that would be necessary to have on the read-side of this to ensure 1:1 compilation.
Finally, I haven't done the step that would map from the compilation options + compilation references to a proper FSharpProjectOptions - that would probably need to be done to show a true end-to-end in an editor.

I would love any and all review/pointers for the next steps here.
