### PR TITLE
Treat usage of BinaryFormatter as error

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -45,6 +45,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <ReflectionFree Condition=" '$(ReflectionFree)' == '' ">false</ReflectionFree>
   </PropertyGroup>
 
+  <!-- BinaryFormatter is disabled (warning is treated as error) by default in .NET8+, this mirroring the change in SDK (https://github.com/dotnet/sdk/pull/31591) -->
+  <PropertyGroup>
+    <WarningsAsErrors Condition="'$(_BinaryFormatterObsoleteAsError)' == 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols Condition="'$(DebugSymbols)' == '' ">true</DebugSymbols>
     <Optimize Condition="'$(Optimize)' == '' ">false</Optimize>


### PR DESCRIPTION
Mirroring chages in https://github.com/dotnet/sdk/pull/31591, but for F# targets