### PR TITLE
Parser: recover on missing types in patterns

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -3020,6 +3020,11 @@ simplePattern:
   | simplePattern COLON typeWithTypeConstraints
       { SynPat.Typed($1, $3, lhs parseState) }
 
+  | simplePattern COLON recover
+      { let mColon = rhs parseState 2
+        let ty = SynType.FromParseError(mColon.EndRange)
+        SynPat.Typed($1, ty, unionRanges $1.Range mColon) }
+
   | attributes simplePattern %prec paren_pat_attribs
       { SynPat.Attrib($2, $1, lhs parseState) }
 
@@ -3341,9 +3346,14 @@ parenPattern:
   | conjParenPatternElements
       { SynPat.Ands(List.rev $1, rhs2 parseState 1 3) }
 
-  | parenPattern COLON  typeWithTypeConstraints %prec paren_pat_colon
-      { let mLhs = lhs parseState 
-        SynPat.Typed($1, $3, mLhs) } 
+  | parenPattern COLON typeWithTypeConstraints %prec paren_pat_colon
+      { let mLhs = lhs parseState
+        SynPat.Typed($1, $3, mLhs) }
+
+  | parenPattern COLON recover
+      { let mColon = rhs parseState 2
+        let ty = SynType.FromParseError(mColon.EndRange)
+        SynPat.Typed($1, ty, unionRanges $1.Range mColon) }
 
   | attributes parenPattern  %prec paren_pat_attribs
       { let mLhs = lhs parseState 
@@ -5094,15 +5104,20 @@ topTypeWithTypeConstraints:
        // nb. it doesn't matter where the constraints go in the structure of the type. 
        SynType.WithGlobalConstraints(ty, List.rev $3, lhs parseState), arity }
 
-opt_topReturnTypeWithTypeConstraints: 
-  |             
-     { None } 
+opt_topReturnTypeWithTypeConstraints:
+  |
+      { None }
 
-  | COLON topTypeWithTypeConstraints 
-     { let mColon = rhs parseState 1
-       let ty, arity = $2 
-       let arity = (match arity with SynValInfo([], rmdata)-> rmdata | _ -> SynInfo.unnamedRetVal)
-       Some (Some mColon, SynReturnInfo((ty, arity), rhs parseState 2)) }
+  | COLON topTypeWithTypeConstraints
+      { let mColon = rhs parseState 1
+        let ty, arity = $2
+        let arity = (match arity with SynValInfo([], rmdata)-> rmdata | _ -> SynInfo.unnamedRetVal)
+        Some (Some mColon, SynReturnInfo((ty, arity), rhs parseState 2)) }
+
+  | COLON recover
+      { let mColon = rhs parseState 1
+        let ty, arity = SynType.FromParseError(mColon.EndRange), SynInfo.unnamedRetVal
+        Some (Some mColon, SynReturnInfo((ty, arity), mColon.EndRange)) }
 
 topType: 
   | topTupleType RARROW topType 
@@ -5136,31 +5151,61 @@ topTupleTypeElements:
        [ SynTupleTypeSegment.Type t, Some argInfo ] }
 
 topAppType:
-  | attributes appType COLON appType 
-     { match $2 with 
-       | SynType.LongIdent(SynLongIdent([id], _, _)) -> 
-           let m = rhs2 parseState 1 4
-           SynType.SignatureParameter($1, false, Some id, $4, m), SynArgInfo($1, false, Some id)
-       | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType())  }
+  | attributes appType COLON appType
+      { match $2 with
+        | SynType.LongIdent(SynLongIdent([id], _, _)) ->
+            let m = unionRanges (rhs parseState 1) $4.Range
+            SynType.SignatureParameter($1, false, Some id, $4, m), SynArgInfo($1, false, Some id)
+        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType()) }
 
-  | attributes QMARK ident COLON appType 
-     { let m = rhs2 parseState 1 5
-       SynType.SignatureParameter($1, true, Some $3, $5, m), SynArgInfo($1, true, Some $3) }
+  | attributes appType COLON recover
+      { match $2 with
+        | SynType.LongIdent(SynLongIdent([id], _, _)) ->
+            let mColon = rhs parseState 2
+            let m = unionRanges (rhs parseState 1) mColon
+            let ty = SynType.FromParseError(mColon.EndRange)
+            SynType.SignatureParameter($1, false, Some id, ty, m), SynArgInfo($1, false, Some id)
+        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType()) }
 
-  | attributes appType 
-     { let m = rhs2 parseState 1 2
-       SynType.SignatureParameter($1, false, None, $2, m), SynArgInfo($1, false, None) }
+  | attributes QMARK ident COLON appType
+      { let m = unionRanges (rhs parseState 1) $5.Range
+        SynType.SignatureParameter($1, true, Some $3, $5, m), SynArgInfo($1, true, Some $3) }
 
-  | appType COLON appType 
-     { match $1 with 
-       | SynType.LongIdent(SynLongIdent([id], _, _)) -> 
-           let m = rhs2 parseState 1 3
-           SynType.SignatureParameter([], false, Some id, $3, m), SynArgInfo([], false, Some id)
-       | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType())  }
+  | attributes QMARK ident COLON recover
+      { let mColon = rhs parseState 4
+        let m = unionRanges (rhs parseState 1) mColon
+        let ty = SynType.FromParseError(mColon.EndRange)
+        SynType.SignatureParameter($1, true, Some $3, ty, m), SynArgInfo($1, true, Some $3) }
 
-  | QMARK ident COLON appType 
-     { let m = rhs2 parseState 1 4
-       SynType.SignatureParameter([], true, Some $2, $4, m), SynArgInfo([], true, Some $2) }
+  | attributes appType
+      { let m = unionRanges (rhs parseState 1) $2.Range
+        SynType.SignatureParameter($1, false, None, $2, m), SynArgInfo($1, false, None) }
+
+  | appType COLON appType
+      { match $1 with
+        | SynType.LongIdent(SynLongIdent([id], _, _)) ->
+            let m = unionRanges (rhs parseState 1) $3.Range
+            SynType.SignatureParameter([], false, Some id, $3, m), SynArgInfo([], false, Some id)
+        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType()) }
+
+  | appType COLON recover
+      { match $1 with
+        | SynType.LongIdent(SynLongIdent([id], _, _)) ->
+            let mColon = rhs parseState 2
+            let m = unionRanges $1.Range mColon
+            let ty = SynType.FromParseError(mColon.EndRange)
+            SynType.SignatureParameter([], false, Some id, ty, m), SynArgInfo([], false, Some id)
+        | _ -> raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsSyntaxErrorInLabeledType()) }
+
+  | QMARK ident COLON appType
+      { let m = unionRanges (rhs parseState 1) $4.Range
+        SynType.SignatureParameter([], true, Some $2, $4, m), SynArgInfo([], true, Some $2) }
+
+  | QMARK ident COLON recover
+      { let mColon = rhs parseState 3
+        let m = unionRanges (rhs parseState 1) mColon
+        let ty = SynType.FromParseError(mColon.EndRange)
+        SynType.SignatureParameter([], true, Some $2, ty, m), SynArgInfo([], true, Some $2) }
 
   | appType 
      { $1, SynArgInfo([], false, None) }

--- a/tests/fsharpqa/Source/Diagnostics/NONTERM/tuplewithlazy01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/NONTERM/tuplewithlazy01.fs
@@ -1,8 +1,8 @@
 // #Regression #Diagnostics 
 // Regression test for DevDiv:64339
 // Note that the bug still repros in CHK/DBG bits - we will knownfail it
-//<Expects status="error" span="(10,25-10,29)" id="FS0010">Unexpected keyword 'lazy' in type definition$</Expects>
-//<Expects status="error" span="(13,29-13,33)" id="FS0010">Unexpected keyword 'lazy'$</Expects>
+//<Expects status="error" span="(10,24-10,28)" id="FS0010">Unexpected keyword 'lazy' in type definition$</Expects>
+//<Expects status="error" span="(13,28-13,32)" id="FS0010">Unexpected keyword 'lazy'$</Expects>
 
 // 5 elements -> ok
 type Ok(a, b, c, d, e : lazy<int>) = class end

--- a/tests/fsharpqa/Source/Diagnostics/NONTERM/tuplewithlazy01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/NONTERM/tuplewithlazy01.fs
@@ -2,9 +2,7 @@
 // Regression test for DevDiv:64339
 // Note that the bug still repros in CHK/DBG bits - we will knownfail it
 //<Expects status="error" span="(10,25-10,29)" id="FS0010">Unexpected keyword 'lazy' in type definition$</Expects>
-//<Expects status="error" span="(10,8-10,9)" id="FS0583">Unmatched '\('$</Expects>
 //<Expects status="error" span="(13,29-13,33)" id="FS0010">Unexpected keyword 'lazy'$</Expects>
-//<Expects status="error" span="(13,9-13,10)" id="FS0583">Unmatched '\('$</Expects>
 
 // 5 elements -> ok
 type Ok(a, b, c, d, e : lazy<int>) = class end

--- a/tests/fsharpqa/Source/Diagnostics/NONTERM/tuplewithlazy01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/NONTERM/tuplewithlazy01.fs
@@ -1,8 +1,8 @@
 // #Regression #Diagnostics 
 // Regression test for DevDiv:64339
 // Note that the bug still repros in CHK/DBG bits - we will knownfail it
-//<Expects status="error" span="(10,24-10,28)" id="FS0010">Unexpected keyword 'lazy' in type definition$</Expects>
-//<Expects status="error" span="(13,28-13,32)" id="FS0010">Unexpected keyword 'lazy'$</Expects>
+//<Expects status="error" span="(8,25-8,29)" id="FS0010">Unexpected keyword 'lazy' in type definition$</Expects>
+//<Expects status="error" span="(11,29-11,33)" id="FS0010">Unexpected keyword 'lazy'$</Expects>
 
 // 5 elements -> ok
 type Ok(a, b, c, d, e : lazy<int>) = class end

--- a/tests/service/data/SyntaxTree/Lambda/Param - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Lambda/Param - Missing type 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+(fun i:)

--- a/tests/service/data/SyntaxTree/Lambda/Param - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/Param - Missing type 01.fs.bsl
@@ -1,0 +1,26 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Lambda/Param - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (FromParseError
+                   (Lambda
+                      (false, false,
+                       SimplePats
+                         ([Id (i, None, false, false, false, (3,5--3,6))],
+                          (3,5--3,6)),
+                       ArbitraryAfterError ("anonLambdaExpr4", (3,6--3,6)),
+                       Some
+                         ([Named (SynIdent (i, None), false, None, (3,5--3,6))],
+                          ArbitraryAfterError ("anonLambdaExpr4", (3,6--3,6))),
+                       (3,1--3,6), { ArrowRange = None }), (3,1--3,6)),
+                 (3,0--3,1), Some (3,7--3,8), (3,0--3,8)), (3,0--3,8))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,8), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,6)-(3,7) parse error Unexpected symbol ':' in lambda expression. Expected '->' or other token.

--- a/tests/service/data/SyntaxTree/Lambda/Param - Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/Lambda/Param - Missing type 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+(fun i: -> ())

--- a/tests/service/data/SyntaxTree/Lambda/Param - Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/Param - Missing type 02.fs.bsl
@@ -1,0 +1,26 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Lambda/Param - Missing type 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (FromParseError
+                   (Lambda
+                      (false, false,
+                       SimplePats
+                         ([Id (i, None, false, false, false, (3,5--3,6))],
+                          (3,5--3,6)),
+                       ArbitraryAfterError ("anonLambdaExpr4", (3,6--3,6)),
+                       Some
+                         ([Named (SynIdent (i, None), false, None, (3,5--3,6))],
+                          ArbitraryAfterError ("anonLambdaExpr4", (3,6--3,6))),
+                       (3,1--3,6), { ArrowRange = None }), (3,1--3,6)),
+                 (3,0--3,1), Some (3,13--3,14), (3,0--3,14)), (3,0--3,14))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,14), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,6)-(3,7) parse error Unexpected symbol ':' in lambda expression. Expected '->' or other token.

--- a/tests/service/data/SyntaxTree/Lambda/Param - Missing type 03.fs
+++ b/tests/service/data/SyntaxTree/Lambda/Param - Missing type 03.fs
@@ -1,0 +1,3 @@
+module Module
+
+(fun (i:) -> ())

--- a/tests/service/data/SyntaxTree/Lambda/Param - Missing type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/Param - Missing type 03.fs.bsl
@@ -1,0 +1,30 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Lambda/Param - Missing type 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Lambda
+                   (false, false,
+                    SimplePats
+                      ([Typed
+                          (Id (i, None, false, false, false, (3,6--3,7)),
+                           FromParseError (3,8--3,8), (3,6--3,8))], (3,5--3,9)),
+                    Const (Unit, (3,13--3,15)),
+                    Some
+                      ([Paren
+                          (Typed
+                             (Named
+                                (SynIdent (i, None), false, None, (3,6--3,7)),
+                              FromParseError (3,8--3,8), (3,6--3,8)), (3,5--3,9))],
+                       Const (Unit, (3,13--3,15))), (3,1--3,15),
+                    { ArrowRange = Some (3,10--3,12) }), (3,0--3,1),
+                 Some (3,15--3,16), (3,0--3,16)), (3,0--3,16))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,16), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,8)-(3,9) parse error Unexpected symbol ')' in pattern

--- a/tests/service/data/SyntaxTree/Lambda/Param - Missing type 04.fs
+++ b/tests/service/data/SyntaxTree/Lambda/Param - Missing type 04.fs
@@ -1,0 +1,3 @@
+module Module
+
+(fun (i:, j) -> ())

--- a/tests/service/data/SyntaxTree/Lambda/Param - Missing type 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Lambda/Param - Missing type 04.fs.bsl
@@ -1,0 +1,36 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Lambda/Param - Missing type 04.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Lambda
+                   (false, false,
+                    SimplePats
+                      ([Typed
+                          (Id (i, None, false, false, false, (3,6--3,7)),
+                           FromParseError (3,8--3,8), (3,6--3,8));
+                        Id (j, None, false, false, false, (3,10--3,11))],
+                       (3,5--3,12)), Const (Unit, (3,16--3,18)),
+                    Some
+                      ([Paren
+                          (Tuple
+                             (false,
+                              [Typed
+                                 (Named
+                                    (SynIdent (i, None), false, None, (3,6--3,7)),
+                                  FromParseError (3,8--3,8), (3,6--3,8));
+                               Named
+                                 (SynIdent (j, None), false, None, (3,10--3,11))],
+                              (3,6--3,11)), (3,5--3,12))],
+                       Const (Unit, (3,16--3,18))), (3,1--3,18),
+                    { ArrowRange = Some (3,13--3,15) }), (3,0--3,1),
+                 Some (3,18--3,19), (3,0--3,19)), (3,0--3,19))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,19), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,8)-(3,9) parse error Unexpected symbol ',' in pattern

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Missing type 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i:) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Missing type 01.fs.bsl
@@ -1,0 +1,42 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                FromParseError (3,9--3,9), (3,7--3,9))],
+                            (3,6--3,10)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,13--3,22)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               FromParseError (3,9--3,9), (3,7--3,9))],
+                           (3,6--3,10)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,11--3,12)
+                    WithKeyword = None })], (3,0--3,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,9)-(3,10) parse error Unexpected symbol ')' in type definition

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Missing type 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i:, j) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Missing type 02.fs.bsl
@@ -1,0 +1,44 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Missing type 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                FromParseError (3,9--3,9), (3,7--3,9));
+                             Id (j, None, false, false, false, (3,11--3,12))],
+                            (3,6--3,13)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,16--3,25)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               FromParseError (3,9--3,9), (3,7--3,9));
+                            Id (j, None, false, false, false, (3,11--3,12))],
+                           (3,6--3,13)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,25),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,14--3,15)
+                    WithKeyword = None })], (3,0--3,25))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,25), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,9)-(3,10) parse error Unexpected symbol ',' in type definition

--- a/tests/service/data/SyntaxTree/Member/Member - Param - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Member - Param - Missing type 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    member this.M(i:) = ()

--- a/tests/service/data/SyntaxTree/Member/Member - Param - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member - Param - Missing type 01.fs.bsl
@@ -1,0 +1,56 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member - Param - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)];
+                                   [SynArgInfo ([], false, Some i)]],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; M], [(4,15--4,16)], [None; None]), None,
+                               None,
+                               Pats
+                                 [Paren
+                                    (Typed
+                                       (Named
+                                          (SynIdent (i, None), false, None,
+                                           (4,18--4,19)),
+                                        FromParseError (4,20--4,20),
+                                        (4,18--4,20)), (4,17--4,21))], None,
+                               (4,11--4,21)), None, Const (Unit, (4,24--4,26)),
+                            (4,11--4,21), NoneAtInvisible,
+                            { LeadingKeyword = Member (4,4--4,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,22--4,23) }), (4,4--4,26))],
+                     (4,4--4,26)), [], None, (3,5--4,26),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,26))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,26), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,20)-(4,21) parse error Unexpected symbol ')' in pattern

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 01.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 01.fs
@@ -1,0 +1,5 @@
+module Module
+
+let i:
+
+()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 01.fs.bsl
@@ -1,0 +1,32 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Named (SynIdent (i, None), false, None, (3,4--3,5)),
+                  Some
+                    (SynBindingReturnInfo
+                       (FromParseError (3,6--3,6), (3,6--3,6), [],
+                        { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (ArbitraryAfterError ("localBinding2", (5,1--5,1)),
+                     FromParseError (3,6--3,6), (5,1--5,1)), (3,4--3,5),
+                  Yes (3,0--5,1), { LeadingKeyword = Let (3,0--3,3)
+                                    InlineKeyword = None
+                                    EqualsRange = None })], (3,0--5,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,1) parse error Incomplete structured construct at or before this point in binding
+(6,0)-(6,0) parse error Unexpected end of input in value, function or member definition
+(3,0)-(3,3) parse error Incomplete value or function definition. If this is in an expression, the body of the expression must be indented to the same column as the 'let' keyword.

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 02.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 02.fs
@@ -1,0 +1,5 @@
+module Module
+
+let i: = 1
+
+()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 02.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Named (SynIdent (i, None), false, None, (3,4--3,5)),
+                  Some
+                    (SynBindingReturnInfo
+                       (FromParseError (3,6--3,6), (3,6--3,6), [],
+                        { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Int32 1, (3,9--3,10)), FromParseError (3,6--3,6),
+                     (3,9--3,10)), (3,4--3,5), Yes (3,0--3,10),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,7--3,8) })], (3,0--3,10));
+           Expr (Const (Unit, (5,0--5,2)), (5,0--5,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,7)-(3,8) parse error Unexpected symbol '=' in binding

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 03.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 03.fs
@@ -1,0 +1,3 @@
+module Module
+
+let ((i:) as _) = ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 03.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Paren
+                    (As
+                       (Paren
+                          (Typed
+                             (Named
+                                (SynIdent (i, None), false, None, (3,6--3,7)),
+                              FromParseError (3,8--3,8), (3,6--3,8)), (3,5--3,9)),
+                        Wild (3,13--3,14), (3,5--3,14)), (3,4--3,15)), None,
+                  Const (Unit, (3,18--3,20)), (3,4--3,15), Yes (3,0--3,20),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,16--3,17) })], (3,0--3,20))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,20), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,8)-(3,9) parse error Unexpected symbol ')' in pattern

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 04.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 04.fs
@@ -1,0 +1,3 @@
+module Module
+
+let (i: as _) = ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 04.fs.bsl
@@ -1,0 +1,29 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 04.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Paren
+                    (As
+                       (Typed
+                          (Named (SynIdent (i, None), false, None, (3,5--3,6)),
+                           FromParseError (3,7--3,7), (3,5--3,7)),
+                        Wild (3,11--3,12), (3,5--3,12)), (3,4--3,13)), None,
+                  Const (Unit, (3,16--3,18)), (3,4--3,13), Yes (3,0--3,18),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,14--3,15) })], (3,0--3,18))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,18), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,8)-(3,10) parse error Unexpected keyword 'as' in pattern

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 05.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 05.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    let i:
+
+    ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 05.fs.bsl
@@ -1,0 +1,43 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 05.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (FromParseError
+                   (LetOrUse
+                      (false, false,
+                       [SynBinding
+                          (None, Normal, false, false, [],
+                           PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                           SynValData
+                             (None,
+                              SynValInfo ([], SynArgInfo ([], false, None)),
+                              None),
+                           Named (SynIdent (i, None), false, None, (4,8--4,9)),
+                           Some
+                             (SynBindingReturnInfo
+                                (FromParseError (4,10--4,10), (4,10--4,10), [],
+                                 { ColonRange = Some (4,9--4,10) })),
+                           Typed
+                             (ArbitraryAfterError ("localBinding2", (6,5--6,5)),
+                              FromParseError (4,10--4,10), (6,5--6,5)),
+                           (4,8--4,9), Yes (4,4--6,5),
+                           { LeadingKeyword = Let (4,4--4,7)
+                             InlineKeyword = None
+                             EqualsRange = None })],
+                       ArbitraryAfterError ("seqExpr", (6,5--6,5)), (4,4--6,5),
+                       { InKeyword = None }), (4,4--6,5)), (3,0--6,5)),
+              (3,0--6,5))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,5), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,5) parse error Incomplete structured construct at or before this point in binding
+(7,0)-(7,0) parse error Unexpected end of input in value, function or member definition
+(4,4)-(4,7) parse error Incomplete value or function definition. If this is in an expression, the body of the expression must be indented to the same column as the 'let' keyword.
+(4,4)-(4,7) parse error The block following this 'let' is unfinished. Every code block is an expression and must have a result. 'let' cannot be the final code element in a block. Consider giving this block an explicit result.
+(7,0)-(7,0) parse error Unexpected end of input in expression

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 06.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 06.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    let i: = 1
+    
+    ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 06.fs.bsl
@@ -1,0 +1,36 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 06.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (LetOrUse
+                   (false, false,
+                    [SynBinding
+                       (None, Normal, false, false, [],
+                        PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                        SynValData
+                          (None, SynValInfo ([], SynArgInfo ([], false, None)),
+                           None),
+                        Named (SynIdent (i, None), false, None, (4,8--4,9)),
+                        Some
+                          (SynBindingReturnInfo
+                             (FromParseError (4,10--4,10), (4,10--4,10), [],
+                              { ColonRange = Some (4,9--4,10) })),
+                        Typed
+                          (Const (Int32 1, (4,13--4,14)),
+                           FromParseError (4,10--4,10), (4,13--4,14)),
+                        (4,8--4,9), Yes (4,4--4,14),
+                        { LeadingKeyword = Let (4,4--4,7)
+                          InlineKeyword = None
+                          EqualsRange = Some (4,11--4,12) })],
+                    Const (Unit, (6,4--6,6)), (4,4--6,6), { InKeyword = None }),
+                 (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,11)-(4,12) parse error Unexpected symbol '=' in binding

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 07.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 07.fs
@@ -1,0 +1,4 @@
+module Module
+
+match () with
+| i:

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 07.fs.bsl
@@ -1,0 +1,25 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 07.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Typed
+                       (Named (SynIdent (i, None), false, None, (4,2--4,3)),
+                        FromParseError (4,4--4,4), (4,2--4,4)), None,
+                     ArbitraryAfterError ("patternClauses2", (4,4--4,4)),
+                     (4,2--4,4), Yes, { ArrowRange = None
+                                        BarRange = Some (4,0--4,1) })],
+                 (3,0--4,4), { MatchKeyword = (3,0--3,5)
+                               WithKeyword = (3,9--3,13) }), (3,0--4,4))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,4), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in pattern
+(3,9)-(3,13) parse error Unexpected end of input in 'match' or 'try' expression

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 08.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 08.fs
@@ -1,0 +1,4 @@
+module Module
+
+match () with
+| i: -> ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 08.fs.bsl
@@ -1,0 +1,24 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 08.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Typed
+                       (Named (SynIdent (i, None), false, None, (4,2--4,3)),
+                        FromParseError (4,4--4,4), (4,2--4,4)), None,
+                     Const (Unit, (4,8--4,10)), (4,2--4,10), Yes,
+                     { ArrowRange = Some (4,5--4,7)
+                       BarRange = Some (4,0--4,1) })], (3,0--4,10),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--4,10))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,10), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,5)-(4,7) parse error Unexpected symbol '->' in pattern

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 09.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 09.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    let (i:)
+
+    ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 09.fs.bsl
@@ -1,0 +1,35 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 09.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (LetOrUse
+                   (false, false,
+                    [SynBinding
+                       (None, Normal, false, false, [],
+                        PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                        SynValData
+                          (None, SynValInfo ([], SynArgInfo ([], false, None)),
+                           None),
+                        Paren
+                          (Typed
+                             (Named
+                                (SynIdent (i, None), false, None, (4,9--4,10)),
+                              FromParseError (4,11--4,11), (4,9--4,11)),
+                           (4,8--4,12)), None,
+                        ArbitraryAfterError ("localBinding2", (4,12--4,12)),
+                        (4,8--4,12), Yes (4,4--4,12),
+                        { LeadingKeyword = Let (4,4--4,7)
+                          InlineKeyword = None
+                          EqualsRange = None })], Const (Unit, (6,4--6,6)),
+                    (4,4--6,6), { InKeyword = None }), (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,11)-(4,12) parse error Unexpected symbol ')' in pattern
+(6,4)-(6,5) parse error Incomplete structured construct at or before this point in binding. Expected '=' or other token.

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 10.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 10.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    let (i:) = 1
+
+    ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 10.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 10.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 10.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (LetOrUse
+                   (false, false,
+                    [SynBinding
+                       (None, Normal, false, false, [],
+                        PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                        SynValData
+                          (None, SynValInfo ([], SynArgInfo ([], false, None)),
+                           None),
+                        Paren
+                          (Typed
+                             (Named
+                                (SynIdent (i, None), false, None, (4,9--4,10)),
+                              FromParseError (4,11--4,11), (4,9--4,11)),
+                           (4,8--4,12)), None, Const (Int32 1, (4,15--4,16)),
+                        (4,8--4,12), Yes (4,4--4,16),
+                        { LeadingKeyword = Let (4,4--4,7)
+                          InlineKeyword = None
+                          EqualsRange = Some (4,13--4,14) })],
+                    Const (Unit, (6,4--6,6)), (4,4--6,6), { InKeyword = None }),
+                 (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,11)-(4,12) parse error Unexpected symbol ')' in pattern

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 11.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 11.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    let f (i:) = 1
+
+    ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 11.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 11.fs.bsl
@@ -1,0 +1,40 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 11.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (LetOrUse
+                   (false, false,
+                    [SynBinding
+                       (None, Normal, false, false, [],
+                        PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                        SynValData
+                          (None,
+                           SynValInfo
+                             ([[SynArgInfo ([], false, Some i)]],
+                              SynArgInfo ([], false, None)), None),
+                        LongIdent
+                          (SynLongIdent ([f], [], [None]), None, None,
+                           Pats
+                             [Paren
+                                (Typed
+                                   (Named
+                                      (SynIdent (i, None), false, None,
+                                       (4,11--4,12)),
+                                    FromParseError (4,13--4,13), (4,11--4,13)),
+                                 (4,10--4,14))], None, (4,8--4,14)), None,
+                        Const (Int32 1, (4,17--4,18)), (4,8--4,14), NoneAtLet,
+                        { LeadingKeyword = Let (4,4--4,7)
+                          InlineKeyword = None
+                          EqualsRange = Some (4,15--4,16) })],
+                    Const (Unit, (6,4--6,6)), (4,4--6,6), { InKeyword = None }),
+                 (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,13)-(4,14) parse error Unexpected symbol ')' in pattern

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 12.fs
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 12.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    let f (i:, j) = 1
+
+    ()

--- a/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 12.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Typed - Missing type 12.fs.bsl
@@ -1,0 +1,47 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/Typed - Missing type 12.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (LetOrUse
+                   (false, false,
+                    [SynBinding
+                       (None, Normal, false, false, [],
+                        PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                        SynValData
+                          (None,
+                           SynValInfo
+                             ([[SynArgInfo ([], false, Some i);
+                                SynArgInfo ([], false, Some j)]],
+                              SynArgInfo ([], false, None)), None),
+                        LongIdent
+                          (SynLongIdent ([f], [], [None]), None, None,
+                           Pats
+                             [Paren
+                                (Tuple
+                                   (false,
+                                    [Typed
+                                       (Named
+                                          (SynIdent (i, None), false, None,
+                                           (4,11--4,12)),
+                                        FromParseError (4,13--4,13),
+                                        (4,11--4,13));
+                                     Named
+                                       (SynIdent (j, None), false, None,
+                                        (4,15--4,16))], (4,11--4,16)),
+                                 (4,10--4,17))], None, (4,8--4,17)), None,
+                        Const (Int32 1, (4,20--4,21)), (4,8--4,17), NoneAtLet,
+                        { LeadingKeyword = Let (4,4--4,7)
+                          InlineKeyword = None
+                          EqualsRange = Some (4,18--4,19) })],
+                    Const (Unit, (6,4--6,6)), (4,4--6,6), { InKeyword = None }),
+                 (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,13)-(4,14) parse error Unexpected symbol ',' in pattern


### PR DESCRIPTION
Adds recovery for various cases where a type is missing in a pattern, like these:
```fsharp
let i: = 1
```

```fsharp
let (i:) = 1
```

```fsharp
let f (i:) = 1
```

```fsharp
type T(i:) = class end
```

```fsharp
type T =
    member this.M(i:) = 1
```

```fsharp
fun (i:) -> ()
```