### PR TITLE
Fix parameter name hints crashing with multi-line arguments

### DIFF
--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -9,6 +9,7 @@ open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text
 open Hints
+open Microsoft.VisualStudio.FSharp.Editor
 
 module InlineParameterNameHints =
 
@@ -56,10 +57,8 @@ module InlineParameterNameHints =
         >> Seq.contains range
 
     let private getSourceTextAtRange (sourceText: SourceText) (range: range) =
-
-        let line = sourceText.Lines[ range.Start.Line - 1 ].ToString()
-        let length = range.EndColumn - range.StartColumn
-        line.Substring(range.Start.Column, length)
+        (RoslynHelpers.FSharpRangeToTextSpan(sourceText, range) |> sourceText.GetSubText)
+            .ToString()
 
     let isMemberOrFunctionOrValueValidForHint (symbol: FSharpMemberOrFunctionOrValue) (symbolUse: FSharpSymbolUse) =
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -494,7 +494,7 @@ let q = query { for x in { 1 .. 10 } do select x }
         Assert.Empty actual
 
     [<Fact>]
-    let ``Hints are not shown when parameter names coinside with variable names`` () =
+    let ``Hints are not shown when parameter names coincide with variable names`` () =
         let code =
             """
 let getFullName name surname = $"{name} {surname}"
@@ -511,6 +511,31 @@ let fullName = getFullName name lastName
                 {
                     Content = "surname = "
                     Location = (5, 33)
+                }
+            ]
+
+        let actual = getParameterNameHints document
+
+        Assert.Equal(expected, actual)
+
+    [<Fact>]
+    let ``Hints don't break with multi-line arguments`` () =
+        let code =
+            """
+None
+|> Option.map (fun x ->
+    x + 5
+    )
+|> ignore
+        """
+
+        let document = getFsDocument code
+
+        let expected =
+            [
+                {
+                    Content = "mapping = "
+                    Location = (2, 15)
                 }
             ]
 


### PR DESCRIPTION
Fixes #14885 which caused hints to stop working in certain files when parameter name hints were enabled. 

The cause was that we're trying to look at arguments passed to a function and see if they're variables with the same name as the named parameter name. And we looked at a line substring between `range.StartColumn` and `range.EndColumn`. However the argument doesn't have to be a variable and can span multiple lines (like a lambda or a list) and then we're trying to get an impossible substring, e.g. of negative length. 