### PR TITLE
Parser: recover on missing types in decls

### DIFF
--- a/src/Compiler/SyntaxTree/LexFilter.fs
+++ b/src/Compiler/SyntaxTree/LexFilter.fs
@@ -2382,11 +2382,12 @@ type LexFilterImpl (
             returnToken tokenLexbufState OFUN
 
         | INTERFACE, _ ->
-            let lookaheadTokenTup = peekNextTokenTup()
+            let lookaheadTokenTup = peekNextTokenTup ()
             let lookaheadTokenStartPos = startPosOfTokenTup lookaheadTokenTup
             match lookaheadTokenTup.Token with
             // type I = interface .... end
-            | DEFAULT | OVERRIDE | INTERFACE | NEW | TYPE | STATIC | END | MEMBER | ABSTRACT | INHERIT | LBRACK_LESS ->
+            | DEFAULT | OVERRIDE | INTERFACE | NEW | TYPE | STATIC | END | MEMBER | ABSTRACT | INHERIT | LBRACK_LESS when
+                    not strictIndentation || (tokenStartCol < lookaheadTokenStartPos.Column || match lookaheadTokenTup.Token with END -> true | _ -> false) ->
                 if debug then dprintf "INTERFACE, pushing CtxtParen, tokenStartPos = %a, lookaheadTokenStartPos = %a\n" outputPos tokenStartPos outputPos lookaheadTokenStartPos
                 pushCtxt tokenTup (CtxtParen (token, tokenStartPos))
                 pushCtxtSeqBlock tokenTup AddBlockEnd

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -156,6 +156,7 @@ let parse_error_rich = Some(fun (ctxt: ParseErrorContext<_>) ->
 %type <ParsedSigFile> signatureFile
 %type <ParsedScriptInteraction> interaction
 %type <Ident> ident
+%type <Ident option> optBaseSpec
 %type <SynType> typ typEOF
 %type <SynTypeDefnSig list> tyconSpfnList
 %type <SynArgPats * Range> atomicPatsOrNamePatPairs
@@ -972,24 +973,36 @@ classMemberSpfn:
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
        SynMemberSig.Interface($4, unionRanges (rhs parseState 3) ($4).Range) }
 
-  | opt_attributes opt_access INHERIT appType
+  | opt_attributes opt_access interfaceMember recover
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-       SynMemberSig.Inherit($4, unionRanges (rhs parseState 3) ($4).Range) }
+       let mEnd = (rhs parseState 3).EndRange
+       let ty = SynType.FromParseError(mEnd)
+       SynMemberSig.Interface(ty, rhs parseState 3) }
+
+  | opt_attributes opt_access INHERIT appType
+      { if Option.isSome $2 then errorR (Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+        SynMemberSig.Inherit($4, unionRanges (rhs parseState 3) $4.Range) }
+
+  | opt_attributes opt_access INHERIT recover 
+      { if Option.isSome $2 then errorR (Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+        let mEnd = (rhs parseState 3).EndRange
+        let ty = SynType.FromParseError(mEnd)
+        SynMemberSig.Inherit(ty, rhs parseState 3) }
 
   | opt_attributes opt_access VAL fieldDecl
-     { let mWhole = rhs2 parseState 1 4
-       if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+     { let mStart = rhs parseState 1
+       if Option.isSome $2 then errorR (Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
        let mVal = rhs parseState 3
-       let (SynField(xmlDoc = xmlDoc)) as field = $4 $1 false mWhole (Some(SynLeadingKeyword.Val mVal))
+       let (SynField(xmlDoc = xmlDoc; range = mWhole)) as field = $4 $1 false mStart (Some(SynLeadingKeyword.Val mVal))
        let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
        SynMemberSig.ValField(field, mWhole) }
 
   | opt_attributes opt_access STATIC VAL fieldDecl
-     { let mWhole = rhs2 parseState 1 5
+     { let mStart = rhs parseState 1
        if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
        let mStatic = rhs parseState 3
        let mVal = rhs parseState 4
-       let (SynField(xmlDoc = xmlDoc)) as field = $5 $1 true mWhole (Some(SynLeadingKeyword.StaticVal(mStatic, mVal)))
+       let (SynField(xmlDoc = xmlDoc; range = mWhole)) as field = $5 $1 true mStart (Some(SynLeadingKeyword.StaticVal(mStatic, mVal)))
        let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
        SynMemberSig.ValField(field, mWhole) }
 
@@ -1950,6 +1963,13 @@ classDefnMember:
            | Some(mWithKwd, members, m) -> Some mWithKwd, Some members, unionRanges (rhs2 parseState 1 4) m
        [ SynMemberDefn.Interface($4, mWithKwd, members, mWhole) ] }
 
+  | opt_attributes opt_access interfaceMember recover
+     { let mInterface = rhs parseState 3
+       if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesAreNotPermittedOnInterfaceImplementations(), rhs parseState 1))
+       if Option.isSome $2 then errorR(Error(FSComp.SR.parsInterfacesHaveSameVisibilityAsEnclosingType(), mInterface))
+       let ty = SynType.FromParseError(mInterface.EndRange)
+       [ SynMemberDefn.Interface(ty, None, None, rhs2 parseState 1 3) ] }
+
   | opt_attributes opt_access abstractMemberFlags opt_inline nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet opt_ODECLEND
      { let ty, arity = $8
        let isInline, doc, id, explicitValTyparDecls = (Option.isSome $4), grabXmlDoc(parseState, $1, 1), $5, $6
@@ -2015,19 +2035,51 @@ classDefnMember:
 /* A 'val' definition in an object type definition */
 valDefnDecl:
   | VAL opt_mutable opt_access ident COLON typ
-     { let mVal = rhs parseState 1
-       let mRhs = rhs2 parseState 4 6
-       let mValDecl = rhs2 parseState 1 6
-       (fun rangeStart attribs mStaticOpt ->
-           let isStatic = Option.isSome mStaticOpt
-           let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
-           let mValDecl = unionRanges rangeStart mValDecl |> unionRangeWithXmlDoc xmlDoc
-           let leadingKeyword =
-               match mStaticOpt with
-               | None -> SynLeadingKeyword.Val mVal
-               | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
-           let fld = SynField(attribs, isStatic, Some $4, $6, $2, xmlDoc, $3, mRhs, { LeadingKeyword = Some leadingKeyword })
-           [ SynMemberDefn.ValField(fld, mValDecl) ]) }
+      { let mVal = rhs parseState 1
+        let mRhs = unionRanges (rhs2 parseState 4 5) $6.Range 
+        let mWhole = unionRanges mVal mRhs
+        (fun rangeStart attribs mStaticOpt ->
+            let isStatic = Option.isSome mStaticOpt
+            let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
+            let mWhole = unionRanges rangeStart mWhole |> unionRangeWithXmlDoc xmlDoc
+            let leadingKeyword =
+                match mStaticOpt with
+                | None -> SynLeadingKeyword.Val mVal
+                | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
+            let fld = SynField(attribs, isStatic, Some $4, $6, $2, xmlDoc, $3, mRhs, { LeadingKeyword = Some leadingKeyword })
+            [ SynMemberDefn.ValField(fld, mWhole) ]) }
+
+  | VAL opt_mutable opt_access ident COLON recover
+      { let mVal = rhs parseState 1
+        let mRhs = rhs2 parseState 4 5
+        let mWhole = unionRanges mVal mRhs
+        let ty = SynType.FromParseError(mWhole.EndRange)
+        (fun mStart attribs mStaticOpt ->
+            let isStatic = Option.isSome mStaticOpt
+            let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, mStart)
+            let mWhole = unionRanges mStart mWhole |> unionRangeWithXmlDoc xmlDoc
+            let leadingKeyword =
+                match mStaticOpt with
+                | None -> SynLeadingKeyword.Val mVal
+                | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
+            let fld = SynField(attribs, isStatic, Some $4, ty, $2, xmlDoc, $3, mRhs, { LeadingKeyword = Some leadingKeyword })
+            [ SynMemberDefn.ValField(fld, mWhole) ]) }
+
+  | VAL opt_mutable opt_access ident recover
+      { let mVal = rhs parseState 1
+        let mRhs = rhs parseState 4
+        let mWhole = unionRanges mVal mRhs
+        let ty = SynType.FromParseError(mWhole.EndRange)
+        (fun mStart attribs mStaticOpt ->
+            let isStatic = Option.isSome mStaticOpt
+            let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, mStart)
+            let mWhole = unionRanges mStart mWhole |> unionRangeWithXmlDoc xmlDoc
+            let leadingKeyword =
+                match mStaticOpt with
+                | None -> SynLeadingKeyword.Val mVal
+                | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
+            let fld = SynField(attribs, isStatic, Some $4, ty, $2, xmlDoc, $3, mRhs, { LeadingKeyword = Some leadingKeyword })
+            [ SynMemberDefn.ValField(fld, mWhole) ]) }
 
 
 /* An auto-property definition in an object type definition */
@@ -2037,7 +2089,7 @@ autoPropsDefnDecl:
        let mWith, (getSet, getSetOpt) = $8
        let mEquals = rhs parseState 6
        if $2 then
-           errorR (Error (FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 3))
+           errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 3))
        (fun attribs flags rangeStart ->
            let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
            let memberRange = unionRanges rangeStart $7.Range |> unionRangeWithXmlDoc xmlDoc
@@ -2049,10 +2101,60 @@ autoPropsDefnDecl:
            let trivia = { LeadingKeyword = leadingKeyword; WithKeyword = mWith; EqualsRange = Some mEquals; GetSetKeywords = getSetOpt }
            [ SynMemberDefn.AutoProperty(attribs, isStatic, $4, $5, getSet, memberFlags, memberFlagsForSet, xmlDoc, $3, $7, memberRange, trivia) ]) }
 
+  | VAL opt_mutable opt_access ident opt_typ ends_coming_soon_or_recover
+     { let mVal = rhs parseState 1
+       let mEnd =
+           match $5 with
+           | Some t -> t.Range
+           | _ -> $4.idRange
+       let expr = arbExpr ("autoProp1", mEnd.EndRange)
+       if $2 then
+           errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 3))
+       (fun attribs flags rangeStart ->
+           let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
+           let memberRange = unionRanges rangeStart mEnd
+           let flags, leadingKeyword = flags
+           let leadingKeyword = appendValToLeadingKeyword mVal leadingKeyword
+           let memberFlags = flags SynMemberKind.Member
+           let memberFlagsForSet = flags SynMemberKind.PropertySet
+           let isStatic = not memberFlags.IsInstance
+           let trivia = { LeadingKeyword = leadingKeyword; WithKeyword = None; EqualsRange = None; GetSetKeywords = None }
+           [ SynMemberDefn.AutoProperty(attribs, isStatic, $4, $5, SynMemberKind.Member, memberFlags, memberFlagsForSet, xmlDoc, $3, expr, memberRange, trivia) ]) }
+
+  | VAL opt_mutable opt_access ident opt_typ OBLOCKSEP
+     { errorR (Error(FSComp.SR.parsMissingMemberBody(), rhs parseState 6))
+       let mVal = rhs parseState 1
+       let mEnd =
+           match $5 with
+           | Some t -> t.Range
+           | _ -> $4.idRange
+       let expr = arbExpr ("autoProp2", mEnd.EndRange)
+       if $2 then
+           errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 3))
+       (fun attribs flags rangeStart ->
+           let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
+           let memberRange = unionRanges rangeStart mEnd
+           let flags, leadingKeyword = flags
+           let leadingKeyword = appendValToLeadingKeyword mVal leadingKeyword
+           let memberFlags = flags SynMemberKind.Member
+           let memberFlagsForSet = flags SynMemberKind.PropertySet
+           let isStatic = not memberFlags.IsInstance
+           let trivia = { LeadingKeyword = leadingKeyword; WithKeyword = None; EqualsRange = None; GetSetKeywords = None }
+           [ SynMemberDefn.AutoProperty(attribs, isStatic, $4, $5, SynMemberKind.Member, memberFlags, memberFlagsForSet, xmlDoc, $3, expr, memberRange, trivia) ]) }
+
+
 /* An optional type on an auto-property definition */
 opt_typ:
-   | /* EMPTY */ { None }
-   | COLON typ { Some $2 }
+  | /* EMPTY */
+      { None }
+
+  | COLON typ
+      { Some $2 }
+
+  | COLON recover
+      { let mEnd = (rhs parseState 1).EndRange
+        let ty = SynType.FromParseError(mEnd)
+        Some ty }
 
 
 atomicPatternLongIdent:
@@ -2133,17 +2235,34 @@ opt_classDefn:
 /* An 'inherits' definition in an object type definition */
 inheritsDefn:
   | INHERIT atomTypeNonAtomicDeprecated optBaseSpec
-     { let mDecl = unionRanges (rhs parseState 1) (($2): SynType).Range
-       SynMemberDefn.Inherit($2, $3, mDecl) }
+      { let mDecl = unionRanges (rhs parseState 1) (($2): SynType).Range
+        let mWhole =
+            match $3 with
+            | Some id -> unionRanges mDecl id.idRange
+            | _ -> mDecl
+        SynMemberDefn.Inherit($2, $3, mWhole) }
+
+  | INHERIT recover optBaseSpec
+      { let mDecl = rhs parseState 1
+        let ty = SynType.FromParseError(mDecl.EndRange)
+        let mWhole =
+            match $3 with
+            | Some id -> unionRanges mDecl id.idRange
+            | _ -> mDecl
+        SynMemberDefn.Inherit(ty, $3, mWhole) }
 
   | INHERIT atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType optBaseSpec
-     { let mDecl = unionRanges (rhs parseState 1) $4.Range
-       SynMemberDefn.ImplicitInherit($2, $4, $5, mDecl) }
+      { let mDecl = unionRanges (rhs parseState 1) $4.Range
+        let mWhole =
+            match $5 with
+            | Some id -> unionRanges mDecl id.idRange
+            | _ -> mDecl
+        SynMemberDefn.ImplicitInherit($2, $4, $5, mWhole) }
 
   | INHERIT ends_coming_soon_or_recover
-     { let mDecl = (rhs parseState 1)
+     { let mDecl = rhs parseState 1
        if not $2 then errorR(Error(FSComp.SR.parsTypeNameCannotBeEmpty(), mDecl))
-       SynMemberDefn.Inherit(SynType.LongIdent(SynLongIdent([], [], [])), None, mDecl) }
+       SynMemberDefn.Inherit(SynType.FromParseError(mDecl.EndRange), None, mDecl) }
 
 optAsSpec:
   | asSpec
@@ -2629,9 +2748,19 @@ unionCaseReprElements:
 
 unionCaseReprElement:
   | ident COLON appType
-     { let xmlDoc = grabXmlDoc(parseState, [], 1)
-       let mWhole = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-       mkSynNamedField ($1, $3, xmlDoc, mWhole) }
+      { let xmlDoc = grabXmlDoc (parseState, [], 1)
+        let mWhole =
+            rhs2 parseState 1 2
+            |> unionRanges $3.Range
+            |> unionRangeWithXmlDoc xmlDoc
+        mkSynNamedField ($1, $3, xmlDoc, mWhole) }
+
+  | ident COLON recover
+      { let xmlDoc = grabXmlDoc (parseState, [], 1)
+        let mEnd = (rhs parseState 2).EndRange
+        let ty = SynType.FromParseError(mEnd)
+        let mWhole = rhs2 parseState 1 2 |> unionRangeWithXmlDoc xmlDoc
+        mkSynNamedField ($1, ty, xmlDoc, mWhole) }
 
   | appType
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
@@ -2656,8 +2785,8 @@ recdFieldDeclList:
 /* A field declaration in a record type */
 recdFieldDecl:
   | opt_attributes fieldDecl
-     { let mWhole = rhs2 parseState 1 2
-       let fld = $2 $1 false mWhole None
+     { let mStart = rhs parseState 1
+       let fld = $2 $1 false mStart None
        let (SynField (a, b, c, d, e, xmlDoc, vis, mWhole, trivia)) = fld
        if Option.isSome vis then errorR (Error (FSComp.SR.parsRecordFieldsCannotHaveVisibilityDeclarations (), rhs parseState 2))
        let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
@@ -2666,9 +2795,27 @@ recdFieldDecl:
 /* Part of a field or val declaration in a record type or object type */
 fieldDecl:
   | opt_mutable opt_access ident COLON typ
-     { fun attrs stat mWhole leadingKeyword ->
-           let xmlDoc = grabXmlDocAtRangeStart(parseState, attrs, mWhole)
-           SynField(attrs, stat, Some $3, $5, $1, xmlDoc, $2, mWhole, { LeadingKeyword = leadingKeyword }) }
+      { fun attrs stat mStart leadingKeyword ->
+          let xmlDoc = grabXmlDocAtRangeStart (parseState, attrs, mStart)
+          let mWhole = unionRanges mStart $5.Range
+          SynField(attrs, stat, Some $3, $5, $1, xmlDoc, $2, mWhole, { LeadingKeyword = leadingKeyword }) }
+
+  | opt_mutable opt_access ident COLON recover
+      { let mEnd = (rhs parseState 4).EndRange
+        fun attrs stat mStart leadingKeyword ->
+          let xmlDoc = grabXmlDocAtRangeStart (parseState, attrs, mStart)
+          let mWhole = unionRanges mStart mEnd
+          let ty = SynType.FromParseError mEnd
+          SynField(attrs, stat, Some $3, ty, $1, xmlDoc, $2, mWhole, { LeadingKeyword = leadingKeyword }) }
+
+  | opt_mutable opt_access ident recover
+      { let mEnd = (rhs parseState 3).EndRange
+        fun attrs stat mStart leadingKeyword ->
+            let xmlDoc = grabXmlDocAtRangeStart (parseState, attrs, mStart)
+            let mWhole = unionRanges mStart mEnd
+            let ty = SynType.FromParseError mEnd
+            SynField(attrs, stat, Some $3, ty, $1, xmlDoc, $2, mWhole, { LeadingKeyword = leadingKeyword }) }
+
 
 /* An exception definition */
 exconDefn:

--- a/tests/service/data/SyntaxTree/Member/Auto property - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property - Missing type 01.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T() =
+    member val P1:
+
+    member this.P2 = 1

--- a/tests/service/data/SyntaxTree/Member/Auto property - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property - Missing type 01.fs.bsl
@@ -1,0 +1,79 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ImplicitCtor
+                        (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None });
+                      AutoProperty
+                        ([], false, P1, Some (FromParseError (4,18--4,18)),
+                         Member, { IsInstance = true
+                                   IsDispatchSlot = false
+                                   IsOverrideOrExplicitImpl = false
+                                   IsFinal = false
+                                   GetterOrSetterIsCompilerGenerated = false
+                                   MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, ArbitraryAfterError ("autoProp2", (4,18--4,18)),
+                         (4,4--4,18),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = None
+                           GetSetKeywords = None });
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P2], [(6,15--6,16)], [None; None]),
+                               None, None, Pats [], None, (6,11--6,18)), None,
+                            Const (Int32 1, (6,21--6,22)), (6,11--6,18),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,4--6,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,19--6,20) }), (6,4--6,22))],
+                     (4,4--6,22)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--6,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,9--3,10)
+                    WithKeyword = None })], (3,0--6,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,19)-(6,4) parse error Incomplete structured construct at or before this point in member definition
+(4,19)-(6,4) parse error Expecting member body

--- a/tests/service/data/SyntaxTree/Member/Auto property - Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property - Missing type 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T() =
+    member val P1: = 1
+
+    member this.P2 = 1

--- a/tests/service/data/SyntaxTree/Member/Auto property - Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property - Missing type 02.fs.bsl
@@ -1,0 +1,77 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property - Missing type 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ImplicitCtor
+                        (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None });
+                      AutoProperty
+                        ([], false, P1, Some (FromParseError (4,18--4,18)),
+                         Member, { IsInstance = true
+                                   IsDispatchSlot = false
+                                   IsOverrideOrExplicitImpl = false
+                                   IsFinal = false
+                                   GetterOrSetterIsCompilerGenerated = false
+                                   MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,21--4,22)), (4,4--4,22),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = Some (4,19--4,20)
+                           GetSetKeywords = None });
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P2], [(6,15--6,16)], [None; None]),
+                               None, None, Pats [], None, (6,11--6,18)), None,
+                            Const (Int32 1, (6,21--6,22)), (6,11--6,18),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,4--6,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,19--6,20) }), (6,4--6,22))],
+                     (4,4--6,22)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--6,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,9--3,10)
+                    WithKeyword = None })], (3,0--6,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,19)-(4,20) parse error Unexpected symbol '=' in member definition

--- a/tests/service/data/SyntaxTree/Member/Auto property - Missing type 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property - Missing type 03.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T() =
+    member val P1:

--- a/tests/service/data/SyntaxTree/Member/Auto property - Missing type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property - Missing type 03.fs.bsl
@@ -1,0 +1,54 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property - Missing type 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ImplicitCtor
+                        (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None });
+                      AutoProperty
+                        ([], false, P1, Some (FromParseError (4,18--4,18)),
+                         Member, { IsInstance = true
+                                   IsDispatchSlot = false
+                                   IsOverrideOrExplicitImpl = false
+                                   IsFinal = false
+                                   GetterOrSetterIsCompilerGenerated = false
+                                   MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, ArbitraryAfterError ("autoProp1", (4,18--4,18)),
+                         (4,4--4,18),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = None
+                           GetSetKeywords = None })], (4,4--4,18)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--4,18),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,9--3,10)
+                    WithKeyword = None })], (3,0--4,18))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,18), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Auto property - Missing type 04.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property - Missing type 04.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T() =
+    member val P1:
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property - Missing type 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property - Missing type 04.fs.bsl
@@ -1,0 +1,55 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property - Missing type 04.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ImplicitCtor
+                        (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None });
+                      AutoProperty
+                        ([], false, P1, Some (FromParseError (4,18--4,18)),
+                         Member, { IsInstance = true
+                                   IsDispatchSlot = false
+                                   IsOverrideOrExplicitImpl = false
+                                   IsFinal = false
+                                   GetterOrSetterIsCompilerGenerated = false
+                                   MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, ArbitraryAfterError ("autoProp1", (4,18--4,18)),
+                         (4,4--4,18),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = None
+                           GetSetKeywords = None })], (4,4--4,18)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--4,18),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,9--3,10)
+                    WithKeyword = None })], (3,0--4,18));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Field - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Field - Missing type 01.fs
@@ -1,0 +1,5 @@
+module Module
+
+type T =
+    val F1
+    val F2: int

--- a/tests/service/data/SyntaxTree/Member/Field - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field - Missing type 01.fs.bsl
@@ -1,0 +1,39 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F1, FromParseError (4,10--4,10),
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,8--4,10),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--4,10));
+                      ValField
+                        (SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                         (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,11)-(5,4) parse error Incomplete structured construct at or before this point in type definition. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Member/Field - Missing type 01.fsi
+++ b/tests/service/data/SyntaxTree/Member/Field - Missing type 01.fsi
@@ -1,0 +1,5 @@
+module Module
+
+type T =
+    val F1
+    val F2: int

--- a/tests/service/data/SyntaxTree/Member/Field - Missing type 01.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field - Missing type 01.fsi.bsl
@@ -1,0 +1,39 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Member/Field - Missing type 01.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F1, FromParseError (4,10--4,10),
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,4--4,10),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--4,10));
+                      ValField
+                        (SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,4--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                         (5,4--5,15))], (4,4--5,15)), [], (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,15), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,11)-(5,4) parse error Incomplete structured construct at or before this point in field declaration. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Member/Field - Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Field - Missing type 02.fs
@@ -1,0 +1,5 @@
+module Module
+
+type T =
+    val F1:
+    val F2: int

--- a/tests/service/data/SyntaxTree/Member/Field - Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field - Missing type 02.fs.bsl
@@ -1,0 +1,39 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field - Missing type 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F1, FromParseError (4,11--4,11),
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,8--4,11),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--4,11));
+                      ValField
+                        (SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                         (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,12)-(5,4) parse error Incomplete structured construct at or before this point in type definition

--- a/tests/service/data/SyntaxTree/Member/Field - Missing type 02.fsi
+++ b/tests/service/data/SyntaxTree/Member/Field - Missing type 02.fsi
@@ -1,0 +1,5 @@
+module Module
+
+type T =
+    val F1:
+    val F2: int

--- a/tests/service/data/SyntaxTree/Member/Field - Missing type 02.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field - Missing type 02.fsi.bsl
@@ -1,0 +1,39 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Member/Field - Missing type 02.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F1, FromParseError (4,11--4,11),
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,4--4,11),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--4,11));
+                      ValField
+                        (SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,4--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                         (5,4--5,15))], (4,4--5,15)), [], (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,15), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,12)-(5,4) parse error Incomplete structured construct at or before this point in field declaration

--- a/tests/service/data/SyntaxTree/Member/Inherit - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Inherit - Missing type 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    inherit

--- a/tests/service/data/SyntaxTree/Member/Inherit - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit - Missing type 01.fs.bsl
@@ -1,0 +1,25 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Inherit - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Inherit (FromParseError (4,11--4,11), None, (4,4--4,11))],
+                     (4,4--4,11)), [], None, (3,5--4,11),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,4)-(4,11) parse error Type name cannot be empty.

--- a/tests/service/data/SyntaxTree/Member/Inherit - Missing type 01.fsi
+++ b/tests/service/data/SyntaxTree/Member/Inherit - Missing type 01.fsi
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    inherit

--- a/tests/service/data/SyntaxTree/Member/Inherit - Missing type 01.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit - Missing type 01.fsi.bsl
@@ -1,0 +1,25 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Member/Inherit - Missing type 01.fsi", QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Inherit (FromParseError (4,11--4,11), (4,4--4,11))],
+                     (4,4--4,11)), [], (3,5--4,11),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,11), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in member signature

--- a/tests/service/data/SyntaxTree/Member/Inherit - Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Inherit - Missing type 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    inherit as t
+
+    member this.P = 1

--- a/tests/service/data/SyntaxTree/Member/Inherit - Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit - Missing type 02.fs.bsl
@@ -1,0 +1,50 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Inherit - Missing type 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Inherit
+                        (FromParseError (4,11--4,11), Some base, (4,4--4,16));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P], [(6,15--6,16)], [None; None]), None,
+                               None, Pats [], None, (6,11--6,17)), None,
+                            Const (Int32 1, (6,20--6,21)), (6,11--6,17),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,4--6,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,18--6,19) }), (6,4--6,21))],
+                     (4,4--6,21)), [], None, (3,5--6,21),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,21))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,21), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,12)-(4,14) parse error Unexpected keyword 'as' in type definition
+(4,12)-(4,16) parse error 'inherit' declarations cannot have 'as' bindings. To access members of the base class when overriding a method, the syntax 'base.SomeMember' may be used; 'base' is a keyword. Remove this 'as' binding.

--- a/tests/service/data/SyntaxTree/Member/Inherit - Missing type 02.fsi
+++ b/tests/service/data/SyntaxTree/Member/Inherit - Missing type 02.fsi
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    inherit as t
+
+    member this.P = 1

--- a/tests/service/data/SyntaxTree/Member/Inherit - Missing type 02.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit - Missing type 02.fsi.bsl
@@ -1,0 +1,26 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Member/Inherit - Missing type 02.fsi", QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Inherit (FromParseError (4,11--4,11), (4,4--4,11))],
+                     (4,4--4,11)), [], (3,5--4,11),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,11), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,12)-(4,14) parse error Unexpected keyword 'as' in member signature
+(7,0)-(7,0) parse error Incomplete structured construct at or before this point in signature file

--- a/tests/service/data/SyntaxTree/Member/Interface - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Interface - Missing type 01.fs
@@ -1,0 +1,8 @@
+module Module
+
+type T =
+    interface
+
+    member this.P = 1
+
+()

--- a/tests/service/data/SyntaxTree/Member/Interface - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Interface - Missing type 01.fs.bsl
@@ -1,0 +1,50 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Interface - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Interface
+                        (FromParseError (4,13--4,13), None, None, (4,4--4,13));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P], [(6,15--6,16)], [None; None]), None,
+                               None, Pats [], None, (6,11--6,17)), None,
+                            Const (Int32 1, (6,20--6,21)), (6,11--6,17),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,4--6,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,18--6,19) }), (6,4--6,21))],
+                     (4,4--6,21)), [], None, (3,5--6,21),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,21));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,14)-(6,4) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Interface - Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Interface - Missing type 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    interface
+
+()

--- a/tests/service/data/SyntaxTree/Member/Interface - Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Interface - Missing type 02.fs.bsl
@@ -1,0 +1,27 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Interface - Missing type 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Interface
+                        (FromParseError (4,13--4,13), None, None, (4,4--4,13))],
+                     (4,4--4,13)), [], None, (3,5--4,13),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,13));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Interface - Missing type 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Interface - Missing type 03.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    member this.P = 1
+    interface
+
+2

--- a/tests/service/data/SyntaxTree/Member/Interface - Missing type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Interface - Missing type 03.fs.bsl
@@ -1,0 +1,50 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Interface - Missing type 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P], [(4,15--4,16)], [None; None]), None,
+                               None, Pats [], None, (4,11--4,17)), None,
+                            Const (Int32 1, (4,20--4,21)), (4,11--4,17),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,4--4,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,18--4,19) }), (4,4--4,21));
+                      Interface
+                        (FromParseError (5,13--5,13), None, None, (5,4--5,13))],
+                     (4,4--5,13)), [], None, (3,5--5,13),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,13));
+           Expr (Const (Int32 2, (7,0--7,1)), (7,0--7,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(7,0)-(7,1) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Interface - Missing type 04.fs
+++ b/tests/service/data/SyntaxTree/Member/Interface - Missing type 04.fs
@@ -1,0 +1,8 @@
+module Module
+
+type T =
+    member this.P1 = 1
+    interface
+    member this.P2 = 2
+
+3

--- a/tests/service/data/SyntaxTree/Member/Interface - Missing type 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Interface - Missing type 04.fs.bsl
@@ -1,0 +1,73 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Interface - Missing type 04.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,15--4,16)], [None; None]),
+                               None, None, Pats [], None, (4,11--4,18)), None,
+                            Const (Int32 1, (4,21--4,22)), (4,11--4,18),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,4--4,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,19--4,20) }), (4,4--4,22));
+                      Interface
+                        (FromParseError (5,13--5,13), None, None, (5,4--5,13));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P2], [(6,15--6,16)], [None; None]),
+                               None, None, Pats [], None, (6,11--6,18)), None,
+                            Const (Int32 2, (6,21--6,22)), (6,11--6,18),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,4--6,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,19--6,20) }), (6,4--6,22))],
+                     (4,4--6,22)), [], None, (3,5--6,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,22));
+           Expr (Const (Int32 3, (8,0--8,1)), (8,0--8,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,14)-(6,4) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+type R =
+    { F }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 01.fs.bsl
@@ -1,0 +1,29 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Record/Field - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F, FromParseError (4,7--4,7), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { LeadingKeyword = None })],
+                        (4,4--4,9)), (4,4--4,9)), [], None, (3,5--4,9),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,9))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,9), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,8)-(4,9) parse error Unexpected symbol '}' in field declaration. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 01.fsi
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 01.fsi
@@ -1,0 +1,4 @@
+module Module
+
+type R =
+    { F }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 01.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 01.fsi.bsl
@@ -1,0 +1,29 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Record/Field - Missing type 01.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F, FromParseError (4,7--4,7), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { LeadingKeyword = None })],
+                        (4,4--4,9)), (4,4--4,9)), [], (3,5--4,9),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,9))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,9), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,8)-(4,9) parse error Unexpected symbol '}' in field declaration. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 02.fs
@@ -1,0 +1,4 @@
+module Module
+
+type R =
+    { F: }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 02.fs.bsl
@@ -1,0 +1,29 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Record/Field - Missing type 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F, FromParseError (4,8--4,8), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,8), { LeadingKeyword = None })],
+                        (4,4--4,10)), (4,4--4,10)), [], None, (3,5--4,10),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,10))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,10), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,9)-(4,10) parse error Unexpected symbol '}' in field declaration

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 02.fsi
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 02.fsi
@@ -1,0 +1,4 @@
+module Module
+
+type R =
+    { F: }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 02.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 02.fsi.bsl
@@ -1,0 +1,29 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Record/Field - Missing type 02.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F, FromParseError (4,8--4,8), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,8), { LeadingKeyword = None })],
+                        (4,4--4,10)), (4,4--4,10)), [], (3,5--4,10),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,10))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,10), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,9)-(4,10) parse error Unexpected symbol '}' in field declaration

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 03.fs
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 03.fs
@@ -1,0 +1,5 @@
+module Module
+
+type R =
+    { F1: int
+      F2 }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 03.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Record/Field - Missing type 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,13), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2, FromParseError (5,8--5,8), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,8), { LeadingKeyword = None })],
+                        (4,4--5,10)), (4,4--5,10)), [], None, (3,5--5,10),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,10))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,10), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,9)-(5,10) parse error Unexpected symbol '}' in field declaration. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 03.fsi
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 03.fsi
@@ -1,0 +1,5 @@
+module Module
+
+type R =
+    { F1: int
+      F2 }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 03.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 03.fsi.bsl
@@ -1,0 +1,34 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Record/Field - Missing type 03.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,13), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2, FromParseError (5,8--5,8), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,8), { LeadingKeyword = None })],
+                        (4,4--5,10)), (4,4--5,10)), [], (3,5--5,10),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,10))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,10), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,9)-(5,10) parse error Unexpected symbol '}' in field declaration. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 04.fs
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 04.fs
@@ -1,0 +1,5 @@
+module Module
+
+type R =
+    { F1: int
+      F2: }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 04.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Record/Field - Missing type 04.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,13), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2, FromParseError (5,9--5,9), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,9), { LeadingKeyword = None })],
+                        (4,4--5,11)), (4,4--5,11)), [], None, (3,5--5,11),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,10)-(5,11) parse error Unexpected symbol '}' in field declaration

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 04.fsi
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 04.fsi
@@ -1,0 +1,5 @@
+module Module
+
+type R =
+    { F1: int
+      F2: }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 04.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 04.fsi.bsl
@@ -1,0 +1,34 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Record/Field - Missing type 04.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,13), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2, FromParseError (5,9--5,9), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,9), { LeadingKeyword = None })],
+                        (4,4--5,11)), (4,4--5,11)), [], (3,5--5,11),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,11), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,10)-(5,11) parse error Unexpected symbol '}' in field declaration

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 05.fs
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 05.fs
@@ -1,0 +1,5 @@
+module Module
+
+type R =
+    { F1
+      F2: int }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 05.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Record/Field - Missing type 05.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1, FromParseError (4,8--4,8), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,8), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,13), { LeadingKeyword = None })],
+                        (4,4--5,15)), (4,4--5,15)), [], None, (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,9)-(5,6) parse error Incomplete structured construct at or before this point in field declaration. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 05.fsi
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 05.fsi
@@ -1,0 +1,5 @@
+module Module
+
+type R =
+    { F1
+      F2: int }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 05.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 05.fsi.bsl
@@ -1,0 +1,34 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Record/Field - Missing type 05.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1, FromParseError (4,8--4,8), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,8), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,13), { LeadingKeyword = None })],
+                        (4,4--5,15)), (4,4--5,15)), [], (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,15), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,9)-(5,6) parse error Incomplete structured construct at or before this point in field declaration. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 06.fs
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 06.fs
@@ -1,0 +1,5 @@
+module Module
+
+type R =
+    { F1:
+      F2: int }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 06.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Record/Field - Missing type 06.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1, FromParseError (4,9--4,9), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,9), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,13), { LeadingKeyword = None })],
+                        (4,4--5,15)), (4,4--5,15)), [], None, (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,10)-(5,6) parse error Incomplete structured construct at or before this point in field declaration

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 06.fsi
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 06.fsi
@@ -1,0 +1,5 @@
+module Module
+
+type R =
+    { F1:
+      F2: int }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 06.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 06.fsi.bsl
@@ -1,0 +1,34 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Record/Field - Missing type 06.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1, FromParseError (4,9--4,9), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,9), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,13), { LeadingKeyword = None })],
+                        (4,4--5,15)), (4,4--5,15)), [], (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,15), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,10)-(5,6) parse error Incomplete structured construct at or before this point in field declaration

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 07.fs
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 07.fs
@@ -1,0 +1,6 @@
+module Module
+
+type R =
+    { F1:
+      [<A>]
+      F2: int }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 07.fs.bsl
@@ -1,0 +1,40 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Record/Field - Missing type 07.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1, FromParseError (4,9--4,9), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,9), { LeadingKeyword = None });
+                         SynField
+                           ([{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (5,8--5,9))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,8--5,9) }]
+                               Range = (5,6--5,11) }], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--6,13), { LeadingKeyword = None })],
+                        (4,4--6,15)), (4,4--6,15)), [], None, (3,5--6,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,10)-(5,6) parse error Incomplete structured construct at or before this point in field declaration

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 07.fsi
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 07.fsi
@@ -1,0 +1,6 @@
+module Module
+
+type R =
+    { F1:
+      [<A>]
+      F2: int }

--- a/tests/service/data/SyntaxTree/Record/Field - Missing type 07.fsi.bsl
+++ b/tests/service/data/SyntaxTree/Record/Field - Missing type 07.fsi.bsl
@@ -1,0 +1,40 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/Record/Field - Missing type 07.fsi", QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1, FromParseError (4,9--4,9), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,9), { LeadingKeyword = None });
+                         SynField
+                           ([{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (5,8--5,9))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,8--5,9) }]
+                               Range = (5,6--5,11) }], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--6,13), { LeadingKeyword = None })],
+                        (4,4--6,15)), (4,4--6,15)), [], (3,5--6,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,15), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,10)-(5,6) parse error Incomplete structured construct at or before this point in field declaration

--- a/tests/service/data/SyntaxTree/Type/Interface 01.fs
+++ b/tests/service/data/SyntaxTree/Type/Interface 01.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    interface
+    end
+
+1

--- a/tests/service/data/SyntaxTree/Type/Interface 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Interface 01.fs.bsl
@@ -1,0 +1,20 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Interface 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel (Interface, [], (4,4--5,7)), [], None, (3,5--5,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,7));
+           Expr (Const (Int32 1, (7,0--7,1)), (7,0--7,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/Interface 02.fs
+++ b/tests/service/data/SyntaxTree/Type/Interface 02.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    interface
+      end
+
+1

--- a/tests/service/data/SyntaxTree/Type/Interface 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Interface 02.fs.bsl
@@ -1,0 +1,20 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Interface 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel (Interface, [], (4,4--5,9)), [], None, (3,5--5,9),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,9));
+           Expr (Const (Int32 1, (7,0--7,1)), (7,0--7,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/Interface 03.fs
+++ b/tests/service/data/SyntaxTree/Type/Interface 03.fs
@@ -1,0 +1,8 @@
+module Module
+
+type T =
+    interface
+        abstract P: int
+    end
+
+1

--- a/tests/service/data/SyntaxTree/Type/Interface 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Interface 03.fs.bsl
@@ -1,0 +1,41 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Interface 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Interface,
+                     [AbstractSlot
+                        (SynValSig
+                           ([], SynIdent (P, None),
+                            SynValTyparDecls (None, true),
+                            LongIdent (SynLongIdent ([int], [], [None])),
+                            SynValInfo ([], SynArgInfo ([], false, None)), false,
+                            false,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, None, (5,8--5,23),
+                            { LeadingKeyword = Abstract (5,8--5,16)
+                              InlineKeyword = None
+                              WithKeyword = None
+                              EqualsRange = None }),
+                         { IsInstance = true
+                           IsDispatchSlot = true
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertyGet }, (5,8--5,23),
+                         { GetSetKeywords = None })], (4,4--6,7)), [], None,
+                  (3,5--6,7), { LeadingKeyword = Type (3,0--3,4)
+                                EqualsRange = Some (3,7--3,8)
+                                WithKeyword = None })], (3,0--6,7));
+           Expr (Const (Int32 1, (8,0--8,1)), (8,0--8,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/UnionCase/Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing type 01.fs
@@ -1,0 +1,5 @@
+module Module
+
+type U =
+    | A of i:
+    | B

--- a/tests/service/data/SyntaxTree/UnionCase/Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing type 01.fs.bsl
@@ -1,0 +1,39 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing type 01.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, Some i, FromParseError (4,13--4,13),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,13), { LeadingKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--5,5), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (B, None), Fields [],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,7), { BarRange = Some (5,4--5,5) })],
+                        (4,4--5,7)), (4,4--5,7)), [], None, (3,5--5,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,4)-(5,5) parse error Unexpected symbol '|' in union case

--- a/tests/service/data/SyntaxTree/UnionCase/Missing type 01.fsi
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing type 01.fsi
@@ -1,0 +1,5 @@
+module Module
+
+type U =
+    | A of i:
+    | B

--- a/tests/service/data/SyntaxTree/UnionCase/Missing type 01.fsi.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing type 01.fsi.bsl
@@ -1,0 +1,38 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/UnionCase/Missing type 01.fsi", QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, Some i, FromParseError (4,13--4,13),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,13), { LeadingKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--5,5), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (B, None), Fields [],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,7), { BarRange = Some (5,4--5,5) })],
+                        (4,4--5,7)), (4,4--5,7)), [], (3,5--5,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,7), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,4)-(5,5) parse error Unexpected symbol '|' in union case

--- a/tests/service/data/SyntaxTree/UnionCase/Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing type 02.fs
@@ -1,0 +1,7 @@
+module Module
+
+type U =
+    | A of i:
+
+    /// B
+    | B

--- a/tests/service/data/SyntaxTree/UnionCase/Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing type 02.fs.bsl
@@ -1,0 +1,39 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing type 02.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, Some i, FromParseError (4,13--4,13),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,13), { LeadingKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--7,5), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (B, None), Fields [],
+                            PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,4--7,7), { BarRange = Some (7,4--7,5) })],
+                        (4,4--7,7)), (4,4--7,7)), [], None, (3,5--7,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--7,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(7,4)-(7,5) parse error Unexpected symbol '|' in union case

--- a/tests/service/data/SyntaxTree/UnionCase/Missing type 02.fsi
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing type 02.fsi
@@ -1,0 +1,7 @@
+module Module
+
+type U =
+    | A of i:
+
+    /// B
+    | B

--- a/tests/service/data/SyntaxTree/UnionCase/Missing type 02.fsi.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing type 02.fsi.bsl
@@ -1,0 +1,38 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/UnionCase/Missing type 02.fsi", QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefnSig
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, Some i, FromParseError (4,13--4,13),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,13), { LeadingKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--7,5), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (B, None), Fields [],
+                            PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,4--7,7), { BarRange = Some (7,4--7,5) })],
+                        (4,4--7,7)), (4,4--7,7)), [], (3,5--7,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--7,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,7), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(7,4)-(7,5) parse error Unexpected symbol '|' in union case


### PR DESCRIPTION
Adds recovery for missing types in declarations:

```fsharp
type R =
    { F: }
```

```fsharp
type R =
    { F }
```

```fsharp
type U =
    | A of i:
```

```fsharp
type T =
    val x:
```

```fsharp
type T() =
    inherit
```

```fsharp
type T() =
    interface
```

```fsharp
type T() =
    member val P: = 1
```

It also disallows interface declaration members to be at the same indentation when the new indentation rules are enabled:
```fsharp
type I =
    interface
    abstract P: int
    end
```
and requires at least one additional space:
```fsharp
type I =
    interface
        abstract P: int
    end
```

It's needed for recovery of unfinished interface members:
```fsharp
type T() =
    interface // unfinished
    member this.P = 1 // was incorrectly parsed as an interface member
```