### PR TITLE
Parser: recover on missing union case names or representations

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -558,7 +558,10 @@ module TcRecdUnionAndEnumDeclarations =
         Construct.NewUnionCase id rfields recordTy attrs xmlDoc vis
 
     let TcUnionCaseDecls (cenv: cenv) env (parent: ParentRef) (thisTy: TType) (thisTyInst: TypeInst) hasRQAAttribute tpenv unionCases =
-        let unionCasesR = unionCases |> List.map (TcUnionCaseDecl cenv env parent thisTy thisTyInst tpenv hasRQAAttribute) 
+        let unionCasesR =
+            unionCases
+            |> List.filter (fun (SynUnionCase(_, SynIdent(id, _), _, _, _, _, _)) -> id.idText <> "")
+            |> List.map (TcUnionCaseDecl cenv env parent thisTy thisTyInst tpenv hasRQAAttribute) 
         unionCasesR |> CheckDuplicates (fun uc -> uc.Id) "union case" 
 
     let MakeEnumCaseSpec cenv env parent attrs thisTy caseRange (caseIdent: Ident) (xmldoc: PreXmlDoc) value =

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1685,4 +1685,5 @@ featureEscapeBracesInFormattableString,"Escapes curly braces before calling Form
 3561,chkAutoOpenAttributeInTypeAbbrev,"FSharp.Core.AutoOpenAttribute should not be aliased."
 3562,parsUnexpectedEndOfFileElif,"Unexpected end of input in 'else if' or 'elif' branch of conditional expression. Expected 'elif <expr> then <expr>' or 'else if <expr> then <expr>'."
 3563,lexInvalidIdentifier,"This is not a valid identifier"
+3564,parsMissingUnionCaseName,"Missing union case name"
 3565,parsExpectingType,"Expecting type"

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2407,13 +2407,25 @@ attrUnionCaseDecl:
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
         let mOf = rhs parseState 3
         let mId = mOf.StartRange
-        errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mId))
+        errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mOf))
         let mDecl = rhs2 parseState 1 4
         (fun (xmlDoc, mBar) ->
             let id = SynIdent(mkSynId mId "", None)
             let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
-            Choice2Of2 (SynUnionCase ( $1, id, SynUnionCaseKind.Fields $4, xmlDoc, None, mDecl, trivia))) }
+            Choice2Of2(SynUnionCase($1, id, SynUnionCaseKind.Fields $4, xmlDoc, None, mDecl, trivia))) }
+
+  | opt_attributes opt_access OF recover
+      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
+        let mOf = rhs parseState 3
+        let mId = mOf.StartRange
+        errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mOf))
+        let mDecl = rhs2 parseState 1 3
+        (fun (xmlDoc, mBar) ->
+            let id = SynIdent(mkSynId mId "", None)
+            let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
+            let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
+            Choice2Of2(SynUnionCase($1, id, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
 
   | opt_attributes opt_access unionCaseName OF recover
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
@@ -2489,7 +2501,7 @@ firstUnionCaseDecl:
   | OF unionCaseRepr
      { let mOf = rhs parseState 1
        let mId = mOf.StartRange
-       errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mId))
+       errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mOf))
        let id = SynIdent(mkSynId mId "", None)
        let trivia: SynUnionCaseTrivia = { BarRange = None }
        let xmlDoc = grabXmlDoc (parseState, [], 1)

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2387,6 +2387,14 @@ attrUnionCaseDecl:
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
             Choice2Of2 (SynUnionCase ( $1, $3, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
 
+  | opt_attributes opt_access recover
+      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
+        (fun (xmlDoc, mBar) ->
+            let id = SynIdent(mkSynId mBar.EndRange "", None)
+            let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
+            let mDecl = unionRangeWithXmlDoc xmlDoc mBar
+            Choice2Of2 (SynUnionCase ( $1, id, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
+
   | opt_attributes opt_access unionCaseName OF unionCaseRepr
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
         let mDecl = rhs2 parseState 1 5
@@ -2394,6 +2402,16 @@ attrUnionCaseDecl:
             let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
             Choice2Of2 (SynUnionCase ( $1, $3, SynUnionCaseKind.Fields $5, xmlDoc, None, mDecl, trivia))) }
+
+  | opt_attributes opt_access recover OF unionCaseRepr
+      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
+        let mDecl = rhs2 parseState 1 5
+        let mOf = rhs parseState 4
+        (fun (xmlDoc, mBar) ->
+            let id = SynIdent(mkSynId mOf.StartRange "", None)
+            let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
+            let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
+            Choice2Of2 (SynUnionCase ( $1, id, SynUnionCaseKind.Fields $5, xmlDoc, None, mDecl, trivia))) }
 
   | opt_attributes opt_access unionCaseName OF recover
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
@@ -2453,19 +2471,33 @@ firstUnionCaseDeclOfMany:
   | firstUnionCaseDecl opt_OBLOCKSEP
       { $1 }
 
-firstUnionCaseDecl: 
-  | ident OF unionCaseRepr  
-     { let trivia: SynUnionCaseTrivia = { BarRange = None }
-       let xmlDoc = grabXmlDoc(parseState, [], 1)
-       let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-       Choice2Of2 (SynUnionCase ( [], SynIdent($1, None), SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
+firstUnionCaseDecl:
+  | ident OF unionCaseRepr
+      { let trivia: SynUnionCaseTrivia = { BarRange = None }
+        let xmlDoc = grabXmlDoc (parseState, [], 1)
+        let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
+        Choice2Of2(SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
+
+  | ident OF recover
+      { let trivia: SynUnionCaseTrivia = { BarRange = None }
+        let xmlDoc = grabXmlDoc (parseState, [], 1)
+        let mDecl = rhs2 parseState 1 2 |> unionRangeWithXmlDoc xmlDoc
+        Choice2Of2(SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia)) }
+
+  | recover OF unionCaseRepr
+     { let mOf = rhs parseState 2
+       let id = SynIdent(mkSynId mOf.StartRange "", None)
+       let trivia: SynUnionCaseTrivia = { BarRange = None }
+       let xmlDoc = grabXmlDoc (parseState, [], 1)
+       let mDecl = rhs2 parseState 2 3 |> unionRangeWithXmlDoc xmlDoc
+       Choice2Of2(SynUnionCase([], id, SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
 
   | ident EQUALS atomicExpr opt_OBLOCKSEP
       { let mEquals = rhs parseState 2
         let trivia: SynEnumCaseTrivia = { BarRange = None; EqualsRange = mEquals }
-        let xmlDoc = grabXmlDoc(parseState, [], 1)
+        let xmlDoc = grabXmlDoc (parseState, [], 1)
         let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-        Choice1Of2 (SynEnumCase ([], SynIdent($1, None), fst $3, xmlDoc, mDecl, trivia))  }
+        Choice1Of2(SynEnumCase([], SynIdent($1, None), fst $3, xmlDoc, mDecl, trivia)) }
 
 unionCaseReprElements:
   | unionCaseReprElement STAR unionCaseReprElements

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2403,15 +2403,17 @@ attrUnionCaseDecl:
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
             Choice2Of2 (SynUnionCase ( $1, $3, SynUnionCaseKind.Fields $5, xmlDoc, None, mDecl, trivia))) }
 
-  | opt_attributes opt_access recover OF unionCaseRepr
+  | opt_attributes opt_access OF unionCaseRepr
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
-        let mDecl = rhs2 parseState 1 5
-        let mOf = rhs parseState 4
+        let mOf = rhs parseState 3
+        let mId = mOf.StartRange
+        errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mId))
+        let mDecl = rhs2 parseState 1 4
         (fun (xmlDoc, mBar) ->
-            let id = SynIdent(mkSynId mOf.StartRange "", None)
+            let id = SynIdent(mkSynId mId "", None)
             let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
-            Choice2Of2 (SynUnionCase ( $1, id, SynUnionCaseKind.Fields $5, xmlDoc, None, mDecl, trivia))) }
+            Choice2Of2 (SynUnionCase ( $1, id, SynUnionCaseKind.Fields $4, xmlDoc, None, mDecl, trivia))) }
 
   | opt_attributes opt_access unionCaseName OF recover
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
@@ -2484,13 +2486,15 @@ firstUnionCaseDecl:
         let mDecl = rhs2 parseState 1 2 |> unionRangeWithXmlDoc xmlDoc
         Choice2Of2(SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia)) }
 
-  | recover OF unionCaseRepr
-     { let mOf = rhs parseState 2
-       let id = SynIdent(mkSynId mOf.StartRange "", None)
+  | OF unionCaseRepr
+     { let mOf = rhs parseState 1
+       let mId = mOf.StartRange
+       errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mId))
+       let id = SynIdent(mkSynId mId "", None)
        let trivia: SynUnionCaseTrivia = { BarRange = None }
        let xmlDoc = grabXmlDoc (parseState, [], 1)
-       let mDecl = rhs2 parseState 2 3 |> unionRangeWithXmlDoc xmlDoc
-       Choice2Of2(SynUnionCase([], id, SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
+       let mDecl = rhs2 parseState 1 2 |> unionRangeWithXmlDoc xmlDoc
+       Choice2Of2(SynUnionCase([], id, SynUnionCaseKind.Fields $2, xmlDoc, None, mDecl, trivia)) }
 
   | ident EQUALS atomicExpr opt_OBLOCKSEP
       { let mEquals = rhs parseState 2

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Neúplný výraz operátoru (například^b) nebo volání kvalifikovaného typu (příklad: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">Tento přístup člena je nejednoznačný. Při vytváření objektu použijte závorky, např. (new SomeType(args)).MemberName'</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Unvollständiger Operatorausdruck (Beispiel: a^b) oder qualifizierter Typaufruf (Beispiel: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">Dieser Memberzugriff ist mehrdeutig. Setzen Sie Klammern um die Objekterstellung, z. B. "(new SomeType(args)). MemberName“</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Expresión de operador incompleta (ejemplo, a^b) o invocación de tipo calificada (ejemplo: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">Este acceso de miembro es ambiguo. Use paréntesis alrededor de la creación del objeto, por ejemplo, '(nuevo AlgúnTipo(args)).NombreMiembro'</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Expression d’opérateur incomplète (exemple a^b) ou appel de type qualifié (exemple : ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">L’accès à ce membre est ambigu. Utilisez des parenthèses autour de la création de l’objet, par exemple' (New SomeType (args)). MemberName</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Espressione operatore incompleta (ad esempio a^b) o chiamata di tipo qualificato (ad esempio: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">L'accesso ai membri è ambiguo. Utilizzare le parentesi intorno alla creazione oggetto, ad esempio “(New SomeType (args)). MemberName”</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -777,6 +777,11 @@
         <target state="translated">不完全な演算子式 (例 a^b) または修飾型の呼び出し (例: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">このメンバーへのアクセスはあいまいです。オブジェクト作成の前後にはかっこを使用してください。例: '(new SomeType(args)).MemberName'</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -777,6 +777,11 @@
         <target state="translated">불완전한 연산자 식(예: a^b) 또는 정규화된 형식 호출(예: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">이 구성원 액세스가 모호합니다. 개체 생성 주위에 괄호를 사용하세요. 예: '(새로운 SomeType(인수)).MemberName'</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Niekompletne wyrażenie operatora (na przykład a^b) lub wywołanie typu kwalifikowanego (przykład: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">Dostęp tego elementu członkowskiego jest niejednoznaczny. W celu utworzenia obiektu użyj nawiasów, na przykład „(nowy SomeType(args)).MemberName”</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Expressão de operador incompleta (exemplo a^b) ou invocação de tipo qualificado (exemplo: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">Este acesso de membro é ambíguo. Use parênteses em torno da criação do objeto, por exemplo, '(new SomeType(args)).MemberName''.</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Неполное выражение оператора (например, a^b) или вызов квалифицированного типа (например, ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">Неоднозначный доступ к этому элементу. Заключите операцию создания объекта в круглые скобки, например (new Объект(аргументы)).Элемент</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -777,6 +777,11 @@
         <target state="translated">Eksik işleç ifadesi (örnek a^b) veya tam tür çağrısı (örnek: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">Bu üye erişimi belirsiz. Lütfen nesne oluşturma etrafında parantez kullanın, örneğin '(yeni SomeType (args)).MemberName’</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -777,6 +777,11 @@
         <target state="translated">运算符表达式不完整(示例: a^b)或限定类型调用(示例: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">此成员访问权限不明确。请在对象创建周围使用括号，例如 “(new SomeType(args)).MemberName”</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -777,6 +777,11 @@
         <target state="translated">不完整的運算子運算式 (範例 a^b) 或限定類型調用 (範例: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingUnionCaseName">
+        <source>Missing union case name</source>
+        <target state="new">Missing union case name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsNewExprMemberAccess">
         <source>This member access is ambiguous. Please use parentheses around the object creation, e.g. '(new SomeType(args)).MemberName'</source>
         <target state="translated">此成員存取不明確。請在物件建立前後加上括弧，例如「(new SomeType(args)).MemberName」</target>

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/TypeAbbreviations/TypeAbbreviations.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/TypeAbbreviations/TypeAbbreviations.fs
@@ -138,7 +138,7 @@ module TypeAbbreviations =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 3564, Line 6, Col 16, Line 6, Col 16, "Missing union case name")
+            (Error 3564, Line 6, Col 16, Line 6, Col 18, "Missing union case name")
         ]
 
     //SOURCE=E_IncorrectRightSide_Quotation.fsx SCFLAGS="--test:ErrorRanges"                                    # E_IncorrectRightSide_Quotation.fsx

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/TypeAbbreviations/TypeAbbreviations.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicTypeAndModuleDefinitions/TypeAbbreviations/TypeAbbreviations.fs
@@ -138,7 +138,7 @@ module TypeAbbreviations =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 10, Line 6, Col 16, Line 6, Col 18, "Unexpected keyword 'of' in type definition")
+            (Error 3564, Line 6, Col 16, Line 6, Col 16, "Missing union case name")
         ]
 
     //SOURCE=E_IncorrectRightSide_Quotation.fsx SCFLAGS="--test:ErrorRanges"                                    # E_IncorrectRightSide_Quotation.fsx

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/UnionTypes/UnionTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/UnionTypes/UnionTypes.fs
@@ -71,7 +71,7 @@ module UnionTypes =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 10, Line 8, Col 12, Line 8, Col 13, "Unexpected integer literal in union case. Expected identifier, '(', '(*)' or other token.")
+            (Error 10, Line 8, Col 12, Line 8, Col 13, "Unexpected integer literal in union case")
         ]
 
     //SOURCE=E_BeginWithUppercase03.fsx SCFLAGS="--test:ErrorRanges"                              # E_BeginWithUppercase03.fsx
@@ -81,7 +81,7 @@ module UnionTypes =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 10, Line 9, Col 12, Line 9, Col 15, "Unexpected string literal in union case. Expected identifier, '(', '(*)' or other token.")
+            (Error 10, Line 9, Col 12, Line 9, Col 15, "Unexpected string literal in union case")
         ]
 
     //SOURCE=E_BeginWithUppercase04.fsx SCFLAGS="--test:ErrorRanges"                              # E_BeginWithUppercase04.fsx

--- a/tests/fsharpqa/Source/Diagnostics/NONTERM/attrUnionCaseDecl01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/NONTERM/attrUnionCaseDecl01.fs
@@ -1,6 +1,6 @@
 // #Regression #Diagnostics 
 // Regression test for FSharp1.0:3702
-//<Expects id="FS0010" span="(10,5-10,9)" status="error">Incomplete structured construct at or before this point in union case\. Expected identifier, '\(', '\(\*\)' or other token\.$</Expects>
+//<Expects id="FS0010" span="(10,5-10,9)" status="error">Incomplete structured construct at or before this point in union case</Expects>
 #light
            
     type Stuff = | AnonymousVariableType of string

--- a/tests/fsharpqa/Source/Diagnostics/NONTERM/attrUnionCaseDecl01b.fs
+++ b/tests/fsharpqa/Source/Diagnostics/NONTERM/attrUnionCaseDecl01b.fs
@@ -1,7 +1,7 @@
 // #Regression #Diagnostics 
 // Regression test for FSharp1.0:3702
 //<Expects status="notin">NONTERM</Expects>
-//<Expects id="FS0010" status="error" span="(12,5-12,9)">Incomplete structured construct at or before this point in union case\. Expected identifier, '\(', '\(\*\)' or other token\.$</Expects>
+//<Expects id="FS0010" status="error" span="(12,5-12,9)">Incomplete structured construct at or before this point in union case</Expects>
 
 
            

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/E_type_id_equal_pipe.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/E_type_id_equal_pipe.fsx
@@ -1,5 +1,5 @@
 // #Regression #NoMT #FSI 
 // Regression test for FSHARP1.0:5629
-//<Expects status="error" span="(4,12)" id="FS0010">Incomplete structured construct at or before this point in union case\. Expected identifier, '\(', '\(\*\)' or other token\.$</Expects>
+//<Expects status="error" span="(4,12)" id="FS0010">Incomplete structured construct at or before this point in union case</Expects>
 type R = | ;;
 exit 1;;

--- a/tests/service/SyntaxTreeTests.fs
+++ b/tests/service/SyntaxTreeTests.fs
@@ -185,7 +185,7 @@ let ParseFile fileName =
 
     let testUpdateBSLEnv = System.Environment.GetEnvironmentVariable("TEST_UPDATE_BSL")
 
-    if not (isNull testUpdateBSLEnv) && testUpdateBSLEnv.Trim() = "1" then
+    if true then
         File.WriteAllText(bslPath, actual)
 
     Assert.AreEqual(expected, actual)

--- a/tests/service/SyntaxTreeTests.fs
+++ b/tests/service/SyntaxTreeTests.fs
@@ -185,7 +185,7 @@ let ParseFile fileName =
 
     let testUpdateBSLEnv = System.Environment.GetEnvironmentVariable("TEST_UPDATE_BSL")
 
-    if true then
+    if not (isNull testUpdateBSLEnv) && testUpdateBSLEnv.Trim() = "1" then
         File.WriteAllText(bslPath, actual)
 
     Assert.AreEqual(expected, actual)

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 01.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+type U =
+    |

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 01.fs.bsl
@@ -26,4 +26,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(5,0)-(5,0) parse error Incomplete structured construct at or before this point in union case. Expected identifier, '(', '(*)' or other token.
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in union case

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 01.fs.bsl
@@ -1,0 +1,29 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 01.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,4--4,5), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,5)), (4,4--4,5)), [], None, (3,5--4,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,5))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,5), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in union case. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 02.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+type U =
+    | A
+    |
+    | C

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 02.fs.bsl
@@ -34,4 +34,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(6,4)-(6,5) parse error Unexpected symbol '|' in union case. Expected identifier, '(', '(*)' or other token.
+(6,4)-(6,5) parse error Unexpected symbol '|' in union case

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 02.fs.bsl
@@ -1,0 +1,37 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 02.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (, None), Fields [],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,4--5,5), { BarRange = Some (5,4--5,5) });
+                         SynUnionCase
+                           ([], SynIdent (C, None), Fields [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,6--6,7), { BarRange = Some (6,4--6,5) })],
+                        (4,4--6,7)), (4,4--6,7)), [], None, (3,5--6,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,5) parse error Unexpected symbol '|' in union case. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs
@@ -1,0 +1,6 @@
+module Module
+
+type U =
+    of int
+
+type A = int

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs.bsl
@@ -46,4 +46,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(4,4)-(4,6) parse error Unexpected keyword 'of' in type definition
+(4,4)-(4,4) parse error Missing union case name

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs.bsl
@@ -46,4 +46,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(4,4)-(4,4) parse error Missing union case name
+(4,4)-(4,6) parse error Missing union case name

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs.bsl
@@ -1,0 +1,49 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 03.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,7), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,7--4,10), { LeadingKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,4--4,10), { BarRange = None })],
+                        (4,4--4,10)), (4,4--4,10)), [], None, (3,5--4,10),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,10));
+           Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [A],
+                     PreXmlDoc ((6,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (6,5--6,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (6,9--6,12)), (6,9--6,12)), [], None, (6,5--6,12),
+                  { LeadingKeyword = Type (6,0--6,4)
+                    EqualsRange = Some (6,7--6,8)
+                    WithKeyword = None })], (6,0--6,12))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,12), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,4)-(4,6) parse error Unexpected keyword 'of' in type definition

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs
@@ -1,0 +1,6 @@
+module Module
+
+type U =
+    | A
+    | of int
+    | C

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs.bsl
@@ -41,4 +41,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(5,6)-(5,6) parse error Missing union case name
+(5,6)-(5,8) parse error Missing union case name

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs.bsl
@@ -1,0 +1,44 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 04.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((5,9), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (5,9--5,12), { LeadingKeyword = None })],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,12), { BarRange = Some (5,4--5,5) });
+                         SynUnionCase
+                           ([], SynIdent (C, None), Fields [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,6--6,7), { BarRange = Some (6,4--6,5) })],
+                        (4,4--6,7)), (4,4--6,7)), [], None, (3,5--6,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,6)-(5,8) parse error Unexpected keyword 'of' in union case. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs.bsl
@@ -41,4 +41,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(5,6)-(5,8) parse error Unexpected keyword 'of' in union case. Expected identifier, '(', '(*)' or other token.
+(5,6)-(5,6) parse error Missing union case name

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs
@@ -1,0 +1,6 @@
+module Module
+
+type U =
+    | A
+    | internal of int
+    | C

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs.bsl
@@ -41,5 +41,5 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(5,15)-(5,17) parse error Unexpected keyword 'of' in union case. Expected identifier, '(', '(*)' or other token.
 (5,6)-(5,14) parse error Accessibility modifiers are not permitted on union cases. Use 'type U = internal ...' or 'type U = private ...' to give an accessibility to the whole representation.
+(5,15)-(5,15) parse error Missing union case name

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs.bsl
@@ -1,0 +1,45 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 05.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((5,18), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (5,18--5,21), { LeadingKeyword = None })],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,21), { BarRange = Some (5,4--5,5) });
+                         SynUnionCase
+                           ([], SynIdent (C, None), Fields [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,6--6,7), { BarRange = Some (6,4--6,5) })],
+                        (4,4--6,7)), (4,4--6,7)), [], None, (3,5--6,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,15)-(5,17) parse error Unexpected keyword 'of' in union case. Expected identifier, '(', '(*)' or other token.
+(5,6)-(5,14) parse error Accessibility modifiers are not permitted on union cases. Use 'type U = internal ...' or 'type U = private ...' to give an accessibility to the whole representation.

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs.bsl
@@ -42,4 +42,4 @@ ImplFile
         CodeComments = [] }, set []))
 
 (5,6)-(5,14) parse error Accessibility modifiers are not permitted on union cases. Use 'type U = internal ...' or 'type U = private ...' to give an accessibility to the whole representation.
-(5,15)-(5,15) parse error Missing union case name
+(5,15)-(5,17) parse error Missing union case name

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 06.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 06.fs
@@ -1,0 +1,6 @@
+module Module
+
+type U =
+    | A
+    | internal of 
+    | C

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 06.fs.bsl
@@ -18,16 +18,13 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,6--4,7), { BarRange = Some (4,4--4,5) });
                          SynUnionCase
-                           ([], SynIdent (, None),
-                            Fields
-                              [SynField
-                                 ([], false, None,
-                                  LongIdent (SynLongIdent ([C], [], [None])),
-                                  false,
-                                  PreXmlDoc ((6,6), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (6,6--6,7), { LeadingKeyword = None })],
+                           ([], SynIdent (, None), Fields [],
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,6--6,7), { BarRange = Some (5,4--5,5) })],
+                            None, (5,4--5,5), { BarRange = Some (5,4--5,5) });
+                         SynUnionCase
+                           ([], SynIdent (C, None), Fields [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,6--6,7), { BarRange = Some (6,4--6,5) })],
                         (4,4--6,7)), (4,4--6,7)), [], None, (3,5--6,7),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
@@ -37,5 +34,5 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(5,15)-(5,17) parse error Unexpected keyword 'of' in union case. Expected identifier, '(', '(*)' or other token.
+(6,4)-(6,5) parse error Unexpected symbol '|' in union case
 (5,6)-(5,14) parse error Accessibility modifiers are not permitted on union cases. Use 'type U = internal ...' or 'type U = private ...' to give an accessibility to the whole representation.

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 06.fs.bsl
@@ -1,0 +1,41 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 06.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([C], [], [None])),
+                                  false,
+                                  PreXmlDoc ((6,6), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (6,6--6,7), { LeadingKeyword = None })],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--6,7), { BarRange = Some (5,4--5,5) })],
+                        (4,4--6,7)), (4,4--6,7)), [], None, (3,5--6,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,15)-(5,17) parse error Unexpected keyword 'of' in union case. Expected identifier, '(', '(*)' or other token.
+(5,6)-(5,14) parse error Accessibility modifiers are not permitted on union cases. Use 'type U = internal ...' or 'type U = private ...' to give an accessibility to the whole representation.

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 06.fs.bsl
@@ -20,7 +20,7 @@ ImplFile
                          SynUnionCase
                            ([], SynIdent (, None), Fields [],
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,4--5,5), { BarRange = Some (5,4--5,5) });
+                            None, (5,6--5,17), { BarRange = Some (5,4--5,5) });
                          SynUnionCase
                            ([], SynIdent (C, None), Fields [],
                             PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
@@ -36,3 +36,4 @@ ImplFile
 
 (6,4)-(6,5) parse error Unexpected symbol '|' in union case
 (5,6)-(5,14) parse error Accessibility modifiers are not permitted on union cases. Use 'type U = internal ...' or 'type U = private ...' to give an accessibility to the whole representation.
+(5,15)-(5,17) parse error Missing union case name

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 07.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 07.fs
@@ -1,0 +1,7 @@
+module Module
+
+type U =
+    | A
+    | of 
+    | C
+    | D

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 07.fs.bsl
@@ -20,7 +20,7 @@ ImplFile
                          SynUnionCase
                            ([], SynIdent (, None), Fields [],
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,4--5,5), { BarRange = Some (5,4--5,5) });
+                            None, (5,6--5,8), { BarRange = Some (5,4--5,5) });
                          SynUnionCase
                            ([], SynIdent (C, None), Fields [],
                             PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
@@ -39,3 +39,4 @@ ImplFile
         CodeComments = [] }, set []))
 
 (6,4)-(6,5) parse error Unexpected symbol '|' in union case
+(5,6)-(5,8) parse error Missing union case name

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 07.fs.bsl
@@ -18,16 +18,13 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,6--4,7), { BarRange = Some (4,4--4,5) });
                          SynUnionCase
-                           ([], SynIdent (, None),
-                            Fields
-                              [SynField
-                                 ([], false, None,
-                                  LongIdent (SynLongIdent ([C], [], [None])),
-                                  false,
-                                  PreXmlDoc ((6,6), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (6,6--6,7), { LeadingKeyword = None })],
+                           ([], SynIdent (, None), Fields [],
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,6--6,7), { BarRange = Some (5,4--5,5) });
+                            None, (5,4--5,5), { BarRange = Some (5,4--5,5) });
+                         SynUnionCase
+                           ([], SynIdent (C, None), Fields [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,6--6,7), { BarRange = Some (6,4--6,5) });
                          SynUnionCase
                            ([], SynIdent (D, None), Fields [],
                             PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
@@ -41,4 +38,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(5,6)-(5,8) parse error Unexpected keyword 'of' in union case. Expected identifier, '(', '(*)' or other token.
+(6,4)-(6,5) parse error Unexpected symbol '|' in union case

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 07.fs.bsl
@@ -1,0 +1,44 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 07.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([C], [], [None])),
+                                  false,
+                                  PreXmlDoc ((6,6), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (6,6--6,7), { LeadingKeyword = None })],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--6,7), { BarRange = Some (5,4--5,5) });
+                         SynUnionCase
+                           ([], SynIdent (D, None), Fields [],
+                            PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (7,6--7,7), { BarRange = Some (7,4--7,5) })],
+                        (4,4--7,7)), (4,4--7,7)), [], None, (3,5--7,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--7,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,6)-(5,8) parse error Unexpected keyword 'of' in union case. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 08.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 08.fs
@@ -1,0 +1,6 @@
+module Module
+
+type U =
+    A of
+
+type A = int    

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 08.fs.bsl
@@ -1,0 +1,42 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 08.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,4--4,8), { BarRange = None })], (4,4--4,8)),
+                     (4,4--4,8)), [], None, (3,5--4,8),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,8));
+           Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [A],
+                     PreXmlDoc ((6,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (6,5--6,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (6,9--6,12)), (6,9--6,12)), [], None, (6,5--6,12),
+                  { LeadingKeyword = Type (6,0--6,4)
+                    EqualsRange = Some (6,7--6,8)
+                    WithKeyword = None })], (6,0--6,12))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,12), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,4) parse error Incomplete structured construct at or before this point in type definition

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 09.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 09.fs
@@ -1,0 +1,5 @@
+module Module
+
+type U =
+    A of
+    | B

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 09.fs.bsl
@@ -1,0 +1,33 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Missing name 09.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,4--4,8), { BarRange = None });
+                         SynUnionCase
+                           ([], SynIdent (B, None), Fields [],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,7), { BarRange = Some (5,4--5,5) })],
+                        (4,4--5,7)), (4,4--5,7)), [], None, (3,5--5,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,4)-(5,5) parse error Unexpected symbol '|' in type definition


### PR DESCRIPTION
Recover on various cases of missing union case names or representations:

```fsharp
type U =
    |
```

```fsharp
type U =
    | of int
```

```fsharp
type U =
    A of
```

```fsharp
type U =
    of int
```