### PR TITLE
VS: Restore the small link tooltip

### DIFF
--- a/vsintegration/src/FSharp.Editor/QuickInfo/WpfFactories.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/WpfFactories.fs
@@ -52,7 +52,7 @@ type WpfClassifiedTextElementFactory [<ImportingConstructor>]
                     match run.NavigationAction |> Option.ofObj with
                     | Some action ->
                         let link =
-                            { new Documents.Hyperlink(inl) with
+                            { new Documents.Hyperlink(inl, ToolTip = run.Tooltip) with
                                 override _.OnClick() = action.Invoke()
                             }
 


### PR DESCRIPTION
I forgot to add this back in #14995:

![image](https://user-images.githubusercontent.com/1760221/230452438-f40c6e80-f5d0-4cf7-a630-6386a142d83a.png)
