### PR TITLE
Do not skip locals init in state machines

### DIFF
--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -1317,6 +1317,12 @@ let AddStorageForLocalWitness eenv (w, s) =
 let AddStorageForLocalWitnesses witnesses eenv =
     (eenv, witnesses) ||> List.fold AddStorageForLocalWitness
 
+let ForceInitLocals eenv =
+    if eenv.initLocals then
+        eenv
+    else
+        { eenv with initLocals = true }
+
 //--------------------------------------------------------------------------
 // Lookup eenv
 //--------------------------------------------------------------------------
@@ -5933,6 +5939,9 @@ and GenStructStateMachine cenv cgbuf eenvouter (res: LoweredStateMachine) sequel
 
     let eenvinner =
         AddTemplateReplacement eenvinner (templateTyconRef, ilCloTypeRef, cloinfo.cloFreeTyvars, templateTypeInst)
+
+    // In MoveNext we're relying on default initialization of locals, so force it in spite of the presence of any SkipLocalsInit
+    let eenvinner = ForceInitLocals eenvinner
 
     let infoReader = InfoReader.InfoReader(g, cenv.amap)
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SkipLocalsInit.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SkipLocalsInit.fs
@@ -180,3 +180,36 @@ IL_001a:  ldloc.0
 IL_001b:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<valuetype [runtime]System.Nullable`1<int64>,!!a>::Invoke(!0)
 IL_0020:  stloc.2
 IL_0021:  ret"""]
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``Zero init performed in state machine MoveNext despite the attribute``() =
+        FSharp """
+module SkipLocalsInit
+open System
+
+[<System.Runtime.CompilerServices.SkipLocalsInit>]
+let compute () =
+    task {
+        try
+            do! System.Threading.Tasks.Task.Delay 10
+        with e ->
+            printfn "%s" (e.ToString())
+    }
+        """
+        |> compile
+        |> shouldSucceed
+        |> verifyIL ["""
+.override [runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+
+.maxstack  5
+.locals init (int32 V_0,
+        """
+
+                     """
+.method public static class [runtime]System.Threading.Tasks.Task`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> 
+        compute() cil managed 
+{
+	.custom instance void [runtime]System.Runtime.CompilerServices.SkipLocalsInitAttribute::.ctor() = ( 01 00 00 00 )
+
+	.maxstack  4
+	.locals (valuetype SkipLocalsInit/compute@7 V_0,"""]

--- a/tests/FSharp.Compiler.ComponentTests/Language/StateMachineTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/StateMachineTests.fs
@@ -84,3 +84,25 @@ foo()
 """
         |> verify3511AndRun
         |> shouldSucceed
+
+    [<FSharp.Test.FactForNETCOREAPP>] // https://github.com/dotnet/fsharp/issues/13386
+    let ``SkipLocalsInit does not cause an exception``() =
+        FSharp """
+module TestProject1
+
+[<System.Runtime.CompilerServices.SkipLocalsInit>]
+let compute () =
+    task {
+        try
+            do! System.Threading.Tasks.Task.Delay 10
+        with e ->
+            printfn "%s" (e.ToString())
+    }
+
+// multiple invocations to trigger tiered compilation
+for i in 1 .. 100 do
+    compute().Wait ()
+"""
+        |> withOptimize
+        |> compileExeAndRun
+        |> shouldSucceed


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/13386.

The problem turned out not to be the `initobj` for `TaskAwaiter`, but the fact that the code emitted by task builder relies on locals being initialized. Randomly initialized bool flags could result in semi-arbitrary code being executed, like an exception handler despite no exception being thrown.

An alternative solution would have been to manually initialize every local used by the state machine in `MoveNext`, enabling user code, which is inlined, to potentially benefit from no initialization.
