### PR TITLE
Fix:  Codegen for DynamicDependencyAttribute creates unnecessary property setters.

### DIFF
--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -91,27 +91,6 @@ let mkLdfldMethodDef (ilMethName, iLAccess, isStatic, ilTy, ilFieldName, ilPropT
 
     ilMethodDef.With(customAttrs = mkILCustomAttrs customAttrs).WithSpecialName
 
-/// Make a method that simply stores a field
-let mkStsfldMethodDef (ilMethName, iLAccess, isStatic, ilTy, ilFieldName, ilPropType, customAttrs) =
-    let ilFieldSpec = mkILFieldSpecInTy (ilTy, ilFieldName, ilPropType)
-    let ilParams = [ mkILParamNamed ("value", ilPropType) ]
-    let ilReturn = mkILReturn ILType.Void
-
-    let ilMethodDef =
-        if isStatic then
-            let body =
-                mkMethodBody (true, [], 2, nonBranchingInstrsToCode [ mkLdarg0; mkNormalStsfld ilFieldSpec ], None, None)
-
-            mkILNonGenericStaticMethod (ilMethName, iLAccess, ilParams, ilReturn, body)
-
-        else
-            let body =
-                mkMethodBody (true, [], 2, nonBranchingInstrsToCode [ mkLdarg0; mkLdarg 1us; mkNormalStfld ilFieldSpec ], None, None)
-
-            mkILNonGenericInstanceMethod (ilMethName, iLAccess, ilParams, ilReturn, body)
-
-    ilMethodDef.With(customAttrs = mkILCustomAttrs customAttrs).WithSpecialName
-
 /// Choose the constructor parameter names for fields
 let ChooseParamNames fieldNamesAndTypes =
     let takenFieldNames = fieldNamesAndTypes |> List.map p23 |> Set.ofList
@@ -634,12 +613,12 @@ let mkLocalPrivateAttributeWithDefaultConstructor (cenv: cenv, name: string) =
         ILTypeInit.BeforeField
     )
 
-let mkILNonGenericInstanceProperty (name, ilTypeRef, ilType, propertyAttribute, customAttributes) =
+let mkILNonGenericInstanceProperty (name, ilType, propertyAttribute, customAttributes, getMethod, setMethod) =
     ILPropertyDef(
         name = name,
         attributes = propertyAttribute,
-        setMethod = Some(mkILMethRef (ilTypeRef, ILCallingConv.Instance, "set_" + name, 0, [ ilType ], ILType.Void)),
-        getMethod = Some(mkILMethRef (ilTypeRef, ILCallingConv.Instance, "get_" + name, 0, [], ilType)),
+        setMethod = setMethod,
+        getMethod = getMethod,
         callingConv = ILThisConvention.Instance,
         propertyType = ilType,
         init = None,
@@ -661,11 +640,15 @@ let mkLocalPrivateAttributeWithPropertyConstructors (cenv, name: string, attrPro
             (cenv.g.AddMethodGeneratedAttributes(
                 mkLdfldMethodDef ($"get_{name}", ILMemberAccess.Public, false, ilTy, fieldName, ilType, [])
             )),
-            (cenv.g.AddMethodGeneratedAttributes(
-                mkStsfldMethodDef ($"set_{name}", ILMemberAccess.Private, false, ilTy, fieldName, ilType, [])
-            )),
             (cenv.g.AddPropertyGeneratedAttributes(
-                mkILNonGenericInstanceProperty (name, ilTypeRef, ilType, PropertyAttributes.None, emptyILCustomAttrs)
+                mkILNonGenericInstanceProperty (
+                    name,
+                    ilType,
+                    PropertyAttributes.None,
+                    emptyILCustomAttrs,
+                    Some(mkILMethRef (ilTypeRef, ILCallingConv.Instance, "get_" + name, 0, [], ilType)),
+                    None
+                )
             )),
             (name, fieldName, ilType))
 
@@ -676,7 +659,7 @@ let mkLocalPrivateAttributeWithPropertyConstructors (cenv, name: string, attrPro
                 Some cenv.g.ilg.typ_Attribute.TypeSpec,
                 ilTy,
                 [],
-                (ilElements |> List.map (fun (_, _, _, _, fieldInfo) -> fieldInfo)),
+                (ilElements |> List.map (fun (_, _, _, fieldInfo) -> fieldInfo)),
                 ILMemberAccess.Public,
                 None,
                 None
@@ -691,12 +674,11 @@ let mkLocalPrivateAttributeWithPropertyConstructors (cenv, name: string, attrPro
         ILTypes.Empty,
         mkILMethods (
             ilCtorDef
-            :: (ilElements
-                |> List.fold (fun acc (_, getter, setter, _, _) -> getter :: (setter :: acc)) [])
+            :: (ilElements |> List.fold (fun acc (_, getter, _, _) -> getter :: acc) [])
         ),
-        mkILFields (ilElements |> List.map (fun (field, _, _, _, _) -> field)),
+        mkILFields (ilElements |> List.map (fun (field, _, _, _) -> field)),
         emptyILTypeDefs,
-        mkILProperties (ilElements |> List.map (fun (_, _, _, property, _) -> property)),
+        mkILProperties (ilElements |> List.map (fun (_, _, property, _) -> property)),
         emptyILEvents,
         emptyILCustomAttrs,
         ILTypeInit.BeforeField

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare06.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare06.fsx.il.net472.bsl
@@ -586,19 +586,6 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_Type(class [runtime]System.Type 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::Type@
-    IL_0007:  ret
-  } 
-
   .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 
           get_MemberType() cil managed
   {
@@ -611,25 +598,11 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::MemberType@
-    IL_0007:  ret
-  } 
-
   .property instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
           MemberType()
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes)
     .get instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_MemberType()
   } 
   .property instance class [runtime]System.Type
@@ -637,7 +610,6 @@
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_Type(class [runtime]System.Type)
     .get instance class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_Type()
   } 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals05.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals05.fsx.il.net472.bsl
@@ -588,19 +588,6 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_Type(class [runtime]System.Type 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::Type@
-    IL_0007:  ret
-  } 
-
   .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 
           get_MemberType() cil managed
   {
@@ -613,25 +600,11 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::MemberType@
-    IL_0007:  ret
-  } 
-
   .property instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
           MemberType()
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes)
     .get instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_MemberType()
   } 
   .property instance class [runtime]System.Type
@@ -639,7 +612,6 @@
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_Type(class [runtime]System.Type)
     .get instance class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_Type()
   } 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash08.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash08.fsx.il.net472.bsl
@@ -576,19 +576,6 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_Type(class [runtime]System.Type 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::Type@
-    IL_0007:  ret
-  } 
-
   .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 
           get_MemberType() cil managed
   {
@@ -601,25 +588,11 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::MemberType@
-    IL_0007:  ret
-  } 
-
   .property instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
           MemberType()
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes)
     .get instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_MemberType()
   } 
   .property instance class [runtime]System.Type
@@ -627,7 +600,6 @@
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_Type(class [runtime]System.Type)
     .get instance class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_Type()
   } 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.net472.debug.bsl
@@ -653,19 +653,6 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_Type(class [runtime]System.Type 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::Type@
-    IL_0007:  ret
-  } 
-
   .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 
           get_MemberType() cil managed
   {
@@ -678,25 +665,11 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::MemberType@
-    IL_0007:  ret
-  } 
-
   .property instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
           MemberType()
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes)
     .get instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_MemberType()
   } 
   .property instance class [runtime]System.Type
@@ -704,7 +677,6 @@
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_Type(class [runtime]System.Type)
     .get instance class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_Type()
   } 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.net472.release.bsl
@@ -587,19 +587,6 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_Type(class [runtime]System.Type 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::Type@
-    IL_0007:  ret
-  } 
-
   .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 
           get_MemberType() cil managed
   {
@@ -612,25 +599,11 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::MemberType@
-    IL_0007:  ret
-  } 
-
   .property instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
           MemberType()
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes)
     .get instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_MemberType()
   } 
   .property instance class [runtime]System.Type
@@ -638,7 +611,6 @@
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_Type(class [runtime]System.Type)
     .get instance class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_Type()
   } 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.net472.debug.bsl
@@ -1002,19 +1002,6 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_Type(class [runtime]System.Type 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::Type@
-    IL_0007:  ret
-  } 
-
   .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 
           get_MemberType() cil managed
   {
@@ -1027,25 +1014,11 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::MemberType@
-    IL_0007:  ret
-  } 
-
   .property instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
           MemberType()
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes)
     .get instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_MemberType()
   } 
   .property instance class [runtime]System.Type
@@ -1053,7 +1026,6 @@
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_Type(class [runtime]System.Type)
     .get instance class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_Type()
   } 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.net472.release.bsl
@@ -888,19 +888,6 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_Type(class [runtime]System.Type 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::Type@
-    IL_0007:  ret
-  } 
-
   .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 
           get_MemberType() cil managed
   {
@@ -913,25 +900,11 @@
     IL_0006:  ret
   } 
 
-  .method private hidebysig specialname instance void 
-          set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 'value') cil managed
-  {
-    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldarg.1
-    IL_0002:  stfld      valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::MemberType@
-    IL_0007:  ret
-  } 
-
   .property instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
           MemberType()
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_MemberType(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes)
     .get instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_MemberType()
   } 
   .property instance class [runtime]System.Type
@@ -939,7 +912,6 @@
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .set instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::set_Type(class [runtime]System.Type)
     .get instance class [runtime]System.Type System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::get_Type()
   } 
 } 


### PR DESCRIPTION
Fixes #15064

By removing unneeded removing property setters.