### PR TITLE
Parser: recover on missing types in tuple and function types

### DIFF
--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1685,3 +1685,4 @@ featureEscapeBracesInFormattableString,"Escapes curly braces before calling Form
 3561,chkAutoOpenAttributeInTypeAbbrev,"FSharp.Core.AutoOpenAttribute should not be aliased."
 3562,parsUnexpectedEndOfFileElif,"Unexpected end of input in 'else if' or 'elif' branch of conditional expression. Expected 'elif <expr> then <expr>' or 'else if <expr> then <expr>'."
 3563,lexInvalidIdentifier,"This is not a valid identifier"
+3565,parsExpectingType,"Expecting type"

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -5139,32 +5139,64 @@ opt_topReturnTypeWithTypeConstraints:
         let ty, arity = SynType.FromParseError(mColon.EndRange), SynInfo.unnamedRetVal
         Some (Some mColon, SynReturnInfo((ty, arity), mColon.EndRange)) }
 
-topType: 
-  | topTupleType RARROW topType 
-     { let dty, dmdata= $1 
-       let rty, (SynValInfo(dmdatas, rmdata)) = $3
+topType:
+  | topTupleType RARROW topType
+      { let dty, dmdata = $1
+        let rty, (SynValInfo(dmdatas, rmdata)) = $3
+        let mArrow = rhs parseState 2
+        SynType.Fun(dty, rty, lhs parseState, { ArrowRange = mArrow }), SynValInfo(dmdata :: dmdatas, rmdata) }
+
+  | topTupleType RARROW recover
+     { let dty, dmdata = $1
        let mArrow = rhs parseState 2
-       SynType.Fun(dty, rty, lhs parseState, { ArrowRange = mArrow }), (SynValInfo(dmdata :: dmdatas, rmdata)) }
+       let rty = SynType.FromParseError(mArrow.EndRange)
+       SynType.Fun(dty, rty, lhs parseState, { ArrowRange = mArrow }), SynValInfo([dmdata], SynInfo.unnamedRetVal) }
 
   | topTupleType 
      { let ty, rmdata = $1 in ty, (SynValInfo([], (match rmdata with [md] -> md | _ -> SynInfo.unnamedRetVal))) }
 
 topTupleType:
-  | topAppType STAR topTupleTypeElements 
-     { let t, argInfo = $1
+  | topAppType STAR topTupleTypeElements
+      { let t, argInfo = $1
+        let mStar = rhs parseState 2
+        let path = SynTupleTypeSegment.Type t :: SynTupleTypeSegment.Star mStar :: (List.map fst $3)
+        let mdata = argInfo :: (List.choose snd $3)
+        mkSynTypeTuple path, mdata }
+
+  | topAppType STAR recover
+     { let ty1, argInfo = $1
        let mStar = rhs parseState 2
-       let path = SynTupleTypeSegment.Type t :: SynTupleTypeSegment.Star mStar :: (List.map fst $3)
-       let mdata = argInfo :: (List.choose snd $3)
-       mkSynTypeTuple path, mdata }
+       let ty2 = SynType.FromParseError(mStar.EndRange)
+       let path = [SynTupleTypeSegment.Type ty1; SynTupleTypeSegment.Star mStar; SynTupleTypeSegment.Type ty2]
+       mkSynTypeTuple path, [argInfo] }
+
+  | STAR topTupleTypeElements
+      { let mStar = rhs parseState 1
+        let ty = SynType.FromParseError(mStar.EndRange)
+        reportParseErrorAt mStar (FSComp.SR.parsExpectingType ())
+        let path = SynTupleTypeSegment.Type ty :: SynTupleTypeSegment.Star mStar :: (List.map fst $2)
+        mkSynTypeTuple path, List.choose snd $2 }
 
   | topAppType                 
      { let ty, mdata = $1 in ty, [mdata] }
 
 topTupleTypeElements:
-  | topAppType STAR topTupleTypeElements       
-     { let t, argInfo = $1
-       let mStar = rhs parseState 2
-       (SynTupleTypeSegment.Type t, Some argInfo) :: (SynTupleTypeSegment.Star mStar, None) :: $3 }
+  | topAppType STAR topTupleTypeElements
+      { let t, argInfo = $1
+        let mStar = rhs parseState 2
+        (SynTupleTypeSegment.Type t, Some argInfo) :: (SynTupleTypeSegment.Star mStar, None) :: $3 }
+
+  | topAppType STAR recover
+      { let ty1, argInfo = $1
+        let mStar = rhs parseState 2
+        let ty2 = SynType.FromParseError(mStar.EndRange)
+        [(SynTupleTypeSegment.Type ty1, Some argInfo); (SynTupleTypeSegment.Star mStar, None); (SynTupleTypeSegment.Type ty2, None)] }
+
+  | STAR topTupleTypeElements
+      { let mStar = rhs parseState 1
+        let ty = SynType.FromParseError(mStar.EndRange)
+        reportParseErrorAt mStar (FSComp.SR.parsExpectingType ())
+        (SynTupleTypeSegment.Type ty, None) :: (SynTupleTypeSegment.Star mStar, None) :: $2 }
 
   | topAppType %prec prec_toptuptyptail_prefix 
      { let t, argInfo = $1

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -5233,50 +5233,117 @@ topAppType:
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
 typ:
-  | tupleType RARROW typ  
-     { let mArrow = rhs parseState 2
-       SynType.Fun($1, $3, lhs parseState, { ArrowRange = mArrow }) }
+  | tupleType RARROW typ
+      { let mArrow = rhs parseState 2
+        let m = unionRanges (rhs2 parseState 1 2) $3.Range
+        SynType.Fun($1, $3, m, { ArrowRange = mArrow }) }
 
-  | tupleType %prec prec_typ_prefix 
-     { $1 }
+  | tupleType RARROW recover
+      { let mArrow = rhs parseState 2
+        let ty = SynType.FromParseError(mArrow.EndRange)
+        let m = rhs2 parseState 1 2
+        SynType.Fun($1, ty, m, { ArrowRange = mArrow }) }
+
+  | tupleType RARROW RARROW typ
+      { let mArrow1 = rhs parseState 2
+        let mArrow2 = rhs parseState 3
+        reportParseErrorAt mArrow2 (FSComp.SR.parsExpectingType ())
+        let ty = SynType.FromParseError(mArrow2.StartRange)
+        let m1 = unionRanges $1.Range $4.Range
+        let m2 = unionRanges mArrow2 $4.Range
+        SynType.Fun($1, SynType.Fun(ty, $4, m2, { ArrowRange = mArrow2 }), m1, { ArrowRange = mArrow1 }) }
+
+  | tupleType %prec prec_typ_prefix
+      { $1 }
 
 typEOF:
   | typ EOF { checkEndOfFileError $2; $1 }
 
 
 tupleType:
-  | appType STAR tupleOrQuotTypeElements 
-    { let mStar = rhs parseState 2
-      let path = SynTupleTypeSegment.Type $1 :: SynTupleTypeSegment.Star mStar :: $3
-      mkSynTypeTuple path }
+  | appType STAR tupleOrQuotTypeElements
+      { let mStar = rhs parseState 2
+        let path = SynTupleTypeSegment.Type $1 :: SynTupleTypeSegment.Star mStar :: $3
+        mkSynTypeTuple path }
+
+  | appType STAR recover
+      { let mStar = rhs parseState 2
+        let ty = SynType.FromParseError(mStar.EndRange)
+        let path = [SynTupleTypeSegment.Type $1; SynTupleTypeSegment.Star mStar; SynTupleTypeSegment.Type ty]
+        mkSynTypeTuple path }
+
+  | STAR tupleOrQuotTypeElements
+      { let mStar = rhs parseState 1
+        let ty = SynType.FromParseError(mStar.EndRange)
+        reportParseErrorAt mStar (FSComp.SR.parsExpectingType ())
+        let path = SynTupleTypeSegment.Type ty :: SynTupleTypeSegment.Star mStar :: $2
+        mkSynTypeTuple path }
 
   | INFIX_STAR_DIV_MOD_OP tupleOrQuotTypeElements
-    { if $1 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator());
-      let mSlash = rhs parseState 1
-      let path = SynTupleTypeSegment.Slash mSlash :: $2
-      mkSynTypeTuple path }
+      { if $1 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator ())
+        let mSlash = rhs parseState 1
+        let path = SynTupleTypeSegment.Slash mSlash :: $2
+        mkSynTypeTuple path }
+
+  | INFIX_STAR_DIV_MOD_OP recover
+      { if $1 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator ())
+        let mSlash = rhs parseState 1
+        let ty = SynType.FromParseError(mSlash.EndRange)
+        let path = [SynTupleTypeSegment.Slash mSlash; SynTupleTypeSegment.Type ty]
+        mkSynTypeTuple path }
 
   | appType INFIX_STAR_DIV_MOD_OP tupleOrQuotTypeElements
-    { if $2 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator());
-      let mSlash = rhs parseState 2
-      let path = SynTupleTypeSegment.Type $1 :: SynTupleTypeSegment.Slash mSlash :: $3
-      mkSynTypeTuple path }
+      { if $2 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator())
+        let mSlash = rhs parseState 2
+        let path = SynTupleTypeSegment.Type $1 :: SynTupleTypeSegment.Slash mSlash :: $3
+        mkSynTypeTuple path }
 
-  | appType %prec prec_tuptyp_prefix 
-    { $1 }
+  | appType INFIX_STAR_DIV_MOD_OP recover
+      { if $2 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator ())
+        let mSlash = rhs parseState 2
+        let ty = SynType.FromParseError(mSlash.EndRange)
+        let path = [SynTupleTypeSegment.Type $1; SynTupleTypeSegment.Slash mSlash; SynTupleTypeSegment.Type ty]
+        mkSynTypeTuple path }
+
+  | appType %prec prec_tuptyp_prefix
+      { $1 }
 
 tupleOrQuotTypeElements:
-  | appType STAR tupleOrQuotTypeElements              
-    { let mStar = rhs parseState 2
-      SynTupleTypeSegment.Type $1 :: SynTupleTypeSegment.Star mStar :: $3 }
+  | appType STAR tupleOrQuotTypeElements
+      { let mStar = rhs parseState 2
+        SynTupleTypeSegment.Type $1 :: SynTupleTypeSegment.Star mStar :: $3 }
 
-  | appType INFIX_STAR_DIV_MOD_OP tupleOrQuotTypeElements 
-    { if $2 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator());
-      let mSlash = rhs parseState 2
-      SynTupleTypeSegment.Type $1 :: SynTupleTypeSegment.Slash mSlash :: $3 }
+  | appType STAR recover
+      { let mStar = rhs parseState 2
+        let ty = SynType.FromParseError(mStar.EndRange)
+        [SynTupleTypeSegment.Type $1; SynTupleTypeSegment.Star mStar; SynTupleTypeSegment.Type ty] }
 
-  | appType %prec prec_tuptyptail_prefix 
-    { [ SynTupleTypeSegment.Type $1 ] }
+  | STAR tupleOrQuotTypeElements
+      { let mStar = rhs parseState 1
+        let ty = SynType.FromParseError(mStar.EndRange)
+        reportParseErrorAt mStar (FSComp.SR.parsExpectingType ())
+        SynTupleTypeSegment.Type ty :: SynTupleTypeSegment.Star mStar :: $2 }
+
+  | appType INFIX_STAR_DIV_MOD_OP tupleOrQuotTypeElements
+      { if $2 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator ())
+        let mSlash = rhs parseState 2
+        SynTupleTypeSegment.Type $1 :: SynTupleTypeSegment.Slash mSlash :: $3 }
+
+  | appType INFIX_STAR_DIV_MOD_OP recover
+      { if $2 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator ())
+        let mSlash = rhs parseState 2
+        let ty = SynType.FromParseError(mSlash.EndRange)
+        [SynTupleTypeSegment.Type $1; SynTupleTypeSegment.Slash mSlash; SynTupleTypeSegment.Type ty] }
+
+  | INFIX_STAR_DIV_MOD_OP tupleOrQuotTypeElements
+      { if $1 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedInfixOperator ())
+        let mSlash = rhs parseState 1
+        let ty = SynType.FromParseError(mSlash.EndRange)
+        reportParseErrorAt mSlash (FSComp.SR.parsExpectingType ())
+        SynTupleTypeSegment.Type ty :: SynTupleTypeSegment.Slash mSlash :: $2 }
+
+  | appType %prec prec_tuptyptail_prefix
+      { [ SynTupleTypeSegment.Type $1 ] }
 
 appTypeCon:
   | path %prec prec_atomtyp_path 

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Očekává se vzorek.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Neúplný znakový literál (příklad: Q) nebo volání kvalifikovaného typu (příklad: T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Muster wird erwartet</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Unvollständiges Zeichenliteral (Beispiel: „Q“) oder qualifizierter Typaufruf (Beispiel: „T.Name“)</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Se espera un patrón</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Literal de carácter incompleto (ejemplo: 'Q') o invocación de tipo completo (ejemplo: 'T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Modèle attendu</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Littéral de caractère incomplet (exemple : 'Q') ou appel de type qualifié (exemple : 'T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Criterio previsto</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Valore letterale carattere incompleto (ad esempio: 'Q') o chiamata di tipo qualificato (ad esempio: 'T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -762,6 +762,11 @@
         <target state="translated">必要なパターン</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">不完全な文字リテラル (例: 'Q') または修飾型の呼び出し (例: 'T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -762,6 +762,11 @@
         <target state="translated">예상되는 패턴</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">불완전한 문자 리터럴(예: 'Q') 또는 정규화된 형식 호출(예: 'T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Oczekiwano wzorca</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Niekompletny literał znaku (przykład: „Q”) lub wywołanie typu kwalifikowanego (przykład: „T.Name”)</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Padrão esperado</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Literal de caractere incompleto (exemplo: 'Q') ou invocação de tipo qualificado (exemplo: 'T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Ожидается шаблон</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Неполный символьный литерал (например: "Q") или вызов квалифицированного типа (например: "T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -762,6 +762,11 @@
         <target state="translated">Desen bekleniyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">Eksik karakter değişmez değeri (örnek: 'Q') veya tam tür çağrısı (örnek: 'T.Name)</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -762,6 +762,11 @@
         <target state="translated">预期模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">字符文本不完整(示例: "Q")或限定类型调用(示例: "T.Name")</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -762,6 +762,11 @@
         <target state="translated">必須是模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingType">
+        <source>Expecting type</source>
+        <target state="new">Expecting type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">
         <source>Incomplete character literal (example: 'Q') or qualified type invocation (example: 'T.Name)</source>
         <target state="translated">不完整的字元文字 (範例: 'Q') 或限定類型調用 (範例: 'T.Name)</target>

--- a/tests/fsharpqa/Source/Diagnostics/NONTERM/typ01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/NONTERM/typ01.fs
@@ -1,6 +1,6 @@
 // #Regression #Diagnostics 
 // Regression test for FSHARP1.0:2467
-//<Expects id="FS0010" span="(9,115-9,117)" status="error">Unexpected symbol '->' in type</Expects>
+//<Expects id="FS3565" span="(9,115-9,115)" status="error">Expecting type</Expects>
 
 #light
 

--- a/tests/fsharpqa/Source/Diagnostics/NONTERM/typ01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/NONTERM/typ01.fs
@@ -1,6 +1,6 @@
 // #Regression #Diagnostics 
 // Regression test for FSHARP1.0:2467
-//<Expects id="FS3565" span="(9,115-9,115)" status="error">Expecting type</Expects>
+//<Expects id="FS3565" span="(9,115-9,117)" status="error">Expecting type</Expects>
 
 #light
 

--- a/tests/fsharpqa/Source/Diagnostics/NONTERM/typ01b.fs
+++ b/tests/fsharpqa/Source/Diagnostics/NONTERM/typ01b.fs
@@ -1,7 +1,7 @@
 // #Regression #Diagnostics 
 // Regression test for FSHARP1.0:2467
 //<Expects status="notin">NONTERM</Expects>
-//<Expects id="FS0010" status="error">Unexpected symbol '->' in type</Expects>
+//<Expects id="FS3565" status="error">Expecting type</Expects>
 
 #light
 

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a -> b) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 01.fs.bsl
@@ -1,0 +1,46 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Fun 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Fun
+                                  (LongIdent (SynLongIdent ([a], [], [None])),
+                                   LongIdent (SynLongIdent ([b], [], [None])),
+                                   (3,10--3,16), { ArrowRange = (3,12--3,14) }),
+                                (3,7--3,16))], (3,6--3,17)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,20--3,29)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Fun
+                                 (LongIdent (SynLongIdent ([a], [], [None])),
+                                  LongIdent (SynLongIdent ([b], [], [None])),
+                                  (3,10--3,16), { ArrowRange = (3,12--3,14) }),
+                               (3,7--3,16))], (3,6--3,17)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,29),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,18--3,19)
+                    WithKeyword = None })], (3,0--3,29))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,29), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a -> b -> c) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 02.fs.bsl
@@ -1,0 +1,53 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Fun 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Fun
+                                  (LongIdent (SynLongIdent ([a], [], [None])),
+                                   Fun
+                                     (LongIdent (SynLongIdent ([b], [], [None])),
+                                      LongIdent (SynLongIdent ([c], [], [None])),
+                                      (3,15--3,21),
+                                      { ArrowRange = (3,17--3,19) }),
+                                   (3,10--3,21), { ArrowRange = (3,12--3,14) }),
+                                (3,7--3,21))], (3,6--3,22)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,25--3,34)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Fun
+                                 (LongIdent (SynLongIdent ([a], [], [None])),
+                                  Fun
+                                    (LongIdent (SynLongIdent ([b], [], [None])),
+                                     LongIdent (SynLongIdent ([c], [], [None])),
+                                     (3,15--3,21), { ArrowRange = (3,17--3,19) }),
+                                  (3,10--3,21), { ArrowRange = (3,12--3,14) }),
+                               (3,7--3,21))], (3,6--3,22)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,34),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,23--3,24)
+                    WithKeyword = None })], (3,0--3,34))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,34), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 03.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a -> b -> c) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 03.fs.bsl
@@ -1,0 +1,53 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Fun 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Fun
+                                  (LongIdent (SynLongIdent ([a], [], [None])),
+                                   Fun
+                                     (LongIdent (SynLongIdent ([b], [], [None])),
+                                      LongIdent (SynLongIdent ([c], [], [None])),
+                                      (3,15--3,21),
+                                      { ArrowRange = (3,17--3,19) }),
+                                   (3,10--3,21), { ArrowRange = (3,12--3,14) }),
+                                (3,7--3,21))], (3,6--3,22)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,25--3,34)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Fun
+                                 (LongIdent (SynLongIdent ([a], [], [None])),
+                                  Fun
+                                    (LongIdent (SynLongIdent ([b], [], [None])),
+                                     LongIdent (SynLongIdent ([c], [], [None])),
+                                     (3,15--3,21), { ArrowRange = (3,17--3,19) }),
+                                  (3,10--3,21), { ArrowRange = (3,12--3,14) }),
+                               (3,7--3,21))], (3,6--3,22)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,34),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,23--3,24)
+                    WithKeyword = None })], (3,0--3,34))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,34), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 04.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 04.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a -> ) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 04.fs.bsl
@@ -1,0 +1,48 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Fun 04.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Fun
+                                  (LongIdent (SynLongIdent ([a], [], [None])),
+                                   FromParseError (3,14--3,14), (3,10--3,14),
+                                   { ArrowRange = (3,12--3,14) }), (3,7--3,16))],
+                            (3,6--3,16)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,19--3,28)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Fun
+                                 (LongIdent (SynLongIdent ([a], [], [None])),
+                                  FromParseError (3,14--3,14), (3,10--3,14),
+                                  { ArrowRange = (3,12--3,14) }), (3,7--3,16))],
+                           (3,6--3,16)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,17--3,18)
+                    WithKeyword = None })], (3,0--3,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,15)-(3,16) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 05.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 05.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a -> -> c) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 05.fs.bsl
@@ -1,0 +1,55 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Fun 05.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Fun
+                                  (LongIdent (SynLongIdent ([a], [], [None])),
+                                   Fun
+                                     (FromParseError (3,15--3,15),
+                                      LongIdent (SynLongIdent ([c], [], [None])),
+                                      (3,15--3,19),
+                                      { ArrowRange = (3,15--3,17) }),
+                                   (3,10--3,19), { ArrowRange = (3,12--3,14) }),
+                                (3,7--3,19))], (3,6--3,20)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,23--3,32)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Fun
+                                 (LongIdent (SynLongIdent ([a], [], [None])),
+                                  Fun
+                                    (FromParseError (3,15--3,15),
+                                     LongIdent (SynLongIdent ([c], [], [None])),
+                                     (3,15--3,19), { ArrowRange = (3,15--3,17) }),
+                                  (3,10--3,19), { ArrowRange = (3,12--3,14) }),
+                               (3,7--3,19))], (3,6--3,20)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,32),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,21--3,22)
+                    WithKeyword = None })], (3,0--3,32))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,32), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,15)-(3,17) parse error Expecting type

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 06.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 06.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a -> -> c * ) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Fun 06.fs.bsl
@@ -1,0 +1,69 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Fun 06.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Fun
+                                  (LongIdent (SynLongIdent ([a], [], [None])),
+                                   Fun
+                                     (FromParseError (3,15--3,15),
+                                      Tuple
+                                        (false,
+                                         [Type
+                                            (LongIdent
+                                               (SynLongIdent ([c], [], [None])));
+                                          Star (3,20--3,21);
+                                          Type (FromParseError (3,21--3,21))],
+                                         (3,18--3,21)), (3,15--3,21),
+                                      { ArrowRange = (3,15--3,17) }),
+                                   (3,10--3,21), { ArrowRange = (3,12--3,14) }),
+                                (3,7--3,23))], (3,6--3,23)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,26--3,35)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Fun
+                                 (LongIdent (SynLongIdent ([a], [], [None])),
+                                  Fun
+                                    (FromParseError (3,15--3,15),
+                                     Tuple
+                                       (false,
+                                        [Type
+                                           (LongIdent
+                                              (SynLongIdent ([c], [], [None])));
+                                         Star (3,20--3,21);
+                                         Type (FromParseError (3,21--3,21))],
+                                        (3,18--3,21)), (3,15--3,21),
+                                     { ArrowRange = (3,15--3,17) }),
+                                  (3,10--3,21), { ArrowRange = (3,12--3,14) }),
+                               (3,7--3,23))], (3,6--3,23)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,35),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,24--3,25)
+                    WithKeyword = None })], (3,0--3,35))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,35), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,22)-(3,23) parse error Unexpected symbol ')' in type
+(3,15)-(3,17) parse error Expecting type

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a * b) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 01.fs.bsl
@@ -1,0 +1,56 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Tuple 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Tuple
+                                  (false,
+                                   [Type
+                                      (LongIdent
+                                         (SynLongIdent ([a], [], [None])));
+                                    Star (3,12--3,13);
+                                    Type
+                                      (LongIdent
+                                         (SynLongIdent ([b], [], [None])))],
+                                   (3,10--3,15)), (3,7--3,15))], (3,6--3,16)),
+                         None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,19--3,28)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Tuple
+                                 (false,
+                                  [Type
+                                     (LongIdent (SynLongIdent ([a], [], [None])));
+                                   Star (3,12--3,13);
+                                   Type
+                                     (LongIdent (SynLongIdent ([b], [], [None])))],
+                                  (3,10--3,15)), (3,7--3,15))], (3,6--3,16)),
+                        None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,17--3,18)
+                    WithKeyword = None })], (3,0--3,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a * b * c) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 02.fs.bsl
@@ -1,0 +1,63 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Tuple 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Tuple
+                                  (false,
+                                   [Type
+                                      (LongIdent
+                                         (SynLongIdent ([a], [], [None])));
+                                    Star (3,12--3,13);
+                                    Type
+                                      (LongIdent
+                                         (SynLongIdent ([b], [], [None])));
+                                    Star (3,16--3,17);
+                                    Type
+                                      (LongIdent
+                                         (SynLongIdent ([c], [], [None])))],
+                                   (3,10--3,19)), (3,7--3,19))], (3,6--3,20)),
+                         None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,23--3,32)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Tuple
+                                 (false,
+                                  [Type
+                                     (LongIdent (SynLongIdent ([a], [], [None])));
+                                   Star (3,12--3,13);
+                                   Type
+                                     (LongIdent (SynLongIdent ([b], [], [None])));
+                                   Star (3,16--3,17);
+                                   Type
+                                     (LongIdent (SynLongIdent ([c], [], [None])))],
+                                  (3,10--3,19)), (3,7--3,19))], (3,6--3,20)),
+                        None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,32),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,21--3,22)
+                    WithKeyword = None })], (3,0--3,32))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,32), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 03.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a * ) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 03.fs.bsl
@@ -1,0 +1,55 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Tuple 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Tuple
+                                  (false,
+                                   [Type
+                                      (LongIdent
+                                         (SynLongIdent ([a], [], [None])));
+                                    Star (3,12--3,13);
+                                    Type (FromParseError (3,13--3,13))],
+                                   (3,10--3,13)), (3,7--3,15))], (3,6--3,15)),
+                         None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,18--3,27)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Tuple
+                                 (false,
+                                  [Type
+                                     (LongIdent (SynLongIdent ([a], [], [None])));
+                                   Star (3,12--3,13);
+                                   Type (FromParseError (3,13--3,13))],
+                                  (3,10--3,13)), (3,7--3,15))], (3,6--3,15)),
+                        None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,27),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,16--3,17)
+                    WithKeyword = None })], (3,0--3,27))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,27), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,14)-(3,15) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 04.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 04.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a * b * ) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 04.fs.bsl
@@ -1,0 +1,62 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Tuple 04.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Tuple
+                                  (false,
+                                   [Type
+                                      (LongIdent
+                                         (SynLongIdent ([a], [], [None])));
+                                    Star (3,12--3,13);
+                                    Type
+                                      (LongIdent
+                                         (SynLongIdent ([b], [], [None])));
+                                    Star (3,16--3,17);
+                                    Type (FromParseError (3,17--3,17))],
+                                   (3,10--3,17)), (3,7--3,19))], (3,6--3,19)),
+                         None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,22--3,31)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Tuple
+                                 (false,
+                                  [Type
+                                     (LongIdent (SynLongIdent ([a], [], [None])));
+                                   Star (3,12--3,13);
+                                   Type
+                                     (LongIdent (SynLongIdent ([b], [], [None])));
+                                   Star (3,16--3,17);
+                                   Type (FromParseError (3,17--3,17))],
+                                  (3,10--3,17)), (3,7--3,19))], (3,6--3,19)),
+                        None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,31),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,20--3,21)
+                    WithKeyword = None })], (3,0--3,31))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,31), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,18)-(3,19) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 05.fs
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 05.fs
@@ -1,0 +1,3 @@
+module Module
+
+type T(i: a * * c ) = class end

--- a/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Implicit ctor - Type - Tuple 05.fs.bsl
@@ -1,0 +1,62 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Implicit ctor - Type - Tuple 05.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Class,
+                     [ImplicitCtor
+                        (None, [],
+                         SimplePats
+                           ([Typed
+                               (Id (i, None, false, false, false, (3,7--3,8)),
+                                Tuple
+                                  (false,
+                                   [Type
+                                      (LongIdent
+                                         (SynLongIdent ([a], [], [None])));
+                                    Star (3,12--3,13);
+                                    Type (FromParseError (3,15--3,15));
+                                    Star (3,14--3,15);
+                                    Type
+                                      (LongIdent
+                                         (SynLongIdent ([c], [], [None])))],
+                                   (3,10--3,17)), (3,7--3,17))], (3,6--3,19)),
+                         None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None })], (3,22--3,31)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [],
+                        SimplePats
+                          ([Typed
+                              (Id (i, None, false, false, false, (3,7--3,8)),
+                               Tuple
+                                 (false,
+                                  [Type
+                                     (LongIdent (SynLongIdent ([a], [], [None])));
+                                   Star (3,12--3,13);
+                                   Type (FromParseError (3,15--3,15));
+                                   Star (3,14--3,15);
+                                   Type
+                                     (LongIdent (SynLongIdent ([c], [], [None])))],
+                                  (3,10--3,17)), (3,7--3,17))], (3,6--3,19)),
+                        None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--3,31),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,20--3,21)
+                    WithKeyword = None })], (3,0--3,31))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,31), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,14)-(3,15) parse error Expecting type

--- a/tests/service/data/SyntaxTree/SynType/Div 01.fs
+++ b/tests/service/data/SyntaxTree/SynType/Div 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a / b)

--- a/tests/service/data/SyntaxTree/SynType/Div 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Div 01.fs.bsl
@@ -1,0 +1,20 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Div 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Slash (3,7--3,8);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])))],
+                       (3,5--3,10)), (3,1--3,10)), (3,0--3,1), Some (3,10--3,11),
+                 (3,0--3,11)), (3,0--3,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Div 02.fs
+++ b/tests/service/data/SyntaxTree/SynType/Div 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a / b / c)

--- a/tests/service/data/SyntaxTree/SynType/Div 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Div 02.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Div 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Slash (3,7--3,8);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])));
+                        Slash (3,11--3,12);
+                        Type (LongIdent (SynLongIdent ([c], [], [None])))],
+                       (3,5--3,14)), (3,1--3,14)), (3,0--3,1), Some (3,14--3,15),
+                 (3,0--3,15)), (3,0--3,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Div 03.fs
+++ b/tests/service/data/SyntaxTree/SynType/Div 03.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): / a)

--- a/tests/service/data/SyntaxTree/SynType/Div 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Div 03.fs.bsl
@@ -1,0 +1,19 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Div 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Slash (3,5--3,6);
+                        Type (LongIdent (SynLongIdent ([a], [], [None])))],
+                       (3,5--3,8)), (3,1--3,8)), (3,0--3,1), Some (3,8--3,9),
+                 (3,0--3,9)), (3,0--3,9))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,9), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Div 04.fs
+++ b/tests/service/data/SyntaxTree/SynType/Div 04.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): / a / b )

--- a/tests/service/data/SyntaxTree/SynType/Div 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Div 04.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Div 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Slash (3,5--3,6);
+                        Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Slash (3,9--3,10);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])))],
+                       (3,5--3,12)), (3,1--3,12)), (3,0--3,1), Some (3,13--3,14),
+                 (3,0--3,14)), (3,0--3,14))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,14), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Div 05.fs
+++ b/tests/service/data/SyntaxTree/SynType/Div 05.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a / b / )

--- a/tests/service/data/SyntaxTree/SynType/Div 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Div 05.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Div 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Slash (3,7--3,8);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])));
+                        Slash (3,11--3,12); Type (FromParseError (3,12--3,12))],
+                       (3,5--3,12)), (3,1--3,12)), (3,0--3,1), Some (3,13--3,14),
+                 (3,0--3,14)), (3,0--3,14))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,14), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,13)-(3,14) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/SynType/Div 06.fs
+++ b/tests/service/data/SyntaxTree/SynType/Div 06.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a / / c)

--- a/tests/service/data/SyntaxTree/SynType/Div 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Div 06.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Div 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Slash (3,7--3,8); Type (FromParseError (3,10--3,10));
+                        Slash (3,9--3,10);
+                        Type (LongIdent (SynLongIdent ([c], [], [None])))],
+                       (3,5--3,12)), (3,1--3,12)), (3,0--3,1), Some (3,12--3,13),
+                 (3,0--3,13)), (3,0--3,13))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,13), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,9)-(3,10) parse error Expecting type

--- a/tests/service/data/SyntaxTree/SynType/Fun 01.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a -> b)

--- a/tests/service/data/SyntaxTree/SynType/Fun 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 01.fs.bsl
@@ -1,0 +1,18 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Fun
+                      (LongIdent (SynLongIdent ([a], [], [None])),
+                       LongIdent (SynLongIdent ([b], [], [None])), (3,5--3,11),
+                       { ArrowRange = (3,7--3,9) }), (3,1--3,11)), (3,0--3,1),
+                 Some (3,11--3,12), (3,0--3,12)), (3,0--3,12))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,12), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Fun 02.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a -> b -> c)

--- a/tests/service/data/SyntaxTree/SynType/Fun 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 02.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Fun
+                      (LongIdent (SynLongIdent ([a], [], [None])),
+                       Fun
+                         (LongIdent (SynLongIdent ([b], [], [None])),
+                          LongIdent (SynLongIdent ([c], [], [None])),
+                          (3,10--3,16), { ArrowRange = (3,12--3,14) }),
+                       (3,5--3,16), { ArrowRange = (3,7--3,9) }), (3,1--3,16)),
+                 (3,0--3,1), Some (3,16--3,17), (3,0--3,17)), (3,0--3,17))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,17), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Fun 03.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 03.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a -> )

--- a/tests/service/data/SyntaxTree/SynType/Fun 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 03.fs.bsl
@@ -1,0 +1,20 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Fun
+                      (LongIdent (SynLongIdent ([a], [], [None])),
+                       FromParseError (3,9--3,9), (3,5--3,9),
+                       { ArrowRange = (3,7--3,9) }), (3,1--3,9)), (3,0--3,1),
+                 Some (3,10--3,11), (3,0--3,11)), (3,0--3,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,10)-(3,11) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/SynType/Fun 04.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 04.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a -> b -> )

--- a/tests/service/data/SyntaxTree/SynType/Fun 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 04.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Fun
+                      (LongIdent (SynLongIdent ([a], [], [None])),
+                       Fun
+                         (LongIdent (SynLongIdent ([b], [], [None])),
+                          FromParseError (3,14--3,14), (3,10--3,14),
+                          { ArrowRange = (3,12--3,14) }), (3,5--3,14),
+                       { ArrowRange = (3,7--3,9) }), (3,1--3,14)), (3,0--3,1),
+                 Some (3,15--3,16), (3,0--3,16)), (3,0--3,16))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,16), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,15)-(3,16) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/SynType/Fun 05.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 05.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a -> -> c)

--- a/tests/service/data/SyntaxTree/SynType/Fun 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 05.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Fun
+                      (LongIdent (SynLongIdent ([a], [], [None])),
+                       Fun
+                         (FromParseError (3,10--3,10),
+                          LongIdent (SynLongIdent ([c], [], [None])),
+                          (3,10--3,14), { ArrowRange = (3,10--3,12) }),
+                       (3,5--3,14), { ArrowRange = (3,7--3,9) }), (3,1--3,14)),
+                 (3,0--3,1), Some (3,14--3,15), (3,0--3,15)), (3,0--3,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,10)-(3,12) parse error Expecting type

--- a/tests/service/data/SyntaxTree/SynType/Fun 06.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 06.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a -> b = ()

--- a/tests/service/data/SyntaxTree/SynType/Fun 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 06.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (LongIdent (SynLongIdent ([a], [], [None])),
+                           LongIdent (SynLongIdent ([b], [], [None])),
+                           (3,7--3,13), { ArrowRange = (3,9--3,11) }),
+                        (3,7--3,13), [], { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,16--3,18)),
+                     Fun
+                       (LongIdent (SynLongIdent ([a], [], [None])),
+                        LongIdent (SynLongIdent ([b], [], [None])), (3,7--3,13),
+                        { ArrowRange = (3,9--3,11) }), (3,16--3,18)), (3,4--3,5),
+                  Yes (3,0--3,18), { LeadingKeyword = Let (3,0--3,3)
+                                     InlineKeyword = None
+                                     EqualsRange = Some (3,14--3,15) })],
+              (3,0--3,18))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,18), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Fun 07.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 07.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a -> b -> c = ()

--- a/tests/service/data/SyntaxTree/SynType/Fun 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 07.fs.bsl
@@ -1,0 +1,40 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 07.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (LongIdent (SynLongIdent ([a], [], [None])),
+                           Fun
+                             (LongIdent (SynLongIdent ([b], [], [None])),
+                              LongIdent (SynLongIdent ([c], [], [None])),
+                              (3,12--3,18), { ArrowRange = (3,14--3,16) }),
+                           (3,7--3,18), { ArrowRange = (3,9--3,11) }),
+                        (3,7--3,18), [], { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,21--3,23)),
+                     Fun
+                       (LongIdent (SynLongIdent ([a], [], [None])),
+                        Fun
+                          (LongIdent (SynLongIdent ([b], [], [None])),
+                           LongIdent (SynLongIdent ([c], [], [None])),
+                           (3,12--3,18), { ArrowRange = (3,14--3,16) }),
+                        (3,7--3,18), { ArrowRange = (3,9--3,11) }), (3,21--3,23)),
+                  (3,4--3,5), Yes (3,0--3,23),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,19--3,20) })], (3,0--3,23))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,23), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Fun 08.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 08.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a -> = ()

--- a/tests/service/data/SyntaxTree/SynType/Fun 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 08.fs.bsl
@@ -1,0 +1,36 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 08.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (LongIdent (SynLongIdent ([a], [], [None])),
+                           FromParseError (3,11--3,11), (3,7--3,13),
+                           { ArrowRange = (3,9--3,11) }), (3,7--3,13), [],
+                        { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,14--3,16)),
+                     Fun
+                       (LongIdent (SynLongIdent ([a], [], [None])),
+                        FromParseError (3,11--3,11), (3,7--3,13),
+                        { ArrowRange = (3,9--3,11) }), (3,14--3,16)), (3,4--3,5),
+                  Yes (3,0--3,16), { LeadingKeyword = Let (3,0--3,3)
+                                     InlineKeyword = None
+                                     EqualsRange = Some (3,12--3,13) })],
+              (3,0--3,16))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,16), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,12)-(3,13) parse error Unexpected symbol '=' in binding

--- a/tests/service/data/SyntaxTree/SynType/Fun 09.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 09.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a -> b -> = ()

--- a/tests/service/data/SyntaxTree/SynType/Fun 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 09.fs.bsl
@@ -1,0 +1,42 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 09.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (LongIdent (SynLongIdent ([a], [], [None])),
+                           Fun
+                             (LongIdent (SynLongIdent ([b], [], [None])),
+                              FromParseError (3,16--3,16), (3,12--3,18),
+                              { ArrowRange = (3,14--3,16) }), (3,7--3,18),
+                           { ArrowRange = (3,9--3,11) }), (3,7--3,18), [],
+                        { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,19--3,21)),
+                     Fun
+                       (LongIdent (SynLongIdent ([a], [], [None])),
+                        Fun
+                          (LongIdent (SynLongIdent ([b], [], [None])),
+                           FromParseError (3,16--3,16), (3,12--3,18),
+                           { ArrowRange = (3,14--3,16) }), (3,7--3,18),
+                        { ArrowRange = (3,9--3,11) }), (3,19--3,21)), (3,4--3,5),
+                  Yes (3,0--3,21), { LeadingKeyword = Let (3,0--3,3)
+                                     InlineKeyword = None
+                                     EqualsRange = Some (3,17--3,18) })],
+              (3,0--3,21))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,21), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,17)-(3,18) parse error Unexpected symbol '=' in binding

--- a/tests/service/data/SyntaxTree/SynType/Fun 10.fs
+++ b/tests/service/data/SyntaxTree/SynType/Fun 10.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a -> -> c = ()

--- a/tests/service/data/SyntaxTree/SynType/Fun 10.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Fun 10.fs.bsl
@@ -1,0 +1,36 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Fun 10.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (LongIdent (SynLongIdent ([a], [], [None])),
+                           FromParseError (3,11--3,11), (3,7--3,14),
+                           { ArrowRange = (3,9--3,11) }), (3,7--3,14), [],
+                        { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,19--3,21)),
+                     Fun
+                       (LongIdent (SynLongIdent ([a], [], [None])),
+                        FromParseError (3,11--3,11), (3,7--3,14),
+                        { ArrowRange = (3,9--3,11) }), (3,19--3,21)), (3,4--3,5),
+                  Yes (3,0--3,21), { LeadingKeyword = Let (3,0--3,3)
+                                     InlineKeyword = None
+                                     EqualsRange = Some (3,17--3,18) })],
+              (3,0--3,21))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,21), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,12)-(3,14) parse error Unexpected symbol '->' in binding

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 01.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * (b1 * b2))

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 01.fs.bsl
@@ -1,0 +1,30 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple - Nested 01.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type
+                          (Paren
+                             (Tuple
+                                (false,
+                                 [Type
+                                    (LongIdent (SynLongIdent ([b1], [], [None])));
+                                  Star (3,13--3,14);
+                                  Type
+                                    (LongIdent (SynLongIdent ([b2], [], [None])))],
+                                 (3,10--3,17)), (3,9--3,18)))], (3,5--3,18)),
+                    (3,1--3,18)), (3,0--3,1), Some (3,18--3,19), (3,0--3,19)),
+              (3,0--3,19))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,19), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 02.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): (a1 * a2) * b)

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 02.fs.bsl
@@ -1,0 +1,29 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple - Nested 02.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type
+                          (Paren
+                             (Tuple
+                                (false,
+                                 [Type
+                                    (LongIdent (SynLongIdent ([a1], [], [None])));
+                                  Star (3,9--3,10);
+                                  Type
+                                    (LongIdent (SynLongIdent ([a2], [], [None])))],
+                                 (3,6--3,13)), (3,5--3,14))); Star (3,15--3,16);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])))],
+                       (3,5--3,18)), (3,1--3,18)), (3,0--3,1), Some (3,18--3,19),
+                 (3,0--3,19)), (3,0--3,19))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,19), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 03.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 03.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * (b1 * b2 * b3))

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 03.fs.bsl
@@ -1,0 +1,33 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple - Nested 03.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type
+                          (Paren
+                             (Tuple
+                                (false,
+                                 [Type
+                                    (LongIdent (SynLongIdent ([b1], [], [None])));
+                                  Star (3,13--3,14);
+                                  Type
+                                    (LongIdent (SynLongIdent ([b2], [], [None])));
+                                  Star (3,18--3,19);
+                                  Type
+                                    (LongIdent (SynLongIdent ([b3], [], [None])))],
+                                 (3,10--3,22)), (3,9--3,23)))], (3,5--3,23)),
+                    (3,1--3,23)), (3,0--3,1), Some (3,23--3,24), (3,0--3,24)),
+              (3,0--3,24))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,24), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 04.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 04.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * ( * b2 * b3))

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 04.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple - Nested 04.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type
+                          (Paren
+                             (Tuple
+                                (false,
+                                 [Type (FromParseError (3,12--3,12));
+                                  Star (3,11--3,12);
+                                  Type
+                                    (LongIdent (SynLongIdent ([b2], [], [None])));
+                                  Star (3,16--3,17);
+                                  Type
+                                    (LongIdent (SynLongIdent ([b3], [], [None])))],
+                                 (3,11--3,20)), (3,9--3,21)))], (3,5--3,21)),
+                    (3,1--3,21)), (3,0--3,1), Some (3,21--3,22), (3,0--3,22)),
+              (3,0--3,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,11)-(3,12) parse error Expecting type

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 05.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 05.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * (b1 * * b3))

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 05.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple - Nested 05.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type
+                          (Paren
+                             (Tuple
+                                (false,
+                                 [Type
+                                    (LongIdent (SynLongIdent ([b1], [], [None])));
+                                  Star (3,13--3,14);
+                                  Type (FromParseError (3,16--3,16));
+                                  Star (3,15--3,16);
+                                  Type
+                                    (LongIdent (SynLongIdent ([b3], [], [None])))],
+                                 (3,10--3,19)), (3,9--3,20)))], (3,5--3,20)),
+                    (3,1--3,20)), (3,0--3,1), Some (3,20--3,21), (3,0--3,21)),
+              (3,0--3,21))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,21), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,15)-(3,16) parse error Expecting type

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 06.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 06.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * (b1 * b2 * ))

--- a/tests/service/data/SyntaxTree/SynType/Tuple - Nested 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple - Nested 06.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple - Nested 06.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type
+                          (Paren
+                             (Tuple
+                                (false,
+                                 [Type
+                                    (LongIdent (SynLongIdent ([b1], [], [None])));
+                                  Star (3,13--3,14);
+                                  Type
+                                    (LongIdent (SynLongIdent ([b2], [], [None])));
+                                  Star (3,18--3,19);
+                                  Type (FromParseError (3,19--3,19))],
+                                 (3,10--3,19)), (3,9--3,21)))], (3,5--3,21)),
+                    (3,1--3,21)), (3,0--3,1), Some (3,21--3,22), (3,0--3,22)),
+              (3,0--3,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,20)-(3,21) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/SynType/Tuple 01.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * b)

--- a/tests/service/data/SyntaxTree/SynType/Tuple 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 01.fs.bsl
@@ -1,0 +1,20 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])))],
+                       (3,5--3,10)), (3,1--3,10)), (3,0--3,1), Some (3,10--3,11),
+                 (3,0--3,11)), (3,0--3,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Tuple 02.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * b * c)

--- a/tests/service/data/SyntaxTree/SynType/Tuple 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 02.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])));
+                        Star (3,11--3,12);
+                        Type (LongIdent (SynLongIdent ([c], [], [None])))],
+                       (3,5--3,14)), (3,1--3,14)), (3,0--3,1), Some (3,14--3,15),
+                 (3,0--3,15)), (3,0--3,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Tuple 03.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 03.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * b * c * d)

--- a/tests/service/data/SyntaxTree/SynType/Tuple 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 03.fs.bsl
@@ -1,0 +1,24 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])));
+                        Star (3,11--3,12);
+                        Type (LongIdent (SynLongIdent ([c], [], [None])));
+                        Star (3,15--3,16);
+                        Type (LongIdent (SynLongIdent ([d], [], [None])))],
+                       (3,5--3,18)), (3,1--3,18)), (3,0--3,1), Some (3,18--3,19),
+                 (3,0--3,19)), (3,0--3,19))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,19), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Tuple 04.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 04.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * )

--- a/tests/service/data/SyntaxTree/SynType/Tuple 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 04.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8); Type (FromParseError (3,8--3,8))],
+                       (3,5--3,8)), (3,1--3,8)), (3,0--3,1), Some (3,9--3,10),
+                 (3,0--3,10)), (3,0--3,10))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,10), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,9)-(3,10) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/SynType/Tuple 05.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 05.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): * b)

--- a/tests/service/data/SyntaxTree/SynType/Tuple 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 05.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (FromParseError (3,6--3,6)); Star (3,5--3,6);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])))],
+                       (3,5--3,8)), (3,1--3,8)), (3,0--3,1), Some (3,8--3,9),
+                 (3,0--3,9)), (3,0--3,9))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,9), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,5)-(3,6) parse error Expecting type

--- a/tests/service/data/SyntaxTree/SynType/Tuple 06.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 06.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * * c)

--- a/tests/service/data/SyntaxTree/SynType/Tuple 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 06.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8); Type (FromParseError (3,10--3,10));
+                        Star (3,9--3,10);
+                        Type (LongIdent (SynLongIdent ([c], [], [None])))],
+                       (3,5--3,12)), (3,1--3,12)), (3,0--3,1), Some (3,12--3,13),
+                 (3,0--3,13)), (3,0--3,13))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,13), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,9)-(3,10) parse error Expecting type

--- a/tests/service/data/SyntaxTree/SynType/Tuple 07.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 07.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * b * c *)

--- a/tests/service/data/SyntaxTree/SynType/Tuple 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 07.fs.bsl
@@ -1,0 +1,25 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 07.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])));
+                        Star (3,11--3,12);
+                        Type (LongIdent (SynLongIdent ([c], [], [None])));
+                        Star (3,15--3,16); Type (FromParseError (3,16--3,16))],
+                       (3,5--3,16)), (3,1--3,16)), (3,0--3,1), Some (3,16--3,17),
+                 (3,0--3,17)), (3,0--3,17))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,17), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,16)-(3,17) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/SynType/Tuple 08.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 08.fs
@@ -1,0 +1,3 @@
+module Module
+
+((): a * b * )

--- a/tests/service/data/SyntaxTree/SynType/Tuple 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 08.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 08.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Paren
+                (Typed
+                   (Const (Unit, (3,1--3,3)),
+                    Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                        Star (3,7--3,8);
+                        Type (LongIdent (SynLongIdent ([b], [], [None])));
+                        Star (3,11--3,12); Type (FromParseError (3,12--3,12))],
+                       (3,5--3,12)), (3,1--3,12)), (3,0--3,1), Some (3,13--3,14),
+                 (3,0--3,14)), (3,0--3,14))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,14), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,13)-(3,14) parse error Unexpected symbol ')' in type

--- a/tests/service/data/SyntaxTree/SynType/Tuple 09.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 09.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a -> b * = ()

--- a/tests/service/data/SyntaxTree/SynType/Tuple 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 09.fs.bsl
@@ -1,0 +1,44 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 09.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (LongIdent (SynLongIdent ([a], [], [None])),
+                           Tuple
+                             (false,
+                              [Type (LongIdent (SynLongIdent ([b], [], [None])));
+                               Star (3,14--3,15);
+                               Type (FromParseError (3,15--3,15))], (3,12--3,15)),
+                           (3,7--3,17), { ArrowRange = (3,9--3,11) }),
+                        (3,7--3,17), [], { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,18--3,20)),
+                     Fun
+                       (LongIdent (SynLongIdent ([a], [], [None])),
+                        Tuple
+                          (false,
+                           [Type (LongIdent (SynLongIdent ([b], [], [None])));
+                            Star (3,14--3,15);
+                            Type (FromParseError (3,15--3,15))], (3,12--3,15)),
+                        (3,7--3,17), { ArrowRange = (3,9--3,11) }), (3,18--3,20)),
+                  (3,4--3,5), Yes (3,0--3,20),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,16--3,17) })], (3,0--3,20))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,20), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,16)-(3,17) parse error Unexpected symbol '=' in binding

--- a/tests/service/data/SyntaxTree/SynType/Tuple 10.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 10.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a * -> b = ()

--- a/tests/service/data/SyntaxTree/SynType/Tuple 10.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 10.fs.bsl
@@ -1,0 +1,44 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 10.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (Tuple
+                             (false,
+                              [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                               Star (3,9--3,10);
+                               Type (FromParseError (3,10--3,10))], (3,7--3,10)),
+                           LongIdent (SynLongIdent ([b], [], [None])),
+                           (3,7--3,15), { ArrowRange = (3,11--3,13) }),
+                        (3,7--3,15), [], { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,18--3,20)),
+                     Fun
+                       (Tuple
+                          (false,
+                           [Type (LongIdent (SynLongIdent ([a], [], [None])));
+                            Star (3,9--3,10); Type (FromParseError (3,10--3,10))],
+                           (3,7--3,10)),
+                        LongIdent (SynLongIdent ([b], [], [None])), (3,7--3,15),
+                        { ArrowRange = (3,11--3,13) }), (3,18--3,20)),
+                  (3,4--3,5), Yes (3,0--3,20),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,16--3,17) })], (3,0--3,20))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,20), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,11)-(3,13) parse error Unexpected symbol '->' in binding

--- a/tests/service/data/SyntaxTree/SynType/Tuple 11.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 11.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a -> b1 * b2 * = ()

--- a/tests/service/data/SyntaxTree/SynType/Tuple 11.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 11.fs.bsl
@@ -1,0 +1,50 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 11.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (LongIdent (SynLongIdent ([a], [], [None])),
+                           Tuple
+                             (false,
+                              [Type
+                                 (LongIdent (SynLongIdent ([b1], [], [None])));
+                               Star (3,15--3,16);
+                               Type
+                                 (LongIdent (SynLongIdent ([b2], [], [None])));
+                               Star (3,20--3,21);
+                               Type (FromParseError (3,21--3,21))], (3,12--3,21)),
+                           (3,7--3,23), { ArrowRange = (3,9--3,11) }),
+                        (3,7--3,23), [], { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,24--3,26)),
+                     Fun
+                       (LongIdent (SynLongIdent ([a], [], [None])),
+                        Tuple
+                          (false,
+                           [Type (LongIdent (SynLongIdent ([b1], [], [None])));
+                            Star (3,15--3,16);
+                            Type (LongIdent (SynLongIdent ([b2], [], [None])));
+                            Star (3,20--3,21);
+                            Type (FromParseError (3,21--3,21))], (3,12--3,21)),
+                        (3,7--3,23), { ArrowRange = (3,9--3,11) }), (3,24--3,26)),
+                  (3,4--3,5), Yes (3,0--3,26),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,22--3,23) })], (3,0--3,26))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,26), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,22)-(3,23) parse error Unexpected symbol '=' in binding

--- a/tests/service/data/SyntaxTree/SynType/Tuple 12.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 12.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a1 * a2 * -> b = ()

--- a/tests/service/data/SyntaxTree/SynType/Tuple 12.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 12.fs.bsl
@@ -1,0 +1,50 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 12.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (Tuple
+                             (false,
+                              [Type
+                                 (LongIdent (SynLongIdent ([a1], [], [None])));
+                               Star (3,10--3,11);
+                               Type
+                                 (LongIdent (SynLongIdent ([a2], [], [None])));
+                               Star (3,15--3,16);
+                               Type (FromParseError (3,16--3,16))], (3,7--3,16)),
+                           LongIdent (SynLongIdent ([b], [], [None])),
+                           (3,7--3,21), { ArrowRange = (3,17--3,19) }),
+                        (3,7--3,21), [], { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,24--3,26)),
+                     Fun
+                       (Tuple
+                          (false,
+                           [Type (LongIdent (SynLongIdent ([a1], [], [None])));
+                            Star (3,10--3,11);
+                            Type (LongIdent (SynLongIdent ([a2], [], [None])));
+                            Star (3,15--3,16);
+                            Type (FromParseError (3,16--3,16))], (3,7--3,16)),
+                        LongIdent (SynLongIdent ([b], [], [None])), (3,7--3,21),
+                        { ArrowRange = (3,17--3,19) }), (3,24--3,26)),
+                  (3,4--3,5), Yes (3,0--3,26),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,22--3,23) })], (3,0--3,26))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,26), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,17)-(3,19) parse error Unexpected symbol '->' in binding

--- a/tests/service/data/SyntaxTree/SynType/Tuple 13.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 13.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a -> b1 * * b3 = ()

--- a/tests/service/data/SyntaxTree/SynType/Tuple 13.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 13.fs.bsl
@@ -1,0 +1,52 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 13.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (LongIdent (SynLongIdent ([a], [], [None])),
+                           Tuple
+                             (false,
+                              [Type
+                                 (LongIdent (SynLongIdent ([b1], [], [None])));
+                               Star (3,15--3,16);
+                               Type (FromParseError (3,18--3,18));
+                               Star (3,17--3,18);
+                               Type
+                                 (LongIdent (SynLongIdent ([b3], [], [None])))],
+                              (3,12--3,21)), (3,7--3,21),
+                           { ArrowRange = (3,9--3,11) }), (3,7--3,21), [],
+                        { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,24--3,26)),
+                     Fun
+                       (LongIdent (SynLongIdent ([a], [], [None])),
+                        Tuple
+                          (false,
+                           [Type (LongIdent (SynLongIdent ([b1], [], [None])));
+                            Star (3,15--3,16);
+                            Type (FromParseError (3,18--3,18));
+                            Star (3,17--3,18);
+                            Type (LongIdent (SynLongIdent ([b3], [], [None])))],
+                           (3,12--3,21)), (3,7--3,21),
+                        { ArrowRange = (3,9--3,11) }), (3,24--3,26)), (3,4--3,5),
+                  Yes (3,0--3,26), { LeadingKeyword = Let (3,0--3,3)
+                                     InlineKeyword = None
+                                     EqualsRange = Some (3,22--3,23) })],
+              (3,0--3,26))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,26), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,17)-(3,18) parse error Expecting type

--- a/tests/service/data/SyntaxTree/SynType/Tuple 14.fs
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 14.fs
@@ -1,0 +1,3 @@
+module Module
+
+let _: a1 * * a3 -> b = ()

--- a/tests/service/data/SyntaxTree/SynType/Tuple 14.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Tuple 14.fs.bsl
@@ -1,0 +1,52 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Tuple 14.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
+                  Wild (3,4--3,5),
+                  Some
+                    (SynBindingReturnInfo
+                       (Fun
+                          (Tuple
+                             (false,
+                              [Type
+                                 (LongIdent (SynLongIdent ([a1], [], [None])));
+                               Star (3,10--3,11);
+                               Type (FromParseError (3,13--3,13));
+                               Star (3,12--3,13);
+                               Type
+                                 (LongIdent (SynLongIdent ([a3], [], [None])))],
+                              (3,7--3,16)),
+                           LongIdent (SynLongIdent ([b], [], [None])),
+                           (3,7--3,21), { ArrowRange = (3,17--3,19) }),
+                        (3,7--3,21), [], { ColonRange = Some (3,5--3,6) })),
+                  Typed
+                    (Const (Unit, (3,24--3,26)),
+                     Fun
+                       (Tuple
+                          (false,
+                           [Type (LongIdent (SynLongIdent ([a1], [], [None])));
+                            Star (3,10--3,11);
+                            Type (FromParseError (3,13--3,13));
+                            Star (3,12--3,13);
+                            Type (LongIdent (SynLongIdent ([a3], [], [None])))],
+                           (3,7--3,16)),
+                        LongIdent (SynLongIdent ([b], [], [None])), (3,7--3,21),
+                        { ArrowRange = (3,17--3,19) }), (3,24--3,26)),
+                  (3,4--3,5), Yes (3,0--3,26),
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,22--3,23) })], (3,0--3,26))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,26), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,12)-(3,13) parse error Expecting type


### PR DESCRIPTION
Adds recovery for missing types in tuple and function types.

```fsharp
type T(i: a * ) = class end
```

```fsharp
type T(i: a -> b * ) = class end
```

```fsharp
let _: a * = ()
```

```fsharp
let _: a * * c = ()
```

```fsharp
let _: a -> = ()
```