### PR TITLE
BenchmarkDotnet config option - ignore that Test.Utilities is not optimized

### DIFF
--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/Program.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/Program.fs
@@ -4,5 +4,6 @@ open BenchmarkDotNet.Configs
 
 [<EntryPoint>]
 let main args =
-    BenchmarkSwitcher.FromAssembly(typeof<DecentlySizedStandAloneFileBenchmark>.Assembly).Run(args) |> ignore
+    let cfg = ManualConfig.Create(DefaultConfig.Instance).WithOptions(ConfigOptions.DisableOptimizationsValidator)
+    BenchmarkSwitcher.FromAssembly(typeof<DecentlySizedStandAloneFileBenchmark>.Assembly).Run(args,cfg) |> ignore
     0


### PR DESCRIPTION
This addresses https://github.com/dotnet/fsharp/issues/14913 

"Assembly FSharp.Compiler.Benchmarks which defines benchmarks references non-optimized FSharp.Test.Utilities".

Test.Utilities is used for the ProjectWorkflowBuilder, which is not what we are benchmarking - it is just sugar to describe scenarios.
We want to keep it unoptimized for easier debugging of tests, which also make use of it.