### PR TITLE
Improve when SimplifyNames analyzer is triggered

### DIFF
--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -25,7 +25,7 @@ type internal SimplifyNameDiagnosticAnalyzer [<ImportingConstructor>] () =
 
     static let userOpName = "SimplifyNameDiagnosticAnalyzer"
     static let cache = new MemoryCache("FSharp.Editor." + userOpName)
-    // Make sure only a few  documents is being analyzed at a time, to be nice
+    // Make sure only a few  documents are being analyzed at a time, to be nice
     static let guard = new SemaphoreSlim(3)
 
     static member LongIdentPropertyKey = "FullName"
@@ -39,7 +39,7 @@ type internal SimplifyNameDiagnosticAnalyzer [<ImportingConstructor>] () =
                     do Trace.TraceInformation("{0:n3} (start) SimplifyName", DateTime.Now.TimeOfDay.TotalSeconds)
                     let! textVersion = document.GetTextVersionAsync(cancellationToken)
                     let textVersionHash = textVersion.GetHashCode()
-                    let! lockObtained = guard.WaitAsync(TimeSpan.FromSeconds 10. ,cancellationToken) |> Async.AwaitTask |> liftAsync
+                    let! lockObtained = guard.WaitAsync(DefaultTuning.PerDocumentSavedDataSlidingWindow ,cancellationToken) |> Async.AwaitTask |> liftAsync
                     do! Option.guard lockObtained
 
                     try


### PR DESCRIPTION
SimplifyNames  analyzer is responsible for reducing qualified names if the respective namespaces/modules are being opened.
However, it was not triggering most of the time.

This PR addresses this by reducing the lock contention of this service:
- Adding timeout to waiting on SemaphoreSlim to prevent a never ending queue of requests
- Increasing the bandwith to 3 operations at the same time
- Giving up if the lock is not obtained


On top of that, when I was debugging, the project was treated as "FSharpMiscellaneous". Which meant regular .fs files (not scripts) were not analyzed in that situation:
`if document.Project.IsFSharpMiscellaneousOrMetadata && not document.IsFSharpScript`
