### PR TITLE
Fix send to vsfsi when using older dotnet sdks

### DIFF
--- a/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -534,15 +534,27 @@ type internal FsiToolWindow() as this =
             executeTextNoHistory null text
         with _ -> ()
 
+    let hide =
+        if sessions.SupportsInteractivePrompt then
+            """#interactiveprompt "hide" """
+        else
+            ""
+
+    let show =
+        if sessions.SupportsInteractivePrompt then
+            """#interactiveprompt "hide" """
+        else
+            ""
+
     let executeInteraction dbgBreak dir filename topLine (text:string) =
         let interaction = $"""
-#interactiveprompt "hide"
+{hide.ToString()}
 #silentCd @"{dir}";;
 {if dbgBreak then "#dbgbreak" else ""}
 #{topLine} @"{filename}"
 {text.ToString()}
 #1 "stdin"
-#interactiveprompt "show";;
+{show.ToString()}
 """
         executeTextNoHistory filename interaction
 


### PR DESCRIPTION
When using a global.json to pin the version of an sdk to an older one, I.e the last LTS version of the sdk, the F# script displays an obtrusive error when code is sent to fsi.  This PR reverts the behaviour to it's original behaviour when using pre-7.0 sdks.

Before and after:
![image](https://user-images.githubusercontent.com/5175830/230211048-4b87cea4-9c58-4b68-8fea-2134df5226bc.png)
